### PR TITLE
[SYCL-MLIR][LICM] Always check that operations can be hoisted recursively

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -507,6 +507,13 @@ static bool canBeHoisted(LICMCandidate &candidate, LoopLikeOpInterface loop,
     }
   }
 
+  if (op.hasTrait<OpTrait::IsIsolatedFromAbove>()) {
+    LLVM_DEBUG({
+      llvm::dbgs().indent(2) << "**** isolated from above: can be hoisted\n\n";
+    });
+    return true;
+  }
+
   // Recurse into the regions for this op and check whether the contained ops
   // can be hoisted. We can inductively assume that this op will have its
   // block args available outside the loop.

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LICM.cpp
@@ -480,7 +480,7 @@ static bool canBeHoisted(LICMCandidate &candidate, LoopLikeOpInterface loop,
        op.hasTrait<OpTrait::IsIsolatedFromAbove>())) {
     LLVM_DEBUG({
       llvm::dbgs() << "Operation: " << op << "\n";
-      llvm::dbgs().indent(2) << "**** has no side effects: can be hoisted\n\n";
+      llvm::dbgs().indent(2) << "**** can be hoisted: has no side effects\n\n";
     });
     return true;
   }

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -435,7 +435,6 @@ func.func @affine_if_within_for_hoist() {
     scf.if %true {
       arith.cmpi eq, %c0, %c1 : i32
     }
-    affine.yield
   }
   func.return
 }
@@ -464,7 +463,6 @@ func.func @affine_if_within_for_not_hoist() {
     scf.if %true {
       arith.cmpi eq, %0, %1 : i32
     }
-    affine.yield
   }
   func.return
 }

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -1,5 +1,5 @@
-// RUN: polygeist-opt --licm="relaxed-aliasing=false" --split-input-file %s 2>&1 | FileCheck %s
-// RUN: polygeist-opt --licm="relaxed-aliasing=true" --split-input-file %s 2>&1 | FileCheck --check-prefix=CHECK-RELAXED-ALIASING %s
+// RUN: polygeist-opt --allow-unregistered-dialect --licm="relaxed-aliasing=false" --split-input-file %s 2>&1 | FileCheck %s
+// RUN: polygeist-opt --allow-unregistered-dialect --licm="relaxed-aliasing=true" --split-input-file %s 2>&1 | FileCheck --check-prefix=CHECK-RELAXED-ALIASING %s
 
 // COM: Test LICM on scf.for loops.
 module {
@@ -405,4 +405,66 @@ func.func @affine_parallel_hoist1(%arg0: memref<?xf32>, %arg1: index, %arg2: ind
   }
   return
 }
+}
+
+// -----
+
+// COM: Every operation in the loop is safe to hoist.
+
+// CHECK: #set = affine_set<() : (9 >= 0)>
+
+// CHECK-LABEL:   func.func @affine_if_within_for_hoist() {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant true
+// CHECK-NEXT:      affine.if #set() {
+// CHECK-NEXT:        scf.if %[[VAL_2]] {
+// CHECK-NEXT:          %[[VAL_3:.*]] = arith.cmpi eq, %[[VAL_0]], %[[VAL_1]] : i32
+// CHECK-NEXT:        }
+// CHECK-NEXT:        affine.for %[[VAL_4:.*]] = 0 to 10 {
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @affine_if_within_for_hoist() {
+  affine.for %arg0 = 0 to 10 {
+    %c0 = arith.constant 0 : i32
+    %c1 = arith.constant 1 : i32
+    %true = arith.constant true
+    scf.if %true {
+      arith.cmpi eq, %c0, %c1 : i32
+    }
+    affine.yield
+  }
+  func.return
+}
+
+// -----
+
+// COM: Only `%true` is safe to hoist. The rest of the operations cannot be hoisted.
+
+// CHECK-LABEL:   func.func @affine_if_within_for_not_hoist() {
+// CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant true
+// CHECK-NEXT:      affine.for %[[VAL_1:.*]] = 0 to 10 {
+// CHECK-NEXT:        %[[VAL_2:.*]] = "gen"() : () -> i32
+// CHECK-NEXT:        %[[VAL_3:.*]] = "gen"() : () -> i32
+// CHECK-NEXT:        scf.if %[[VAL_0]] {
+// CHECK-NEXT:          %[[VAL_4:.*]] = arith.cmpi eq, %[[VAL_2]], %[[VAL_3]] : i32
+// CHECK-NEXT:        }
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }
+
+func.func @affine_if_within_for_not_hoist() {
+  affine.for %arg0 = 0 to 10 {
+    %0 = "gen"() : () -> i32
+    %1 = "gen"() : () -> i32
+    %true = arith.constant true
+    scf.if %true {
+      arith.cmpi eq, %0, %1 : i32
+    }
+    affine.yield
+  }
+  func.return
 }


### PR DESCRIPTION
An early exit in `canBeHoisted` (returning `true`) lead to hoisting operations which could not be hoisted because operations inside their regions used values defined inside the loop and not hoisted, e.g.:

```mlir
affine.for %arg0 = 0 to 10 {
  %0 = "gen"() : () -> i32
  %1 = "gen"() : () -> i32
  %true = arith.constant true
  scf.if %true {
    arith.cmpi eq, %0, %1 : i32
  }
  affine.yield
}
```

would have been transformed into:

```mlir
%true = arith.constant true
scf.if #set {
  scf.if %true {
    arith.cmpi eq, %0, %1 : i32
  }
  affine.for %arg0 = 0 to 10 {
    %0 = "gen"() : () -> i32
    %1 = "gen"() : () -> i32
    affine.yield
  }
}
```

which is clearly illegal as `%0` and `%1` do not dominate their uses (in the `arith.cmpi` operation inside the `scf.if` operation, hoisted as it is has no memory effects).

By removing this early exit, we ensure every operation is checked recursively.