### PR TITLE
[SYCL][UR][CUDA] Update CODEOWNERS for Unified Runtime CUDA Adapter

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -45,6 +45,7 @@ sycl/plugins/esimd_emulator/ @intel/dpcpp-esimd-reviewers
 
 # CUDA plugin
 sycl/plugins/cuda/ @intel/llvm-reviewers-cuda
+sycl/plugins/unified_runtime/ur/adapters/cuda/ @intel/llvm-reviewers-cuda
 
 # XPTI instrumentation utilities
 xpti/ @intel/llvm-reviewers-runtime

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -44,8 +44,7 @@ sycl/plugins/unified_runtime/ @intel/dpcpp-l0-pi-reviewers
 sycl/plugins/esimd_emulator/ @intel/dpcpp-esimd-reviewers
 
 # CUDA plugin
-sycl/plugins/cuda/ @intel/llvm-reviewers-cuda
-sycl/plugins/unified_runtime/ur/adapters/cuda/ @intel/llvm-reviewers-cuda
+sycl/plugins/**/cuda/ @intel/llvm-reviewers-cuda
 
 # XPTI instrumentation utilities
 xpti/ @intel/llvm-reviewers-runtime


### PR DESCRIPTION
Mark newly ported UR CUDA plugin as owned by CUDA reviewer group