### PR TITLE
[SYCL][NFC] Modernize getting host accessor

### DIFF
--- a/sycl/test-e2e/Basic/fpga_tests/buffer_location.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/buffer_location.cpp
@@ -17,7 +17,7 @@ int main() {
 
   Queue.wait();
 
-  auto Acc = Buf.template get_access<sycl::access::mode::read_write>();
+  auto Acc = Buf.get_host_access();
   assert(Acc[0] == 42 && "Value mismatch");
 
   return 0;

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_io_pipes.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_io_pipes.cpp
@@ -77,7 +77,7 @@ int test_io_nb_pipe(sycl::queue Queue) {
     });
   });
 
-  auto readHostBuffer = writeBuf.get_access<sycl::access::mode::read>();
+  auto readHostBuffer = writeBuf.get_host_access();
   if (readHostBuffer[0] != InputData) {
     std::cout << "Read from a file mismatches " << readHostBuffer[0]
               << " Vs expected " << InputData << std::endl;
@@ -102,7 +102,7 @@ int test_io_bl_pipe(sycl::queue Queue) {
     });
   });
 
-  auto readHostBuffer = writeBuf.get_access<sycl::access::mode::read>();
+  auto readHostBuffer = writeBuf.get_host_access();
   if (readHostBuffer[0] != InputData) {
     std::cout << "Read from a file mismatches " << readHostBuffer[0]
               << " Vs expected " << InputData << std::endl;

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_pipes_legacy_ns.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_pipes_legacy_ns.cpp
@@ -41,7 +41,7 @@ template <typename PipeName> int test_simple_nb_pipe(sycl::queue Queue) {
     });
   });
 
