### PR TITLE
[SYCL-MLIR] Define `sycl.id.constructor` operation

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -59,6 +59,13 @@ class SYCLMethodOpInterfaceImpl<
   }];
 }
 
+class SYCLConstructor<string name, list<Trait> traits = []>
+    : SYCL_Op<name # ".constructor", traits # [MemoryEffectsOpInterface]> {
+  let assemblyFormat = [{
+    `(` operands `)` attr-dict `:` functional-type(operands, results)
+  }];
+}
+
 ////////////////////////////////////////////////////////////////////////////////
 // TRAIT DECLARATIONS
 ////////////////////////////////////////////////////////////////////////////////
@@ -608,6 +615,45 @@ def SYCLNdRangeGetGroupRange
   let extraClassDeclaration = extraClassDeclarationBase;
 
   let results = (outs SYCL_RangeType:$Res);
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// id.constructor OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLIDConstructorOp : SYCLConstructor<"id"> {
+  let summary = "Operation returning a new sycl.id value";
+  let description = [{
+    This operation creates a new `sycl.id`. The following signatures are
+    provided:
+    ```mlir
+    # 0-initialize object:
+    () -> memref<1x!sycl_id_N>
+    # Initialize each dimension:
+    (index) -> memref<1x!sycl_id_1>
+    (index, index) -> memref<1x!sycl_id_2>
+    (index, index, index) -> memref<1x!sycl_id_3>
+    # Copy the dimensions of the input:
+    (memref<?x!sycl_id_N>) -> memref<1x!sycl_id_N>
+    (memref<?x!sycl_range_N>) -> memref<1x!sycl_id_N>
+    # Construct from `sycl.item.get_id`'s result:
+    (memref<?x!sycl_item_N>) -> memref<1x!sycl_item_N>
+    ```
+    In addition of initializing the values, this operation also allocates the
+    object.
+  }];
+  let arguments = (ins Arg<Variadic<AnyType>, "Constructor arguments">:$Args);
+  let results =
+      (outs Res<MemRefRankOf<[SYCL_IDType], [1]>, "constructed object">:$id);
+  let extraClassDeclaration = [{
+    /// Return the memory effects associated to each argument.
+    ///
+    /// Each argument will have `MemoryEffects::Read` if they're a
+    /// pointer/memref and no memory effect otherwise.
+    void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+                        ::mlir::MemoryEffects::Effect>> &effects);
+  }];
+  let hasVerifier = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -610,6 +610,34 @@ public:
   }
 };
 
+/// Base pattern for operations implementing a specific constructor for a type,
+/// i.e., `sycl.ty.constructor`.
+template <typename Op>
+class BaseConstructorPattern : public ConvertOpToLLVMPattern<Op> {
+protected:
+  using typename ConvertOpToLLVMPattern<Op>::OpAdaptor;
+  using ConvertOpToLLVMPattern<Op>::ConvertOpToLLVMPattern;
+
+  virtual void initialize(Value alloca, Op op, OpAdaptor adaptor,
+                          OpBuilder &builder) const = 0;
+
+public:
+  virtual ~BaseConstructorPattern() = default;
+
+  void rewrite(Op op, OpAdaptor adaptor,
+               ConversionPatternRewriter &rewriter) const final {
+    LLVMTypeConverter *typeConverter =
+        ConvertOpToLLVMPattern<Op>::getTypeConverter();
+    Type ET = typeConverter->convertType(op.getType().getElementType());
+    // The constructor value corresponds with the value defined by the alloca
+    // operation.
+    Value alloca = rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
+        op, typeConverter->getPointerType(ET), ET,
+        rewriter.create<arith::ConstantIntOp>(op.getLoc(), 1, 32));
+    initialize(alloca, op, adaptor, rewriter);
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Type conversion
 //===----------------------------------------------------------------------===//
@@ -2106,6 +2134,194 @@ public:
 };
 
 //===----------------------------------------------------------------------===//
