### PR TITLE
[CI] Move lint job to self-hosted runner

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -31,19 +31,42 @@ jobs:
     uses: ./.github/workflows/sycl_detect_changes.yml
 
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: cuda
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
+      # actions/checkout fails without "--privileged".
+      options: -u 1001:1001 --privileged
     steps:
+    - name: Fake actions/checkout task
+      uses: actions/checkout@v3
+      with:
+        # cached_checkout below uses actions/checkout internally. However, when
+        # actions/checkout is run from within another action step (not from
+        # workflow), github seems to try to download from within the container
+        # and doesn't have requried filesystem permissions. Make sure it's
+        # already downloaded by the time it's needed by checking out some small
+        # repository.
+        repository: actions/checkout
+        path: fake-checkout
     - name: 'PR commits + 1'
       run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
-    - uses: actions/checkout@v3
+    - name: Setup action
+      # We can switch to `cp -r /actions .` once changes in cached_checkout are
+      # propagated into the nightly container image.
+      run: |
+        mkdir -p actions/cached_checkout
+        wget raw.githubusercontent.com/intel/llvm/sycl/devops/actions/cached_checkout/action.yml   -P ./actions/cached_checkout
+    - uses: ./actions/cached_checkout
       with:
-        ref: ${{ github.event.pull_request.head.sha }}
-        persist-credentials: false
+        path: src
         fetch-depth: ${{ env.PR_FETCH_DEPTH }}
+        ref: ${{ github.event.pull_request.head.sha }}
+        cache_path: "/__w/repo_cache/"
+        merge: false
     - name: Run clang-format
-      uses: ./devops/actions/clang-format
+      uses: ./src/devops/actions/clang-format
+      with:
+        path: src
 
   # This job generates matrix of tests for SYCL End-to-End tests
   test_matrix:

--- a/devops/actions/clang-format/action.yml
+++ b/devops/actions/clang-format/action.yml
@@ -1,14 +1,19 @@
 name: 'clang-format'
 description: 'Run clang-format on pull request'
+inputs:
+  path:
+    description: Path to the checkout
+    required: true
+
 runs:
   using: "composite"
   steps:
   - name: Run clang-format for the patch
     shell: bash {0}
     run: |
-      git config --global --add safe.directory /__w/llvm/llvm
-      git clang-format ${{ github.event.pull_request.base.sha }}
-      git diff > ./clang-format.patch
+      git config --global --add safe.directory ${{ inputs.path }}
+      git -C ${{ inputs.path }} clang-format ${{ github.event.pull_request.base.sha }}
+      git -C ${{ inputs.path }} diff > ./clang-format.patch
   # Add patch with formatting fixes to CI job artifacts
   - uses: actions/upload-artifact@v1
     with:


### PR DESCRIPTION
Github's allocation of default ubuntu-* runners isn't reliably stable,
so keep moving tasks to self hosted runners. We don't use the cuda runner 
currently, so assign those to it for the time being. Later we should be 
able to extend those utility tasks to run on generic `Linux` class of 
self-hosted runners.