### PR TITLE
[SYCL] Remove XFAIL from SPMD_invoke_ESIMD_external.cpp

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/SPMD_invoke_ESIMD_external.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/SPMD_invoke_ESIMD_external.cpp
@@ -1,6 +1,3 @@
-// TODO: enable when Jira ticket resolved
-// XFAIL: gpu
-//
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../SPMD_invoke_ESIMD_external.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //

--- a/sycl/test-e2e/InvokeSimd/Feature/SPMD_invoke_ESIMD_external.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/SPMD_invoke_ESIMD_external.cpp
@@ -1,6 +1,3 @@
-// TODO: enable when Jira ticket resolved
-// XFAIL: gpu
-//
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //


### PR DESCRIPTION
These tests now pass after this commit: https://github.com/intel/llvm/commit/841768794f7ae59e592d066bb0f695f413c8c6c6

> Unexpectedly Passed Tests (2):
  SYCL :: InvokeSimd/Feature/ImplicitSubgroup/SPMD_invoke_ESIMD_external.cpp
  SYCL :: InvokeSimd/Feature/SPMD_invoke_ESIMD_external.cpp