### PR TITLE
[SYCL][E2E] Enable device_architecture_on_host for Windows

### DIFF
--- a/sycl/test-e2e/DeviceArchitecture/device_architecture_on_host.cpp
+++ b/sycl/test-e2e/DeviceArchitecture/device_architecture_on_host.cpp
@@ -1,8 +1,5 @@
 // UNSUPPORTED: cuda, hip, esimd_emulator
 
-// Enable this test, when GPU driver on Windows CI machines will be updated
-// XFAIL: windows
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Test is unexpectedly passing in both pre-commit and post-commit.