### PR TITLE
[SYCL] Combine ADL-S and RPL-S architectures

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -237,13 +237,11 @@ of these enumerators, and it provides a brief description of their meanings.
 |-
 |Rocket Lake Intel graphics architecture.
 
-|`intel_gpu_adl_s`
+|`intel_gpu_adl_s` +
+`intel_gpu_rpl_s`
 |-
-|Alder Lake S Intel graphics architecture.
-
-|`intel_gpu_rpl_s`
-|-
-|Raptor Lake Intel graphics architecture.
+|Alder Lake S Intel graphics architecture or Raptor Lake Intel graphics 
+architecture.
 
 |`intel_gpu_adl_p`
 |-

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -112,7 +112,7 @@ enum class architecture : /* unspecified */ {
   intel_gpu_tgllp,
   intel_gpu_rkl,
   intel_gpu_adl_s,
-  intel_gpu_rpl_s,
+  intel_gpu_rpl_s = intel_gpu_adl_s,
   intel_gpu_adl_p,
   intel_gpu_adl_n,
   intel_gpu_dg1,

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -21,7 +21,7 @@ enum class architecture {
   intel_gpu_tgllp,
   intel_gpu_rkl,
   intel_gpu_adl_s,
-  intel_gpu_rpl_s,
+  intel_gpu_rpl_s = intel_gpu_adl_s,
   intel_gpu_adl_p,
   intel_gpu_adl_n,
   intel_gpu_dg1,

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -604,7 +604,6 @@ struct get_device_info_impl<
           {0x03000000, oneapi_exp_arch::intel_gpu_tgllp},
           {0x03004000, oneapi_exp_arch::intel_gpu_rkl},
           {0x03008000, oneapi_exp_arch::intel_gpu_adl_s},
-          {0x03008000, oneapi_exp_arch::intel_gpu_rpl_s},
           {0x0300c000, oneapi_exp_arch::intel_gpu_adl_p},
           {0x03010000, oneapi_exp_arch::intel_gpu_adl_n},
           {0x03028000, oneapi_exp_arch::intel_gpu_dg1},


### PR DESCRIPTION
This patch combines ADL-S and RPL-S architectures for
 sycl_ext_oneapi_device_architecture extension. These 
two architectures are the same.

Fixes https://github.com/intel/llvm/issues/10184