### PR TITLE
[SYCL-MLIR][NFC] Move functions from `MemoryAccessAnalysis` to `TransformUtils`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.h
@@ -449,17 +449,6 @@ public:
   std::optional<MemoryAccess>
   getMemoryAccess(const affine::MemRefAccess &access) const;
 
-  /// Return a vector containing thread values corresponding to the global
-  /// thread declarations in \p funcOp. The returned vector has size equal to
-  /// the thread grid dimension and is sorted based on the dimension.
-  /// For example given:
-  ///   %c1_i32 = arith.constant 1 : i32
-  ///   %ty = sycl.nd_item.get_global_id(%arg1, %c1_i32)
-  /// The corresponding vector entry is %ty and the vector has size equal to 2
-  /// where the first element is a null value.
-  SmallVector<Value> getThreadVector(FunctionOpInterface funcOp,
-                                     DataFlowSolver &solver) const;
-
 private:
   /// Construct the access matrix and offset vector for the memory accesses
   /// contained in the operation associated with the analysis.

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -77,6 +77,17 @@ bool isTailCall(CallOpInterface);
 /// Return zero if it cannot identify the grid dimension.
 unsigned getGridDimension(FunctionOpInterface func);
 
+/// Return a vector containing thread values corresponding to the global
+/// thread declarations in \p funcOp. The returned vector has size equal to
+/// the thread grid dimension and is sorted based on the dimension.
+/// For example given:
+///   %c1_i32 = arith.constant 1 : i32
+///   %ty = sycl.nd_item.get_global_id(%arg1, %c1_i32)
+/// The corresponding vector entry is %ty and the vector has size equal to 2
+/// where the first element is a null value.
+SmallVector<Value> getThreadVector(FunctionOpInterface funcOp,
+                                   DataFlowSolver &solver);
+
 /// Return the accessor used by \p op if found, and std::nullopt otherwise.
 Optional<Value> getAccessorUsedByOperation(const Operation &op);
 

--- a/polygeist/lib/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.cpp
@@ -70,57 +70,6 @@ static bool isSmallerThanNegativeOne(IntegerValueRange range) {
   return (constVal && constVal->slt(-1));
 }
 