-  auto readHostBuffer = writeBuf.get_access<sycl::access::mode::read>();
+  auto readHostBuffer = writeBuf.get_host_access();
   if (readHostBuffer[0] != 42) {
     std::cout << "Result mismatches " << readHostBuffer[0] << " Vs expected "
               << 42 << std::endl;

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_queue.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_queue.cpp
@@ -116,7 +116,7 @@ int main() {
       return -1;
     }
 
-    auto readBufferC = bufC.get_access<access::mode::read>();
+    auto readBufferC = bufC.get_host_access();
     for (size_t i = 0; i != dataSize; ++i) {
       if (readBufferC[i] != 2 * i) {
         std::cout << "Result mismatches " << readBufferC[i] << " Vs expected "

--- a/sycl/test-e2e/Basic/handler/interop_task.cpp
+++ b/sycl/test-e2e/Basic/handler/interop_task.cpp
@@ -48,7 +48,7 @@ int main() {
   });
 
   {
-    auto DstAcc = DstBuf.template get_access<sycl::access::mode::read_write>();
+    auto DstAcc = DstBuf.get_host_access();
     const int Expected = 42;
     for (int I = 0; I < DstAcc.get_count(); ++I)
       if (DstAcc[I] != Expected) {
@@ -59,8 +59,7 @@ int main() {
   }
 
   {
-    auto DstAcc2 =
-        DstBuf2.template get_access<sycl::access::mode::read_write>();
+    auto DstAcc2 = DstBuf2.get_host_access();
     const int Expected = 42;
     for (int I = 0; I < DstAcc2.get_count(); ++I)
       if (DstAcc2[I] != Expected) {

--- a/sycl/test-e2e/Basic/multisource.cpp
+++ b/sycl/test-e2e/Basic/multisource.cpp
@@ -68,7 +68,7 @@ int main() {
 
     calc_buf(q, a, b, c, r);
 
-    auto C = c.get_access<access::mode::read>();
+    auto C = c.get_host_access();
     for (size_t i = 0; i < N; i++) {
       if (C[i] != 1) {
         std::cout << "Wrong value " << C[i] << " for element " << i

--- a/sycl/test-e2e/HostInteropTask/host-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task.cpp
@@ -59,7 +59,7 @@ void test2(queue &Q) {
   });
 
   {
-    auto Acc = Buffer2.get_access<mode::read>();
+    auto Acc = Buffer2.get_host_access();
 
     for (size_t Idx = 0; Idx < Acc.get_count(); ++Idx) {
       std::cout << "Second buffer [" << Idx << "] = " << Acc[Idx] << std::endl;

--- a/sycl/test-e2e/HostInteropTask/interop-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task.cpp
@@ -19,7 +19,7 @@ template <typename T> class Init;
 
 template <typename BufferT, typename ValueT>
 void checkBufferValues(BufferT Buffer, ValueT Value) {
-  auto Acc = Buffer.template get_access<mode::read>();
+  auto Acc = Buffer.get_host_access();
   for (size_t Idx = 0; Idx < Acc.get_count(); ++Idx) {
     if (Acc[Idx] != Value) {
       std::cerr << "buffer[" << Idx << "] = " << Acc[Idx]

--- a/sycl/test-e2e/InorderQueue/in_order_buffs.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_buffs.cpp
@@ -51,7 +51,7 @@ int main() {
       cgh.parallel_for<class ordered_reader>(myRange, myKernel);
     });
 
-    auto readBufferB = bufB.get_access<access::mode::read>();
+    auto readBufferB = bufB.get_host_access();
     for (size_t i = 0; i != dataSize; ++i) {
       if (readBufferB[i] != i) {
         std::cout << "Result mismatches " << readBufferB[i] << " vs expected "

--- a/sycl/test-e2e/KernelParams/array-kernel-param-nested-run.cpp
+++ b/sycl/test-e2e/KernelParams/array-kernel-param-nested-run.cpp
@@ -81,7 +81,7 @@ bool test_accessor_array_in_struct(queue &myQueue) {
           output_accessor[index] = S.a[0][index] + S.a[1][index] + S.x + S.y;
         });
   });
-  const auto HostAccessor = out_buffer.get_access<sycl::access::mode::read>();
+  const auto HostAccessor = out_buffer.get_host_access();
 
   return verify_1D("Accessor array in struct", c_num_items, output, ref);
 }
@@ -109,7 +109,7 @@ bool test_templated_array_in_struct(queue &myQueue) {
           output_accessor[index] = sint.a[index] + sll.a[index];
         });
   });
-  const auto HostAccessor = out_buffer.get_access<sycl::access::mode::read>();
+  const auto HostAccessor = out_buffer.get_host_access();
 
   return verify_1D("Templated array in struct", c_num_items, output, ref);
 }

--- a/sycl/test-e2e/KernelParams/array-kernel-param-run.cpp
+++ b/sycl/test-e2e/KernelParams/array-kernel-param-run.cpp
@@ -73,7 +73,7 @@ bool test_one_array(queue &myQueue) {
       output_accessor[index] = input1[0][index] + input2[2][1][index] + 1;
     });
   });
-  const auto HostAccessor = out_buffer.get_access<sycl::access::mode::read>();
+  const auto HostAccessor = out_buffer.get_host_access();
 
   return verify_1D<int *>("One array", c_num_items, output, ref);
 }
@@ -96,7 +96,7 @@ bool test_two_arrays(queue &myQueue) {
       output_accessor[index] = input1[index] + input2[index];
     });
   });
-  const auto HostAccessor = out_buffer.get_access<sycl::access::mode::read>();
+  const auto HostAccessor = out_buffer.get_host_access();
 
   return verify_1D<int *>("Two arrays", c_num_items, output, ref);
 }
@@ -129,7 +129,7 @@ bool test_accessor_arrays_1(queue &myQueue) {
           a[0][index] = a[1][index] + input3[index] + input4[index] + 2;
         });
   });
-  const auto HostAccessor = in_buffer1.get_access<sycl::access::mode::read>();
+  const auto HostAccessor = in_buffer1.get_host_access();
 
   return verify_1D<std::array<int, c_num_items>>("Accessor arrays 1",
                                                  c_num_items, input1, ref);
@@ -162,7 +162,7 @@ bool test_accessor_arrays_2(queue &myQueue) {
           output_accessor[index] = a[0][index] + a[3][index];
         });
   });
