### PR TITLE
[SYCL][E2E] Use cpu selector for subdevice_pi test

### DIFF
--- a/sycl/test-e2e/Basic/subdevice_pi.cpp
+++ b/sycl/test-e2e/Basic/subdevice_pi.cpp
@@ -195,7 +195,7 @@ int main(int argc, const char **argv) {
   std::string test(argv[1]);
   std::string partition_type(argv[2]);
 
-  device dev(default_selector_v);
+  device dev(cpu_selector_v);
 
   std::vector<int> host_mem(1024, 1);
   buffer<int, 1> buf(&host_mem[0], host_mem.size());


### PR DESCRIPTION
This test states at the top that it is only compatible with a cpu device. However it was using a default_selector which can be a GPU. This PR changes it to a cpu selector