### PR TITLE
[SYCL] Add dummy memory handle for zero-sized accessors

### DIFF
--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -241,6 +241,9 @@ public:
                        const std::set<std::uintptr_t> &ImgIdentifiers,
                        const std::string &ObjectTypeName);
 
+  /// Initializes (if needed) and returns the dummy memory handle.
+  sycl::detail::pi::PiMem getDummyMemoryHandle();
+
   enum PropertySupport { NotSupported = 0, Supported = 1, NotChecked = 2 };
 
 private:
@@ -304,6 +307,13 @@ private:
            std::unique_ptr<std::byte[]>>
       MDeviceGlobalUnregisteredData;
   std::mutex MDeviceGlobalUnregisteredDataMutex;
+
+  // For empty accessors the backends may still need some valid memory object
+  // passed to them. To minimize the overhead of this, a small allocation is
+  // created to be used by all zero-sized accessors. The creation of this memory
+  // is done lazily and is guarded by MDummyMemoryHandleOnceFlag.
+  sycl::detail::pi::PiMem MDummyMemoryHandle = nullptr;
+  std::once_flag MDummyMemoryHandleOnceFlag;
 };
 
 template <typename T, typename Capabilities>

--- a/sycl/test-e2e/Regression/empty_accessor_use.cpp
+++ b/sycl/test-e2e/Regression/empty_accessor_use.cpp
@@ -1,0 +1,25 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests that 3D accessors with 0 elements are allowed to be captured in a
+// kernel.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  queue Q;
+
+  buffer<int, 3> Buf{range<3>{1, 1, 1}};
+  assert(Buf.size() == 1);
+  Q.submit([&](handler &CGH) {
+    accessor Acc{Buf, CGH, range<3>{0, 0, 0}, read_write};
+    // assert(Acc.empty());
+    CGH.single_task([=] {
+      if (!Acc.empty())
+        Acc[id<3>{0, 0, 0}] = 42;
+    });
+  });
+  return 0;
+}


### PR DESCRIPTION
This commit adds the notion of a "dummy" handle on a context. This handle is created whenever a zero-sized accessor needs a memory object to use, avoiding the backend complaining due to invalid memory arguments to the corresponding kernel.

Additionally, this commit removes a check when setting kernel arguments that would skip 3D accessors with 0 elements.