### PR TITLE
[SYCL-MLIR] Restrict `MoveWhileToFor` `-canonicalize-scf-for` applicability

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/CanonicalizeFor.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CanonicalizeFor.cpp
@@ -453,9 +453,8 @@ struct WhileToForHelper {
       Operation *op = value.getDefiningOp();
       return op && before.isAncestor(op->getParentRegion());
     };
-    if (llvm::any_of(condOp.getArgs(), isDefinedInBeforeRegion)) {
+    if (llvm::any_of(condOp.getArgs(), isDefinedInBeforeRegion))
       return false;
-    }
 
     indVar = dyn_cast<BlockArgument>(cmpIOp.getLhs());
     Type extType = nullptr;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CanonicalizeFor.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CanonicalizeFor.cpp
@@ -445,6 +445,18 @@ struct WhileToForHelper {
     negativeStep = false;
 
     auto condOp = loop.getConditionOp();
+
+    // This pattern cannot be applied if any of the `scf.condition` operands is
+    // defined in the before region.
+    Region &before = loop.getBefore();
+    const auto isDefinedInBeforeRegion = [&](Value value) {
+      Operation *op = value.getDefiningOp();
+      return op && before.isAncestor(op->getParentRegion());
+    };
+    if (llvm::any_of(condOp.getArgs(), isDefinedInBeforeRegion)) {
+      return false;
+    }
+
     indVar = dyn_cast<BlockArgument>(cmpIOp.getLhs());
     Type extType = nullptr;
     // todo handle ext

--- a/polygeist/test/polygeist-opt/whiletofor.mlir
+++ b/polygeist/test/polygeist-opt/whiletofor.mlir
@@ -36,6 +36,10 @@ module {
 
 func.func private @foo(i64, i32)
 
+// COM: This tests that we can convert an `scf.while` operation whose
+// COM: `scf.condition` recieves a value defined in the before block as an
+// COM: argument to an `scf.for` operation.
+
 // CHECK-LABEL:   func.func @extsi(
 // CHECK-SAME:                     %[[VAL_0:.*]]: i64) -> i32 {
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index

--- a/polygeist/test/polygeist-opt/whiletofor.mlir
+++ b/polygeist/test/polygeist-opt/whiletofor.mlir
@@ -31,3 +31,37 @@ module {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
+
+// -----
+
+func.func private @foo(i64, i32)
+
+// CHECK-LABEL:   func.func @extsi(
+// CHECK-SAME:                     %[[VAL_0:.*]]: i64) -> i32 {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.index_cast %[[VAL_0]] : i64 to index
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.index_cast %[[VAL_3]] : index to i32
+// CHECK-NEXT:      scf.for %[[VAL_5:.*]] = %[[VAL_1]] to %[[VAL_3]] step %[[VAL_2]] {
+// CHECK-NEXT:        %[[VAL_6:.*]] = arith.index_cast %[[VAL_5]] : index to i32
+// CHECK-NEXT:        %[[VAL_7:.*]] = arith.extsi %[[VAL_6]] : i32 to i64
+// CHECK-NEXT:        func.call @foo(%[[VAL_7]], %[[VAL_6]]) : (i64, i32) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return %[[VAL_4]] : i32
+// CHECK-NEXT:    }
+
+func.func @extsi(%ub: i64) -> i32 {
+  %c0_i32 = arith.constant 0 : i32
+  %res:2 = scf.while (%arg = %c0_i32) : (i32) -> (i64, i32) {
+    %ext = arith.extsi %arg : i32 to i64
+    %cond = arith.cmpi slt, %ext, %ub : i64
+    scf.condition(%cond) %ext, %arg : i64, i32
+  } do {
+   ^bb0(%arg0: i64, %arg1: i32):
+    func.call @foo(%arg0, %arg1) : (i64, i32) -> ()
+    %c1_i32 = arith.constant 1 : i32
+    %next = arith.addi %arg1, %c1_i32 : i32
+    scf.yield %next : i32
+  }
+  return %res#1 : i32
+}

--- a/polygeist/test/polygeist-opt/whiletofor.mlir
+++ b/polygeist/test/polygeist-opt/whiletofor.mlir
@@ -37,7 +37,7 @@ module {
 func.func private @foo(i64, i32)
 
 // COM: This tests that we can convert an `scf.while` operation whose
-// COM: `scf.condition` recieves a value defined in the before block as an
+// COM: `scf.condition` receives a value defined in the before block as an
 // COM: argument to an `scf.for` operation.
 
 // CHECK-LABEL:   func.func @extsi(

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -260,7 +260,6 @@ ESIMD/regression/bit_shift_compilation_test.cpp
 ESIMD/regression/copyto_char_test.cpp
 ESIMD/regression/dgetrf.cpp
 ESIMD/regression/dgetrf_8x8.cpp
-ESIMD/regression/dgetrf_ref.cpp
 ESIMD/regression/double_conversion.cpp
 ESIMD/regression/fmod_compatibility_test.cpp
 ESIMD/regression/globals.cpp


### PR DESCRIPTION
Fail if any of the `scf.condition` operands is defined by an operation in the before block.