### PR TITLE
[CI] Make build artifact archive name/compression parameters

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -36,6 +36,15 @@ on:
       build_artifact_suffix:
         type: string
         required: true
+      artifact_archive_name:
+        type: string
+        default: llvm_sycl.tar.zst
+      artifact_compress_command:
+        type: string
+        default: zstd -9
+      artifact_decompress_command:
+        type: string
+        default: zstd
       lts_matrix:
         type: string
         required: false
@@ -176,13 +185,13 @@ jobs:
 
     - name: Pack toolchain
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
-      run: tar -I 'zstd -9' -cf llvm_sycl.tar.zst -C $GITHUB_WORKSPACE/build/install .
+      run: tar -I '${{ inputs.artifact_compress_command }}' -cf ${{ inputs.artifact_archive_name }} -C $GITHUB_WORKSPACE/build/install .
     - name: Upload toolchain
       if: ${{ always() && !cancelled() && steps.build.conclusion == 'success' }}
       uses: actions/upload-artifact@v3
       with:
         name: sycl_linux_${{ inputs.build_artifact_suffix }}
-        path: llvm_sycl.tar.zst
+        path: ${{ inputs.artifact_archive_name }}
 
   aws-start:
     name: Start AWS
@@ -238,7 +247,8 @@ jobs:
       name: Run SYCL End-to-End tests
       with:
         sycl_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
-        sycl_archive: llvm_sycl.tar.zst
+        sycl_archive: ${{ inputs.artifact_archive_name }}
+        decompress_command: ${{ inputs.artifact_decompress_command }}
         targets: ${{ matrix.targets }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
 
@@ -284,7 +294,8 @@ jobs:
       with:
         test_ref: ${{ inputs.cts_ref }}
         sycl_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
-        sycl_archive: llvm_sycl.tar.zst
+        sycl_archive: ${{ inputs.artifact_archive_name }}
+        decompress_command: ${{ inputs.artifact_decompress_command }}
         sycl_device_filter: ${{ matrix.sycl_device_filter }}
         cmake_args: '${{ matrix.cmake_args }} ${{ inputs.cts_cmake_extra_args }}'
 

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -23,6 +23,9 @@ on:
         description: 'Filter matches for the changed files in the PR'
         default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
         required: false
+      artifact_archive_name:
+        type: string
+        default: llvm_sycl.tar.gz
 
 jobs:
   build:
@@ -108,12 +111,12 @@ jobs:
     - name: Pack toolchain
       shell: bash
       run: |
-        tar -czf llvm_sycl.tar.gz -C install .
+        tar -czf ${{ inputs.artifact_archive_name }} -C install .
     - name: Upload toolchain
       uses: actions/upload-artifact@v3
       with:
         name: sycl_windows_default
-        path: llvm_sycl.tar.gz
+        path: ${{ inputs.artifact_archive_name }}
 
   e2e-tests:
     needs: build

--- a/devops/actions/e2e-tests-win/action.yml
+++ b/devops/actions/e2e-tests-win/action.yml
@@ -10,6 +10,10 @@ inputs:
   cmake_args:
     description: 'Extra arguments to cmake command'
     required: false
+  sycl_archive:
+    description: 'Name of SYCL toolchain archive file'
+    required: false
+    default: 'llvm_sycl.tar.gz'
 
 post-if: false
 runs:
@@ -23,8 +27,8 @@ runs:
     shell: bash
     run: |
       mkdir install
-      tar -xf llvm_sycl.tar.gz -C install
-      rm llvm_sycl.tar.gz
+      tar -xf ${{ inputs.sycl_archive }} -C install
+      rm ${{ inputs.sycl_archive }}
   - name: Configure
     shell: cmd
     run: |

--- a/devops/actions/e2e-tests/action.yml
+++ b/devops/actions/e2e-tests/action.yml
@@ -8,6 +8,8 @@ inputs:
     description: 'Name of SYCL toolchain archive file'
     required: false
     default: 'llvm_sycl.tar.zst'
+  decompress_command:
+    default: zstd
   targets:
     description: 'List of SYCL backends with set of target devices per each to be tested iteratively'
     required: true
@@ -30,7 +32,7 @@ runs:
     shell: bash
     run: |
       mkdir toolchain
-      tar -I 'zstd -d' -xf ${{ inputs.sycl_archive }} -C toolchain
+      tar -I '${{ inputs.decompress_command }}' -xf ${{ inputs.sycl_archive }} -C toolchain
       rm -f ${{ inputs.sycl_archive }}
   - name: Configure
     shell: bash

--- a/devops/actions/khronos_cts_test/action.yml
+++ b/devops/actions/khronos_cts_test/action.yml
@@ -12,6 +12,8 @@ inputs:
     description: 'Name of SYCL toolchain archive file'
     required: false
     default: 'llvm_sycl.tar.zst'
+  decompress_command:
+    default: zstd
   sycl_device_filter:
     description: 'List of SYCL backends with set of target devices per each to be tested iteratively'
     required: true
@@ -49,7 +51,7 @@ runs:
     shell: bash
     run: |
       mkdir toolchain
-      tar -I 'zstd -d' -xf ${{ inputs.sycl_archive }} -C toolchain
+      tar -I '${{ inputs.decompress_command }}' -xf ${{ inputs.sycl_archive }} -C toolchain
       rm -f ${{ inputs.sycl_archive }}
   - name: Build SYCL-CTS
     shell: bash


### PR DESCRIPTION
I plan to enable making releases from Github CI tasks and we'll need to use gzip compression instead of zstd as well as provide distinct names for Linux/Windows.

An alternative would be to unpack/repack in the release action, but the solution implemented in this PR seems to be clearer.