### PR TITLE
[SYCL-MLIR][LoopInternalization] Simplify code generation

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
@@ -28,12 +28,12 @@ inline AccessorType getAccessorType(SYCLAccessorSubscriptOp op) {
 
 /// Create sycl.id.get with id \p id and index \p index.
 SYCLIDGetOp createSYCLIDGetOp(TypedValue<MemRefType> id, unsigned index,
-                              OpBuilder builder, Location loc);
+                              bool memrefTy, OpBuilder builder, Location loc);
 
 /// Create sycl.range.get with id \p range and index \p index.
 SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
-                                    unsigned index, OpBuilder builder,
-                                    Location loc);
+                                    unsigned index, bool memrefTy,
+                                    OpBuilder builder, Location loc);
 
 /// Construct sycl.id with id type \p idTy and indexes \p indexes.
 TypedValue<MemRefType> constructSYCLID(IDType idTy, ArrayRef<Value> indexes,
@@ -52,7 +52,12 @@ sycl::SYCLWorkGroupSizeOp createWorkGroupSize(unsigned numDims,
 /// Populate \p wgSizes with workgroup size per dimensionality, given the rank
 /// \p numDims.
 void populateWorkGroupSize(SmallVectorImpl<Value> &wgSizes, unsigned numDims,
-                           OpBuilder builder);
+                           OpBuilder builder, Location loc);
+
+/// Populate \p localIDs with local id per dimensionality, given the rank
+/// \p numDims.
+void populateLocalID(SmallVectorImpl<Value> &localIDs, unsigned numDims,
+                     OpBuilder builder, Location loc);
 
 } // namespace sycl
 } // namespace mlir

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Utils/Utils.h
@@ -26,14 +26,15 @@ inline AccessorType getAccessorType(SYCLAccessorSubscriptOp op) {
   return AccessorPtrValue(op.getAcc()).getAccessorType();
 }
 
-/// Create sycl.id.get with id \p id and index \p index.
-SYCLIDGetOp createSYCLIDGetOp(TypedValue<MemRefType> id, unsigned index,
-                              bool memrefTy, OpBuilder builder, Location loc);
+/// Create sycl.id.get with result type \resTy, id \p id and index \p index.
+SYCLIDGetOp createSYCLIDGetOp(Type resTy, TypedValue<MemRefType> id,
+                              unsigned index, OpBuilder builder, Location loc);
 
