### PR TITLE
[CI] Move auxilliary tasks from cuda to Linux/build runners

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -12,7 +12,7 @@ jobs:
     name: Decide which tests could be affected by the changes
     # Github's ubuntu-* runners are slow to allocate. Use our CUDA runner since
     # we don't use it for anything right now.
-    runs-on: cuda
+    runs-on: [Linux, build]
     timeout-minutes: 3
     outputs:
       filters: ${{ steps.changes.outputs.changes }}

--- a/.github/workflows/sycl_gen_test_matrix.yml
+++ b/.github/workflows/sycl_gen_test_matrix.yml
@@ -51,7 +51,7 @@ jobs:
     name: Generate Test Matrix
     # Github's ubuntu-* runner are slow to allocate. Use our CUDA runner since
     # we don't use it for anything right now.
-    runs-on: cuda
+    runs-on: [Linux, build]
     outputs:
       lts_lx_matrix: ${{ steps.work.outputs.lts_lx_matrix }}
       lts_wn_matrix: ${{ steps.work.outputs.lts_wn_matrix }}

--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -29,7 +29,7 @@ jobs:
     needs: [detect_changes]
     if: |
       !contains(needs.detect_changes.outputs.filters, 'ci')
-    runs-on: cuda
+    runs-on: [Linux, build]
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
       # actions/checkout fails without "--privileged".


### PR DESCRIPTION
We are going to re-build the cuda runner, need to ensure CI continues working while it will be offline. The move is also good by itself as there was nothing cuda-specific in those tasks.