### PR TITLE
[SYCL][libclc] Removing unused SYCL targets for libclc

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -20,8 +20,8 @@ def do_configure(args):
     if sys.platform != "darwin":
         llvm_external_projects += ';libdevice'
 
-    libclc_amd_target_names = ';amdgcn--;amdgcn--amdhsa'
-    libclc_nvidia_target_names = ';nvptx64--;nvptx64--nvidiacl'
+    libclc_amd_target_names = ';amdgcn--amdhsa'
+    libclc_nvidia_target_names = ';nvptx64--nvidiacl'
 
     sycl_enable_fusion = "OFF"
     if not args.disable_fusion:


### PR DESCRIPTION
Some minor housekeeping. We don't need the `amdgcn` and `ptx` dirs of `libclc` for SYCL compilation