### PR TITLE
[CI] Fix GPU reset

### DIFF
--- a/.github/workflows/linux_matrix_e2e_on_nightly.yml
+++ b/.github/workflows/linux_matrix_e2e_on_nightly.yml
@@ -25,6 +25,7 @@ jobs:
             extra_cmake_args: -DHIP_PLATFORM="AMD" -DAMD_ARCH="gfx1031"
             extra_image_opts: --device=/dev/kfd
             target_devices: all
+            reset_gpu: false
 
           - name: Intel
             runner: '["Linux", "gen9"]'
@@ -32,6 +33,7 @@ jobs:
             extra_cmake_args:
             extra_image_opts: -u 1001
             target_devices: all
+            reset_gpu: true
 
           - name: ESIMD Emu
             runner: '["Linux", "x86-cpu"]'
@@ -39,6 +41,7 @@ jobs:
             extra_cmake_args:
             extra_image_opts: -u 1001
             target_devices: ext_intel_esimd_emulator:gpu
+            reset_gpu: false
     uses: ./.github/workflows/linux_single_e2e_on_nightly.yml
     with:
       name: ${{ matrix.name }}
@@ -48,6 +51,7 @@ jobs:
       extra_image_opts: ${{ matrix.extra_image_opts }}
       target_devices: ${{ matrix.target_devices }}
       ref: ${{ inputs.ref }}
+      reset_gpu: ${{ matrix.reset_gpu }}
 
   aws_start:
     name: AWS Start
@@ -69,6 +73,7 @@ jobs:
       extra_image_opts: --gpus all
       target_devices: all
       ref: ${{ inputs.ref }}
+      reset_gpu: false
 
   aws_stop:
     name: AWS Stop

--- a/.github/workflows/linux_single_e2e_on_nightly.yml
+++ b/.github/workflows/linux_single_e2e_on_nightly.yml
@@ -17,6 +17,8 @@ on:
         type: string
       ref:
         type: string
+      reset_gpu:
+        type: string
 
 jobs:
   lin_e2e_only:
@@ -26,6 +28,11 @@ jobs:
       image: ${{ inputs.image }}
       options: --device=/dev/dri --privileged --cap-add SYS_ADMIN ${{ inputs.extra_image_opts }}
     steps:
+    - name: Reset GPU
+      if: inputs.reset_gpu == 'true'
+      run: |
+        sudo mount -t debugfs none /sys/kernel/debug
+        sudo bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
     - uses: actions/checkout@v3
       with:
         path: llvm

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -211,7 +211,7 @@ jobs:
       options: ${{ matrix.container_options }}
     steps:
     - name: Reset GPU
-      if: ${{ contains(matrix.config, 'gen9') }}
+      if: ${{ contains(matrix.runs-on, 'gen9') && contains(matrix.runs-on, 'Linux') }}
       run: |
         sudo mount -t debugfs none /sys/kernel/debug
         sudo bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'


### PR DESCRIPTION
https://github.com/intel/llvm/pull/9546 and similar accidentally broke
code that was responsible to reset Intel GPU before running End-to-End
tests. Restore functionality + add reset for the pre-commit task running
End-to-End tests with a nightly build.