### PR TITLE
[SYCL][CUDA] Fix post merge errors from #9512

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/tracing.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/tracing.cpp
@@ -19,22 +19,20 @@
 #include <exception>
 #include <iostream>
 
+#ifdef XPTI_ENABLE_INSTRUMENTATION
 constexpr auto CUDA_CALL_STREAM_NAME = "sycl.experimental.cuda.call";
 constexpr auto CUDA_DEBUG_STREAM_NAME = "sycl.experimental.cuda.debug";
 
 thread_local uint64_t CallCorrelationID = 0;
 thread_local uint64_t DebugCorrelationID = 0;
 
-#ifdef XPTI_ENABLE_INSTRUMENTATION
 static xpti_td *GCallEvent = nullptr;
 static xpti_td *GDebugEvent = nullptr;
-#endif // XPTI_ENABLE_INSTRUMENTATION
 
 constexpr auto GVerStr = "0.1";
 constexpr int GMajVer = 0;
 constexpr int GMinVer = 1;
 
-#ifdef XPTI_ENABLE_INSTRUMENTATION
 static void cuptiCallback(void *, CUpti_CallbackDomain, CUpti_CallbackId CBID,
                           const void *CBData) {
   if (xptiTraceEnabled()) {

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
@@ -19,9 +19,9 @@
 
 /// USM: Implements USM Host allocations using CUDA Pinned Memory
 /// https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#page-locked-host-memory
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
-               ur_usm_pool_handle_t pool, size_t size, void **ppMem) {
+UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAlloc(
+    ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
+    [[maybe_unused]] ur_usm_pool_handle_t pool, size_t size, void **ppMem) {
   UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
@@ -55,10 +55,10 @@ urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
 
 /// USM: Implements USM device allocations using a normal CUDA device pointer
 ///
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
-                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
-                 size_t size, void **ppMem) {
+UR_APIEXPORT ur_result_t UR_APICALL urUSMDeviceAlloc(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    const ur_usm_desc_t *pUSMDesc, [[maybe_unused]] ur_usm_pool_handle_t pool,
+    size_t size, void **ppMem) {
   UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
@@ -92,10 +92,10 @@ urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
 
 /// USM: Implements USM Shared allocations using CUDA Managed Memory
 ///
-UR_APIEXPORT ur_result_t UR_APICALL
-urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
-                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
-                 size_t size, void **ppMem) {
+UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    const ur_usm_desc_t *pUSMDesc, [[maybe_unused]] ur_usm_pool_handle_t pool,
+    size_t size, void **ppMem) {
   UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);


### PR DESCRIPTION
Resolves the warnings as errors reported in [post merge](https://github.com/intel/llvm/actions/runs/5266121277/jobs/9519634360) as a result of merging #9512. Additionally move pre-processor guards to resolve unused global variables which would also fail in this build configuration (clang & SYCL_ENABLE_WERROR=ON).
