### PR TITLE
[SYCL][ESIMD][E2E] Run operator_assignment_glb_mask.cpp on non-PVC hardware

### DIFF
--- a/sycl/test-e2e/ESIMD/api/functional/operators/operator_assignment_glb_mask.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/operators/operator_assignment_glb_mask.cpp
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===---------------------------------------------------------------===//
-// TODO: Remove when GPU driver is updated
-// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include "common.hpp"


### PR DESCRIPTION
The driver uplift fixed the issues on other platforms.