### PR TITLE
[SYCL-MLIR] Allow `llvm.array` as `memref` type in `polygeist`

### DIFF
--- a/polygeist/test/polygeist-opt/types.mlir
+++ b/polygeist/test/polygeist-opt/types.mlir
@@ -1,0 +1,11 @@
+// RUN: polygeist-opt -allow-unregistered-dialect %s -split-input-file -mlir-print-local-scope \
+// RUN: | FileCheck %s
+
+// Verify the generic printed output can be parsed.
+// RUN: polygeist-opt -allow-unregistered-dialect %s -split-input-file -mlir-print-local-scope \
+// RUN: | polygeist-opt -allow-unregistered-dialect | FileCheck %s
+
+// CHECK-LABEL: func.func @llvm_array_memref(%arg0: memref<!llvm.array<16 x i8>>)
+func.func @llvm_array_memref(%arg0: memref<!llvm.array<16 x i8>>) {
+  return
+}

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -257,6 +257,7 @@ static void loadDialects(MLIRContext &Ctx, const bool SYCLIsDevice) {
   // TODO: We should not be using these extensions. Make sure we do not generate
   // invalid pointers/memrefs from codegen. Also present in polygeist-opt.cc.
   LLVM::LLVMPointerType::attachInterface<MemRefInsider>(Ctx);
+  LLVM::LLVMArrayType::attachInterface<MemRefInsider>(Ctx);
   LLVM::LLVMStructType::attachInterface<MemRefInsider>(Ctx);
   MemRefType::attachInterface<PtrElementModel<MemRefType>>(Ctx);
   IndexType::attachInterface<PtrElementModel<IndexType>>(Ctx);

--- a/polygeist/tools/polygeist-opt/polygeist-opt.cpp
+++ b/polygeist/tools/polygeist-opt/polygeist-opt.cpp
@@ -98,6 +98,9 @@ int main(int argc, char **argv) {
     LLVM::LLVMPointerType::attachInterface<MemRefInsider>(*ctx);
   });
   registry.addExtension(+[](MLIRContext *ctx, LLVM::LLVMDialect *dialect) {
+    LLVM::LLVMArrayType::attachInterface<MemRefInsider>(*ctx);
+  });
+  registry.addExtension(+[](MLIRContext *ctx, LLVM::LLVMDialect *dialect) {
     LLVM::LLVMStructType::attachInterface<MemRefInsider>(*ctx);
   });
   registry.addExtension(+[](MLIRContext *ctx, memref::MemRefDialect *dialect) {


### PR DESCRIPTION
Attach `MemRefInsider` interface to `llvm.array` type both in `cgeist` and `polygeist-opt`.