### PR TITLE
[SYCL][Docs] Move sycl_ext_oneapi_device_global out of proposed

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
@@ -38,7 +38,7 @@ constructors/destructors.
 
 == Notice
 
-Copyright (c) 2021 - 2022 Intel Corporation.  All rights reserved.
+Copyright (c) 2021 - 2023 Intel Corporation.  All rights reserved.
 
 NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
 trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
@@ -46,20 +46,12 @@ used by permission by Khronos.
 
 == Status
 
-Working Draft
-
-This is a preview extension specification, intended to provide early access to
-a feature for review and community feedback. When the feature matures, this
-specification may be released as a formal extension.
-
-Because the interfaces defined by this specification are not final and are
-subject to change they are not intended to be used by shipping software
-products.
-
-== Version
-
-Built On: 2021-09-30 +
-Revision: 3
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
+*Shipping software products should not rely on APIs defined in this
+specification.*
 
 == Contact
 
@@ -147,7 +139,7 @@ For both `dm1` and `dm2`, the `MyClass` and `int[4]` allocations on each device
 in the context associated with `Q` are zero-initialized before any
 non-initialization accesses occur.
 
-== Proposal
+== Specification
 
 === Feature test macro
 

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -82,6 +82,7 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 #endif
 #define SYCL_EXT_INTEL_CACHE_CONFIG 1
 #define SYCL_EXT_CODEPLAY_MAX_REGISTERS_PER_WORK_GROUP_QUERY 1
+#define SYCL_EXT_ONEAPI_DEVICE_GLOBAL 1
 
 #ifndef __has_include
 #define __has_include(x) 0


### PR DESCRIPTION
This commit moves the sycl_ext_oneapi_device_global extension from "proposed" to "experimental" and defined the
SYCL_EXT_ONEAPI_DEVICE_GLOBAL feature test macro.