+// IDConstructor - Convert `sycl.id.constructor` to LLVM.
+//===----------------------------------------------------------------------===//
+
+// () -> memref<1x!sycl_id_N_>
+class IDDefaultConstructorPattern
+    : public BaseConstructorPattern<SYCLIDConstructorOp> {
+public:
+  using BaseConstructorPattern<SYCLIDConstructorOp>::BaseConstructorPattern;
+
+  LogicalResult match(SYCLIDConstructorOp op) const final {
+    return success(op.getOperands().empty());
+  }
+
+protected:
+  // We can simply zero-initialize the array using `llvm.intr.memset`.
+  void initialize(Value alloca, SYCLIDConstructorOp op, OpAdaptor adaptor,
+                  OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    Value zero = builder.create<LLVM::ConstantOp>(loc, builder.getI8Type(), 0);
+    unsigned dimension = getDimensions(op.getId().getType());
+    unsigned indexWidth =
+        BaseConstructorPattern<SYCLIDConstructorOp>::getTypeConverter()
+            ->getIndexTypeBitwidth();
+    Value len = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
+                                                 dimension * indexWidth / 8);
+    Value isVolatile =
+        builder.create<LLVM::ConstantOp>(loc, builder.getI1Type(), 0);
+    builder.create<LLVM::MemsetOp>(loc, alloca, zero, len, isVolatile);
+  }
+};
+
+// (!memref<?x!sycl_id_N_) -> !memref<?x!sycl_id_N_>
+class IDCopyConstructorPattern
+    : public BaseConstructorPattern<SYCLIDConstructorOp> {
+public:
+  using BaseConstructorPattern<SYCLIDConstructorOp>::BaseConstructorPattern;
+
+  LogicalResult match(SYCLIDConstructorOp op) const final {
+    OperandRange::type_range types = op.getOperands().getTypes();
+    if (types.size() != 1)
+      return failure();
+    auto MT = dyn_cast<MemRefType>(types.front());
+    return success(MT && isa<IDType>(MT.getElementType()));
+  }
+
+protected:
+  // We can simply copy the source array into the new one using
+  // `llvm.intr.memcpy`.
+  void initialize(Value alloca, SYCLIDConstructorOp op, OpAdaptor adaptor,
+                  OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    Value src = adaptor.getOperands()[0];
+    unsigned dimension = getDimensions(op.getId().getType());
+    unsigned indexWidth =
+        BaseConstructorPattern<SYCLIDConstructorOp>::getTypeConverter()
+            ->getIndexTypeBitwidth();
+    Value len = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
+                                                 dimension * indexWidth / 8);
+    Value isVolatile =
+        builder.create<LLVM::ConstantOp>(loc, builder.getI1Type(), 0);
+    builder.create<LLVM::MemcpyOp>(loc, alloca, src, len, isVolatile);
+  }
+};
+
+class IDConstructorBase : public BaseConstructorPattern<SYCLIDConstructorOp> {
+public:
+  using BaseConstructorPattern<SYCLIDConstructorOp>::BaseConstructorPattern;
+
+protected:
+  /// Returns a vector with the values the array should be initialized with.
+  virtual SmallVector<Value> getValues(SYCLIDConstructorOp op,
+                                       OpAdaptor adaptor,
+                                       OpBuilder &builder) const = 0;
+
+  // We will initialize each element of the new allocated array using
+  // `sycl.id.get` and `llvm.store`.
+  void initialize(Value alloca, SYCLIDConstructorOp op, OpAdaptor adaptor,
+                  OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    // We need a `sycl` type to use `sycl.id.get`, so we
+    // `unrealized_conversion_cast` the allocated value.
+    alloca =
+        builder.create<UnrealizedConversionCastOp>(loc, op.getType(), alloca)
+            .getOutputs()[0];
+    SmallVector<Value> values = getValues(op, adaptor, builder);
+    auto MT =
+        MemRefType::get(/*shape=*/ShapedType::kDynamic, builder.getIndexType());
+    Type PT = ConvertOpToLLVMPattern<SYCLIDConstructorOp>::getTypeConverter()
+                  ->convertType(MT);
+    Type i32Ty = builder.getI32Type();
+    for (const auto &[i, value] : llvm::enumerate(values)) {
+      Value offset = builder.create<LLVM::ConstantOp>(loc, i32Ty, i);
+      Value ptr = builder.create<SYCLIDGetOp>(loc, MT, alloca, offset);
+      /// Avoid inserting operations from the `memref` dialect by inserting this
+      /// `unrealized_conversion_cast`:
+      ptr = builder.create<UnrealizedConversionCastOp>(loc, PT, ptr)
+                .getOutputs()[0];
+      builder.create<LLVM::StoreOp>(loc, value, ptr);
+    }
+  }
+};
+
+// ({index}N) -> memref<1x!sycl_id_N_>
+class IDIndexConstructorPattern : public IDConstructorBase {
+public:
+  using IDConstructorBase::IDConstructorBase;
+
+  LogicalResult match(SYCLIDConstructorOp op) const final {
+    OperandRange::type_range types = op.getOperands().getTypes();
+    return success(!types.empty() && llvm::all_of(types, [](Type ty) {
+      return isa<IndexType>(ty);
+    }));
+  }
+
+protected:
+  SmallVector<Value> getValues(SYCLIDConstructorOp op, OpAdaptor adaptor,
+                               OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    SmallVector<Value> values;
+    Type indexTy =
+        ConvertOpToLLVMPattern<SYCLIDConstructorOp>::getTypeConverter()
+            ->getIndexType();
+    llvm::transform(
+        adaptor.getOperands(), std::back_inserter(values), [&](Value val) {
+          return builder.create<UnrealizedConversionCastOp>(loc, indexTy, val)
+              .getOutputs()[0];
+        });
+    return values;
+  }
+};
+
+/// Base class for `sycl.id.constructor` signatures receiving a pointer to an
+/// object.
+template <typename SrcTy, typename OpTy>
+class IDStructConstructorPattern : public IDConstructorBase {
+public:
+  using IDConstructorBase::IDConstructorBase;
+
+  LogicalResult match(SYCLIDConstructorOp op) const final {
+    OperandRange::type_range types = op.getOperands().getTypes();
+    if (types.size() != 1)
+      return failure();
+    auto MT = dyn_cast<MemRefType>(types.front());
+    return success(MT && isa<SrcTy>(MT.getElementType()));
+  }
+
+protected:
+  SmallVector<Value> getValues(SYCLIDConstructorOp op, OpAdaptor adaptor,
+                               OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    SmallVector<Value> values;
+    Type i32Ty = builder.getI32Type();
+    Type indexTy =
+        ConvertOpToLLVMPattern<SYCLIDConstructorOp>::getTypeConverter()
+            ->getIndexType();
+    auto srcTy = cast<SrcTy>(
+        cast<MemRefType>(op.getOperands()[0].getType()).getElementType());
+    Value orig =
+        builder
+            .create<UnrealizedConversionCastOp>(
+                loc, op.getOperands()[0].getType(), adaptor.getOperands()[0])
+            .getOutputs()[0];
+    for (unsigned i = 0, dimension = srcTy.getDimension(); i < dimension; ++i) {
+      Value offset = builder.create<LLVM::ConstantOp>(loc, i32Ty, i);
+      Value val = builder.create<OpTy>(loc, indexTy, orig, offset);
+      values.push_back(val);
+    }
+    return values;
+  }
+};
+
+// (!memref<?x!sycl_item_N_) -> !memref<?x!sycl_item_N_>
+class IDItemConstructorPattern
+    : public IDStructConstructorPattern<ItemType, SYCLItemGetIDOp> {
+public:
+  using IDStructConstructorPattern<ItemType,
+                                   SYCLItemGetIDOp>::IDStructConstructorPattern;
+};
+
+// (!memref<?x!sycl_range_N_) -> !memref<?x!sycl_range_N_>
+class IDRangeConstructorPattern
+    : public IDStructConstructorPattern<RangeType, SYCLRangeGetOp> {
+public:
+  using IDStructConstructorPattern<RangeType,
+                                   SYCLRangeGetOp>::IDStructConstructorPattern;
+};
+
+//===----------------------------------------------------------------------===//
 // GroupGetGroupRange - Converts `sycl.group.get_group_range` to LLVM.
 //===----------------------------------------------------------------------===//
 
