### PR TITLE
[SYCL][HIP][E2E] Disable failing 2D USM tests for HIP

### DIFF
--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
@@ -11,7 +11,8 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_device.cpp
@@ -11,7 +11,8 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
@@ -11,7 +11,8 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_device.cpp
@@ -11,7 +11,8 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
 
 #include "memcpy2d_common.hpp"
 


### PR DESCRIPTION
As described in https://github.com/intel/llvm/issues/10157, certain configurations of 2D USM memory copies currently fail for HIP. This commit temporarily disables these.