### PR TITLE
[SYCL][CODEOWNERS] Make intel/llvm-reviewers-runtime design docs codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -30,7 +30,7 @@ sycl/ @intel/llvm-reviewers-runtime
 # Documentation
 sycl/ReleaseNotes.md @intel/dpcpp-doc-reviewers @tfzhu
 sycl/doc/ @intel/dpcpp-doc-reviewers
-sycl/doc/design/ @intel/dpcpp-specification-reviewers
+sycl/doc/design/ @intel/llvm-reviewers-runtime
 sycl/doc/design/spirv-extensions/ @intel/dpcpp-spirv-doc-reviewers
 sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 


### PR DESCRIPTION
This commit changes the code-owners of the sycl/docs/design section from @intel/dpcpp-specification-reviewers to intel/llvm-reviewers-runtime. With this, the intel/llvm-reviewers-runtime would be responsible for either reviewing the design changes or assign the appropriate teams to make a design review.