### PR TITLE
[SYCL-MLIR][NFC] Use `sycl::constructSYCLID` in `VersionConditionBuilder`

### DIFF
--- a/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
@@ -25,29 +25,30 @@
 // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_gb, 4>) {
 
 // COM: Obtain a pointer to the beginning of the accessor %arg0.
-// CHECK:         %alloca_7 = memref.alloca() : memref<1x!sycl_id_1_>
-// CHECK-NEXT:    %c0_8 = arith.constant 0 : index
+// CHECK:         %alloca_8 = memref.alloca() : memref<1x!sycl_id_1_>
+// CHECK-NEXT:    %c0_9 = arith.constant 0 : index
 // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
-// CHECK-NEXT:    %2 = sycl.id.get %alloca_7[%c0_i32] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
-// CHECK-NEXT:    memref.store %c0_8, %2[%c0_8] : memref<?xindex>
-// CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca_7] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
+// CHECK-NEXT:    %2 = sycl.id.get %alloca_8[%c0_i32] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+// CHECK-NEXT:    memref.store %c0_7, %2[%c0_9] : memref<?xindex>
+// CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca_8] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
 
 // COM: Obtain a pointer to the end of the accessor %arg0.
 // CHECK-NEXT:    %4 = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>) -> !sycl_range_1_
-// CHECK-NEXT:    %alloca_9 = memref.alloca() : memref<1x!sycl_range_1_>
-// CHECK-NEXT:    %c0_10 = arith.constant 0 : index
-// CHECK-NEXT:    memref.store %4, %alloca_9[%c0_10] : memref<1x!sycl_range_1_>
-// CHECK-NEXT:    %alloca_11 = memref.alloca() : memref<1x!sycl_id_1_>
+// CHECK-NEXT:    %alloca_10 = memref.alloca() : memref<1x!sycl_range_1_>
+// CHECK-NEXT:    %c0_11 = arith.constant 0 : index
+// CHECK-NEXT:    memref.store %4, %alloca_10[%c0_11] : memref<1x!sycl_range_1_>
 // CHECK-NEXT:    %c1_12 = arith.constant 1 : index
 // CHECK-NEXT:    %c0_i32_13 = arith.constant 0 : i32
-// CHECK-NEXT:    %5 = sycl.id.get %alloca_11[%c0_i32_13] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %c0_i32_14 = arith.constant 0 : i32
-// CHECK-NEXT:    %6 = sycl.range.get %alloca_9[%c0_i32_14] : (memref<1x!sycl_range_1_>, i32) -> index
-// CHECK-NEXT:    memref.store %6, %5[%c0_10] : memref<?xindex>
-// CHECK-NEXT:    [[ARG0_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_11] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
+// CHECK-NEXT:    %5 = sycl.range.get %alloca_10[%c0_i32_13] : (memref<1x!sycl_range_1_>, i32) -> index
+// CHECK-NEXT:    %alloca_14 = memref.alloca() : memref<1x!sycl_id_1_>
+// CHECK-NEXT:    %c0_15 = arith.constant 0 : index
+// CHECK-NEXT:    %c0_i32_16 = arith.constant 0 : i32
+// CHECK-NEXT:    %6 = sycl.id.get %alloca_14[%c0_i32_16] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+// CHECK-NEXT:    memref.store %5, %6[%c0_15] : memref<?xindex>
+// CHECK-NEXT:    [[ARG0_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_14] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
 
-// CHECK:         [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_15]
-// CHECK:         [[ARG1_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_20]
+// CHECK:         [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_18]
+// CHECK:         [[ARG1_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_25]
 // CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xi32, 1>) -> !llvm.ptr<1>
 // CHECK-DAG:     [[ARG1_BEGIN_PTR:%.*]] = "polygeist.memref2pointer"([[ARG1_BEGIN]]) : (memref<?xi32, 1>) -> !llvm.ptr<1>
 // CHECK-NEXT:    [[BEFORE_COND:%.*]] = llvm.icmp "ule" [[ARG0_END_PTR]], [[ARG1_BEGIN_PTR]] : !llvm.ptr<1>

