### PR TITLE
[SYCL] Allow zero-sized 3D accessors

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2206,8 +2206,6 @@ static pi_result SetKernelParamsAndLaunch(
       break;
     case kernel_param_kind_t::kind_accessor: {
       Requirement *Req = (Requirement *)(Arg.MPtr);
-      if (Req->MAccessRange == range<3>({0, 0, 0}))
-        break;
       assert(getMemAllocationFunc != nullptr &&
              "We should have caught this earlier.");
 

--- a/sycl/test-e2e/Regression/empty_accessor_use.cpp
+++ b/sycl/test-e2e/Regression/empty_accessor_use.cpp
@@ -15,7 +15,7 @@ int main() {
   assert(Buf.size() == 1);
   Q.submit([&](handler &CGH) {
     accessor Acc{Buf, CGH, range<3>{0, 0, 0}, read_write};
-    // assert(Acc.empty());
+    assert(Acc.empty());
     CGH.single_task([=] {
       if (!Acc.empty())
         Acc[id<3>{0, 0, 0}] = 42;

--- a/sycl/test-e2e/Regression/empty_accessor_use.cpp
+++ b/sycl/test-e2e/Regression/empty_accessor_use.cpp
@@ -1,0 +1,25 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests that 3D accessors with 0 elements are allowed to be captured in a
+// kernel.
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  queue Q;
+
+  buffer<int, 3> Buf{range<3>{1, 1, 1}};
+  assert(Buf.size() == 1);
+  Q.submit([&](handler &CGH) {
+    accessor Acc{Buf, CGH, range<3>{0, 0, 0}, read_write};
+    // assert(Acc.empty());
+    CGH.single_task([=] {
+      if (!Acc.empty())
+        Acc[id<3>{0, 0, 0}] = 42;
+    });
+  });
+  return 0;
+}


### PR DESCRIPTION
There is currently a restriction in commands.cpp that prevents the setting of kernel arugments for accessors with zero in all three dimensions. This only affects empty 3D accessors, as others have 1-padding in the missing dimensions. Since we now allow empty accessors, this restriction should be lifted.