### PR TITLE
[SYCL] Add defines for built-in transition

### DIFF
--- a/sycl/include/sycl/builtins.hpp
+++ b/sycl/include/sycl/builtins.hpp
@@ -48,6 +48,274 @@ template <class T, int N> marray<T, N> to_marray(vec<T, N> x) {
 namespace __sycl_std = __host_std;
 #endif
 
+#define __SYCL_DEF_BUILTIN_VEC(TYPE)                                           \
+  __SYCL_BUILTIN_DEF(TYPE##2)                                                  \
+  __SYCL_BUILTIN_DEF(TYPE##3)                                                  \
+  __SYCL_BUILTIN_DEF(TYPE##4)                                                  \
+  __SYCL_BUILTIN_DEF(TYPE##8)                                                  \
+  __SYCL_BUILTIN_DEF(TYPE##16)
+
+#define __SYCL_DEF_BUILTIN_GEOVEC(TYPE)                                        \
+  __SYCL_BUILTIN_DEF(TYPE##2)                                                  \
+  __SYCL_BUILTIN_DEF(TYPE##3)                                                  \
+  __SYCL_BUILTIN_DEF(TYPE##4)
+
+#define __SYCL_DEF_BUILTIN_MARRAY(TYPE)
+
+#define __SYCL_DEF_BUILTIN_CHAR_SCALAR __SYCL_BUILTIN_DEF(char)
+#define __SYCL_DEF_BUILTIN_CHAR_VEC __SYCL_DEF_BUILTIN_VEC(char)
+#define __SYCL_DEF_BUILTIN_CHAR_MARRAY __SYCL_DEF_BUILTIN_MARRAY(char)
+#define __SYCL_DEF_BUILTIN_CHARN                                               \
+  __SYCL_DEF_BUILTIN_CHAR_VEC                                                  \
+  __SYCL_DEF_BUILTIN_CHAR_MARRAY
+#define __SYCL_DEF_BUILTIN_SCHAR_SCALAR __SYCL_BUILTIN_DEF(signed char)
+#define __SYCL_DEF_BUILTIN_SCHAR_VEC __SYCL_DEF_BUILTIN_VEC(schar)
+#define __SYCL_DEF_BUILTIN_SCHAR_MARRAY __SYCL_DEF_BUILTIN_MARRAY(signed char)
+#define __SYCL_DEF_BUILTIN_SCHARN                                              \
+  __SYCL_DEF_BUILTIN_SCHAR_VEC                                                 \
+  __SYCL_DEF_BUILTIN_SCHAR_MARRAY
+#define __SYCL_DEF_BUILTIN_IGENCHAR                                            \
+  __SYCL_DEF_BUILTIN_SCHAR_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_SCHARN
+#define __SYCL_DEF_BUILTIN_UCHAR_SCALAR __SYCL_BUILTIN_DEF(unsigned char)
+#define __SYCL_DEF_BUILTIN_UCHAR_VEC __SYCL_DEF_BUILTIN_VEC(uchar)
+#define __SYCL_DEF_BUILTIN_UCHAR_MARRAY __SYCL_DEF_BUILTIN_MARRAY(unsigned char)
+#define __SYCL_DEF_BUILTIN_UCHARN                                              \
+  __SYCL_DEF_BUILTIN_UCHAR_VEC                                                 \
+  __SYCL_DEF_BUILTIN_UCHAR_MARRAY
+#define __SYCL_DEF_BUILTIN_UGENCHAR                                            \
+  __SYCL_DEF_BUILTIN_UCHAR_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_UCHARN
+// schar{n} and char{n} have the same type, so we skip the char{n} variants.
+#define __SYCL_DEF_BUILTIN_GENCHAR                                             \
+  __SYCL_DEF_BUILTIN_CHAR_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_CHAR_MARRAY                                               \
+  __SYCL_DEF_BUILTIN_IGENCHAR                                                  \
+  __SYCL_DEF_BUILTIN_UGENCHAR
+
+#define __SYCL_DEF_BUILTIN_SHORT_SCALAR __SYCL_BUILTIN_DEF(short)
+#define __SYCL_DEF_BUILTIN_SHORT_VEC __SYCL_DEF_BUILTIN_VEC(short)
+#define __SYCL_DEF_BUILTIN_SHORT_MARRAY __SYCL_DEF_BUILTIN_MARRAY(short)
+#define __SYCL_DEF_BUILTIN_SHORTN                                              \
+  __SYCL_DEF_BUILTIN_SHORT_VEC                                                 \
+  __SYCL_DEF_BUILTIN_SHORT_MARRAY
+#define __SYCL_DEF_BUILTIN_GENSHORT                                            \
+  __SYCL_DEF_BUILTIN_SHORT_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_SHORTN
+#define __SYCL_DEF_BUILTIN_USHORT_SCALAR __SYCL_BUILTIN_DEF(unsigned short)
+#define __SYCL_DEF_BUILTIN_USHORT_VEC __SYCL_DEF_BUILTIN_VEC(ushort)
+#define __SYCL_DEF_BUILTIN_USHORT_MARRAY                                       \
+  __SYCL_DEF_BUILTIN_MARRAY(unsigned short)
+#define __SYCL_DEF_BUILTIN_USHORTN                                             \
+  __SYCL_DEF_BUILTIN_USHORT_VEC                                                \
+  __SYCL_DEF_BUILTIN_USHORT_MARRAY
+#define __SYCL_DEF_BUILTIN_UGENSHORT                                           \
+  __SYCL_DEF_BUILTIN_USHORT_SCALAR                                             \
+  __SYCL_DEF_BUILTIN_USHORTN
+
+#define __SYCL_DEF_BUILTIN_INT_SCALAR __SYCL_BUILTIN_DEF(int)
+#define __SYCL_DEF_BUILTIN_INT_VEC __SYCL_DEF_BUILTIN_VEC(int)
+#define __SYCL_DEF_BUILTIN_INT_MARRAY __SYCL_DEF_BUILTIN_MARRAY(int)
+#define __SYCL_DEF_BUILTIN_INTN                                                \
+  __SYCL_DEF_BUILTIN_INT_VEC                                                   \
+  __SYCL_DEF_BUILTIN_INT_MARRAY
+#define __SYCL_DEF_BUILTIN_GENINT                                              \
+  __SYCL_DEF_BUILTIN_INT_SCALAR                                                \
+  __SYCL_DEF_BUILTIN_INTN
+#define __SYCL_DEF_BUILTIN_UINT_SCALAR __SYCL_BUILTIN_DEF(unsigned int)
+#define __SYCL_DEF_BUILTIN_UINT_VEC __SYCL_DEF_BUILTIN_VEC(uint)
+#define __SYCL_DEF_BUILTIN_UINT_MARRAY __SYCL_DEF_BUILTIN_MARRAY(unsigned int)
+#define __SYCL_DEF_BUILTIN_UINTN                                               \
+  __SYCL_DEF_BUILTIN_UINT_VEC                                                  \
+  __SYCL_DEF_BUILTIN_UINT_MARRAY
+#define __SYCL_DEF_BUILTIN_UGENINT                                             \
+  __SYCL_DEF_BUILTIN_UINT_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_UINTN
+
+#define __SYCL_DEF_BUILTIN_LONG_SCALAR __SYCL_BUILTIN_DEF(long)
+#define __SYCL_DEF_BUILTIN_LONG_VEC __SYCL_DEF_BUILTIN_VEC(long)
+#define __SYCL_DEF_BUILTIN_LONG_MARRAY __SYCL_DEF_BUILTIN_MARRAY(long)
+#define __SYCL_DEF_BUILTIN_LONGN                                               \
+  __SYCL_DEF_BUILTIN_LONG_VEC                                                  \
+  __SYCL_DEF_BUILTIN_LONG_MARRAY
+#define __SYCL_DEF_BUILTIN_GENLONG                                             \
+  __SYCL_DEF_BUILTIN_LONG_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_LONGN
+#define __SYCL_DEF_BUILTIN_ULONG_SCALAR __SYCL_BUILTIN_DEF(unsigned long)
+#define __SYCL_DEF_BUILTIN_ULONG_VEC __SYCL_DEF_BUILTIN_VEC(ulong)
+#define __SYCL_DEF_BUILTIN_ULONG_MARRAY __SYCL_DEF_BUILTIN_MARRAY(unsigned long)
+#define __SYCL_DEF_BUILTIN_ULONGN                                              \
+  __SYCL_DEF_BUILTIN_ULONG_VEC                                                 \
+  __SYCL_DEF_BUILTIN_ULONG_MARRAY
+#define __SYCL_DEF_BUILTIN_UGENLONG                                            \
+  __SYCL_DEF_BUILTIN_ULONG_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_ULONGN
+
+#define __SYCL_DEF_BUILTIN_LONGLONG_SCALAR __SYCL_BUILTIN_DEF(long long)
+#define __SYCL_DEF_BUILTIN_LONGLONG_VEC __SYCL_DEF_BUILTIN_VEC(longlong)
+#define __SYCL_DEF_BUILTIN_LONGLONG_MARRAY __SYCL_DEF_BUILTIN_MARRAY(long long)
+#define __SYCL_DEF_BUILTIN_LONGLONGN                                           \
+  __SYCL_DEF_BUILTIN_LONGLONG_VEC                                              \
+  __SYCL_DEF_BUILTIN_LONGLONG_MARRAY
+#define __SYCL_DEF_BUILTIN_GENLONGLONG                                         \
+  __SYCL_DEF_BUILTIN_LONGLONG_SCALAR                                           \
+  __SYCL_DEF_BUILTIN_LONGLONGN
+#define __SYCL_DEF_BUILTIN_ULONGLONG_SCALAR                                    \
+  __SYCL_BUILTIN_DEF(unsigned long long)
+#define __SYCL_DEF_BUILTIN_ULONGLONG_VEC __SYCL_DEF_BUILTIN_VEC(ulonglong)
+#define __SYCL_DEF_BUILTIN_ULONGLONG_MARRAY                                    \
+  __SYCL_DEF_BUILTIN_MARRAY(unsigned long long)
+#define __SYCL_DEF_BUILTIN_ULONGLONGN                                          \
+  __SYCL_DEF_BUILTIN_ULONGLONG_VEC                                             \
+  __SYCL_DEF_BUILTIN_ULONGLONG_MARRAY
+#define __SYCL_DEF_BUILTIN_UGENLONGLONG                                        \
+  __SYCL_DEF_BUILTIN_ULONGLONG_SCALAR                                          \
+  __SYCL_DEF_BUILTIN_ULONGLONGN
+
+// longlongn and long{n} have the same types, so we only include one here.
+#define __SYCL_DEF_BUILTIN_IGENLONGINTEGER                                     \
+  __SYCL_DEF_BUILTIN_LONG_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_LONG_MARRAY                                               \
+  __SYCL_DEF_BUILTIN_LONGLONG_SCALAR                                           \
+  __SYCL_DEF_BUILTIN_LONGLONG_MARRAY                                           \
+  __SYCL_DEF_BUILTIN_LONG_VEC
+
+// longlong{n} and long{n} have the same types, so we only include one here.
+#define __SYCL_DEF_BUILTIN_UGENLONGINTEGER                                     \
+  __SYCL_DEF_BUILTIN_ULONG_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_ULONG_MARRAY                                              \
+  __SYCL_DEF_BUILTIN_ULONGLONG_SCALAR                                          \
+  __SYCL_DEF_BUILTIN_ULONGLONG_MARRAY                                          \
+  __SYCL_DEF_BUILTIN_ULONG_VEC
+
+#define __SYCL_DEF_BUILTIN_SIGENINTEGER                                        \
+  __SYCL_DEF_BUILTIN_SCHAR_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_SHORT_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_INT_SCALAR                                                \
+  __SYCL_DEF_BUILTIN_LONG_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_LONGLONG_SCALAR
+
+// longlongn and longn have the same types, so we only include one here.
+#define __SYCL_DEF_BUILTIN_VIGENINTEGER                                        \
+  __SYCL_DEF_BUILTIN_CHAR_VEC                                                  \
+  __SYCL_DEF_BUILTIN_SHORT_VEC                                                 \
+  __SYCL_DEF_BUILTIN_INT_VEC                                                   \
+  __SYCL_DEF_BUILTIN_LONG_VEC
+
+#define __SYCL_DEF_BUILTIN_IGENINTEGER                                         \
+  __SYCL_DEF_BUILTIN_IGENCHAR                                                  \
+  __SYCL_DEF_BUILTIN_GENSHORT                                                  \
+  __SYCL_DEF_BUILTIN_GENINT                                                    \
+  __SYCL_DEF_BUILTIN_IGENLONGINTEGER
+
+#define __SYCL_DEF_BUILTIN_SUGENINTEGER                                        \
+  __SYCL_DEF_BUILTIN_UCHAR_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_USHORT_SCALAR                                             \
+  __SYCL_DEF_BUILTIN_UINT_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_ULONG_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_ULONGLONG_SCALAR
+
+// longlongn and longn have the same types, so we only include one here.
+#define __SYCL_DEF_BUILTIN_VUGENINTEGER                                        \
+  __SYCL_DEF_BUILTIN_UCHAR_VEC                                                 \
+  __SYCL_DEF_BUILTIN_USHORT_VEC                                                \
+  __SYCL_DEF_BUILTIN_UINT_VEC                                                  \
+  __SYCL_DEF_BUILTIN_ULONG_VEC
+
+#define __SYCL_DEF_BUILTIN_UGENINTEGER                                         \
+  __SYCL_DEF_BUILTIN_UGENCHAR                                                  \
+  __SYCL_DEF_BUILTIN_UGENSHORT                                                 \
+  __SYCL_DEF_BUILTIN_UGENINT                                                   \
+  __SYCL_DEF_BUILTIN_UGENLONGINTEGER
+
+#define __SYCL_DEF_BUILTIN_SGENINTEGER                                         \
+  __SYCL_DEF_BUILTIN_CHAR_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_SIGENINTEGER                                              \
+  __SYCL_DEF_BUILTIN_SUGENINTEGER
+
+// longlongn and long{n} have the same types, so we only include one here.
+#define __SYCL_DEF_BUILTIN_VGENINTEGER                                         \
+  __SYCL_DEF_BUILTIN_CHAR_VEC                                                  \
+  __SYCL_DEF_BUILTIN_SHORT_VEC                                                 \
+  __SYCL_DEF_BUILTIN_USHORT_VEC                                                \
+  __SYCL_DEF_BUILTIN_INT_VEC                                                   \
+  __SYCL_DEF_BUILTIN_UINT_VEC                                                  \
+  __SYCL_DEF_BUILTIN_LONG_VEC                                                  \
+  __SYCL_DEF_BUILTIN_ULONG_VEC
+
+#define __SYCL_DEF_BUILTIN_GENINTEGER                                          \
+  __SYCL_DEF_BUILTIN_GENCHAR                                                   \
+  __SYCL_DEF_BUILTIN_GENSHORT                                                  \
+  __SYCL_DEF_BUILTIN_UGENSHORT                                                 \
+  __SYCL_DEF_BUILTIN_GENINT                                                    \
+  __SYCL_DEF_BUILTIN_UGENINT                                                   \
+  __SYCL_DEF_BUILTIN_UGENLONGINTEGER                                           \
+  __SYCL_DEF_BUILTIN_IGENLONGINTEGER
+
+#define __SYCL_DEF_BUILTIN_FLOAT_SCALAR __SYCL_BUILTIN_DEF(float)
+#define __SYCL_DEF_BUILTIN_FLOAT_VEC __SYCL_DEF_BUILTIN_VEC(float)
+#define __SYCL_DEF_BUILTIN_FLOAT_GEOVEC __SYCL_DEF_BUILTIN_GEOVEC(float)
+#define __SYCL_DEF_BUILTIN_FLOAT_MARRAY __SYCL_DEF_BUILTIN_MARRAY(float)
+#define __SYCL_DEF_BUILTIN_FLOATN                                              \
+  __SYCL_DEF_BUILTIN_FLOAT_VEC                                                 \
+  __SYCL_DEF_BUILTIN_FLOAT_MARRAY
+#define __SYCL_DEF_BUILTIN_GENFLOATF                                           \
+  __SYCL_DEF_BUILTIN_FLOAT_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_FLOATN
+#define __SYCL_DEF_BUILTIN_GENGEOFLOATF                                        \
+  __SYCL_DEF_BUILTIN_FLOAT_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_FLOAT_GEOVEC
+
+#define __SYCL_DEF_BUILTIN_DOUBLE_SCALAR __SYCL_BUILTIN_DEF(double)
+#define __SYCL_DEF_BUILTIN_DOUBLE_VEC __SYCL_DEF_BUILTIN_VEC(double)
+#define __SYCL_DEF_BUILTIN_DOUBLE_GEOVEC __SYCL_DEF_BUILTIN_GEOVEC(double)
+#define __SYCL_DEF_BUILTIN_DOUBLE_MARRAY __SYCL_DEF_BUILTIN_MARRAY(double)
+#define __SYCL_DEF_BUILTIN_DOUBLEN                                             \
+  __SYCL_DEF_BUILTIN_DOUBLE_VEC                                                \
+  __SYCL_DEF_BUILTIN_DOUBLE_MARRAY
+#define __SYCL_DEF_BUILTIN_GENFLOATD                                           \
+  __SYCL_DEF_BUILTIN_DOUBLE_SCALAR                                             \
+  __SYCL_DEF_BUILTIN_DOUBLEN
+#define __SYCL_DEF_BUILTIN_GENGEOFLOATD                                        \
+  __SYCL_DEF_BUILTIN_DOUBLE_SCALAR                                             \
+  __SYCL_DEF_BUILTIN_DOUBLE_GEOVEC
+
+#define __SYCL_DEF_BUILTIN_HALF_SCALAR __SYCL_BUILTIN_DEF(half)
+#define __SYCL_DEF_BUILTIN_HALF_VEC __SYCL_DEF_BUILTIN_VEC(half)
+#define __SYCL_DEF_BUILTIN_HALF_GEOVEC __SYCL_DEF_BUILTIN_GEOVEC(half)
+#define __SYCL_DEF_BUILTIN_HALF_MARRAY __SYCL_DEF_BUILTIN_MARRAY(half)
+#define __SYCL_DEF_BUILTIN_HALFN                                               \
+  __SYCL_DEF_BUILTIN_HALF_VEC                                                  \
+  __SYCL_DEF_BUILTIN_HALF_MARRAY
+#define __SYCL_DEF_BUILTIN_GENFLOATH                                           \
+  __SYCL_DEF_BUILTIN_HALF_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_HALFN
+#define __SYCL_DEF_BUILTIN_GENGEOFLOATH                                        \
+  __SYCL_DEF_BUILTIN_HALF_SCALAR                                               \
+  __SYCL_DEF_BUILTIN_HALF_GEOVEC
+
+#define __SYCL_DEF_BUILTIN_SGENFLOAT                                           \
+  __SYCL_DEF_BUILTIN_FLOAT_SCALAR                                              \
+  __SYCL_DEF_BUILTIN_DOUBLE_SCALAR                                             \
+  __SYCL_DEF_BUILTIN_HALF_SCALAR
+
+#define __SYCL_DEF_BUILTIN_VGENFLOAT                                           \
+  __SYCL_DEF_BUILTIN_FLOAT_VEC                                                 \
+  __SYCL_DEF_BUILTIN_DOUBLE_VEC                                                \
+  __SYCL_DEF_BUILTIN_HALF_VEC
+
+#define __SYCL_DEF_BUILTIN_GENFLOAT                                            \
+  __SYCL_DEF_BUILTIN_GENFLOATF                                                 \
+  __SYCL_DEF_BUILTIN_GENFLOATD                                                 \
+  __SYCL_DEF_BUILTIN_GENFLOATH
+
+#define __SYCL_DEF_BUILTIN_GENGEOFLOAT                                         \
+  __SYCL_DEF_BUILTIN_GENGEOFLOATF                                              \
+  __SYCL_DEF_BUILTIN_GENGEOFLOATD                                              \
+  __SYCL_DEF_BUILTIN_GENGEOFLOATH
+
+// TODO: Replace with overloads.
+
 #ifdef __FAST_MATH__
 #define __FAST_MATH_GENFLOAT(T)                                                \
   (detail::is_svgenfloatd<T>::value || detail::is_svgenfloath<T>::value)
@@ -57,6 +325,22 @@ namespace __sycl_std = __host_std;
 #define __FAST_MATH_GENFLOAT(T) (detail::is_svgenfloat<T>::value)
 #define __FAST_MATH_SGENFLOAT(T) (detail::is_sgenfloat<T>::value)
 #endif
+
+#ifdef __FAST_MATH__
+#define __SYCL_DEF_BUILTIN_FAST_MATH_GENFLOAT                                  \
+  __SYCL_DEF_BUILTIN_GENFLOATD                                                 \
+  __SYCL_DEF_BUILTIN_GENFLOATH
+#else
+#define __SYCL_DEF_BUILTIN_FAST_MATH_GENFLOAT __SYCL_DEF_BUILTIN_GENFLOAT
+#endif
+
+#define __SYCL_DEF_BUILTIN_SGENTYPE                                            \
+  __SYCL_DEF_BUILTIN_SGENINTEGER                                               \
+  __SYCL_DEF_BUILTIN_SGENFLOAT
+
+#define __SYCL_DEF_BUILTIN_GENTYPE                                             \
+  __SYCL_DEF_BUILTIN_GENINTEGER                                                \
+  __SYCL_DEF_BUILTIN_GENFLOAT
 
 /* ----------------- 4.13.3 Math functions. ---------------------------------*/
 
@@ -2560,6 +2844,103 @@ std::enable_if_t<detail::is_svgenfloatf<T>::value, T> tan(T x) __NOEXC {
 }
 
 #endif // __FAST_MATH__
+
+#undef __SYCL_DEF_BUILTIN_VEC
+#undef __SYCL_DEF_BUILTIN_GEOVEC
+#undef __SYCL_DEF_BUILTIN_MARRAY
+#undef __SYCL_DEF_BUILTIN_CHAR_SCALAR
+#undef __SYCL_DEF_BUILTIN_CHAR_VEC
+#undef __SYCL_DEF_BUILTIN_CHAR_MARRAY
+#undef __SYCL_DEF_BUILTIN_CHARN
+#undef __SYCL_DEF_BUILTIN_SCHAR_SCALAR
+#undef __SYCL_DEF_BUILTIN_SCHAR_VEC
+#undef __SYCL_DEF_BUILTIN_SCHAR_MARRAY
+#undef __SYCL_DEF_BUILTIN_SCHARN
+#undef __SYCL_DEF_BUILTIN_IGENCHAR
+#undef __SYCL_DEF_BUILTIN_UCHAR_SCALAR
+#undef __SYCL_DEF_BUILTIN_UCHAR_VEC
+#undef __SYCL_DEF_BUILTIN_UCHAR_MARRAY
+#undef __SYCL_DEF_BUILTIN_UCHARN
+#undef __SYCL_DEF_BUILTIN_UGENCHAR
+#undef __SYCL_DEF_BUILTIN_GENCHAR
+#undef __SYCL_DEF_BUILTIN_SHORT_SCALAR
+#undef __SYCL_DEF_BUILTIN_SHORT_VEC
+#undef __SYCL_DEF_BUILTIN_SHORT_MARRAY
+#undef __SYCL_DEF_BUILTIN_SHORTN
+#undef __SYCL_DEF_BUILTIN_GENSHORT
+#undef __SYCL_DEF_BUILTIN_USHORT_SCALAR
+#undef __SYCL_DEF_BUILTIN_USHORT_MARRAY
+#undef __SYCL_DEF_BUILTIN_USHORTN
+#undef __SYCL_DEF_BUILTIN_UGENSHORT
+#undef __SYCL_DEF_BUILTIN_INT_SCALAR
+#undef __SYCL_DEF_BUILTIN_INT_VEC
+#undef __SYCL_DEF_BUILTIN_INT_MARRAY
+#undef __SYCL_DEF_BUILTIN_INTN
+#undef __SYCL_DEF_BUILTIN_GENINT
+#undef __SYCL_DEF_BUILTIN_UINT_SCALAR
+#undef __SYCL_DEF_BUILTIN_UINT_VEC
+#undef __SYCL_DEF_BUILTIN_UINT_MARRAY
+#undef __SYCL_DEF_BUILTIN_UINTN
+#undef __SYCL_DEF_BUILTIN_UGENINT
+#undef __SYCL_DEF_BUILTIN_LONG_SCALAR
+#undef __SYCL_DEF_BUILTIN_LONG_VEC
+#undef __SYCL_DEF_BUILTIN_LONG_MARRAY
+#undef __SYCL_DEF_BUILTIN_LONGN
+#undef __SYCL_DEF_BUILTIN_GENLONG
+#undef __SYCL_DEF_BUILTIN_ULONG_SCALAR
+#undef __SYCL_DEF_BUILTIN_ULONG_VEC
+#undef __SYCL_DEF_BUILTIN_ULONG_MARRAY
+#undef __SYCL_DEF_BUILTIN_ULONGN
+#undef __SYCL_DEF_BUILTIN_UGENLONG
+#undef __SYCL_DEF_BUILTIN_LONGLONG_SCALAR
+#undef __SYCL_DEF_BUILTIN_LONGLONG_VEC
+#undef __SYCL_DEF_BUILTIN_LONGLONG_MARRAY
+#undef __SYCL_DEF_BUILTIN_LONGLONGN
+#undef __SYCL_DEF_BUILTIN_GENLONGLONG
+#undef __SYCL_DEF_BUILTIN_ULONGLONG_SCALAR
+#undef __SYCL_DEF_BUILTIN_ULONGLONG_VEC
+#undef __SYCL_DEF_BUILTIN_ULONGLONG_MARRAY
+#undef __SYCL_DEF_BUILTIN_ULONGLONGN
+#undef __SYCL_DEF_BUILTIN_UGENLONGLONG
+#undef __SYCL_DEF_BUILTIN_IGENLONGINTEGER
+#undef __SYCL_DEF_BUILTIN_UGENLONGINTEGER
+#undef __SYCL_DEF_BUILTIN_SIGENINTEGER
+#undef __SYCL_DEF_BUILTIN_VIGENINTEGER
+#undef __SYCL_DEF_BUILTIN_IGENINTEGER
+#undef __SYCL_DEF_BUILTIN_SUGENINTEGER
+#undef __SYCL_DEF_BUILTIN_VUGENINTEGER
+#undef __SYCL_DEF_BUILTIN_UGENINTEGER
+#undef __SYCL_DEF_BUILTIN_SGENINTEGER
+#undef __SYCL_DEF_BUILTIN_VGENINTEGER
+#undef __SYCL_DEF_BUILTIN_GENINTEGER
+#undef __SYCL_DEF_BUILTIN_FLOAT_SCALAR
+#undef __SYCL_DEF_BUILTIN_FLOAT_VEC
+#undef __SYCL_DEF_BUILTIN_FLOAT_GEOVEC
+#undef __SYCL_DEF_BUILTIN_FLOAT_MARRAY
+#undef __SYCL_DEF_BUILTIN_FLOATN
+#undef __SYCL_DEF_BUILTIN_GENFLOATF
+#undef __SYCL_DEF_BUILTIN_GENGEOFLOATF
+#undef __SYCL_DEF_BUILTIN_DOUBLE_SCALAR
+#undef __SYCL_DEF_BUILTIN_DOUBLE_VEC
+#undef __SYCL_DEF_BUILTIN_DOUBLE_GEOVEC
+#undef __SYCL_DEF_BUILTIN_DOUBLE_MARRAY
+#undef __SYCL_DEF_BUILTIN_DOUBLEN
+#undef __SYCL_DEF_BUILTIN_GENFLOATD
+#undef __SYCL_DEF_BUILTIN_GENGEOFLOATD
+#undef __SYCL_DEF_BUILTIN_HALF_SCALAR
+#undef __SYCL_DEF_BUILTIN_HALF_VEC
+#undef __SYCL_DEF_BUILTIN_HALF_GEOVEC
+#undef __SYCL_DEF_BUILTIN_HALF_MARRAY
+#undef __SYCL_DEF_BUILTIN_HALFN
+#undef __SYCL_DEF_BUILTIN_GENFLOATH
+#undef __SYCL_DEF_BUILTIN_GENGEOFLOATH
+#undef __SYCL_DEF_BUILTIN_SGENFLOAT
+#undef __SYCL_DEF_BUILTIN_VGENFLOAT
+#undef __SYCL_DEF_BUILTIN_GENFLOAT
+#undef __SYCL_DEF_BUILTIN_GENGEOFLOAT
+#undef __SYCL_DEF_BUILTIN_FAST_MATH_GENFLOAT
+#undef __SYCL_DEF_BUILTIN_SGENTYPE
+#undef __SYCL_DEF_BUILTIN_GENTYPE
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
 


### PR DESCRIPTION
We are going to change built-ins implementation from templates to overloads according to KhronosGroup/SYCL-Docs#428. This patch is intended to unblock the parallel transition of the different groups of built-ins.