-  const auto HostAccessor = out_buffer.get_access<sycl::access::mode::read>();
+  const auto HostAccessor = out_buffer.get_host_access();
 
   return verify_1D<std::array<int, c_num_items>>("Accessor arrays 2",
                                                  c_num_items, output, ref);

--- a/sycl/test-e2e/OnlineCompiler/online_compiler_common.hpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_common.hpp
@@ -43,7 +43,7 @@ void testSyclKernel(sycl::queue &Q, sycl::kernel Kernel) {
     CGH.parallel_for(sycl::range<1>{N}, Kernel);
   });
 
-  auto Out = OutputBuf.get_access<sycl::access::mode::read>();
+  auto Out = OutputBuf.get_host_access();
   for (int I = 0; I < N; I++)
     std::cout << I << "*2 + 100 = " << Out[I] << "\n";
 }

--- a/sycl/test-e2e/Plugin/sycl-targets-order.cpp
+++ b/sycl/test-e2e/Plugin/sycl-targets-order.cpp
@@ -48,9 +48,9 @@ int main(int argc, char **argv) {
     });
   });
 
-  // get read-only access to the buffer on the host
+  // get access to the buffer on the host
   // introduce an implicit barrier waiting for queue to complete the work
-  const auto host_accessor = buffer.get_access<sycl::access::mode::read>();
+  const auto host_accessor = buffer.get_host_access();
 
   // check the results
   bool mismatch = false;

--- a/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
+++ b/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
@@ -22,7 +22,7 @@ int main() {
         Acc[0] = kh.get_specialization_constant<test_id_1>();
       });
     });
-    auto Acc = Buf.get_access<sycl::access::mode::read>();
+    auto Acc = Buf.get_host_access();
     assert(Acc[0] == 1);
   }
   return 0;

--- a/sycl/test-e2e/Regression/fp16-with-unnamed-lambda.cpp
+++ b/sycl/test-e2e/Regression/fp16-with-unnamed-lambda.cpp
@@ -29,7 +29,7 @@ int main() {
 
   Q.wait_and_throw();
 
-  auto Acc = Buf.get_access<sycl::access::mode::read>();
+  auto Acc = Buf.get_host_access();
   if (1 != Acc[0]) {
     std::cerr << "Incorrect result, got: " << Acc[0] << ", expected: 1"
               << std::endl;

--- a/sycl/test-e2e/Regression/local-arg-align.cpp
+++ b/sycl/test-e2e/Regression/local-arg-align.cpp
@@ -39,7 +39,7 @@ int main(int argc, char *argv[]) {
      });
    }).wait_and_throw();
 
-  auto hres = res.get_access<access::mode::read_write>();
+  auto hres = res.get_host_access();
 
   int ret = 0;
   // Check that the addresses are aligned as expected

--- a/sycl/test-e2e/Regression/mad_sat.cpp
+++ b/sycl/test-e2e/Regression/mad_sat.cpp
@@ -30,7 +30,7 @@ int main() {
         resultPtr[0] = sycl::mad_sat(inputData_0, inputData_1, inputData_2);
       });
     });
-    const auto HostAccessor = buffer.get_access<sycl::access::mode::read>();
+    const auto HostAccessor = buffer.get_host_access();
     for (int i = 0; i < 3; i++)
       assert((HostAccessor[0][i] == verification3[i]) && "Incorrect result");
   }
@@ -54,7 +54,7 @@ int main() {
         resultPtr[0] = sycl::mad_sat(inputData_0, inputData_1, inputData_2);
       });
     });
-    const auto HostAccessor = buffer.get_access<sycl::access::mode::read>();
+    const auto HostAccessor = buffer.get_host_access();
     for (int i = 0; i < 4; i++)
       assert((HostAccessor[0][i] == verification4[i]) && "Incorrect result");
   }
@@ -85,7 +85,7 @@ int main() {
         resultPtr[0] = sycl::mad_sat(inputData_0, inputData_1, inputData_2);
       });
     });