@@ -2390,32 +2606,33 @@ populateSYCLToLLVMSPIRConversionPatterns(LLVMTypeConverter &typeConverter,
   patterns.add<CallPattern>(typeConverter);
   patterns.add<CastPattern>(typeConverter);
   patterns.add<BarePtrCastPattern>(typeConverter, /*benefit*/ 2);
-  patterns.add<AccessorGetPointerPattern, AccessorGetRangePattern,
-               AccessorSizePattern, AddZeroArgPattern<SYCLIDGetOp>,
-               AddZeroArgPattern<SYCLItemGetIDOp>, AtomicSubscriptIDOffset,
-               BarePtrAddrSpaceCastPattern, GroupGetGroupIDPattern,
-               GroupGetGroupLinearRangePattern, GroupGetGroupRangeDimPattern,
-               GroupGetLocalIDPattern, GroupGetLocalLinearRangePattern,
-               GroupGetLocalRangeDimPattern, IDGetPattern, IDGetRefPattern,
-               ItemGetIDDimPattern, ItemGetRangeDimPattern, ItemGetRangePattern,
-               NDItemGetGlobalIDDimPattern, NDItemGetGlobalIDPattern,
-               NDItemGetGlobalRangeDimPattern, NDItemGetGlobalRangePattern,
-               NDItemGetGroupPattern, NDItemGetGroupRangeDimPattern,
-               NDItemGetLocalIDDimPattern, NDItemGetLocalLinearIDPattern,
-               NDItemGetNDRange, NDRangeGetGroupRangePattern,
-               NDRangeGetLocalRangePattern, RangeGetRefPattern,
-               RangeSizePattern, SubscriptScalarOffsetND,
-               GroupGetGroupIDDimPattern, GroupGetGroupLinearIDPattern,
-               GroupGetGroupRangePattern, GroupGetLocalIDDimPattern,
-               GroupGetLocalLinearIDPattern, GroupGetLocalRangePattern,
-               GroupGetMaxLocalRangePattern, ItemGetIDPattern,
-               ItemNoOffsetGetLinearIDPattern, ItemOffsetGetLinearIDPattern,
-               NDItemGetGlobalLinearIDPattern, NDItemGetGroupDimPattern,
-               NDItemGetGroupLinearIDPattern, NDItemGetGroupRangePattern,
-               NDItemGetLocalIDPattern, NDItemGetLocalRangeDimPattern,
-               NDItemGetLocalRangePattern, NDRangeGetGlobalRangePattern,
-               RangeGetPattern, SubscriptIDOffset, SubscriptScalarOffset1D>(
-      typeConverter);
+  patterns.add<
+      AccessorGetPointerPattern, AccessorGetRangePattern, AccessorSizePattern,
+      AddZeroArgPattern<SYCLIDGetOp>, AddZeroArgPattern<SYCLItemGetIDOp>,
+      AtomicSubscriptIDOffset, BarePtrAddrSpaceCastPattern,
+      GroupGetGroupIDPattern, GroupGetGroupLinearRangePattern,
+      GroupGetGroupRangeDimPattern, GroupGetLocalIDPattern,
+      GroupGetLocalLinearRangePattern, GroupGetLocalRangeDimPattern,
+      IDCopyConstructorPattern, IDDefaultConstructorPattern,
+      IDIndexConstructorPattern, IDItemConstructorPattern,
+      IDRangeConstructorPattern, IDGetPattern, IDGetRefPattern,
+      ItemGetIDDimPattern, ItemGetRangeDimPattern, ItemGetRangePattern,
+      NDItemGetGlobalIDDimPattern, NDItemGetGlobalIDPattern,
+      NDItemGetGlobalRangeDimPattern, NDItemGetGlobalRangePattern,
+      NDItemGetGroupPattern, NDItemGetGroupRangeDimPattern,
+      NDItemGetLocalIDDimPattern, NDItemGetLocalLinearIDPattern,
+      NDItemGetNDRange, NDRangeGetGroupRangePattern,
+      NDRangeGetLocalRangePattern, RangeGetRefPattern, RangeSizePattern,
+      SubscriptScalarOffsetND, GroupGetGroupIDDimPattern,
+      GroupGetGroupLinearIDPattern, GroupGetGroupRangePattern,
+      GroupGetLocalIDDimPattern, GroupGetLocalLinearIDPattern,
+      GroupGetLocalRangePattern, GroupGetMaxLocalRangePattern, ItemGetIDPattern,
+      ItemNoOffsetGetLinearIDPattern, ItemOffsetGetLinearIDPattern,
+      NDItemGetGlobalLinearIDPattern, NDItemGetGroupDimPattern,
+      NDItemGetGroupLinearIDPattern, NDItemGetGroupRangePattern,
+      NDItemGetLocalIDPattern, NDItemGetLocalRangeDimPattern,
+      NDItemGetLocalRangePattern, NDRangeGetGlobalRangePattern, RangeGetPattern,
+      SubscriptIDOffset, SubscriptScalarOffset1D>(typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
 }
 

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -219,8 +219,9 @@ void SYCLIDConstructorOp::getEffects(
     }
   }
   // The result will be allocated
