### PR TITLE
[SYCL][FE][Driver] Disable fp-accuracy tests

### DIFF
--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -31,7 +31,7 @@
 // RUN: | FileCheck --check-prefixes=CHECK-DEFAULT %s
 
 // Disabled due to https://github.com/intel/llvm/issues/9934
-// XFAIL: *
+// XFAIL: system-linux
 
 #ifdef SPIR
 // This is a declaration when compiling with -fsycl to avoid

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -31,7 +31,7 @@
 // RUN: | FileCheck --check-prefixes=CHECK-DEFAULT %s
 
 // Disabled due to https://github.com/intel/llvm/issues/9934
-// XFAIL: system-linux
+// UNSUPPORTED: system-linux
 
 #ifdef SPIR
 // This is a declaration when compiling with -fsycl to avoid

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -30,6 +30,9 @@
 // RUN: -Wno-return-type -Wno-implicit-function-declaration -emit-llvm -o - %s \
 // RUN: | FileCheck --check-prefixes=CHECK-DEFAULT %s
 
+// Disabled due to https://github.com/intel/llvm/issues/9934
+// XFAIL: *
+
 #ifdef SPIR
 // This is a declaration when compiling with -fsycl to avoid
 // the compilation error "function with no prototype cannot use

--- a/clang/test/Driver/fp-accuracy.c
+++ b/clang/test/Driver/fp-accuracy.c
@@ -48,6 +48,8 @@
 // RUN: -fmath-errno %s 2>&1  \
 // RUN: | FileCheck %s --check-prefixes=ERR-3
 
+// Disabled due to https://github.com/intel/llvm/issues/9934
+// XFAIL: *
 
 // HIGH: "-ffp-builtin-accuracy=high"
 // LOW: "-ffp-builtin-accuracy=low"

--- a/clang/test/Driver/fp-accuracy.c
+++ b/clang/test/Driver/fp-accuracy.c
@@ -49,7 +49,7 @@
 // RUN: | FileCheck %s --check-prefixes=ERR-3
 
 // Disabled due to https://github.com/intel/llvm/issues/9934
-// XFAIL: system-linux
+// UNSUPPORTED: system-linux
 
 // HIGH: "-ffp-builtin-accuracy=high"
 // LOW: "-ffp-builtin-accuracy=low"

--- a/clang/test/Driver/fp-accuracy.c
+++ b/clang/test/Driver/fp-accuracy.c
@@ -49,7 +49,7 @@
 // RUN: | FileCheck %s --check-prefixes=ERR-3
 
 // Disabled due to https://github.com/intel/llvm/issues/9934
-// XFAIL: *
+// XFAIL: system-linux
 
 // HIGH: "-ffp-builtin-accuracy=high"
 // LOW: "-ffp-builtin-accuracy=low"


### PR DESCRIPTION
They fail in post commit for a couple of days.

https://github.com/intel/llvm/issues/9934