### PR TITLE
[test-e2e][Matrix] Fix joint matrix load address

### DIFF
--- a/sycl/test-e2e/Matrix/get_coord_bf16_matA_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_bf16_matA_impl.hpp
@@ -117,7 +117,7 @@ void matrix_sum_rows(queue q, big_matrix<T, M, K> &A, nd_range<2> &r) {
                sub_a;
 
           joint_matrix_load(
-                 sg, sub_a, accA.template get_multi_ptr<access::decorated::no>() + (global_idx * TM * K) + TK,
+                 sg, sub_a, accA.template get_multi_ptr<access::decorated::no>() + (global_idx * TM * K) + sg_starty / SG_SZ * TK,
                  K); 
 
            // calculate sum of rows in sum_rows_v[8], there are 8 rows in sub_a
@@ -175,7 +175,7 @@ int main() {
 
   for (int i = 0; i < MATRIX_M; i++) {
     for (int j = 0; j < MATRIX_K; j++) {
-      A[i][j] = i;
+      A[i][j] = j;
     }
   }
 


### PR DESCRIPTION
The loading address offset didn't calculate the column offset right w.r.t the sub-group id.

Signed-off-by: Yilong Guo <yilong.guo@intel.com>