### PR TITLE
 [SYCL] Make AccessorBaseHost::getPtr noexcept

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -514,13 +514,13 @@ public:
   id<3> &getOffset();
   range<3> &getAccessRange();
   range<3> &getMemoryRange();
-  void *getPtr();
+  void *getPtr() noexcept;
   unsigned int getElemSize() const;
 
   const id<3> &getOffset() const;
   const range<3> &getAccessRange() const;
   const range<3> &getMemoryRange() const;
-  void *getPtr() const;
+  void *getPtr() const noexcept;
   bool isPlaceholder() const;
 
   detail::AccHostDataT &getAccData();

--- a/sycl/source/accessor.cpp
+++ b/sycl/source/accessor.cpp
@@ -43,7 +43,7 @@ AccessorBaseHost::AccessorBaseHost(id<3> Offset, range<3> AccessRange,
 id<3> &AccessorBaseHost::getOffset() { return impl->MOffset; }
 range<3> &AccessorBaseHost::getAccessRange() { return impl->MAccessRange; }
 range<3> &AccessorBaseHost::getMemoryRange() { return impl->MMemoryRange; }
-void *AccessorBaseHost::getPtr() { return impl->MData; }
+void *AccessorBaseHost::getPtr() noexcept { return impl->MData; }
 
 detail::AccHostDataT &AccessorBaseHost::getAccData() { return impl->MAccData; }
 
@@ -60,7 +60,7 @@ const range<3> &AccessorBaseHost::getAccessRange() const {
 const range<3> &AccessorBaseHost::getMemoryRange() const {
   return impl->MMemoryRange;
 }
-void *AccessorBaseHost::getPtr() const {
+void *AccessorBaseHost::getPtr() const noexcept {
   return const_cast<void *>(impl->MData);
 }
 


### PR DESCRIPTION
Add noexcept to AccessorBaseHost::getPtr since get_pointer is noexcept in SYCL 2020 