### PR TITLE
[SYCL][CUDA] Remove size checks from USM allocations

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
@@ -25,15 +25,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAlloc(
   UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
-  size_t DeviceMaxMemAllocSize = 0;
-  UR_ASSERT(urDeviceGetInfo(hContext->getDevice(),
-                            UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE, sizeof(size_t),
-                            static_cast<void *>(&DeviceMaxMemAllocSize),
-                            nullptr) == UR_RESULT_SUCCESS,
-            UR_RESULT_ERROR_INVALID_DEVICE);
-  UR_ASSERT(size > 0 && size <= DeviceMaxMemAllocSize,
-            UR_RESULT_ERROR_INVALID_USM_SIZE);
-
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {
     ScopedContext Active(hContext);
@@ -66,15 +57,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMDeviceAlloc(
                           ((pUSMDesc->align & (pUSMDesc->align - 1)) == 0)),
             UR_RESULT_ERROR_INVALID_VALUE);
 
-  size_t DeviceMaxMemAllocSize = 0;
-  UR_ASSERT(urDeviceGetInfo(hDevice, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,
-                            sizeof(size_t),
-                            static_cast<void *>(&DeviceMaxMemAllocSize),
-                            nullptr) == UR_RESULT_SUCCESS,
-            UR_RESULT_ERROR_INVALID_DEVICE);
-  UR_ASSERT(size > 0 && size <= DeviceMaxMemAllocSize,
-            UR_RESULT_ERROR_INVALID_USM_SIZE);
-
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {
     ScopedContext Active(hContext);
@@ -102,15 +84,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
   UR_ASSERT(!pUSMDesc || (pUSMDesc->align == 0 ||
                           ((pUSMDesc->align & (pUSMDesc->align - 1)) == 0)),
             UR_RESULT_ERROR_INVALID_VALUE);
-
-  size_t DeviceMaxMemAllocSize = 0;
-  UR_ASSERT(urDeviceGetInfo(hDevice, UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE,
-                            sizeof(size_t),
-                            static_cast<void *>(&DeviceMaxMemAllocSize),
-                            nullptr) == UR_RESULT_SUCCESS,
-            UR_RESULT_ERROR_INVALID_DEVICE);
-  UR_ASSERT(size > 0 && size <= DeviceMaxMemAllocSize,
-            UR_RESULT_ERROR_INVALID_USM_SIZE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
@@ -24,6 +24,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAlloc(
     [[maybe_unused]] ur_usm_pool_handle_t pool, size_t size, void **ppMem) {
   UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
   UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(!pUSMDesc || (pUSMDesc->align == 0 ||
+                          ((pUSMDesc->align & (pUSMDesc->align - 1)) == 0)),
+            UR_RESULT_ERROR_INVALID_VALUE);
 
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {
@@ -33,13 +36,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMHostAlloc(
     Result = Err;
   }
 
-  UR_ASSERT(!pUSMDesc || (pUSMDesc->align == 0 ||
-                          ((pUSMDesc->align & (pUSMDesc->align - 1)) == 0)),
-            UR_RESULT_ERROR_INVALID_VALUE);
-
-  assert(Result == UR_RESULT_SUCCESS &&
-         (!pUSMDesc || pUSMDesc->align == 0 ||
-          reinterpret_cast<std::uintptr_t>(*ppMem) % pUSMDesc->align == 0));
+  if (Result == UR_RESULT_SUCCESS) {
+    assert((!pUSMDesc || pUSMDesc->align == 0 ||
+            reinterpret_cast<std::uintptr_t>(*ppMem) % pUSMDesc->align == 0));
+  }
 
   return Result;
 }
@@ -65,9 +65,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMDeviceAlloc(
     return Err;
   }
 
-  assert(Result == UR_RESULT_SUCCESS &&
-         (!pUSMDesc || pUSMDesc->align == 0 ||
-          reinterpret_cast<std::uintptr_t>(*ppMem) % pUSMDesc->align == 0));
+  if (Result == UR_RESULT_SUCCESS) {
+    assert((!pUSMDesc || pUSMDesc->align == 0 ||
+            reinterpret_cast<std::uintptr_t>(*ppMem) % pUSMDesc->align == 0));
+  }
 
   return Result;
 }
@@ -94,9 +95,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
     return Err;
   }
 
-  assert(Result == UR_RESULT_SUCCESS &&
-         (!pUSMDesc || pUSMDesc->align == 0 ||
-          reinterpret_cast<std::uintptr_t>(*ppMem) % pUSMDesc->align == 0));
+  if (Result == UR_RESULT_SUCCESS) {
+    assert((!pUSMDesc || pUSMDesc->align == 0 ||
+            reinterpret_cast<std::uintptr_t>(*ppMem) % pUSMDesc->align == 0));
+  }
 
   return Result;
 }


### PR DESCRIPTION
These checks are causing issues for very large USM allocations because the `MAX_MEM_ALLOC_SIZE` reported is lower than what CUDA actually supports.

We will follow up with an update on the reported `MAX_MEM_ALLOC_SIZE`, but it makes sense to remove the checks either way, as the CUDA allocation functions will return an error if they can't allocate the memory.