### PR TITLE
[CI] Enable End-to-End tests in Nightly task

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -4,10 +4,6 @@ on:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'
-  pull_request:
-    paths:
-      - 'devops/containers/ubuntu2204_preinstalled.Dockerfile'
-      - '.github/workflows/sycl_nightly.yml'
 
 jobs:
   test_matrix:
@@ -15,7 +11,7 @@ jobs:
     name: Generate Test Matrix
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
-      lts_config: "ocl_gen9;ocl_x64"
+      lts_config: "hip_amdgpu;ocl_gen9;ocl_x64;l0_gen9;esimd_emu;cuda_aws;win_l0_gen12"
 
   ubuntu2204_build_test:
     if: github.repository == 'intel/llvm'
@@ -28,6 +24,8 @@ jobs:
       build_configure_extra_args: '--hip --cuda --enable-esimd-emulator'
       merge: false
       retention-days: 90
+      lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
+      lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
 
   ubuntu2204_opaque_pointers_build_test:
     if: github.repository == 'intel/llvm'
@@ -47,6 +45,7 @@ jobs:
     uses: ./.github/workflows/sycl_windows_build_and_test.yml
     with:
       retention-days: 90
+      lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}
 
   ubuntu2204_docker_build_push:
     if: github.repository == 'intel/llvm'

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -43,6 +43,7 @@ jobs:
     name: Windows
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_windows_build_and_test.yml
+    needs: test_matrix
     with:
       retention-days: 90
       lts_matrix: ${{ needs.test_matrix.outputs.lts_wn_matrix }}


### PR DESCRIPTION
I plan to add automatic "lastest-good-nightly" release to it, we need to extend the testing for that.