### PR TITLE
[SYCL][UR] Map UR/PI adapter specific error code.

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -48,6 +48,8 @@ static pi_result ur2piResult(ur_result_t urResult) {
     return PI_ERROR_BUILD_PROGRAM_FAILURE;
   case UR_RESULT_ERROR_UNINITIALIZED:
     return PI_ERROR_UNINITIALIZED;
+  case UR_RESULT_ERROR_ADAPTER_SPECIFIC:
+    return PI_ERROR_PLUGIN_SPECIFIC_ERROR;
   default:
     return PI_ERROR_UNKNOWN;
   };


### PR DESCRIPTION
detail/plugin.hpp in SYCL runtime relies on `PI_ERROR_PLUGIN_SPECIFIC_ERROR` here https://github.com/intel/llvm/blob/83f877975c97acdb38d84f94dc146571cd522e0e/sycl/source/detail/plugin.hpp#L119
Currently `UR_RESULT_ERROR_ADAPTER_SPECIFIC` is mapped to `PI_ERROR_UNKNOWN`.
This PR fixes this.