-/// Create sycl.range.get with id \p range and index \p index.
-SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
-                                    unsigned index, bool memrefTy,
-                                    OpBuilder builder, Location loc);
+/// Create sycl.range.get with result type \p resTy, range \p range and index \p
+/// index.
+SYCLRangeGetOp createSYCLRangeGetOp(Type resTy, TypedValue<MemRefType> range,
+                                    unsigned index, OpBuilder builder,
+                                    Location loc);
 
 /// Construct sycl.id with id type \p idTy and indexes \p indexes.
 TypedValue<MemRefType> constructSYCLID(IDType idTy, ArrayRef<Value> indexes,

--- a/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Utils/Utils.cpp
@@ -16,20 +16,23 @@ using namespace mlir;
 using namespace mlir::sycl;
 
 SYCLIDGetOp sycl::createSYCLIDGetOp(TypedValue<MemRefType> id, unsigned index,
-                                    OpBuilder builder, Location loc) {
+                                    bool memrefTy, OpBuilder builder,
+                                    Location loc) {
   const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
-  const auto resTy = builder.getIndexType();
-  return builder.create<SYCLIDGetOp>(
-      loc, MemRefType::get(ShapedType::kDynamic, resTy), id, indexOp);
+  Type resTy = builder.getIndexType();
+  if (memrefTy)
+    resTy = MemRefType::get(ShapedType::kDynamic, resTy);
+  return builder.create<SYCLIDGetOp>(loc, resTy, id, indexOp);
 }
 
 SYCLRangeGetOp sycl::createSYCLRangeGetOp(TypedValue<MemRefType> range,
-                                          unsigned index, OpBuilder builder,
-                                          Location loc) {
+                                          unsigned index, bool memrefTy,
+                                          OpBuilder builder, Location loc) {
   const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
-  const auto resTy = builder.getIndexType();
-  return builder.create<SYCLRangeGetOp>(
-      loc, MemRefType::get(ShapedType::kDynamic, resTy), range, indexOp);
+  Type resTy = builder.getIndexType();
+  if (memrefTy)
+    resTy = MemRefType::get(ShapedType::kDynamic, resTy);
+  return builder.create<SYCLRangeGetOp>(loc, resTy, range, indexOp);
 }
 
 TypedValue<MemRefType> sycl::constructSYCLID(IDType idTy,
@@ -41,7 +44,7 @@ TypedValue<MemRefType> sycl::constructSYCLID(IDType idTy,
   auto id = builder.create<memref::AllocaOp>(loc, MemRefType::get(1, idTy));
   const Value zeroIndex = builder.create<arith::ConstantIndexOp>(loc, 0);
   for (unsigned dim = 0; dim < idTy.getDimension(); ++dim) {
-    Value idGetOp = createSYCLIDGetOp(id, dim, builder, loc);
+    Value idGetOp = createSYCLIDGetOp(id, dim, true /*memrefTy*/, builder, loc);
     builder.create<memref::StoreOp>(loc, indexes[dim], idGetOp, zeroIndex);
   }
   return id;
@@ -68,19 +71,31 @@ sycl::createWorkGroupSize(unsigned numDims, OpBuilder builder, Location loc) {
 }
 
 void sycl::populateWorkGroupSize(SmallVectorImpl<Value> &wgSizes,
-                                 unsigned numDims, OpBuilder builder) {
+                                 unsigned numDims, OpBuilder builder,
+                                 Location loc) {
   const auto arrayType = builder.getType<sycl::ArrayType>(
       numDims, MemRefType::get(numDims, builder.getIndexType()));
   const auto rangeTy = builder.getType<sycl::RangeType>(numDims, arrayType);
-  Location loc = builder.getUnknownLoc();
   auto wgSize = createWorkGroupSize(numDims, builder, loc);
   auto range =
       builder.create<memref::AllocaOp>(loc, MemRefType::get(1, rangeTy));
   const Value zeroIndex = builder.create<arith::ConstantIndexOp>(loc, 0);
   builder.create<memref::StoreOp>(loc, wgSize, range, zeroIndex);
-  for (unsigned dim = 0; dim < numDims; ++dim) {
-    Value rangeGetOp = sycl::createSYCLRangeGetOp(range, dim, builder, loc);
-    wgSizes.push_back(
-        builder.create<memref::LoadOp>(loc, rangeGetOp, zeroIndex));
-  }
+  for (unsigned dim = 0; dim < numDims; ++dim)
+    wgSizes.push_back(sycl::createSYCLRangeGetOp(range, dim, false /*memrefTy*/,
+                                                 builder, loc));
+}
+
+void sycl::populateLocalID(SmallVectorImpl<Value> &localIDs, unsigned numDims,
+                           OpBuilder builder, Location loc) {
+  const auto arrayType = builder.getType<sycl::ArrayType>(
+      numDims, MemRefType::get(numDims, builder.getIndexType()));
+  const auto idTy = builder.getType<sycl::IDType>(numDims, arrayType);
+  auto localID = builder.create<sycl::SYCLLocalIDOp>(loc, idTy);
+  auto id = builder.create<memref::AllocaOp>(loc, MemRefType::get(1, idTy));
+  const Value zeroIndex = builder.create<arith::ConstantIndexOp>(loc, 0);
+  builder.create<memref::StoreOp>(loc, localID, id, zeroIndex);
+  for (unsigned dim = 0; dim < numDims; ++dim)
+    localIDs.push_back(
+        sycl::createSYCLIDGetOp(id, dim, false /*memrefTy*/, builder, loc));
 }

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -719,15 +719,6 @@ bool LoopTools::arePerfectlyNested(LoopLikeOpInterface outer,
 // VersionConditionBuilder
 //===----------------------------------------------------------------------===//
 
-static sycl::SYCLRangeGetOp createSYCLRangeGetOp(TypedValue<MemRefType> range,
-                                                 unsigned index,
-                                                 OpBuilder builder,
-                                                 Location loc) {
-  const Value indexOp = builder.create<arith::ConstantIntOp>(loc, index, 32);
-  const auto resTy = builder.getIndexType();
-  return builder.create<sycl::SYCLRangeGetOp>(loc, resTy, range, indexOp);
-}
-
 static sycl::SYCLAccessorGetRangeOp
 createSYCLAccessorGetRangeOp(sycl::AccessorPtrValue accessor, OpBuilder builder,
                              Location loc) {
@@ -781,8 +772,10 @@ static Value getSYCLAccessorEnd(sycl::AccessorPtrValue accessor,
   const Value one = builder.create<arith::ConstantIndexOp>(loc, 1);
   SmallVector<Value> indexes;
   unsigned dim = accTy.getDimension();
+  Type resTy = builder.getIndexType();
   for (unsigned i = 0; i < dim; ++i) {
-    Value rangeGetOp = createSYCLRangeGetOp(range, i, builder, loc);
+    Value rangeGetOp =
+        sycl::createSYCLRangeGetOp(resTy, range, i, builder, loc);
     indexes.push_back(
         (i == dim - 1) ? rangeGetOp
                        : builder.create<arith::SubIOp>(loc, rangeGetOp, one));

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -23,11 +23,9 @@
 // CHECK-NEXT:    %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-NEXT:    memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_id_2_1>
 // CHECK-NEXT:    %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:    %[[VAL_6:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[VAL_7:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID0:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_id_2_1>, i32) -> index
 // CHECK-NEXT:    %[[VAL_8:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_9:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID1:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_id_2_1>, i32) -> index
 
 // COM: Original code:
 // CHECK-NEXT:    %[[VAL_11:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
@@ -52,9 +50,9 @@
 // CHECK-NEXT:      %[[VAL_22:.*]] = affine.apply [[MAP2]](%[[VAL_19]]){{\[}}%[[TILESIZE]]]
 
 // COM: Calculate indexes for global memory:
-// CHECK-NEXT:      %[[VAL_23:.*]] = arith.addi %[[WGSIZE1]], %[[VAL_22]] : index
+// CHECK-NEXT:      %[[VAL_23:.*]] = arith.addi %[[LOCALID1]], %[[VAL_22]] : index
 // CHECK-NEXT:      %[[VAL_24:.*]] = arith.index_cast %[[VAL_23]] : index to i64
-// CHECK-NEXT:      %[[VAL_25:.*]] = arith.addi %[[WGSIZE1]], %[[VAL_22]] : index
+// CHECK-NEXT:      %[[VAL_25:.*]] = arith.addi %[[LOCALID1]], %[[VAL_22]] : index
 // CHECK-NEXT:      %[[VAL_26:.*]] = arith.index_cast %[[VAL_25]] : index to i64
 
 // COM: Copy to shared local memory for 1st memref:
@@ -69,7 +67,7 @@
 // CHECK-NEXT:      %[[VAL_33:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_34:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_27]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 // CHECK-NEXT:      %[[VAL_35:.*]] = memref.load %[[VAL_34]]{{\[}}%[[VAL_33]]] : memref<?xf32, 1>
-// CHECK-NEXT:      memref.store %[[VAL_35]], %[[VAL_21]]{{\[}}%[[VAL_7]], %[[WGSIZE1]]] : memref<2x4xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:      memref.store %[[VAL_35]], %[[VAL_21]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<2x4xf32, #sycl.access.address_space<local>>
 
 // COM: Get pointer to the shared local memory portion for 2nd memref:
 // CHECK-NEXT:      %[[VAL_36:.*]] = arith.constant 32 : index
@@ -87,7 +85,7 @@
 // CHECK-NEXT:      %[[VAL_44:.*]] = arith.constant 0 : index
 // CHECK-NEXT:      %[[VAL_45:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_38]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 // CHECK-NEXT:      %[[VAL_46:.*]] = memref.load %[[VAL_45]]{{\[}}%[[VAL_44]]] : memref<?xf32, 1>
-// CHECK-NEXT:      memref.store %[[VAL_46]], %[[VAL_37]]{{\[}}%[[VAL_7]], %[[WGSIZE1]]] : memref<2x4xf32, #sycl.access.address_space<local>>
+// CHECK-NEXT:      memref.store %[[VAL_46]], %[[VAL_37]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<2x4xf32, #sycl.access.address_space<local>>
 
 // CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:      affine.for %[[VAL_47:.*]] = [[MAP2]](%[[VAL_19]]){{\[}}%[[TILESIZE]]] to min [[MAP3]](%[[VAL_19]]){{\[}}%[[TILESIZE]]] {
@@ -97,8 +95,8 @@
 // CHECK-NEXT:        %[[VAL_51:.*]] = arith.index_cast %[[VAL_48]] : index to i64
 // COM: TODO: sycl.constructor can be removed.
 // CHECK-NEXT:        sycl.constructor @id(%[[VAL_12]], %[[VAL_15]], %[[VAL_49]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-DAG:         %[[VAL_52:.*]] = memref.load %[[VAL_21]]{{\[}}%[[VAL_7]], %[[VAL_48]]] : memref<2x4xf32, #sycl.access.address_space<local>>
-// CHECK-DAG:         %[[VAL_53:.*]] = memref.load %[[VAL_37]]{{\[}}%[[VAL_7]], %[[VAL_48]]] : memref<2x4xf32, #sycl.access.address_space<local>>
+// CHECK-DAG:         %[[VAL_52:.*]] = memref.load %[[VAL_21]]{{\[}}%[[LOCALID0]], %[[VAL_48]]] : memref<2x4xf32, #sycl.access.address_space<local>>
+// CHECK-DAG:         %[[VAL_53:.*]] = memref.load %[[VAL_37]]{{\[}}%[[LOCALID0]], %[[VAL_48]]] : memref<2x4xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:      }
 // CHECK-NEXT:      spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
 // CHECK-NEXT:    }
@@ -152,14 +150,11 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:    %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-NEXT:    memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_range_3_1>
 // CHECK-NEXT:    %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:    %[[VAL_6:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[WGSIZE0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[WGSIZE0:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_3_1>, i32) -> index
 // CHECK-NEXT:    %[[VAL_8:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_9:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[WGSIZE1:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_3_1>, i32) -> index
 // CHECK-NEXT:    %[[VAL_11:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:    %[[VAL_12:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_11]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[WGSIZE2:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:    %[[WGSIZE2:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_11]]] : (memref<1x!sycl_range_3_1>, i32) -> index
 
 // COM: Get shared local memory required:
 // COM:   for each loop, get the max of:
@@ -180,14 +175,11 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:    %[[VAL_24:.*]] = arith.constant 0 : index
 // CHECK-NEXT:    memref.store %[[VAL_22]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<1x!sycl_id_3_1>
 // CHECK-NEXT:    %[[VAL_25:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:    %[[VAL_26:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[LOCALID0:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID0:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> index
 // CHECK-NEXT:    %[[VAL_28:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:    %[[VAL_29:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[LOCALID1:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID1:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> index
 // CHECK-NEXT:    %[[VAL_31:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:    %[[VAL_32:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_31]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:    %[[LOCALID2:.*]] = memref.load %[[VAL_32]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:    %[[LOCALID2:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_31]]] : (memref<1x!sycl_id_3_1>, i32) -> index
 
 // COM: Original code:
 // CHECK-NEXT:    %[[VAL_34:.*]] = memref.alloca() : memref<1x!sycl_id_3_>
@@ -306,11 +298,9 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:        %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_range_2_1>
 // CHECK-NEXT:        %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_6:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[WGSIZE0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE0:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_2_1>, i32) -> index
 // CHECK-NEXT:        %[[VAL_8:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE1:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_2_1>, i32) -> index
 
 // COM: Get local memory required:
 // CHECK-NEXT:        %[[VAL_11:.*]] = arith.constant 0 : index
@@ -331,11 +321,9 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:        %[[VAL_24:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        memref.store %[[VAL_22]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<1x!sycl_id_2_1>
 // CHECK-NEXT:        %[[VAL_25:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_26:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[LOCALID0:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID0:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_2_1>, i32) -> index
 // CHECK-NEXT:        %[[VAL_28:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_29:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[LOCALID1:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID1:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_2_1>, i32) -> index
 
 // COM: Original code:
 // CHECK-NEXT:        %[[VAL_31:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
@@ -486,14 +474,11 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:        %[[VAL_4:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        memref.store %[[VAL_2]], %[[VAL_3]]{{\[}}%[[VAL_4]]] : memref<1x!sycl_range_3_1>
 // CHECK-NEXT:        %[[VAL_5:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_6:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[WGSIZE0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE0:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_range_3_1>, i32) -> index
 // CHECK-NEXT:        %[[VAL_8:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[WGSIZE1:.*]] = memref.load %[[VAL_9]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE1:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_8]]] : (memref<1x!sycl_range_3_1>, i32) -> index
 // CHECK-NEXT:        %[[VAL_11:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:        %[[VAL_12:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_11]]] : (memref<1x!sycl_range_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[WGSIZE2:.*]] = memref.load %[[VAL_12]]{{\[}}%[[VAL_4]]] : memref<?xindex>
+// CHECK-NEXT:        %[[WGSIZE2:.*]] = sycl.range.get %[[VAL_3]]{{\[}}%[[VAL_11]]] : (memref<1x!sycl_range_3_1>, i32) -> index
 
 // COM: Get shared local memory required:
 // CHECK-NEXT:        %[[VAL_14:.*]] = arith.constant 0 : index
@@ -511,14 +496,11 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:        %[[VAL_24:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        memref.store %[[VAL_22]], %[[VAL_23]]{{\[}}%[[VAL_24]]] : memref<1x!sycl_id_3_1>
 // CHECK-NEXT:        %[[VAL_25:.*]] = arith.constant 0 : i32
-// CHECK-NEXT:        %[[VAL_26:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[LOCALID0:.*]] = memref.load %[[VAL_26]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID0:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_id_3_1>, i32) -> index
 // CHECK-NEXT:        %[[VAL_28:.*]] = arith.constant 1 : i32
-// CHECK-NEXT:        %[[VAL_29:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[LOCALID1:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID1:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_28]]] : (memref<1x!sycl_id_3_1>, i32) -> index
 // CHECK-NEXT:        %[[VAL_31:.*]] = arith.constant 2 : i32
-// CHECK-NEXT:        %[[VAL_32:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_31]]] : (memref<1x!sycl_id_3_1>, i32) -> memref<?xindex>
-// CHECK-NEXT:        %[[LOCALID2:.*]] = memref.load %[[VAL_32]]{{\[}}%[[VAL_24]]] : memref<?xindex>
+// CHECK-NEXT:        %[[LOCALID2:.*]] = sycl.id.get %[[VAL_23]]{{\[}}%[[VAL_31]]] : (memref<1x!sycl_id_3_1>, i32) -> index
 
 // COM: Original code:
 // CHECK-NEXT:        %[[VAL_34:.*]] = memref.alloca() : memref<1x!sycl_id_3_>


### PR DESCRIPTION
`sycl.id.get` and `sycl.range.get` can directly return `index` instead of `memref<?xindex>`, by doing that we can simplify codegen to not generate the load from it after.

For example:
```
%[[VAL_6:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_id_2_1>, i32) -> memref<?xindex>
%[[LOCALID0:.*]] = memref.load %[[VAL_6]]{{\[}}%[[VAL_4]]] : memref<?xindex>
```
can be simplified to:
```
%[[LOCALID0:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_5]]] : (memref<1x!sycl_id_2_1>, i32) -> index
```