### PR TITLE
[SYCL-MLIR] Change handling of sycl::accessor with target::local

### DIFF
--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -287,12 +287,15 @@ mlir::Type getSYCLType(const clang::RecordType *RT,
             return mlir::sycl::symbolizeTarget(val);
           });
 
-      // The SYCL RT specialize the accessor class for local memory accesses.
-      // That specialization is derived from a non-empty base class, so push it.
-      // TODO: we should push the non-empty base classes in a more general way.
+      // The deprecated sycl::accessor with access::target::local has the same
+      // semantics and restrictions as the sycl::local_accessor and, in the
+      // DPC++ implementation, a layout different from the regular
+      // sycl::accessor, so treat it just like a local_accessor.
       if (MemTargetMode == mlir::sycl::Target::Local) {
         assert(Body.empty());
         Body.push_back(CGT.getMLIRTypeForMem(CTS->bases_begin()->getType()));
+        return mlir::sycl::LocalAccessorType::get(CGT.getModule()->getContext(),
+                                                  Type, Dim, Body);
       }
 
       return mlir::sycl::AccessorType::get(CGT.getModule()->getContext(), Type,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/accessor-local.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/accessor-local.cpp
@@ -1,0 +1,54 @@
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O0 -w %s -o %t.O0.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O1 -w %s -o %t.O1.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O2 -w %s -o %t.O2.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
+
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+
+// Test that the LLVMIR generated is verifiable.
+// RUN: opt -passes=verify -disable-output < %t.bc
+
+// Verify that LLVMIR generated is translatable to SPIRV.
+// RUN: llvm-spirv %t.bc
+
+// Test that all referenced sycl header functions are generated.
+// RUN: llvm-dis %t.bc
+// RUN: cat %t.ll | FileCheck %s --check-prefix=LLVM 
+
+// Test that the kernel named `kernel_stream_triad` is generated with the correct signature.
+// LLVM: define weak_odr spir_kernel void {{.*}}acc_local_kernel
+// LLVM-SAME: (ptr addrspace(3) noundef align 4 %0, ptr noundef byval([[RANGE_TY:%"class.sycl::_V1::range.1"]]) {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[ID_TY:%"class.sycl::_V1::id.1"]]) {{.*}}, ptr addrspace(1) noundef align 4 {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[RANGE_TY]]) {{.*}}, ptr noundef byval([[ID_TY]]) {{.*}})
+
+#include <vector>
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  auto q = sycl::queue{};
+  auto range = sycl::range<1>{256};
+  std::vector<int> data(256, 0);
+  {
+    auto buf = buffer{data};
+    q.submit([&](sycl::handler &cgh) {
+      auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
+      sycl::accessor<int, 1, sycl::access::mode::read_write, target::local>
+          local{8, cgh};
+      cgh.parallel_for<class acc_local_kernel>(
+          nd_range<1>{{256}, {8}}, [=](nd_item<1> item) {
+            auto global_id = item.get_global_id();
+            auto local_id = item.get_local_id();
+            local[local_id] = local_id;
+            acc[global_id] = local[local_id];
+          });
+    });
+  }
+
+  for (int i = 0; i < 256; ++i) {
+    assert(data[i] == (i % 8));
+  }
+
+  return 0;
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -4,7 +4,6 @@
 #include <sycl/sycl.hpp>
 
 // CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_1_i32_rw_l = !sycl.accessor<[1, i32, read_write, local], (!sycl_local_accessor_base_1_i32_rw)>
 // CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
 // CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(memref<?xf32, 1>)>)>
 // CHECK-DAG: !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb = !sycl.accessor<[1, !sycl_vec_i32_4_, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?x!sycl_vec_i32_4_, 1>)>)>
@@ -59,7 +58,7 @@ SYCL_EXTERNAL void accessor_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mo
 
 // COM: Local Accessor Test
 // CHECK-LABEL: func.func @_Z10accessor_4N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2016ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_l> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_l, llvm.noundef}) 
+// CHECK:          %arg0: memref<?x!sycl_local_accessor_1_i32_> {llvm.align = 8 : i64, llvm.byval = !sycl_local_accessor_1_i32_, llvm.noundef}) 
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
 SYCL_EXTERNAL void accessor_4(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::local>) {}
 


### PR DESCRIPTION
The specialization of `sycl::accessor` with `target::local` is a deprecated feature in SYCL 2020 and has the same semantics and restrictions as `sycl::local_accessor`. 

So far, the specialization was treated like a regular `sycl::accessor` in the MLIR compilation flow, causing issues in `KernelDisjointSpecialization` and in lowering of the subscript operator, as the implementation-specific layout of the specialization is very different from regular `sycl::accessor`. 

This patch changes the handling of the `sycl::accessor` specialization with `target::local` to make it identical to the handling of `local_accessor`, resolving the issues in compilation pipeline.