### PR TITLE
[SYCL-MLIR][MathOps] Add `sycl::half` support

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMathOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMathOps.td
@@ -20,9 +20,8 @@ include "mlir/Interfaces/InferTypeOpInterface.td"
 ////////////////////////////////////////////////////////////////////////////////
 
 // Generic floating-point types (§4.17.1).
-// TODO: Add `sycl::half`.
 // TODO: Add vectors and marrays.
-def SYCLGenfloat : AnyTypeOf<[F32, F64]>;
+def SYCLGenfloat : AnyTypeOf<[F32, F64, SYCL_HalfType]>;
 
 // Trait to mark ops representing a SYCL math function (§4.17.5).
 def SYCLMathFunc : SYCLOpTrait<"SYCLMathFunc">;

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
@@ -105,6 +105,7 @@ def SYCL_GroupType : SYCL_Type<"Group", "group"> {
 }
 
 def SYCL_HalfType : SYCL_Type<"Half", "half"> {
+  let summary = "sycl::half";
   let parameters = (ins ArrayRefParameter<"mlir::Type">:$body);
   let assemblyFormat = "`<` `(` $body `)` `>`";
 }

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -2744,7 +2744,8 @@ struct WrapPattern : public ConvertOpToLLVMPattern<SYCLWrapOp> {
   LogicalResult
   matchAndRewrite(SYCLWrapOp op, OpAdaptor opAdaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    Value undef = rewriter.create<LLVM::UndefOp>(op->getLoc(), op.getType());
+    Type structType = typeConverter->convertType(op.getType());
+    Value undef = rewriter.create<LLVM::UndefOp>(op->getLoc(), structType);
     rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
         op, undef, opAdaptor.getSource(), rewriter.getDenseI64ArrayAttr(0));
     return success();

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -2735,6 +2735,35 @@ protected:
 };
 
 //===----------------------------------------------------------------------===//
+// Wrap/UnwrapPattern - Converts `sycl.mlir.wrap` and `.unwrap` to LLVM.
+//===----------------------------------------------------------------------===//
+
+struct WrapPattern : public ConvertOpToLLVMPattern<SYCLWrapOp> {
+  using ConvertOpToLLVMPattern<SYCLWrapOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(SYCLWrapOp op, OpAdaptor opAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    Value undef = rewriter.create<LLVM::UndefOp>(op->getLoc(), op.getType());
+    rewriter.replaceOpWithNewOp<LLVM::InsertValueOp>(
+        op, undef, opAdaptor.getSource(), rewriter.getDenseI64ArrayAttr(0));
+    return success();
+  }
+};
+
+struct UnwrapPattern : public ConvertOpToLLVMPattern<SYCLUnwrapOp> {
+  using ConvertOpToLLVMPattern<SYCLUnwrapOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(SYCLUnwrapOp op, OpAdaptor opAdaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    rewriter.replaceOpWithNewOp<LLVM::ExtractValueOp>(
+        op, opAdaptor.getSource(), rewriter.getDenseI64ArrayAttr(0));
+    return success();
+  }
+};
+
+//===----------------------------------------------------------------------===//
 // Pattern population
 //===----------------------------------------------------------------------===//
 
