### PR TITLE
[SYCL][CUDA] Fix cuDeviceGetUuid for older CUDA version

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -884,11 +884,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_UUID: {
     CUuuid UUID;
 #if (CUDA_VERSION >= 11040)
-      sycl::detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
-                                  CUDA_SUCCESS);
+    sycl::detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
+                                CUDA_SUCCESS);
 #else
-      sycl::detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
-                                  CUDA_SUCCESS);
+    sycl::detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
+                                CUDA_SUCCESS);
 #endif
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -882,18 +882,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(Value);
   }
   case UR_DEVICE_INFO_UUID: {
-    int DriverVersion = 0;
-    cuDriverGetVersion(&DriverVersion);
-    int Major = DriverVersion / 1000;
-    int Minor = DriverVersion % 1000 / 10;
     CUuuid UUID;
-    if ((Major > 11) || (Major == 11 && Minor >= 4)) {
+#if (CUDA_VERSION >= 11040)
       sycl::detail::ur::assertion(cuDeviceGetUuid_v2(&UUID, hDevice->get()) ==
                                   CUDA_SUCCESS);
-    } else {
+#else
       sycl::detail::ur::assertion(cuDeviceGetUuid(&UUID, hDevice->get()) ==
                                   CUDA_SUCCESS);
-    }
+#endif
     std::array<unsigned char, 16> Name;
     std::copy(UUID.bytes, UUID.bytes + 16, Name.begin());
     return ReturnValue(Name.data(), 16);


### PR DESCRIPTION
This patch re-introduces the fix from https://github.com/intel/llvm/pull/8765

Which seems to have been accidentally dropped by the UR port.