-/// Return a vector with \p gridDim entries, containing thread values
-/// corresponding to each global thread declarations in \p funcOp.
-/// For example, assuming that the thread grid dimension is two, and \p funcOp
-/// contains:
-///   %c1_i32 = arith.constant 1 : i32
-///   %ty = sycl.nd_item.get_global_id(%arg1, %c1_i32)
-/// The result vector is [null, %ty].
-template <typename T,
-          typename = std::enable_if_t<llvm::is_one_of<
-              T, sycl::SYCLNDItemGetGlobalIDOp, sycl::SYCLItemGetIDOp>::value>>
-static SmallVector<Value> computeThreadVector(FunctionOpInterface funcOp,
-                                              unsigned gridDim,
-                                              DataFlowSolver &solver) {
-  if (gridDim == 0)
-    return {};
-
-  // Collect the operations yielding the global thread ids.
-  std::vector<T> getGlobalIdOps = getOperationsOfType<T>(funcOp).takeVector();
-  if (getGlobalIdOps.empty())
-    return {};
-
-  // Return the index value of an operation.
-  auto getIndexValue = [&](T &op) -> std::optional<APInt> {
-    TypedValue<IntegerType> idx = op.getIndex();
-    return idx ? getConstIntegerValue(idx, solver) : APInt();
-  };
-
-  // Ensure that all operations collected have known index values.
-  if (llvm::any_of(getGlobalIdOps,
-                   [&](T &op) { return !getIndexValue(op).has_value(); }))
-    return {};
-
-  // Create a map from operation index to operation result.
-  std::map<unsigned, Value> indexToGlobalOp;
-  for (T &getGlobalIdOp : getGlobalIdOps) {
-    APInt index = *getIndexValue(getGlobalIdOp);
-    indexToGlobalOp[index.getZExtValue()] = getGlobalIdOp.getResult();
-  }
-
-  // Collect the thread values/index.
-  SmallVector<Value> threadVars;
-  for (unsigned dim = 0; dim < gridDim; ++dim) {
-    auto it = indexToGlobalOp.find(dim);
-    threadVars.emplace_back(it != indexToGlobalOp.end() ? it->second : Value());
-  }
-  assert(threadVars.size() == gridDim &&
-         "Expecting size of threadVars to be same as the grid dimension");
-
-  return threadVars;
-}
-
 /// Determine whether \p op uses \p val (directly or indirectly).
 static bool usesValue(Operation *op, Value val) {
   if (!op || !val)
@@ -1227,29 +1176,6 @@ MemoryAccessAnalysis::getMemoryAccess(const MemRefAccess &access) const {
   if (it == accessMap.end())
     return std::nullopt;
   return it->second;
-}
-
-SmallVector<Value>
-MemoryAccessAnalysis::getThreadVector(FunctionOpInterface funcOp,
-                                      DataFlowSolver &solver) const {
-  unsigned gridDim = getGridDimension(funcOp);
-  if (gridDim == 0)
-    return {};
-
-  // Collect global thread ids.
-  SmallVector<Value> ndItemThreadVars =
-      computeThreadVector<sycl::SYCLNDItemGetGlobalIDOp>(funcOp, gridDim,
-                                                         solver);
-  SmallVector<Value> itemThreadVars =
-      computeThreadVector<sycl::SYCLItemGetIDOp>(funcOp, gridDim, solver);
-
-  if (!ndItemThreadVars.empty() && itemThreadVars.empty())
-    return ndItemThreadVars;
-  if (!itemThreadVars.empty() && ndItemThreadVars.empty())
-    return itemThreadVars;
-
-  // Give up if we find both nditem and item thread values or none of them.
-  return {};
 }
 
 void MemoryAccessAnalysis::build() {

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -123,6 +123,79 @@ unsigned polygeist::getGridDimension(FunctionOpInterface func) {
       .Default([](auto) { return 0; });
 }
 
+/// Return a vector with \p gridDim entries, containing thread values
+/// corresponding to each global thread declarations in \p funcOp.
+/// For example, assuming that the thread grid dimension is two, and \p funcOp
+/// contains:
+///   %c1_i32 = arith.constant 1 : i32
+///   %ty = sycl.nd_item.get_global_id(%arg1, %c1_i32)
+/// The result vector is [null, %ty].
+template <typename T,
+          typename = std::enable_if_t<llvm::is_one_of<
+              T, sycl::SYCLNDItemGetGlobalIDOp, sycl::SYCLItemGetIDOp>::value>>
+static SmallVector<Value> computeThreadVector(FunctionOpInterface funcOp,
+                                              unsigned gridDim,
+                                              DataFlowSolver &solver) {
+  if (gridDim == 0)
+    return {};
+
+  // Collect the operations yielding the global thread ids.
+  std::vector<T> getGlobalIdOps = getOperationsOfType<T>(funcOp).takeVector();
+  if (getGlobalIdOps.empty())
+    return {};
+
+  // Return the index value of an operation.
+  auto getIndexValue = [&](T &op) -> std::optional<APInt> {
+    TypedValue<IntegerType> idx = op.getIndex();
+    return idx ? getConstIntegerValue(idx, solver) : APInt();
+  };
+
+  // Ensure that all operations collected have known index values.
+  if (llvm::any_of(getGlobalIdOps,
+                   [&](T &op) { return !getIndexValue(op).has_value(); }))
+    return {};
+
+  // Create a map from operation index to operation result.
+  std::map<unsigned, Value> indexToGlobalOp;
+  for (T &getGlobalIdOp : getGlobalIdOps) {
+    APInt index = *getIndexValue(getGlobalIdOp);
+    indexToGlobalOp[index.getZExtValue()] = getGlobalIdOp.getResult();
+  }
+
+  // Collect the thread values/index.
+  SmallVector<Value> threadVars;
+  for (unsigned dim = 0; dim < gridDim; ++dim) {
+    auto it = indexToGlobalOp.find(dim);
+    threadVars.emplace_back(it != indexToGlobalOp.end() ? it->second : Value());
+  }
+  assert(threadVars.size() == gridDim &&
+         "Expecting size of threadVars to be same as the grid dimension");
+
+  return threadVars;
+}
+
+SmallVector<Value> polygeist::getThreadVector(FunctionOpInterface funcOp,
+                                              DataFlowSolver &solver) {
+  unsigned gridDim = getGridDimension(funcOp);
+  if (gridDim == 0)
+    return {};
+
+  // Collect global thread ids.
+  SmallVector<Value> ndItemThreadVars =
+      computeThreadVector<sycl::SYCLNDItemGetGlobalIDOp>(funcOp, gridDim,
+                                                         solver);
+  SmallVector<Value> itemThreadVars =
+      computeThreadVector<sycl::SYCLItemGetIDOp>(funcOp, gridDim, solver);
+
+  if (!ndItemThreadVars.empty() && itemThreadVars.empty())
+    return ndItemThreadVars;
+  if (!itemThreadVars.empty() && ndItemThreadVars.empty())
+    return itemThreadVars;
+
+  // Give up if we find both nditem and item thread values or none of them.
+  return {};
+}
+
 Optional<Value> polygeist::getAccessorUsedByOperation(const Operation &op) {
   auto getMemrefOp = [](const Operation &op) {
     return TypeSwitch<const Operation &, Operation *>(op)


### PR DESCRIPTION
The functions that get moved will be used in `LoopInternalization` to fix SYCL-Bench runtime failures with `LoopInternalization`.