### PR TITLE
[SYCL-MLIR] Define `sycl.host.handler.set_nd_range`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -94,4 +94,20 @@ def SYCLHostHandlerSetKernel
   }];
 }
 
+def SYCLHostHandlerSetNDRange : SYCL_HostOp<"handler.set_nd_range"> {
+  let summary = [{
+    Operation assigning an nd-range to a `sycl::handler`, setting the nd-range
+    of the kernel to be launched.
+
+    The input nd-range can be specified either with a memref to a
+    `sycl.nd_range` or a memref to a `sycl.range` (global size) and an optional
+    memref to a `sycl.id` (offset).
+  }];
+  let arguments = (ins LLVM_AnyPointer:$handler, Variadic<AnyType>:$nd_range);
+  let assemblyFormat = [{
+    $handler `->` $nd_range attr-dict `:` type(operands)
+  }];
+  let hasVerifier = 1;
+}
+
 #endif // SYCL_HOST_OPS

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -468,7 +468,7 @@ LogicalResult SYCLHostHandlerSetNDRange::verify() {
                                  "the same number of dimensions");
       }
     }
-    [[fallthrough]];
+    break;
   default:
     break;
   }

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -2,6 +2,8 @@
 // RUN: sycl-mlir-opt %s --mlir-print-op-generic | sycl-mlir-opt | FileCheck %s
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_accessor_2_i32_r_gb = !sycl.accessor<[2, i32, read, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
@@ -47,5 +49,33 @@ func.func @f() -> !llvm.ptr {
 // CHECK-NEXT:     sycl.host.handler.set_kernel %[[VAL_0]] -> @kernels::@k0
 func.func @set_kernel(%handler: !llvm.ptr) {
   sycl.host.handler.set_kernel %handler -> @kernels::@k0 : !llvm.ptr
+  func.return
+}
+
+// CHECK-LABEL:   func.func @set_nd_range(
+// CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                            %[[VAL_1:.*]]: memref<?x!sycl_nd_range_1_>) {
+// CHECK-NEXT:      sycl.host.handler.set_nd_range %[[VAL_0]] -> %[[VAL_1]] : !llvm.ptr, memref<?x!sycl_nd_range_1_>
+func.func @set_nd_range(%handler: !llvm.ptr, %nd_range: memref<?x!sycl_nd_range_1_>) {
+  sycl.host.handler.set_nd_range %handler -> %nd_range : !llvm.ptr, memref<?x!sycl_nd_range_1_>
+  func.return
+}
+
+// CHECK-LABEL:   func.func @set_nd_range_range(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                  %[[VAL_1:.*]]: memref<?x!sycl_range_1_>) {
+// CHECK-NEXT:      sycl.host.handler.set_nd_range %[[VAL_0]] -> %[[VAL_1]] : !llvm.ptr, memref<?x!sycl_range_1_>
+func.func @set_nd_range_range(%handler: !llvm.ptr, %range: memref<?x!sycl_range_1_>) {
+  sycl.host.handler.set_nd_range %handler -> %range : !llvm.ptr, memref<?x!sycl_range_1_>
+  func.return
+}
+
+// CHECK-LABEL:   func.func @set_nd_range_range_with_offset(
+// CHECK-SAME:                                              %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                              %[[VAL_1:.*]]: memref<?x!sycl_range_1_>,
+// CHECK-SAME:                                              %[[VAL_2:.*]]: memref<?x!sycl_id_1_>) {
+// CHECK-NEXT:      sycl.host.handler.set_nd_range %[[VAL_0]] -> %[[VAL_1]], %[[VAL_2]] : !llvm.ptr, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>
+func.func @set_nd_range_range_with_offset(%handler: !llvm.ptr, %range: memref<?x!sycl_range_1_>, %offset: memref<?x!sycl_id_1_>) {
+  sycl.host.handler.set_nd_range %handler -> %range, %offset : !llvm.ptr, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>
   func.return
 }

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -553,3 +553,26 @@ func.func @test_unwrap(%arg0 : !sycl.half<(f16)>) {
   %0 = sycl.mlir.unwrap %arg0 : !sycl.half<(f16)> to i16
   return
 }
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
+
+func.func @set_nd_range_bad_signature(%handler: !llvm.ptr, %nd_range: memref<?x!sycl_nd_range_1_>, %offset: memref<?x!sycl_id_1_>) {
+// expected-error @below {{'sycl.host.handler.set_nd_range' op expects a different signature. Check documentation for details}}
+  sycl.host.handler.set_nd_range %handler -> %nd_range, %offset : !llvm.ptr, memref<?x!sycl_nd_range_1_>, memref<?x!sycl_id_1_>
+  func.return
+}
+
+// -----
+
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
+!sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
+
+func.func @set_nd_range_bad_signature(%handler: !llvm.ptr, %range: memref<?x!sycl_range_2_>, %offset: memref<?x!sycl_id_1_>) {
+// expected-error @below {{'sycl.host.handler.set_nd_range' op expects both global size and offset to have the same number of dimensions}}
+  sycl.host.handler.set_nd_range %handler -> %range, %offset : !llvm.ptr, memref<?x!sycl_range_2_>, memref<?x!sycl_id_1_>
+  func.return
+}


### PR DESCRIPTION
Operation assigning an nd-range to a `sycl::handler`, setting the nd-range of the kernel to be launched.

The input nd-range can be specified either with a memref to a `sycl.nd_range` or a memref to a `sycl.range` (global size) and an optional memref to a `sycl.id` (offset).