### PR TITLE
[SYCL] Revert recent copy requirements temporarily

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2289,8 +2289,7 @@ public:
                   "Invalid accessor target for the copy method.");
     static_assert(isValidModeForDestinationAccessor(AccessMode),
                   "Invalid accessor mode for the copy method.");
-    static_assert(is_device_copyable<T_Src>::value,
-                  "Pattern must be device copyable");
+    // TODO: Require is_device_copyable when vec is device-copyable.
     // Make sure data shared_ptr points to is not released until we finish
     // work with it.
     CGData.MSharedPtrStorage.push_back(Src);
@@ -2360,8 +2359,7 @@ public:
                   "Invalid accessor target for the copy method.");
     static_assert(isValidModeForDestinationAccessor(AccessMode),
                   "Invalid accessor mode for the copy method.");
-    static_assert(is_device_copyable<T_Src>::value,
-                  "Pattern must be device copyable");
+    // TODO: Require is_device_copyable when vec is device-copyable.
 #ifndef __SYCL_DEVICE_ONLY__
     if (MIsHost) {
       // TODO: Temporary implementation for host. Should be handled by memory


### PR DESCRIPTION
This commit reverts the recently introduced requirements on `is_device_copyable` in copy commands. This is a temporary revert until `sycl::vec` is made trivially copyable, to appropriately satisfy `is_device_copyable` implicitly.