### PR TITLE
[SYCL] Fix sycl::sub_group by-value semantics

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -769,6 +769,27 @@ struct sub_group {
 #endif
   }
 
+  // Common member functions for by-value semantics
+  friend bool operator==(const sub_group &lhs, const sub_group &rhs) {
+#ifdef __SYCL_DEVICE_ONLY__
+    return (rhs.dimensions == lhs.dimensions) &&
+           (rhs.fence_scope == lhs.fence_scope) &&
+           (rhs.get_group_id() == lhs.get_group_id());
+#else
+    throw runtime_error("Sub-groups are not supported on host device.",
+                        PI_ERROR_INVALID_DEVICE);
+#endif
+  }
+
+  friend bool operator!=(const sub_group &lhs, const sub_group &rhs) {
+#ifdef __SYCL_DEVICE_ONLY__
+    return !(lhs == rhs);
+#else
+    throw runtime_error("Sub-groups are not supported on host device.",
+                        PI_ERROR_INVALID_DEVICE);
+#endif
+  }
+
 protected:
   template <int dimensions> friend class sycl::nd_item;
   friend sub_group this_sub_group();

--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -772,9 +772,7 @@ struct sub_group {
   // Common member functions for by-value semantics
   friend bool operator==(const sub_group &lhs, const sub_group &rhs) {
 #ifdef __SYCL_DEVICE_ONLY__
-    return (rhs.dimensions == lhs.dimensions) &&
-           (rhs.fence_scope == lhs.fence_scope) &&
-           (rhs.get_group_id() == lhs.get_group_id());
+    return lhs.get_group_id() == rhs.get_group_id();
 #else
     throw runtime_error("Sub-groups are not supported on host device.",
                         PI_ERROR_INVALID_DEVICE);

--- a/sycl/test-e2e/SubGroup/sub_group_by_value_semantics.cpp
+++ b/sycl/test-e2e/SubGroup/sub_group_by_value_semantics.cpp
@@ -8,30 +8,30 @@ int main() {
   sycl::queue queue;
   {
     sycl::buffer<bool, 1> res_buf(&result, 1);
-    queue.submit([&](sycl::handler& cgh) {
+    queue.submit([&](sycl::handler &cgh) {
       auto res_acc = res_buf.get_access<sycl::access_mode::read_write>(cgh);
 
-      cgh.parallel_for<class kernel>(
-          sycl::nd_range<3>({1, 1, 1}, {1, 1, 1}), [=](sycl::nd_item<3> item) {
-            sycl::sub_group a = item.get_sub_group();
+      cgh.parallel_for<class kernel>(sycl::nd_range<3>({1, 1, 1}, {1, 1, 1}),
+                                     [=](sycl::nd_item<3> item) {
+                                       sycl::sub_group a = item.get_sub_group();
 
-            // check for reflexivity
-            res_acc[0] &= (a == a);
-            res_acc[0] &= !(a != a);
+                                       // check for reflexivity
+                                       res_acc[0] &= (a == a);
+                                       res_acc[0] &= !(a != a);
 
-            // check for symmetry
-            auto copied = a;
-            auto& b = copied;
-            res_acc[0] &= (a == b);
-            res_acc[0] &= (b == a);
-            res_acc[0] &= !(a != b);
-            res_acc[0] &= !(b != a);
+                                       // check for symmetry
+                                       auto copied = a;
+                                       auto &b = copied;
+                                       res_acc[0] &= (a == b);
+                                       res_acc[0] &= (b == a);
+                                       res_acc[0] &= !(a != b);
+                                       res_acc[0] &= !(b != a);
 
-            // check for transitivity
-            auto copiedTwice = copied;
-            const auto& c = copiedTwice;
-            res_acc[0] &= (c == a);
-        });
+                                       // check for transitivity
+                                       auto copiedTwice = copied;
+                                       const auto &c = copiedTwice;
+                                       res_acc[0] &= (c == a);
+                                     });
     });
     queue.wait_and_throw();
   }

--- a/sycl/test-e2e/SubGroup/sub_group_by_value_semantics.cpp
+++ b/sycl/test-e2e/SubGroup/sub_group_by_value_semantics.cpp
@@ -1,0 +1,41 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl.hpp>
+
+int main() {
+  bool result = true;
+  sycl::queue queue;
+  {
+    sycl::buffer<bool, 1> res_buf(&result, 1);
+    queue.submit([&](sycl::handler& cgh) {
+      auto res_acc = res_buf.get_access<sycl::access_mode::read_write>(cgh);
+
+      cgh.parallel_for<class kernel>(
+          sycl::nd_range<3>({1, 1, 1}, {1, 1, 1}), [=](sycl::nd_item<3> item) {
+            sycl::sub_group a = item.get_sub_group();
+
+            // check for reflexivity
+            res_acc[0] &= (a == a);
+            res_acc[0] &= !(a != a);
+
+            // check for symmetry
+            auto copied = a;
+            auto& b = copied;
+            res_acc[0] &= (a == b);
+            res_acc[0] &= (b == a);
+            res_acc[0] &= !(a != b);
+            res_acc[0] &= !(b != a);
+
+            // check for transitivity
+            auto copiedTwice = copied;
+            const auto& c = copiedTwice;
+            res_acc[0] &= (c == a);
+        });
+    });
+    queue.wait_and_throw();
+  }
+
+  assert(result);
+  return 0;
+}


### PR DESCRIPTION
According to SYCL2020 sycl::sub_group must follow by-value semantics.