### PR TITLE
[CI] Don't install lz4

### DIFF
--- a/devops/scripts/install_build_tools.sh
+++ b/devops/scripts/install_build_tools.sh
@@ -19,7 +19,6 @@ apt update && apt install -yqq \
       libdw1 \
       wget \
       sudo \
-      lz4 \
       zstd
 
 pip3 install psutil


### PR DESCRIPTION
We decided to use "zstd" instead.