### PR TITLE
[LIBCLC] Use default compilation DB for ClangTool run

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -449,8 +449,7 @@ private:
     auto *FTD = FunctionTemplateDecl::Create(*AST, FD->getDeclContext(),
                                              SourceLocation(),
                                              DeclarationName(), TPL, FD);
-    auto TAArr =
-        makeArrayRef(TemplateArguments.begin(), TemplateArguments.size());
+    auto TAArr = ArrayRef(TemplateArguments.begin(), TemplateArguments.size());
     auto *TAL = TemplateArgumentList::CreateCopy(*AST, TAArr);
     FDSpecialization->setTemplateParameterListsInfo(*AST, TPL);
     FDSpecialization->setFunctionTemplateSpecialization(
@@ -962,9 +961,10 @@ int main(int argc, const char **argv) {
     return 1;
   }
 
-  CommonOptionsParser &OptionsParser = ExpectedParser.get();
-  ClangTool Tool(OptionsParser.getCompilations(),
-                 OptionsParser.getSourcePathList());
+  // Use a default Compilation DB instead of the build one, as it might contain
+  // toolchain specific options, not compatible with clang.
+  FixedCompilationDatabase Compilations("/", std::vector<std::string>());
+  ClangTool Tool(Compilations, ExpectedParser->getSourcePathList());
 
   LibCLCRemanglerActionFactory LRAF{};
   std::unique_ptr<FrontendActionFactory> FrontendFactory;


### PR DESCRIPTION
Since https://github.com/intel/llvm/commit/94f7c961c78d8fdbc05898cfbbf88094de45c1ad landed the `-fno-lifetime-dse` option is added to the compilation database, if using non-llvm based toolchains, this option is not compatible with clang and as tools invocation in libclc does not relay on the content of the DB, use the default, empty one.

Also fix deprecated `makeArrayRef` warning.

cc: [abagusetty](https://github.com/abagusetty)