### PR TITLE
online_compiler load via loadOSLibrary, not loadOSPlugin

### DIFF
--- a/sycl/include/sycl/detail/pi.hpp
+++ b/sycl/include/sycl/detail/pi.hpp
@@ -153,11 +153,20 @@ __SYCL_EXPORT void contextSetExtendedDeleter(const sycl::context &constext,
                                              pi_context_extended_deleter func,
                                              void *user_data);
 
-// Function to load the shared library
+// Function to load a shared library
+// Implementation is OS dependent
+void *loadOsLibrary(const std::string &Library);
+
+// Function to unload a shared library
+// Implementation is OS dependent (see posix-pi.cpp and windows-pi.cpp)
+int unloadOsLibrary(void *Library);
+
+// Function to load the shared plugin library
+// On Windows, this will have been pre-loaded by proxy loader.
 // Implementation is OS dependent.
 void *loadOsPluginLibrary(const std::string &Library);
 
-// Function to unload the shared library
+// Function to unload the shared plugin library
 // Implementation is OS dependent (see posix-pi.cpp and windows-pi.cpp)
 int unloadOsPluginLibrary(void *Library);
 

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -108,7 +108,6 @@ std::string getCurrentDSODir() {
 #define __SYCL_ESIMD_EMULATOR_PLUGIN_NAME "pi_esimd_emulator.dll"
 #define __SYCL_HIP_PLUGIN_NAME "libpi_hip.dll"
 #define __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME "pi_unified_runtime.dll"
-#define __SYCL_ONLINE_COMPILER_LIBRARY_NAME "ocloc64.dll"
 #else // llvm-mingw
 #define __SYCL_OPENCL_PLUGIN_NAME "libpi_opencl.dll"
 #define __SYCL_LEVEL_ZERO_PLUGIN_NAME "libpi_level_zero.dll"
@@ -116,7 +115,6 @@ std::string getCurrentDSODir() {
 #define __SYCL_ESIMD_EMULATOR_PLUGIN_NAME "libpi_esimd_emulator.dll"
 #define __SYCL_HIP_PLUGIN_NAME "libpi_hip.dll"
 #define __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME "libpi_unified_runtime.dll"
-#define __SYCL_ONLINE_COMPILER_LIBRARY_NAME "ocloc64.dll"
 #endif
 
 // ------------------------------------
@@ -167,9 +165,6 @@ void preloadLibraries() {
 
   std::string ur_path = LibSYCLDir + __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME;
   dllMap.emplace(ur_path, LoadLibraryA(ur_path.c_str()));
-
-  std::string ocloc_path = __SYCL_ONLINE_COMPILER_LIBRARY_NAME;
-  dllMap.emplace(ocloc_path, LoadLibraryA(ocloc_path.c_str()));
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);

--- a/sycl/source/detail/online_compiler/online_compiler.cpp
+++ b/sycl/source/detail/online_compiler/online_compiler.cpp
@@ -94,7 +94,7 @@ compileToSPIRV(const std::string &Source, sycl::info::device_type DeviceType,
 #else
     static const std::string OclocLibraryName = "libocloc.so";
 #endif
-    void *OclocLibrary = sycl::detail::pi::loadOsPluginLibrary(OclocLibraryName);
+    void *OclocLibrary = sycl::detail::pi::loadOsLibrary(OclocLibraryName);
     if (!OclocLibrary)
       throw online_compile_error("Cannot load ocloc library: " +
                                  OclocLibraryName);

--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -16,17 +16,24 @@ namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail::pi {
 
-void *loadOsPluginLibrary(const std::string &PluginPath) {
+void *loadOsLibrary(const std::string &LibraryPath) {
   // TODO: Check if the option RTLD_NOW is correct. Explore using
   // RTLD_DEEPBIND option when there are multiple plugins.
-  void *so = dlopen(PluginPath.c_str(), RTLD_NOW);
+  void *so = dlopen(LibraryPath.c_str(), RTLD_NOW);
   if (!so && trace(TraceLevel::PI_TRACE_ALL)) {
     char *Error = dlerror();
-    std::cerr << "SYCL_PI_TRACE[-1]: dlopen(" << PluginPath << ") failed with <"
-              << (Error ? Error : "unknown error") << ">" << std::endl;
+    std::cerr << "SYCL_PI_TRACE[-1]: dlopen(" << LibraryPath
+              << ") failed with <" << (Error ? Error : "unknown error") << ">"
+              << std::endl;
   }
   return so;
 }
+
+void *loadOsPluginLibrary(const std::string &PluginPath) {
+  return loadOsLibrary(PluginPath);
+}
+
+int unloadOsLibrary(void *Library) { return dlclose(Library); }
 
 int unloadOsPluginLibrary(void *Library) {
   // The mock plugin does not have an associated library, so we allow nullptr

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -20,12 +20,36 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
 namespace pi {
 
+void *loadOsLibrary(const std::string &LibraryPath) {
+  // Tells the system to not display the critical-error-handler message box.
+  // Instead, the system sends the error to the calling process.
+  // This is crucial for graceful handling of shared libs that can't be
+  // loaded, e.g. due to missing native run-times.
+
+  UINT SavedMode = SetErrorMode(SEM_FAILCRITICALERRORS);
+  // Exclude current directory from DLL search path
+  if (!SetDllDirectoryA("")) {
+    assert(false && "Failed to update DLL search path");
+  }
+  auto Result = (void *)LoadLibraryA(LibraryPath.c_str());
+  (void)SetErrorMode(SavedMode);
+  if (!SetDllDirectoryA(nullptr)) {
+    assert(false && "Failed to restore DLL search path");
+  }
+
+  return Result;
+}
+
 void *loadOsPluginLibrary(const std::string &PluginPath) {
   // We fetch the preloaded plugin from the pi_win_proxy_loader.
   // The proxy_loader handles any required error suppression.
   auto Result = getPreloadedPlugin(PluginPath);
 
   return Result;
+}
+
+int unloadOsLibrary(void *Library) {
+  return (int)FreeLibrary((HMODULE)Library);
 }
 
 int unloadOsPluginLibrary(void *Library) {

--- a/sycl/test-e2e/OnlineCompiler/online_compiler_L0.cpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_L0.cpp
@@ -7,7 +7,7 @@
 // All Level-Zero specific code is kept here and the common part that can be
 // re-used by other backends is kept in online_compiler_common.hpp file.
 
-#include <sycl/ext/intel/online_compiler.hpp>
+#include <sycl/ext/intel/experimental/online_compiler.hpp>
 #include <sycl/sycl.hpp>
 
 #include <vector>

--- a/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
@@ -8,7 +8,7 @@
 // re-used by other backends is kept in online_compiler_common.hpp file.
 
 #include <sycl/backend/opencl.hpp>
-#include <sycl/ext/intel/online_compiler.hpp>
+#include <sycl/ext/intel/experimental/online_compiler.hpp>
 #include <sycl/sycl.hpp>
 
 #include <vector>

--- a/sycl/test-e2e/OnlineCompiler/online_compiler_common.hpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_common.hpp
@@ -1,4 +1,4 @@
-#include <sycl/ext/intel/online_compiler.hpp>
+#include <sycl/ext/intel/experimental/online_compiler.hpp>
 #include <sycl/sycl.hpp>
 
 #include <iostream>


### PR DESCRIPTION
The online_compiler loads ocloc and was doing so via the function that SYCL uses to load its own Plugins. The win-proxy-loader changes that and loads the plugins earlier. I inadvertently swept the online compiler into that work, which was a mistake. It should be separate. I am restoring that separation here.

I also have a tiny fix to one of the end-to-end tests that merely avoids a deprecation warning, not worth opening a separate PR for that. 