### PR TITLE
[SYCL-MLIR][NFC] Remove unused variable definition

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1088,15 +1088,6 @@ ValueCategory MLIRScanner::VisitBinaryOperator(clang::BinaryOperator *BO) {
     assert(RHS.val);
   }
 
-  // TODO note assumptions made here about unsigned / unordered
-  bool SignedType = true;
-  if (const auto *Bit = dyn_cast<clang::BuiltinType>(&*BO->getType())) {
-    if (Bit->isUnsignedInteger())
-      SignedType = false;
-    if (Bit->isSignedInteger())
-      SignedType = true;
-  }
-
   switch (BO->getOpcode()) {
   case clang::BinaryOperator::Opcode::BO_Comma:
     return RHS;


### PR DESCRIPTION
Remove definition of variable `SignedType`, which is no longer used since commit ee166e0ed812cd7aea11311adb650a58501c8ef7.