### PR TITLE
[CI] Use devops/actions/clang-format from github.base_ref

### DIFF
--- a/.github/workflows/sycl_devops_precommit.yml
+++ b/.github/workflows/sycl_devops_precommit.yml
@@ -1,0 +1,43 @@
+name: SYCL Devops Pre Commit
+
+on:
+  pull_request_target:
+    paths:
+    - .github/workflows
+    - devops
+
+permissions: write-all
+
+jobs:
+  devops:
+    runs-on: ubuntu-latest
+    environment: devops
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      PR: ${{ github.event.number }}
+      HEADER: "Accept: application/vnd.github.v3+json"
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 2
+      - name: Devops CI
+        run: |
+          set -x
+          gh auth setup-git
+
+          # Create base branch and trigger post-commit CI.
+          git push origin HEAD:refs/heads/test-devops-pr/$PR --force
+
+          # Create fake test PR to trigger pre-commit CI.
+          git checkout -b trigger-pre-commit/$PR HEAD
+          echo '// RUN: true' > sycl/test-e2e/a.cpp
+          git add sycl/test-e2e/a.cpp
+          git config user.email fake@example.com
+          git config user.name Fake
+          git commit -m '[DO NOT MERGE] Test PR'
+          # If PR was created on a previous revision, it will be updated
+          # automatically.
+          git push origin HEAD:refs/heads/trigger-pre-commit/$PR --force
+          # Create PR if it doesn't exist yet.
+          gh pr create --fill --draft -B test-devops-pr/$PR || true

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -39,8 +39,10 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
+        ref: ${{ github.base_ref }}
         sparse-checkout: |
           devops/actions/cached_checkout
+          devops/actions/clang-format
     - name: 'PR commits + 2'
       run: echo "PR_FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 2 ))" >> "${GITHUB_ENV}"
     - uses: ./devops/actions/cached_checkout
@@ -51,7 +53,7 @@ jobs:
         cache_path: "/__w/repo_cache/"
         merge: false
     - name: Run clang-format
-      uses: ./src/devops/actions/clang-format
+      uses: ./devops/actions/clang-format
       with:
         path: src
 


### PR DESCRIPTION
Arbitrary PR shouldn't be able to modify the action and use it in the pre-commit CI run.