### PR TITLE
[LIBCLC] Remove unnecessary unroll pragma

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/group/collectives.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/group/collectives.cl
@@ -177,7 +177,7 @@ __CLC_SUBGROUP_COLLECTIVE(Any, __CLC_OR, bool, a, true)
     /* Perform InclusiveScan over sub-group results */                         \
     TYPE sg_prefix;                                                            \
     TYPE sg_aggregate = scratch[0];                                            \
-    _Pragma("unroll") for (int s = 1; s < num_sg; ++s) {                       \
+    for (int s = 1; s < num_sg; ++s) {                                         \
       if (sg_id == s) {                                                        \
         sg_prefix = sg_aggregate;                                              \
       }                                                                        \

--- a/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
+++ b/libclc/ptx-nvidiacl/libspirv/group/collectives.cl
@@ -453,7 +453,7 @@ __CLC_SUBGROUP_COLLECTIVE(LogicalAndKHR, __CLC_LOGICAL_AND, bool, true)
   /* Perform InclusiveScan over sub-group results */                           \
   TYPE sg_prefix;                                                              \
   TYPE sg_aggregate = scratch[0];                                              \
-  _Pragma("unroll") for (int s = 1; s < num_sg; ++s) {                         \
+  for (int s = 1; s < num_sg; ++s) {                                           \
     if (sg_id == s) {                                                          \
       sg_prefix = sg_aggregate;                                                \
     }                                                                          \


### PR DESCRIPTION
As the loop count is not statically known and llvm can not guarantee that the target allows remainders, this loop is not unrolled.

Fixes: https://github.com/intel/llvm/issues/9783