### PR TITLE
Revert "[CI] Enable HIP/CUDA/ESIMD plugins in nightly build (#9850)"

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -57,3 +57,5 @@ jobs:
             test_build:
               - *sycl
               - *drivers_and_configs
+              # Temporary, until plugins are enabled in nightly image.
+              - sycl/**

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -11,7 +11,9 @@ jobs:
     name: Generate Test Matrix
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
-      lts_config: "hip_amdgpu;ocl_gen9;ocl_x64;l0_gen9;esimd_emu;cuda_aws;win_l0_gen12"
+      # Restore once plugins are enabled in the build.
+      # lts_config: "hip_amdgpu;ocl_gen9;ocl_x64;l0_gen9;esimd_emu;cuda_aws;win_l0_gen12"
+      lts_config: "ocl_gen9;ocl_x64;l0_gen9;win_l0_gen12"
 
   ubuntu2204_build_test:
     if: github.repository == 'intel/llvm'
@@ -21,11 +23,11 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default-2204
-      build_configure_extra_args: '--hip --cuda --enable-esimd-emulator'
       merge: false
       retention-days: 90
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
+      build_configure_extra_args: ''
 
   ubuntu2204_opaque_pointers_build_test:
     if: github.repository == 'intel/llvm'


### PR DESCRIPTION
This reverts commit 6b7424349ee3592909afde25f9921c4e8b83db10.

Needs adjustments in E2E-testing performed on the build as that has been enabled since #9850. Also, disable E2E on nightly in pre-commit as that requires an image with all plugins enabled.