### PR TITLE
[SYCL-MLIR] Raise buffer and accessor constructors

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
@@ -68,6 +68,16 @@ def SYCL_AccessorType
       "`<` `[` $dimension `,` $type `,` ` ` $accessMode `,` ` ` $targetMode `]` `,` `(` $body `)` `>`";
 }
 
+def SYCL_BufferType : SYCL_Type<"Buffer", "buffer"> {
+  let summary = "SYCL Buffer";
+  let description = [{ Shared array of one, two or three dimensions,
+                        accessed through accessors.}];
+  let parameters = (ins "::mlir::Type":$type,
+                        "unsigned":$dimension);
+  let assemblyFormat = 
+      "`<` `[` $dimension `,` $type `]` `>`";
+}
+
 def SYCL_AccessorSubscriptType :
     SYCL_Type<"AccessorSubscript", "accessor_subscript"> {
   let parameters = (ins "int":$currentDimension,

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -70,8 +70,9 @@ unsigned getDimensions(Type type) {
   if (auto memRefTy = dyn_cast<MemRefType>(type))
     type = memRefTy.getElementType();
   return TypeSwitch<Type, unsigned>(type)
-      .Case<AccessorType, GroupType, IDType, ItemType, NdItemType, NdRangeType,
-            RangeType>([](auto type) { return type.getDimension(); });
+      .Case<AccessorType, BufferType, GroupType, IDType, ItemType, NdItemType,
+            NdRangeType, RangeType>(
+          [](auto type) { return type.getDimension(); });
 }
 
 template <typename T> bool isPtrOf(Type type) {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -26,6 +26,9 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRPolygeistOpsIncGen
   MLIRPolygeistPassIncGen
 
+  LINK_COMPONENTS
+  Demangle
+
   LINK_LIBS PUBLIC
   MLIRAffineDialect
   MLIRAffineToStandard

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -21,7 +21,9 @@
 #include "mlir/Dialect/Polygeist/Utils/Utils.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Debug.h"
+#include "llvm/Support/Regex.h"
 
 namespace mlir {
 namespace polygeist {
@@ -45,6 +47,90 @@ public:
 };
 
 } // anonymous namespace
+
+//===----------------------------------------------------------------------===//
+// Helper
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+bool isConstructor(CallOpInterface call, LLVM::AllocaOp alloc) {
+  if (call->getOperand(0) != alloc) {
+    // Allocation ('this*') must be first argument for constructor call.
+    return false;
+  }
+
+  CallInterfaceCallable callableOp = call.getCallableForCallee();
+  StringRef funcName = callableOp.get<SymbolRefAttr>().getLeafReference();
+
+  llvm::ItaniumPartialDemangler Demangler;
+  Demangler.partialDemangle(funcName.data());
+  if (!Demangler.isCtorOrDtor())
+    return false;
+
+  char *demangled = Demangler.finishDemangle(nullptr, 0);
+  if (!demangled)
+    // Demangling failed
+    return false;
+
+  llvm::StringRef demangledName{demangled};
+  bool isDestructor = demangledName.contains('~');
+  free(demangled);
+  return !isDestructor;
+}
+
+bool anyUsesBetween(LLVM::AllocaOp alloc, Operation *end) {
+  assert(alloc->getBlock() && end->getBlock() &&
+         "Expecting operations to be aprt of a block");
+
+  if (alloc->getBlock() != end->getBlock())
+    return true;
+
+  llvm::SmallPtrSet<Operation *, 8> uses(alloc->user_begin(),
+                                         alloc->user_end());
+
+  bool started = false;
+  for (auto &op : *alloc->getBlock()) {
+    if (&op == alloc)
+      started = true;
+
+    if (started) {
+      if (&op == end)
+        return false;
+
+      if (uses.contains(&op))
+        return true;
+    }
+  }
+  llvm_unreachable("'end' operation before allocation");
+}
+
+sycl::BufferType getBufferTypeFromConstructor(CallOpInterface constructor) {
+  CallInterfaceCallable callableOp = constructor.getCallableForCallee();
+  StringRef constructorName =
+      callableOp.get<SymbolRefAttr>().getLeafReference();
+
+  auto demangledName = llvm::demangle(constructorName);
+
+  // Try to determine the dimensions of the buffer by parsing the template
+  // parameter from the demangled name of the constructor.
+  llvm::Regex bufferTemplate("buffer<.*, ([0-9]+)");
+  llvm::SmallVector<StringRef> matches;
+  bool regexMatch = bufferTemplate.match(demangledName, &matches);
+  unsigned dimensions = 1;
+  if (regexMatch)
+    std::stoul(matches[1].str());
+
+  // FIXME: There's currently no good way to obtain the element type of the
+  // buffer from the constructor call (or allocation). Parsing it from the
+  // demangled name, as done for 'dimensions' above, would require translation
+  // from C++ types to MLIR types, which is not available here.
+  Type elemTy = LLVM::LLVMVoidType::get(constructor->getContext());
+
+  return sycl::BufferType::get(constructor->getContext(), elemTy, dimensions);
+}
+
+} // namespace
 
 //===----------------------------------------------------------------------===//
 // Pattern
@@ -107,6 +193,54 @@ private:
                                        : std::nullopt;
   }
 };
