### PR TITLE
[SYCL][E2E] Require aspect-ext_intel_legacy_image in Basic/sampler/sampler.cpp

### DIFF
--- a/sycl/test-e2e/Basic/sampler/sampler.cpp
+++ b/sycl/test-e2e/Basic/sampler/sampler.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aspect-image
+// REQUIRES: aspect-ext_intel_legacy_image
 // TODO: Can we move it to sycl/test?
 // RUN: %{build} -fsycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/sampler/sampler.cpp
+++ b/sycl/test-e2e/Basic/sampler/sampler.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: aspect-image
 // TODO: Can we move it to sycl/test?
 // RUN: %{build} -fsycl-dead-args-optimization -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
It has very limited checks of sycl::sampler so might pass on some devices/backends that don't support the aspect but that isn't guaranteed and there are ones where it fails (i.e., with an accelerator device).