### PR TITLE
[CI] Use CMAKE_*_COMPILER_LAUNCHER for ccache configuration

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -113,20 +113,19 @@ jobs:
       env:
         CC: ${{ inputs.cc }}
         CXX: ${{ inputs.cxx }}
-        CACHE_ROOT: ${{ inputs.build_cache_root }}
-        CACHE_SUFFIX: ${{ inputs.build_cache_suffix }}
+        CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
+        CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
         ARGS: ${{ inputs.build_configure_extra_args }}
         CUDA_LIB_PATH: "/usr/local/cuda/lib64/stubs"
-        CCACHE_LAUNCHER: ccache --dir ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }} --max-size ${{ inputs.build_cache_size }}
       run: |
-        mkdir -p $CACHE_ROOT/build_cache_$CACHE_SUFFIX
+        mkdir -p $CCACHE_DIR
         mkdir -p $GITHUB_WORKSPACE/build
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults $ARGS \
-          "--cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
-          "--cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
+          --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           --cmake-opt="-DLLVM_INSTALL_UTILS=ON" \
           --cmake-opt="-DSYCL_PI_TESTS=OFF"
     - name: Compile

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -96,6 +96,9 @@ jobs:
       options: -u 1001:1001
     outputs:
       build_conclusion: ${{ steps.build.conclusion }}
+    env:
+      CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
+      CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
     steps:
     # GHA requires relative paths for actions. Copy actions from container root
     # to CWD.
@@ -113,8 +116,6 @@ jobs:
       env:
         CC: ${{ inputs.cc }}
         CXX: ${{ inputs.cxx }}
-        CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
-        CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
         ARGS: ${{ inputs.build_configure_extra_args }}
         CUDA_LIB_PATH: "/usr/local/cuda/lib64/stubs"
       run: |

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -115,9 +115,9 @@ jobs:
         CXX: ${{ inputs.cxx }}
         CACHE_ROOT: ${{ inputs.build_cache_root }}
         CACHE_SUFFIX: ${{ inputs.build_cache_suffix }}
-        CACHE_SIZE: ${{ inputs.build_cache_size }}
         ARGS: ${{ inputs.build_configure_extra_args }}
         CUDA_LIB_PATH: "/usr/local/cuda/lib64/stubs"
+        CCACHE_LAUNCHER: ccache --dir ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }} --max-size ${{ inputs.build_cache_size }}
       run: |
         mkdir -p $CACHE_ROOT/build_cache_$CACHE_SUFFIX
         mkdir -p $GITHUB_WORKSPACE/build
@@ -125,9 +125,8 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults $ARGS \
-          --cmake-opt="-DLLVM_CCACHE_BUILD=ON" \
-          --cmake-opt="-DLLVM_CCACHE_DIR=$CACHE_ROOT/build_cache_$CACHE_SUFFIX" \
-          --cmake-opt="-DLLVM_CCACHE_MAXSIZE=$CACHE_SIZE" \
+          "--cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
+          "--cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
           --cmake-opt="-DLLVM_INSTALL_UTILS=ON" \
           --cmake-opt="-DSYCL_PI_TESTS=OFF"
     - name: Compile

--- a/.github/workflows/sycl_macos_build_and_test.yml
+++ b/.github/workflows/sycl_macos_build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Configure
       env:
         CACHE_SUFFIX: ${{ inputs.build_cache_suffix }}
-        CACHE_SIZE: ${{ inputs.build_cache_size }}
+        CCACHE_LAUNCHER: ccache --dir $GITHUB_WORKSPACE/build_cache_${{ inputs.build_cache_suffix }} --max-size ${{ inputs.build_cache_size }}
         ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
         mkdir -p $GITHUB_WORKSPACE/build_cache_$CACHE_SUFFIX
