### PR TITLE
[SYCL][NFC] annotated_arg headers code refactor

### DIFF
--- a/sycl/include/sycl/ext/oneapi/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/annotated_arg/annotated_arg.hpp
@@ -30,18 +30,6 @@ struct HasSubscriptOperator
     : std::bool_constant<
           !std::is_void_v<decltype(std::declval<T>().operator[](0))>> {};
 
-// Deduce a `properties<>` type from given variadic properties
-template <typename... Args> struct DeducedProperties {
-  using type = decltype(properties{std::declval<Args>()...});
-};
-
-// Partial specialization for deducing a `properties<>` type by forwarding the
-// given `properties<>` type
-template <typename... Args>
-struct DeducedProperties<detail::properties_t<Args...>> {
-  using type = detail::properties_t<Args...>;
-};
-
 } // namespace detail
 
 // Deduction guide

--- a/sycl/include/sycl/ext/oneapi/annotated_arg/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/annotated_arg/properties.hpp
@@ -369,7 +369,6 @@ template <int N> struct PropertyMetaInfo<alignment_key::value_t<N>> {
 
 } // namespace detail
 
-
 //===----------------------------------------------------------------------===//
 //   Utility type trait for annotated_arg/annotated_ptr deduction guide
 //===----------------------------------------------------------------------===//

--- a/sycl/include/sycl/ext/oneapi/annotated_arg/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/annotated_arg/properties.hpp
@@ -369,6 +369,25 @@ template <int N> struct PropertyMetaInfo<alignment_key::value_t<N>> {
 
 } // namespace detail
 
+
+//===----------------------------------------------------------------------===//
+//   Utility type trait for annotated_arg/annotated_ptr deduction guide
+//===----------------------------------------------------------------------===//
+//
+namespace detail {
+// Deduce a `properties<>` type from given variadic properties
+template <typename... Args> struct DeducedProperties {
+  using type = decltype(properties{std::declval<Args>()...});
+};
+
+// Partial specialization for deducing a `properties<>` type by forwarding the
+// given `properties<>` type
+template <typename... Args>
+struct DeducedProperties<detail::properties_t<Args...>> {
+  using type = detail::properties_t<Args...>;
+};
+} // namespace detail
+
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext


### PR DESCRIPTION
Move the `DeducedProperties` type-trait utility from 
```include/sycl/ext/oneapi/annotated_arg/annotated_arg.hpp```
to the common header
```include/sycl/ext/oneapi/annotated_arg/properties.hpp```
so that it can be used by both `annotated_arg` and `annotated_ptr` classes.