### PR TITLE
[SYCL][E2E] Add SPIR-V fat object smoke test

### DIFF
--- a/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
+++ b/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
@@ -1,0 +1,37 @@
+// UNSUPPORTED: cuda || hip
+// RUN: clang++ -fsycl -fsycl-device-obj=spirv -c -o %t.o %s
+// RUN: clang++ -fsycl -o %t.out %t.o
+// RUN: %{run} %t.out
+
+// This test verifies SPIR-V based fat objects.
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::buffer<size_t, 1> Buffer(4);
+
+  sycl::queue Queue;
+
+  sycl::range<1> NumOfWorkItems{Buffer.size()};
+
+  Queue.submit([&](sycl::handler &cgh) {
+    sycl::accessor Accessor{Buffer, cgh, sycl::write_only};
+    cgh.parallel_for<class FillBuffer>(NumOfWorkItems, [=](sycl::id<1> WIid) {
+      Accessor[WIid] = WIid.get(0);
+    });
+  });
+
+  sycl::host_accessor HostAccessor{Buffer, sycl::read_only};
+
+  bool MismatchFound = false;
+  for (size_t I = 0; I < Buffer.size(); ++I) {
+    if (HostAccessor[I] != I) {
+      std::cout << "The result is incorrect for element: " << I
+                << " , expected: " << I << " , got: " << HostAccessor[I]
+                << std::endl;
+      MismatchFound = true;
+    }
+  }
+
+  return MismatchFound;
+}


### PR DESCRIPTION
Add a test for the most basic use case to make sure we don't break anything.