### PR TITLE
[SYCL-MLIR] Skip inline namespaces in `getNamespaceKind(...)`.

### DIFF
--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1396,7 +1396,10 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
         return getSYCLType(RT, *this);
 
       assert((AllowUndefinedSYCLTypes ||
-              NamespaceKind != mlirclang::NamespaceKind::SYCL) &&
+              // Accept types nested in other namespaces, e.g. `sycl::detail`.
+              NamespaceKind != mlirclang::NamespaceKind::SYCL ||
+              // Accept types nested in other structs/classes.
+              !RD->getDeclContext()->isNamespace()) &&
              "Found type in the sycl namespace, but not in the SYCL dialect");
     }
 

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -59,6 +59,10 @@ NamespaceKind getNamespaceKind(const clang::DeclContext *DC) {
   if (!DC)
     return NamespaceKind::Other;
 
+  // Skip inline namespaces.
+  while (DC && DC->isInlineNamespace())
+    DC = DC->getParent();
+
   if (const auto *ND = dyn_cast<clang::NamespaceDecl>(DC)) {
     if (const auto *II = ND->getIdentifier()) {
       if (II->isStr("sycl"))

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -102,6 +102,7 @@ Basic/image/srgba-read.cpp
 Basic/multi_ptr.cpp
 Basic/multi_ptr_legacy_usm_addr_ext.cpp
 Basic/multi_ptr_usm_addr_ext.cpp
+Basic/sampler/sampler.cpp
 Basic/scalar_vec_access.cpp
 Basic/span.cpp
 Basic/stream/auto_flush.cpp


### PR DESCRIPTION
Nowadays the SYCL API classes live in the inline namespace `_V1` inside `sycl::`, and were wrongly classified as being `NamespaceKind::WithinSYCL` instead of `SYCL`. This PR changes the helper to look through inline namespaces.

In consequence, the check for undefined (in the dialect) SYCL types works again as intended, however we need to allow helper structs and unions defined in the API classes as well.

Lastly, the `sycl::sampler` class is actually a type that is not represented in the dialect, so I had to add the corresponding e2e test to the XFAIL list.