### PR TITLE
[SYCL][HIP] Ignore unused PI command-buffer parameters

### DIFF
--- a/sycl/plugins/hip/pi_hip.cpp
+++ b/sycl/plugins/hip/pi_hip.cpp
@@ -5641,6 +5641,7 @@ pi_result hip_piextCommandBufferNDRangeKernel(
   (void)local_work_size;
   (void)num_sync_points_in_wait_list;
   (void)sync_point_wait_list;
+  (void)sync_point;
 
   sycl::detail::pi::die("command-buffer API not implemented in HIP backend");
   return {};
@@ -5700,6 +5701,8 @@ pi_result hip_piextCommandBufferMemBufferCopyRect(
   (void)region;
   (void)src_row_pitch;
   (void)src_slice_pitch;
+  (void)dst_row_pitch;
+  (void)dst_slice_pitch;
   (void)num_sync_points_in_wait_list;
   (void)sync_point_wait_list;
   (void)sync_point;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -127,6 +127,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendMembufferCopyRectExp(
   (void)dstOrigin;
   (void)region;
   (void)srcRowPitch;
+  (void)srcSlicePitch;
+  (void)dstRowPitch;
+  (void)dstSlicePitch;
   (void)numSyncPointsInWaitList;
   (void)pSyncPointWaitList;
   (void)pSyncPoint;


### PR DESCRIPTION
Fixes error found in [post-commit CI](https://github.com/intel/llvm/actions/runs/5454766342/jobs/9925392005) after the merge of https://github.com/intel/llvm/pull/9992

```
 /__w/llvm/llvm/src/sycl/plugins/hip/pi_hip.cpp:5635:24: error: unused parameter 'sync_point' [-Werror,-Wunused-parameter]
 5635 |     pi_ext_sync_point *sync_point) {
      |                        ^
/__w/llvm/llvm/src/sycl/plugins/hip/pi_hip.cpp:5691:12: error: unused parameter 'dst_row_pitch' [-Werror,-Wunused-parameter]
 5691 |     size_t dst_row_pitch, size_t dst_slice_pitch,
      |            ^
/__w/llvm/llvm/src/sycl/plugins/hip/pi_hip.cpp:5691:34: error: unused parameter 'dst_slice_pitch' [-Werror,-Wunused-parameter]
 5691 |     size_t dst_row_pitch, size_t dst_slice_pitch,
      |                                  ^
3 errors generated.
```