### PR TITLE
[SYCL][NFC] Fix unused variables warning in sub_group extension

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group.hpp
@@ -774,6 +774,8 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
     return lhs.get_group_id() == rhs.get_group_id();
 #else
+    std::ignore = lhs;
+    std::ignore = rhs;
     throw runtime_error("Sub-groups are not supported on host device.",
                         PI_ERROR_INVALID_DEVICE);
 #endif
@@ -783,6 +785,8 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
     return !(lhs == rhs);
 #else
+    std::ignore = lhs;
+    std::ignore = rhs;
     throw runtime_error("Sub-groups are not supported on host device.",
                         PI_ERROR_INVALID_DEVICE);
 #endif


### PR DESCRIPTION
Fixes post-commit after https://github.com/intel/llvm/commit/064f332f156c606c43f4909dc041d28468b793f9