### PR TITLE
[SYCL-MLIR] Basic skeleton for host raising pass

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.h
@@ -59,6 +59,9 @@ createParallelLowerPass(const ParallelLowerOptions &options);
 std::unique_ptr<Pass> createRaiseSCFToAffinePass();
 std::unique_ptr<Pass> createRemoveTrivialUsePass();
 std::unique_ptr<Pass> createReplaceAffineCFGPass();
+std::unique_ptr<Pass> createSYCLHostRaisingPass();
+std::unique_ptr<Pass>
+createSYCLHostRaisingPass(const SYCLRaiseHostConstructsOptions &options);
 
 //===----------------------------------------------------------------------===//
 // Registration

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -10,6 +10,7 @@
 #define MLIR_DIALECT_POLYGEIST_TRANSFORMS_PASSES
 
 include "mlir/Pass/PassBase.td"
+include "mlir/Rewrite/PassUtil.td"
 
 def AffineCFG : Pass<"affine-cfg"> {
   let summary = "Replace scf.if and similar with affine.if";
@@ -185,6 +186,15 @@ def LICM : Pass<"licm"> {
   let statistics = [
     Statistic<"numOpHoisted", "num-operations-hoisted", "Number of operations hoisted">
   ];
+}
+
+def SYCLRaiseHostConstructs : Pass<"sycl-raise-host"> {
+  let summary = "Raise relevant sequences of host code to SYCL dialect operations";
+  // TODO: Description
+  let dependentDialects = ["sycl::SYCLDialect"];
+  let constructor = "mlir::polygeist::createSYCLHostRaisingPass()";
+  let options = RewritePassUtils.options;
+  // TODO: Statistics
 }
 
 def OpenMPOptPass : Pass<"openmp-opt"> {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -16,6 +16,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   ParallelLoopDistribute.cpp
   ParallelLower.cpp
   RaiseToAffine.cpp
+  SYCLRaiseHost.cpp
   TrivialUse.cpp
 
   ADDITIONAL_HEADER_DIRS

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -1,0 +1,74 @@
+//=== SYCLRaiseHost.cpp - Raise host constructs to SYCL dialect operations ===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This pass attempts to detect instruction sequences of interest in the MLIR
+// (mostly LLVM dialect) for the SYCL host side and raise them to types and
+// operations from the SYCL dialect to facilitate analysis in other passes.
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Polygeist/Transforms/Passes.h"
+
+#include "mlir/Dialect/Func/IR/FuncOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Polygeist/IR/PolygeistOps.h"
+#include "mlir/Dialect/Polygeist/Utils/TransformUtils.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Support/Debug.h"
+
+namespace mlir {
+namespace polygeist {
+#define GEN_PASS_DEF_SYCLRAISEHOSTCONSTRUCTS
+#include "mlir/Dialect/Polygeist/Transforms/Passes.h.inc"
+} // namespace polygeist
+} // namespace mlir
+
+using namespace mlir;
+
+namespace {
+
+class SYCLRaiseHostConstructsPass
+    : public polygeist::impl::SYCLRaiseHostConstructsBase<
+          SYCLRaiseHostConstructsPass> {
+public:
+  using polygeist::impl::SYCLRaiseHostConstructsBase<
+      SYCLRaiseHostConstructsPass>::SYCLRaiseHostConstructsBase;
+
+  void runOnOperation() override;
+};
+
+} // anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// Pattern
+//===----------------------------------------------------------------------===//
+
+//===----------------------------------------------------------------------===//
+// SYCLRaiseHostConstructsPass
+//===----------------------------------------------------------------------===//
+
+void SYCLRaiseHostConstructsPass::runOnOperation() {
+  Operation *scopeOp = getOperation();
+
+  RewritePatternSet rewritePatterns{&getContext()};
+  // rewritePatterns.add<...>(...);
+  FrozenRewritePatternSet frozen(std::move(rewritePatterns));
+
+  if (failed(applyPatternsAndFoldGreedily(scopeOp, frozen)))
+    signalPassFailure();
+}
+
+std::unique_ptr<Pass> mlir::polygeist::createSYCLHostRaisingPass() {
+  return std::make_unique<SYCLRaiseHostConstructsPass>();
+}
+
+std::unique_ptr<Pass> mlir::polygeist::createSYCLHostRaisingPass(
+    const polygeist::SYCLRaiseHostConstructsOptions &options) {
+  return std::make_unique<SYCLRaiseHostConstructsPass>(options);
+}


### PR DESCRIPTION
Add a basic skeleton for an MLIR pass raising SYCL constructs in host code from LLVM dialect to SYCL dialect.

The pass is based on patterns which will detect the relevant constructs and replace them by SYCL dialect operations.