### PR TITLE
[CI] Let sycl-devops-pr/** branches trigger pre/post-commit

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
     - sycl
-    - test-devops-pr/**
+    - sycl-devops-pr/**
 
 jobs:
   # This job generates matrix of tests for SYCL End-to-End tests

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     branches:
     - sycl
+    - sycl-devops-pr/**
     # Do not run builds if changes are only in the following locations
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
In #9950 I envisioned a setup when there will be a dedicated devops pre-commit task that would create fake branch/PR in the repository to verify changes affecting CI. I later realized that we can just push the source branch for such a PR directly to origin and use that for testing.

As such, rename which branch is allowed to trigger post-commit and allow the same for pre-commit.