### PR TITLE
[SYCL-MLIR][LoopInternalization] Remove codegen dependency on `nd_item`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
@@ -30,6 +30,11 @@ inline AccessorType getAccessorType(SYCLAccessorSubscriptOp op) {
 SYCLIDGetOp createSYCLIDGetOp(TypedValue<MemRefType> id, unsigned index,
                               OpBuilder builder, Location loc);
 
+/// Create sycl.range.get with id \p range and index \p index.
+SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
+                                    unsigned index, OpBuilder builder,
+                                    Location loc);
+
 /// Construct sycl.id with id type \p idTy and indexes \p indexes.
 TypedValue<MemRefType> constructSYCLID(IDType idTy, ArrayRef<Value> indexes,
                                        OpBuilder builder, Location loc);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
@@ -45,6 +45,11 @@ SYCLAccessorSubscriptOp createSYCLAccessorSubscriptOp(AccessorPtrValue accessor,
                                                       OpBuilder builder,
                                                       Location loc);
 
+/// Populate \p wgSizes with workgroup size per dimensionality, given the rank
+/// \p numDims.
+void populateWorkGroupSize(SmallVectorImpl<Value> &wgSizes, unsigned numDims,
+                           OpBuilder builder);
+
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
@@ -45,6 +45,10 @@ SYCLAccessorSubscriptOp createSYCLAccessorSubscriptOp(AccessorPtrValue accessor,
                                                       OpBuilder builder,
                                                       Location loc);
 
