### PR TITLE
[SYCL-MLIR] Define mem effects of host constructor

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -29,7 +29,8 @@ class SYCL_HostOp<string mnemonic, list<Trait> traits = []> :
 // OPERATIONS
 ////////////////////////////////////////////////////////////////////////////////
 
-def SYCLHostConstructorOp : SYCL_HostOp<"constructor"> {
+def SYCLHostConstructorOp : SYCL_HostOp<"constructor",
+    [MemoryEffectsOpInterface]> {
   let summary = [{
     Operation representing the construction of a SYCL object, i.e., allocation,
     and member initialization.
@@ -51,6 +52,18 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor"> {
   let assemblyFormat = [{
     `(` operands `)` attr-dict `:` functional-type(operands, results)
   }];
+
+  let extraClassDeclaration = [{
+      /// Return the memory effects associated to each argument.
+      ///
+      /// The first argument, `this` will have `MemoryEffects::Write` memory
+      /// effect associated and the rest of argument will also have
+      /// `MemoryEffects::Write` if they're a pointer/memref and no memory
+      /// effect otherwise.
+      void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
+                          ::mlir::MemoryEffects::Effect>> &effects);
+    }];
+
   let hasVerifier = true;
 }
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -58,8 +58,8 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor",
       ///
       /// The first argument, `this` will have `MemoryEffects::Write` memory
       /// effect associated and the rest of argument will have
-      /// `MemoryEffects::Read` and `MemoryEffects::Write if they're a pointer/
-      /// memref and no memory effect otherwise.
+      /// `MemoryEffects::Read` if they're a pointer/memref and no memory effect
+      /// otherwise.
       void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
                           ::mlir::MemoryEffects::Effect>> &effects);
     }];

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -57,9 +57,9 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor",
       /// Return the memory effects associated to each argument.
       ///
       /// The first argument, `this` will have `MemoryEffects::Write` memory
-      /// effect associated and the rest of argument will also have
-      /// `MemoryEffects::Write` if they're a pointer/memref and no memory
-      /// effect otherwise.
+      /// effect associated and the rest of argument will have
+      /// `MemoryEffects::Read` and `MemoryEffects::Write if they're a pointer/
+      /// memref and no memory effect otherwise.
       void getEffects(::llvm::SmallVectorImpl<::mlir::SideEffects::EffectInstance<
                           ::mlir::MemoryEffects::Effect>> &effects);
     }];

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
@@ -21,9 +21,7 @@ void SYCLHostConstructorOp::getEffects(
   // The `this` argument will always be written to
   effects.emplace_back(MemoryEffects::Write::get(), getDst(), defaultResource);
   // For the remaining non-scalar arguments we also assume they are written.
-  for (auto value : getArgs()) {
-    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType())) {
+  for (auto value : getArgs())
+    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType()))
       effects.emplace_back(MemoryEffects::Write::get(), value, defaultResource);
-    }
-  }
 }

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
@@ -10,3 +10,20 @@ LogicalResult SYCLHostConstructorOp::verify() {
            << type;
   return success();
 }
+
+void SYCLHostConstructorOp::getEffects(
+    SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
+        &effects) {
+  // NOTE: This definition conservatively assumes that all (pointer) arguments
+  // are written to. This is definitely true for the first argument ('this'
+  // pointer), but a pessimistic assumption for the remaining arguments.
+  auto *defaultResource = SideEffects::DefaultResource::get();
+  // The `this` argument will always be written to
+  effects.emplace_back(MemoryEffects::Write::get(), getDst(), defaultResource);
+  // For the remaining non-scalar arguments we also assume they are written.
+  for (auto value : getArgs()) {
+    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType())) {
+      effects.emplace_back(MemoryEffects::Write::get(), value, defaultResource);
+    }
+  }
+}

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
@@ -14,14 +14,18 @@ LogicalResult SYCLHostConstructorOp::verify() {
 void SYCLHostConstructorOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
-  // NOTE: This definition conservatively assumes that all (pointer) arguments
-  // are written to. This is definitely true for the first argument ('this'
-  // pointer), but a pessimistic assumption for the remaining arguments.
+  // NOTE: This definition assumes only the first (`this`) argument is written
+  // to and the remaining arguments, if they are memory arguments, are both read
+  // and written. The latter is a conservative assumption about the behavior of
+  // the constructors and could be changed to enable better analysis.
   auto *defaultResource = SideEffects::DefaultResource::get();
   // The `this` argument will always be written to
   effects.emplace_back(MemoryEffects::Write::get(), getDst(), defaultResource);
-  // For the remaining non-scalar arguments we also assume they are written.
-  for (auto value : getArgs())
-    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType()))
+  // The rest of the arguments will be scalar or read and write.
+  for (auto value : getArgs()) {
+    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType())) {
+      effects.emplace_back(MemoryEffects::Read::get(), value, defaultResource);
       effects.emplace_back(MemoryEffects::Write::get(), value, defaultResource);
+    }
+  }
 }

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostOps.cpp
@@ -15,17 +15,14 @@ void SYCLHostConstructorOp::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   // NOTE: This definition assumes only the first (`this`) argument is written
-  // to and the remaining arguments, if they are memory arguments, are both read
-  // and written. The latter is a conservative assumption about the behavior of
-  // the constructors and could be changed to enable better analysis.
+  // to and the remaining arguments, if they are memory arguments, are only read
+  // from. This is optimistic assumption, but enables better analysis and is
+  // true for the types and properties we are most interested in right now.
   auto *defaultResource = SideEffects::DefaultResource::get();
   // The `this` argument will always be written to
   effects.emplace_back(MemoryEffects::Write::get(), getDst(), defaultResource);
-  // The rest of the arguments will be scalar or read and write.
-  for (auto value : getArgs()) {
-    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType())) {
+  // The rest of the arguments will be scalar or read from
+  for (auto value : getArgs())
+    if (isa<MemRefType, LLVM::LLVMPointerType>(value.getType()))
       effects.emplace_back(MemoryEffects::Read::get(), value, defaultResource);
-      effects.emplace_back(MemoryEffects::Write::get(), value, defaultResource);
-    }
-  }
 }


### PR DESCRIPTION
Define the memory effects of the `sycl.host.constructor` operation. For now, optimistically it is assumed that any memory (pointer or memref) argument, except for the `this` pointer, will be only be read.