### PR TITLE
[SYCL-MLIR] Raise construct to `sycl.host.get_kernel`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/Utils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/Utils.h
@@ -17,8 +17,11 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/IntegerSet.h"
+#include <llvm/ADT/StringRef.h>
 
 namespace mlir {
+constexpr llvm::StringLiteral DeviceModuleName = "device_functions";
+
 static inline mlir::scf::IfOp cloneWithoutResults(scf::IfOp op,
                                                   OpBuilder &rewriter,
                                                   IRMapping mapping = {},

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/Utils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/Utils.h
@@ -17,7 +17,7 @@
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/IRMapping.h"
 #include "mlir/IR/IntegerSet.h"
-#include <llvm/ADT/StringRef.h>
+#include "llvm/ADT/StringRef.h"
 
 namespace mlir {
 constexpr llvm::StringLiteral DeviceModuleName = "device_functions";

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -18,6 +18,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Polygeist/IR/PolygeistOps.h"
 #include "mlir/Dialect/Polygeist/Utils/TransformUtils.h"
+#include "mlir/Dialect/Polygeist/Utils/Utils.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/Support/Debug.h"
@@ -49,15 +50,94 @@ public:
 // Pattern
 //===----------------------------------------------------------------------===//
 
+namespace {
+struct RaiseKernelName : public OpRewritePattern<LLVM::GlobalOp> {
+public:
+  using OpRewritePattern<LLVM::GlobalOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::GlobalOp op,
+                                PatternRewriter &rewriter) const final {
+    // Get a reference to the kernel this global references
+    std::optional<SymbolRefAttr> ref = getKernelRef(op);
+    if (!ref)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<sycl::SYCLHostKernelNameOp>(op, op.getSymName(),
+                                                            *ref);
+    return success();
+  }
+
+private:
+  /// If the input global contains a constant string representing the name of a
+  /// SYCL kernel, returns a reference to the `gpu.func` implementing this
+  /// kernel.
+  ///
+  /// The string will contain a trailing character we need to get rid of before
+  /// searching.
+  static std::optional<SymbolRefAttr> getKernelRef(LLVM::GlobalOp op) {
+    // Check the operation has a value
+    std::optional<Attribute> attr = op.getValue();
+    if (!attr)
+      return std::nullopt;
+
+    // Check it is a string
+    auto strAttr = dyn_cast<StringAttr>(*attr);
+    if (!strAttr)
+      return std::nullopt;
+
+    // Drop the trailing `0` character
+    StringRef name = strAttr.getValue().drop_back();
+
+    // Search the `gpu.func` in the device module
+    SymbolTableCollection symbolTable;
+    auto ref =
+        SymbolRefAttr::get(op->getContext(), DeviceModuleName,
+                           FlatSymbolRefAttr::get(op->getContext(), name));
+    auto kernel = symbolTable.lookupNearestSymbolFrom<gpu::GPUFuncOp>(op, ref);
+
+    // If it was found and it is a kernel, return the reference
+    return kernel && kernel.isKernel() ? std::optional<SymbolRefAttr>(ref)
+                                       : std::nullopt;
+  }
+};
+
+struct RaiseGetKernelName : public OpRewritePattern<LLVM::AddressOfOp> {
+public:
+  using OpRewritePattern<LLVM::AddressOfOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::AddressOfOp op,
+                                PatternRewriter &rewriter) const final {
+    // Get the reference to the kernel
+    sycl::SYCLHostKernelNameOp kernelName = getKernelNameOp(op);
+    if (!kernelName)
+      return failure();
+
+    rewriter.replaceOpWithNewOp<sycl::SYCLHostGetKernelOp>(
+        op, op.getType(), kernelName.getKernelName());
+
+    return success();
+  }
+
+private:
+  /// Returns the `sycl.host.kernel_name` operation this operation references.
+  static sycl::SYCLHostKernelNameOp getKernelNameOp(LLVM::AddressOfOp op) {
+    SymbolTableCollection symbolTable;
+    return symbolTable.lookupNearestSymbolFrom<sycl::SYCLHostKernelNameOp>(
+        op, op.getGlobalNameAttr());
+  }
+};
+} // namespace
+
 //===----------------------------------------------------------------------===//
 // SYCLRaiseHostConstructsPass
 //===----------------------------------------------------------------------===//
 
 void SYCLRaiseHostConstructsPass::runOnOperation() {
   Operation *scopeOp = getOperation();
+  MLIRContext *context = &getContext();
 
-  RewritePatternSet rewritePatterns{&getContext()};
-  // rewritePatterns.add<...>(...);
+  RewritePatternSet rewritePatterns{context};
+  rewritePatterns.add<RaiseKernelName, RaiseGetKernelName>(context);
   FrozenRewritePatternSet frozen(std::move(rewritePatterns));
 
   if (failed(applyPatternsAndFoldGreedily(scopeOp, frozen)))

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -65,7 +65,7 @@ public:
       return failure();
 
     // Get a reference to the kernel the global references
-    std::optional<SymbolRefAttr> ref = getKernelRef(global);
+    std::optional<SymbolRefAttr> ref = getKernelRef(global, symbolTable);
     if (!ref)
       return failure();
 
@@ -81,7 +81,8 @@ private:
   ///
   /// The string will contain a trailing character we need to get rid of before
   /// searching.
-  static std::optional<SymbolRefAttr> getKernelRef(LLVM::GlobalOp op) {
+  static std::optional<SymbolRefAttr>
+  getKernelRef(LLVM::GlobalOp op, SymbolTableCollection &symbolTable) {
     // Check the operation has a value
     std::optional<Attribute> attr = op.getValue();
     if (!attr)
@@ -96,7 +97,6 @@ private:
     StringRef name = strAttr.getValue().drop_back();
 
     // Search the `gpu.func` in the device module
-    SymbolTableCollection symbolTable;
     auto ref =
         SymbolRefAttr::get(op->getContext(), DeviceModuleName,
                            FlatSymbolRefAttr::get(op->getContext(), name));

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -1,0 +1,14 @@
+// RUN: polygeist-opt --sycl-raise-host --split-input-file %s
+
+gpu.module @device_functions {
+  gpu.func @foo() kernel {
+    gpu.return
+  }
+}
+
+llvm.mlir.global private unnamed_addr constant @kernel_ref("foo\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+
+llvm.func @f() -> !llvm.ptr {
+  %kn = llvm.mlir.addressof @kernel_ref : !llvm.ptr
+  llvm.return %kn : !llvm.ptr
+}

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -1,16 +1,20 @@
 // RUN: polygeist-opt --sycl-raise-host --split-input-file %s | FileCheck %s
 
+// CHECK-LABEL: gpu.module @device_functions
 gpu.module @device_functions {
+// CHECK:         gpu.func @foo() kernel
   gpu.func @foo() kernel {
     gpu.return
   }
 }
 
-// CHECK-LABEL: sycl.host.kernel_name @kernel_ref -> @device_functions::@foo
+// CHECK-LABEL: llvm.mlir.global private unnamed_addr constant @kernel_ref("foo\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
 llvm.mlir.global private unnamed_addr constant @kernel_ref("foo\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
 
+// CHECK-LABEL: llvm.func @f() -> !llvm.ptr
+// CHECK-NEXT:    %[[VAL_0:.*]] = sycl.host.get_kernel @device_functions::@foo : !llvm.ptr
+// CHECK-NEXT:    llvm.return %[[VAL_0]] : !llvm.ptr
 llvm.func @f() -> !llvm.ptr {
-  // CHECK-LABEL: %0 = sycl.host.get_kernel @device_functions::@foo : !llvm.ptr
   %kn = llvm.mlir.addressof @kernel_ref : !llvm.ptr
   llvm.return %kn : !llvm.ptr
 }

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt --sycl-raise-host --split-input-file %s
+// RUN: polygeist-opt --sycl-raise-host --split-input-file %s | FileCheck %s
 
 gpu.module @device_functions {
   gpu.func @foo() kernel {
@@ -6,9 +6,11 @@ gpu.module @device_functions {
   }
 }
 
+// CHECK-LABEL: sycl.host.kernel_name @kernel_ref -> @device_functions::@foo
 llvm.mlir.global private unnamed_addr constant @kernel_ref("foo\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
 
 llvm.func @f() -> !llvm.ptr {
+  // CHECK-LABEL: %0 = sycl.host.get_kernel @device_functions::@foo : !llvm.ptr
   %kn = llvm.mlir.addressof @kernel_ref : !llvm.ptr
   llvm.return %kn : !llvm.ptr
 }

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -61,8 +61,6 @@ static llvm::cl::opt<bool>
     EnableAttributes("enable-attributes", llvm::cl::init(false),
                      llvm::cl::desc("Enable setting of attributes"));
 
-constexpr llvm::StringLiteral MLIRASTConsumer::DeviceModuleName;
-
 /******************************************************************************/
 /*                               MLIRScanner                                  */
 /******************************************************************************/

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -140,8 +140,6 @@ private:
       CGFunctionInfos;
 
 public:
-  static constexpr llvm::StringLiteral DeviceModuleName{"device_functions"};
-
   MLIRASTConsumer(
       std::set<std::string> &EmitIfFound,
       std::set<std::pair<InsertionContext, std::string>> &Done,

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -13,6 +13,7 @@
 
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Dialect/Polygeist/Utils/Utils.h"
 #include "mlir/IR/Builders.h"
 #include "mlir/IR/Operation.h"
 #include "mlir/IR/OperationSupport.h"
@@ -78,8 +79,7 @@ NamespaceKind getNamespaceKind(const clang::DeclContext *DC) {
 }
 
 gpu::GPUModuleOp getDeviceModule(ModuleOp Module) {
-  return cast<gpu::GPUModuleOp>(
-      Module.lookupSymbol(MLIRASTConsumer::DeviceModuleName));
+  return cast<gpu::GPUModuleOp>(Module.lookupSymbol(DeviceModuleName));
 }
 
 void setInsertionPoint(OpBuilder &Builder, InsertionContext FuncContext,

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -33,6 +33,7 @@
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Linalg/IR/Linalg.h"
 #include "mlir/Dialect/OpenMP/OpenMPDialect.h"
+#include "mlir/Dialect/Polygeist/Utils/Utils.h"
 #include "mlir/Dialect/SCF/IR/SCF.h"
 #include "mlir/Dialect/SCF/Transforms/Passes.h"
 #include "mlir/Dialect/SPIRV/IR/SPIRVDialect.h"
@@ -1309,8 +1310,8 @@ int main(int argc, char **argv) {
   const Location Loc = Builder.getUnknownLoc();
   mlir::OwningOpRef<mlir::ModuleOp> Module(mlir::ModuleOp::create(Loc));
   Builder.setInsertionPointToEnd(Module->getBody());
-  auto DeviceModule = Builder.create<mlir::gpu::GPUModuleOp>(
-      Loc, MLIRASTConsumer::DeviceModuleName);
+  auto DeviceModule =
+      Builder.create<mlir::gpu::GPUModuleOp>(Loc, DeviceModuleName);
 
   llvm::DataLayout DL("");
   llvm::Triple Triple;


### PR DESCRIPTION
Transform:

```mlir
gpu.module @kernels {
  gpu.func @k0() kernel {
    gpu.return
  }
}

llvm.mlir.global private unnamed_addr constant @kernel_ref("k0\00") 
    {addr_space = 0 : i32, alignment = 1 : i64, dso_local}

func.func @f() -> !llvm.ptr {
  %0 = llvm.mlir.addressof @kernel_ref : !llvm.ptr
  func.return %0 : !llvm.ptr
}
```

into:

```mlir
gpu.module @kernels {
  gpu.func @k0() kernel {
    gpu.return
  }
}

llvm.mlir.global private unnamed_addr constant @kernel_ref("k0\00") 
    {addr_space = 0 : i32, alignment = 1 : i64, dso_local}

func.func @f() -> !llvm.ptr {
  %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
  func.return %0 : !llvm.ptr
}
```

In order to do this transformation, the name of the `gpu.module` holding the kernels comes handy, so that was moved to an accessible header file. Note that this name could be configurable in the future using a pass argument.