### PR TITLE
[SYCL] Const-qualify sycl::logical_{or, and}

### DIFF
--- a/sycl/include/sycl/functional.hpp
+++ b/sycl/include/sycl/functional.hpp
@@ -24,13 +24,13 @@ template <typename T = void> using bit_xor = std::bit_xor<T>;
 // std:logical_and/std::logical_or with a non-void type returns bool,
 // sycl requires returning T.
 template <typename T = void> struct logical_and {
-  T operator()(const T &lhs, const T &rhs) { return lhs && rhs; }
+  T operator()(const T &lhs, const T &rhs) const { return lhs && rhs; }
 };
 
 template <> struct logical_and<void> : std::logical_and<void> {};
 
 template <typename T = void> struct logical_or {
-  T operator()(const T &lhs, const T &rhs) { return lhs || rhs; }
+  T operator()(const T &lhs, const T &rhs) const { return lhs || rhs; }
 };
 
 template <> struct logical_or<void> : std::logical_or<void> {};


### PR DESCRIPTION
These operators were changed from aliasing their `std` counterparts in https://github.com/intel/llvm/pull/9298 but a const-qualification was not added (as required by [4.17.2. Function objects](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#sec:function-objects)).