### PR TITLE
[SYCL-MLIR] SYCL 'id' and 'range' analysis

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
@@ -62,7 +62,9 @@ class SYCLIDAndRangeAnalysis {
 public:
   SYCLIDAndRangeAnalysis(Operation *op, AnalysisManager &am);
 
-  void initialize(bool useRelaxedAliasing = false);
+  /// Consumers of the analysis must call this member function immediately after
+  /// construction and before requesting any information from the analysis.
+  SYCLIDAndRangeAnalysis &initialize(bool useRelaxedAliasing);
 
   template <typename Type>
   std::optional<IDRangeInformation>

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
@@ -1,0 +1,71 @@
+//===- SYCLIDAndRangeAnalysis.h - Analysis for sycl::id/range ---*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains an analysis to derive interesting properties about
+// sycl::id and sycl::range in SYCL host code.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
+#define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
+
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Pass/AnalysisManager.h"
+
+namespace mlir {
+namespace polygeist {
+
+class IDRangeInformation {
+public:
+  IDRangeInformation();
+
+  explicit IDRangeInformation(size_t dim);
+
+  explicit IDRangeInformation(llvm::ArrayRef<size_t> constVals);
+
+  bool hasFixedDimensions() const;
+
+  size_t getNumDimensions() const;
+
+  bool isConstant() const;
+
+  const llvm::SmallVector<size_t, 3> &getConstantValues() const;
+
+  const IDRangeInformation join(const IDRangeInformation &other) const;
+
+private:
+  std::optional<size_t> dimensions;
+
+  std::optional<llvm::SmallVector<size_t, 3>> constantValues;
+
+  friend raw_ostream &operator<<(raw_ostream &, const IDRangeInformation &);
+};
+
+class SYCLIDAndRangeAnalysis {
+public:
+  SYCLIDAndRangeAnalysis(Operation *op, AnalysisManager &am);
+
+  template <typename Type>
+  std::optional<IDRangeInformation> getIDRangeInformation(Operation *op,
+                                                          Value operand);
+
+private:
+  void initialize();
+
+  Operation *operation;
+
+  AnalysisManager &am;
+
+  DataFlowSolver solver;
+
+  bool initialized = false;
+};
+} // namespace polygeist
+} // namespace mlir
+
+#endif // MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLIDANDRANGEANALYSIS_H

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
@@ -20,6 +20,8 @@
 namespace mlir {
 namespace polygeist {
 
+/// Represents information about a `sycl::id` or `sycl::range` gathered from its
+/// construction.
 class IDRangeInformation {
 public:
   IDRangeInformation();
@@ -28,12 +30,20 @@ public:
 
   explicit IDRangeInformation(llvm::ArrayRef<size_t> constVals);
 
+  /// Returns true if the id/range is always constructed with the same number of
+  /// dimensions.
   bool hasFixedDimensions() const;
 
+  /// Returns the number of dimensions for an id or range, in case it is always
+  /// constructed with the same number of dimensions.
   size_t getNumDimensions() const;
 
+  /// Returns true if the id/range is always constructed with the same constant
+  /// values.
   bool isConstant() const;
 
+  /// Returns the constant values with which this id/range is constructed, in
+  /// case it is always constructed with the same constant values.
   const llvm::SmallVector<size_t, 3> &getConstantValues() const;
 
   const IDRangeInformation join(const IDRangeInformation &other) const;
@@ -46,6 +56,8 @@ private:
   friend raw_ostream &operator<<(raw_ostream &, const IDRangeInformation &);
 };
 
+/// Analysis to determine properties of interest about `sycl::id` or
+/// `sycl::range` from their construction.
 class SYCLIDAndRangeAnalysis {
 public:
   SYCLIDAndRangeAnalysis(Operation *op, AnalysisManager &am);

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h
@@ -62,13 +62,13 @@ class SYCLIDAndRangeAnalysis {
 public:
   SYCLIDAndRangeAnalysis(Operation *op, AnalysisManager &am);
 
+  void initialize(bool useRelaxedAliasing = false);
+
   template <typename Type>
-  std::optional<IDRangeInformation> getIDRangeInformation(Operation *op,
-                                                          Value operand);
+  std::optional<IDRangeInformation>
+  getIDRangeInformationFromConstruction(Operation *op, Value operand);
 
 private:
-  void initialize();
-
   Operation *operation;
 
   AnalysisManager &am;

--- a/polygeist/lib/Dialect/Polygeist/Analysis/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRPolygeistAnalysis
   MemoryAccessAnalysis.cpp
   ReachingDefinitionAnalysis.cpp
+  SYCLIDAndRangeAnalysis.cpp
   UniformityAnalysis.cpp
   
   ADDITIONAL_HEADER_DIRS

--- a/polygeist/lib/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.cpp
@@ -160,7 +160,7 @@ void SYCLIDAndRangeAnalysis::initialize() {
   // Initialize the dataflow solver
   AliasAnalysis &aliasAnalysis = am.getAnalysis<mlir::AliasAnalysis>();
   aliasAnalysis.addAnalysisImplementation(
-      sycl::AliasAnalysis(/* TODO */ false));
+      sycl::AliasAnalysis(/* relaxedAliasing */ false));
 
   // Populate the solver and run the analyses needed by this analysis.
   solver.load<dataflow::DeadCodeAnalysis>();

--- a/polygeist/lib/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.cpp
@@ -1,0 +1,240 @@
+//===- SYCLIDAndRangeAnalysis.h - Analysis for sycl::id/range -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
+
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLDialect.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
+
+#define DEBUG_TYPE "sycl-id-range-analysis"
+
+namespace mlir {
+namespace polygeist {
+
+//===----------------------------------------------------------------------===//
+// IDRangeInformation
+//===----------------------------------------------------------------------===//
+
+raw_ostream &operator<<(raw_ostream &os, const IDRangeInformation &info) {
+  if (!info.hasFixedDimensions()) {
+    os.indent(4) << "<unknown>\n";
+    return os;
+  }
+
+  if (info.isConstant()) {
+    os.indent(4) << "constant<";
+    llvm::interleaveComma(info.getConstantValues(), os);
+    os << ">\n";
+    return os;
+  }
+
+  os.indent(4) << "fixed<" << info.getNumDimensions() << ">\n";
+  return os;
+}
+
+IDRangeInformation::IDRangeInformation()
+    : dimensions{std::nullopt}, constantValues{std::nullopt} {}
+
+IDRangeInformation::IDRangeInformation(size_t dim)
+    : dimensions{dim}, constantValues{std::nullopt} {}
+
+IDRangeInformation::IDRangeInformation(llvm::ArrayRef<size_t> constVals)
+    : dimensions{constVals.size()}, constantValues{constVals} {}
+
+bool IDRangeInformation::hasFixedDimensions() const {
+  return dimensions.has_value();
+}
+
+size_t IDRangeInformation::getNumDimensions() const {
+  assert(dimensions.has_value() &&
+         "Requesting fixed dimensions from non-fixed id/range");
+  return *dimensions;
+}
+
+bool IDRangeInformation::isConstant() const {
+  return constantValues.has_value();
+}
+
+const llvm::SmallVector<size_t, 3> &
+IDRangeInformation::getConstantValues() const {
+  assert(constantValues.has_value() &&
+         "Requesting constant values from non-constant id/range");
+  return *constantValues;
+}
+
+const IDRangeInformation
+IDRangeInformation::join(const IDRangeInformation &other) const {
+  if (isConstant() && other.isConstant()) {
+    if (getConstantValues() == other.getConstantValues())
+      return *this;
+  }
+  if (hasFixedDimensions() && other.hasFixedDimensions()) {
+    if (getNumDimensions() == other.getNumDimensions())
+      return IDRangeInformation{getNumDimensions()};
+  }
+  return IDRangeInformation{};
+}
+
+//===----------------------------------------------------------------------===//
+// Helpers
+//===----------------------------------------------------------------------===//
+
+namespace {
+
+static std::optional<int> getConstantUInt(Value v) {
+  Operation *op = v.getDefiningOp();
+  if (!op)
+    return std::nullopt;
+
+  if (!op->hasTrait<OpTrait::ConstantLike>())
+    return std::nullopt;
+
+  llvm::SmallVector<OpFoldResult> folded;
+  if (failed(op->fold({}, folded)) || folded.size() != 1)
+    return std::nullopt;
+
+  if (!folded.front().is<Attribute>() ||
+      !isa<IntegerAttr>(folded.front().get<Attribute>()))
+    return std::nullopt;
+
+  return cast<IntegerAttr>(folded.front().get<Attribute>()).getInt();
+}
+
+template <typename Type> bool isConstructor(const Definition &def) {
+  if (!def.isOperation())
+    return false;
+
+  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
+  if (!constructor)
+    return false;
+
+  return isa<Type>(constructor.getType().getValue());
+}
+
+template <typename IDRange>
+IDRangeInformation getInformation(const Definition &def) {
+  assert(def.isOperation() && "Expecting operation");
+
+  auto constructor = cast<sycl::SYCLHostConstructorOp>(def.getOperation());
+
+  auto type = cast<IDRange>(constructor.getType().getValue());
+
+  SmallVector<std::optional<int>> constValues;
+  llvm::transform(constructor.getArgs(), std::back_inserter(constValues),
+                  getConstantUInt);
+
+  if (llvm::all_of(constValues, [](auto &opt) { return opt.has_value(); })) {
+    SmallVector<size_t, 3> constInt;
+    llvm::transform(constValues, std::back_inserter(constInt),
+                    [](auto &opt) { return *opt; });
+    return IDRangeInformation(constInt);
+  }
+
+  return IDRangeInformation(type.getDimension());
+}
+
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// SYCLIDAndRangeAnalysis
+//===----------------------------------------------------------------------===//
+
+SYCLIDAndRangeAnalysis::SYCLIDAndRangeAnalysis(Operation *op,
+                                               AnalysisManager &mgr)
+    : operation(op), am(mgr) {
+  initialize();
+}
+
+void SYCLIDAndRangeAnalysis::initialize() {
+
+  // Initialize the dataflow solver
+  AliasAnalysis &aliasAnalysis = am.getAnalysis<mlir::AliasAnalysis>();
+  aliasAnalysis.addAnalysisImplementation(
+      sycl::AliasAnalysis(/* TODO */ false));
+
+  // Populate the solver and run the analyses needed by this analysis.
+  solver.load<dataflow::DeadCodeAnalysis>();
+  solver.load<dataflow::SparseConstantPropagation>();
+  solver.load<ReachingDefinitionAnalysis>(aliasAnalysis);
+
+  if (failed(solver.initializeAndRun(operation))) {
+    operation->emitError("Failed to run required dataflow analyses");
+    return;
+  }
+
+  initialized = true;
+}
+
+template <typename Type>
+std::optional<IDRangeInformation>
+SYCLIDAndRangeAnalysis::getIDRangeInformation(Operation *op, Value operand) {
+  assert(initialized &&
+         "Analysis only available after successful initialization");
+
+  const polygeist::ReachingDefinition *reachingDef =
+      solver.lookupState<polygeist::ReachingDefinition>(op);
+  assert(reachingDef && "expected a reaching definition");
+
+  auto mods = reachingDef->getModifiers(operand);
+  if (!mods || mods->empty())
+    return std::nullopt;
+
+  if (!llvm::all_of(*mods, isConstructor<Type>))
+    return std::nullopt;
+
+  auto pMods = reachingDef->getPotentialModifiers(operand);
+  if (pMods) {
+    if (!llvm::all_of(*pMods, isConstructor<Type>))
+      return std::nullopt;
+  }
+
+  bool first = true;
+  IDRangeInformation info;
+  for (const Definition &def : *mods) {
+    if (first) {
+      info = getInformation<Type>(def);
+      first = false;
+    } else {
+      info = info.join(getInformation<Type>(def));
+      if (!info.hasFixedDimensions())
+        // Early return: As soon as joining of the different information has led
+        // to an info with no fixed dimension (and therefore also non-constant
+        // values), we can end the processing.
+        return info;
+    }
+  }
+
+  if (pMods) {
+    for (const Definition &def : *pMods) {
+      info = info.join(getInformation<Type>(def));
+      if (!info.hasFixedDimensions())
+        // Early return: As soon as joining of the different information has led
+        // to an info with no fixed dimension (and therefore also non-constant
+        // values), we can end the processing.
+        return info;
+    }
+  }
+
+  return info;
+}
+
+template std::optional<IDRangeInformation>
+SYCLIDAndRangeAnalysis::getIDRangeInformation<sycl::IDType>(Operation *,
+                                                            Value);
+
+template std::optional<IDRangeInformation>
+SYCLIDAndRangeAnalysis::getIDRangeInformation<sycl::RangeType>(Operation *,
+                                                               Value);
+
+} // namespace polygeist
+} // namespace mlir

--- a/polygeist/lib/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.cpp
@@ -180,6 +180,8 @@ std::optional<IDRangeInformation>
 SYCLIDAndRangeAnalysis::getIDRangeInformation(Operation *op, Value operand) {
   assert(initialized &&
          "Analysis only available after successful initialization");
+  assert(isa<LLVM::LLVMPointerType>(operand.getType()) &&
+         "Expecting an LLVM pointer");
 
   const polygeist::ReachingDefinition *reachingDef =
       solver.lookupState<polygeist::ReachingDefinition>(op);
@@ -229,8 +231,7 @@ SYCLIDAndRangeAnalysis::getIDRangeInformation(Operation *op, Value operand) {
 }
 
 template std::optional<IDRangeInformation>
-SYCLIDAndRangeAnalysis::getIDRangeInformation<sycl::IDType>(Operation *,
-                                                            Value);
+SYCLIDAndRangeAnalysis::getIDRangeInformation<sycl::IDType>(Operation *, Value);
 
 template std::optional<IDRangeInformation>
 SYCLIDAndRangeAnalysis::getIDRangeInformation<sycl::RangeType>(Operation *,

--- a/polygeist/test/lib/Dialect/Polygeist/CMakeLists.txt
+++ b/polygeist/test/lib/Dialect/Polygeist/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(MLIR_INCLUDE_TESTS)
   add_mlir_library(MLIRPolygeistTestAnalysis
+    TestIDAndRangeAnalysis.cpp
     TestMemoryAccessAnalysis.cpp
     TestReachingDefinitionsAnalysis.cpp
     TestUniformityAnalysis.cpp

--- a/polygeist/test/lib/Dialect/Polygeist/TestIDAndRangeAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestIDAndRangeAnalysis.cpp
@@ -23,6 +23,7 @@ struct TestIDAndRangeAnalysisPass
   void runOnOperation() override {
     Operation *op = getOperation();
     auto &IDRangeAnalysis = getAnalysis<polygeist::SYCLIDAndRangeAnalysis>();
+    IDRangeAnalysis.initialize();
 
     op->walk([&](Operation *op) {
       auto tag = op->getAttrOfType<StringAttr>("tag");
@@ -33,13 +34,16 @@ struct TestIDAndRangeAnalysisPass
       for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
         llvm::errs().indent(2) << "operand #" << index << "\n";
         auto idResult =
-            IDRangeAnalysis.getIDRangeInformation<sycl::IDType>(op, operand);
+            IDRangeAnalysis.getIDRangeInformationFromConstruction<sycl::IDType>(
+                op, operand);
         if (idResult) {
           llvm::errs().indent(2) << "id:\n";
           llvm::errs() << *idResult;
         }
         auto rangeResult =
-            IDRangeAnalysis.getIDRangeInformation<sycl::RangeType>(op, operand);
+            IDRangeAnalysis
+                .getIDRangeInformationFromConstruction<sycl::RangeType>(
+                    op, operand);
         if (rangeResult) {
           llvm::errs().indent(2) << "range:\n";
           llvm::errs() << *rangeResult;

--- a/polygeist/test/lib/Dialect/Polygeist/TestIDAndRangeAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestIDAndRangeAnalysis.cpp
@@ -1,0 +1,61 @@
+//===----------- TestIDAndRangeAnalysis.cpp -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestIDAndRangeAnalysisPass
+    : public PassWrapper<TestIDAndRangeAnalysisPass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestIDAndRangeAnalysisPass)
+
+  StringRef getArgument() const override { return "test-id-range-analysis"; }
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    auto &IDRangeAnalysis = getAnalysis<polygeist::SYCLIDAndRangeAnalysis>();
+
+    op->walk([&](Operation *op) {
+      auto tag = op->getAttrOfType<StringAttr>("tag");
+      if (!tag)
+        return WalkResult::skip();
+
+      llvm::errs() << "test_tag: " << tag.getValue() << ":\n";
+      for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
+        llvm::errs().indent(2) << "operand #" << index << "\n";
+        auto idResult =
+            IDRangeAnalysis.getIDRangeInformation<sycl::IDType>(op, operand);
+        if (idResult) {
+          llvm::errs().indent(2) << "id:\n";
+          llvm::errs() << *idResult;
+        }
+        auto rangeResult =
+            IDRangeAnalysis.getIDRangeInformation<sycl::RangeType>(op, operand);
+        if (rangeResult) {
+          llvm::errs().indent(2) << "range:\n";
+          llvm::errs() << *rangeResult;
+        }
+      }
+      return WalkResult::advance();
+    });
+  };
+};
+
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestIDAndRangeAnalysisPass() {
+  PassRegistration<TestIDAndRangeAnalysisPass>();
+}
+} // end namespace test
+} // end namespace mlir

--- a/polygeist/test/lib/Dialect/Polygeist/TestIDAndRangeAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestIDAndRangeAnalysis.cpp
@@ -22,8 +22,10 @@ struct TestIDAndRangeAnalysisPass
 
   void runOnOperation() override {
     Operation *op = getOperation();
-    auto &IDRangeAnalysis = getAnalysis<polygeist::SYCLIDAndRangeAnalysis>();
-    IDRangeAnalysis.initialize();
+    bool relaxedAliasing = true;
+    auto &IDRangeAnalysis =
+        getAnalysis<polygeist::SYCLIDAndRangeAnalysis>().initialize(
+            relaxedAliasing);
 
     op->walk([&](Operation *op) {
       auto tag = op->getAttrOfType<StringAttr>("tag");

--- a/polygeist/test/polygeist-opt/sycl/id-range-analysis.mlir
+++ b/polygeist/test/polygeist-opt/sycl/id-range-analysis.mlir
@@ -109,6 +109,21 @@ llvm.func @control_flow_non_fixed(%arg0 : i1, %arg1 : !llvm.ptr) -> !llvm.ptr {
   llvm.return %arg1 : !llvm.ptr
 }
 
+// CHECK-LABEL: test_tag: control_flow_aliased:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           <unknown>
+llvm.func @control_flow_aliased(%arg0 : i1, %arg1 : !llvm.ptr, %arg2 : !llvm.ptr) -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %c42_i64 = arith.constant 42 : i64
+  sycl.host.constructor(%arg1, %c42_i64, %c42_i64) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  scf.if %arg0 {
+    sycl.host.constructor(%arg2, %c42_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+  }
+  %0 = llvm.load %arg1 {tag = "control_flow_aliased"} : !llvm.ptr -> i32
+  llvm.return %arg1 : !llvm.ptr
+}
+
 
 // -----
 

--- a/polygeist/test/polygeist-opt/sycl/id-range-analysis.mlir
+++ b/polygeist/test/polygeist-opt/sycl/id-range-analysis.mlir
@@ -1,0 +1,149 @@
+// RUN: polygeist-opt -split-input-file -test-id-range-analysis %s 2>&1 | FileCheck %s
+
+!sycl_id_1_ = !sycl.id<[1], (i64)>
+!sycl_id_2_ = !sycl.id<[2], (i64)>
+!sycl_id_3_ = !sycl.id<[3], (i64)>
+  
+// CHECK-LABEL: test_tag: constant_id:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           constant<42, 42>
+llvm.func @constant_id() -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %c42_i64 = arith.constant 42 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%0, %c42_i64, %c42_i64) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  %1 = llvm.load %0 {tag = "constant_id"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+
+// CHECK-LABEL: test_tag: non_constant_id:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           fixed<3>
+llvm.func @non_constant_id() -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id.5", (struct<"class.sycl::_V1::detail::array.7", (array<3 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.call @_Z6numberv() : () -> i64
+  %2 = llvm.call @_Z6numberv() : () -> i64
+  %3 = llvm.call @_Z6numberv() : () -> i64
+  sycl.host.constructor(%0, %1, %2, %3) {type = !sycl_id_3_} : (!llvm.ptr, i64, i64, i64) -> ()
+  %4 = llvm.load %0 {tag = "non_constant_id"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+llvm.func @_Z6numberv() -> i64
+
+
+// CHECK-LABEL: test_tag: constrol_flow_constant:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           constant<42, 42>
+llvm.func @control_flow_constant(%arg0 : i1) -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  scf.if %arg0 {
+    %c42_i64 = arith.constant 42 : i64
+    sycl.host.constructor(%0, %c42_i64, %c42_i64) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  } else {
+    %c42_alias = arith.constant 42 : i64
+    sycl.host.constructor(%0, %c42_alias, %c42_alias) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  }
+  %1 = llvm.load %0 {tag = "constrol_flow_constant"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+
+// CHECK-LABEL: test_tag: constrol_flow_non_constant:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           fixed<2>
+llvm.func @control_flow_non_constant(%arg0 : i1) -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  scf.if %arg0 {
+    %c42_i64 = arith.constant 42 : i64
+    sycl.host.constructor(%0, %c42_i64, %c42_i64) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  } else {
+    %c25_i64 = arith.constant 25 : i64
+    sycl.host.constructor(%0, %c25_i64, %c25_i64) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  }
+  %1 = llvm.load %0 {tag = "constrol_flow_non_constant"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+
+// CHECK-LABEL: test_tag: multiple_use_1:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           constant<42>
+// CHECK-LABEL: test_tag: multiple_use_2:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           constant<42>
+llvm.func @multiple_use() -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %c42_i64 = arith.constant 42 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%0, %c42_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+  %1 = llvm.load %0 {tag = "multiple_use_1"} : !llvm.ptr -> i32
+  %2 = llvm.load %0 {tag = "multiple_use_2"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+
+// CHECK-LABEL: test_tag: control_flow_non_fixed:
+// CHECK:         operand #0
+// CHECK:         id:
+// CHECK:           <unknown>
+llvm.func @control_flow_non_fixed(%arg0 : i1, %arg1 : !llvm.ptr) -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %c42_i64 = arith.constant 42 : i64
+  scf.if %arg0 {
+    sycl.host.constructor(%arg1, %c42_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+  } else {
+    sycl.host.constructor(%arg1, %c42_i64, %c42_i64) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+  }
+  %0 = llvm.load %arg1 {tag = "control_flow_non_fixed"} : !llvm.ptr -> i32
+  llvm.return %arg1 : !llvm.ptr
+}
+
+
+// -----
+
+!sycl_range_1_ = !sycl.range<[1], (i64)>
+!sycl_range_2_ = !sycl.range<[2], (i64)>
+!sycl_range_3_ = !sycl.range<[3], (i64)>
+
+
+// CHECK-LABEL: test_tag: constant_range:
+// CHECK:         operand #0
+// CHECK:         range:
+// CHECK:           constant<42, 42>
+llvm.func @constant_range() -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %c42_i64 = arith.constant 42 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<2 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%0, %c42_i64, %c42_i64) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+  %1 = llvm.load %0 {tag = "constant_range"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+
+// CHECK-LABEL: test_tag: non_constant_range:
+// CHECK:         operand #0
+// CHECK:         range:
+// CHECK:           fixed<3>
+llvm.func @non_constant_range() -> !llvm.ptr {
+  %c1_i32 = arith.constant 1 : i32
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.5", (struct<"class.sycl::_V1::detail::array.7", (array<3 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.call @_Z6numberv() : () -> i64
+  %2 = llvm.call @_Z6numberv() : () -> i64
+  %3 = llvm.call @_Z6numberv() : () -> i64
+  sycl.host.constructor(%0, %1, %2, %3) {type = !sycl_range_3_} : (!llvm.ptr, i64, i64, i64) -> ()
+  %4 = llvm.load %0 {tag = "non_constant_range"} : !llvm.ptr -> i32
+  llvm.return %0 : !llvm.ptr
+}
+
+llvm.func @_Z6numberv() -> i64

--- a/polygeist/tools/polygeist-opt/polygeist-opt.cpp
+++ b/polygeist/tools/polygeist-opt/polygeist-opt.cpp
@@ -49,6 +49,7 @@ struct PtrElementModel
 
 namespace mlir {
 namespace test {
+void registerTestIDAndRangeAnalysisPass();
 void registerTestMemoryAccessAnalysisPass();
 void registerTestReachingDefinitionAnalysisPass();
 void registerTestUniformityAnalysisPass();
@@ -57,6 +58,7 @@ void registerTestUniformityAnalysisPass();
 
 #ifdef MLIR_INCLUDE_TESTS
 void registerTestPasses() {
+  mlir::test::registerTestIDAndRangeAnalysisPass();
   mlir::test::registerTestMemoryAccessAnalysisPass();
   mlir::test::registerTestReachingDefinitionAnalysisPass();
   mlir::test::registerTestUniformityAnalysisPass();


### PR DESCRIPTION
MLIR analysis to infer properties of interest about instances of `sycl::id` or `sycl::range` from their construction in host code.