### PR TITLE
[SYCL][CODEOWNERS] update CODEOWNERS for syclcompat library 

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -120,3 +120,8 @@ sycl/include/sycl/ext/oneapi/experimental/graph.hpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.cpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.hpp @intel/sycl-graphs-reviewers
 sycl/unittests/Extensions/CommandGraph.cpp @intel/sycl-graphs-reviewers
+
+# syclcompat library
+sycl/**/syclcompat/ @intel/syclcompat-lib-reviewers
+sycl/cmake/modules/AddSYCLLibraryUnitTest.cmake @intel/syclcompat-lib-reviewers
+sycl/include/syclcompat.hpp @intel/syclcompat-lib-reviewers


### PR DESCRIPTION
have @intel/syclcompat-lib-reviewers own:

sycl/include/syclcompat/
sycl/doc/syclcompat/
sycl/unittests/syclcompat/
sycl/cmake/modules/AddSYCLLibraryUnitTest.cmake
sycl/include/syclcompat.hpp

which equates to

sycl/**/syclcompat/ @intel/syclcompat-lib-reviewers
sycl/cmake/modules/AddSYCLLibraryUnitTest.cmake @intel/syclcompat-lib-reviewers
sycl/include/syclcompat.hpp @intel/syclcompat-lib-reviewers
