### PR TITLE
[SYCL][NFC] Modernize use of accessor in stream

### DIFF
--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -66,21 +66,19 @@ using EnableIfFP = typename std::enable_if_t<std::is_same_v<F, float> ||
                                              T>;
 
 using GlobalBufAccessorT = accessor<char, 1, sycl::access::mode::read_write,
-                                    sycl::access::target::global_buffer,
-                                    sycl::access::placeholder::false_t>;
+                                    sycl::access::target::device>;
 
 constexpr static access::address_space GlobalBufAS =
-    TargetToAS<sycl::access::target::global_buffer>::AS;
+    TargetToAS<sycl::access::target::device>::AS;
 using GlobalBufPtrType =
     typename detail::DecoratedType<char, GlobalBufAS>::type *;
 constexpr static int GlobalBufDim = 1;
 
 using GlobalOffsetAccessorT = accessor<unsigned, 1, sycl::access::mode::atomic,
-                                       sycl::access::target::global_buffer,
-                                       sycl::access::placeholder::false_t>;
+                                       sycl::access::target::device>;
 
 constexpr static access::address_space GlobalOffsetAS =
-    TargetToAS<sycl::access::target::global_buffer>::AS;
+    TargetToAS<sycl::access::target::device>::AS;
 using GlobalOffsetPtrType =
     typename detail::DecoratedType<unsigned, GlobalBufAS>::type *;
 constexpr static int GlobalOffsetDim = 1;


### PR DESCRIPTION
`global_buffer` target is deprecated in SYCL 2020 in favor of `device`.
`isPlaceholder` template argument defaults to `false` and ignored in SYCL 2020.