### PR TITLE
[CI] Change trigger events for post commit task

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -4,16 +4,7 @@ on:
   push:
     branches:
     - sycl
-  pull_request:
-    branches:
-    - sycl
-    paths:
-    - .github/workflows/sycl_post_commit.yml
-    - .github/workflows/sycl_gen_test_matrix.yml
-    - .github/workflows/sycl_linux_build_and_test.yml
-    - .github/workflows/sycl_windows_build_and_test.yml
-    - .github/workflows/sycl_macos_build_and_test.yml
-  workflow_dispatch:
+    - test-devops-pr/**
 
 jobs:
   # This job generates matrix of tests for SYCL End-to-End tests


### PR DESCRIPTION
1) Don't run in pre-commit to enhance security
2) Run automatically when on a push to a branch starting with
   "test-devops-pr" to enable testing for CI-related changes