--- a/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
@@ -29,26 +29,28 @@ gpu.module @device_func {
   // CHECK-LABEL: gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) kernel {
 
   // COM: Obtain a pointer to the beginning of the first accessor.
-  // CHECK-NEXT:    %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   // CHECK-NEXT:    %c0 = arith.constant 0 : index
+  // CHECK-NEXT:    %alloca = memref.alloca() : memref<1x!sycl_id_1_>
+  // CHECK-NEXT:    %c0_0 = arith.constant 0 : index
   // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
   // CHECK-NEXT:    %0 = sycl.id.get %alloca[%c0_i32] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
-  // CHECK-NEXT:    memref.store %c0, %0[%c0] : memref<?xindex>
+  // CHECK-NEXT:    memref.store %c0, %0[%c0_0] : memref<?xindex>
   // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Obtain a pointer to the end of the first accessor.
   // CHECK-NEXT:    %2 = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_f32_r_gb>) -> !sycl_range_1_
-  // CHECK-NEXT:    %alloca_0 = memref.alloca() : memref<1x!sycl_range_1_>
-  // CHECK-NEXT:    %c0_1 = arith.constant 0 : index
-  // CHECK-NEXT:    memref.store %2, %alloca_0[%c0_1] : memref<1x!sycl_range_1_>
-  // CHECK-NEXT:    %alloca_2 = memref.alloca() : memref<1x!sycl_id_1_>
+  // CHECK-NEXT:    %alloca_1 = memref.alloca() : memref<1x!sycl_range_1_>
+  // CHECK-NEXT:    %c0_2 = arith.constant 0 : index
+  // CHECK-NEXT:    memref.store %2, %alloca_1[%c0_2] : memref<1x!sycl_range_1_>
   // CHECK-NEXT:    %c1 = arith.constant 1 : index
   // CHECK-NEXT:    %c0_i32_3 = arith.constant 0 : i32
-  // CHECK-NEXT:    %3 = sycl.id.get %alloca_2[%c0_i32_3] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
-  // CHECK-NEXT:    %c0_i32_4 = arith.constant 0 : i32
-  // CHECK-NEXT:    %4 = sycl.range.get %alloca_0[%c0_i32_4] : (memref<1x!sycl_range_1_>, i32) -> index
-  // CHECK-NEXT:    memref.store %4, %3[%c0_1] : memref<?xindex>
-  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    %3 = sycl.range.get %alloca_1[%c0_i32_3] : (memref<1x!sycl_range_1_>, i32) -> index
+  // CHECK-NEXT:    %alloca_4 = memref.alloca() : memref<1x!sycl_id_1_>
+  // CHECK-NEXT:    %c0_5 = arith.constant 0 : index
+  // CHECK-NEXT:    %c0_i32_6 = arith.constant 0 : i32
+  // CHECK-NEXT:    %4 = sycl.id.get %alloca_4[%c0_i32_6] : (memref<1x!sycl_id_1_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    memref.store %3, %4[%c0_5] : memref<?xindex>
+  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_4] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
   // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}]  : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
@@ -102,39 +104,41 @@ gpu.module @device_func {
   // CHECK-LABEL: gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_accessor_2_f32_w_gb>) kernel {
 
   // COM: Obtain a pointer to the beginning of the first accessor.
-  // CHECK-NEXT:    %alloca = memref.alloca() : memref<1x!sycl_id_2_>
   // CHECK-NEXT:    %c0 = arith.constant 0 : index
+  // CHECK-NEXT:    %alloca = memref.alloca() : memref<1x!sycl_id_2_>
+  // CHECK-NEXT:    %c0_0 = arith.constant 0 : index
   // CHECK-NEXT:    %c0_i32 = arith.constant 0 : i32
   // CHECK-NEXT:    %0 = sycl.id.get %alloca[%c0_i32] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-  // CHECK-NEXT:    memref.store %c0, %0[%c0] : memref<?xindex>
+  // CHECK-NEXT:    memref.store %c0, %0[%c0_0] : memref<?xindex>
   // CHECK-NEXT:    %c1_i32 = arith.constant 1 : i32
   // CHECK-NEXT:    %1 = sycl.id.get %alloca[%c1_i32] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-  // CHECK-NEXT:    memref.store %c0, %1[%c0] : memref<?xindex>
+  // CHECK-NEXT:    memref.store %c0, %1[%c0_0] : memref<?xindex>
   // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%alloca] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 
   // COM: Obtain a pointer to the end of the first accessor.
   // CHECK-NEXT:    %3 = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_f32_r_gb>) -> !sycl_range_2_
-  // CHECK-NEXT:    %alloca_0 = memref.alloca() : memref<1x!sycl_range_2_>
-  // CHECK-NEXT:    %c0_1 = arith.constant 0 : index
-  // CHECK-NEXT:    memref.store %3, %alloca_0[%c0_1] : memref<1x!sycl_range_2_>
-  // CHECK-NEXT:    %alloca_2 = memref.alloca() : memref<1x!sycl_id_2_>
+  // CHECK-NEXT:    %alloca_1 = memref.alloca() : memref<1x!sycl_range_2_>
+  // CHECK-NEXT:    %c0_2 = arith.constant 0 : index
+  // CHECK-NEXT:    memref.store %3, %alloca_1[%c0_2] : memref<1x!sycl_range_2_>
   // CHECK-NEXT:    %c1 = arith.constant 1 : index
   // CHECK-NEXT:    %c0_i32_3 = arith.constant 0 : i32
-  // CHECK-NEXT:    %4 = sycl.id.get %alloca_2[%c0_i32_3] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-  // CHECK-NEXT:    %c0_i32_4 = arith.constant 0 : i32
-  // CHECK-NEXT:    %5 = sycl.range.get %alloca_0[%c0_i32_4] : (memref<1x!sycl_range_2_>, i32) -> index
-  // CHECK-NEXT:    %6 = arith.subi %5, %c1 : index
-  // CHECK-NEXT:    memref.store %6, %4[%c0_1] : memref<?xindex>
-  // CHECK-NEXT:    %c1_i32_5 = arith.constant 1 : i32
-  // CHECK-NEXT:    %7 = sycl.id.get %alloca_2[%c1_i32_5] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
-  // CHECK-NEXT:    %c1_i32_6 = arith.constant 1 : i32
-  // CHECK-NEXT:    %8 = sycl.range.get %alloca_0[%c1_i32_6] : (memref<1x!sycl_range_2_>, i32) -> index
-  // CHECK-NEXT:    memref.store %8, %7[%c0_1] : memref<?xindex>
-  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_2] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    %4 = sycl.range.get %alloca_1[%c0_i32_3] : (memref<1x!sycl_range_2_>, i32) -> index
+  // CHECK-NEXT:    %5 = arith.subi %4, %c1 : index
+  // CHECK-NEXT:    %c1_i32_4 = arith.constant 1 : i32
+  // CHECK-NEXT:    %6 = sycl.range.get %alloca_1[%c1_i32_4] : (memref<1x!sycl_range_2_>, i32) -> index
+  // CHECK-NEXT:    %alloca_5 = memref.alloca() : memref<1x!sycl_id_2_>
+  // CHECK-NEXT:    %c0_6 = arith.constant 0 : index
+  // CHECK-NEXT:    %c0_i32_7 = arith.constant 0 : i32
+  // CHECK-NEXT:    %7 = sycl.id.get %alloca_5[%c0_i32_7] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    memref.store %5, %7[%c0_6] : memref<?xindex>
+  // CHECK-NEXT:    %c1_i32_8 = arith.constant 1 : i32
+  // CHECK-NEXT:    %8 = sycl.id.get %alloca_5[%c1_i32_8] : (memref<1x!sycl_id_2_>, i32) -> memref<?xindex>
+  // CHECK-NEXT:    memref.store %6, %8[%c0_6] : memref<?xindex>
+  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0[%alloca_5] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
-  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_7] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
-  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_13] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%alloca_10] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%alloca_19] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
   // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
   // CHECK-NEXT:    %22 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<1>

