### PR TITLE
[CI] Add debug output for the clang-format task

### DIFF
--- a/devops/actions/clang-format/action.yml
+++ b/devops/actions/clang-format/action.yml
@@ -14,6 +14,11 @@ runs:
       git config --global --add safe.directory ${{ inputs.path }}
       git -C ${{ inputs.path }} clang-format ${{ github.event.pull_request.base.sha }}
       git -C ${{ inputs.path }} diff > ./clang-format.patch
+  - name: Debug
+    shell: bash
+    run: |
+      git -C ${{ inputs.path }} log ${{ github.event.pull_request.base.sha }}..HEAD
+      git -C ${{ inputs.path }} diff ${{ github.event.pull_request.base.sha }}..HEAD
   # Add patch with formatting fixes to CI job artifacts
   - uses: actions/upload-artifact@v1
     with:


### PR DESCRIPTION
Manual testing before merging lint-related PRs didn't reveal issues but it seems to misbehave after merge. Add some debug output to root cause. I hope to address the issues during the day, if not I'm going to revert the changes in the evening.