### PR TITLE
[SYCL] Disable ZE_DEBUG test for interop

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/spec_constants_after_link.cpp
+++ b/sycl/test-e2e/KernelAndProgram/spec_constants_after_link.cpp
@@ -7,8 +7,8 @@
 // HIP backend does not currently implement linking.
 // UNSUPPORTED: hip
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
+// This test uses interop that has the ownership on a kernel.
+// UNSUPPORTED: ze_debug
 
 // This test checks that specialization constant information is available on
 // kernel bundles produced by sycl::link.


### PR DESCRIPTION
This test uses an interop API to create a kernel.
So, ZE_DEBUG should be disabled.