### PR TITLE
[SYCL][ABI-Break][PI] Remove deprecated piclCreateProgramWithSource

### DIFF
--- a/sycl/doc/design/PluginInterface.md
+++ b/sycl/doc/design/PluginInterface.md
@@ -190,23 +190,10 @@ in a data section.
 
 These are APIs needed to implement DPC++ runtime interoperability with
 underlying "native" device runtimes such as OpenCL.
-There are some OpenCL interoperability APIs, which are to be implemented
-by the OpenCL PI plugin only. These APIs match semantics of the corresponding
-OpenCL APIs exactly.
-For example:
 
-```
-pi_result piclProgramCreateWithSource(
-  pi_context        context,
-  pi_uint32         count,
-  const char **     strings,
-  const size_t *    lengths,
-  pi_program *      ret_program);
-```
-
-Some interoperability extension APIs have been added to get native runtime
-handles from the backend-agnostic PI Objects or to create PI Objects using the
-native handles. Eg:
+Interoperability extension APIs have been added to get native runtime handles
+from the backend-agnostic PI Objects or to create PI Objects using the native
+handles. Eg:
 
 ```
 pi_result piextDeviceGetNativeHandle(

--- a/sycl/include/sycl/detail/pi.def
+++ b/sycl/include/sycl/detail/pi.def
@@ -64,7 +64,6 @@ _PI_API(piextMemCreateWithNativeHandle)
 _PI_API(piextMemImageCreateWithNativeHandle)
 // Program
 _PI_API(piProgramCreate)
-_PI_API(piclProgramCreateWithSource)
 _PI_API(piProgramCreateWithBinary)
 _PI_API(piProgramGetInfo)
 _PI_API(piProgramCompile)

--- a/sycl/include/sycl/detail/pi.h
+++ b/sycl/include/sycl/detail/pi.h
@@ -1353,12 +1353,6 @@ __SYCL_EXPORT pi_result piextMemImageCreateWithNativeHandle(
 __SYCL_EXPORT pi_result piProgramCreate(pi_context context, const void *il,
                                         size_t length, pi_program *res_program);
 
-__SYCL_EXPORT pi_result piclProgramCreateWithSource(pi_context context,
-                                                    pi_uint32 count,
-                                                    const char **strings,
-                                                    const size_t *lengths,
-                                                    pi_program *ret_program);
-
 /// Creates a PI program for a context and loads the given binary into it.
 ///
 /// \param context is the PI context to associate the program with.

--- a/sycl/plugins/cuda/pi_cuda.cpp
+++ b/sycl/plugins/cuda/pi_cuda.cpp
@@ -92,7 +92,6 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
 
   // Program
   _PI_CL(piProgramCreate, pi2ur::piProgramCreate)
-  _PI_CL(piclProgramCreateWithSource, pi2ur::piclProgramCreateWithSource)
   _PI_CL(piProgramCreateWithBinary, pi2ur::piProgramCreateWithBinary)
   _PI_CL(piProgramGetInfo, pi2ur::piProgramGetInfo)
   _PI_CL(piProgramCompile, pi2ur::piProgramCompile)

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
@@ -1355,11 +1355,6 @@ pi_result piclProgramCreateWithBinary(pi_context, pi_uint32, const pi_device *,
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piclProgramCreateWithSource(pi_context, pi_uint32, const char **,
-                                      const size_t *, pi_program *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
 pi_result piProgramGetInfo(pi_program, pi_program_info, size_t, void *,
                            size_t *) {
   DIE_NO_IMPLEMENTATION;

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -97,7 +97,6 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextMemCreateWithNativeHandle, pi2ur::piextMemCreateWithNativeHandle)
   // Program
   _PI_CL(piProgramCreate, pi2ur::piProgramCreate)
-  _PI_CL(piclProgramCreateWithSource, pi2ur::piclProgramCreateWithSource)
   _PI_CL(piProgramCreateWithBinary, pi2ur::piProgramCreateWithBinary)
   _PI_CL(piProgramGetInfo, pi2ur::piProgramGetInfo)
   _PI_CL(piProgramCompile, pi2ur::piProgramCompile)

--- a/sycl/plugins/level_zero/pi_level_zero.cpp
+++ b/sycl/plugins/level_zero/pi_level_zero.cpp
@@ -279,14 +279,6 @@ pi_result piextMemImageCreateWithNativeHandle(
       NativeHandle, Context, OwnNativeHandle, ImageFormat, ImageDesc, Img);
 }
 
-pi_result piclProgramCreateWithSource(pi_context Context, pi_uint32 Count,
-                                      const char **Strings,
-                                      const size_t *Lengths,
-                                      pi_program *RetProgram) {
-  return pi2ur::piclProgramCreateWithSource(Context, Count, Strings, Lengths,
-                                            RetProgram);
-}
-
 pi_result piProgramGetInfo(pi_program Program, pi_program_info ParamName,
                            size_t ParamValueSize, void *ParamValue,
                            size_t *ParamValueSizeRet) {

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -1366,18 +1366,6 @@ pi_result piextMemImageCreateWithNativeHandle(
   return PI_SUCCESS;
 }
 
-pi_result piclProgramCreateWithSource(pi_context context, pi_uint32 count,
-                                      const char **strings,
-                                      const size_t *lengths,
-                                      pi_program *ret_program) {
-
-  pi_result ret_err = PI_ERROR_INVALID_OPERATION;
-  *ret_program = cast<pi_program>(
-      clCreateProgramWithSource(cast<cl_context>(context), cast<cl_uint>(count),
-                                strings, lengths, cast<cl_int *>(&ret_err)));
-  return ret_err;
-}
-
 pi_result piProgramCreateWithBinary(
     pi_context context, pi_uint32 num_devices, const pi_device *device_list,
     const size_t *lengths, const unsigned char **binaries,
@@ -2637,7 +2625,6 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextMemCreateWithNativeHandle, piextMemCreateWithNativeHandle)
   // Program
   _PI_CL(piProgramCreate, piProgramCreate)
-  _PI_CL(piclProgramCreateWithSource, piclProgramCreateWithSource)
   _PI_CL(piProgramCreateWithBinary, piProgramCreateWithBinary)
   _PI_CL(piProgramGetInfo, clGetProgramInfo)
   _PI_CL(piProgramCompile, clCompileProgram)

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -1743,20 +1743,6 @@ inline pi_result piProgramCreateWithBinary(
   return PI_SUCCESS;
 }
 
-inline pi_result piclProgramCreateWithSource(pi_context Context,
-                                             pi_uint32 Count,
-                                             const char **Strings,
-                                             const size_t *Lengths,
-                                             pi_program *RetProgram) {
-  std::ignore = Context;
-  std::ignore = Count;
-  std::ignore = Strings;
-  std::ignore = Lengths;
-  std::ignore = RetProgram;
-  die("piclProgramCreateWithSource: not supported in UR\n");
-  return PI_ERROR_INVALID_OPERATION;
-}
-
 inline pi_result piProgramGetInfo(pi_program Program, pi_program_info ParamName,
                                   size_t ParamValueSize, void *ParamValue,
                                   size_t *ParamValueSizeRet) {

--- a/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
+++ b/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
@@ -576,15 +576,6 @@ __SYCL_EXPORT pi_result piProgramCreateWithBinary(
                                           Metadata, BinaryStatus, Program);
 }
 
-__SYCL_EXPORT pi_result piclProgramCreateWithSource(pi_context Context,
-                                                    pi_uint32 Count,
-                                                    const char **Strings,
-                                                    const size_t *Lengths,
-                                                    pi_program *RetProgram) {
-  return pi2ur::piclProgramCreateWithSource(Context, Count, Strings, Lengths,
-                                            RetProgram);
-}
-
 __SYCL_EXPORT pi_result piProgramGetInfo(pi_program Program,
                                          pi_program_info ParamName,
                                          size_t ParamValueSize,
@@ -1196,7 +1187,6 @@ __SYCL_EXPORT pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_API(piextKernelSetArgSampler)
   _PI_API(piKernelGetSubGroupInfo)
   _PI_API(piProgramCreateWithBinary)
-  _PI_API(piclProgramCreateWithSource)
   _PI_API(piProgramGetInfo)
   _PI_API(piProgramCompile)
   _PI_API(piProgramGetBuildInfo)

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -156,22 +156,6 @@ public:
   void compile_with_kernel_name(std::string KernelName,
                                 std::string CompileOptions);
 
-  /// Compiles the OpenCL C kernel function defined by source string.
-  ///
-  /// This member function sets the state of this SYCL program to
-  /// program_state::compiled.
-  /// If the program was not in the program_state::none state,
-  /// an invalid_object_error SYCL exception is thrown. If the compilation
-  /// fails, a compile_program_error SYCL exception is thrown. If any device
-  /// that the program is being compiled for returns false for the device
-  /// information query info::device::is_compiler_available, a
-  /// feature_not_supported SYCL exception is thrown.
-  ///
-  /// \param KernelSource is a string containing OpenCL C kernel source code.
-  /// \param CompileOptions is a string containing OpenCL compile options.
-  void compile_with_source(std::string KernelSource,
-                           std::string CompileOptions = "");
-
   /// Builds the SYCL kernel function into encapsulated raw program.
   ///
   /// The SYCL kernel function is defined by the kernel name.
@@ -188,22 +172,6 @@ public:
   /// \param BuildOptions is a string containing OpenCL compile options.
   /// \param M is an OS handle to user code module.
   void build_with_kernel_name(std::string KernelName, std::string BuildOptions);
-
-  /// Builds the OpenCL C kernel function defined by source code.
-  ///
-  /// This member function sets the state of this SYCL program to
-  /// program_state::linked. If this program was not in program_state::none,
-  /// an invalid_object_error SYCL exception is thrown. If the compilation
-  /// fails, a compile_program_error SYCL exception is thrown. If any device
-  /// that the program is being built for returns false for the device
-  /// information queries info::device::is_compiler_available or
-  /// info::device::is_linker_available, a feature_not_supported SYCL
-  /// exception is thrown.
-  ///
-  /// \param KernelSource is a string containing OpenCL C kernel source code.
-  /// \param BuildOptions is a string containing OpenCL build options.
-  void build_with_source(std::string KernelSource,
-                         std::string BuildOptions = "");
 
   /// Links encapsulated raw program.
   ///
@@ -363,11 +331,6 @@ private:
   void
   create_pi_program_with_kernel_name(const std::string &KernelName,
                                      bool JITCompilationIsRequired = false);
-
-  /// Creates an OpenCL program from OpenCL C source code.
-  ///
-  /// \param Source is a string containing OpenCL C source code.
-  void create_cl_program_with_source(const std::string &Source);
 
   /// Compiles underlying plugin interface program.
   ///

--- a/sycl/test/abi/pi_level_zero_symbol_check.dump
+++ b/sycl/test/abi/pi_level_zero_symbol_check.dump
@@ -81,7 +81,6 @@ piSamplerGetInfo
 piSamplerRelease
 piSamplerRetain
 piTearDown
-piclProgramCreateWithSource
 piextCommandBufferCreate
 piextCommandBufferFinalize
 piextCommandBufferMemBufferCopy

--- a/sycl/test/abi/pi_opencl_symbol_check.dump
+++ b/sycl/test/abi/pi_opencl_symbol_check.dump
@@ -34,7 +34,6 @@ piQueueCreate
 piQueueGetInfo
 piSamplerCreate
 piTearDown
-piclProgramCreateWithSource
 piextCommandBufferCreate
 piextCommandBufferFinalize
 piextCommandBufferMemBufferCopy

--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -507,15 +507,6 @@ inline pi_result mock_piProgramCreate(pi_context context, const void *il,
   return PI_SUCCESS;
 }
 
-inline pi_result mock_piclProgramCreateWithSource(pi_context context,
-                                                  pi_uint32 count,
-                                                  const char **strings,
-                                                  const size_t *lengths,
-                                                  pi_program *ret_program) {
-  *ret_program = createDummyHandle<pi_program>();
-  return PI_SUCCESS;
-}
-
 inline pi_result mock_piProgramCreateWithBinary(
     pi_context context, pi_uint32 num_devices, const pi_device *device_list,
     const size_t *lengths, const unsigned char **binaries,


### PR DESCRIPTION
This patch removes the OpenCL specific, and deprecated, entry-point
`piclCreateProgramWithSource`. This change is being made in preparation
for porting the OpenCL plugin to Unified Runtime which does not intend
to support compilation from source directly, instead this should be
performed using OpenCL specific interop via native handles.