-  effects.emplace_back(MemoryEffects::Allocate::get(), getId(),
-                       defaultResource);
+  Value id = getId();
+  effects.emplace_back(MemoryEffects::Allocate::get(), id, defaultResource);
+  effects.emplace_back(MemoryEffects::Write::get(), id, defaultResource);
 }
 
 LogicalResult SYCLIDConstructorOp::verify() {

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -12,6 +12,7 @@
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
 #include "mlir/IR/OpImplementation.h"
+#include "mlir/Support/LLVM.h"
 #include "llvm/ADT/TypeSwitch.h"
 
 using namespace mlir;
@@ -205,6 +206,56 @@ void SYCLConstructorOp::getEffects(
       effects.emplace_back(MemoryEffects::Read::get(), value, defaultResource);
     }
   }
+}
+
+void SYCLIDConstructorOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  auto *defaultResource = SideEffects::DefaultResource::get();
+  // All of the arguments will be scalar or read from
+  for (auto value : getArgs()) {
+    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType())) {
+      effects.emplace_back(MemoryEffects::Read::get(), value, defaultResource);
+    }
+  }
+  // The result will be allocated
+  effects.emplace_back(MemoryEffects::Allocate::get(), getId(),
+                       defaultResource);
+}
+
+LogicalResult SYCLIDConstructorOp::verify() {
+  OperandRange::type_range argTypes = getArgs().getTypes();
+  if (argTypes.empty()) {
+    // sycl.id.constructor() -> memref<1x!sycl_id_N>
+    return success();
+  }
+  MemRefType type = getId().getType();
+  unsigned dimensions = getDimensions(type);
+  if (llvm::all_of(argTypes, [](Type type) { return isa<IndexType>(type); })) {
+    // sycl.id.constructor({index}N) -> memref<1x!sycl_id_N>
+    if (argTypes.size() != dimensions) {
+      return emitOpError("expects to be passed the same number of 'index' "
+                         "numbers as the number of dimensions of the input: ")
+             << argTypes.size() << " vs " << dimensions;
+    }
+    return success();
+  }
+  if (argTypes.size() == 1) {
+    if (auto MT = dyn_cast<MemRefType>(argTypes.front());
+        MT && isa<IDType, ItemType, RangeType>(MT.getElementType())) {
+      // sycl.id.constructor(memref<?x!sycl_[id|item|range]_N>) ->
+      // memref<1x!sycl_id_N>
+      unsigned argDimensions = getDimensions(MT);
+      if (dimensions != argDimensions) {
+        return emitOpError("expects input and output to have the same number "
+                           "of dimensions: ")
+               << argDimensions << " vs " << dimensions;
+      }
+      return success();
+    }
+  }
+  return emitOpError(
+      "expects a different signature. Check documentation for details");
 }
 
 #define GET_OP_CLASSES

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -218,7 +218,7 @@ void SYCLIDConstructorOp::getEffects(
       effects.emplace_back(MemoryEffects::Read::get(), value, defaultResource);
     }
   }
