### PR TITLE
[SYCL][UR][L0] Defer setting null and argPointer arguments

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -1943,6 +1943,8 @@ inline pi_result piKernelSetArg(pi_kernel Kernel, pi_uint32 ArgIndex,
 
   ur_kernel_handle_t UrKernel = reinterpret_cast<ur_kernel_handle_t>(Kernel);
 
+  // printf("%s %d\n", __FILE__, __LINE__);
+
   HANDLE_ERRORS(urKernelSetArgValue(UrKernel, ArgIndex, ArgSize, ArgValue));
   return PI_SUCCESS;
 }
@@ -2211,7 +2213,7 @@ inline pi_result piextKernelSetArgPointer(pi_kernel Kernel, pi_uint32 ArgIndex,
                                           const void *ArgValue) {
   ur_kernel_handle_t UrKernel = reinterpret_cast<ur_kernel_handle_t>(Kernel);
 
-  HANDLE_ERRORS(urKernelSetArgValue(UrKernel, ArgIndex, ArgSize, ArgValue));
+  HANDLE_ERRORS(urKernelSetArgPointer(UrKernel, ArgIndex, ArgValue));
 
   return PI_SUCCESS;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero_kernel.hpp
@@ -83,7 +83,8 @@ struct ur_kernel_handle_t_ : _ur_object {
   struct ArgumentInfo {
     uint32_t Index;
     size_t Size;
-    // const ur_mem_handle_t_ *Value;
+    bool isNullArg = false;
+    void *ArgValue;
     ur_mem_handle_t_ *Value;
     ur_mem_handle_t_::access_mode_t AccessMode{ur_mem_handle_t_::unknown};
   };


### PR DESCRIPTION
If a null argument is being set or through setArgPointer, just deferred it until enqueueKernelLaunch. This allows having more setKernel calls close in time, reducing some host call overhead.