### PR TITLE
[SYCL] Update Level Zero Loader to v1.11.0

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.10.0",
-      "version": "v1.10.0",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.10.0",
+      "github_tag": "v1.11.0",
+      "version": "v1.11.0",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.11.0",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
   message(STATUS "Download Level Zero loader and headers from github.com")
 
   set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-  set(LEVEL_ZERO_LOADER_TAG v1.8.8)
+  set(LEVEL_ZERO_LOADER_TAG v1.11.0)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)


### PR DESCRIPTION
This patch updates Level Zero Loader to version v1.11.0 because
the previous version does not support implementation of 
https://github.com/oneapi-src/level-zero-spec/pull/23 Level Zero extension, required for 
implementing sycl_ext_oneapi_device_architecture on host

Addresses https://github.com/intel/llvm/pull/9843#discussion_r1230254447