### PR TITLE
[CI] Skip pre-commit jobs when CI-related files are modified

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -1,5 +1,4 @@
-name: Identify impacted LIT tests
-# Outlined into a separate reusable workflow to ease testing for new rules.
+name: Identify changed files
 
 on:
   workflow_call:
@@ -48,3 +47,6 @@ jobs:
               - *libclc
               - 'sycl/*'
               - 'sycl/!(test-e2e|doc)/**'
+            ci:
+              - .github/workflows/**
+              - devops/**

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -9,20 +9,15 @@ on:
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'
     - '.github/CODEOWNERS'
-    - '.github/workflows/sycl_update_gpu_driver.yml'
-    - '.github/workflows/sycl_containers.yaml'
-    - '.github/workflows/sycl_nightly.yml'
-    - '.github/workflows/sycl_post_commit.yml'
-    - '.github/workflows/sycl_windows_build_and_test.yml'
-    - '.github/workflows/sycl_macos_build_and_test.yml'
-    - 'devops/containers/**'
-    - 'devops/scripts/install_drivers.sh'
-    - 'devops/scripts/install_build_tools.sh'
     - 'sycl/doc/**'
     - 'sycl/gdb/**'
     - 'clang/docs/**'
     - '**.md'
     - '**.rst'
+    # For CI-related files we explicitly skip all the jobs below even if there
+    # were other (non-ignored) files modified in this PR.
+    - '.github/workflows/**'
+    - 'devops/**'
 
 permissions:
   contents: read
@@ -32,6 +27,9 @@ jobs:
     uses: ./.github/workflows/sycl_detect_changes.yml
 
   lint:
+    needs: [detect_changes]
+    if: |
+      !contains(needs.detect_changes.outputs.filters, 'ci')
     runs-on: cuda
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
@@ -60,6 +58,9 @@ jobs:
 
   # This job generates matrix of tests for SYCL End-to-End tests
   test_matrix:
+    needs: [detect_changes]
+    if: |
+      !contains(needs.detect_changes.outputs.filters, 'ci')
     name: Generate Test Matrix
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
@@ -71,7 +72,11 @@ jobs:
     # Only build and test patches, that have passed all linter checks, because
     # the next commit is likely to be a follow-up on that job.
     needs: [lint, test_matrix, detect_changes]
-    if: ${{ always() && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint')) && contains(needs.detect_changes.outputs.filters, 'sycl') }}
+    if: |
+      always()
+      && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
+      && contains(needs.detect_changes.outputs.filters, 'sycl')
+      && !contains(needs.detect_changes.outputs.filters, 'ci')
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     secrets: inherit
     with:
@@ -87,7 +92,9 @@ jobs:
   linux_e2e_on_nightly:
     name: Linux SYCL E2E on Nightly
     needs: [detect_changes]
-    if: ${{ !contains(needs.detect_changes.outputs.filters, 'sycl') }}
+    if: |
+      !contains(needs.detect_changes.outputs.filters, 'sycl')
+      && !contains(needs.detect_changes.outputs.filters, 'ci')
     uses: ./.github/workflows/linux_matrix_e2e_on_nightly.yml
     secrets: inherit
     with:
@@ -96,7 +103,9 @@ jobs:
   windows_default:
     name: Windows
     needs: [lint, test_matrix, detect_changes]
-    if: github.repository == 'intel/llvm'
+    if: |
+      github.repository == 'intel/llvm'
+      && !contains(needs.detect_changes.outputs.filters, 'ci')
     uses: ./.github/workflows/sycl_windows_build_and_test.yml
     with:
       lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}


### PR DESCRIPTION
[CI] Skip pre-commit jobs when CI-related files are modified

That has to be tested via auxiliary draft pull request. The pattern
would be:

  - create branch `sycl-devops-pr/<name>` in *intel*/llvm repo, it will
    run post-commit testing
  - create PR out of that branch
  - create an extra draft PR with a target branch set to the same
    `sycl-devops-pr/<name>`, that will run pre-commit testing
