### PR TITLE
[SYCL][E2E] Enable device_global tests

### DIFF
--- a/sycl/test-e2e/DeviceGlobal/device_global_arrow.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_arrow.cpp
@@ -1,15 +1,8 @@
-// TODO: device_global without the device_image_scope property is not currently
-//       initialized on device. Enable the following test cases when it is
-//       supported.
-// RUNx: %{build} -o %t.out
-// RUNx: %{run} %t.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 //
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t_dev_img_scope.out
 // RUN: %{run} %t_dev_img_scope.out
-//
-// CPU and accelerators are not currently guaranteed to support the required
-// extensions they are disabled until they are.
-// UNSUPPORTED: cpu, accelerator
 //
 // Tests operator-> on device_global.
 // NOTE: USE_DEVICE_IMAGE_SCOPE needs both kernels to be in the same image so

--- a/sycl/test-e2e/DeviceGlobal/device_global_device_image_scope_unused.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_device_image_scope_unused.cpp
@@ -1,5 +1,5 @@
-// RUNx: %{build} -o %t.out
-// RUNx: %{run} %t.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 //
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t_dev_img_scope.out
 // RUN: %{run} %t_dev_img_scope.out

--- a/sycl/test-e2e/DeviceGlobal/device_global_device_only.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_device_only.cpp
@@ -1,15 +1,8 @@
-// TODO: device_global without the device_image_scope property is not currently
-//       initialized on device. Enable the following test cases when it is
-//       supported.
-// RUNx: %{build} -o %t.out
-// RUNx: %{run} %t.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 //
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t_dev_img_scope.out
 // RUN: %{run} %t_dev_img_scope.out
-//
-// CPU and accelerators are not currently guaranteed to support the required
-// extensions they are disabled until they are.
-// UNSUPPORTED: cpu, accelerator
 //
 // Tests basic device_global access through device kernels.
 // NOTE: USE_DEVICE_IMAGE_SCOPE needs both kernels to be in the same image so

--- a/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough.cpp
@@ -1,15 +1,8 @@
-// TODO: device_global without the device_image_scope property is not currently
-//       initialized on device. Enable the following test cases when it is
-//       supported.
-// RUNx: %{build} -o %t.out
-// RUNx: %{run} %t.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 //
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t_dev_img_scope.out
 // RUN: %{run} %t_dev_img_scope.out
-//
-// CPU and accelerators are not currently guaranteed to support the required
-// extensions they are disabled until they are.
-// UNSUPPORTED: cpu, accelerator
 //
 // Tests the passthrough of operators on device_global.
 // NOTE: USE_DEVICE_IMAGE_SCOPE needs both kernels to be in the same image so

--- a/sycl/test-e2e/DeviceGlobal/device_global_subscript.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_subscript.cpp
@@ -1,8 +1,5 @@
-// TODO: device_global without the device_image_scope property is not currently
-//       initialized on device. Enable the following test cases when it is
-//       supported.
-// RUNx: %{build} -o %t.out
-// RUNx: %{run} %t.out
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 //
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t_dev_img_scope.out
 // RUN: %{run} %t_dev_img_scope.out


### PR DESCRIPTION
This commit enables a selection of previously disabled paths for the SYCL E2E tests related to the device_global extension.