### PR TITLE
[SYCL-MLIR] Raise constructs to `sycl.host.handler.set_kernel`

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -53,6 +53,4 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRSideEffectInterfaces
   MLIRSCFToControlFlow
   MLIRTransformUtils
-
-  LINK_COMPONENTS Demangle
 )

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -53,4 +53,6 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRSideEffectInterfaces
   MLIRSCFToControlFlow
   MLIRTransformUtils
+
+  LINK_COMPONENTS Demangle
 )

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -74,7 +74,7 @@ public:
   explicit operator StringRef() const { return {buf, size - 1}; }
 
   DemangleResult(const DemangleResult &other)
-      : buf(new char[other.size]), size(other.size) {
+      : DemangleResult(new char[other.size], other.size) {
     std::memcpy(buf, other.buf, size);
   }
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -238,9 +238,7 @@ public:
 
     // Check whether the type allocated for the first argument ('this') matches
     // the expected type.
-    auto allocTy = *alloc.getElemType();
-    auto structAllocTy = dyn_cast<LLVM::LLVMStructType>(allocTy);
-    if (!structAllocTy || structAllocTy.getName() != TypeTag::getTypeName())
+    if (!isClassType(*alloc.getElemType(), TypeTag::getTypeName()))
       return failure();
 
     if (constructor.getNumResults())

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -25,6 +25,8 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Regex.h"
 
+#include <type_traits>
+
 namespace mlir {
 namespace polygeist {
 #define GEN_PASS_DEF_SYCLRAISEHOSTCONSTRUCTS
@@ -60,7 +62,10 @@ constexpr StringLiteral stdNamespace = "std";
 /// Result is owned by this type.
 class DemangleResult {
 public:
-  template <typename FuncTy> static FailureOr<DemangleResult> get(FuncTy f) {
+  template <typename FuncTy,
+            typename = std::enable_if_t<std::is_same_v<
+                char *, std::invoke_result_t<FuncTy, char *, std::size_t *>>>>
+  static FailureOr<DemangleResult> get(FuncTy f) {
     char *buf = nullptr;
     std::size_t size = 0;
     buf = f(buf, &size);

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -69,38 +69,12 @@ public:
     return DemangleResult(buf, size);
   }
 
-  ~DemangleResult() { free(buf); }
-
-  explicit operator StringRef() const { return {buf, size - 1}; }
-
-  DemangleResult(const DemangleResult &other)
-      : DemangleResult(new char[other.size], other.size) {
-    std::memcpy(buf, other.buf, size);
-  }
-
-  DemangleResult(DemangleResult &&other)
-      : DemangleResult(other.buf, other.size) {
-    other.buf = nullptr;
-  }
-
-  DemangleResult &operator=(const DemangleResult &other) {
-    buf = new char[other.size];
-    size = other.size;
-    std::memcpy(buf, other.buf, size);
-    return *this;
-  }
-
-  DemangleResult &operator=(DemangleResult &&other) {
-    buf = other.buf;
-    size = other.size;
-    other.buf = nullptr;
-    return *this;
-  }
+  explicit operator StringRef() const { return {buf.get(), size - 1}; }
 
 private:
   DemangleResult(char *buf, std::size_t size) : buf(buf), size(size) {}
 
-  char *buf;
+  std::unique_ptr<char[]> buf;
   std::size_t size;
 };
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -592,7 +592,7 @@ struct RaiseRangeConstructor
 /// This pattern acts on `FunctionOpInterface` instances as it will not be
 /// removing the operations assigning the kernel name, but creating additional
 /// ones to mark the construct.
-struct RaiseSetKernel : public OpInterfaceRewritePattern<FunctionOpInterface> {
+class RaiseSetKernel : public OpInterfaceRewritePattern<FunctionOpInterface> {
 public:
   using OpInterfaceRewritePattern<
       FunctionOpInterface>::OpInterfaceRewritePattern;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -277,14 +277,15 @@ private:
     if (!Demangler.isCtorOrDtor())
       return false;
 
-    char *demangled = Demangler.finishDemangle(nullptr, 0);
-    if (!demangled)
+    FailureOr<DemangleResult> demangled =
+        DemangleResult::get([&](char *buf, std::size_t *size) {
+          return Demangler.finishDemangle(buf, size);
+        });
+    if (failed(demangled))
       // Demangling failed
       return false;
 
-    llvm::StringRef demangledName{demangled};
-    bool isDestructor = demangledName.contains('~');
-    free(demangled);
+    bool isDestructor = static_cast<StringRef>(*demangled).contains('~');
     return !isDestructor;
   }
 };

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -614,6 +614,11 @@ public:
           continue;
         invoke->setAttr(alreadyVisitedAttrName, rewriter.getAttr<UnitAttr>());
 
+        // Arity check
+        constexpr unsigned expectedArity = 5;
+        if (invoke.getNumOperands() != expectedArity)
+          continue;
+
         // Check the 4th argument (input `str`) is defined by the
         // `sycl.host.get_kernel` operation
         constexpr unsigned inputStringArgumentNumber = 3;


### PR DESCRIPTION
Detect `std::string::replace` calls receiving a pointer to a member of a `sycl::handler` and a kernel name (`sycl.host.get_kernel`) as operands and raise.