### PR TITLE
[SYCL] Update some SYCL FPGA tests after https://github.com/intel/llvm/pull/8874

### DIFF
--- a/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_lsu.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_lsu.cpp
@@ -38,8 +38,10 @@ int test_latency_control(queue Queue) {
       auto output_accessor = output_buffer.get_access<access::mode::write>(cgh);
 
       cgh.single_task<class kernel>([=] {
-        auto in_ptr = input_accessor.get_pointer();
-        auto out_ptr = output_accessor.get_pointer();
+        auto in_ptr =
+            input_accessor.get_multi_ptr<sycl::access::decorated::no>();
+        auto out_ptr =
+            output_accessor.get_multi_ptr<sycl::access::decorated::no>();
 
         float value = PrefetchingLSU::load(
             in_ptr, ext::oneapi::experimental::properties(

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_lsu.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_lsu.cpp
@@ -35,8 +35,10 @@ int test_lsu(sycl::queue Queue) {
           input_buffer.get_access<sycl::access::mode::read>(cgh);
 
       cgh.single_task<class kernel>([=] {
-        auto input_ptr = input_accessor.get_pointer();
-        auto output_ptr = output_accessor.get_pointer();
+        auto input_ptr =
+            input_accessor.get_multi_ptr<sycl::access::decorated::no>();
+        auto output_ptr =
+            output_accessor.get_multi_ptr<sycl::access::decorated::no>();
 
         using PrefetchingLSU =
             sycl::ext::intel::lsu<sycl::ext::intel::prefetch<true>,


### PR DESCRIPTION
This patch fixes compilation error in fpga_lsu.cpp and fpga_latency_control_lsu.cpp. Tested locally with open-source and closed-source compilers.
Currently there is no external testing with the accelerator device in open source.