### PR TITLE
[SYCL][Doc] Update sycl_ext_oneapi_local_memory

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
@@ -194,6 +194,10 @@ myQueue.submit([&](handler &h) {
 The example above creates a kernel with four work-groups, each containing 32
 work-items. An `int[64]` object is defined in group-local memory, and
 each work-item in the work-group obtains a `multi_ptr` to the same allocation.
+The array is aggregate initialized, but since there are no arguments supplied
+after `item.get_group()` there are no arguments to forward to the array
+constructor. The result is that all array elements are value initialized
+(to zero, since that is the value initialization behavior for `float`).
 
 
 == Issues

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
@@ -129,39 +129,46 @@ group_local_memory_for_overwrite(Group g);
 } // namespace sycl::ext::oneapi
 ----
 
-[frame="topbot",options="header,footer"]
-|======================
-|Functions |Description
+[source,c++]
+----
+template <typename T, typename Group, typename ... Args>
+multi_ptr<T, access::address_space::local_space>
+group_local_memory(Group g, Args&&... args)
+----
+_Constraints_: `Group` must be `sycl::group`, and `T` must be trivially
+destructible.
 
-|`template <typename T, typename Group, typename ... Args>
- multi_ptr<T, access::address_space::local_space>
- group_local_memory(Group g, Args&&... args)` |
-Constructs an object of type `T` in an address space accessible by all
-work-items in group _g_, forwarding _args_ to the constructor's parameter list.
-If _args_ is empty, the object is value initialized. For array types, the
-_args_ parameter pack is used to initialize the array using aggregate
+_Preconditions_: All arguments in `args` must be the same for all work-items in
+the group.
+
+_Effects_: Constructs an object of type `T` in an address space accessible by
+all work-items in group `g`, forwarding `args` to the constructor's parameter
+list. If `args` is empty, the object is value initialized. For array types, the
+`args` parameter pack is used to initialize the array using aggregate
 initialization. The constructor is called once per group, upon or before the
-first call to `group_local_memory`.  The storage for the object is allocated
+first call to `group_local_memory`. The storage for the object is allocated
 upon or before the first call to `group_local_memory`, and deallocated when all
 work-items in the group have completed execution of the kernel.
 
-All arguments in _args_ must be the same for all work-items in the group.
+_Returns_: A `multi_ptr` to the constructed object.
 
-`Group` must be `sycl::group`, and `T` must be trivially destructible.
+[source,c++]
+----
+template <typename T, typename Group>
+multi_ptr<T, access::address_space::local_space>
+group_local_memory_for_overwrite(Group g)
+----
+_Constraints_: `Group` must be `sycl::group`, and `T` must be trivially
+destructible.
 
-|`template <typename T, typename Group>
- multi_ptr<T, access::address_space::local_space>
- group_local_memory_for_overwrite(Group g)` |
-Constructs an object of type `T` in an address space accessible by all
-work-items in group _g_, using default initialization.  The object is
-initialized upon or before the first call to `group_local_memory`.  The storage
+_Effects_: Constructs an object of type `T` in an address space accessible by
+all work-items in group `g`, using default initialization.  The object is
+initialized upon or before the first call to `group_local_memory`. The storage
 for the object is allocated upon or before the first call to
 `group_local_memory`, and deallocated when all work-items in the group have
 completed execution of the kernel.
 
-`Group` must be `sycl::group`, and `T` must be trivially destructible.
-
-|======================
+_Returns_: A `multi_ptr` to the constructed object.
 
 NOTE: The restrictions on supported types for `Group` and `T` may be lifted
 in a future version of this extension.

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
@@ -32,7 +32,7 @@ objects at the kernel functor scope.
 
 == Notice
 
-Copyright (c) 2021 Intel Corporation.  All rights reserved.
+Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
 
 == Status
 
@@ -48,7 +48,7 @@ products.
 
 == Version
 
-Revision: 1
+Revision: 2
 
 == Contact
 
@@ -62,7 +62,7 @@ Michael Kinsner, Intel +
 
 == Dependencies
 
-This extension is written against the SYCL 2020 specification, Revision 3.
+This extension is written against the SYCL 2020 specification, Revision 7.
 
 == Feature Test Macro
 
@@ -78,6 +78,7 @@ value to determine which of the extension's APIs the implementation supports.
 |===
 |Value |Description
 |1     |Initial extension version.  Base features are supported.
+|2     |Support for aggregate initialization of arrays.
 |===
 
 == Overview
@@ -131,10 +132,12 @@ namespace ext {
 namespace oneapi {
 
 template <typename T, typename Group, typename... Args>
-multi_ptr<T, Group::address_space> group_local_memory(Group g, Args&&... args);
+multi_ptr<T, access::address_space::local_space>
+group_local_memory(Group g, Args&&... args);
 
 template <typename T, typename Group>
-multi_ptr<T, Group::address_space> group_local_memory_for_overwrite(Group g);
+multi_ptr<T, access::address_space::local_space>
+group_local_memory_for_overwrite(Group g);
 
 } // namespace oneapi
 } // namespace ext
@@ -146,21 +149,24 @@ multi_ptr<T, Group::address_space> group_local_memory_for_overwrite(Group g);
 |Functions |Description
 
 |`template <typename T, typename Group, typename ... Args>
- multi_ptr<T, Group::address_space> group_local_memory(Group g, Args&&... args)` |
+ multi_ptr<T, access::address_space::local_space>
+ group_local_memory(Group g, Args&&... args)` |
 Constructs an object of type `T` in an address space accessible by all
 work-items in group _g_, forwarding _args_ to the constructor's parameter list.
-If _args_ is empty, the object is value initialized.
-The constructor is called once per group, upon or before the first call to
-`group_local_memory`.  The storage for the object is allocated upon or before
-the first call to `group_local_memory`, and deallocated when all work-items in
-the group have completed execution of the kernel.
+If _args_ is empty, the object is value initialized. For array types, the
+_args_ parameter pack is used to initialize the array using aggregate
+initialization. The constructor is called once per group, upon or before the
+first call to `group_local_memory`.  The storage for the object is allocated
+upon or before the first call to `group_local_memory`, and deallocated when all
+work-items in the group have completed execution of the kernel.
 
 All arguments in _args_ must be the same for all work-items in the group.
 
 `Group` must be `sycl::group`, and `T` must be trivially destructible.
 
 |`template <typename T, typename Group>
- multi_ptr<T, Group::address_space> group_local_memory_for_overwrite(Group g)` |
+ multi_ptr<T, access::address_space::local_space>
+ group_local_memory_for_overwrite(Group g)` |
 Constructs an object of type `T` in an address space accessible by all
 work-items in group _g_, using default initialization.  The object is
 initialized upon or before the first call to `group_local_memory`.  The storage

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
@@ -9,87 +9,50 @@
 :toc: left
 :encoding: utf-8
 :lang: en
-
-:blank: pass:[ +]
+:dpcpp: pass:[DPC++]
 
 // Set the default source code type in this document to C++,
 // for syntax highlighting purposes.  This is needed because
 // docbook uses c++ and html5 uses cpp.
 :language: {basebackend@docbook:c++:cpp}
 
-// This is necessary for asciidoc, but not for asciidoctor
-:cpp: C++
-
-== Introduction
-IMPORTANT: This specification is a draft.
-
-NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
-trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
-used by permission by Khronos.
-
-This document describes an extension enabling the declaration of local memory
-objects at the kernel functor scope.
-
 == Notice
 
-Copyright (c) 2021-2023 Intel Corporation.  All rights reserved.
+[%hardbreaks]
+Copyright (C) 2021-2023 Intel Corporation.  All rights reserved.
 
-== Status
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
+permission by Khronos.
 
-Working Draft
-
-This is a preview extension specification, intended to provide early access to
-a feature for review and community feedback. When the feature matures, this
-specification may be released as a formal extension.
-
-Because the interfaces defined by this specification are not final and are
-subject to change they are not intended to be used by shipping software
-products.
-
-== Version
-
-Revision: 2
 
 == Contact
 
-John Pennycook, Intel (john 'dot' pennycook 'at' intel 'dot' com) +
-Roland Schulz, Intel (roland 'dot' schulz 'at' intel 'dot' com) +
+To report problems with this extension, please open a new issue at:
 
-== Contributors
+https://github.com/intel/llvm/issues
 
-Felipe de Azevedo Piovezan, Intel +
-Michael Kinsner, Intel +
 
 == Dependencies
 
-This extension is written against the SYCL 2020 specification, Revision 7.
+This extension is written against the SYCL 2020 revision 7 specification.  All
+references below to the "core SYCL specification" or to section numbers in the
+SYCL specification refer to that revision.
 
-== Feature Test Macro
 
-This extension provides a feature-test macro as described in the core SYCL
-specification section 6.3.3 "Feature test macros".  Therefore, an
-implementation supporting this extension must predefine the macro
-`SYCL_EXT_ONEAPI_LOCAL_MEMORY` to one of the values defined in the table below.
-Applications can test for the existence of this macro to determine if the
-implementation supports this feature, or applications can test the macro's
-value to determine which of the extension's APIs the implementation supports.
+== Status
 
-[%header,cols="1,5"]
-|===
-|Value |Description
-|1     |Initial extension version.  Base features are supported.
-|2     |Support for aggregate initialization of arrays.
-|===
+This extension is implemented and fully supported by {dpcpp}.
+
 
 == Overview
 
 OpenCL provides two ways for local memory to be used in a kernel:
 
 * The kernel accepts a pointer in the `local` address space as an argument,
-and the host passes the size of the allocation to the OpenCL runtime when
-the kernel is launched.
-* The kernel declares `local` variables in the kernel function
-scope.
+and the host passes the size of the allocation to the OpenCL runtime when the
+kernel is launched.
+* The kernel declares `local` variables in the kernel function scope.
 
 In SYCL, programmers have two choices:
 
@@ -112,7 +75,33 @@ This extension introduces a concept of group-local memory, with semantics
 similar to OpenCL kernel-scope `local` variables and C++ `thread_local`
 variables.
 
-== Allocating Local Memory
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.  An implementation supporting this extension must predefine the
+macro `SYCL_EXT_ONEAPI_LOCAL_MEMORY` to one of the values defined in the table
+below.  Applications can test for the existence of this macro to determine if
+the implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's features the implementation
+supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|Initial extension version.  Base features are supported.
+
+|2
+|Support for aggregate initialization of arrays.
+|===
+
+
+== Allocating local memory
 
 The `sycl::ext::oneapi::group_local_memory` and
 `sycl::ext::oneapi::group_local_memory_for_overwrite` functions can be used to
@@ -127,9 +116,7 @@ work-items in the group, and is shared by all work-items of the group.
 
 [source,c++]
 ----
-namespace sycl {
-namespace ext {
-namespace oneapi {
+namespace sycl::ext::oneapi {
 
 template <typename T, typename Group, typename... Args>
 multi_ptr<T, access::address_space::local_space>
@@ -139,9 +126,7 @@ template <typename T, typename Group>
 multi_ptr<T, access::address_space::local_space>
 group_local_memory_for_overwrite(Group g);
 
-} // namespace oneapi
-} // namespace ext
-} // namespace sycl
+} // namespace sycl::ext::oneapi
 ----
 
 [frame="topbot",options="header,footer"]
@@ -181,6 +166,7 @@ completed execution of the kernel.
 NOTE: The restrictions on supported types for `Group` and `T` may be lifted
 in a future version of this extension.
 
+
 == Example Usage
 
 This non-normative section shows some example usages of the extension.
@@ -201,25 +187,7 @@ The example above creates a kernel with four work-groups, each containing 32
 work-items. An `int[64]` object is defined in group-local memory, and
 each work-item in the work-group obtains a `multi_ptr` to the same allocation.
 
+
 == Issues
 
 None.
-
-== Revision History
-
-[cols="5,15,15,70"]
-[grid="rows"]
-[options="header"]
-|========================================
-|Rev|Date|Author|Changes
-|1|2021-08-12|John Pennycook|*Initial public working draft*
-|========================================
-
-//************************************************************************
-//Other formatting suggestions:
-//
-//* Use *bold* text for host APIs, or [source] syntax highlighting.
-//* Use +mono+ text for device APIs, or [source] syntax highlighting.
-//* Use +mono+ text for extension names, types, or enum values.
-//* Use _italics_ for parameters.
-//************************************************************************

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
@@ -163,10 +163,11 @@ destructible.
 
 _Effects_: Constructs an object of type `T` in an address space accessible by
 all work-items in group `g`, using default initialization.  The object is
-initialized upon or before the first call to `group_local_memory`. The storage
-for the object is allocated upon or before the first call to
-`group_local_memory`, and deallocated when all work-items in the group have
-completed execution of the kernel.
+initialized upon or before the first call to
+`group_local_memory_for_overwrite`. The storage for the object is allocated
+upon or before the first call to `group_local_memory_for_overwrite`, and
+deallocated when all work-items in the group have completed execution of the
+kernel.
 
 _Returns_: A `multi_ptr` to the constructed object.
 


### PR DESCRIPTION
- Fix return type of multi_ptr; Group::address_space does not exist.
- Clarify the constructor behavior for array types.