### PR TITLE
[SYCL-MLIR][IntegerRangeAnalysis] Loop UB may be uninitialized

### DIFF
--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -184,7 +184,7 @@ void IntegerRangeAnalysis::visitNonControlFlowArguments(
       } else if (auto value = llvm::dyn_cast_if_present<Value>(*loopBound)) {
         const IntegerValueRangeLattice *lattice =
             getLatticeElementFor(op, value);
-        if (lattice != nullptr)
+        if (lattice != nullptr && !lattice->getValue().isUninitialized())
           return getUpper ? lattice->getValue().getValue().smax()
                           : lattice->getValue().getValue().smin();
       }

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -730,3 +730,24 @@ func.func @extui_uses_unsigned(%arg0 : i32) -> i1 {
     %4 = arith.andi %2, %3 : i1
     func.return %4 : i1
 }
+
+/// Catch a bug that crash in getLoopBoundFromFold when
+/// SparseConstantPropagation loaded in the solver.
+
+// CHECK-LABEL: func.func @caller(%[[ARG0:.*]]
+// CHECK: call @callee(%[[ARG0]])
+// CHECK-LABEL: func.func @callee(%[[ARG0]]
+// CHECK: %[[LOAD:.*]] = affine.load %[[ARG0]]
+// CHECK: scf.for {{.*}} to %[[LOAD]] 
+func.func @caller(%arg0: memref<?xindex, 4>) {
+  call @callee(%arg0) : (memref<?xindex, 4>) -> ()
+  return
+}
+func.func private @callee(%arg0: memref<?xindex, 4>) {
+  %c1 = arith.constant 1 : index
+  %c0 = arith.constant 0 : index
+  %0 = affine.load %arg0[0] : memref<?xindex, 4>
+  scf.for %arg1 = %c0 to %0 step %c1 {
+  }
+  return
+}

--- a/mlir/test/lib/Transforms/TestIntRangeInference.cpp
+++ b/mlir/test/lib/Transforms/TestIntRangeInference.cpp
@@ -9,6 +9,7 @@
 // functionality has been integrated into SCCP.
 //===----------------------------------------------------------------------===//
 
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
 #include "mlir/Interfaces/SideEffectInterfaces.h"
@@ -107,6 +108,7 @@ struct TestIntRangeInference
     Operation *op = getOperation();
     DataFlowSolver solver;
     solver.load<DeadCodeAnalysis>();
+    solver.load<dataflow::SparseConstantPropagation>();
     solver.load<IntegerRangeAnalysis>();
     if (failed(solver.initializeAndRun(op)))
       return signalPassFailure();


### PR DESCRIPTION
This problem is exposed when adding `LoopInternalization` in the pipeline and running SYCL-Bench convariance. 
The problem is only exposed when `SparseConstantPropagation` is also loaded in the solver with `IntegerRangeAnalysis`.