### PR TITLE
[CI] Use cached_checkouts for E2E tests on Linux

### DIFF
--- a/.github/workflows/linux_matrix_e2e_on_nightly.yml
+++ b/.github/workflows/linux_matrix_e2e_on_nightly.yml
@@ -52,6 +52,8 @@ jobs:
       target_devices: ${{ matrix.target_devices }}
       ref: ${{ inputs.ref }}
       reset_gpu: ${{ matrix.reset_gpu }}
+      # TODO: should we do the merge?
+      merge: false
 
   aws_start:
     name: AWS Start
@@ -74,6 +76,8 @@ jobs:
       target_devices: all
       ref: ${{ inputs.ref }}
       reset_gpu: false
+      # TODO: should we do the merge?
+      merge: false
 
   aws_stop:
     name: AWS Stop

--- a/.github/workflows/linux_single_e2e.yml
+++ b/.github/workflows/linux_single_e2e.yml
@@ -19,6 +19,8 @@ on:
         type: string
       reset_gpu:
         type: string
+      merge:
+        type: string
 
       sycl_toolchain_artifact:
         type: string
@@ -50,13 +52,15 @@ jobs:
         sudo bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
     - uses: actions/checkout@v3
       with:
-        path: llvm
         ref: ${{ inputs.ref }}
         sparse-checkout: |
           devops/actions
-          devops/scripts/get_release.py
-          sycl/test-e2e
-          llvm/utils
+    - uses: ./devops/actions/cached_checkout
+      with:
+        path: llvm
+        ref: ${{ inputs.ref }}
+        cache_path: "/__w/repo_cache/"
+        merge: ${{ inputs.merge }}
     - name: Install drivers
       if: env.compute_runtime_tag != ''
       run: |
@@ -66,7 +70,7 @@ jobs:
           sudo -E /opt/install_drivers.sh --all
         fi
     - name: Register cleanup after job is finished
-      uses: ./llvm/devops/actions/cleanup
+      uses: ./devops/actions/cleanup
     - name: Source OneAPI TBB vars.sh
       shell: bash
       run: |

--- a/.github/workflows/linux_single_e2e.yml
+++ b/.github/workflows/linux_single_e2e.yml
@@ -55,6 +55,8 @@ jobs:
         ref: ${{ inputs.ref }}
         sparse-checkout: |
           devops/actions
+    - name: Register cleanup after job is finished
+      uses: ./devops/actions/cleanup
     - uses: ./devops/actions/cached_checkout
       with:
         path: llvm
@@ -69,8 +71,6 @@ jobs:
           sudo cp llvm/devops/scripts/get_release.py /opt/
           sudo -E /opt/install_drivers.sh --all
         fi
-    - name: Register cleanup after job is finished
-      uses: ./devops/actions/cleanup
     - name: Source OneAPI TBB vars.sh
       shell: bash
       run: |

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -232,6 +232,7 @@ jobs:
       target_devices: ${{ matrix.targets }}
       ref: ${{ inputs.build_ref || github.sha }}
       reset_gpu: ${{ contains(matrix.runs-on, 'gen9') && contains(matrix.runs-on, 'Linux') }}
+      merge: ${{ inputs.merge }}
 
       sycl_toolchain_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
       sycl_toolchain_archive: ${{ inputs.artifact_archive_name }}


### PR DESCRIPTION
This change better aligns checkout between build/e2e-tests. Next step would be to make them use the same commit for the merge but I plan to do that in a separate PR.