### PR TITLE
[SYCL][CODEOWNERS] Update CODEOWNERS for Native CPU Device

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,3 +120,4 @@ llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h @intel/dpcpp-nativecpu-pi-r
 llvm/lib/SYCLLowerIR/EmitSYCLNativeCPUHeader.cpp @intel/dpcpp-nativecpu-pi-reviewers 
 llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp @intel/dpcpp-nativecpu-pi-reviewers 
 sycl/doc/design/SYCLNativeCPU.md @intel/dpcpp-nativecpu-pi-reviewers
+sycl/include/sycl/detail/native_cpu.hpp @intel/dpcpp-nativecpu-pi-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -109,10 +109,8 @@ sycl/test-e2e/Matrix @dkhaldi @YuriPlyakhin @yubingex007-a11y
 #Native CPU PI 
 sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
 clang/include/clang/Basic/SYCLNativeCPUHelpers.h @intel/dpcpp-nativecpu-pi-reviewers 
-clang/test/CodeGenSYCL/native_cpu_basic.cpp @intel/dpcpp-nativecpu-pi-reviewers 
-clang/test/Driver/sycl-native-cpu-fsycl.cpp @intel/dpcpp-nativecpu-pi-reviewers 
-clang/test/Driver/sycl-native-cpu-warn.cpp @intel/dpcpp-nativecpu-pi-reviewers 
-clang/test/Driver/sycl-native-cpu.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+clang/test/CodeGenSYCL/native_cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+clang/test/Driver/sycl-native-cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 
 llvm/include/llvm/SYCLLowerIR/EmitSYCLNativeCPUHeader.h @intel/dpcpp-nativecpu-pi-reviewers 
 llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h @intel/dpcpp-nativecpu-pi-reviewers 
 llvm/lib/SYCLLowerIR/EmitSYCLNativeCPUHeader.cpp @intel/dpcpp-nativecpu-pi-reviewers 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -105,3 +105,18 @@ sycl/test-e2e/KernelFusion @victor-eds @Naghasan @sommerlukas
 
 # Matrix tests
 sycl/test-e2e/Matrix @dkhaldi @YuriPlyakhin @yubingex007-a11y
+
+#Native CPU PI 
+sycl/plugins/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
+sycl/test/check_device_code/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers 
+sycl/test/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers 
+clang/include/clang/Basic/SYCLNativeCPUHelpers.h @intel/dpcpp-nativecpu-pi-reviewers 
+clang/test/CodeGenSYCL/native_cpu_basic.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+clang/test/Driver/sycl-native-cpu-fsycl.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+clang/test/Driver/sycl-native-cpu-warn.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+clang/test/Driver/sycl-native-cpu.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+llvm/include/llvm/SYCLLowerIR/EmitSYCLNativeCPUHeader.h @intel/dpcpp-nativecpu-pi-reviewers 
+llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h @intel/dpcpp-nativecpu-pi-reviewers 
+llvm/lib/SYCLLowerIR/EmitSYCLNativeCPUHeader.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+sycl/doc/design/SYCLNativeCPU.md @intel/dpcpp-nativecpu-pi-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -111,9 +111,6 @@ sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
 clang/include/clang/Basic/SYCLNativeCPUHelpers.h @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/CodeGenSYCL/native_cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/Driver/sycl-native-cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 
-llvm/include/llvm/SYCLLowerIR/EmitSYCLNativeCPUHeader.h @intel/dpcpp-nativecpu-pi-reviewers 
-llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h @intel/dpcpp-nativecpu-pi-reviewers 
-llvm/lib/SYCLLowerIR/EmitSYCLNativeCPUHeader.cpp @intel/dpcpp-nativecpu-pi-reviewers 
-llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp @intel/dpcpp-nativecpu-pi-reviewers 
+llvm/**/*SYCLNativeCPU* @intel/dpcpp-nativecpu-pi-reviewers 
 sycl/doc/design/SYCLNativeCPU.md @intel/dpcpp-nativecpu-pi-reviewers
 sycl/include/sycl/detail/native_cpu.hpp @intel/dpcpp-nativecpu-pi-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,9 +107,7 @@ sycl/test-e2e/KernelFusion @victor-eds @Naghasan @sommerlukas
 sycl/test-e2e/Matrix @dkhaldi @YuriPlyakhin @yubingex007-a11y
 
 #Native CPU PI 
-sycl/plugins/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
-sycl/test/check_device_code/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers 
-sycl/test/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers 
+sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
 clang/include/clang/Basic/SYCLNativeCPUHelpers.h @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/CodeGenSYCL/native_cpu_basic.cpp @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/Driver/sycl-native-cpu-fsycl.cpp @intel/dpcpp-nativecpu-pi-reviewers 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -107,10 +107,10 @@ sycl/test-e2e/KernelFusion @victor-eds @Naghasan @sommerlukas
 sycl/test-e2e/Matrix @dkhaldi @YuriPlyakhin @yubingex007-a11y
 
 # Native CPU
-sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
+llvm/**/*SYCLNativeCPU* @intel/dpcpp-nativecpu-pi-reviewers 
 clang/include/clang/Basic/SYCLNativeCPUHelpers.h @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/CodeGenSYCL/native_cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/Driver/sycl-native-cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 
-llvm/**/*SYCLNativeCPU* @intel/dpcpp-nativecpu-pi-reviewers 
+sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
 sycl/doc/design/SYCLNativeCPU.md @intel/dpcpp-nativecpu-pi-reviewers
 sycl/include/sycl/detail/native_cpu.hpp @intel/dpcpp-nativecpu-pi-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -106,7 +106,7 @@ sycl/test-e2e/KernelFusion @victor-eds @Naghasan @sommerlukas
 # Matrix tests
 sycl/test-e2e/Matrix @dkhaldi @YuriPlyakhin @yubingex007-a11y
 
-#Native CPU PI 
+# Native CPU
 sycl/**/native_cpu/ @intel/dpcpp-nativecpu-pi-reviewers
 clang/include/clang/Basic/SYCLNativeCPUHelpers.h @intel/dpcpp-nativecpu-pi-reviewers 
 clang/test/CodeGenSYCL/native_cpu*.cpp @intel/dpcpp-nativecpu-pi-reviewers 


### PR DESCRIPTION
have @intel/dpcpp-nativecpu-pi-reviewers own:
sycl/plugins/native_cpu/
sycl/test/check_device_code/native_cpu/
sycl/test/native_cpu/
clang/include/clang/Basic/SYCLNativeCPUHelpers.h
clang/test/CodeGenSYCL/native_cpu_basic.cpp
clang/test/Driver/sycl-native-cpu-fsycl.cpp
clang/test/Driver/sycl-native-cpu-warn.cpp
clang/test/Driver/sycl-native-cpu.cpp
llvm/include/llvm/SYCLLowerIR/EmitSYCLNativeCPUHeader.h
llvm/include/llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h
llvm/lib/SYCLLowerIR/EmitSYCLNativeCPUHeader.cpp
llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
sycl/doc/design/SYCLNativeCPU.md
