### PR TITLE
[SYCL][UR][CUDA] Fix typo in ur_device_handle_t

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
@@ -29,7 +29,7 @@ public:
       : CuDevice(cuDevice), CuContext(cuContext), EvBase(evBase), RefCount{1},
         Platform(platform) {}
 
-  ur_device_handle_t_() { cuDevicePrimaryCtxRelease(CuDevice); }
+  ~ur_device_handle_t_() { cuDevicePrimaryCtxRelease(CuDevice); }
 
   native_type get() const noexcept { return CuDevice; };
 


### PR DESCRIPTION
The destructor should be calling `cuDevicePrimaryCtxRelease`