@@ -47,9 +47,8 @@ jobs:
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults $ARGS \
-          --cmake-opt="-DLLVM_CCACHE_BUILD=ON" \
-          --cmake-opt="-DLLVM_CCACHE_DIR=$GITHUB_WORKSPACE/build_cache_$CACHE_SUFFIX" \
-          --cmake-opt="-DLLVM_CCACHE_MAXSIZE=$CACHE_SIZE" \
+          "--cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
+          "--cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
           --cmake-opt="-DLLVM_INSTALL_UTILS=ON" \
           --cmake-opt="-DSYCL_PI_TESTS=OFF"
     - name: Compile

--- a/.github/workflows/sycl_macos_build_and_test.yml
+++ b/.github/workflows/sycl_macos_build_and_test.yml
@@ -24,7 +24,7 @@ jobs:
     name: Build
     runs-on: macos-12
     env:
-      CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
+      CCACHE_DIR: $GITHUB_WORKSPACE/build_cache_${{ inputs.build_cache_suffix }}
       CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
     steps:
     - name: Install dependencies

--- a/.github/workflows/sycl_macos_build_and_test.yml
+++ b/.github/workflows/sycl_macos_build_and_test.yml
@@ -37,18 +37,18 @@ jobs:
         restore-keys: sycl-${{ runner.os }}-${{ inputs.build_cache_suffix }}-
     - name: Configure
       env:
-        CACHE_SUFFIX: ${{ inputs.build_cache_suffix }}
-        CCACHE_LAUNCHER: ccache --dir $GITHUB_WORKSPACE/build_cache_${{ inputs.build_cache_suffix }} --max-size ${{ inputs.build_cache_size }}
+        CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
+        CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
         ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
-        mkdir -p $GITHUB_WORKSPACE/build_cache_$CACHE_SUFFIX
+        mkdir -p $CCACHE_DIR
         mkdir -p $GITHUB_WORKSPACE/build
         cd $GITHUB_WORKSPACE/build
         python3 $GITHUB_WORKSPACE/src/buildbot/configure.py -w $GITHUB_WORKSPACE \
           -s $GITHUB_WORKSPACE/src -o $GITHUB_WORKSPACE/build -t Release \
           --ci-defaults $ARGS \
-          "--cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
-          "--cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=$CCACHE_LAUNCHER" \
+          --cmake-opt=-DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          --cmake-opt=-DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           --cmake-opt="-DLLVM_INSTALL_UTILS=ON" \
           --cmake-opt="-DSYCL_PI_TESTS=OFF"
     - name: Compile

--- a/.github/workflows/sycl_macos_build_and_test.yml
+++ b/.github/workflows/sycl_macos_build_and_test.yml
@@ -23,6 +23,9 @@ jobs:
   build:
     name: Build
     runs-on: macos-12
+    env:
+      CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
+      CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
     steps:
     - name: Install dependencies
       run: brew install ccache ninja
@@ -37,8 +40,6 @@ jobs:
         restore-keys: sycl-${{ runner.os }}-${{ inputs.build_cache_suffix }}-
     - name: Configure
       env:
-        CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
-        CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
         ARGS: ${{ inputs.build_configure_extra_args }}
       run: |
         mkdir -p $CCACHE_DIR


### PR DESCRIPTION
LLVM's in-tree LLVM_CCACHE_BUILD=ON is deprecated - https://discourse.llvm.org/t/llvm-ccache-build-is-deprecated/68431

I wasn't able to make CMake/ccache work by using `ccache`'s arguments in the `CMAKE_CXX_COMPILER_LAUNCHER` with it failing like this:

```
"ccache --dir /__w/llvm/build_cache_sprod_shared --max-size 8G" /opt/sycl/bin/clang++ -DENABLE_OPAQUE_POINTERS=1 ...
/bin/sh: 1: ccache --dir /__w/llvm/build_cache_sprod_shared --max-size 8G: not found
```

so I decided to use environment variables to control that behavior instead.

Resolves #8336.