### PR TITLE
[SYCL-MLIR] Define `sycl.host.[kernel_name|get_kernel]`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -16,6 +16,7 @@
 
 include "mlir/Dialect/LLVMIR/LLVMOpBase.td"
 include "mlir/IR/BuiltinAttributes.td"
+include "mlir/IR/SymbolInterfaces.td"
 
 ////////////////////////////////////////////////////////////////////////////////
 // BASE DECLARATIONS
@@ -54,6 +55,33 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor"> {
     `(` operands `)` attr-dict `:` functional-type(operands, results)
   }];
   let hasVerifier = true;
+}
+
+def SYCLHostKernelNameOp
+    : SYCL_HostOp<"kernel_name",
+        [Symbol, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = [{
+    Operation representing a constant holding the name of a kernel, i.e., a
+    `gpu.func` with the `kernel` attribute.
+  }];
+  let arguments = (ins SymbolNameAttr:$sym_name, SymbolRefAttr:$kernel_name);
+  let assemblyFormat = [{
+    $sym_name `->` $kernel_name attr-dict
+  }];
+}
+
+def SYCLHostGetKernelOp
+    : SYCL_HostOp<"get_kernel",
+        [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = [{
+    Operation that defines a reference to a kernel, i.e., a `gpu.func` with the
+    `kernel` attribute.
+  }];
+  let arguments = (ins SymbolRefAttr:$kernel_name);
+  let results = (outs LLVM_AnyPointer:$res);
+  let assemblyFormat = [{
+    $kernel_name attr-dict `:` type($res)
+  }];
 }
 
 #endif // SYCL_HOST_OPS

--- a/mlir-sycl/lib/Dialect/SYCL/IR/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/CMakeLists.txt
@@ -4,6 +4,7 @@ if (TARGET MLIRArithmetic)
     MLIRCallInterfaces
     MLIRCastInterfaces
     MLIRControlFlowInterfaces
+    MLIRGPUDialect
     MLIRIR
     MLIRSideEffectInterfaces
     MLIRVectorInterfaces
@@ -18,6 +19,7 @@ else()
     MLIRCallInterfaces
     MLIRCastInterfaces
     MLIRControlFlowInterfaces
+    MLIRGPUDialect
     MLIRIR
     MLIRSideEffectInterfaces
     MLIRVectorInterfaces

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -259,5 +259,26 @@ LogicalResult SYCLIDConstructorOp::verify() {
       "expects a different signature. Check documentation for details");
 }
 
+static LogicalResult verifyReferencesKernel(SymbolUserOpInterface user,
+                                            SymbolTableCollection &symbolTable,
+                                            SymbolRefAttr symbol) {
+  auto kernel =
+      symbolTable.lookupNearestSymbolFrom<gpu::GPUFuncOp>(user, symbol);
+  if (!kernel || !kernel.isKernel())
+    return user->emitOpError("'")
+           << symbol << "' does not reference a valid kernel";
+  return success();
+}
+
+LogicalResult
+SYCLHostKernelNameOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
+}
+
+LogicalResult
+SYCLHostGetKernelOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
+}
+
 #define GET_OP_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOps.cpp.inc"

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -19,3 +19,19 @@ func.func @test_host_constructor_args(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> !ll
   %0 = sycl.host.constructor(%arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
   return %0 : !llvm.ptr
 }
+
+gpu.module @kernels {
+  gpu.func @k0() kernel {
+    gpu.return
+  }
+}
+
+// CHECK-LABEL:  sycl.host.kernel_name @kernel_ref -> @kernels::@k0
+sycl.host.kernel_name @kernel_ref -> @kernels::@k0
+
+// CHECK-LABEL:  func.func @f() -> !llvm.ptr {
+// CHECK-NEXT:     %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
+func.func @f() -> !llvm.ptr {
+  %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
+  func.return %0 : !llvm.ptr
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -355,3 +355,16 @@ func.func @math_op_invalid_type(%arg0 : i32) {
   %0 = sycl.math.sin %arg0 : i32
   return
 }
+
+// -----
+
+// expected-error @below {{'sycl.host.kernel_name' op '@kernels::@k0' does not reference a valid kernel}}
+sycl.host.kernel_name @kernel_ref -> @kernels::@k0
+
+// -----
+
+func.func @f() -> !llvm.ptr {
+  // expected-error @below {{'sycl.host.get_kernel' op '@kernels::@k0' does not reference a valid kernel}}
+  %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
+  func.return %0 : !llvm.ptr
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -358,10 +358,68 @@ func.func @math_op_invalid_type(%arg0 : i32) {
 
 // -----
 
+// COM: Check inexistent symbol.
+
 // expected-error @below {{'sycl.host.kernel_name' op '@kernels::@k0' does not reference a valid kernel}}
 sycl.host.kernel_name @kernel_ref -> @kernels::@k0
 
 // -----
+
+// COM: Check inexistent symbol.
+
+func.func @f() -> !llvm.ptr {
+  // expected-error @below {{'sycl.host.get_kernel' op '@kernels::@k0' does not reference a valid kernel}}
+  %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
+  func.return %0 : !llvm.ptr
+}
+
+// -----
+
+// COM: Check function is not a gpu.func
+
+// expected-error @below {{'sycl.host.kernel_name' op '@f0' does not reference a valid kernel}}
+sycl.host.kernel_name @kernel_ref -> @f0
+
+func.func @f0() {
+  func.return
+}
+
+// -----
+
+// COM: Check function is not a gpu.func
+
+func.func @f() -> !llvm.ptr {
+  // expected-error @below {{'sycl.host.get_kernel' op '@f0' does not reference a valid kernel}}
+  %0 = sycl.host.get_kernel @f0 : !llvm.ptr
+  func.return %0 : !llvm.ptr
+}
+
+func.func @f0() {
+  func.return
+}
+
+// -----
+
+// COM: Check function is not a kernel
+
+gpu.module @kernels {
+  gpu.func @k0() {
+    gpu.return
+  }
+}
+
+// expected-error @below {{'sycl.host.kernel_name' op '@kernels::@k0' does not reference a valid kernel}}
+sycl.host.kernel_name @kernel_ref -> @kernels::@k0
+
+// -----
+
+// COM: Check function is not a kernel
+
+gpu.module @kernels {
+  gpu.func @k0() {
+    gpu.return
+  }
+}
 
 func.func @f() -> !llvm.ptr {
   // expected-error @below {{'sycl.host.get_kernel' op '@kernels::@k0' does not reference a valid kernel}}


### PR DESCRIPTION
- `sycl.host.kernel_name`: Symbol referencing a kernel. Set to replace `llvm.mlir.global` operations with constant string values referencing a kernel.
- `sycl.host.get_kernel`: Operation defining a value representing a reference to a kernel. Set to replace `llvm.mlir.addressof` operations referencing operations that can be replaced with `sycl.host.kernel_name`.

Using these operations, we can transform:

```mlir
gpu.module @kernels {
  gpu.func @k0() kernel {
    gpu.return
  }
}

llvm.mlir.global private unnamed_addr constant @kernel_ref("k0\00") 
    {addr_space = 0 : i32, alignment = 1 : i64, dso_local}

func.func @f() -> !llvm.ptr {
  %0 = llvm.mlir.addressof @kernel_ref : !llvm.ptr
  func.return %0 : !llvm.ptr
}
```

into:

```mlir
gpu.module @kernels {
  gpu.func @k0() kernel {
    gpu.return
  }
}

sycl.host.kernel_name @kernel_ref -> @kernels::@k0

func.func @f() -> !llvm.ptr {
  %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
  func.return %0 : !llvm.ptr
}
```