### PR TITLE
[SYCL] Change unique prefix to start with "uid"

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -6950,7 +6950,7 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
            types::isSrcFile(I.first))) {
         // Unique ID is generated for source files and preprocessed files.
         SmallString<128> ResultID;
-        llvm::sys::fs::createUniquePath("%%%%%%%%%%%%%%%%", ResultID, false);
+        llvm::sys::fs::createUniquePath("uid%%%%%%%%%%%%%%%%", ResultID, false);
         addSYCLUniqueID(Args.MakeArgString(ResultID.str()), SrcFileName);
       }
       if (!types::isSrcFile(I.first))

--- a/clang/test/Driver/sycl-unique-prefix.cpp
+++ b/clang/test/Driver/sycl-unique-prefix.cpp
@@ -3,10 +3,10 @@
 // RUN: touch %t_file2.cpp
 // RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown,spir64_gen-unknown-unknown -c %t_file1.cpp %t_file2.cpp -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_PREFIX %s
-// CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1:([A-z0-9]){16}]]"{{.*}} "{{.*}}_file1.cpp"
+// CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1:uid([A-z0-9]){16}]]"{{.*}} "{{.*}}_file1.cpp"
 // CHECK_PREFIX: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX1]]"{{.*}} "{{.*}}_file1.cpp"
 // CHECK_PREFIX: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX1]]"{{.*}} "-fsycl-is-host"{{.*}} "{{.*}}_file1.cpp"
-// CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2:([A-z0-9]){16}]]"{{.*}} "{{.*}}_file2.cpp"
+// CHECK_PREFIX: clang{{.*}} "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2:uid([A-z0-9]){16}]]"{{.*}} "{{.*}}_file2.cpp"
 // CHECK_PREFIX: clang{{.*}} "-triple" "spir64_gen-unknown-unknown"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX2]]"{{.*}} "{{.*}}_file2.cpp"
 // CHECK_PREFIX: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX2]]"{{.*}} "-fsycl-is-host"{{.*}}  "{{.*}}_file2.cpp"
 
@@ -14,5 +14,5 @@
 // RUN: touch %t.ii
 // RUN: %clangxx -fsycl -c %t.ii -### 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_PREFIX_II %s
-// CHECK_PREFIX_II: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX:([A-z0-9]){16}]]"{{.*}} "{{.*}}.ii"
+// CHECK_PREFIX_II: clang{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-unique-prefix=[[PREFIX:uid([A-z0-9]){16}]]"{{.*}} "{{.*}}.ii"
 // CHECK_PREFIX_II: clang{{.*}} "-fsycl-unique-prefix=[[PREFIX]]"{{.*}} "-fsycl-is-host"{{.*}} "{{.*}}.ii"


### PR DESCRIPTION
This commit changes unique ID prefix to start with "uid" to avoid the name having a number as the first character. This is needed for IGC to correctly handle the names when used for externally visible device_global.