### PR TITLE
[SYCL] Add note about making immediate command lists default

### DIFF
--- a/sycl/ReleaseNotes.md
+++ b/sycl/ReleaseNotes.md
@@ -1,6 +1,6 @@
-# April'23 release notes
+# March'23 release notes
 
-Release notes for commit range [`ca54ea30..9e5b2ed1`](https://github.com/intel/llvm/compare/ca54ea30...9e5b2ed1)
+Release notes for commit range [`ca54ea30..cb91c232`](https://github.com/intel/llvm/compare/ca54ea30...cb91c232)
 
 ## New features
 
@@ -13,7 +13,6 @@ codes in the same translation unit [31608c24] [f5126d28]
 `-fsycl-targets` [5e86a41d]
 
 ### SYCL Library
-- Made use of immediate command lists the default on Intel® Data Center GPU Max Series on Linux [9e5b2ed1] (https://www.intel.com/content/www/us/en/developer/articles/guide/level-zero-immediate-command-lists.html)
 - Implemented [`sycl_ext_oneapi_matrix`](doc/extensions/experimental/sycl_ext_oneapi_matrix/sycl_ext_oneapi_matrix.asciidoc) extension using new unified interface [f4a9ef1b]
 - Partially implemented [`sycl_ext_codeplay_kernel_fusion`](doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc) extension for Linux: Intel CPU and GPU devices are fully supported, except specialization constants, streams, images and reductions [89e82e3f] 
 [5d7e86d4] [ab0c46bd] [b5d5aada] [325bc4e2] [cf245f62]
@@ -80,6 +79,9 @@ backends [632946ac1cbf]
 extension [25d0475f]
 - Made `sycl::ext::oneapi::experimental::joint_reduce` work with 
 `sycl::sub_group` [cb91c232]
+- Made use of immediate command lists the default on Intel® Data Center GPU Max Series on Linux when
+using the Level Zero backend [9e5b2ed1]
+(https://www.intel.com/content/www/us/en/developer/articles/guide/level-zero-immediate-command-lists.html)
 
 ### Documentation
 - Added [`sycl_ext_oneapi_annotated_ptr`](doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc), [`sycl_ext_intel_fpga_kernel_arg_properties`](doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc), and 

--- a/sycl/ReleaseNotes.md
+++ b/sycl/ReleaseNotes.md
@@ -1,6 +1,6 @@
-# March'23 release notes
+# April'23 release notes
 
-Release notes for commit range [`ca54ea30..cb91c232`](https://github.com/intel/llvm/compare/ca54ea30...cb91c232)
+Release notes for commit range [`ca54ea30..9e5b2ed1`](https://github.com/intel/llvm/compare/ca54ea30...9e5b2ed1)
 
 ## New features
 
@@ -13,6 +13,7 @@ codes in the same translation unit [31608c24] [f5126d28]
 `-fsycl-targets` [5e86a41d]
 
 ### SYCL Library
+- Made use of immediate command lists the default on Intel® Data Center GPU Max Series on Linux [9e5b2ed1] (https://www.intel.com/content/www/us/en/developer/articles/guide/level-zero-immediate-command-lists.html)
 - Implemented [`sycl_ext_oneapi_matrix`](doc/extensions/experimental/sycl_ext_oneapi_matrix/sycl_ext_oneapi_matrix.asciidoc) extension using new unified interface [f4a9ef1b]
 - Partially implemented [`sycl_ext_codeplay_kernel_fusion`](doc/extensions/experimental/sycl_ext_codeplay_kernel_fusion.asciidoc) extension for Linux: Intel CPU and GPU devices are fully supported, except specialization constants, streams, images and reductions [89e82e3f] 
 [5d7e86d4] [ab0c46bd] [b5d5aada] [325bc4e2] [cf245f62]


### PR DESCRIPTION
Add item to Release Notes about making immediate command lists the default on Intel Data Center Max GPUs on Linux, with a link to additional material describing the change.