### PR TITLE
[SYCL][UR][L0] Do not destroy build log on piProgramBuild

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_program.cpp
@@ -154,10 +154,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(
     // RT calls piProgramRelease().
     Program->State = ur_program_handle_t_::Invalid;
     Result = ze2urResult(ZeResult);
-    if (Program->ZeBuildLog) {
-      ZE_CALL_NOCHECK(zeModuleBuildLogDestroy, (Program->ZeBuildLog));
-      Program->ZeBuildLog = nullptr;
-    }
     if (ZeModule) {
       ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
       ZeModule = nullptr;


### PR DESCRIPTION
If piProgramBuild fails, do not remove L0 build log, which is expected to be read later in piProgramGetBuildInfo.