### PR TITLE
[SYCL-MLIR] Define `sycl.range.constructor`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -563,6 +563,40 @@ def SYCLRangeSizeOp
 }
 
 ////////////////////////////////////////////////////////////////////////////////
+// range.constructor OPERATION
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLRangeConstructorOp : SYCLConstructor<"range"> {
+  let summary = "Operation returning a new sycl.range value";
+  let description = [{
+    This operation creates a new `sycl.range`. The following signatures are
+    provided:
+    ```mlir
+    # Initialize each member
+    (index) -> memref<1x!sycl_range_1>
+    (index, index) -> memref<1x!sycl_range_2>
+    (index, index, index) -> memref<1x!sycl_range_3>
+    # Copy constructor
+    (memref<?xsycl_range_N>) -> memref<1x!sycl_range_N>
+    ```
+    In addition of initializing the values, this operation also allocates the
+    object.
+  }];
+  let arguments = (ins Arg<Variadic<AnyType>, "Constructor arguments">:$Args);
+  let results =
+      (outs Res<MemRefRankOf<[SYCL_RangeType], [1]>, "constructed object">:$range);
+  let extraClassDeclaration = [{
+    /// Return the memory effects associated to each argument.
+    ///
+    /// Each argument will have `MemoryEffects::Read` if they're a
+    /// pointer/memref and no memory effect otherwise.
+    void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+                        ::mlir::MemoryEffects::Effect>> &effects);
+  }];
+  let hasVerifier = true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
 // nd_range.get_global_range OPERATION
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -586,7 +586,7 @@ def SYCLRangeConstructorOp : SYCLConstructor<"range"> {
   let results =
       (outs Res<MemRefRankOf<[SYCL_RangeType], [1]>, "constructed object">:$range);
   let extraClassDeclaration = [{
-    /// Return the memory effects associated to each argument.
+    /// Return the memory effects associated with each argument.
     ///
     /// Each argument will have `MemoryEffects::Read` if they're a
     /// pointer/memref and no memory effect otherwise.
@@ -682,7 +682,7 @@ def SYCLIDConstructorOp : SYCLConstructor<"id"> {
   let results =
       (outs Res<MemRefRankOf<[SYCL_IDType], [1]>, "constructed object">:$id);
   let extraClassDeclaration = [{
-    /// Return the memory effects associated to each argument.
+    /// Return the memory effects associated with each argument.
     ///
     /// Each argument will have `MemoryEffects::Read` if they're a
     /// pointer/memref and no memory effect otherwise.

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -638,6 +638,84 @@ public:
   }
 };
 
+template <typename Op>
+class CopyConstructorPattern : public BaseConstructorPattern<Op> {
+public:
+  using BaseConstructorPattern<Op>::BaseConstructorPattern;
+
+  LogicalResult match(Op op) const final {
+    OperandRange::type_range types = op.getOperands().getTypes();
+    if (types.size() != 1)
+      return failure();
+    auto MT = dyn_cast<MemRefType>(types.front());
+    Type resElTy = op.getType().getElementType();
+    return success(MT && MT.getElementType() == resElTy);
+  }
+
+protected:
+  /// Returns the size to be passed to `llvm.intr.memcpy`
+  int64_t getSize(Op op) const;
+
+  // We can simply copy the source array into the new one using
+  // `llvm.intr.memcpy`.
+  void initialize(Value alloca, Op op, typename Op::Adaptor adaptor,
+                  OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    Value src = adaptor.getOperands()[0];
+    Value len = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
+                                                 getSize(op));
+    Value isVolatile =
+        builder.create<LLVM::ConstantOp>(loc, builder.getI1Type(), 0);
+    builder.create<LLVM::MemcpyOp>(loc, alloca, src, len, isVolatile);
+  }
+};
+
+template <typename Op>
+class BaseInitializeConstructorPattern : public BaseConstructorPattern<Op> {
+public:
+  using BaseConstructorPattern<Op>::BaseConstructorPattern;
+
+protected:
+  /// Returns a vector with the values the struct should be initialized with.
+  virtual SmallVector<Value> getValues(Op op, typename Op::Adaptor adaptor,
+                                       OpBuilder &builder) const = 0;
+  /// Returns a pointer to the i-th element.
+  virtual Value getElementPtr(Op op, Value alloca, int64_t i,
+                              OpBuilder &builder) const = 0;
+  /// Transforms the initial alloca value
+  virtual Value transform([[maybe_unused]] Op op, Value alloca,
+                          [[maybe_unused]] OpBuilder &builder) const {
+    return alloca;
+  }
+
+  void initialize(Value alloca, Op op, typename Op::Adaptor adaptor,
+                  OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    // Initial transformation
+    alloca = transform(op, alloca, builder);
+    // GEP + store loop
+    SmallVector<Value> values = getValues(op, adaptor, builder);
+    for (const auto &[i, value] : llvm::enumerate(values)) {
+      Value ptr = getElementPtr(op, alloca, i, builder);
+      builder.create<LLVM::StoreOp>(loc, value, ptr);
+    }
+  }
+};
+
+template <typename Op>
+class BaseUnrealizedConversionCastInitializeConstructorPattern
+    : public BaseInitializeConstructorPattern<Op> {
+public:
+  using BaseInitializeConstructorPattern<Op>::BaseInitializeConstructorPattern;
+
+protected:
+  Value transform(Op op, Value alloca, OpBuilder &builder) const final {
+    return builder
+        .create<UnrealizedConversionCastOp>(op.getLoc(), op.getType(), alloca)
+        .getOutputs()[0];
+  }
+};
+
 //===----------------------------------------------------------------------===//
 // Type conversion
 //===----------------------------------------------------------------------===//
@@ -2160,73 +2238,41 @@ protected:
 };
 
 // (!memref<?x!sycl_id_N_) -> !memref<?x!sycl_id_N_>
-class IDCopyConstructorPattern
-    : public BaseConstructorPattern<SYCLIDConstructorOp> {
-public:
-  using BaseConstructorPattern<SYCLIDConstructorOp>::BaseConstructorPattern;
+using IDCopyConstructorPattern = CopyConstructorPattern<SYCLIDConstructorOp>;
 
-  LogicalResult match(SYCLIDConstructorOp op) const final {
-    OperandRange::type_range types = op.getOperands().getTypes();
-    if (types.size() != 1)
-      return failure();
-    auto MT = dyn_cast<MemRefType>(types.front());
-    return success(MT && isa<IDType>(MT.getElementType()));
-  }
+template <>
+int64_t IDCopyConstructorPattern::getSize(SYCLIDConstructorOp op) const {
+  unsigned dimension = getDimensions(op.getId().getType());
+  unsigned indexWidth =
+      BaseConstructorPattern<SYCLIDConstructorOp>::getTypeConverter()
+          ->getIndexTypeBitwidth();
+  return dimension * indexWidth / 8;
+}
+
+class IDConstructorBase
+    : public BaseUnrealizedConversionCastInitializeConstructorPattern<
+          SYCLIDConstructorOp> {
+public:
+  using BaseUnrealizedConversionCastInitializeConstructorPattern<
+      SYCLIDConstructorOp>::
+      BaseUnrealizedConversionCastInitializeConstructorPattern;
 
 protected:
-  // We can simply copy the source array into the new one using
-  // `llvm.intr.memcpy`.
-  void initialize(Value alloca, SYCLIDConstructorOp op, OpAdaptor adaptor,
-                  OpBuilder &builder) const final {
+  /// Returns a pointer to the i-th element.
+  virtual Value getElementPtr(SYCLIDConstructorOp op, Value alloca, int64_t i,
+                              OpBuilder &builder) const final {
     Location loc = op.getLoc();
-    Value src = adaptor.getOperands()[0];
-    unsigned dimension = getDimensions(op.getId().getType());
-    unsigned indexWidth =
-        BaseConstructorPattern<SYCLIDConstructorOp>::getTypeConverter()
-            ->getIndexTypeBitwidth();
-    Value len = builder.create<LLVM::ConstantOp>(loc, builder.getI64Type(),
-                                                 dimension * indexWidth / 8);
-    Value isVolatile =
-        builder.create<LLVM::ConstantOp>(loc, builder.getI1Type(), 0);
-    builder.create<LLVM::MemcpyOp>(loc, alloca, src, len, isVolatile);
-  }
-};
-
-class IDConstructorBase : public BaseConstructorPattern<SYCLIDConstructorOp> {
-public:
-  using BaseConstructorPattern<SYCLIDConstructorOp>::BaseConstructorPattern;
-
-protected:
-  /// Returns a vector with the values the array should be initialized with.
-  virtual SmallVector<Value> getValues(SYCLIDConstructorOp op,
-                                       OpAdaptor adaptor,
-                                       OpBuilder &builder) const = 0;
-
-  // We will initialize each element of the new allocated array using
-  // `sycl.id.get` and `llvm.store`.
-  void initialize(Value alloca, SYCLIDConstructorOp op, OpAdaptor adaptor,
-                  OpBuilder &builder) const final {
-    Location loc = op.getLoc();
-    // We need a `sycl` type to use `sycl.id.get`, so we
-    // `unrealized_conversion_cast` the allocated value.
-    alloca =
-        builder.create<UnrealizedConversionCastOp>(loc, op.getType(), alloca)
-            .getOutputs()[0];
-    SmallVector<Value> values = getValues(op, adaptor, builder);
     auto MT =
         MemRefType::get(/*shape=*/ShapedType::kDynamic, builder.getIndexType());
+    Value offset =
+        builder.create<LLVM::ConstantOp>(loc, builder.getI32Type(), i);
+    Value ptr = builder.create<SYCLIDGetOp>(loc, MT, alloca, offset);
+    /// Avoid inserting operations from the `memref` dialect by inserting this
+    /// `unrealized_conversion_cast`:
     Type PT = ConvertOpToLLVMPattern<SYCLIDConstructorOp>::getTypeConverter()
                   ->convertType(MT);
-    Type i32Ty = builder.getI32Type();
-    for (const auto &[i, value] : llvm::enumerate(values)) {
-      Value offset = builder.create<LLVM::ConstantOp>(loc, i32Ty, i);
-      Value ptr = builder.create<SYCLIDGetOp>(loc, MT, alloca, offset);
-      /// Avoid inserting operations from the `memref` dialect by inserting this
-      /// `unrealized_conversion_cast`:
-      ptr = builder.create<UnrealizedConversionCastOp>(loc, PT, ptr)
-                .getOutputs()[0];
-      builder.create<LLVM::StoreOp>(loc, value, ptr);
-    }
+    return builder.create<UnrealizedConversionCastOp>(loc, PT, ptr)
+        .getOutputs()[0];
   }
 };
 
@@ -2313,6 +2359,79 @@ class IDRangeConstructorPattern
 public:
   using IDStructConstructorPattern<RangeType,
                                    SYCLRangeGetOp>::IDStructConstructorPattern;
+};
+
+//===----------------------------------------------------------------------===//
+// RangeConstructor - Convert `sycl.range.constructor` to LLVM.
+//===----------------------------------------------------------------------===//
+
+// (!memref<?x!sycl_range_N_) -> !memref<?x!sycl_range_N_>
+using RangeCopyConstructorPattern =
+    CopyConstructorPattern<SYCLRangeConstructorOp>;
+
+template <>
+int64_t RangeCopyConstructorPattern::getSize(SYCLRangeConstructorOp op) const {
+  unsigned dimension = getDimensions(op.getRange().getType());
+  unsigned indexWidth =
+      BaseConstructorPattern<SYCLRangeConstructorOp>::getTypeConverter()
+          ->getIndexTypeBitwidth();
+  return dimension * indexWidth / 8;
+}
+
+class RangeConstructorBase
+    : public BaseUnrealizedConversionCastInitializeConstructorPattern<
+          SYCLRangeConstructorOp> {
+public:
+  using BaseUnrealizedConversionCastInitializeConstructorPattern<
+      SYCLRangeConstructorOp>::
+      BaseUnrealizedConversionCastInitializeConstructorPattern;
+
+protected:
+  /// Returns a pointer to the i-th element.
+  virtual Value getElementPtr(SYCLRangeConstructorOp op, Value alloca,
+                              int64_t i, OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    auto MT =
+        MemRefType::get(/*shape=*/ShapedType::kDynamic, builder.getIndexType());
+    Value offset =
+        builder.create<LLVM::ConstantOp>(loc, builder.getI32Type(), i);
+    Value ptr = builder.create<SYCLRangeGetOp>(loc, MT, alloca, offset);
+    /// Avoid inserting operations from the `memref` dialect by inserting this
+    /// `unrealized_conversion_cast`:
+    Type PT = ConvertOpToLLVMPattern<SYCLRangeConstructorOp>::getTypeConverter()
+                  ->convertType(MT);
+    return builder.create<UnrealizedConversionCastOp>(loc, PT, ptr)
+        .getOutputs()[0];
+  }
+};
+
+// ({index}N) -> memref<1x!sycl_id_N_>
+class RangeIndexConstructorPattern : public RangeConstructorBase {
+public:
+  using RangeConstructorBase::RangeConstructorBase;
+
+  LogicalResult match(SYCLRangeConstructorOp op) const final {
+    OperandRange::type_range types = op.getOperands().getTypes();
+    return success(!types.empty() && llvm::all_of(types, [](Type ty) {
+      return isa<IndexType>(ty);
+    }));
+  }
+
+protected:
+  SmallVector<Value> getValues(SYCLRangeConstructorOp op, OpAdaptor adaptor,
+                               OpBuilder &builder) const final {
+    Location loc = op.getLoc();
+    SmallVector<Value> values;
+    Type indexTy =
+        ConvertOpToLLVMPattern<SYCLRangeConstructorOp>::getTypeConverter()
+            ->getIndexType();
+    llvm::transform(
+        adaptor.getOperands(), std::back_inserter(values), [&](Value val) {
+          return builder.create<UnrealizedConversionCastOp>(loc, indexTy, val)
+              .getOutputs()[0];
+        });
+    return values;
+  }
 };
 
 //===----------------------------------------------------------------------===//
@@ -2623,6 +2742,7 @@ populateSYCLToLLVMSPIRConversionPatterns(LLVMTypeConverter &typeConverter,
       NDItemGetGroupLinearIDPattern, NDItemGetGroupRangePattern,
       NDItemGetLocalIDPattern, NDItemGetLocalRangeDimPattern,
       NDItemGetLocalRangePattern, NDRangeGetGlobalRangePattern, RangeGetPattern,
+      RangeCopyConstructorPattern, RangeIndexConstructorPattern,
       SubscriptIDOffset, SubscriptScalarOffset1D>(typeConverter);
   patterns.add<ConstructorPattern>(typeConverter);
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructors-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructors-to-llvm.mlir
@@ -252,3 +252,92 @@ func.func @id_id(%arg0: memref<?x!sycl_id_1_>,
   func.return %id1, %id2, %id3
       : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
 }
+
+// CHECK-LABEL:   llvm.func @range_index(
+// CHECK-SAME:                           %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64) -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_6]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_10]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_8]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_12]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.alloca %[[VAL_13]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.constant(0 : i32) : i32
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.getelementptr inbounds %[[VAL_14]][0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_0]], %[[VAL_16]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.getelementptr inbounds %[[VAL_14]][0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_1]], %[[VAL_18]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_19:.*]] = llvm.mlir.constant(2 : i32) : i32
+// CHECK-NEXT:      %[[VAL_20:.*]] = llvm.getelementptr inbounds %[[VAL_14]][0, 0, 0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)>
+// CHECK-NEXT:      llvm.store %[[VAL_2]], %[[VAL_20]] : i64, !llvm.ptr
+// CHECK-NEXT:      %[[VAL_21:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_22:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_21]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_23:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_22]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_24:.*]] = llvm.insertvalue %[[VAL_14]], %[[VAL_23]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_24]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @range_index(%arg0: index, %arg1: index, %arg2: index)
+    -> (memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>) {
+  %range1 = sycl.range.constructor(%arg0)
+      : (index) -> memref<1x!sycl_range_1_>
+  %range2 = sycl.range.constructor(%arg0, %arg1)
+      : (index, index) -> memref<1x!sycl_range_2_>
+  %range3 = sycl.range.constructor(%arg0, %arg1, %arg2)
+      : (index, index, index) -> memref<1x!sycl_range_3_>
+  func.return %range1, %range2, %range3
+      : memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>
+}
+
+// CHECK-LABEL:   llvm.func @range_range(
+// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr) -> !llvm.struct<(ptr, ptr, ptr)> {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(8 : i64) : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_0]], %[[VAL_5]], %[[VAL_6]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(16 : i64) : i64
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_8]], %[[VAL_1]], %[[VAL_9]], %[[VAL_10]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_12]], %[[VAL_2]], %[[VAL_13]], %[[VAL_14]]) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.mlir.undef : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.insertvalue %[[VAL_4]], %[[VAL_15]][0] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.insertvalue %[[VAL_8]], %[[VAL_16]][1] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_17]][2] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.struct<(ptr, ptr, ptr)>
+// CHECK-NEXT:    }
+func.func @range_range(%arg0: memref<?x!sycl_range_1_>,
+                       %arg1: memref<?x!sycl_range_2_>,
+                       %arg2: memref<?x!sycl_range_3_>)
+    -> (memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>) {
+  %range1 = sycl.range.constructor(%arg0)
+      : (memref<?x!sycl_range_1_>) -> memref<1x!sycl_range_1_>
+  %range2 = sycl.range.constructor(%arg1)
+      : (memref<?x!sycl_range_2_>) -> memref<1x!sycl_range_2_>
+  %range3 = sycl.range.constructor(%arg2)
+      : (memref<?x!sycl_range_3_>) -> memref<1x!sycl_range_3_>
+  func.return %range1, %range2, %range3
+      : memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>
+}

