### PR TITLE
[SYCL-MLIR][LoopInternalization] Restrict transformation

### DIFF
--- a/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
@@ -99,7 +99,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 
 // -----
 
-// COM: Not candidate: Access references more than one global id or innerloop induction variable.
+// COM: Not candidate: Access references more than one global id or innermost loop induction variable.
 // CHECK: LoopInternalization
 // CHECK:   (S) 0 num-tiled - Number of loops tiled
 

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
@@ -96,3 +96,48 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
   gpu.return
 }
 }
+
+// -----
+
+// COM: Not candidate: Access references more than one global id or innerloop induction variable.
+// CHECK: LoopInternalization
+// CHECK:   (S) 0 num-tiled - Number of loops tiled
+
+!sycl_array_2 = !sycl.array<[2], (memref<2xi64, 4>)>
+!sycl_id_2 = !sycl.id<[2], (!sycl_array_2)>
+!sycl_range_2 = !sycl.range<[2], (!sycl_array_2)>
+!sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
+!sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
+!sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
+!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
+!sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
+
+gpu.module @device_func {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+  %alloca = memref.alloca() : memref<1x!sycl_id_2>
+  %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
+  %c0_i32 = arith.constant 0 : i32
+  %c1_i32 = arith.constant 1 : i32
+  %tx = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_2>, i32) -> i64
+  %ty = sycl.nd_item.get_global_id(%arg1, %c1_i32) : (memref<?x!sycl_nd_item_2>, i32) -> i64
+
+  affine.for %ii = 0 to 256 {
+    %i = arith.index_cast %ii : index to i64
+    %add1 = arith.addi %i, %ty : i64
+    sycl.constructor @id(%id, %tx, %add1) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %load1 = affine.load %subscr1[0] : memref<?xf32>
+
+    %add2 = arith.addi %tx, %ty : i64
+    sycl.constructor @id(%id, %add2, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)    
+    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %load2 = affine.load %subscr2[0] : memref<?xf32>
+  }
+  return
+}
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
+  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+  gpu.return
+}
+}


### PR DESCRIPTION
`LoopInternalization` is unable to correctly transform memory access with indexes that use more than one innermost loop induction variable or thread ids in the same dimension. Adding this restriction in `isCandidateAccess` to avoid incorrect transformation.