@@ -2866,7 +2895,8 @@ populateSYCLToLLVMSPIRConversionPatterns(LLVMTypeConverter &typeConverter,
       NDItemGetLocalIDPattern, NDItemGetLocalRangeDimPattern,
       NDItemGetLocalRangePattern, NDRangeGetGlobalRangePattern, RangeGetPattern,
       RangeCopyConstructorPattern, RangeIndexConstructorPattern,
-      SubscriptIDOffset, SubscriptScalarOffset1D>(typeConverter);
+      SubscriptIDOffset, SubscriptScalarOffset1D, UnwrapPattern, WrapPattern>(
+      typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
 }
 

--- a/mlir-sycl/lib/Conversion/SYCLToMath/SYCLToMath.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToMath/SYCLToMath.cpp
@@ -50,7 +50,7 @@ struct OneToOneMappingPattern : public OpConversionPattern<SYCLOpT> {
     // wrap the result.
     assert(isSYCLType(type));
 
-    if (type.isa<HalfType>()) {
+    if (isa<HalfType>(type)) {
       auto loc = op.getLoc();
       SmallVector<Value, 3> unwrappedOperands;
       for (auto operand : adaptor.getOperands())

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -416,6 +416,7 @@ bool SYCLUnwrapOp::areCastCompatible(TypeRange inputs, TypeRange outputs) {
   Type sourceType = inputs.front();
   Type resultType = outputs.front();
   Type bodyType = getBodyType(sourceType);
+
   return bodyType && resultType == bodyType;
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-aux-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-aux-to-llvm.mlir
@@ -1,6 +1,8 @@
 // RUN: sycl-mlir-opt -convert-sycl-to-llvm %s | FileCheck %s
 
 !sycl_half = !sycl.half<(f16)>
+!sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
+!sycl_vec_sycl_half_2_ = !sycl.vec<[!sycl_half, 2], (vector<2xf16>)>
 
 // CHECK-LABEL:   llvm.func @test_half(
 // CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::half", (f16)>, %[[VAL_1:.*]]: !llvm.struct<"class.sycl::_V1::half", (f16)>) -> !llvm.struct<"class.sycl::_V1::half", (f16)> {
@@ -16,5 +18,39 @@ func.func @test_half(%arg0 : !sycl_half, %arg1 : !sycl_half) -> !sycl_half {
   %1 = sycl.mlir.unwrap %arg1 : !sycl_half to f16
   %2 = arith.addf %0, %1 : f16
   %3 = sycl.mlir.wrap %2 : f16 to !sycl_half
-  return %3: !sycl_half
+  return %3 : !sycl_half
+}
+
+// CHECK-LABEL:   llvm.func @test_vector_of_native(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>, %[[VAL_1:.*]]: !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>) -> !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)> {
+// CHECK:           %[[VAL_2:.*]] = llvm.extractvalue %[[VAL_0]][0] : !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_1]][0] : !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>
+// CHECK:           %[[VAL_4:.*]] = llvm.add %[[VAL_2]], %[[VAL_3]]  : vector<4xi32>
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>
+// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_5]][0] : !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>
+// CHECK:           llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::vec", (vector<4xi32>)>
+// CHECK:         }
+func.func @test_vector_of_native(%arg0 : !sycl_vec_i32_4_, %arg1 : !sycl_vec_i32_4_) -> !sycl_vec_i32_4_ {
+  %0 = sycl.mlir.unwrap %arg0 : !sycl_vec_i32_4_ to vector<4xi32>
+  %1 = sycl.mlir.unwrap %arg1 : !sycl_vec_i32_4_ to vector<4xi32>
+  %2 = arith.addi %0, %1 : vector<4xi32>
+  %3 = sycl.mlir.wrap %2 : vector<4xi32> to !sycl_vec_i32_4_
+  return %3 : !sycl_vec_i32_4_
+}
+
+// CHECK-LABEL:   llvm.func @test_vector_of_half(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>, %[[VAL_1:.*]]: !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>) -> !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)> {
+// CHECK:           %[[VAL_2:.*]] = llvm.extractvalue %[[VAL_0]][0] : !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>
+// CHECK:           %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_1]][0] : !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>
+// CHECK:           %[[VAL_4:.*]] = llvm.fadd %[[VAL_2]], %[[VAL_3]]  : vector<2xf16>
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>
+// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_5]][0] : !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>
+// CHECK:           llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::vec.1", (vector<2xf16>)>
+// CHECK:         }
+func.func @test_vector_of_half(%arg0 : !sycl_vec_sycl_half_2_, %arg1 : !sycl_vec_sycl_half_2_) -> !sycl_vec_sycl_half_2_ {
+  %0 = sycl.mlir.unwrap %arg0 : !sycl_vec_sycl_half_2_ to vector<2xf16>
+  %1 = sycl.mlir.unwrap %arg1 : !sycl_vec_sycl_half_2_ to vector<2xf16>
+  %2 = arith.addf %0, %1 : vector<2xf16>
+  %3 = sycl.mlir.wrap %2 : vector<2xf16> to !sycl_vec_sycl_half_2_
+  return %3 : !sycl_vec_sycl_half_2_
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-aux-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-aux-to-llvm.mlir
@@ -1,0 +1,20 @@
+// RUN: sycl-mlir-opt -convert-sycl-to-llvm %s | FileCheck %s
+
+!sycl_half = !sycl.half<(f16)>
+
+// CHECK-LABEL:   llvm.func @test_half(
+// CHECK-SAME:                         %[[VAL_0:.*]]: !llvm.struct<"class.sycl::_V1::half", (f16)>, %[[VAL_1:.*]]: !llvm.struct<"class.sycl::_V1::half", (f16)>) -> !llvm.struct<"class.sycl::_V1::half", (f16)> {
+// CHECK:           %[[VAL_2:.*]] = llvm.extractvalue %[[VAL_0]][0] : !llvm.struct<"class.sycl::_V1::half", (f16)>
+// CHECK:           %[[VAL_3:.*]] = llvm.extractvalue %[[VAL_1]][0] : !llvm.struct<"class.sycl::_V1::half", (f16)>
+// CHECK:           %[[VAL_4:.*]] = llvm.fadd %[[VAL_2]], %[[VAL_3]]  : f16
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.struct<"class.sycl::_V1::half", (f16)>
+// CHECK:           %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_5]][0] : !llvm.struct<"class.sycl::_V1::half", (f16)>
+// CHECK:           llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::half", (f16)>
+// CHECK:         }
+func.func @test_half(%arg0 : !sycl_half, %arg1 : !sycl_half) -> !sycl_half {
+  %0 = sycl.mlir.unwrap %arg0 : !sycl_half to f16
+  %1 = sycl.mlir.unwrap %arg1 : !sycl_half to f16
+  %2 = arith.addf %0, %1 : f16
+  %3 = sycl.mlir.wrap %2 : f16 to !sycl_half
+  return %3: !sycl_half
+}

--- a/mlir-sycl/test/Conversion/SYCLToMath/math-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToMath/math-ops.mlir
@@ -83,3 +83,105 @@ func.func @test_math_ops_double(%arg0 : f64, %arg1 : f64, %arg2 : f64) {
 
   return
 }
+
+!sycl_half = !sycl.half<(f16)>
+
+// CHECK-LABEL: func.func @test_math_ops_half(
+// CHECK-SAME:    %[[VAL_0:.*]]: !sycl_half, %[[VAL_1:.*]]: !sycl_half, %[[VAL_2:.*]]: !sycl_half) {
+func.func @test_math_ops_half(%arg0 : !sycl_half, %arg1 : !sycl_half, %arg2 : !sycl_half) {
+  // CHECK:  %[[VAL_3:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_4:.*]] = math.ceil %[[VAL_3]] : f16
+  // CHECK:  %[[VAL_5:.*]] = sycl.mlir.wrap %[[VAL_4]] : f16 to !sycl_half
+  %c0 = sycl.math.ceil %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_6:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_7:.*]] = sycl.mlir.unwrap %[[VAL_1]] : !sycl_half to f16
+  // CHECK:  %[[VAL_8:.*]] = math.copysign %[[VAL_6]], %[[VAL_7]] : f16
+  // CHECK:  %[[VAL_9:.*]] = sycl.mlir.wrap %[[VAL_8]] : f16 to !sycl_half
+  %c1 = sycl.math.copysign %arg0, %arg1 : !sycl_half
+
+  // CHECK:  %[[VAL_10:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_11:.*]] = math.cos %[[VAL_10]] : f16
+  // CHECK:  %[[VAL_12:.*]] = sycl.mlir.wrap %[[VAL_11]] : f16 to !sycl_half
+  %c2 = sycl.math.cos %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_13:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_14:.*]] = math.exp2 %[[VAL_13]] : f16
+  // CHECK:  %[[VAL_15:.*]] = sycl.mlir.wrap %[[VAL_14]] : f16 to !sycl_half
+  %e0 = sycl.math.exp2 %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_16:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_17:.*]] = math.expm1 %[[VAL_16]] : f16
+  // CHECK:  %[[VAL_18:.*]] = sycl.mlir.wrap %[[VAL_17]] : f16 to !sycl_half
+  %e1 = sycl.math.expm1 %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_19:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_20:.*]] = math.exp %[[VAL_19]] : f16
+  // CHECK:  %[[VAL_21:.*]] = sycl.mlir.wrap %[[VAL_20]] : f16 to !sycl_half
+  %e2 = sycl.math.exp %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_22:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_23:.*]] = math.absf %[[VAL_22]] : f16
+  // CHECK:  %[[VAL_24:.*]] = sycl.mlir.wrap %[[VAL_23]] : f16 to !sycl_half
+  %f0 = sycl.math.fabs %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_25:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_26:.*]] = math.floor %[[VAL_25]] : f16
+  // CHECK:  %[[VAL_27:.*]] = sycl.mlir.wrap %[[VAL_26]] : f16 to !sycl_half
+  %f1 = sycl.math.floor %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_28:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_29:.*]] = sycl.mlir.unwrap %[[VAL_1]] : !sycl_half to f16
+  // CHECK:  %[[VAL_30:.*]] = sycl.mlir.unwrap %[[VAL_2]] : !sycl_half to f16
+  // CHECK:  %[[VAL_31:.*]] = math.fma %[[VAL_28]], %[[VAL_29]], %[[VAL_30]] : f16
+  // CHECK:  %[[VAL_32:.*]] = sycl.mlir.wrap %[[VAL_31]] : f16 to !sycl_half
+  %f2 = sycl.math.fma %arg0, %arg1, %arg2 : !sycl_half
+
+  // CHECK:  %[[VAL_33:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_34:.*]] = math.log10 %[[VAL_33]] : f16
+  // CHECK:  %[[VAL_35:.*]] = sycl.mlir.wrap %[[VAL_34]] : f16 to !sycl_half
+  %l0 = sycl.math.log10 %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_36:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_37:.*]] = math.log2 %[[VAL_36]] : f16
+  // CHECK:  %[[VAL_38:.*]] = sycl.mlir.wrap %[[VAL_37]] : f16 to !sycl_half
+  %l1 = sycl.math.log2 %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_39:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_40:.*]] = math.log %[[VAL_39]] : f16
+  // CHECK:  %[[VAL_41:.*]] = sycl.mlir.wrap %[[VAL_40]] : f16 to !sycl_half
+  %l2 = sycl.math.log %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_42:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_43:.*]] = sycl.mlir.unwrap %[[VAL_1]] : !sycl_half to f16
+  // CHECK:  %[[VAL_44:.*]] = math.powf %[[VAL_42]], %[[VAL_43]] : f16
+  // CHECK:  %[[VAL_45:.*]] = sycl.mlir.wrap %[[VAL_44]] : f16 to !sycl_half
+  %p0 = sycl.math.pow %arg0, %arg1 : !sycl_half
+
+  // CHECK:  %[[VAL_46:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_47:.*]] = math.round %[[VAL_46]] : f16
+  // CHECK:  %[[VAL_48:.*]] = sycl.mlir.wrap %[[VAL_47]] : f16 to !sycl_half
+  %r0 = sycl.math.round %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_49:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_50:.*]] = math.rsqrt %[[VAL_49]] : f16
+  // CHECK:  %[[VAL_51:.*]] = sycl.mlir.wrap %[[VAL_50]] : f16 to !sycl_half
+  %r1 = sycl.math.rsqrt %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_52:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_53:.*]] = math.sin %[[VAL_52]] : f16
+  // CHECK:  %[[VAL_54:.*]] = sycl.mlir.wrap %[[VAL_53]] : f16 to !sycl_half
+  %s0 = sycl.math.sin %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_55:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_56:.*]] = math.sqrt %[[VAL_55]] : f16
+  // CHECK:  %[[VAL_57:.*]] = sycl.mlir.wrap %[[VAL_56]] : f16 to !sycl_half
+  %s1 = sycl.math.sqrt %arg0 : !sycl_half
+
+  // CHECK:  %[[VAL_58:.*]] = sycl.mlir.unwrap %[[VAL_0]] : !sycl_half to f16
+  // CHECK:  %[[VAL_59:.*]] = math.trunc %[[VAL_58]] : f16
+  // CHECK:  %[[VAL_60:.*]] = sycl.mlir.wrap %[[VAL_59]] : f16 to !sycl_half
+  %t0 = sycl.math.trunc %arg0 : !sycl_half
+  
+  return
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -422,7 +422,7 @@ func.func @test_nd_constructor_bad_local_size(%globalSize: memref<?x!sycl_range_
 // -----
 
 func.func @math_op_invalid_type(%arg0 : i32) {
-  // expected-error @+1 {{op operand #0 must be 32-bit float or 64-bit float, but got 'i32'}}
+  // expected-error @+1 {{op operand #0 must be 32-bit float or 64-bit float or sycl::half, but got 'i32'}}
   %0 = sycl.math.sin %arg0 : i32
   return
 }

--- a/mlir-sycl/test/Dialect/SYCL/math-ops.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/math-ops.mlir
@@ -84,3 +84,47 @@ func.func @test_math_ops_double(%arg0 : f64, %arg1 : f64, %arg2 : f64) {
 
   return
 }
+
+!sycl_half = !sycl.half<(f16)>
+
+// CHECK-LABEL: test_math_ops_half
+func.func @test_math_ops_half(%arg0 : !sycl_half, %arg1 : !sycl_half, %arg2 : !sycl_half) {
+  // CHECK: %{{.*}} = sycl.math.ceil %arg0 : !sycl_half
+  %c0 = sycl.math.ceil %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.copysign %arg0, %arg1 : !sycl_half
+  %c1 = sycl.math.copysign %arg0, %arg1 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.cos %arg0 : !sycl_half
+  %c2 = sycl.math.cos %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.exp %arg0 : !sycl_half
+  %e2 = sycl.math.exp %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.exp2 %arg0 : !sycl_half
+  %e0 = sycl.math.exp2 %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.expm1 %arg0 : !sycl_half
+  %e1 = sycl.math.expm1 %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.fabs %arg0 : !sycl_half
+  %f0 = sycl.math.fabs %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.floor %arg0 : !sycl_half
+  %f1 = sycl.math.floor %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.fma %arg0, %arg1, %arg2 : !sycl_half
+  %f2 = sycl.math.fma %arg0, %arg1, %arg2 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.log %arg0 : !sycl_half
+  %l2 = sycl.math.log %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.log10 %arg0 : !sycl_half
+  %l0 = sycl.math.log10 %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.log2 %arg0 : !sycl_half
+  %l1 = sycl.math.log2 %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.pow %arg0, %arg1 : !sycl_half
+  %p0 = sycl.math.pow %arg0, %arg1 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.round %arg0 : !sycl_half
+  %r0 = sycl.math.round %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.rsqrt %arg0 : !sycl_half
+  %r1 = sycl.math.rsqrt %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.sin %arg0 : !sycl_half
+  %s0 = sycl.math.sin %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.sqrt %arg0 : !sycl_half
+  %s1 = sycl.math.sqrt %arg0 : !sycl_half
+  // CHECK: %{{.*}} = sycl.math.trunc %arg0 : !sycl_half
+  %t0 = sycl.math.trunc %arg0 : !sycl_half
+
+  return
+}


### PR DESCRIPTION
**Lowering:**
```mlir
%res = sycl.math.sqrt(%arg) : !sycl_half
```
⬇️
```mlir
%0 = sycl.mlir.unwrap(%arg) : !sycl_half to f16
%1 = math.sqrt(%0) : f16
%res = sycl.mlir.wrap(%1) : f16 to !sycl_half
```
⬇️
```llvm
%0 = extractvalue %"class.sycl::_V1::half" %arg, 0
%1 = call half @llvm.sqrt.f16(half %0)
%res = insertvalue %"class.sycl::_V1::half" undef, half %1, 0
```