### PR TITLE
[SYCL][CUDA] Re-enable same_unnamed_kernels test

### DIFF
--- a/sycl/test-e2e/Regression/same_unnamed_kernels.cpp
+++ b/sycl/test-e2e/Regression/same_unnamed_kernels.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Temporarily disabled on CUDA: https://github.com/intel/llvm/issues/9174
-// UNSUPPORTED: cuda
-
 //==----- same_unnamed_kernels.cpp - SYCL kernel naming variants test ------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
I believe the issue was that the tests wasn't getting the CUDA target flags properly and this would have been fixed as part of the E2E tests rework (in https://github.com/intel/llvm/pull/9336).

Fixes: https://github.com/intel/llvm/issues/9174