### PR TITLE
[SYCL] Fix multi_ptr ctor for extended address spaces

### DIFF
--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -136,7 +136,9 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, access::target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()) {}
+      : multi_ptr(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space || generic_space
   template <int Dimensions, access::mode Mode,
@@ -186,8 +188,9 @@ public:
   multi_ptr(accessor<typename std::remove_const_t<RelayElementType>, Dimensions,
                      Mode, access::target::device, isPlaceholder, PropertyListT>
                 Accessor)
-      : m_Pointer(Accessor.template get_multi_ptr<DecorateAddress>()
-                      .get_decorated()) {}
+      : m_Pointer(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space || generic_space and element type is const
   template <int Dimensions, access::mode Mode,
@@ -450,7 +453,9 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, access::target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()) {}
+      : multi_ptr(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space
   template <
@@ -575,7 +580,9 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, access::target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()) {}
+      : multi_ptr(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space
   template <

--- a/sycl/test/multi_ptr/ext_addr_spaces.cpp
+++ b/sycl/test/multi_ptr/ext_addr_spaces.cpp
@@ -1,0 +1,33 @@
+// RUN: %clangxx -fsycl -D__ENABLE_USM_ADDR_SPACE__ -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=note,warning
+// expected-no-diagnostics
+
+// Checks that extended address spaces are allowed when creating multi_ptr from
+// accessors.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  queue Q;
+
+  buffer<int> Buf{1};
+  Q.submit([&](handler &CGH) {
+     accessor Acc{Buf, CGH, read_write};
+     CGH.single_task([=]() {
+       device_ptr<int, access::decorated::yes> MPtr1{Acc};
+       device_ptr<int, access::decorated::no> MPtr2{Acc};
+       device_ptr<int, access::decorated::legacy> MPtr3{Acc};
+       device_ptr<const int, access::decorated::yes> MPtr4{Acc};
+       device_ptr<const int, access::decorated::no> MPtr5{Acc};
+       device_ptr<const int, access::decorated::legacy> MPtr6{Acc};
+       device_ptr<void, access::decorated::yes> MPtr7{Acc};
+       device_ptr<void, access::decorated::no> MPtr8{Acc};
+       device_ptr<void, access::decorated::legacy> MPtr9{Acc};
+       device_ptr<const void, access::decorated::yes> MPtr10{Acc};
+       device_ptr<const void, access::decorated::no> MPtr11{Acc};
+       device_ptr<const void, access::decorated::legacy> MPtr12{Acc};
+     });
+   }).wait_and_throw();
+  return 0;
+}


### PR DESCRIPTION
The sycl_ext_usm_address_spaces extension adds the ext_intel_global_device_space address space together with additional multi_ptr constructors for creating a multi_ptr from an accessor. However, the current implementation fails to construct the multi_ptr from an accessor when the extended address space decorations are enabled (through __ENABLE_USM_ADDR_SPACE__) as it attempts to use the normal global address space decoration.
This commit fixes these constructors by doing a legal cast of the underlying global-space pointer to a ext_intel_global_device_space decorated pointer.