### PR TITLE
[CI] Remove "--privileged" from the lint task

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -32,8 +32,7 @@ jobs:
     runs-on: [Linux, build]
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
-      # actions/checkout fails without "--privileged".
-      options: -u 1001:1001 --privileged
+      options: -u 1001:1001
     steps:
     - uses: actions/checkout@v3
       with:


### PR DESCRIPTION
We've switched the task to use "[Linux, build]" runners in #10074 and this option isn't needed anymore.