### PR TITLE
[SYCL-MLIR] Construct array member in-place in initializer lists

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -368,14 +368,8 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value ToInit,
     }
 
     if (auto *AIL = dyn_cast<ArrayInitLoopExpr>(Expr)) {
-      // In-house bitcast from `memref<-xarray<N x Ty>>` to `memref<? x Ty>`
-      ValueCategory ArrayPtr(ToInit, /*IsReference=*/true, ElementTy);
-      mlir::Type ET = cast<LLVM::LLVMArrayType>(ElementTy).getElementType();
-      ArrayPtr = ArrayPtr.MemRef2Ptr(Builder, Loc);
-      ArrayPtr.ElementType = ET;
-      ArrayPtr = ArrayPtr.Ptr2MemRef(Builder, Loc);
       // Build array in place
-      VisitArrayInitLoop(AIL, ArrayPtr);
+      VisitArrayInitLoop(AIL, {ToInit, /*IsReference=*/true, ElementTy});
       return mlir::DenseElementsAttr();
     }
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -626,7 +626,7 @@ ValueCategory MLIRScanner::CommonArrayToPointer(ValueCategory Scalar) {
 
   mlir::Type ET = MT.getElementType();
   if (auto AT = dyn_cast<LLVM::LLVMArrayType>(ET)) {
-    // In-house bitcast from `memref<-xarray<N x Ty>>` to `memref<? x Ty>`
+    // In-house bitcast from `memref<- x array<N x Ty>>` to `memref<? x Ty>`
     Scalar = Scalar.MemRef2Ptr(Builder, Loc);
     Scalar.ElementType = AT.getElementType();
     return Scalar.Ptr2MemRef(Builder, Loc);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-copy.cpp
@@ -4,6 +4,8 @@
 // Possibly fails due to the bad handling of `memref<?x!llvm.array<NxTy>>` in
 // `VisitArraySubscriptExpr`
 
+// Remove array-member.cpp when this passes, as this covers it.
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-copy.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-copy.cpp
@@ -1,0 +1,24 @@
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -w -emit-mlir %s -o -
+// XFAIL: *
+
+// Possibly fails due to the bad handling of `memref<?x!llvm.array<NxTy>>` in
+// `VisitArraySubscriptExpr`
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main(){
+  queue q;
+  range range{8};
+
+  buffer<float, 1> buf{nullptr, range};
+
+  q.submit([&](handler& cgh){
+    auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+    const float array[] = {1, 2, 3, 4, 5, 6, 7, 8};
+    cgh.parallel_for(range, [=](id<1> i){ acc[i] = array[static_cast<unsigned>(i)]; });
+  });
+
+  return 0;
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-member.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-member.cpp
@@ -21,15 +21,16 @@ int main(){
 // CHECK-SAME:                            %[[VAL_219:.*]]: !llvm.ptr
 // CHECK:             %[[VAL_220:.*]] = arith.constant 1 : i64
 // CHECK:             %[[VAL_227:.*]] = llvm.alloca %[[VAL_220]] x !llvm.struct<(array<8 x f32>)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:        %[[VAL_228:.*]] = llvm.getelementptr inbounds %[[VAL_219]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<8 x f32>)>
+// CHECK-NEXT:        %[[VAL_228:.*]] = llvm.getelementptr inbounds %[[VAL_227]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<8 x f32>)>
 // CHECK-NEXT:        %[[VAL_229:.*]] = llvm.getelementptr inbounds %[[VAL_228]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
-// CHECK-NEXT:        affine.for %[[VAL_230:.*]] = 0 to 8 {
-// CHECK-NEXT:          %[[VAL_231:.*]] = arith.index_cast %[[VAL_230]] : index to i64
-// CHECK-NEXT:          %[[VAL_232:.*]] = llvm.getelementptr %[[VAL_229]]{{\[}}%[[VAL_231]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
-// CHECK-NEXT:          %[[VAL_233:.*]] = llvm.load %[[VAL_232]] : !llvm.ptr -> f32
-// CHECK-NEXT:          %[[VAL_234:.*]] = arith.index_cast %[[VAL_230]] : index to i32
-// CHECK-NEXT:          %[[VAL_235:.*]] = llvm.getelementptr %[[VAL_227]]{{\[}}%[[VAL_234]]] : (!llvm.ptr, i32) -> !llvm.ptr, f32
-// CHECK-NEXT:          llvm.store %[[VAL_233]], %[[VAL_235]] : f32, !llvm.ptr
+// CHECK-NEXT:        %[[VAL_230:.*]] = llvm.getelementptr inbounds %[[VAL_219]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<8 x f32>)>
+// CHECK-NEXT:        %[[VAL_231:.*]] = llvm.getelementptr inbounds %[[VAL_230]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
+// CHECK-NEXT:        affine.for %[[VAL_232:.*]] = 0 to 8 {
+// CHECK-NEXT:          %[[VAL_233:.*]] = arith.index_cast %[[VAL_232]] : index to i64
+// CHECK-NEXT:          %[[VAL_234:.*]] = llvm.getelementptr %[[VAL_229]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+// CHECK-NEXT:          %[[VAL_235:.*]] = llvm.getelementptr %[[VAL_231]]{{\[}}%[[VAL_233]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+// CHECK-NEXT:          %[[VAL_236:.*]] = llvm.load %[[VAL_235]] : !llvm.ptr -> f32
+// CHECK-NEXT:          llvm.store %[[VAL_236]], %[[VAL_234]] : f32, !llvm.ptr
 // CHECK-NEXT:        }
 
 // COM: (void)array to ensure the array is captured in the lambda.

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-member.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-member.cpp
@@ -32,6 +32,7 @@ int main(){
 // CHECK-NEXT:          llvm.store %[[VAL_233]], %[[VAL_235]] : f32, !llvm.ptr
 // CHECK-NEXT:        }
 
+// COM: (void)array to ensure the array is captured in the lambda.
     cgh.parallel_for<Kernel>(range, [=](id<1>){ (void)array; });
   });
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-member.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-member.cpp
@@ -1,0 +1,39 @@
+// RUN: clang++ -O0 -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -w -emit-mlir %s -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+class Kernel;
+
+int main(){
+  queue q;
+  range range{8};
+
+  buffer<float, 1> buf{nullptr, range};
+
+  q.submit([&](handler& cgh){
+    auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+    const float array[] = {1, 2, 3, 4, 5, 6, 7, 8};
+
+// COM: Test the array member of the structure is built in place
+// CHECK-LABEL:     gpu.func @_ZTS6Kernel(
+// CHECK-SAME:                            %[[VAL_219:.*]]: !llvm.ptr
+// CHECK:             %[[VAL_220:.*]] = arith.constant 1 : i64
+// CHECK:             %[[VAL_227:.*]] = llvm.alloca %[[VAL_220]] x !llvm.struct<(array<8 x f32>)> : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %[[VAL_228:.*]] = llvm.getelementptr inbounds %[[VAL_219]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<8 x f32>)>
+// CHECK-NEXT:        %[[VAL_229:.*]] = llvm.getelementptr inbounds %[[VAL_228]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
+// CHECK-NEXT:        affine.for %[[VAL_230:.*]] = 0 to 8 {
+// CHECK-NEXT:          %[[VAL_231:.*]] = arith.index_cast %[[VAL_230]] : index to i64
+// CHECK-NEXT:          %[[VAL_232:.*]] = llvm.getelementptr %[[VAL_229]]{{\[}}%[[VAL_231]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+// CHECK-NEXT:          %[[VAL_233:.*]] = llvm.load %[[VAL_232]] : !llvm.ptr -> f32
+// CHECK-NEXT:          %[[VAL_234:.*]] = arith.index_cast %[[VAL_230]] : index to i32
+// CHECK-NEXT:          %[[VAL_235:.*]] = llvm.getelementptr %[[VAL_227]]{{\[}}%[[VAL_234]]] : (!llvm.ptr, i32) -> !llvm.ptr, f32
+// CHECK-NEXT:          llvm.store %[[VAL_233]], %[[VAL_235]] : f32, !llvm.ptr
+// CHECK-NEXT:        }
+
+    cgh.parallel_for<Kernel>(range, [=](id<1>){ (void)array; });
+  });
+
+  return 0;
+}


### PR DESCRIPTION
Construct this members in-place instead of trying to allocate the array, constructing it and then copying.