-  // The result will be allocated
+  // The result will be allocated and written to
   Value id = getId();
   effects.emplace_back(MemoryEffects::Allocate::get(), id, defaultResource);
   effects.emplace_back(MemoryEffects::Write::get(), id, defaultResource);

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructors-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructors-to-llvm.mlir
@@ -1,0 +1,254 @@
+// RUN: sycl-mlir-opt -convert-sycl-to-llvm='use-opaque-pointers=1' -reconcile-unrealized-casts %s | FileCheck %s
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>
+!sycl_item_2_ = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
+!sycl_item_3_ = !sycl.item<[3, false], (!sycl.item_base<[3, false], (!sycl_range_3_, !sycl_id_3_)>)>
+
+// CHECK-LABEL:   llvm.func @id_default() -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, i8, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_6]], %[[VAL_7]], %[[VAL_8]], %[[VAL_9]]) : (!llvm.ptr, i8, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_10]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_11]], %[[VAL_12]], %[[VAL_13]], %[[VAL_14]]) : (!llvm.ptr, i8, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.insertvalue %[[VAL_1]], %[[VAL_15]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_16]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_11]], %[[VAL_17]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @id_default()
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor() : () -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor() : () -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL:   llvm.func @id_index(
+// CHECK-SAME:                        %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_6]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_10]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_12]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.alloca %[[VAL_13]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_14]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_16]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_14]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_18]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_14]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_20]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_22:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_21]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_22]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_24:.*]] = llvm.insertvalue %[[VAL_14]], %[[VAL_23]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_24]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @id_index(%arg0: index, %arg1: index, %arg2: index)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (index) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg0, %arg1)
+      : (index, index) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg0, %arg1, %arg2)
+      : (index, index, index) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL:   llvm.func @id_range(
+// CHECK-SAME:                        %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr) -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_7]], %[[VAL_9]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_10]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.getelementptr inbounds %[[VAL_11]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_14]], %[[VAL_19]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_11]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_17]], %[[VAL_21]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_22:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_23:.*]] = llvm.alloca %[[VAL_22]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_24:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_25:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_27:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_28:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_29:.*]] = llvm.load %[[VAL_28]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_30:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:      %[[VAL_31:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      %[[VAL_32:.*]] = llvm.load %[[VAL_31]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_33:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_34:.*]] = llvm.getelementptr inbounds %[[VAL_23]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_26]], %[[VAL_34]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_35:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_23]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_29]], %[[VAL_36]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_37:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:      %[[VAL_38:.*]] = llvm.getelementptr inbounds %[[VAL_23]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_32]], %[[VAL_38]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_39:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_40:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_39]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_41:.*]] = llvm.insertvalue %[[VAL_11]], %[[VAL_40]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_42:.*]] = llvm.insertvalue %[[VAL_23]], %[[VAL_41]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_42]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @id_range(%arg0: memref<?x!sycl_range_1_>,
+                    %arg1: memref<?x!sycl_range_2_>,
+                    %arg2: memref<?x!sycl_range_3_>)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (memref<?x!sycl_range_1_>) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg1)
+      : (memref<?x!sycl_range_2_>) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg2)
+      : (memref<?x!sycl_range_3_>) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL:   llvm.func @id_item(
+// CHECK-SAME:                       %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr) -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::item.1.false", (struct<"struct.sycl::_V1::detail::ItemBase.1.false", (struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>)>
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_7]], %[[VAL_9]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_10]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 1, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::item.2.false", (struct<"struct.sycl::_V1::detail::ItemBase.2.false", (struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>)>
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.load %[[VAL_13]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::item.2.false", (struct<"struct.sycl::_V1::detail::ItemBase.2.false", (struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>)>)>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.load %[[VAL_16]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.getelementptr inbounds %[[VAL_11]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_14]], %[[VAL_19]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.getelementptr inbounds %[[VAL_11]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_17]], %[[VAL_21]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_22:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_23:.*]] = llvm.alloca %[[VAL_22]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_24:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_25:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 1, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::item.3.false", (struct<"struct.sycl::_V1::detail::ItemBase.3.false", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>)>
+// CHECK-NEXT:      %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_27:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_28:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::item.3.false", (struct<"struct.sycl::_V1::detail::ItemBase.3.false", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>)>
+// CHECK-NEXT:      %[[VAL_29:.*]] = llvm.load %[[VAL_28]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_30:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:      %[[VAL_31:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0, 1, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::item.3.false", (struct<"struct.sycl::_V1::detail::ItemBase.3.false", (struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>)>)>
+// CHECK-NEXT:      %[[VAL_32:.*]] = llvm.load %[[VAL_31]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_33:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_34:.*]] = llvm.getelementptr inbounds %[[VAL_23]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_26]], %[[VAL_34]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_35:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_36:.*]] = llvm.getelementptr inbounds %[[VAL_23]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_29]], %[[VAL_36]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_37:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:      %[[VAL_38:.*]] = llvm.getelementptr inbounds %[[VAL_23]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_32]], %[[VAL_38]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_39:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_40:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_39]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_41:.*]] = llvm.insertvalue %[[VAL_11]], %[[VAL_40]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_42:.*]] = llvm.insertvalue %[[VAL_23]], %[[VAL_41]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_42]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @id_item(%arg0: memref<?x!sycl_item_1_>,
+                   %arg1: memref<?x!sycl_item_2_>,
+                   %arg2: memref<?x!sycl_item_3_>)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (memref<?x!sycl_item_1_>) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg1)
+      : (memref<?x!sycl_item_2_>) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg2)
+      : (memref<?x!sycl_item_3_>) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL:   llvm.func @id_id(
+// CHECK-SAME:                     %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr) -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_0]], %[[VAL_5]], %[[VAL_6]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_8]], %[[VAL_1]], %[[VAL_9]], %[[VAL_10]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_12]], %[[VAL_2]], %[[VAL_13]], %[[VAL_14]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_15]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_16]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_17]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @id_id(%arg0: memref<?x!sycl_id_1_>,
+                 %arg1: memref<?x!sycl_id_2_>,
+                 %arg2: memref<?x!sycl_id_3_>)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (memref<?x!sycl_id_1_>) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg1)
+      : (memref<?x!sycl_id_2_>) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg2)
+      : (memref<?x!sycl_id_3_>) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}

