### PR TITLE
[SYCL-MLIR][LoopInternalization] Revert change to `GPUModule` pass

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -125,7 +125,7 @@ def LLVMLegalizeForSPIRV : Pass<"legalize-for-spirv"> {
   let dependentDialects = ["LLVM::LLVMDialect"];  
 }
 
-def LoopInternalization : Pass<"loop-internalization", "gpu::GPUModuleOp"> {
+def LoopInternalization : Pass<"loop-internalization"> {
   let summary = "Promote SYCL memory accesses in a loop nest to shared local memory";
   let description = [{
     SYCL memory accesses in perfectly nested loops are promoted to shared local

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -978,6 +978,8 @@ struct LoopInternalization
   void runOnOperation() final;
 
 private:
+  void runOnGPUModule(gpu::GPUModuleOp gpuModule);
+
   /// Construct a map from memref accesses in \p loop to their ideal memory
   /// space.
   void selectMemorySpace(LoopLikeOpInterface loop,
@@ -1047,7 +1049,13 @@ private:
 };
 
 void LoopInternalization::runOnOperation() {
-  gpu::GPUModuleOp gpuModule = getOperation();
+  getOperation()->walk([&](Operation *Op) {
+    if (auto gpuModule = dyn_cast<gpu::GPUModuleOp>(Op))
+      runOnGPUModule(gpuModule);
+  });
+}
+
+void LoopInternalization::runOnGPUModule(gpu::GPUModuleOp gpuModule) {
   ModuleAnalysisManager mam(gpuModule, /*passInstrumentor=*/nullptr);
   AnalysisManager am = mam;
   auto &memAccessAnalysis =
@@ -1300,10 +1308,11 @@ void LoopInternalization::transform(FunctionOpInterface func,
   sycl::populateLocalID(localIDs, numDims, builder, func.getLoc());
 
   // Reserve static shared local memory for this function.
+  auto gpuModule = func->getParentOfType<gpu::GPUModuleOp>();
   memref::GlobalOp wgSharedLocalMemory = getWorkGroupSharedLocalMemory(
-      getOperation(), std::holds_alternative<unsigned>(reqdSharedMemory)
-                          ? std::get<unsigned>(reqdSharedMemory)
-                          : sharedMemoryRemaining);
+      gpuModule, std::holds_alternative<unsigned>(reqdSharedMemory)
+                     ? std::get<unsigned>(reqdSharedMemory)
+                     : sharedMemoryRemaining);
 
   // Now that we have a list of memref to promote to shared memory in each
   // loop nest's innermost loop, perform the transformation.

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -1049,10 +1049,8 @@ private:
 };
 
 void LoopInternalization::runOnOperation() {
-  getOperation()->walk([&](Operation *Op) {
-    if (auto gpuModule = dyn_cast<gpu::GPUModuleOp>(Op))
-      runOnGPUModule(gpuModule);
-  });
+  getOperation()->walk(
+      [&](gpu::GPUModuleOp gpuModule) { runOnGPUModule(gpuModule); });
 }
 
 void LoopInternalization::runOnGPUModule(gpu::GPUModuleOp gpuModule) {
@@ -1309,6 +1307,7 @@ void LoopInternalization::transform(FunctionOpInterface func,
 
   // Reserve static shared local memory for this function.
   auto gpuModule = func->getParentOfType<gpu::GPUModuleOp>();
+  assert(gpuModule && "Expecting valid GPUModuleOp");
   memref::GlobalOp wgSharedLocalMemory = getWorkGroupSharedLocalMemory(
       gpuModule, std::holds_alternative<unsigned>(reqdSharedMemory)
                      ? std::get<unsigned>(reqdSharedMemory)


### PR DESCRIPTION
When adding `LoopInternalizationPass` to an existing `OpPassManager`, all passes added to the `OpPassManager` are not performed when the source code doesn't contain a `gpu.module` and  `LoopInternalizationPass` is a `GPUModule` pass, which causes `check-cgeist` to fail. 

After this PR, `check-cgeist` passes with (or without) `LoopInternalization` added in the pipeline.

This reverts commit 46d6cb9f7f1fcfdeec0655702e03e8b0ce41f4b3 partially. 