### PR TITLE
[SYCL][E2E] Fix allowlist test by removing special characters from the regex.

### DIFF
--- a/sycl/test-e2e/Config/allowlist.cpp
+++ b/sycl/test-e2e/Config/allowlist.cpp
@@ -23,7 +23,10 @@ static void replaceSpecialCharacters(std::string &Str) {
   // Replace common special symbols with '.' which matches to any character
   std::replace_if(
       Str.begin(), Str.end(),
-      [](const char Sym) { return '(' == Sym || ')' == Sym; }, '.');
+      [](const char Sym) {
+        return '(' == Sym || ')' == Sym || '[' == Sym || ']' == Sym;
+      },
+      '.');
 }
 
 int main() {


### PR DESCRIPTION
Some device names can contain square brackets. This was making the regex generated by the allowlist test invalid. This commit removes the square brakets from the generated regex.