### PR TITLE
[SYCL-MLIR] Make accessor raising more robust

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -154,6 +154,13 @@ static bool isClassType(Type type, StringRef className) {
   return st && st.isIdentified() && st.getName() == className;
 }
 
+/// Returns whether \p type is an `llvm.struct` type with a name matching 
+/// \p regex.
+static bool isClassType(Type type, llvm::Regex &regex) {
+  auto st = dyn_cast<LLVM::LLVMStructType>(type);
+  return st && st.isIdentified() && regex.match(st.getName());
+}
+
 namespace {
 struct RaiseKernelName : public OpRewritePattern<LLVM::AddressOfOp> {
 public:
@@ -307,7 +314,10 @@ public:
 
 struct BufferTypeTag {
 
-  static llvm::StringRef getTypeName() { return "class.sycl::_V1::buffer"; }
+  static llvm::Regex &getTypeName() {
+    static llvm::Regex regex{"class.sycl::_V1::buffer(\\.[0-9]+])?"};
+    return regex;
+  }
 
   static mlir::Type getTypeFromConstructor(CallOpInterface constructor) {
     CallInterfaceCallable callableOp = constructor.getCallableForCallee();
@@ -343,7 +353,10 @@ struct BufferInvokeConstructorPattern
 
 struct AccessorTypeTag {
 
-  static llvm::StringRef getTypeName() { return "class.sycl::_V1::accessor"; }
+  static llvm::Regex &getTypeName() {
+    static llvm::Regex regex{"class.sycl::_V1::accessor(\\.[0-9]+])?"};
+    return regex;
+  }
 
   static mlir::Type getTypeFromConstructor(CallOpInterface constructor) {
     CallInterfaceCallable callableOp = constructor.getCallableForCallee();

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -156,7 +156,7 @@ static bool isClassType(Type type, StringRef className) {
 
 /// Returns whether \p type is an `llvm.struct` type with a name matching
 /// \p regex.
-static bool isClassType(Type type, llvm::Regex &regex) {
+static bool isClassType(Type type, const llvm::Regex &regex) {
   auto st = dyn_cast<LLVM::LLVMStructType>(type);
   return st && st.isIdentified() && regex.match(st.getName());
 }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -154,7 +154,7 @@ static bool isClassType(Type type, StringRef className) {
   return st && st.isIdentified() && st.getName() == className;
 }
 
-/// Returns whether \p type is an `llvm.struct` type with a name matching 
+/// Returns whether \p type is an `llvm.struct` type with a name matching
 /// \p regex.
 static bool isClassType(Type type, llvm::Regex &regex) {
   auto st = dyn_cast<LLVM::LLVMStructType>(type);

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -83,9 +83,13 @@ llvm.func @__gxx_personality_v0(...) -> i32
 // CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor.5", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK:           sycl.host.constructor(%[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb1
 // CHECK:         ^bb1:
+// CHECK:           sycl.host.constructor(%[[VAL_5]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           llvm.br ^bb2
+// CHECK:         ^bb2:
 // CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr
 // CHECK:         }
 llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
@@ -94,6 +98,7 @@ llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_person
   %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %4 = llvm.alloca %0 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %5 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::accessor.5", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 
   llvm.invoke @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE1ENS0_3ext6oneapi22accessor_property_listIJEEEEC2IiLi1ENS0_6detail17aligned_allocatorIiEEvEERNS0_6bufferIT_XT0_ET1_NSt9enable_ifIXaagtT0_Li0EleT0_Li3EEvE4typeEEERKNS0_13property_listENSC_13code_locationE(%2, %1, %3, %4) to ^bb1 unwind ^bb0 : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
@@ -101,6 +106,11 @@ llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_person
   %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
   llvm.resume %lp : !llvm.struct<(ptr, i32)>
 ^bb1:
+  llvm.invoke @_ZN4sycl3_V18accessorIfLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2IfLi1ENS0_6detail17aligned_allocatorIfEEvEERNS0_6bufferIT_XT0_ET1_NSt9enable_ifIXaagtT0_Li0EleT0_Li3EEvE4typeEEERNS0_7handlerERKNS0_13property_listENSC_13code_locationE(%5, %1, %3, %4) to ^bb3 unwind ^bb2 : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+^bb2:
+  %lp1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %lp1 : !llvm.struct<(ptr, i32)>
+^bb3:
   llvm.return %1 : !llvm.ptr
 }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/host_raising.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/host_raising.cpp
@@ -23,6 +23,7 @@ class KernelName;
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect kernel assignment to a sycl::handler:
 


### PR DESCRIPTION
Make the raising for buffers and accessors more robust by allowing number suffixes for the allocated type name and matching with a regex.