### PR TITLE
[SYCL][CUDA] Add fno-fast-math to tests that rely on it.

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -1,5 +1,6 @@
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // REQUIRES: aspect-ext_oneapi_bfloat16_math_functions
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_80 %} %s -o %t.out %{mathflags}
 // RUN: %{run} %t.out
 // Currently the feature isn't supported on FPGA.
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/DeviceLib/built-ins/scalar_relational.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/scalar_relational.cpp
@@ -1,4 +1,5 @@
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out %{mathflags}
 // RUN: %{run} %t.out
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
Same as #9419. This updates a few tests that were missed where the `fast-math` flag affects at least the cuda backend. These tests assume `no-fast-math` precision.