+
+class BufferConstructorPattern : public OpRewritePattern<LLVM::InvokeOp> {
+
+public:
+  using OpRewritePattern<LLVM::InvokeOp>::OpRewritePattern;
+
+  LogicalResult matchAndRewrite(LLVM::InvokeOp invoke,
+                                PatternRewriter &rewriter) const final {
+
+    if (invoke.getArgOperands().empty())
+      return failure();
+
+    // 'this*' is the first argument to the constructor call, if it is a
+    // constructor.
+    auto alloc = dyn_cast_or_null<LLVM::AllocaOp>(
+        invoke.getArgOperands().front().getDefiningOp());
+
+    if (!alloc)
+      return failure();
+
+    assert(alloc.getElemType().has_value() &&
+           "Expecting element type attribute for opaque alloca");
+
+    auto allocTy = *alloc.getElemType();
+    auto structAllocTy = dyn_cast<LLVM::LLVMStructType>(allocTy);
+    if (!structAllocTy || structAllocTy.getName() != "class.sycl::_V1::buffer")
+      return failure();
+
+    if (invoke.getNumResults())
+      // Constructor should not return anything.
+      return failure();
+
+    if (!isConstructor(invoke, alloc))
+      // Invoke is not a constructor call.
+      return failure();
+
+    rewriter.create<sycl::SYCLHostConstructorOp>(
+        invoke->getLoc(), invoke.getArgOperands().front(),
+        invoke.getArgOperands().drop_front(1),
+        TypeAttr::get(getBufferTypeFromConstructor(invoke)));
+
+    rewriter.create<LLVM::BrOp>(invoke->getLoc(),
+                                invoke.getNormalDestOperands(),
+                                invoke.getNormalDest());
+    rewriter.eraseOp(invoke);
+    return success();
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -118,7 +252,7 @@ void SYCLRaiseHostConstructsPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
   RewritePatternSet rewritePatterns{context};
-  rewritePatterns.add<RaiseKernelName>(context);
+  rewritePatterns.add<RaiseKernelName, BufferConstructorPattern>(context);
   FrozenRewritePatternSet frozen(std::move(rewritePatterns));
 
   if (failed(applyPatternsAndFoldGreedily(scopeOp, frozen)))

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -18,3 +18,68 @@ llvm.func @f() -> !llvm.ptr {
   %kn = llvm.mlir.addressof @kernel_ref : !llvm.ptr
   llvm.return %kn : !llvm.ptr
 }
+
+// -----
+
+llvm.func @__gxx_personality_v0(...) -> i32
+
+// CHECK-LABEL:   llvm.func @raise_buffer() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::range", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           sycl.host.constructor(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]], %[[VAL_4]]) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           llvm.br ^bb1
+// CHECK:         ^bb1:
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr
+// CHECK:         }
+llvm.func @raise_buffer() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %0 = arith.constant 1 : i32
+  %1 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::range", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %4 = llvm.alloca %0 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+
+  llvm.invoke @_ZN4sycl3_V16bufferIiLi1ENS0_6detail17aligned_allocatorIiEEvEC2ERKNS0_5rangeILi1EEERKNS0_13property_listENS2_13code_locationE(%1, %2, %3, %4) to ^bb1 unwind ^bb0 : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+^bb0:
+  %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %lp : !llvm.struct<(ptr, i32)>
+^bb1:
+  llvm.return %1 : !llvm.ptr
+}
+
+
+// -----
+
+llvm.func @__gxx_personality_v0(...) -> i32
+
+// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], ()>
+
+// CHECK-LABEL:   llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           sycl.host.constructor(%[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           llvm.br ^bb1
+// CHECK:         ^bb1:
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr
+// CHECK:         }
+llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %0 = arith.constant 1 : i32
+  %1 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %4 = llvm.alloca %0 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+
+  llvm.invoke @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE1ENS0_3ext6oneapi22accessor_property_listIJEEEEC2IiLi1ENS0_6detail17aligned_allocatorIiEEvEERNS0_6bufferIT_XT0_ET1_NSt9enable_ifIXaagtT0_Li0EleT0_Li3EEvE4typeEEERKNS0_13property_listENSC_13code_locationE(%2, %1, %3, %4) to ^bb1 unwind ^bb0 : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+^bb0:
+  %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %lp : !llvm.struct<(ptr, i32)>
+^bb1:
+  llvm.return %1 : !llvm.ptr
+}


### PR DESCRIPTION
Raise constructors initializing `sycl::buffer` and `sycl::accessor` to SYCL dialect operations (`sycl.host.constructor`) on the host side to facilitate analysis.

Also introduces a simple representation of the `sycl::buffer` type into the SYCL dialect.