### PR TITLE
[CI][WIN] Don't skip E2E tests if only check-* steps in build fail

### DIFF
--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -29,6 +29,8 @@ jobs:
     name: Build + LIT
     runs-on: [Windows, build]
     # TODO use cached checkout
+    outputs:
+      build_conclusion: ${{ steps.build.conclusion }}
     steps:
     - uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
       with:
@@ -92,6 +94,7 @@ jobs:
       run: |
         cmake --build build --target check-libdevice
     - name: Install
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       shell: bash
       # TODO replace utility installation with a single CMake target
       run: |
@@ -106,10 +109,12 @@ jobs:
         cmake --build build --target install-llvm-profdata
         cmake --build build --target install-compiler-rt
     - name: Pack toolchain
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       shell: bash
       run: |
         tar -czf llvm_sycl.tar.gz -C install .
     - name: Upload toolchain
+      if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v3
       with:
         name: sycl_windows_default
@@ -117,7 +122,8 @@ jobs:
 
   e2e-tests:
     needs: build
-    if: ${{ inputs.lts_matrix != '[]' }}
+    # Continue if build was successful.
+    if: ${{ always() && needs.build.outputs.build_conclusion == 'success' && inputs.lts_matrix != '[]' }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Same as was done in https://github.com/intel/llvm/pull/9912 for Linux.