### PR TITLE
[sycl-post-link] Invoke Internalize in sycl-post-link

### DIFF
--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-1.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-1.ll
@@ -27,8 +27,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define dso_local spir_func void @{{.*}}foo{{.*}}()
-; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU1: define internal spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo{{.*}}()
 
 ; CHECK-TU1: call spir_func i32 @{{.*}}bar{{.*}}(i32 1)
 
@@ -66,8 +66,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define dso_local spir_func void @{{.*}}foo1{{.*}}()
-; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU1: define internal spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo1{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo1v() {
@@ -90,8 +90,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1-NOT: define dso_local spir_func void @{{.*}}foo2{{.*}}()
-; CHECK-TU0: define dso_local spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU1-NOT: define {{.*}} spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU0: define internal spir_func void @{{.*}}foo2{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo2v() {

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-2.ll
@@ -32,8 +32,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define dso_local spir_func void @{{.*}}foo{{.*}}()
-; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU1: define internal spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo{{.*}}()
 
 ; CHECK-TU1: call spir_func i32 @{{.*}}bar{{.*}}(i32 1)
 
@@ -71,8 +71,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define dso_local spir_func void @{{.*}}foo1{{.*}}()
-; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU1: define internal spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo1{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo1v() {
@@ -95,8 +95,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1-NOT: define dso_local spir_func void @{{.*}}foo2{{.*}}()
-; CHECK-TU0: define dso_local spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU1-NOT: define {{.*}} spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU0: define internal spir_func void @{{.*}}foo2{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo2v() {

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-2.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-2.ll
@@ -24,7 +24,7 @@ $_Z3barIiET_S0_ = comdat any
 ; CHECK-TU0-NOT: define dso_local spir_kernel void @{{.*}}TU0_kernel0{{.*}}
 ; CHECK-TU0-TXT-NOT: {{.*}}TU0_kernel0{{.*}}
 
-; CHECK-TU1: call spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU1: call spir_func void @{{.*}}foov{{.*}}()
 
 define dso_local spir_kernel void @_ZTSZ4mainE11TU0_kernel0() #0 {
 entry:
@@ -32,8 +32,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define internal spir_func void @{{.*}}foo{{.*}}()
-; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU1: define dso_local spir_func void @{{.*}}foov{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foov{{.*}}()
 
 ; CHECK-TU1: call spir_func i32 @{{.*}}bar{{.*}}(i32 1)
 

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
@@ -10,7 +10,7 @@
 ; RUN:     --implicit-check-not _Z4foo3v
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-TU1-IR \
 ; RUN:     --implicit-check-not TU1_kernel --implicit-check-not _Z4foo2v \
-; RUN:     --implicit-check-not _Z4foo1v
+; RUN:     --implicit-check-not _Z4foo3v --implicit-check-not _Z4foo1v
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-TU0-SYM
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-TU1-SYM
 ;
@@ -26,8 +26,7 @@
 ; CHECK-TU0-IR: define internal spir_func void @_Z4foo2v
 ;
 ; CHECK-TU1-IR: define dso_local spir_kernel void @_ZTSZ4mainE10TU0_kernel
-; CHECK-TU1-IR: define dso_local spir_func void @_Z3foov
-; CHECK-TU1-IR: define dso_local spir_func i32 @_Z4foo3v
+; CHECK-TU1-IR: define internal spir_func void @_Z3foov
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
@@ -10,7 +10,7 @@
 ; RUN:     --implicit-check-not _Z4foo3v
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefixes CHECK-TU1-IR \
 ; RUN:     --implicit-check-not TU1_kernel --implicit-check-not _Z4foo2v \
-; RUN:     --implicit-check-not _Z4foo3v --implicit-check-not _Z4foo1v
+; RUN:     --implicit-check-not _Z4foo1v
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-TU0-SYM
 ; RUN: FileCheck %s -input-file=%t_1.sym --check-prefixes CHECK-TU1-SYM
 ;
@@ -27,6 +27,7 @@
 ;
 ; CHECK-TU1-IR: define dso_local spir_kernel void @_ZTSZ4mainE10TU0_kernel
 ; CHECK-TU1-IR: define internal spir_func void @_Z3foov
+; CHECK-TU1-IR: define dso_local spir_func i32 @_Z4foo3v
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024"
 target triple = "spir64-unknown-linux"

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-3.ll
@@ -21,9 +21,9 @@
 ;
 ; CHECK-TU0-IR: @_ZL2GV = internal addrspace(1) constant
 ; CHECK-TU0-IR: define dso_local spir_kernel void @_ZTSZ4mainE11TU1_kernel0
-; CHECK-TU0-IR: define dso_local spir_func i32 @_Z4foo1v
+; CHECK-TU0-IR: define internal spir_func i32 @_Z4foo1v
 ; CHECK-TU0-IR: define dso_local spir_kernel void @_ZTSZ4mainE11TU1_kernel1
-; CHECK-TU0-IR: define dso_local spir_func void @_Z4foo2v
+; CHECK-TU0-IR: define internal spir_func void @_Z4foo2v
 ;
 ; CHECK-TU1-IR: define dso_local spir_kernel void @_ZTSZ4mainE10TU0_kernel
 ; CHECK-TU1-IR: define dso_local spir_func void @_Z3foov

--- a/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-func-ptr.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/auto-module-split-func-ptr.ll
@@ -13,7 +13,7 @@
 ; CHECK-IR0: define dso_local spir_kernel void @kernel2
 ;
 ; CHECK-IR1: @_Z2f1iTable = weak global ptr @_Z2f1i
-; CHECK-IR1: define dso_local spir_func i32 @_Z2f1i
+; CHECK-IR1: define internal spir_func i32 @_Z2f1i
 ; CHECK-IR1: define weak_odr dso_local spir_kernel void @kernel1
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"

--- a/llvm/test/tools/sycl-post-link/device-code-split/basic-module-split.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/basic-module-split.ll
@@ -27,8 +27,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define dso_local spir_func void @{{.*}}foo{{.*}}()
-; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU1: define internal spir_func void @{{.*}}foo{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo{{.*}}()
 
 ; CHECK-TU1: call spir_func i32 @{{.*}}bar{{.*}}(i32 1)
 
@@ -66,8 +66,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1: define dso_local spir_func void @{{.*}}foo1{{.*}}()
-; CHECK-TU0-NOT: define dso_local spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU1: define internal spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-TU0-NOT: define {{.*}} spir_func void @{{.*}}foo1{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo1v() {
@@ -90,8 +90,8 @@ entry:
   ret void
 }
 
-; CHECK-TU1-NOT: define dso_local spir_func void @{{.*}}foo2{{.*}}()
-; CHECK-TU0: define dso_local spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU1-NOT: define {{.*}} spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-TU0: define internal spir_func void @{{.*}}foo2{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo2v() {

--- a/llvm/test/tools/sycl-post-link/device-code-split/complex-indirect-call-chain.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/complex-indirect-call-chain.ll
@@ -4,11 +4,9 @@
 ; RUN: sycl-post-link -split=auto -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
-; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz \
-; RUN:     --implicit-check-not @BAZ
+; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
-; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C \
-; RUN:     --implicit-check-not @bar --implicit-check-not @BAZ
+; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefix CHECK2 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @bar \
 ; RUN:     --implicit-check-not @BAZ --implicit-check-not @kernel_B \
@@ -17,11 +15,9 @@
 ; RUN: sycl-post-link -split=source -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
-; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz \
-; RUN:     --implicit-check-not @BAZ
+; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
-; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C \
-; RUN:     --implicit-check-not @bar --implicit-check-not @BAZ
+; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefix CHECK2 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @bar \
 ; RUN:     --implicit-check-not @BAZ --implicit-check-not @kernel_B \
@@ -30,21 +26,22 @@
 ; RUN: sycl-post-link -split=kernel -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
-; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz \
-; RUN:     --implicit-check-not @BAZ
+; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
-; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C \
-; RUN:     --implicit-check-not @bar --implicit-check-not @BAZ
+; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefix CHECK2 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @bar \
 ; RUN:     --implicit-check-not @BAZ --implicit-check-not @kernel_B \
 ; RUN:     --implicit-check-not @kernel_C
 
 ; CHECK0-DAG: define spir_kernel void @kernel_C
-; CHECK0-DAG: define internal spir_func i32 @bar
+; CHECK0-DAG: define spir_func i32 @bar
+; CHECK0-DAG: define spir_func void @BAZ
 
 ; CHECK1-DAG: define spir_kernel void @kernel_B
 ; CHECK1-DAG: define internal spir_func i32 @foo
+; CHECK1-DAG: define spir_func i32 @bar
+; CHECK1-DAG: define spir_func void @BAZ
 
 ; CHECK2-DAG: define spir_kernel void @kernel_A
 ; CHECK2-DAG: define internal spir_func void @baz

--- a/llvm/test/tools/sycl-post-link/device-code-split/complex-indirect-call-chain.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/complex-indirect-call-chain.ll
@@ -4,9 +4,11 @@
 ; RUN: sycl-post-link -split=auto -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
-; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz
+; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz \
+; RUN:     --implicit-check-not @BAZ
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
-; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C
+; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C \
+; RUN:     --implicit-check-not @bar --implicit-check-not @BAZ
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefix CHECK2 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @bar \
 ; RUN:     --implicit-check-not @BAZ --implicit-check-not @kernel_B \
@@ -15,9 +17,11 @@
 ; RUN: sycl-post-link -split=source -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
-; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz
+; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz \
+; RUN:     --implicit-check-not @BAZ
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
-; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C
+; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C \
+; RUN:     --implicit-check-not @bar --implicit-check-not @BAZ
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefix CHECK2 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @bar \
 ; RUN:     --implicit-check-not @BAZ --implicit-check-not @kernel_B \
@@ -26,25 +30,24 @@
 ; RUN: sycl-post-link -split=kernel -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll --check-prefix CHECK0 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @kernel_A \
-; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz
+; RUN:     --implicit-check-not @kernel_B --implicit-check-not @baz \
+; RUN:     --implicit-check-not @BAZ
 ; RUN: FileCheck %s -input-file=%t_1.ll --check-prefix CHECK1 \
-; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C
+; RUN:     --implicit-check-not @kernel_A --implicit-check-not @kernel_C \
+; RUN:     --implicit-check-not @bar --implicit-check-not @BAZ
 ; RUN: FileCheck %s -input-file=%t_2.ll --check-prefix CHECK2 \
 ; RUN:     --implicit-check-not @foo --implicit-check-not @bar \
 ; RUN:     --implicit-check-not @BAZ --implicit-check-not @kernel_B \
 ; RUN:     --implicit-check-not @kernel_C
 
 ; CHECK0-DAG: define spir_kernel void @kernel_C
-; CHECK0-DAG: define spir_func i32 @bar
-; CHECK0-DAG: define spir_func void @BAZ
+; CHECK0-DAG: define internal spir_func i32 @bar
 
 ; CHECK1-DAG: define spir_kernel void @kernel_B
-; CHECK1-DAG: define spir_func i32 @foo
-; CHECK1-DAG: define spir_func i32 @bar
-; CHECK1-DAG: define spir_func void @BAZ
+; CHECK1-DAG: define internal spir_func i32 @foo
 
 ; CHECK2-DAG: define spir_kernel void @kernel_A
-; CHECK2-DAG: define spir_func void @baz
+; CHECK2-DAG: define internal spir_func void @baz
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/llvm/test/tools/sycl-post-link/device-code-split/one-kernel-per-module.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/one-kernel-per-module.ll
@@ -30,9 +30,9 @@ entry:
   ret void
 }
 
-; CHECK-MODULE2: define dso_local spir_func void @{{.*}}foo{{.*}}()
-; CHECK-MODULE1-NOT: define dso_local spir_func void @{{.*}}foo{{.*}}()
-; CHECK-MODULE0-NOT: define dso_local spir_func void @{{.*}}foo{{.*}}()
+; CHECK-MODULE2: define internal spir_func void @{{.*}}foo{{.*}}()
+; CHECK-MODULE1-NOT: define {{.*}} spir_func void @{{.*}}foo{{.*}}()
+; CHECK-MODULE0-NOT: define {{.*}} spir_func void @{{.*}}foo{{.*}}()
 
 ; CHECK-MODULE2: call spir_func i32 @{{.*}}bar{{.*}}(i32 1)
 
@@ -73,9 +73,9 @@ entry:
   ret void
 }
 
-; CHECK-MODULE2-NOT: define dso_local spir_func void @{{.*}}foo1{{.*}}()
-; CHECK-MODULE1: define dso_local spir_func void @{{.*}}foo1{{.*}}()
-; CHECK-MODULE0-NOT: define dso_local spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-MODULE2-NOT: define {{.*}} spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-MODULE1: define internal spir_func void @{{.*}}foo1{{.*}}()
+; CHECK-MODULE0-NOT: define {{.*}} spir_func void @{{.*}}foo1{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo1v() {
@@ -100,9 +100,9 @@ entry:
   ret void
 }
 
-; CHECK-MODULE2-NOT: define dso_local spir_func void @{{.*}}foo2{{.*}}()
-; CHECK-MODULE1-NOT: define dso_local spir_func void @{{.*}}foo2{{.*}}()
-; CHECK-MODULE0: define dso_local spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-MODULE2-NOT: define {{.*}} spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-MODULE1-NOT: define {{.*}} spir_func void @{{.*}}foo2{{.*}}()
+; CHECK-MODULE0: define internal spir_func void @{{.*}}foo2{{.*}}()
 
 ; Function Attrs: nounwind
 define dso_local spir_func void @_Z4foo2v() {

--- a/llvm/test/tools/sycl-post-link/device-code-split/split-with-func-ptrs.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/split-with-func-ptrs.ll
@@ -26,6 +26,10 @@ $bar = comdat any
 @"tableX" = weak global [1 x void ()*] [void ()* @foo], align 8
 @"tableY" = weak global [1 x void ()*] [void ()* @bar], align 8
 
+; Ensure that tableX and tableY are not deleted.  This is necessary
+; because otherwise unused weak global symbols can be internalized
+; and then subsequently deleted.
+@llvm.compiler.used = appending global [2 x [1 x void ()*]*] [[1 x void ()*]* @tableX, [1 x void ()*]* @tableY ]
 
 ; Function Attrs: mustprogress norecurse nounwind
 define linkonce_odr dso_local spir_func void @foo() unnamed_addr #0 comdat align 2 {

--- a/llvm/test/tools/sycl-post-link/device-code-split/split-with-func-ptrs.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/split-with-func-ptrs.ll
@@ -33,12 +33,12 @@ $bar = comdat any
 
 ; Function Attrs: mustprogress norecurse nounwind
 define linkonce_odr dso_local spir_func void @foo() unnamed_addr #0 comdat align 2 {
-; CHECK-A0: define linkonce_odr dso_local spir_func void @foo
-; CHECK-A1: define linkonce_odr dso_local spir_func void @foo
+; CHECK-A0: define internal spir_func void @foo
+; CHECK-A1: define internal spir_func void @foo
 ; CHECK-B0: define linkonce_odr dso_local spir_func void @foo
 ; CHECK-B1: define linkonce_odr dso_local spir_func void @foo
-; CHECK-C0: define linkonce_odr dso_local spir_func void @foo
-; CHECK-C1: define linkonce_odr dso_local spir_func void @foo
+; CHECK-C0: define internal spir_func void @foo
+; CHECK-C1: define internal spir_func void @foo
   ret void
 }
 
@@ -57,12 +57,12 @@ define weak dso_local spir_func void @baz() #3 {
 
 ; Function Attrs: mustprogress norecurse nounwind
 define linkonce_odr dso_local spir_func void @bar() unnamed_addr #1 comdat align 2 {
-; CHECK-A0: define linkonce_odr dso_local spir_func void @bar
-; CHECK-A1: define linkonce_odr dso_local spir_func void @bar
+; CHECK-A0: define internal spir_func void @bar
+; CHECK-A1: define internal spir_func void @bar
 ; CHECK-B0: define linkonce_odr dso_local spir_func void @bar
 ; CHECK-B1: define linkonce_odr dso_local spir_func void @bar
-; CHECK-C0: define linkonce_odr dso_local spir_func void @bar
-; CHECK-C1: define linkonce_odr dso_local spir_func void @bar
+; CHECK-C0: define internal spir_func void @bar
+; CHECK-C1: define internal spir_func void @bar
   call void @baz()
   ret void
 }

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/no-sycl-esimd-split-shared-func.ll
@@ -106,7 +106,7 @@ attributes #3 = { "referenced-indirectly" }
 
 ;---------------- Verify IR. Outlined to avoid complications with reordering.
 ; Check the function is modified in ESIMD module.
-; CHECK: define dso_local spir_func <4 x float> @SHARED_F.esimd(i64 %{{.*}}) #[[SHARED_F_ATTRS:[0-9]+]] {
+; CHECK: define internal spir_func <4 x float> @SHARED_F.esimd(i64 %{{.*}}) #[[SHARED_F_ATTRS:[0-9]+]] {
 ; CHECK:   %{{.*}} = call spir_func <4 x float> @__intrin(i64 %{{.*}})
 ; CHECK:   ret <4 x float> %{{.*}}
 
@@ -121,15 +121,15 @@ attributes #3 = { "referenced-indirectly" }
 ; CHECK-NEXT:  %{{.*}} = fadd <4 x float> %{{.*}}, %{{.*}}
 ; CHECK-NEXT:  ret <4 x float> {{.*}}
 
-; Check the original version (for SYCL call graph) is retained
-; CHECK: define dso_local spir_func <4 x float> @SHARED_F(
-
 ; Verify __builtin_invoke_simd lowering
 ; 1) the second argument (function pointer) is removed
 ; 2) The call target (helper) is changed to the optimized one
 ; CHECK: define dso_local spir_func float @SPMD_CALLER(float %{{.*}})
 ; CHECK:   %{{.*}} = call spir_func float @_Z33__regcall3____builtin_invoke_simdXX_{{.+}}(ptr @[[NEW_HELPER_NAME]], float %{{.*}})
 ; CHECK:   ret float %{{.*}}
+
+; Check the original version (for SYCL call graph) is retained
+; CHECK: define internal spir_func <4 x float> @SHARED_F(
 
 ; Check that VCStackCall attribute is added to the invoke_simd helpers functions:
 ; CHECK: attributes #[[SHARED_F_ATTRS]] = { noinline "VCFunction" }

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -132,10 +132,15 @@ bool isESIMDFunction(const Function &F) {
 }
 
 // Predicate for Internalize pass.
+// Functions with the C++ level attribute "intel::device_indirectly_callable"
+// are annotated with the "referenced-indirectly" attribute.  These functions
+// cannot be optimized out due to reachability analysis or by any other
+// optimization.
 bool mustPreserveGV(const GlobalValue &GV) {
   if (const Function *F = dyn_cast<Function>(&GV))
     return F->getCallingConv() == CallingConv::SPIR_KERNEL ||
-           F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
+           F->hasFnAttribute("referenced-indirectly") || F->isDeclaration() ||
+           F->hasFnAttribute("sycl-module-id");
 
   GV.removeDeadConstantUsers();
   return !GV.use_empty();

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -134,7 +134,8 @@ bool isESIMDFunction(const Function &F) {
 // Predicate for Internalize pass.
 bool mustPreserveGV(const GlobalValue &GV) {
   if (const Function *F = dyn_cast<Function>(&GV))
-    return F->getCallingConv() == CallingConv::SPIR_KERNEL || F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
+    return F->getCallingConv() == CallingConv::SPIR_KERNEL ||
+           F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
 
   GV.removeDeadConstantUsers();
   return !GV.use_empty();

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -24,8 +24,8 @@
 #include "llvm/SYCLLowerIR/LowerInvokeSimd.h"
 #include "llvm/SYCLLowerIR/SYCLUtils.h"
 #include "llvm/Transforms/IPO.h"
-#include "llvm/Transforms/IPO/Internalize.h"
 #include "llvm/Transforms/IPO/GlobalDCE.h"
+#include "llvm/Transforms/IPO/Internalize.h"
 #include "llvm/Transforms/IPO/StripDeadPrototypes.h"
 #include "llvm/Transforms/IPO/StripSymbols.h"
 #include "llvm/Transforms/Utils/Cloning.h"
@@ -571,10 +571,12 @@ void ModuleDesc::cleanup() {
   MAM.registerPass([&] { return PassInstrumentationAnalysis(); });
   ModulePassManager MPM;
   // Do cleanup.
-  MPM.addPass(InternalizePass(mustPreserveGV)); // Internalize linkage of globals so that GlobalDCE can delete them
-  MPM.addPass(GlobalDCEPass());                 // Delete unreachable globals.
-  MPM.addPass(StripDeadDebugInfoPass());        // Remove dead debug info.
-  MPM.addPass(StripDeadPrototypesPass());       // Remove dead func decls.
+  MPM.addPass(
+      InternalizePass(mustPreserveGV));   // Internalize linkage of globals so
+                                          // that GlobalDCE can delete them
+  MPM.addPass(GlobalDCEPass());           // Delete unreachable globals.
+  MPM.addPass(StripDeadDebugInfoPass());  // Remove dead debug info.
+  MPM.addPass(StripDeadPrototypesPass()); // Remove dead func decls.
   MPM.run(*M, MAM);
 }
 

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -134,8 +134,7 @@ bool isESIMDFunction(const Function &F) {
 // Predicate for Internalize pass.
 bool mustPreserveGV(const GlobalValue &GV) {
   if (const Function *F = dyn_cast<Function>(&GV))
-    //    return F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
-    return true;
+    return F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
 
   GV.removeDeadConstantUsers();
   return !GV.use_empty();

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -134,7 +134,7 @@ bool isESIMDFunction(const Function &F) {
 // Predicate for Internalize pass.
 bool mustPreserveGV(const GlobalValue &GV) {
   if (const Function *F = dyn_cast<Function>(&GV))
-    return F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
+    return F->getCallingConv() == CallingConv::SPIR_KERNEL || F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
 
   GV.removeDeadConstantUsers();
   return !GV.use_empty();

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -134,7 +134,8 @@ bool isESIMDFunction(const Function &F) {
 // Predicate for Internalize pass.
 bool mustPreserveGV(const GlobalValue &GV) {
   if (const Function *F = dyn_cast<Function>(&GV))
-    return F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
+    //    return F->isDeclaration() || F->hasFnAttribute("sycl-module-id");
+    return true;
 
   GV.removeDeadConstantUsers();
   return !GV.use_empty();


### PR DESCRIPTION
Invoke Internalize in sycl-post-link to convert weak unused globals to have internal linkage.  This allows the subsequent invocation of DCE to eliminate these globals.