### PR TITLE
[SYCL][PI] Map `CL_QUEUED` to `CL_SUBMITTED`

### DIFF
--- a/sycl/test/abi/pi_opencl_symbol_check.dump
+++ b/sycl/test/abi/pi_opencl_symbol_check.dump
@@ -13,6 +13,7 @@ piDeviceGetInfo
 piDevicesGet
 piEnqueueMemBufferMap
 piEventCreate
+piEventGetInfo
 piGetDeviceAndHostTimer
 piKernelCreate
 piKernelGetGroupInfo


### PR DESCRIPTION
Change the result of `CL_EVENT_COMMAND_EXECUTION_STATUS` from  `CL_QUEUED` to `CL_SUBMITTED` since SYCL doesn't have an equivalent to `CL_QUEUED`. This commit adds the `piEventGetInfo` symbol to the OpenCL PI plugin, which is a non-breaking ABI change. Fixes #9099.