### PR TITLE
[SYCL-MLIR] XFAIL ESIMD/accessor_local.cpp

### DIFF
--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -172,6 +172,7 @@ ESIMD/accessor_gather_scatter_stateless.cpp
 ESIMD/accessor_global.cpp
 ESIMD/accessor_load_store.cpp
 ESIMD/accessor_load_store_stateless.cpp
+ESIMD/accessor_local.cpp
 ESIMD/accessor_stateless.cpp
 ESIMD/addc.cpp
 ESIMD/api/ballot.cpp


### PR DESCRIPTION
Test was recently enabled upstream in https://github.com/intel/llvm/commit/fb607c152e6651f6684608d0b2c917c475373c31.