-    const auto HostAccessor = buffer.get_access<sycl::access::mode::read>();
+    const auto HostAccessor = buffer.get_host_access();
     for (int i = 0; i < 8; i++)
       assert((HostAccessor[0][i] == verification8[i]) && "Incorrect result");
   }
@@ -129,7 +129,7 @@ int main() {
         resultPtr[0] = sycl::mad_sat(inputData_0, inputData_1, inputData_2);
       });
     });
-    const auto HostAccessor = buffer.get_access<sycl::access::mode::read>();
+    const auto HostAccessor = buffer.get_host_access();
     for (int i = 0; i < 16; i++)
       assert((HostAccessor[0][i] == verification16[i]) && "Incorrect result");
   }

--- a/sycl/test-e2e/Regression/set-arg-local-accessor.cpp
+++ b/sycl/test-e2e/Regression/set-arg-local-accessor.cpp
@@ -60,7 +60,7 @@ int main() {
     cgh.parallel_for(nd_range<1>(N_wg, 1), K);
   });
 
-  auto acc_global = b.get_access<access::mode::read>();
+  auto acc_global = b.get_host_access();
   for (int i = 0; i < N_wg; i++) {
     if (acc_global[i] != 1) {
       std::cerr << "Error in WG " << i << std::endl;

--- a/sycl/test/extensions/fpga.cpp
+++ b/sycl/test/extensions/fpga.cpp
@@ -59,7 +59,7 @@ int main() {
   });
   Queue.wait();
 
-  auto Acc = Buf.template get_access<sycl::access::mode::read_write>();
+  auto Acc = Buf.get_host_access();
   assert(Acc[0] == 42 && "Value mismatch");
 
   /*Check FPGA-related device parameters*/

--- a/sycl/test/gdb/accessors.cpp
+++ b/sycl/test/gdb/accessors.cpp
@@ -4,7 +4,7 @@
 #include <sycl/sycl.hpp>
 
 void foo(sycl::buffer<int, 1> &BufA) {
-  auto HostAcc = BufA.get_host_access();
+  auto HostAcc = BufA.get_access<sycl::access_mode::read>();
 
   sycl::accessor<char, 1, sycl::access::mode::read_write, sycl::target::local>
       *LocalAcc;

--- a/sycl/test/gdb/accessors.cpp
+++ b/sycl/test/gdb/accessors.cpp
@@ -4,7 +4,7 @@
 #include <sycl/sycl.hpp>
 
 void foo(sycl::buffer<int, 1> &BufA) {
-  auto HostAcc = BufA.get_access<sycl::access_mode::read>();
+  auto HostAcc = BufA.get_host_access();
 
   sycl::accessor<char, 1, sycl::access::mode::read_write, sycl::target::local>
       *LocalAcc;

--- a/sycl/test/regression/check_config_processing.cpp
+++ b/sycl/test/regression/check_config_processing.cpp
@@ -26,7 +26,7 @@ int main() {
   // Config check
   if (testEnvVarValue == "CORRECT_CONFIG_FILE") {
     sycl::buffer<int, 1> Buf(sycl::range<1>{1});
-    auto Acc = Buf.get_access<sycl::access::mode::read>();
+    auto Acc = Buf.get_host_access();
     return 0;
   }
   throw std::logic_error("Environment is incorrect");

--- a/sycl/test/regression/copy-with-unnamed-lambda.cpp
+++ b/sycl/test/regression/copy-with-unnamed-lambda.cpp
@@ -30,7 +30,7 @@ int main() {
 
   Q.wait_and_throw();
 
-  auto Acc = Buf.get_access<sycl::access::mode::read>();
+  auto Acc = Buf.get_host_access();
   for (size_t I = 0; I < Size; ++I) {
     if (ReferenceData[I] != Acc[I]) {
       std::cerr << "Incorrect result, got: " << Acc[I]


### PR DESCRIPTION
`get_access` for host accessor is deprecated by SYCL 2020 in favor of `get_host_access`.

Note: this patch does not update all tests we have, there are still major categories skipped like `XPTI`, `Sampler`, etc.