--- a/mlir-sycl/test/Dialect/SYCL/constructors.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/constructors.mlir
@@ -78,3 +78,40 @@ func.func @id_id(%arg0: memref<?x!sycl_id_1_>,
   func.return %id1, %id2, %id3
       : memref<1x!sycl_id_1_>, memref<1x!sycl_id_2_>, memref<1x!sycl_id_3_>
 }
+
+// CHECK-LABEL: func.func @range_index
+func.func @range_index(%arg0: index, %arg1: index, %arg2: index)
+    -> (memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>) {
+  %range1 = sycl.range.constructor(%arg0)
+      : (index) -> memref<1x!sycl_range_1_>
+  %range2 = sycl.range.constructor(%arg0, %arg1)
+      : (index, index) -> memref<1x!sycl_range_2_>
+  %range3 = sycl.range.constructor(%arg0, %arg1, %arg2)
+      : (index, index, index) -> memref<1x!sycl_range_3_>
+  func.return %range1, %range2, %range3
+      : memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>
+}
+
+// CHECK-LABEL: func.func @range_range
+func.func @range_range(%arg0: memref<?x!sycl_range_1_>,
+                       %arg1: memref<?x!sycl_range_2_>,
+                       %arg2: memref<?x!sycl_range_3_>)
+    -> (memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>) {
+  %range1 = sycl.range.constructor(%arg0)
+      : (memref<?x!sycl_range_1_>) -> memref<1x!sycl_range_1_>
+  %range2 = sycl.range.constructor(%arg1)
+      : (memref<?x!sycl_range_2_>) -> memref<1x!sycl_range_2_>
+  %range3 = sycl.range.constructor(%arg2)
+      : (memref<?x!sycl_range_3_>) -> memref<1x!sycl_range_3_>
+  func.return %range1, %range2, %range3
+      : memref<1x!sycl_range_1_>,
+        memref<1x!sycl_range_2_>,
+        memref<1x!sycl_range_3_>
+}
+

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -352,6 +352,38 @@ func.func @test_id_constructor_wrong_sign(%arg: i32) -> memref<1x!sycl_id_1_> {
 
 // -----
 
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+
+func.func @test_range_constructor_bad_signature(%arg: i32) -> memref<1x!sycl_range_1_> {
+// expected-error @below {{'sycl.range.constructor' op expects a different signature. Check documentation for details}}
+  %0 = sycl.range.constructor(%arg) : (i32) -> memref<1x!sycl_range_1_>
+  func.return %0 : memref<1x!sycl_range_1_>
+}
+
+// -----
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+
+func.func @test_range_constructor_bad_num_dims(%arg: memref<1x!sycl_range_2_>) -> memref<1x!sycl_range_1_> {
+// expected-error @below {{'sycl.range.constructor' op expects input and output to have the same number of dimensions: 2 vs 1}}
+  %0 = sycl.range.constructor(%arg) : (memref<1x!sycl_range_2_>) -> memref<1x!sycl_range_1_>
+  func.return %0 : memref<1x!sycl_range_1_>
+}
+
+// -----
+
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+
+func.func @test_range_constructor_index_wrong_dims(%arg0: index)
+    -> memref<1x!sycl_range_2_> {
+// expected-error @below {{'sycl.range.constructor' op expects to be passed the same number of 'index' numbers as the number of dimensions of the input: 1 vs 2}}
+  %0 = sycl.range.constructor(%arg0) : (index) -> memref<1x!sycl_range_2_>
+  func.return %0 : memref<1x!sycl_range_2_>
+}
+
+// -----
+
 func.func @math_op_invalid_type(%arg0 : i32) {
   // expected-error @+1 {{op operand #0 must be 32-bit float or 64-bit float, but got 'i32'}}
   %0 = sycl.math.sin %arg0 : i32


### PR DESCRIPTION
This operation creates a new `sycl.range`. The following signatures are provided:

```mlir
(index) -> memref<1x!sycl_range_1>
(index, index) -> memref<1x!sycl_range_2>
(index, index, index) -> memref<1x!sycl_range_3>
(memref<?xsycl_range_N>) -> memref<1x!sycl_range_N>
```

In addition of initializing the values, this operation also allocates the object.