### PR TITLE
[SYCL] Fix global memory reporting for Arc

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_device.cpp
@@ -245,9 +245,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
     return ReturnValue(uint64_t{Device->ZeDeviceProperties->maxMemAllocSize});
   case UR_DEVICE_INFO_GLOBAL_MEM_SIZE: {
     uint64_t GlobalMemSize = 0;
+    // Support to read physicalSize depends on kernel,
+    // so fallback into reading totalSize if physicalSize
+    // is not available.
     for (const auto &ZeDeviceMemoryExtProperty :
          Device->ZeDeviceMemoryProperties->second) {
       GlobalMemSize += ZeDeviceMemoryExtProperty.physicalSize;
+    }
+    if (GlobalMemSize == 0) {
+      for (const auto &ZeDeviceMemoryProperty :
+           Device->ZeDeviceMemoryProperties->first) {
+        GlobalMemSize += ZeDeviceMemoryProperty.totalSize;
+      }
     }
     return ReturnValue(uint64_t{GlobalMemSize});
   }


### PR DESCRIPTION
3c35b1b59093a2b34dcaf803f995b3e3ab5c0cde dropped this previous fix by mistake: https://github.com/intel/llvm/pull/8624