### PR TITLE
[SYCL] no ze_debug mem check on image-ownership test

### DIFF
--- a/sycl/test-e2e/Plugin/interop-level-zero-image-ownership.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image-ownership.cpp
@@ -1,4 +1,9 @@
 // REQUIRES: level_zero, level_zero_dev_kit, aspect-ext_intel_legacy_image
+
+// the ze_debug=4 memory check will fail on this test, since it itentionally
+// makes an 'unbalanced' create/destroy situation for the test.
+// UNSUPPORTED: ze_debug
+
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: env ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 


### PR DESCRIPTION
image ownership test shouldn't be subject to mem leak check, since it intentionally creates an unbalanced create/release situation  for the purpose of testing