### PR TITLE
[CI] Checkout devops/actions instead of copying from docker image

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -97,13 +97,14 @@ jobs:
     outputs:
       build_conclusion: ${{ steps.build.conclusion }}
     steps:
-    # GHA requires relative paths for actions. Copy actions from container root
-    # to CWD.
-    - run: cp -r /actions .
+    - uses: actions/checkout@v3
+      with:
+        sparse-checkout: |
+          devops/actions
     # Cleanup will be run after all actions are completed.
     - name: Register cleanup after job is finished
-      uses: ./actions/cleanup
-    - uses: ./actions/cached_checkout
+      uses: ./devops/actions/cleanup
+    - uses: ./devops/actions/cached_checkout
       with:
         path: src
         ref: ${{ inputs.build_ref || github.sha }}
@@ -259,9 +260,12 @@ jobs:
       run: |
         sudo mount -t debugfs none /sys/kernel/debug
         sudo bash -c 'echo 1 > /sys/kernel/debug/dri/0/i915_wedged'
-    - run: cp -r /actions .
+    - uses: actions/checkout@v3
+      with:
+        sparse-checkout: |
+          devops/actions
     - name: Register cleanup after job is finished
-      uses: ./actions/cleanup
+      uses: ./devops/actions/cleanup
     - name: Install drivers
       if: env.compute_runtime_tag != ''
       run: |


### PR DESCRIPTION
Sparse checkout is fast enough but allows testing CI changes as it doesn't need image update that way.