### PR TITLE
[CI] Don't skip E2E tests if only check-* steps in build fail

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -77,6 +77,8 @@ jobs:
     container:
       image: ${{ inputs.build_image }}
       options: -u 1001:1001
+    outputs:
+      build_conclusion: ${{ steps.build.conclusion }}
     steps:
     # GHA requires relative paths for actions. Copy actions from container root
     # to CWD.
@@ -185,7 +187,7 @@ jobs:
   aws-start:
     name: Start AWS
     needs: build
-    if: ${{ always() && !cancelled() && needs.build.build.result == 'success' && inputs.lts_aws_matrix != '[]' }}
+    if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' && inputs.lts_aws_matrix != '[]' }}
     runs-on: ubuntu-20.04
     environment: aws
     steps:
@@ -208,7 +210,7 @@ jobs:
     needs: [build, aws-start]
     # Continue if build was successful. If aws-start is not successful all
     # AWS tasks will fail, but all non-AWS tasks should continue.
-    if: ${{ always() && needs.build.result == 'success' && inputs.lts_matrix != '[]' }}
+    if: ${{ always() && needs.build.outputs.build_conclusion == 'success' && inputs.lts_matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -146,6 +146,7 @@ jobs:
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target check-libdevice
     - name: Install
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       # TODO replace utility installation with a single CMake target
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target deploy-sycl-toolchain
@@ -159,7 +160,7 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-profdata
         cmake --build $GITHUB_WORKSPACE/build --target install-compiler-rt
     - name: Additional Install for "--shared-libs" build
-      if: ${{ contains(inputs.build_configure_extra_args, '--shared-libs') }}
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' && contains(inputs.build_configure_extra_args, '--shared-libs') }}
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-libraries
         cmake --build $GITHUB_WORKSPACE/build --target install-llvm-libraries
@@ -172,8 +173,10 @@ jobs:
         cmake --build $GITHUB_WORKSPACE/build --target install-clang-tidy
 
     - name: Pack toolchain
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       run: tar -I 'zstd -9' -cf llvm_sycl.tar.zst -C $GITHUB_WORKSPACE/build/install .
     - name: Upload toolchain
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v3
       with:
         name: sycl_linux_${{ inputs.build_artifact_suffix }}
@@ -182,7 +185,7 @@ jobs:
   aws-start:
     name: Start AWS
     needs: build
-    if: ${{ always() && needs.build.result == 'success' && inputs.lts_aws_matrix != '[]' }}
+    if: ${{ always() && !cancelled() && needs.build.build.result == 'success' && inputs.lts_aws_matrix != '[]' }}
     runs-on: ubuntu-20.04
     environment: aws
     steps:

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -182,7 +182,7 @@ jobs:
   aws-start:
     name: Start AWS
     needs: build
-    if: ${{ inputs.lts_aws_matrix != '[]' }}
+    if: ${{ always() && needs.build.result == 'success' && inputs.lts_aws_matrix != '[]' }}
     runs-on: ubuntu-20.04
     environment: aws
     steps:


### PR DESCRIPTION
We already have proper check on the `e2e-tests` job, but it depends on the `aws-start` task and that didn't have the check. That resulted in the `aws-start` being skipped whenever any of `check-*` steps failed and resulted in E2E tests not running even though we can easily run them to get better coverage.

This should make our post-commit CI more useful in presence of failures on `check-*` targets during the build stage.