### PR TITLE
[SYCL][ESIMD][E2E] Enable thread_id_test on GPU

### DIFF
--- a/sycl/test-e2e/ESIMD/thread_id_test.cpp
+++ b/sycl/test-e2e/ESIMD/thread_id_test.cpp
@@ -1,6 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: linux && gpu && !esimd_emulator
 //==- thread_id_test.cpp - Test to verify thread id functionlity-==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -10,8 +9,6 @@
 //===----------------------------------------------------------------------===//
 
 // This is basic test to validate thread id functions.
-// TODO: Enable the test once the GPU RT supporting the functionality reaches
-// the CI
 
 #include <cmath>
 #include <iostream>


### PR DESCRIPTION
We updated the GPU driver in https://github.com/intel/llvm/commit/52a0fc8ed65d31b403fa68e24d4db8e77685171f and this test is passing on GPU now.

The test uses XFAIL so the test is actually failing in CI.

Fixes: https://github.com/intel/llvm/issues/9941