--- a/mlir-sycl/test/Dialect/SYCL/constructors.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/constructors.mlir
@@ -1,0 +1,80 @@
+// RUN: sycl-mlir-opt %s | sycl-mlir-opt | FileCheck %s
+// RUN: sycl-mlir-opt %s --mlir-print-op-generic | sycl-mlir-opt | FileCheck %s
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_item_1_ = !sycl.item<[1, false], (!sycl.item_base<[1, false], (!sycl_range_1_, !sycl_id_1_)>)>
+!sycl_item_2_ = !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2_, !sycl_id_2_)>)>
+!sycl_item_3_ = !sycl.item<[3, false], (!sycl.item_base<[3, false], (!sycl_range_3_, !sycl_id_3_)>)>
+
+// CHECK-LABEL: func.func @id_default
+func.func @id_default()
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor() : () -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor() : () -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL: func.func @id_index
+func.func @id_index(%arg0: index, %arg1: index, %arg2: index)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (index) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg0, %arg1)
+      : (index, index) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg0, %arg1, %arg2)
+      : (index, index, index) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL: func.func @id_range
+func.func @id_range(%arg0: memref<?x!sycl_range_1_>,
+                    %arg1: memref<?x!sycl_range_2_>,
+                    %arg2: memref<?x!sycl_range_3_>)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (memref<?x!sycl_range_1_>) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg1)
+      : (memref<?x!sycl_range_2_>) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg2)
+      : (memref<?x!sycl_range_3_>) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL: func.func @id_item
+func.func @id_item(%arg0: memref<?x!sycl_item_1_>,
+                   %arg1: memref<?x!sycl_item_2_>,
+                   %arg2: memref<?x!sycl_item_3_>)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (memref<?x!sycl_item_1_>) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg1)
+      : (memref<?x!sycl_item_2_>) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg2)
+      : (memref<?x!sycl_item_3_>) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}
+
+// CHECK-LABEL: func.func @id_id
+func.func @id_id(%arg0: memref<?x!sycl_id_1_>,
+                 %arg1: memref<?x!sycl_id_2_>,
+                 %arg2: memref<?x!sycl_id_3_>)
+    -> (memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>) {
+  %id1 = sycl.id.constructor(%arg0)
+      : (memref<?x!sycl_id_1_>) -> memref<1x!sycl_id_1_>
+  %id2 = sycl.id.constructor(%arg1)
+      : (memref<?x!sycl_id_2_>) -> memref<1x!sycl_id_2_>
+  %id3 = sycl.id.constructor(%arg2)
+      : (memref<?x!sycl_id_3_>) -> memref<1x!sycl_id_3_>
+  func.return %id1, %id2, %id3
+      : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -314,3 +314,36 @@ func.func @test_host_constructor() -> !llvm.ptr {
   %0 = sycl.host.constructor() {type = i32} : () -> !llvm.ptr
   return %0 : !llvm.ptr
 }
+
+// -----
+
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+
+func.func @test_id_constructor_index_wrong_dims(%arg0: index)
+    -> memref<1x!sycl_id_2_> {
+// expected-error @below {{'sycl.id.constructor' op expects to be passed the same number of 'index' numbers as the number of dimensions of the input: 1 vs 2}}
+  %0 = sycl.id.constructor(%arg0) : (index) -> memref<1x!sycl_id_2_>
+  func.return %0 : memref<1x!sycl_id_2_>
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+
+func.func @test_id_constructor_wrong_copy_dims(%arg: memref<?x!sycl_id_2_>)
+    -> memref<1x!sycl_id_1_> {
+// expected-error @below {{'sycl.id.constructor' op expects input and output to have the same number of dimensions: 2 vs 1}}
+  %0 = sycl.id.constructor(%arg) : (memref<?x!sycl_id_2_>) -> memref<1x!sycl_id_1_>
+  func.return %0 : memref<1x!sycl_id_1_>
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+
+func.func @test_id_constructor_wrong_sign(%arg: i32) -> memref<1x!sycl_id_1_> {
+// expected-error @below {{'sycl.id.constructor' op expects a different signature. Check documentation for details}}
+  %0 = sycl.id.constructor(%arg) : (i32) -> memref<1x!sycl_id_1_>
+  func.return %0 : memref<1x!sycl_id_1_>
+}


### PR DESCRIPTION
This operation creates a new `sycl.id`. The following signatures are provided:

```mlir
() -> memref<1x!sycl_id_N>
(index) -> memref<1x!sycl_id_1>
(index, index) -> memref<1x!sycl_id_2>
(index, index, index) -> memref<1x!sycl_id_3>
(memref<?x!sycl_id_N>) -> memref<1x!sycl_id_N>
(memref<?x!sycl_range_N>) -> memref<1x!sycl_id_N>
(memref<?x!sycl_item_N>) -> memref<1x!sycl_item_N>
```

In addition of initializing the values, this operation also allocates the object.