### PR TITLE
[SYCL][E2E] Mark a test as unsupported on accelerator

### DIFF
--- a/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: opencl, opencl_icd, cm-compiler
+// UNSUPPORTED: accelerator
 
 // RUN: %{build} -DRUN_KERNELS %opencl_lib -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
This test used to be only run on the CPU and GPU but when we moved to the `%{run}` notation, it wasn't marked as unsupported on accelerator.  It seems unsupported on accelerator. The `clCreateProgramWithIL()` call is returning and error -59 when the accelerator device is the one behind the context. I went back and checked and it has never worked on accelerator. I'll make a note in the online compiler tickets and if this is a real error, a ticket will be opened. But the test should be restored so to not be run on accelerator. 