### PR TITLE
[SYCL][E2E] Disable ESIMD/accessor_local.cpp on Linux 

### DIFF
--- a/sycl/test-e2e/ESIMD/accessor_local.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_local.cpp
@@ -4,6 +4,9 @@
 // TODO: GPU driver on Windows requires a fix/update.
 // XFAIL: windows
 
+// Failure on Linux: https://github.com/intel/llvm/issues/10138
+// UNSUPPORTED: linux
+
 // esimd_emulator does not yet support local accessors
 // UNSUPPORTED: esimd_emulator
 


### PR DESCRIPTION
Temporary disabled until the fix is created, the issue is https://github.com/intel/llvm/issues/10138.