### PR TITLE
[SYCL][CUDA][HIP] Block until the event is ready to start profiling.

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -616,6 +616,11 @@ pi_uint64 _pi_event::get_queued_time() const {
   float miliSeconds = 0.0f;
   assert(is_started());
 
+  // hipEventSynchronize waits till the event is ready for call to
+  // hipEventElapsedTime.
+  PI_CHECK_ERROR(hipEventSynchronize(evStart_));
+  PI_CHECK_ERROR(hipEventSynchronize(evEnd_));
+
   PI_CHECK_ERROR(hipEventElapsedTime(&miliSeconds, evStart_, evEnd_));
   return static_cast<pi_uint64>(miliSeconds * 1.0e6);
 }
@@ -624,8 +629,11 @@ pi_uint64 _pi_event::get_start_time() const {
   float miliSeconds = 0.0f;
   assert(is_started());
 
+  // hipEventSynchronize waits till the event is ready for call to
+  // hipEventElapsedTime.
   PI_CHECK_ERROR(hipEventSynchronize(_pi_platform::evBase_));
   PI_CHECK_ERROR(hipEventSynchronize(evStart_));
+
   PI_CHECK_ERROR(
       hipEventElapsedTime(&miliSeconds, _pi_platform::evBase_, evStart_));
   return static_cast<pi_uint64>(miliSeconds * 1.0e6);
@@ -634,6 +642,11 @@ pi_uint64 _pi_event::get_start_time() const {
 pi_uint64 _pi_event::get_end_time() const {
   float miliSeconds = 0.0f;
   assert(is_started() && is_recorded());
+
+  // hipEventSynchronize waits till the event is ready for call to
+  // hipEventElapsedTime.
+  PI_CHECK_ERROR(hipEventSynchronize(_pi_platform::evBase_));
+  PI_CHECK_ERROR(hipEventSynchronize(evEnd_));
 
   PI_CHECK_ERROR(
       hipEventElapsedTime(&miliSeconds, _pi_platform::evBase_, evEnd_));

--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -624,6 +624,8 @@ pi_uint64 _pi_event::get_start_time() const {
   float miliSeconds = 0.0f;
   assert(is_started());
 
+  PI_CHECK_ERROR(hipEventSynchronize(_pi_platform::evBase_));
+  PI_CHECK_ERROR(hipEventSynchronize(evStart_));
   PI_CHECK_ERROR(
       hipEventElapsedTime(&miliSeconds, _pi_platform::evBase_, evStart_));
   return static_cast<pi_uint64>(miliSeconds * 1.0e6);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -23,6 +23,10 @@ int getAttribute(ur_device_handle_t device, CUdevice_attribute attribute) {
 uint64_t ur_device_handle_t_::getElapsedTime(CUevent ev) const {
   float Milliseconds = 0.0f;
 
+  // cuEventSynchronize waits till the event is ready for call to
+  // cuEventElapsedTime.
+  UR_CHECK_ERROR(cuEventSynchronize(EvBase));
+  UR_CHECK_ERROR(cuEventSynchronize(ev));
   UR_CHECK_ERROR(cuEventElapsedTime(&Milliseconds, EvBase, ev));
 
   return static_cast<uint64_t>(Milliseconds * 1.0e6);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
@@ -98,7 +98,6 @@ uint64_t ur_event_handle_t_::getQueuedTime() const {
 
 uint64_t ur_event_handle_t_::getStartTime() const {
   assert(isStarted());
-  UR_CHECK_ERROR(cuEventSynchronize(EvStart));
   return Queue->get_device()->getElapsedTime(EvStart);
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
@@ -98,6 +98,7 @@ uint64_t ur_event_handle_t_::getQueuedTime() const {
 
 uint64_t ur_event_handle_t_::getStartTime() const {
   assert(isStarted());
+  UR_CHECK_ERROR(cuEventSynchronize(EvStart));
   return Queue->get_device()->getElapsedTime(EvStart);
 }
 

--- a/sycl/test-e2e/Basic/event_profiling_info.cpp
+++ b/sycl/test-e2e/Basic/event_profiling_info.cpp
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Flaky with CUDA and HIP (https://github.com/intel/llvm/issues/6495).
-// UNSUPPORTED: cuda, hip
-
 // Fails there.
 // UNSUPPORTED: opencl && gpu && gpu-intel-pvc
 


### PR DESCRIPTION
* Call to `hipEventElapsedTime` return `hipErrorNotReady` when the timestamp has not yet been `recorded` on one or both events.  Calling `hipEventSynchronize` block until the event is ready.
* The issue showed itself when profiling sycl-blas benchmark.
* Enable support for cuda / hip in event_profiling_info.cpp