### PR TITLE
[SYCL-MLIR] Detect construction of sub-buffers

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
@@ -73,9 +73,10 @@ def SYCL_BufferType : SYCL_Type<"Buffer", "buffer"> {
   let description = [{ Shared array of one, two or three dimensions,
                         accessed through accessors.}];
   let parameters = (ins "::mlir::Type":$type,
-                        "unsigned":$dimension);
+                        "unsigned":$dimension,
+                        DefaultValuedParameter<"bool", "false">:$subbuffer);
   let assemblyFormat = 
-      "`<` `[` $dimension `,` $type `]` `>`";
+      "`<` `[` $dimension `,` $type (`,` $subbuffer^)? `]` `>`";
 }
 
 def SYCL_AccessorSubscriptType :

--- a/mlir-sycl/test/Dialect/SYCL/types.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/types.mlir
@@ -258,3 +258,20 @@ func.func @_Z9multi_ptrN4sycl3_V19multi_ptrIiLNS0_6access13address_spaceE1ELNS2_
 func.func @_Z6streamN4sycl3_V16streamE(%arg0: !sycl_stream) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
+
+
+// -----
+
+////////////////////////////////////////////////////////////////////////////////
+// BUFFER
+////////////////////////////////////////////////////////////////////////////////
+
+// CHECK: func @buffer(%arg0: !sycl.buffer<[2, !llvm.void]>)
+func.func @buffer(%arg0 : !sycl.buffer<[2, !llvm.void]>) attributes {llvm.linkage = #llvm.linkage<external>} {
+  return
+}
+
+// CHECK: func @sub_buffer(%arg0: !sycl.buffer<[3, !llvm.void, true]>)
+func.func @sub_buffer(%arg0 : !sycl.buffer<[3, !llvm.void, true]>) attributes {llvm.linkage = #llvm.linkage<external>} {
+  return
+}

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -70,6 +70,35 @@ llvm.func @raise_buffer() -> !llvm.ptr attributes {personality = @__gxx_personal
   llvm.return %1 : !llvm.ptr
 }
 
+// CHECK-LABEL:   llvm.func @raise_sub_buffer() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+// CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
+// CHECK:           %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::id", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::range", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           sycl.host.constructor(%[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl.buffer<[1, !llvm.void, true]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           llvm.br ^bb1
+// CHECK:         ^bb1:
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr
+// CHECK:         }
+llvm.func @raise_sub_buffer() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %0 = arith.constant 1 : i32
+  %1 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::id", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %4 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::range", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %5 = llvm.alloca %0 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+
+  llvm.invoke @_ZN4sycl3_V16bufferIiLi1ENS0_6detail17aligned_allocatorIiEEvEC2ERS5_RKNS0_2idILi1EEERKNS0_5rangeILi1EEENS2_13code_locationE(%2, %1, %3, %4, %5) to ^bb1 unwind ^bb0 : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+^bb0:
+  %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
+  llvm.resume %lp : !llvm.struct<(ptr, i32)>
+^bb1:
+  llvm.return %1 : !llvm.ptr
+}
+
 
 // -----
 


### PR DESCRIPTION
Add field to indicate sub-buffer to SYCL dialect buffer type and detect if a `sycl::buffer` constructed in host code is a sub-buffer of another buffer. 