+/// Create sycl.work_group_size with rank \p numDims.
+sycl::SYCLWorkGroupSizeOp createWorkGroupSize(unsigned numDims,
+                                              OpBuilder builder, Location loc);
+
 /// Populate \p wgSizes with workgroup size per dimensionality, given the rank
 /// \p numDims.
 void populateWorkGroupSize(SmallVectorImpl<Value> &wgSizes, unsigned numDims,

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -83,6 +83,7 @@ template <typename T> bool isPtrOf(Type type) {
 }
 template bool isPtrOf<AccessorType>(Type);
 template bool isPtrOf<IDType>(Type);
+template bool isPtrOf<ItemType>(Type);
 template bool isPtrOf<NdItemType>(Type);
 
 bool AccessorPtrValue::classof(Value v) {

--- a/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
@@ -59,13 +59,21 @@ sycl::createSYCLAccessorSubscriptOp(AccessorPtrValue accessor,
   return builder.create<SYCLAccessorSubscriptOp>(loc, MT, accessor, id);
 }
 
+sycl::SYCLWorkGroupSizeOp
+sycl::createWorkGroupSize(unsigned numDims, OpBuilder builder, Location loc) {
+  const auto arrayType = builder.getType<sycl::ArrayType>(
+      numDims, MemRefType::get(numDims, builder.getIndexType()));
+  const auto rangeTy = builder.getType<sycl::RangeType>(numDims, arrayType);
+  return builder.create<sycl::SYCLWorkGroupSizeOp>(loc, rangeTy);
+}
+
 void sycl::populateWorkGroupSize(SmallVectorImpl<Value> &wgSizes,
                                  unsigned numDims, OpBuilder builder) {
   const auto arrayType = builder.getType<sycl::ArrayType>(
       numDims, MemRefType::get(numDims, builder.getIndexType()));
   const auto rangeTy = builder.getType<sycl::RangeType>(numDims, arrayType);
   Location loc = builder.getUnknownLoc();
-  auto wgSize = builder.create<sycl::SYCLWorkGroupSizeOp>(loc, rangeTy);
+  auto wgSize = createWorkGroupSize(numDims, builder, loc);
   auto range =
       builder.create<memref::AllocaOp>(loc, MemRefType::get(1, rangeTy));
   const Value zeroIndex = builder.create<arith::ConstantIndexOp>(loc, 0);

--- a/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
@@ -23,6 +23,15 @@ SYCLIDGetOp sycl::createSYCLIDGetOp(TypedValue<MemRefType> id, unsigned index,
       loc, MemRefType::get(ShapedType::kDynamic, resTy), id, indexOp);
 }
 
+SYCLRangeGetOp sycl::createSYCLRangeGetOp(TypedValue<MemRefType> range,
+                                          unsigned index, OpBuilder builder,
+                                          Location loc) {
+  const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
+  const auto resTy = builder.getIndexType();
+  return builder.create<SYCLRangeGetOp>(
+      loc, MemRefType::get(ShapedType::kDynamic, resTy), range, indexOp);
+}
+
 TypedValue<MemRefType> sycl::constructSYCLID(IDType idTy,
                                              ArrayRef<Value> indexes,
                                              OpBuilder builder, Location loc) {

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.h
@@ -449,10 +449,6 @@ public:
   std::optional<MemoryAccess>
   getMemoryAccess(const affine::MemRefAccess &access) const;
 
-  /// Return the grid dimension for \p funcOp (e.g the dimension of the
-  /// sycl::nditem or sycl::item argument passed to the to the function).
-  unsigned getGridDimension(FunctionOpInterface funcOp) const;
-
   /// Return a vector containing thread values corresponding to the global
   /// thread declarations in \p funcOp. The returned vector has size equal to
   /// the thread grid dimension and is sorted based on the dimension.

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -72,6 +72,11 @@ void privatize(FunctionOpInterface);
 /// Returns true if the given call is a tail call.
 bool isTailCall(CallOpInterface);
 
+/// Return the grid dimension for \p func (e.g the dimension of the
+/// sycl::nd_item or sycl::item argument passed to the function).
+/// Return zero if it cannot identify the grid dimension.
+unsigned getGridDimension(FunctionOpInterface func);
+
 /// Return the accessor used by \p op if found, and std::nullopt otherwise.
 Optional<Value> getAccessorUsedByOperation(const Operation &op);
 

--- a/polygeist/lib/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.cpp
@@ -1229,26 +1229,6 @@ MemoryAccessAnalysis::getMemoryAccess(const MemRefAccess &access) const {
   return it->second;
 }
 
-unsigned
-MemoryAccessAnalysis::getGridDimension(FunctionOpInterface func) const {
-  if (func.getNumArguments() == 0)
-    return 0;
-
-  Value lastArg = func.getArguments().back();
-  if (!isa<MemRefType>(lastArg.getType()))
-    return 0;
-
-  Type elemTy = cast<MemRefType>(lastArg.getType()).getElementType();
-
-  return TypeSwitch<Type, unsigned>(elemTy)
-      .Case<sycl::NdItemType, sycl::ItemType>([](auto ty) {
-        unsigned dim = ty.getDimension();
-        assert(dim > 0 && dim <= 3 && "Dimension out of range");
-        return dim;
-      })
-      .Default([](auto) { return 0; });
-}
-
 SmallVector<Value>
 MemoryAccessAnalysis::getThreadVector(FunctionOpInterface funcOp,
                                       DataFlowSolver &solver) const {

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -15,7 +15,7 @@
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<64xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine_2d(
-// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_2_>) {
+// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_item_2_>) {
 
 // COM: Get local ids:
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.local_id : !sycl_id_2_1
@@ -34,7 +34,7 @@
 // CHECK-NEXT:    %[[VAL_12:.*]] = memref.cast %[[VAL_11]] : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT:    %[[VAL_13:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:    %[[VAL_14:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_15:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_13]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64
+// CHECK-NEXT:    %[[VAL_15:.*]] = sycl.item.get_id(%[[VAL_1]], %[[VAL_13]]) : (memref<?x!sycl_item_2_>, i32) -> i64
 // CHECK-NEXT:    %[[VAL_16:.*]] = arith.index_cast %[[VAL_15]] : i64 to index
 
 // COM: Get pointer to local memory:
@@ -105,12 +105,12 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
   %c1_i32 = arith.constant 1 : i32
-  %tx = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_2>, i32) -> i64
+  %tx = sycl.item.get_id(%arg1, %c0_i32) : (memref<?x!sycl_item_2>, i32) -> i64
 
   affine.for %ii = 0 to 256 {
     %i = arith.index_cast %ii : index to i64
@@ -122,8 +122,8 @@ func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: 
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
-  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
+  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_item_2>) -> ()
   gpu.return
 }
 }
@@ -147,99 +147,103 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-SAME:       %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
 
 // COM: Get work group sizes:
-// CHECK-NEXT:    %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:    %[[VAL_3:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_2]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:    %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
-// CHECK-NEXT:    %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_6:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_5]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:    %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
-// CHECK-NEXT:    %[[VAL_8:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:    %[[VAL_9:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_8]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:    %[[WGSIZE2:.*]] = arith.index_cast %[[VAL_9]] : i64 to index
+// CHECK-NEXT:    %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_3_1
+// CHECK-NEXT:    %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_range_3_1>
+// CHECK-NEXT:    %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:    memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_range_3_1>
+// CHECK-NEXT:    %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %[[VAL_6:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %[[WGSIZE0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[VAL_8:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:    %[[VAL_9:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[VAL_11:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:    %[[VAL_12:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_11]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %[[WGSIZE2:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xindex>
 
 // COM: Get local memory required:
 // COM:   for each loop, get the max of:
 // COM:     for each accessor subscript, add:
 // COM:       multiply element size (4) with work group size for each dimension
-// CHECK-NEXT:    %[[VAL_11:.*]] = arith.constant 0 : index
-// CHECK-NEXT:    %[[VAL_12:.*]] = arith.constant 0 : index
-// CHECK-NEXT:    %[[VAL_13:.*]] = arith.constant 4 : index
-// CHECK-NEXT:    %[[VAL_14:.*]] = arith.muli %[[VAL_13]], %[[VAL_4]] : index
-// CHECK-NEXT:    %[[VAL_15:.*]] = arith.muli %[[VAL_14]], %[[VAL_7]] : index
-// CHECK-NEXT:    %[[VAL_16:.*]] = arith.muli %[[VAL_15]], %[[WGSIZE2]] : index
-// CHECK-NEXT:    %[[VAL_17:.*]] = arith.addi %[[VAL_12]], %[[VAL_16]] : index
-// CHECK-NEXT:    %[[VAL_18:.*]] = arith.maxsi %[[VAL_11]], %[[VAL_17]] : index
+// CHECK-NEXT:    %[[VAL_14:.*]] = arith.constant 0 : index
+// CHECK-NEXT:    %[[VAL_15:.*]] = arith.constant 0 : index
+// CHECK-NEXT:    %[[VAL_16:.*]] = arith.constant 4 : index
+// CHECK-NEXT:    %[[VAL_17:.*]] = arith.muli %[[VAL_16]], %[[WGSIZE0]] : index
+// CHECK-NEXT:    %[[VAL_18:.*]] = arith.muli %[[VAL_17]], %[[WGSIZE1]] : index
+// CHECK-NEXT:    %[[VAL_19:.*]] = arith.muli %[[VAL_18]], %[[WGSIZE2]] : index
+// CHECK-NEXT:    %[[VAL_20:.*]] = arith.addi %[[VAL_15]], %[[VAL_19]] : index
+// CHECK-NEXT:    %[[VAL_21:.*]] = arith.maxsi %[[VAL_14]], %[[VAL_20]] : index
 
 // COM: Get local ids:
-// CHECK-NEXT:    %[[VAL_19:.*]] = sycl.local_id : !sycl_id_3_1
-// CHECK-NEXT:    %[[VAL_20:.*]] = memref.alloca() : memref<1x!sycl_id_3_1>
-// CHECK-NEXT:    %[[VAL_21:.*]] = arith.constant 0 : index
-// CHECK-NEXT:    memref.store %[[VAL_19]], %[[VAL_20]]{{\[}}%[[VAL_21]]] : memref<1x!sycl_id_3_1>
-// CHECK-NEXT:    %[[VAL_22:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:    %[[VAL_23:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_22]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[VAL_24:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_21]]] : memref<?xindex>
-// CHECK-NEXT:    %[[VAL_25:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_26:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[VAL_27:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_21]]] : memref<?xindex>
-// CHECK-NEXT:    %[[VAL_28:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:    %[[VAL_29:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[VAL_30:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_21]]] : memref<?xindex>
+// CHECK-NEXT:    %[[VAL_22:.*]] = sycl.local_id : !sycl_id_3_1
+// CHECK-NEXT:    %[[VAL_23:.*]] = memref.alloca() : memref<1x!sycl_id_3_1>
+// CHECK-NEXT:    %[[VAL_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:    memref.store %[[VAL_22]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<1x!sycl_id_3_1>
+// CHECK-NEXT:    %[[VAL_25:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %[[VAL_26:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID0:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:    %[[VAL_28:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:    %[[VAL_29:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID1:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:    %[[VAL_31:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:    %[[VAL_32:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_31]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID2:.*]] = memref.load %[[VAL_32]]{{\[}}%[[VAL_24]]] : memref<?xindex>
 
 // COM: Original code:
-// CHECK-NEXT:    %[[VAL_31:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
-// CHECK-NEXT:    %[[VAL_32:.*]] = memref.cast %[[VAL_31]] : memref<1x!sycl_id_3_> to memref<?x!sycl_id_3_>
-// CHECK-NEXT:    %[[VAL_33:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:    %[[VAL_34:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_35:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:    %[[VAL_36:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_33]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:    %[[VAL_37:.*]] = arith.index_cast %[[VAL_36]] : i64 to index
-// CHECK-NEXT:    %[[VAL_38:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_34]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:    %[[VAL_39:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_35]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:    affine.for %[[VAL_40:.*]] = 0 to 256 {
+// CHECK-NEXT:    %[[VAL_34:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
+// CHECK-NEXT:    %[[VAL_35:.*]] = memref.cast %[[VAL_34]] : memref<1x!sycl_id_3_> to memref<?x!sycl_id_3_>
+// CHECK-NEXT:    %[[VAL_36:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:    %[[VAL_37:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:    %[[VAL_38:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:    %[[VAL_39:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_36]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
+// CHECK-NEXT:    %[[VAL_40:.*]] = arith.index_cast %[[VAL_39]] : i64 to index
+// CHECK-NEXT:    %[[VAL_41:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_37]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
+// CHECK-NEXT:    %[[VAL_42:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_38]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
+// CHECK-NEXT:    affine.for %[[VAL_43:.*]] = 0 to 256 {
 
 // COM: Get pointer to local memory:
-// CHECK-NEXT:      %[[VAL_41:.*]] = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
+// CHECK-NEXT:      %[[VAL_44:.*]] = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 
 // COM: Use work group size of dimension 2 as tile size:
-// CHECK-NEXT:      affine.for %[[VAL_42:.*]] = 1 to [[MAP1]](){{\[}}%[[WGSIZE2]]] {
+// CHECK-NEXT:      affine.for %[[VAL_45:.*]] = 1 to [[MAP1]](){{\[}}%[[WGSIZE2]]] {
 
 // COM: Get pointer to the local memory portion for 1st memref:
-// CHECK-NEXT:        %[[VAL_43:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_44:.*]] = memref.view %[[VAL_41]]{{\[}}%[[VAL_43]]]{{\[}}%[[VAL_4]], %[[VAL_7]], %[[WGSIZE2]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:        %[[VAL_46:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_47:.*]] = memref.view %[[VAL_44]]{{\[}}%[[VAL_46]]]{{\[}}%[[WGSIZE0]], %[[WGSIZE1]], %[[WGSIZE2]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?x?xf32, #sycl.access.address_space<local>>
 
 // COM: Calculate indexes for global memory:
-// CHECK-NEXT:        %[[VAL_45:.*]] = arith.index_cast %[[VAL_40]] : index to i64
-// CHECK-NEXT:        %[[VAL_46:.*]] = affine.apply [[MAP2]](%[[VAL_42]]){{\[}}%[[WGSIZE2]]]
-// CHECK-NEXT:        %[[VAL_47:.*]] = arith.addi %[[VAL_30]], %[[VAL_46]] : index
-// CHECK-NEXT:        %[[VAL_48:.*]] = arith.index_cast %[[VAL_47]] : index to i64
+// CHECK-NEXT:        %[[VAL_48:.*]] = arith.index_cast %[[VAL_43]] : index to i64
+// CHECK-NEXT:        %[[VAL_49:.*]] = affine.apply [[MAP2]](%[[VAL_45]]){{\[}}%[[WGSIZE2]]]
+// CHECK-NEXT:        %[[VAL_50:.*]] = arith.addi %[[LOCALID2]], %[[VAL_49]] : index
+// CHECK-NEXT:        %[[VAL_51:.*]] = arith.index_cast %[[VAL_50]] : index to i64
 
 // COM: Copy to local memory for 1st memref:
-// CHECK-NEXT:        %[[VAL_49:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
-// CHECK-NEXT:        %[[VAL_50:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_51:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_52:.*]] = sycl.id.get %[[VAL_49]]{{\[}}%[[VAL_51]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
-// CHECK-NEXT:        memref.store %[[VAL_37]], %[[VAL_52]]{{\[}}%[[VAL_50]]] : memref<?xindex>
-// CHECK-NEXT:        %[[VAL_53:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_54:.*]] = sycl.id.get %[[VAL_49]]{{\[}}%[[VAL_53]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
-// CHECK-NEXT:        memref.store %[[VAL_40]], %[[VAL_54]]{{\[}}%[[VAL_50]]] : memref<?xindex>
-// CHECK-NEXT:        %[[VAL_55:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:        %[[VAL_56:.*]] = sycl.id.get %[[VAL_49]]{{\[}}%[[VAL_55]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
-// CHECK-NEXT:        memref.store %[[VAL_47]], %[[VAL_56]]{{\[}}%[[VAL_50]]] : memref<?xindex>
-// CHECK-NEXT:        %[[VAL_57:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_58:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_49]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
-// CHECK-NEXT:        %[[VAL_59:.*]] = memref.load %[[VAL_58]]{{\[}}%[[VAL_57]]] : memref<?xf32, 1>
-// CHECK-NEXT:        memref.store %[[VAL_59]], %[[VAL_44]]{{\[}}%[[VAL_24]], %[[VAL_27]], %[[VAL_30]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:        %[[VAL_52:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
+// CHECK-NEXT:        %[[VAL_53:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_54:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_55:.*]] = sycl.id.get %[[VAL_52]]{{\[}}%[[VAL_54]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
+// CHECK-NEXT:        memref.store %[[VAL_40]], %[[VAL_55]]{{\[}}%[[VAL_53]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_56:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_57:.*]] = sycl.id.get %[[VAL_52]]{{\[}}%[[VAL_56]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
+// CHECK-NEXT:        memref.store %[[VAL_43]], %[[VAL_57]]{{\[}}%[[VAL_53]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_58:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:        %[[VAL_59:.*]] = sycl.id.get %[[VAL_52]]{{\[}}%[[VAL_58]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
+// CHECK-NEXT:        memref.store %[[VAL_50]], %[[VAL_59]]{{\[}}%[[VAL_53]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_60:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_61:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_52]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
+// CHECK-NEXT:        %[[VAL_62:.*]] = memref.load %[[VAL_61]]{{\[}}%[[VAL_60]]] : memref<?xf32, 1>
+// CHECK-NEXT:        memref.store %[[VAL_62]], %[[VAL_47]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[LOCALID2]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
 
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
-// CHECK-NEXT:        affine.for %[[VAL_60:.*]] = [[MAP2]](%[[VAL_42]]){{\[}}%[[WGSIZE2]]] to min [[MAP3]](%[[VAL_42]]){{\[}}%[[WGSIZE2]]] {
-// CHECK-NEXT:          %[[VAL_61:.*]] = arith.subi %[[VAL_60]], %[[VAL_46]] : index
-// CHECK-NEXT:          %[[VAL_62:.*]] = arith.index_cast %[[VAL_60]] : index to i64
-// CHECK-NEXT:          %[[VAL_63:.*]] = arith.index_cast %[[VAL_61]] : index to i64
-// CHECK-NEXT:          sycl.constructor @id(%[[VAL_32]], %[[VAL_36]], %[[VAL_45]], %[[VAL_62]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:          %[[VAL_64:.*]] = memref.load %[[VAL_44]]{{\[}}%[[VAL_24]], %[[VAL_27]], %[[VAL_61]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
-// CHECK-NEXT:          sycl.constructor @id(%[[VAL_32]], %[[VAL_36]], %[[VAL_38]], %[[VAL_39]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:          %[[VAL_65:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_32]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3_>) -> memref<?xf32>
-// CHECK-NEXT:          %[[VAL_66:.*]] = affine.load %[[VAL_65]][0] : memref<?xf32>
+// CHECK-NEXT:        affine.for %[[VAL_63:.*]] = [[MAP2]](%[[VAL_45]]){{\[}}%[[WGSIZE2]]] to min [[MAP3]](%[[VAL_45]]){{\[}}%[[WGSIZE2]]] {
+// CHECK-NEXT:          %[[VAL_64:.*]] = arith.subi %[[VAL_63]], %[[VAL_49]] : index
+// CHECK-NEXT:          %[[VAL_65:.*]] = arith.index_cast %[[VAL_63]] : index to i64
+// CHECK-NEXT:          %[[VAL_66:.*]] = arith.index_cast %[[VAL_64]] : index to i64
+// CHECK-NEXT:          sycl.constructor @id(%[[VAL_35]], %[[VAL_39]], %[[VAL_48]], %[[VAL_65]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
+// CHECK-NEXT:          %[[VAL_67:.*]] = memref.load %[[VAL_47]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[VAL_64]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:          sycl.constructor @id(%[[VAL_35]], %[[VAL_39]], %[[VAL_41]], %[[VAL_42]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
+// CHECK-NEXT:          %[[VAL_68:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3_>) -> memref<?xf32>
+// CHECK-NEXT:          %[[VAL_69:.*]] = affine.load %[[VAL_68]][0] : memref<?xf32>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      }
@@ -297,137 +301,141 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_2_>) {
 
 // COM: Get work group sizes:
-// CHECK-NEXT:        %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_3:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_2]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64
-// CHECK-NEXT:        %[[WGSIZE0:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
-// CHECK-NEXT:        %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_6:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_5]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64
-// CHECK-NEXT:        %[[WGSIZE1:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
+// CHECK-NEXT:        %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_2_1
+// CHECK-NEXT:        %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_range_2_1>
+// CHECK-NEXT:        %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_range_2_1>
+// CHECK-NEXT:        %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_6:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_2_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_8:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_2_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
 
 // COM: Get local memory required:
-// CHECK-NEXT:        %[[VAL_8:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_9:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_10:.*]] = arith.constant 4 : index
-// CHECK-NEXT:        %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[WGSIZE0]] : index
-// CHECK-NEXT:        %[[VAL_12:.*]] = arith.muli %[[VAL_11]], %[[WGSIZE1]] : index
-// CHECK-NEXT:        %[[VAL_13:.*]] = arith.addi %[[VAL_9]], %[[VAL_12]] : index
-// CHECK-NEXT:        %[[VAL_14:.*]] = arith.constant 4 : index
-// CHECK-NEXT:        %[[VAL_15:.*]] = arith.muli %[[VAL_14]], %[[WGSIZE0]] : index
-// CHECK-NEXT:        %[[VAL_16:.*]] = arith.muli %[[VAL_15]], %[[WGSIZE1]] : index
-// CHECK-NEXT:        %[[VAL_17:.*]] = arith.addi %[[VAL_13]], %[[VAL_16]] : index
-// CHECK-NEXT:        %[[VAL_18:.*]] = arith.maxsi %[[VAL_8]], %[[VAL_17]] : index
+// CHECK-NEXT:        %[[VAL_11:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_12:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_13:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[VAL_14:.*]] = arith.muli %[[VAL_13]], %[[WGSIZE0]] : index
+// CHECK-NEXT:        %[[VAL_15:.*]] = arith.muli %[[VAL_14]], %[[WGSIZE1]] : index
+// CHECK-NEXT:        %[[VAL_16:.*]] = arith.addi %[[VAL_12]], %[[VAL_15]] : index
+// CHECK-NEXT:        %[[VAL_17:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[VAL_18:.*]] = arith.muli %[[VAL_17]], %[[WGSIZE0]] : index
+// CHECK-NEXT:        %[[VAL_19:.*]] = arith.muli %[[VAL_18]], %[[WGSIZE1]] : index
+// CHECK-NEXT:        %[[VAL_20:.*]] = arith.addi %[[VAL_16]], %[[VAL_19]] : index
+// CHECK-NEXT:        %[[VAL_21:.*]] = arith.maxsi %[[VAL_11]], %[[VAL_20]] : index
 
 // COM: Get local ids:
-// CHECK-NEXT:        %[[VAL_19:.*]] = sycl.local_id : !sycl_id_2_1
-// CHECK-NEXT:        %[[VAL_20:.*]] = memref.alloca() : memref<1x!sycl_id_2_1>
-// CHECK-NEXT:        %[[VAL_21:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        memref.store %[[VAL_19]], %[[VAL_20]]{{\[}}%[[VAL_21]]] : memref<1x!sycl_id_2_1>
-// CHECK-NEXT:        %[[VAL_22:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_23:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_22]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[VAL_24:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_21]]] : memref<?xindex>
-// CHECK-NEXT:        %[[VAL_25:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_26:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[VAL_27:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_21]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_22:.*]] = sycl.local_id : !sycl_id_2_1
+// CHECK-NEXT:        %[[VAL_23:.*]] = memref.alloca() : memref<1x!sycl_id_2_1>
+// CHECK-NEXT:        %[[VAL_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        memref.store %[[VAL_22]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<1x!sycl_id_2_1>
+// CHECK-NEXT:        %[[VAL_25:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_26:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID0:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_28:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_29:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID1:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_24]]] : memref<?xindex>
 
 // COM: Original code:
-// CHECK-NEXT:        %[[VAL_28:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT:        %[[VAL_29:.*]] = memref.cast %[[VAL_28]] : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
-// CHECK-NEXT:        %[[VAL_30:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_31:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[VAL_32:.*]] = arith.constant 256 : index
-// CHECK-NEXT:        %[[VAL_33:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_34:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_35:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_33]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64
-// CHECK-NEXT:        %[[VAL_36:.*]] = arith.index_cast %[[VAL_35]] : i64 to index
+// CHECK-NEXT:        %[[VAL_31:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT:        %[[VAL_32:.*]] = memref.cast %[[VAL_31]] : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
+// CHECK-NEXT:        %[[VAL_33:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_34:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[VAL_35:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[VAL_36:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_37:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_38:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_36]]) : (memref<?x!sycl_nd_item_2_>, i32) -> i64
+// CHECK-NEXT:        %[[VAL_39:.*]] = arith.index_cast %[[VAL_38]] : i64 to index
 
 // CHECK-NEXT:        %[[VER_COND:.*]] = arith.cmpi eq, %[[WGSIZE0]], %[[WGSIZE1]] : index
 // CHECK-NEXT:        scf.if %[[VER_COND]] {
 
 // COM: Get pointer to local memory:
-// CHECK-NEXT:        %[[VAL_37:.*]] = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
+// CHECK-NEXT:          %[[VAL_41:.*]] = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 
 // COM: Use work group size as tile size:
-// CHECK-NEXT:        %[[TILESIZE:.*]] = arith.muli %[[VAL_31]], %[[WGSIZE0]] : index
-// CHECK-NEXT:        scf.for %[[VAL_39:.*]] = %[[VAL_30]] to %[[VAL_32]] step %[[TILESIZE]] {
+// CHECK-NEXT:          %[[TILESIZE:.*]] = arith.muli %[[VAL_34]], %[[WGSIZE0]] : index
+// CHECK-NEXT:          scf.for %[[VAL_43:.*]] = %[[VAL_33]] to %[[VAL_35]] step %[[TILESIZE]] {
 
 // COM: Calculate indexes for global memory:
-// CHECK-NEXT:          %[[VAL_40:.*]] = arith.addi %[[VAL_24]], %[[VAL_39]] : index
-// CHECK-NEXT:          %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : index to i64
-// CHECK-NEXT:          %[[VAL_42:.*]] = arith.addi %[[VAL_27]], %[[VAL_39]] : index
-// CHECK-NEXT:          %[[VAL_43:.*]] = arith.index_cast %[[VAL_42]] : index to i64
-// CHECK-NEXT:          %[[VAL_44:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_44:.*]] = arith.addi %[[LOCALID0]], %[[VAL_43]] : index
+// CHECK-NEXT:            %[[VAL_45:.*]] = arith.index_cast %[[VAL_44]] : index to i64
+// CHECK-NEXT:            %[[VAL_46:.*]] = arith.addi %[[LOCALID1]], %[[VAL_43]] : index
+// CHECK-NEXT:            %[[VAL_47:.*]] = arith.index_cast %[[VAL_46]] : index to i64
+// CHECK-NEXT:            %[[VAL_48:.*]] = arith.constant 0 : index
 
 // COM: Get pointer to the local memory portion for 1st memref:
-// CHECK-NEXT:          %[[VAL_45:.*]] = memref.view %[[VAL_37]]{{\[}}%[[VAL_44]]]{{\[}}%[[WGSIZE0]], %[[WGSIZE1]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            %[[VAL_49:.*]] = memref.view %[[VAL_41]]{{\[}}%[[VAL_48]]]{{\[}}%[[WGSIZE0]], %[[WGSIZE1]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?xf32, #sycl.access.address_space<local>>
 
 // COM: Calculate upper bound for the tiled loop:
-// CHECK-NEXT:          %[[VAL_46:.*]] = arith.addi %[[VAL_39]], %[[TILESIZE]] : index
-// CHECK-NEXT:          %[[VAL_47:.*]] = arith.cmpi slt, %[[VAL_32]], %[[VAL_46]] : index
-// CHECK-NEXT:          %[[VAL_48:.*]] = arith.select %[[VAL_47]], %[[VAL_32]], %[[VAL_46]] : index
+// CHECK-NEXT:            %[[VAL_50:.*]] = arith.addi %[[VAL_43]], %[[TILESIZE]] : index
+// CHECK-NEXT:            %[[VAL_51:.*]] = arith.cmpi slt, %[[VAL_35]], %[[VAL_50]] : index
+// CHECK-NEXT:            %[[VAL_52:.*]] = arith.select %[[VAL_51]], %[[VAL_35]], %[[VAL_50]] : index
 
 // COM: Copy to local memory for 1st memref:
-// CHECK-NEXT:          %[[VAL_49:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT:          %[[VAL_50:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_51:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:          %[[VAL_52:.*]] = sycl.id.get %[[VAL_49]]{{\[}}%[[VAL_51]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-// CHECK-NEXT:          memref.store %[[VAL_36]], %[[VAL_52]]{{\[}}%[[VAL_50]]] : memref<?xindex>
-// CHECK-NEXT:          %[[VAL_53:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:          %[[VAL_54:.*]] = sycl.id.get %[[VAL_49]]{{\[}}%[[VAL_53]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-// CHECK-NEXT:          memref.store %[[VAL_42]], %[[VAL_54]]{{\[}}%[[VAL_50]]] : memref<?xindex>
-// CHECK-NEXT:          %[[VAL_55:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_56:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_49]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
-// CHECK-NEXT:          %[[VAL_57:.*]] = memref.load %[[VAL_56]]{{\[}}%[[VAL_55]]] : memref<?xf32, 1>
-// CHECK-NEXT:          memref.store %[[VAL_57]], %[[VAL_45]]{{\[}}%[[VAL_24]], %[[VAL_27]]] : memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            %[[VAL_53:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT:            %[[VAL_54:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_55:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:            %[[VAL_56:.*]] = sycl.id.get %[[VAL_53]]{{\[}}%[[VAL_55]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_39]], %[[VAL_56]]{{\[}}%[[VAL_54]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_57:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:            %[[VAL_58:.*]] = sycl.id.get %[[VAL_53]]{{\[}}%[[VAL_57]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_46]], %[[VAL_58]]{{\[}}%[[VAL_54]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_59:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_60:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_53]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+// CHECK-NEXT:            %[[VAL_61:.*]] = memref.load %[[VAL_60]]{{\[}}%[[VAL_59]]] : memref<?xf32, 1>
+// CHECK-NEXT:            memref.store %[[VAL_61]], %[[VAL_49]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<?x?xf32, #sycl.access.address_space<local>>
 
 // COM: Calculate offset:
-// CHECK-NEXT:          %[[VAL_58:.*]] = arith.constant 4 : index
-// CHECK-NEXT:          %[[VAL_59:.*]] = arith.muli %[[VAL_58]], %[[WGSIZE0]] : index
-// CHECK-NEXT:          %[[VAL_60:.*]] = arith.muli %[[VAL_59]], %[[WGSIZE1]] : index
-// CHECK-NEXT:          %[[VAL_61:.*]] = arith.addi %[[VAL_44]], %[[VAL_60]] : index
+// CHECK-NEXT:            %[[VAL_62:.*]] = arith.constant 4 : index
+// CHECK-NEXT:            %[[VAL_63:.*]] = arith.muli %[[VAL_62]], %[[WGSIZE0]] : index
+// CHECK-NEXT:            %[[VAL_64:.*]] = arith.muli %[[VAL_63]], %[[WGSIZE1]] : index
+// CHECK-NEXT:            %[[VAL_65:.*]] = arith.addi %[[VAL_48]], %[[VAL_64]] : index
 
 // COM: Get pointer to the local memory portion for 2nd memref:
-// CHECK-NEXT:          %[[VAL_62:.*]] = memref.view %[[VAL_37]]{{\[}}%[[VAL_61]]]{{\[}}%[[WGSIZE0]], %[[WGSIZE1]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            %[[VAL_66:.*]] = memref.view %[[VAL_41]]{{\[}}%[[VAL_65]]]{{\[}}%[[WGSIZE0]], %[[WGSIZE1]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?xf32, #sycl.access.address_space<local>>
 
 // COM: Copy to local memory for 2nd memref:
-// CHECK-NEXT:          %[[VAL_63:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
-// CHECK-NEXT:          %[[VAL_64:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_65:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:          %[[VAL_66:.*]] = sycl.id.get %[[VAL_63]]{{\[}}%[[VAL_65]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-// CHECK-NEXT:          memref.store %[[VAL_40]], %[[VAL_66]]{{\[}}%[[VAL_64]]] : memref<?xindex>
-// CHECK-NEXT:          %[[VAL_67:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:          %[[VAL_68:.*]] = sycl.id.get %[[VAL_63]]{{\[}}%[[VAL_67]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-// CHECK-NEXT:          memref.store %[[VAL_36]], %[[VAL_68]]{{\[}}%[[VAL_64]]] : memref<?xindex>
-// CHECK-NEXT:          %[[VAL_69:.*]] = arith.constant 0 : index
-// CHECK-NEXT:          %[[VAL_70:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_63]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
-// CHECK-NEXT:          %[[VAL_71:.*]] = memref.load %[[VAL_70]]{{\[}}%[[VAL_69]]] : memref<?xf32, 1>
-// CHECK-NEXT:          memref.store %[[VAL_71]], %[[VAL_62]]{{\[}}%[[VAL_24]], %[[VAL_27]]] : memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            %[[VAL_67:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
+// CHECK-NEXT:            %[[VAL_68:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_69:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:            %[[VAL_70:.*]] = sycl.id.get %[[VAL_67]]{{\[}}%[[VAL_69]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_44]], %[[VAL_70]]{{\[}}%[[VAL_68]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_71:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:            %[[VAL_72:.*]] = sycl.id.get %[[VAL_67]]{{\[}}%[[VAL_71]]] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_39]], %[[VAL_72]]{{\[}}%[[VAL_68]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_73:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_74:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_67]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+// CHECK-NEXT:            %[[VAL_75:.*]] = memref.load %[[VAL_74]]{{\[}}%[[VAL_73]]] : memref<?xf32, 1>
+// CHECK-NEXT:            memref.store %[[VAL_75]], %[[VAL_66]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<?x?xf32, #sycl.access.address_space<local>>
 
-// CHECK-NEXT:          spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
-// CHECK-NEXT:          scf.for %[[VAL_72:.*]] = %[[VAL_39]] to %[[VAL_48]] step %[[VAL_31]] {
-// CHECK-NEXT:            %[[VAL_73:.*]] = arith.subi %[[VAL_72]], %[[VAL_39]] : index
-// CHECK-NEXT:            %[[VAL_74:.*]] = arith.index_cast %[[VAL_72]] : index to i64
-// CHECK-NEXT:            %[[VAL_75:.*]] = arith.index_cast %[[VAL_73]] : index to i64
-// CHECK-NEXT:            %[[VAL_76:.*]] = arith.index_cast %[[VAL_73]] : index to i64
-// CHECK-NEXT:            sycl.constructor @id(%[[VAL_29]], %[[VAL_35]], %[[VAL_74]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:            memref.load %[[VAL_45]]{{\[}}%[[VAL_24]], %[[VAL_73]]] : memref<?x?xf32, #sycl.access.address_space<local>>
-// CHECK-NEXT:            sycl.constructor @id(%[[VAL_29]], %[[VAL_74]], %[[VAL_35]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:            memref.load %[[VAL_62]]{{\[}}%[[VAL_73]], %[[VAL_27]]] : memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
+// CHECK-NEXT:            scf.for %[[VAL_76:.*]] = %[[VAL_43]] to %[[VAL_52]] step %[[VAL_34]] {
+// CHECK-NEXT:              %[[VAL_77:.*]] = arith.subi %[[VAL_76]], %[[VAL_43]] : index
+// CHECK-NEXT:              %[[VAL_78:.*]] = arith.index_cast %[[VAL_76]] : index to i64
+// CHECK-NEXT:              %[[VAL_79:.*]] = arith.index_cast %[[VAL_77]] : index to i64
+// CHECK-NEXT:              %[[VAL_80:.*]] = arith.index_cast %[[VAL_77]] : index to i64
+// CHECK-NEXT:              sycl.constructor @id(%[[VAL_32]], %[[VAL_38]], %[[VAL_78]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
+// CHECK-NEXT:              %[[VAL_81:.*]] = memref.load %[[VAL_49]]{{\[}}%[[LOCALID0]], %[[VAL_77]]] : memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:              sycl.constructor @id(%[[VAL_32]], %[[VAL_78]], %[[VAL_38]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
+// CHECK-NEXT:              %[[VAL_82:.*]] = memref.load %[[VAL_66]]{{\[}}%[[VAL_77]], %[[LOCALID1]]] : memref<?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            }
+// CHECK-NEXT:            spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:          }
-// CHECK-NEXT:          spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
+// CHECK-NEXT:        } else {
+// CHECK-NEXT:          scf.for %[[VAL_83:.*]] = %[[VAL_33]] to %[[VAL_35]] step %[[VAL_34]] {
+// CHECK-NEXT:            %[[VAL_84:.*]] = arith.index_cast %[[VAL_83]] : index to i64
+// CHECK-NEXT:            sycl.constructor @id(%[[VAL_32]], %[[VAL_38]], %[[VAL_84]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
+// CHECK-NEXT:            %[[VAL_85:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_32]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
+// CHECK-NEXT:            %[[VAL_86:.*]] = affine.load %[[VAL_85]][0] : memref<?xf32>
+// CHECK-NEXT:            sycl.constructor @id(%[[VAL_32]], %[[VAL_84]], %[[VAL_38]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
+// CHECK-NEXT:            %[[VAL_87:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_32]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
+// CHECK-NEXT:            %[[VAL_88:.*]] = affine.load %[[VAL_87]][0] : memref<?xf32>
+// CHECK-NEXT:          }
 // CHECK-NEXT:        }
-// CHECK-NEXT:      } else {
-// CHECK-NEXT:        scf.for %[[VAL_80:.*]] = %[[VAL_30]] to %[[VAL_32]] step %[[VAL_31]] {
-// CHECK-NEXT:          %[[VAL_81:.*]] = arith.index_cast %[[VAL_80]] : index to i64
-// CHECK-NEXT:          sycl.constructor @id(%[[VAL_29]], %[[VAL_35]], %[[VAL_81]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:          %[[VAL_82:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_29]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
-// CHECK-NEXT:          %[[VAL_83:.*]] = affine.load %[[VAL_82]][0] : memref<?xf32>
-// CHECK-NEXT:          sycl.constructor @id(%[[VAL_29]], %[[VAL_81]], %[[VAL_35]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:          %[[VAL_84:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_29]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
-// CHECK-NEXT:          %[[VAL_85:.*]] = affine.load %[[VAL_84]][0] : memref<?xf32>
-// CHECK-NEXT:        }
+// CHECK-NEXT:        return
 // CHECK-NEXT:      }
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
 gpu.module @device_func {
 func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
@@ -473,100 +481,104 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
 
 // COM: Get work group sizes:
-// CHECK-NEXT:        %[[VAL_2:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_3:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_2]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:        %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : i64 to index
-// CHECK-NEXT:        %[[VAL_5:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_6:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_5]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:        %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : i64 to index
-// CHECK-NEXT:        %[[VAL_8:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.nd_item.get_local_range(%[[VAL_1]], %[[VAL_8]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:        %[[WGSIZE2:.*]] = arith.index_cast %[[VAL_9]] : i64 to index
+// CHECK-NEXT:        %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_3_1
+// CHECK-NEXT:        %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_range_3_1>
+// CHECK-NEXT:        %[[VAL_4:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_range_3_1>
+// CHECK-NEXT:        %[[VAL_5:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_6:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_8:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_11:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:        %[[VAL_12:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_11]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE2:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xindex>
 
 // COM: Get local memory required:
-// CHECK-NEXT:        %[[VAL_11:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_12:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_13:.*]] = arith.constant 4 : index
-// CHECK-NEXT:        %[[VAL_14:.*]] = arith.muli %[[VAL_13]], %[[VAL_4]] : index
-// CHECK-NEXT:        %[[VAL_15:.*]] = arith.muli %[[VAL_14]], %[[VAL_7]] : index
-// CHECK-NEXT:        %[[VAL_16:.*]] = arith.muli %[[VAL_15]], %[[WGSIZE2]] : index
-// CHECK-NEXT:        %[[VAL_17:.*]] = arith.addi %[[VAL_12]], %[[VAL_16]] : index
-// CHECK-NEXT:        %[[VAL_18:.*]] = arith.maxsi %[[VAL_11]], %[[VAL_17]] : index
+// CHECK-NEXT:        %[[VAL_14:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_15:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_16:.*]] = arith.constant 4 : index
+// CHECK-NEXT:        %[[VAL_17:.*]] = arith.muli %[[VAL_16]], %[[WGSIZE0]] : index
+// CHECK-NEXT:        %[[VAL_18:.*]] = arith.muli %[[VAL_17]], %[[WGSIZE1]] : index
+// CHECK-NEXT:        %[[VAL_19:.*]] = arith.muli %[[VAL_18]], %[[WGSIZE2]] : index
+// CHECK-NEXT:        %[[VAL_20:.*]] = arith.addi %[[VAL_15]], %[[VAL_19]] : index
+// CHECK-NEXT:        %[[VAL_21:.*]] = arith.maxsi %[[VAL_14]], %[[VAL_20]] : index
 
 // COM: Get local ids:
-// CHECK-NEXT:        %[[VAL_19:.*]] = sycl.local_id : !sycl_id_3_1
-// CHECK-NEXT:        %[[VAL_20:.*]] = memref.alloca() : memref<1x!sycl_id_3_1>
-// CHECK-NEXT:        %[[VAL_21:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        memref.store %[[VAL_19]], %[[VAL_20]]{{\[}}%[[VAL_21]]] : memref<1x!sycl_id_3_1>
-// CHECK-NEXT:        %[[VAL_22:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_23:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_22]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[VAL_24:.*]] = memref.load %[[VAL_23]]{{\[}}%[[VAL_21]]] : memref<?xindex>
-// CHECK-NEXT:        %[[VAL_25:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_26:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[VAL_27:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_21]]] : memref<?xindex>
-// CHECK-NEXT:        %[[VAL_28:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:        %[[VAL_29:.*]] = sycl.id.get %[[VAL_20]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[VAL_30:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_21]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_22:.*]] = sycl.local_id : !sycl_id_3_1
+// CHECK-NEXT:        %[[VAL_23:.*]] = memref.alloca() : memref<1x!sycl_id_3_1>
+// CHECK-NEXT:        %[[VAL_24:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        memref.store %[[VAL_22]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<1x!sycl_id_3_1>
+// CHECK-NEXT:        %[[VAL_25:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_26:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID0:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_28:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_29:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID1:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[VAL_31:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:        %[[VAL_32:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_31]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID2:.*]] = memref.load %[[VAL_32]]{{\[}}%[[VAL_24]]] : memref<?xindex>
 
 // COM: Original code:
-// CHECK-NEXT:        %[[VAL_31:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
-// CHECK-NEXT:        %[[VAL_32:.*]] = memref.cast %[[VAL_31]] : memref<1x!sycl_id_3_> to memref<?x!sycl_id_3_>
-// CHECK-NEXT:        %[[VAL_33:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_34:.*]] = arith.constant 1 : index
-// CHECK-NEXT:        %[[VAL_35:.*]] = arith.constant 256 : index
-// CHECK-NEXT:        %[[VAL_36:.*]] = arith.constant 512 : index
-// CHECK-NEXT:        %[[VAL_37:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_38:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_39:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:        %[[VAL_40:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_37]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
-// CHECK-NEXT:        %[[VAL_41:.*]] = arith.index_cast %[[VAL_40]] : i64 to index
-// CHECK-NEXT:        scf.for %[[VAL_42:.*]] = %[[VAL_33]] to %[[VAL_35]] step %[[VAL_34]] {
+// CHECK-NEXT:        %[[VAL_34:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
+// CHECK-NEXT:        %[[VAL_35:.*]] = memref.cast %[[VAL_34]] : memref<1x!sycl_id_3_> to memref<?x!sycl_id_3_>
+// CHECK-NEXT:        %[[VAL_36:.*]] = arith.constant 0 : index
+// CHECK-NEXT:        %[[VAL_37:.*]] = arith.constant 1 : index
+// CHECK-NEXT:        %[[VAL_38:.*]] = arith.constant 256 : index
+// CHECK-NEXT:        %[[VAL_39:.*]] = arith.constant 512 : index
+// CHECK-NEXT:        %[[VAL_40:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:        %[[VAL_41:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:        %[[VAL_42:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:        %[[VAL_43:.*]] = sycl.nd_item.get_global_id(%[[VAL_1]], %[[VAL_40]]) : (memref<?x!sycl_nd_item_3_>, i32) -> i64
+// CHECK-NEXT:        %[[VAL_44:.*]] = arith.index_cast %[[VAL_43]] : i64 to index
+// CHECK-NEXT:        scf.for %[[VAL_45:.*]] = %[[VAL_36]] to %[[VAL_38]] step %[[VAL_37]] {
 
 // COM: Get pointer to local memory:
-// CHECK-NEXT:          %[[VAL_43:.*]] = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
+// CHECK-NEXT:          %[[VAL_46:.*]] = memref.get_global @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 
-// COM: Use work group size of dimension 1 as tile size:
-// CHECK-NEXT:          %[[VAL_44:.*]] = arith.muli %[[VAL_34]], %[[WGSIZE2]] : index
-// CHECK-NEXT:          scf.for %[[VAL_45:.*]] = %[[VAL_34]] to %[[VAL_36]] step %[[VAL_44]] {
+// COM: Use work group size of dimension 2 as tile size:
+// CHECK-NEXT:          %[[TILESIZE:.*]] = arith.muli %[[VAL_37]], %[[WGSIZE2]] : index
+// CHECK-NEXT:          scf.for %[[VAL_48:.*]] = %[[VAL_37]] to %[[VAL_39]] step %[[TILESIZE]] {
 
 // COM: Calculate indexes for global memory:
-// CHECK-NEXT:            %[[VAL_46:.*]] = arith.addi %[[VAL_30]], %[[VAL_45]] : index
-// CHECK-NEXT:            %[[VAL_47:.*]] = arith.index_cast %[[VAL_46]] : index to i64
-// CHECK-NEXT:            %[[VAL_48:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_49:.*]] = arith.addi %[[LOCALID2]], %[[VAL_48]] : index
+// CHECK-NEXT:            %[[VAL_50:.*]] = arith.index_cast %[[VAL_49]] : index to i64
+// CHECK-NEXT:            %[[VAL_51:.*]] = arith.constant 0 : index
 
 // COM: Get pointer to the local memory portion for 1st memref:
-// CHECK-NEXT:            %[[VAL_49:.*]] = memref.view %[[VAL_43]]{{\[}}%[[VAL_48]]]{{\[}}%[[VAL_4]], %[[VAL_7]], %[[WGSIZE2]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            %[[VAL_52:.*]] = memref.view %[[VAL_46]]{{\[}}%[[VAL_51]]]{{\[}}%[[WGSIZE0]], %[[WGSIZE1]], %[[WGSIZE2]]] : memref<32000xi8, #sycl.access.address_space<local>> to memref<?x?x?xf32, #sycl.access.address_space<local>>
 
 // COM: Calculate upper bound for the tiled loop:
-// CHECK-NEXT:            %[[VAL_50:.*]] = arith.addi %[[VAL_45]], %[[VAL_44]] : index
-// CHECK-NEXT:            %[[VAL_51:.*]] = arith.cmpi slt, %[[VAL_36]], %[[VAL_50]] : index
-// CHECK-NEXT:            %[[VAL_52:.*]] = arith.select %[[VAL_51]], %[[VAL_36]], %[[VAL_50]] : index
+// CHECK-NEXT:            %[[VAL_53:.*]] = arith.addi %[[VAL_48]], %[[TILESIZE]] : index
+// CHECK-NEXT:            %[[VAL_54:.*]] = arith.cmpi slt, %[[VAL_39]], %[[VAL_53]] : index
+// CHECK-NEXT:            %[[VAL_55:.*]] = arith.select %[[VAL_54]], %[[VAL_39]], %[[VAL_53]] : index
 
 // COM: Copy to local memory for 1st memref:
-// CHECK-NEXT:            %[[VAL_53:.*]] = arith.index_cast %[[VAL_42]] : index to i64
-// CHECK-NEXT:            %[[VAL_54:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
-// CHECK-NEXT:            %[[VAL_55:.*]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_56:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:            %[[VAL_57:.*]] = sycl.id.get %[[VAL_54]]{{\[}}%[[VAL_56]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
-// CHECK-NEXT:            memref.store %[[VAL_41]], %[[VAL_57]]{{\[}}%[[VAL_55]]] : memref<?xindex>
-// CHECK-NEXT:            %[[VAL_58:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:            %[[VAL_59:.*]] = sycl.id.get %[[VAL_54]]{{\[}}%[[VAL_58]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
-// CHECK-NEXT:            memref.store %[[VAL_42]], %[[VAL_59]]{{\[}}%[[VAL_55]]] : memref<?xindex>
-// CHECK-NEXT:            %[[VAL_60:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:            %[[VAL_61:.*]] = sycl.id.get %[[VAL_54]]{{\[}}%[[VAL_60]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
-// CHECK-NEXT:            memref.store %[[VAL_46]], %[[VAL_61]]{{\[}}%[[VAL_55]]] : memref<?xindex>
-// CHECK-NEXT:            %[[VAL_62:.*]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_63:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_54]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
-// CHECK-NEXT:            %[[VAL_64:.*]] = memref.load %[[VAL_63]]{{\[}}%[[VAL_62]]] : memref<?xf32, 1>
-// CHECK-NEXT:            memref.store %[[VAL_64]], %[[VAL_49]]{{\[}}%[[VAL_24]], %[[VAL_27]], %[[VAL_30]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            %[[VAL_56:.*]] = arith.index_cast %[[VAL_45]] : index to i64
+// CHECK-NEXT:            %[[VAL_57:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
+// CHECK-NEXT:            %[[VAL_58:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_59:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:            %[[VAL_60:.*]] = sycl.id.get %[[VAL_57]]{{\[}}%[[VAL_59]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_44]], %[[VAL_60]]{{\[}}%[[VAL_58]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_61:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:            %[[VAL_62:.*]] = sycl.id.get %[[VAL_57]]{{\[}}%[[VAL_61]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_45]], %[[VAL_62]]{{\[}}%[[VAL_58]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_63:.*]] = arith.constant 2 : i32
+// CHECK-NEXT:            %[[VAL_64:.*]] = sycl.id.get %[[VAL_57]]{{\[}}%[[VAL_63]]] : (memref<1x!sycl_id_3_>, i32) -> memref<?xindex>
+// CHECK-NEXT:            memref.store %[[VAL_49]], %[[VAL_64]]{{\[}}%[[VAL_58]]] : memref<?xindex>
+// CHECK-NEXT:            %[[VAL_65:.*]] = arith.constant 0 : index
+// CHECK-NEXT:            %[[VAL_66:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_57]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
+// CHECK-NEXT:            %[[VAL_67:.*]] = memref.load %[[VAL_66]]{{\[}}%[[VAL_65]]] : memref<?xf32, 1>
+// CHECK-NEXT:            memref.store %[[VAL_67]], %[[VAL_52]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[LOCALID2]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
 
 // CHECK-NEXT:            spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
-// CHECK-NEXT:            scf.for %[[VAL_65:.*]] = %[[VAL_45]] to %[[VAL_52]] step %[[VAL_34]] {
-// CHECK-NEXT:              %[[VAL_66:.*]] = arith.subi %[[VAL_65]], %[[VAL_45]] : index
-// CHECK-NEXT:              %[[VAL_67:.*]] = arith.index_cast %[[VAL_65]] : index to i64
-// CHECK-NEXT:              %[[VAL_68:.*]] = arith.index_cast %[[VAL_66]] : index to i64
-// CHECK-NEXT:              sycl.constructor @id(%[[VAL_32]], %[[VAL_40]], %[[VAL_53]], %[[VAL_67]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:              %[[VAL_69:.*]] = memref.load %[[VAL_49]]{{\[}}%[[VAL_24]], %[[VAL_27]], %[[VAL_66]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:            scf.for %[[VAL_68:.*]] = %[[VAL_48]] to %[[VAL_55]] step %[[VAL_37]] {
+// CHECK-NEXT:              %[[VAL_69:.*]] = arith.subi %[[VAL_68]], %[[VAL_48]] : index
+// CHECK-NEXT:              %[[VAL_70:.*]] = arith.index_cast %[[VAL_68]] : index to i64
+// CHECK-NEXT:              %[[VAL_71:.*]] = arith.index_cast %[[VAL_69]] : index to i64
+// CHECK-NEXT:              sycl.constructor @id(%[[VAL_35]], %[[VAL_43]], %[[VAL_56]], %[[VAL_70]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
+// CHECK-NEXT:              %[[VAL_72:.*]] = memref.load %[[VAL_52]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[VAL_69]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:            }
 // CHECK-NEXT:            spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:          }


### PR DESCRIPTION
Change code generation of `LoopInternalization` transformation to not rely on `nd_item`. Extend the transformation to allow kernel with input `sycl::item` on top of `sycl::nd_item`.