### PR TITLE
[SYCL-MLIR] Define `sycl.handler.set_kernel`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -81,4 +81,17 @@ def SYCLHostGetKernelOp
   }];
 }
 
+def SYCLHostHandlerSetKernel
+    : SYCL_HostOp<"handler.set_kernel",
+        [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = [{
+    Operation assigning a kernel to a `sycl::handler`, thus pairing the handler
+    and the kernel being launched.
+  }];
+  let arguments = (ins LLVM_AnyPointer:$handler, SymbolRefAttr:$kernel_name);
+  let assemblyFormat = [{
+    $handler `->` $kernel_name attr-dict `:` type($handler)
+  }];
+}
+
 #endif // SYCL_HOST_OPS

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -280,5 +280,10 @@ SYCLHostGetKernelOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
 }
 
+LogicalResult
+SYCLHostHandlerSetKernel::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
+}
+
 #define GET_OP_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOps.cpp.inc"

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -41,3 +41,11 @@ func.func @f() -> !llvm.ptr {
   %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
   func.return %0 : !llvm.ptr
 }
+
+// CHECK-LABEL:  func.func @set_kernel(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.ptr) {
+// CHECK-NEXT:     sycl.host.handler.set_kernel %[[VAL_0]] -> @kernels::@k0
+func.func @set_kernel(%handler: !llvm.ptr) {
+  sycl.host.handler.set_kernel %handler -> @kernels::@k0 : !llvm.ptr
+  func.return
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -428,3 +428,43 @@ func.func @f() -> !llvm.ptr {
   %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
   func.return %0 : !llvm.ptr
 }
+
+// -----
+
+// COM: Check inexistent symbol.
+
+func.func @f(%handler: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.handler.set_kernel' op '@kernels::@k0' does not reference a valid kernel}}
+  sycl.host.handler.set_kernel %handler -> @kernels::@k0 : !llvm.ptr
+  func.return
+}
+
+// -----
+
+// COM: Check function is not a gpu.func
+
+func.func @f(%handler: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.handler.set_kernel' op '@f0' does not reference a valid kernel}}
+  sycl.host.handler.set_kernel %handler -> @f0 : !llvm.ptr
+  func.return
+}
+
+func.func @f0() {
+  func.return
+}
+
+// -----
+
+// COM: Check function is not a kernel
+
+func.func @f(%handler: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.handler.set_kernel' op '@kernels::@k0' does not reference a valid kernel}}
+  sycl.host.handler.set_kernel %handler -> @kernels::@k0 : !llvm.ptr
+  func.return
+}
+
+gpu.module @kernels {
+  gpu.func @k0() {
+    gpu.return
+  }
+}


### PR DESCRIPTION
Define operation assigning a kernel to a `sycl::handler`, thus pairing the handler and the kernel being launched.