### PR TITLE
[SYCL][CUDA] Fix broken synchronization of CUstreams

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.hpp
@@ -99,7 +99,7 @@ struct ur_queue_handle_t_ {
     if (StreamToken == std::numeric_limits<uint32_t>::max()) {
       return false;
     }
-    return LastSyncComputeStreams >= StreamToken;
+    return LastSyncComputeStreams > StreamToken;
   }
 
   bool canReuseStream(uint32_t StreamToken) {

--- a/sycl/test-e2e/KernelFusion/sync_two_queues_event_dep.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_two_queues_event_dep.cpp
@@ -1,6 +1,5 @@
 // For this test, complete_fusion must be supported.
 // REQUIRES: fusion
-// UNSUPPORTED: cuda
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 


### PR DESCRIPTION
This fixes a change in `hasBeenSynchronized` accidentally introduced during the UR port