### PR TITLE
[SYCL] Fix `sycl::remquo` truncation error

### DIFF
--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -872,19 +872,19 @@ MAKE_1V_2V(sycl_host_remainder, s::cl_half, s::cl_half, s::cl_half)
 __SYCL_EXPORT s::cl_float sycl_host_remquo(s::cl_float x, s::cl_float y,
                                            s::cl_int *quo) __NOEXC {
   s::cl_float rem = std::remainder(x, y);
-  *quo = static_cast<int>((x - rem) / y);
+  *quo = static_cast<int>(std::round((x - rem) / y));
   return rem;
 }
 __SYCL_EXPORT s::cl_double sycl_host_remquo(s::cl_double x, s::cl_double y,
                                             s::cl_int *quo) __NOEXC {
   s::cl_double rem = std::remainder(x, y);
-  *quo = static_cast<int>((x - rem) / y);
+  *quo = static_cast<int>(std::round((x - rem) / y));
   return rem;
 }
 __SYCL_EXPORT s::cl_half sycl_host_remquo(s::cl_half x, s::cl_half y,
                                           s::cl_int *quo) __NOEXC {
   s::cl_half rem = std::remainder(x, y);
-  *quo = static_cast<int>((x - rem) / y);
+  *quo = static_cast<int>(std::round((x - rem) / y));
   return rem;
 }
 MAKE_1V_2V_3P(sycl_host_remquo, s::cl_float, s::cl_float, s::cl_float,

--- a/sycl/test-e2e/Basic/built-ins/host_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/host_math.cpp
@@ -52,6 +52,15 @@ void testRemquo() {
     assert(quo == -3);
     assert(rem == -1);
   }
+
+  {
+    int quo = 0;
+    float rem = sycl::remquo(
+        0.552879f, 0.219282f,
+        sycl::multi_ptr<int, sycl::access::address_space::global_space>{&quo});
+    assert(quo == 3);
+    assert(rem == -0.10496702790260315f);
+  }
 }
 
 int main() {


### PR DESCRIPTION
Certain quotient values are off by 1 since the conversion to `int` truncates the decimal value. Use `std::round` to round to the nearest integer before converting to `int`.