### PR TITLE
[SYCL][Matrix] Remove cpu's XFAIL for element_wise_all_ops_tf32.cpp

### DIFF
--- a/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-// XFAIL:*
+// XFAIL:gpu
 
 #include <iostream>
 #include <random>


### PR DESCRIPTION
we remove XFAIL for cpu because sycl runtime will take care of the type and shape checking (optional kernel feature) in the future.
when that feature is done, this testcase will fail as expected and will be set XFAIL again.