### PR TITLE
[SYCL-MLIR] Add pointer to host constructor

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -34,8 +34,8 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor"> {
     Operation representing the construction of a SYCL object, i.e., allocation,
     and member initialization.
 
-    This operation differs from `sycl.constructor` as it will return an 
-    `llvm.ptr` to any type instead of requiring a `sycl` type.
+    This operation differs from `sycl.constructor` as it will take a
+    `llvm.ptr` to any type instead of requiring a memref of a `sycl` type.
 
     This difference is the reason why this operation was introduced in
     the first place: this is a short-term solution to represent construction of

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -34,13 +34,10 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor"> {
     Operation representing the construction of a SYCL object, i.e., allocation,
     and member initialization.
 
-    This operation differs with `sycl.constructor` in two points:
-    - This operation will return a pointer to the constructed object instead of
-      receiving a reference to the object to construct
-    - This operation will return an `llvm.ptr` to any type instead of requiring a
-      `sycl` type.
+    This operation differs from `sycl.constructor` as it will return an 
+    `llvm.ptr` to any type instead of requiring a `sycl` type.
 
-    These two differences are the reason why this operation was introduced in
+    This difference is the reason why this operation was introduced in
     the first place: this is a short-term solution to represent construction of
     a SYCL object in the host side. Using a `sycl.constructor` operation would
     imply performing heavy modifications to the host LLVM code (or blurring the
@@ -49,8 +46,8 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor"> {
     Note that, despite the more relaxed typing, the `type` attribute still needs
     to be a type in the `sycl` dialect.
   }];
-  let arguments = (ins Variadic<AnyType>:$args, Builtin_TypeAttr:$type);
-  let results = (outs LLVM_AnyPointer:$res);
+  let arguments = (ins LLVM_AnyPointer:$dst, Variadic<AnyType>:$args,
+                        Builtin_TypeAttr:$type);
   let assemblyFormat = [{
     `(` operands `)` attr-dict `:` functional-type(operands, results)
   }];

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -7,17 +7,23 @@
 !sycl_accessor_2_i32_r_gb = !sycl.accessor<[2, i32, read, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL: test_host_constructor
-// CHECK-NEXT:  sycl.host.constructor() {type = !sycl_id_1_} : () -> !llvm.ptr
+// CHECK:  %1 = llvm.alloca %0 x !sycl_id_1_ : (i32) -> !llvm.ptr
+// CHECK:  sycl.host.constructor(%1) {type = !sycl_id_1_} : (!llvm.ptr) -> ()
 func.func @test_host_constructor() -> !llvm.ptr {
-  %0 = sycl.host.constructor() {type = !sycl_id_1_} : () -> !llvm.ptr
-  return %0 : !llvm.ptr
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x !sycl_id_1_ : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1) {type = !sycl_id_1_} : (!llvm.ptr) -> ()
+  return %1 : !llvm.ptr
 }
 
 // CHECK-LABEL: test_host_constructor_args
-// CHECK-NEXT:  sycl.host.constructor(%arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
+// CHECK:  %1 = llvm.alloca %0 x !sycl_accessor_2_i32_r_gb : (i32) -> !llvm.ptr
+// CHECK:  sycl.host.constructor(%[[#PTR:]], %arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 func.func @test_host_constructor_args(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> !llvm.ptr {
-  %0 = sycl.host.constructor(%arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-  return %0 : !llvm.ptr
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x !sycl_accessor_2_i32_r_gb : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  return %1 : !llvm.ptr
 }
 
 gpu.module @kernels {

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -310,9 +310,11 @@ func.func @test_vec_nonscalar(%v: !sycl.vec<[!sycl_vec_i8_1_, 2], (vector<2x1xi8
 // -----
 
 func.func @test_host_constructor() -> !llvm.ptr {
+  %0 = llvm.mlir.constant(1 : i32) : i32
+  %1 = llvm.alloca %0 x i32 : (i32) -> !llvm.ptr
 // expected-error @below {{'sycl.host.constructor' op expecting a sycl type as constructed type. Got 'i32'}}
-  %0 = sycl.host.constructor() {type = i32} : () -> !llvm.ptr
-  return %0 : !llvm.ptr
+  sycl.host.constructor(%1) {type = i32} : (!llvm.ptr) -> ()
+  return %1 : !llvm.ptr
 }
 
 // -----


### PR DESCRIPTION
Change the `sycl.host.constructor` operation to take the `this*` pointer of the object to be constructed as first argument.