### PR TITLE
[SYCL-MLIR] Annotate handler::parallel_for arguments

### DIFF
--- a/polygeist/tools/cgeist/Test/Verification/sycl/host_raising.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/host_raising.cpp
@@ -8,6 +8,9 @@ std::vector<float> init(std::size_t);
 
 class KernelName;
 
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[RANGE_STR:.*]]("range\00")
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[KERNEL_STR:.*]]("kernel\00")
+
 // CHECK-DAG: gpu.func @_ZTS10KernelName
 // CHECK-DAG: gpu.func @_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE
 
@@ -21,9 +24,15 @@ class KernelName;
 // COM: Check we can detect accessors construction
 
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
+// CHECK:         %[[N:.*]] = llvm.mlir.constant(1024 : i64) : i64
+// CHECK:         %[[RANGE_STR_ADDR:.*]] = llvm.mlir.addressof @[[RANGE_STR]] : !llvm.ptr
+// CHECK:         %[[KERNEL_STR_ADDR:.*]] = llvm.mlir.addressof @[[KERNEL_STR]] : !llvm.ptr
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor(%[[RANGE:.*]], %[[N]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK:         "llvm.intr.var.annotation"(%[[RANGE]], %[[RANGE_STR_ADDR]], %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
+// CHECK:         "llvm.intr.var.annotation"(%{{.*}}, %[[KERNEL_STR_ADDR]], %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
 
 // COM: Check we can detect kernel assignment to a sycl::handler:
 

--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -85,5 +85,11 @@
 #define __SYCL_STRINGIFY(x) #x
 #endif // __SYCL_STRINGIFY
 
+#ifdef __clang__
+#define __SYCL_ANNOTATE(str) __attribute__((annotate(#str)))
+#else
+#define __SYCL_ANNOTATE(str)
+#endif
+
 static_assert(__cplusplus >= 201703L,
               "DPCPP does not support C++ version earlier than C++17.");

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1241,12 +1241,6 @@ private:
 #define __SYCL_KERNEL_ATTR__
 #endif
 
-#ifdef __clang__
-#define ANNOTATE(str) __attribute__((annotate(#str)))
-#else
-#define ANNOTATE(str)
-#endif
-
   // NOTE: the name of this function - "kernel_single_task" - is used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType, typename... Props>
@@ -1669,24 +1663,24 @@ public:
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<1> NumWorkItems ANNOTATE(range),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(range<1> NumWorkItems __SYCL_ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName>(
         NumWorkItems, ext::oneapi::experimental::detail::empty_properties_t{},
         std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<2> NumWorkItems ANNOTATE(range),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(range<2> NumWorkItems __SYCL_ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName>(
         NumWorkItems, ext::oneapi::experimental::detail::empty_properties_t{},
         std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<3> NumWorkItems ANNOTATE(range),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(range<3> NumWorkItems __SYCL_ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName>(
         NumWorkItems, ext::oneapi::experimental::detail::empty_properties_t{},
         std::move(KernelFunc));
@@ -1736,9 +1730,9 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL2020")
-  void parallel_for(range<Dims> NumWorkItems ANNOTATE(range),
-                    id<Dims> WorkItemOffset ANNOTATE(offset),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(range<Dims> NumWorkItems __SYCL_ANNOTATE(range),
+                    id<Dims> WorkItemOffset __SYCL_ANNOTATE(offset),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1815,18 +1809,18 @@ public:
     MKernelName = getKernelName();
   }
 
-  void parallel_for(range<1> NumWorkItems ANNOTATE(range),
-                    kernel Kernel ANNOTATE(kernel)) {
+  void parallel_for(range<1> NumWorkItems __SYCL_ANNOTATE(range),
+                    kernel Kernel __SYCL_ANNOTATE(kernel)) {
     parallel_for_impl(NumWorkItems, Kernel);
   }
 
-  void parallel_for(range<2> NumWorkItems ANNOTATE(range),
-                    kernel Kernel ANNOTATE(kernel)) {
+  void parallel_for(range<2> NumWorkItems __SYCL_ANNOTATE(range),
+                    kernel Kernel __SYCL_ANNOTATE(kernel)) {
     parallel_for_impl(NumWorkItems, Kernel);
   }
 
-  void parallel_for(range<3> NumWorkItems ANNOTATE(range),
-                    kernel Kernel ANNOTATE(kernel)) {
+  void parallel_for(range<3> NumWorkItems __SYCL_ANNOTATE(range),
+                    kernel Kernel __SYCL_ANNOTATE(kernel)) {
     parallel_for_impl(NumWorkItems, Kernel);
   }
 
@@ -1840,9 +1834,9 @@ public:
   /// \param Kernel is a SYCL kernel function.
   template <int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
-  void parallel_for(range<Dims> NumWorkItems ANNOTATE(range),
-                    id<Dims> WorkItemOffset ANNOTATE(offset),
-                    kernel Kernel ANNOTATE(kernel)) {
+  void parallel_for(range<Dims> NumWorkItems __SYCL_ANNOTATE(range),
+                    id<Dims> WorkItemOffset __SYCL_ANNOTATE(offset),
+                    kernel Kernel __SYCL_ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
@@ -1861,8 +1855,8 @@ public:
   /// well as offset.
   /// \param Kernel is a SYCL kernel function.
   template <int Dims>
-  void parallel_for(nd_range<Dims> NDRange ANNOTATE(nd_range),
-                    kernel Kernel ANNOTATE(kernel)) {
+  void parallel_for(nd_range<Dims> NDRange __SYCL_ANNOTATE(nd_range),
+                    kernel Kernel __SYCL_ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NDRange);
@@ -1924,8 +1918,9 @@ public:
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  void parallel_for(kernel Kernel, range<Dims> NumWorkItems ANNOTATE(range),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(kernel Kernel,
+                    range<Dims> NumWorkItems __SYCL_ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     // Ignore any set kernel bundles and use the one associated with the kernel
     setHandlerKernelBundle(Kernel);
@@ -1962,9 +1957,10 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
-  void parallel_for(kernel Kernel, range<Dims> NumWorkItems ANNOTATE(range),
-                    id<Dims> WorkItemOffset ANNOTATE(offset),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(kernel Kernel,
+                    range<Dims> NumWorkItems __SYCL_ANNOTATE(range),
+                    id<Dims> WorkItemOffset __SYCL_ANNOTATE(offset),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     // Ignore any set kernel bundles and use the one associated with the kernel
     setHandlerKernelBundle(Kernel);
@@ -2001,8 +1997,9 @@ public:
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  void parallel_for(kernel Kernel, nd_range<Dims> NDRange ANNOTATE(nd_range),
-                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  void parallel_for(kernel Kernel,
+                    nd_range<Dims> NDRange __SYCL_ANNOTATE(nd_range),
+                    _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     // Ignore any set kernel bundles and use the one associated with the kernel
     setHandlerKernelBundle(Kernel);
@@ -2121,8 +2118,8 @@ public:
             typename PropertiesT>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<1> NumWorkItems ANNOTATE(range), PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  parallel_for(range<1> NumWorkItems __SYCL_ANNOTATE(range), PropertiesT Props,
+               _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName, KernelType, 1, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2131,8 +2128,8 @@ public:
             typename PropertiesT>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<2> NumWorkItems ANNOTATE(range), PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  parallel_for(range<2> NumWorkItems __SYCL_ANNOTATE(range), PropertiesT Props,
+               _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName, KernelType, 2, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2141,8 +2138,8 @@ public:
             typename PropertiesT>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<3> NumWorkItems ANNOTATE(range), PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  parallel_for(range<3> NumWorkItems __SYCL_ANNOTATE(range), PropertiesT Props,
+               _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName, KernelType, 3, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2151,8 +2148,9 @@ public:
             typename PropertiesT, int Dims>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(nd_range<Dims> Range ANNOTATE(nd_range), PropertiesT Properties,
-               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
+  parallel_for(nd_range<Dims> Range __SYCL_ANNOTATE(nd_range),
+               PropertiesT Properties,
+               _KERNELFUNCPARAM(KernelFunc) __SYCL_ANNOTATE(kernel)) {
     parallel_for_impl<KernelName>(Range, Properties, std::move(KernelFunc));
   }
 

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1241,6 +1241,12 @@ private:
 #define __SYCL_KERNEL_ATTR__
 #endif
 
+#ifdef __clang__
+#define ANNOTATE(str) __attribute__((annotate(#str)))
+#else
+#define ANNOTATE(str)
+#endif
+
   // NOTE: the name of this function - "kernel_single_task" - is used by the
   // Front End to determine kernel invocation kind.
   template <typename KernelName, typename KernelType, typename... Props>
@@ -1663,21 +1669,24 @@ public:
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<1> NumWorkItems, _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(range<1> NumWorkItems ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName>(
         NumWorkItems, ext::oneapi::experimental::detail::empty_properties_t{},
         std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<2> NumWorkItems, _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(range<2> NumWorkItems ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName>(
         NumWorkItems, ext::oneapi::experimental::detail::empty_properties_t{},
         std::move(KernelFunc));
   }
 
   template <typename KernelName = detail::auto_name, typename KernelType>
-  void parallel_for(range<3> NumWorkItems, _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(range<3> NumWorkItems ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName>(
         NumWorkItems, ext::oneapi::experimental::detail::empty_properties_t{},
         std::move(KernelFunc));
@@ -1727,8 +1736,9 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL2020")
-  void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-                    _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(range<Dims> NumWorkItems ANNOTATE(range),
+                    id<Dims> WorkItemOffset ANNOTATE(offset),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     using NameT =
         typename detail::get_kernel_name_t<KernelName, KernelType>::name;
@@ -1805,15 +1815,18 @@ public:
     MKernelName = getKernelName();
   }
 
-  void parallel_for(range<1> NumWorkItems, kernel Kernel) {
+  void parallel_for(range<1> NumWorkItems ANNOTATE(range),
+                    kernel Kernel ANNOTATE(kernel)) {
     parallel_for_impl(NumWorkItems, Kernel);
   }
 
-  void parallel_for(range<2> NumWorkItems, kernel Kernel) {
+  void parallel_for(range<2> NumWorkItems ANNOTATE(range),
+                    kernel Kernel ANNOTATE(kernel)) {
     parallel_for_impl(NumWorkItems, Kernel);
   }
 
-  void parallel_for(range<3> NumWorkItems, kernel Kernel) {
+  void parallel_for(range<3> NumWorkItems ANNOTATE(range),
+                    kernel Kernel ANNOTATE(kernel)) {
     parallel_for_impl(NumWorkItems, Kernel);
   }
 
@@ -1827,8 +1840,9 @@ public:
   /// \param Kernel is a SYCL kernel function.
   template <int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
-  void parallel_for(range<Dims> NumWorkItems, id<Dims> WorkItemOffset,
-                    kernel Kernel) {
+  void parallel_for(range<Dims> NumWorkItems ANNOTATE(range),
+                    id<Dims> WorkItemOffset ANNOTATE(offset),
+                    kernel Kernel ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NumWorkItems, WorkItemOffset);
@@ -1846,7 +1860,9 @@ public:
   /// \param NDRange is a ND-range defining global and local sizes as
   /// well as offset.
   /// \param Kernel is a SYCL kernel function.
-  template <int Dims> void parallel_for(nd_range<Dims> NDRange, kernel Kernel) {
+  template <int Dims>
+  void parallel_for(nd_range<Dims> NDRange ANNOTATE(nd_range),
+                    kernel Kernel ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     MKernel = detail::getSyclObjImpl(std::move(Kernel));
     detail::checkValueRange<Dims>(NDRange);
@@ -1908,8 +1924,8 @@ public:
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
-                    _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(kernel Kernel, range<Dims> NumWorkItems ANNOTATE(range),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     // Ignore any set kernel bundles and use the one associated with the kernel
     setHandlerKernelBundle(Kernel);
@@ -1946,8 +1962,9 @@ public:
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
   __SYCL2020_DEPRECATED("offsets are deprecated in SYCL 2020")
-  void parallel_for(kernel Kernel, range<Dims> NumWorkItems,
-                    id<Dims> WorkItemOffset, _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(kernel Kernel, range<Dims> NumWorkItems ANNOTATE(range),
+                    id<Dims> WorkItemOffset ANNOTATE(offset),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     // Ignore any set kernel bundles and use the one associated with the kernel
     setHandlerKernelBundle(Kernel);
@@ -1984,8 +2001,8 @@ public:
   /// is a host device.
   template <typename KernelName = detail::auto_name, typename KernelType,
             int Dims>
-  void parallel_for(kernel Kernel, nd_range<Dims> NDRange,
-                    _KERNELFUNCPARAM(KernelFunc)) {
+  void parallel_for(kernel Kernel, nd_range<Dims> NDRange ANNOTATE(nd_range),
+                    _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     throwIfActionIsCreated();
     // Ignore any set kernel bundles and use the one associated with the kernel
     setHandlerKernelBundle(Kernel);
@@ -2104,8 +2121,8 @@ public:
             typename PropertiesT>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<1> NumWorkItems, PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  parallel_for(range<1> NumWorkItems ANNOTATE(range), PropertiesT Props,
+               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName, KernelType, 1, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2114,8 +2131,8 @@ public:
             typename PropertiesT>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<2> NumWorkItems, PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  parallel_for(range<2> NumWorkItems ANNOTATE(range), PropertiesT Props,
+               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName, KernelType, 2, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2124,8 +2141,8 @@ public:
             typename PropertiesT>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(range<3> NumWorkItems, PropertiesT Props,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  parallel_for(range<3> NumWorkItems ANNOTATE(range), PropertiesT Props,
+               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_lambda_impl<KernelName, KernelType, 3, PropertiesT>(
         NumWorkItems, Props, std::move(KernelFunc));
   }
@@ -2134,8 +2151,8 @@ public:
             typename PropertiesT, int Dims>
   std::enable_if_t<
       ext::oneapi::experimental::is_property_list<PropertiesT>::value>
-  parallel_for(nd_range<Dims> Range, PropertiesT Properties,
-               _KERNELFUNCPARAM(KernelFunc)) {
+  parallel_for(nd_range<Dims> Range ANNOTATE(nd_range), PropertiesT Properties,
+               _KERNELFUNCPARAM(KernelFunc) ANNOTATE(kernel)) {
     parallel_for_impl<KernelName>(Range, Properties, std::move(KernelFunc));
   }
 


### PR DESCRIPTION
Annotate arguments to make it easier to track them when raising.