--- a/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
@@ -32,11 +32,12 @@
 // CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Obtain a pointer to the beginning of the accessor %arg1.
+// CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
 // CHECK-DAG:  [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
 // CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
-// CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
+// CHECK-DAG:  [[C0_index_:%.*]] = arith.constant 0 : index
 // CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] : (memref<1x[[ID]]>, i32) -> memref<?xindex>
-// CHECK-NEXT: memref.store [[C0_index]], [[ID_GET]][[[C0_index]]] : memref<?xindex>
+// CHECK-NEXT: memref.store [[C0_index]], [[ID_GET]][[[C0_index_]]] : memref<?xindex>
 // CHECK-NEXT: [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 
 // COM: Obtain a pointer to the end of the accessor %arg1.
@@ -44,12 +45,13 @@
 // CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
 // CHECK-DAG:  [[GET_RANGE:%.*]] = sycl.accessor.get_range([[ARG1]]) : (memref<?x[[ACC_R]], 4>) -> [[RANGE]]
 // CHECK-NEXT: memref.store [[GET_RANGE]], [[RANGE_ALLOCA]][[[C0_index]]] : memref<1x[[RANGE]]>
-// CHECK-DAG:  [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
 // CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
 // CHECK-DAG:  [[C1_index:%.*]] = arith.constant 1 : index
-// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] : (memref<1x[[ID]]>, i32) -> memref<?xindex>
-// CHECK-NEXT: [[C0_i32:%.*]] = arith.constant 0 : i32
 // CHECK-NEXT: [[RANGE_GET:%.*]] = sycl.range.get [[RANGE_ALLOCA]][[[C0_i32]]] : (memref<1x[[RANGE]]>, i32) -> index
+// CHECK-NEXT: [[ID_ALLOCA:%.*]] = memref.alloca() : memref<1x[[ID:!sycl_id_1_]]>
+// CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
+// CHECK-DAG:  [[C0_i32:%.*]] = arith.constant 0 : i32
+// CHECK-NEXT: [[ID_GET:%.*]] = sycl.id.get [[ID_ALLOCA]][[[C0_i32]]] : (memref<1x[[ID]]>, i32) -> memref<?xindex>
 // CHECK-NEXT: memref.store [[RANGE_GET]], [[ID_GET]][[[C0_index]]] : memref<?xindex>
 // CHECK-NEXT: [[ARG1_END:%.*]] = sycl.accessor.subscript [[ARG1]][[[ID_ALLOCA]]] : (memref<?x[[ACC_R]], 4>, memref<1x[[ID]]>) -> memref<?xi32, 1>
 


### PR DESCRIPTION
`sycl::constructSYCLID` can be used in the utilities functions of `VersionConditionBuilder` to have a consistent way to construct a `sycl.id`. Ideally we can directly create `sycl.constructor(id, indexes)` and lower it in `SYCLToLLVM`. When we can do that, we only need to change the `sycl::cosntructSYCLID` function.