### PR TITLE
[SYCL] Change linkage to linkonce_odr unless SYCL_EXTERNAL.

### DIFF
--- a/clang/include/clang/Sema/Sema.h
+++ b/clang/include/clang/Sema/Sema.h
@@ -14159,7 +14159,7 @@ public:
                                    SourceLocation RParenLoc);
 
   template <typename AttrTy>
-  bool isTypeDecoratedWithDeclAttribute(QualType Ty) {
+  static bool isTypeDecoratedWithDeclAttribute(QualType Ty) {
     const CXXRecordDecl *RecTy = Ty->getAsCXXRecordDecl();
     if (!RecTy)
       return false;

--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -48,6 +48,7 @@
 #include "clang/CodeGen/BackendUtil.h"
 #include "clang/CodeGen/ConstantInitBuilder.h"
 #include "clang/Frontend/FrontendDiagnostic.h"
+#include "clang/Sema/Sema.h"
 #include "llvm/ADT/STLExtras.h"
 #include "llvm/ADT/StringExtras.h"
 #include "llvm/ADT/StringSwitch.h"
@@ -6081,6 +6082,19 @@ llvm::GlobalValue::LinkageTypes CodeGenModule::getLLVMLinkageForDeclarator(
   // so we can use available_externally linkage.
   if (Linkage == GVA_AvailableExternally)
     return llvm::GlobalValue::AvailableExternallyLinkage;
+
+  // SYCL: Device code is not generally limited to one translation unit, but
+  // anything accessed from another translation unit is required to be annotated
+  // with the SYCL_EXTERNAL macro. For any function or variable that does not
+  // have this, linkonce_odr suffices. If -fno-sycl-rdc is passed, we know there
+  // is only one translation unit and can so mark them internal.
+  if (getLangOpts().SYCLIsDevice && !D->hasAttr<SYCLKernelAttr>() &&
+      !D->hasAttr<SYCLDeviceAttr>() &&
+      !Sema::isTypeDecoratedWithDeclAttribute<SYCLDeviceGlobalAttr>(
+          D->getType()))
+    return getLangOpts().GPURelocatableDeviceCode
+               ? llvm::Function::LinkOnceODRLinkage
+               : llvm::Function::InternalLinkage;
 
   // Note that Apple's kernel linker doesn't support symbol
   // coalescing, so we need to avoid linkonce and weak linkages there.

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -6,7 +6,7 @@
 extern "C" int printf(const char* fmt, ...);
 
 #ifdef __SYCL_DEVICE_ONLY__
-__attribute__((convergent)) extern SYCL_EXTERNAL void
+__attribute__((convergent)) extern __attribute__((sycl_device)) void
 __spirv_ControlBarrier(int, int, int) noexcept;
 #endif
 

--- a/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
@@ -175,7 +175,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !scheduler_target_fmax_mhz
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z3foov()
+    // CHECK: define {{.*}}spir_func void @_Z3foov()
     h.single_task<class kernel_name4>(
         []() { foo(); });
 
@@ -195,7 +195,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name8() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !num_simd_work_items
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo1v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo1v()
     h.single_task<class kernel_name8>(
         []() { foo1(); });
 
@@ -215,7 +215,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name12() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !no_global_work_offset
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo2v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo2v()
     h.single_task<class kernel_name12>(
         []() { foo2(); });
 
@@ -235,7 +235,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name16() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !max_global_work_dim
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo3v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo3v()
     h.single_task<class kernel_name16>(
         []() { foo3(); });
 
@@ -255,7 +255,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name20() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !reqd_sub_group_size
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo4v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo4v()
     Functor4 f4;
     h.single_task<class kernel_name20>(f4);
 
@@ -275,7 +275,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name24() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !reqd_work_group_size
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo5v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo5v()
     Functor6 f6;
     h.single_task<class kernel_name24>(f6);
 
@@ -295,7 +295,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name28() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
     // CHECK-NOT: !max_work_group_size
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo6v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo6v()
     Functor8 f8;
     h.single_task<class kernel_name28>(f8);
 
@@ -320,7 +320,7 @@ int main() {
     // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #3 comdat align 2
     // CHECK-NOT: noalias
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z4foo8v()
+    // CHECK: define {{.*}}spir_func void @_Z4foo8v()
     Functor10 f10;
     h.single_task<class kernel_name32>(f10);
 
@@ -350,7 +350,7 @@ int main() {
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name38()
     // CHECK-NOT: !work_group_size_hint
     // CHECK-SAME: {
-    // CHECK: define dso_local spir_func void @_Z5foo11v()
+    // CHECK: define {{.*}}spir_func void @_Z5foo11v()
     h.single_task<class kernel_name38>(
         []() { foo11(); });
 

--- a/clang/test/CodeGenSYCL/device_has.cpp
+++ b/clang/test/CodeGenSYCL/device_has.cpp
@@ -8,33 +8,33 @@ queue q;
 
 // CHECK-DAG: define dso_local spir_kernel void @{{.*}}kernel_name_1{{.*}} !sycl_declared_aspects ![[ASPECTS1:[0-9]+]] !srcloc ![[SRCLOC1:[0-9]+]]
 
-// CHECK-DAG: define dso_local spir_func void @{{.*}}func1{{.*}} !sycl_declared_aspects ![[ASPECTS1]] !srcloc ![[SRCLOC2:[0-9]+]] {
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func1{{.*}} !sycl_declared_aspects ![[ASPECTS1]] !srcloc ![[SRCLOC2:[0-9]+]] {
 [[sycl::device_has(sycl::aspect::cpu)]] void func1() {}
 
-// CHECK-DAG: define dso_local spir_func void @{{.*}}func2{{.*}} !sycl_declared_aspects ![[ASPECTS2:[0-9]+]] !srcloc ![[SRCLOC3:[0-9]+]] {
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func2{{.*}} !sycl_declared_aspects ![[ASPECTS2:[0-9]+]] !srcloc ![[SRCLOC3:[0-9]+]] {
 [[sycl::device_has(sycl::aspect::fp16, sycl::aspect::gpu)]] void func2() {}
 
-// CHECK-DAG: define dso_local spir_func void @{{.*}}func3{{.*}} !sycl_declared_aspects ![[EMPTYASPECTS:[0-9]+]] !srcloc ![[SRCLOC4:[0-9]+]] {
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func3{{.*}} !sycl_declared_aspects ![[EMPTYASPECTS:[0-9]+]] !srcloc ![[SRCLOC4:[0-9]+]] {
 [[sycl::device_has()]] void func3() {}
 
-// CHECK-DAG: define linkonce_odr spir_func void @{{.*}}func4{{.*}} !sycl_declared_aspects ![[ASPECTS3:[0-9]+]] !srcloc ![[SRCLOC5:[0-9]+]] {
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func4{{.*}} !sycl_declared_aspects ![[ASPECTS3:[0-9]+]] !srcloc ![[SRCLOC5:[0-9]+]] {
 template <sycl::aspect Aspect>
 [[sycl::device_has(Aspect)]] void func4() {}
 
-// CHECK-DAG: define dso_local spir_func void @{{.*}}func5{{.*}} !sycl_declared_aspects ![[ASPECTS1]] !srcloc ![[SRCLOC6:[0-9]+]] {
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func5{{.*}} !sycl_declared_aspects ![[ASPECTS1]] !srcloc ![[SRCLOC6:[0-9]+]] {
 [[sycl::device_has(sycl::aspect::cpu)]] void func5();
 void func5() {}
 
 constexpr sycl::aspect getAspect() { return sycl::aspect::cpu; }
-// CHECK-DAG: define dso_local spir_func void @{{.*}}func6{{.*}} !sycl_declared_aspects ![[ASPECTS1]] !srcloc ![[SRCLOC7:[0-9]+]] {
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func6{{.*}} !sycl_declared_aspects ![[ASPECTS1]] !srcloc ![[SRCLOC7:[0-9]+]] {
 [[sycl::device_has(getAspect())]] void func6() {}
 
-// CHECK-DAG: define linkonce_odr spir_func void @{{.*}}func7{{.*}} !sycl_declared_aspects ![[ASPECTS1]]
-// CHECK-DAG: define linkonce_odr spir_func void @{{.*}}func7{{.*}} !sycl_declared_aspects ![[ASPECTS5:[0-9]+]]
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func7{{.*}} !sycl_declared_aspects ![[ASPECTS1]]
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func7{{.*}} !sycl_declared_aspects ![[ASPECTS5:[0-9]+]]
 template <sycl::aspect... Asp>
 [[sycl::device_has(Asp...)]] void func7() {}
 
-// CHECK-DAG: define linkonce_odr spir_func void @{{.*}}func8{{.*}} !sycl_declared_aspects ![[ASPECTS5]]
+// CHECK-DAG: define {{.*}}spir_func void @{{.*}}func8{{.*}} !sycl_declared_aspects ![[ASPECTS5]]
 template <sycl::aspect Asp, sycl::aspect... AspPack>
 [[sycl::device_has(Asp, AspPack...)]] void func8() {}
 

--- a/clang/test/CodeGenSYCL/function-attrs.cpp
+++ b/clang/test/CodeGenSYCL/function-attrs.cpp
@@ -3,7 +3,7 @@
 
 int foo();
 
-// CHECK: define dso_local spir_func void @_Z3barv() [[BAR:#[0-9]+]]
+// CHECK: define {{.*}}spir_func void @_Z3barv() [[BAR:#[0-9]+]]
 // CHECK: attributes [[BAR]] =
 // CHECK-SAME: convergent
 // CHECK-SAME: nounwind

--- a/clang/test/CodeGenSYCL/functionptr-addrspace.cpp
+++ b/clang/test/CodeGenSYCL/functionptr-addrspace.cpp
@@ -7,7 +7,7 @@ __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {
   kernelFunc();
 }
 
-// CHECK: define dso_local spir_func{{.*}}invoke_function{{.*}}(ptr noundef %fptr, ptr addrspace(4) noundef %ptr)
+// CHECK: define {{.*}}spir_func{{.*}}invoke_function{{.*}}(ptr noundef %fptr, ptr addrspace(4) noundef %ptr)
 void invoke_function(int (*fptr)(), int *ptr) {}
 
 int f() { return 0; }

--- a/clang/test/CodeGenSYCL/loop_unroll.cpp
+++ b/clang/test/CodeGenSYCL/loop_unroll.cpp
@@ -1,7 +1,7 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -disable-llvm-passes -fsycl-is-device -emit-llvm %s -o - | FileCheck %s
 
 void enable() {
-  // CHECK-LABEL: define dso_local spir_func void @_Z6enablev()
+  // CHECK-LABEL: define {{.*}}spir_func void @_Z6enablev()
   int i = 1000;
   // CHECK: br i1 %{{.*}}, label %do.body, label %do.end, !llvm.loop ![[ENABLE:[0-9]+]]
   [[clang::loop_unroll]]
@@ -10,7 +10,7 @@ void enable() {
 
 template <int A>
 void count() {
-  // CHECK-LABEL: define linkonce_odr spir_func void @_Z5countILi4EEvv()
+  // CHECK-LABEL: define {{.*}}spir_func void @_Z5countILi4EEvv()
   // CHECK: br label %for.cond, !llvm.loop ![[COUNT:[0-9]+]]
   [[clang::loop_unroll(8)]]
   for (int i = 0; i < 1000; ++i);
@@ -21,7 +21,7 @@ void count() {
 
 template <int A>
 void disable() {
-  // CHECK-LABEL: define linkonce_odr spir_func void @_Z7disableILi1EEvv()
+  // CHECK-LABEL: define {{.*}}spir_func void @_Z7disableILi1EEvv()
   int i = 1000, j = 100;
   // CHECK: br label %while.cond, !llvm.loop ![[DISABLE:[0-9]+]]
   [[clang::loop_unroll(1)]]

--- a/clang/test/CodeGenSYCL/nontrivial_device_copyable.cpp
+++ b/clang/test/CodeGenSYCL/nontrivial_device_copyable.cpp
@@ -29,7 +29,7 @@ int main() {
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name(ptr noundef byval(%struct.NontriviallyCopyable)
 // CHECK-NOT: define {{.*}}spir_func void @{{.*}}device_func{{.*}}({{.*}}byval(%struct.NontriviallyCopyable)
-// CHECK: define dso_local spir_func void @_Z11device_func20NontriviallyCopyable(ptr noundef %X)
+// CHECK: define {{.*}}spir_func void @_Z11device_func20NontriviallyCopyable(ptr noundef %X)
 // CHECK: %X.indirect_addr = alloca ptr addrspace(4)
 // CHECK: %X.indirect_addr.ascast = addrspacecast ptr %X.indirect_addr to ptr addrspace(4)
 // CHECK: %X.ascast = addrspacecast ptr %X to ptr addrspace(4)

--- a/clang/test/CodeGenSYCL/sycl-cuda-host-device-functions.cu
+++ b/clang/test/CodeGenSYCL/sycl-cuda-host-device-functions.cu
@@ -1,5 +1,6 @@
 // RUN: %clang_cc1 -fsycl-is-host -sycl-std=2020 -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-HOST
-// RUN: %clang_cc1 -fsycl-is-device -sycl-std=2020 -emit-llvm %s -o - | FileCheck %s -check-prefix CHECK-DEV
+// RUN: %clang_cc1 -fsycl-is-device -sycl-std=2020 -fno-gpu-rdc -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-DEV,CHECK-DEV-NORDC
+// RUN: %clang_cc1 -fsycl-is-device -sycl-std=2020 -fgpu-rdc -emit-llvm %s -o - | FileCheck %s -check-prefixes CHECK-DEV,CHECK-DEV-RDC
 
 // This tests
 // - if a dummy __host__ function (returning undef) is generated for every
@@ -63,7 +64,8 @@ __device__ int fun5() { return 5; }
 
 int fun6() { return 7; }
 
-// CHECK-DEV: define dso_local noundef i32 @{{.*}}fun6{{.*}}()
+// CHECK-DEV-RDC: define linkonce_odr{{ dso_local | }}noundef i32 @{{.*}}fun6{{.*}}()
+// CHECK-DEV-NORDC: define internal noundef i32 @{{.*}}fun6{{.*}}()
 // CHECK-DEV: ret i32 7
 
 __attribute((sycl_device)) void test() {
@@ -75,4 +77,3 @@ __attribute((sycl_device)) void test() {
   fun5();
   fun6();
 }
-

--- a/clang/test/CodeGenSYCL/sycl-device-static-init.cpp
+++ b/clang/test/CodeGenSYCL/sycl-device-static-init.cpp
@@ -1,11 +1,11 @@
 // RUN: %clang_cc1 -fno-sycl-force-inline-kernel-lambda -fsycl-is-device -triple spir64-unknown-unknown -disable-llvm-passes %s -emit-llvm -o -  | FileCheck %s
 // Test that static initializers do not force the emission of globals on sycl device
 
-// CHECK-NOT: $_ZN8BaseInitI12TestBaseTypeE15s_regbase_ncsdmE = comdat any
+// CHECK-NOT: $_ZN8BaseInitI12TestBaseTypeE15s_regbase_ncsdmE =
 // CHECK: $_ZN8BaseInitI12TestBaseTypeE3varE = comdat any
-// CHECK: @_ZN8BaseInitI12TestBaseTypeE3varE = weak_odr addrspace(1) constant i32 9, comdat, align 4
-// CHECK-NOT: @_ZN8BaseInitI12TestBaseTypeE15s_regbase_ncsdmE = weak_odr addrspace(1) global %struct._ZTS16RegisterBaseInit.RegisterBaseInit zeroinitializer, comdat, align 1
-// CHECK-NOT: @_ZGVN8BaseInitI12TestBaseTypeE15s_regbase_ncsdmE = weak_odr global i64 0, comdat($_ZN8BaseInitI12TestBaseTypeE9s_regbaseE), align 8
+// CHECK: @_ZN8BaseInitI12TestBaseTypeE3varE = {{.*}}addrspace(1) constant i32 9, comdat, align 4
+// CHECK-NOT: @_ZN8BaseInitI12TestBaseTypeE15s_regbase_ncsdmE =
+// CHECK-NOT: @_ZGVN8BaseInitI12TestBaseTypeE15s_regbase_ncsdmE =
 // CHECK: define {{.*}}spir_kernel void @_ZTSZ4mainE11fake_kernel()
 // CHECK: call spir_func void @_ZZ4mainENKUlvE_clEv
 

--- a/clang/test/CodeGenSYCL/uses_aspects.cpp
+++ b/clang/test/CodeGenSYCL/uses_aspects.cpp
@@ -10,35 +10,42 @@ class [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] Type1WithAspect{}
 class [[__sycl_detail__::__uses_aspects__(sycl::aspect::fp16, sycl::aspect::cpu)]] Type2WithAspect{};
 class [[__sycl_detail__::__uses_aspects__(sycl::aspect::host)]] UnusedType3WithAspect{};
 
-// CHECK: define dso_local spir_func void @{{.*}}func1{{.*}} !sycl_used_aspects ![[ASPECTS1:[0-9]+]] {
+// CHECK: define {{.*}}spir_func void @{{.*}}func1
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1:[0-9]+]]
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] void func1() {}
 
-// CHECK: define dso_local spir_func void @{{.*}}func2{{.*}} !sycl_used_aspects ![[ASPECTS2:[0-9]+]] {
+// CHECK: define {{.*}}spir_func void @{{.*}}func2
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS2:[0-9]+]]
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::fp16, sycl::aspect::gpu)]] void func2() {}
 
-// CHECK: define dso_local spir_func void @{{.*}}func3{{.*}} !sycl_used_aspects ![[EMPTYASPECTS:[0-9]+]] {
+// CHECK: define {{.*}}spir_func void @{{.*}}func3
+// CHECK-SAME: !sycl_used_aspects ![[EMPTYASPECTS:[0-9]+]]
 [[__sycl_detail__::__uses_aspects__()]] void func3() {}
 
-// CHECK: define linkonce_odr spir_func void @{{.*}}func4{{.*}} !sycl_used_aspects ![[ASPECTS3:[0-9]+]] {
+// CHECK: define {{.*}}spir_func void @{{.*}}func4
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS3:[0-9]+]]
 template <sycl::aspect Aspect>
 [[__sycl_detail__::__uses_aspects__(Aspect)]] void func4() {}
 
-// CHECK: define dso_local spir_func void @{{.*}}func5{{.*}} !sycl_used_aspects ![[ASPECTS1]] {
+// CHECK: define {{.*}}spir_func void @{{.*}}func5
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1]]
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] void func5();
 void func5() {}
 
+// CHECK: define {{.*}}spir_func void @{{.*}}func6
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1]]
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] void func6();
-// CHECK: define dso_local spir_func void @{{.*}}func6{{.*}} !sycl_used_aspects ![[ASPECTS1]] {
 void func6() {
   Type1WithAspect TestObj1;
   Type2WithAspect TestObj2;
 }
 
 constexpr sycl::aspect getAspect() { return sycl::aspect::cpu; }
-// CHECK: define dso_local spir_func void @{{.*}}func7{{.*}} !sycl_used_aspects ![[ASPECTS1]] {
+// CHECK: define {{.*}}spir_func void @{{.*}}func7
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1]]
 [[__sycl_detail__::__uses_aspects__(getAspect())]] void func7() {}
 
-// CHECK: declare !sycl_used_aspects ![[ASPECTS1]] spir_func void @{{.*}}func8{{.*}}
+// CHECK: declare !sycl_used_aspects ![[ASPECTS1]] spir_func void @{{.*}}func8
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] SYCL_EXTERNAL void func8();
 
 class KernelFunctor {

--- a/sycl/test/check_device_code/device_has.cpp
+++ b/sycl/test/check_device_code/device_has.cpp
@@ -1,6 +1,4 @@
-// RUN: %clangxx -fsycl -Xclang -fsycl-is-device -fsycl-device-only -Xclang -fno-sycl-early-optimizations -S -emit-llvm %s -o %t.ll
-// RUN: FileCheck %s --input-file %t.ll --check-prefix=CHECK-ASPECTS
-// RUN: FileCheck %s --input-file %t.ll --check-prefix=CHECK-SRCLOC
+// RUN: %clangxx -fsycl -Xclang -fsycl-is-device -fsycl-device-only -Xclang -fno-sycl-early-optimizations -S -emit-llvm %s -o - | FileCheck %s
 
 // Tests for IR of device_has(aspect, ...) attribute and
 // !sycl_used_aspects metadata
@@ -9,38 +7,45 @@
 using namespace sycl;
 queue q;
 
-// CHECK-ASPECTS: define weak_odr dso_local spir_kernel void @{{.*}}kernel_name_1{{.*}} !sycl_declared_aspects ![[ASPECTS1:[0-9]+]] {{.*}}
-// CHECK-SRCLOC: define weak_odr dso_local spir_kernel void @{{.*}}kernel_name_1{{.*}} !srcloc ![[SRCLOC1:[0-9]+]] {{.*}}
+// CHECK: define weak_odr dso_local spir_kernel void @{{.*}}kernel_name_1
+// CHECK-SAME: !sycl_declared_aspects ![[ASPECTS1:[0-9]+]]
+// CHECK-SAME: !srcloc ![[SRCLOC1:[0-9]+]]
 
-// CHECK-ASPECTS: define dso_local spir_func void @{{.*}}func1{{.*}} !sycl_declared_aspects ![[ASPECTS1]]
-// CHECK-ASPECTS-SAME: !sycl_used_aspects ![[ASPECTS1]]
-// CHECK-SRCLOC: define dso_local spir_func void @{{.*}}func1{{.*}} !srcloc ![[SRCLOC2:[0-9]+]]
+// CHECK: define {{.*}}spir_func void @{{.*}}func1
+// CHECK-SAME: !sycl_declared_aspects ![[ASPECTS1]]
+// CHECK-SAME: !srcloc ![[SRCLOC2:[0-9]+]]
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1]]
 [[sycl::device_has(sycl::aspect::cpu)]] void func1() {}
 
-// CHECK-ASPECTS: define dso_local spir_func void @{{.*}}func2{{.*}} !sycl_declared_aspects ![[ASPECTS2:[0-9]+]]
-// CHECK-ASPECTS-SAME: !sycl_used_aspects ![[ASPECTS2]]
-// CHECK-SRCLOC: define dso_local spir_func void @{{.*}}func2{{.*}} !srcloc ![[SRCLOC3:[0-9]+]]
+// CHECK: define {{.*}}spir_func void @{{.*}}func2
+// CHECK-SAME: !sycl_declared_aspects ![[ASPECTS2:[0-9]+]]
+// CHECK-SAME: !srcloc ![[SRCLOC3:[0-9]+]]
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS2]]
 [[sycl::device_has(sycl::aspect::fp16, sycl::aspect::gpu)]] void func2() {}
 
-// CHECK-ASPECTS: define dso_local spir_func void @{{.*}}func3{{.*}} !sycl_declared_aspects ![[EMPTYASPECTS:[0-9]+]]
-// CHECK-SRCLOC: define dso_local spir_func void @{{.*}}func3{{.*}} !srcloc ![[SRCLOC4:[0-9]+]]
+// CHECK: define {{.*}}spir_func void @{{.*}}func3
+// CHECK-SAME: !sycl_declared_aspects ![[EMPTYASPECTS:[0-9]+]]
+// CHECK-SAME: !srcloc ![[SRCLOC4:[0-9]+]]
 [[sycl::device_has()]] void func3() {}
 
-// CHECK-ASPECTS: define linkonce_odr dso_local spir_func void @{{.*}}func4{{.*}} !sycl_declared_aspects ![[ASPECTS3:[0-9]+]]
-// CHECK-ASPECTS-SAME: !sycl_used_aspects ![[ASPECTS3]]
-// CHECK-SRCLOC: define linkonce_odr dso_local spir_func void @{{.*}}func4{{.*}} !srcloc ![[SRCLOC5:[0-9]+]]
+// CHECK: define {{.*}}spir_func void @{{.*}}func4
+// CHECK-SAME: !sycl_declared_aspects ![[ASPECTS3:[0-9]+]]
+// CHECK-SAME: !srcloc ![[SRCLOC5:[0-9]+]]
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS3]]
 template <sycl::aspect Aspect> [[sycl::device_has(Aspect)]] void func4() {}
 
-// CHECK-ASPECTS: define dso_local spir_func void @{{.*}}func5{{.*}} !sycl_declared_aspects ![[ASPECTS1]]
-// CHECK-ASPECTS-SAME: !sycl_used_aspects ![[ASPECTS1]]
-// CHECK-SRCLOC: define dso_local spir_func void @{{.*}}func5{{.*}} !srcloc ![[SRCLOC6:[0-9]+]]
+// CHECK: define {{.*}}spir_func void @{{.*}}func5
+// CHECK-SAME: !sycl_declared_aspects ![[ASPECTS1]]
+// CHECK-SAME: !srcloc ![[SRCLOC6:[0-9]+]]
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1]]
 [[sycl::device_has(sycl::aspect::cpu)]] void func5();
 void func5() {}
 
 constexpr sycl::aspect getAspect() { return sycl::aspect::cpu; }
-// CHECK-ASPECTS: define dso_local spir_func void @{{.*}}func6{{.*}} !sycl_declared_aspects ![[ASPECTS1]]
-// CHECK-ASPECTS-SAME: !sycl_used_aspects ![[ASPECTS1]]
-// CHECK-SRCLOC: define dso_local spir_func void @{{.*}}func6{{.*}} !srcloc ![[SRCLOC7:[0-9]+]]
+// CHECK: define {{.*}}spir_func void @{{.*}}func6
+// CHECK-SAME: !sycl_declared_aspects ![[ASPECTS1]]
+// CHECK-SAME: !srcloc ![[SRCLOC7:[0-9]+]]
+// CHECK-SAME: !sycl_used_aspects ![[ASPECTS1]]
 [[sycl::device_has(getAspect())]] void func6() {}
 
 class KernelFunctor {
@@ -59,23 +64,24 @@ void foo() {
   q.submit([&](handler &h) {
     KernelFunctor f1;
     h.single_task<class kernel_name_1>(f1);
-    // CHECK-ASPECTS: define weak_odr dso_local spir_kernel void @{{.*}}kernel_name_2{{.*}} !sycl_declared_aspects ![[ASPECTS4:[0-9]+]]
-    // CHECK-SRCLOC: define weak_odr dso_local spir_kernel void @{{.*}}kernel_name_2{{.*}} !srcloc ![[SRCLOC8:[0-9]+]] {{.*}}
+    // CHECK: define weak_odr dso_local spir_kernel void @{{.*}}kernel_name_2
+    // CHECK-SAME: !sycl_declared_aspects ![[ASPECTS4:[0-9]+]]
+    // CHECK-SAME: !srcloc ![[SRCLOC8:[0-9]+]] {{.*}}
     h.single_task<class kernel_name_2>(
         []() [[sycl::device_has(sycl::aspect::gpu)]] {});
   });
 }
 
-// CHECK-ASPECTS-DAG: [[ASPECTS1]] = !{i32 1}
-// CHECK-SRCLOC-DAG: [[SRCLOC1]] = !{i32 {{[0-9]+}}}
-// CHECK-ASPECTS-DAG: [[EMPTYASPECTS]] = !{}
-// CHECK-SRCLOC-DAG: [[SRCLOC2]] = !{i32 {{[0-9]+}}}
-// CHECK-ASPECTS-DAG: [[ASPECTS2]] = !{i32 5, i32 2}
-// CHECK-SRCLOC-DAG: [[SRCLOC3]] = !{i32 {{[0-9]+}}}
-// CHECK-SRCLOC-DAG: [[SRCLOC4]] = !{i32 {{[0-9]+}}}
-// CHECK-ASPECTS-DAG: [[ASPECTS3]] = !{i32 0}
-// CHECK-SRCLOC-DAG: [[SRCLOC5]] = !{i32 {{[0-9]+}}}
-// CHECK-SRCLOC-DAG: [[SRCLOC6]] = !{i32 {{[0-9]+}}}
-// CHECK-SRCLOC-DAG: [[SRCLOC7]] = !{i32 {{[0-9]+}}}
-// CHECK-ASPECTS-DAG: [[ASPECTS4]] = !{i32 2}
-// CHECK-SRCLOC-DAG: [[SRCLOC8]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS1]] = !{i32 1}
+// CHECK-DAG: [[SRCLOC1]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[EMPTYASPECTS]] = !{}
+// CHECK-DAG: [[SRCLOC2]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS2]] = !{i32 5, i32 2}
+// CHECK-DAG: [[SRCLOC3]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[SRCLOC4]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS3]] = !{i32 0}
+// CHECK-DAG: [[SRCLOC5]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[SRCLOC6]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[SRCLOC7]] = !{i32 {{[0-9]+}}}
+// CHECK-DAG: [[ASPECTS4]] = !{i32 2}
+// CHECK-DAG: [[SRCLOC8]] = !{i32 {{[0-9]+}}}

--- a/sycl/test/extensions/properties/properties_kernel_device_has_macro.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_macro.cpp
@@ -27,23 +27,14 @@ static constexpr auto device_has_all = device_has<
     aspect::ext_intel_memory_clock_rate, aspect::ext_intel_memory_bus_width>;
 
 // CHECK-IR: spir_func void @{{.*}}Func0{{.*}}(){{.*}} #[[DHAttr1:[0-9]+]]
-SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(device_has_all) void Func0() {}
+SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(device_has_all) void Func0() {}
 
 // CHECK-IR: spir_func void @{{.*}}Func1{{.*}}(){{.*}} #[[DHAttr2:[0-9]+]]
-SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((device_has<>)) void Func1() {}
+SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((device_has<>)) void Func1() {}
 
 // CHECK-IR: spir_func void @{{.*}}Func2{{.*}}(){{.*}} #[[DHAttr3:[0-9]+]]
-SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((device_has<aspect::fp16, aspect::atomic64>))
-void Func2() {}
-
-// TODO: Check that SYCL_EXTERNAL when the attributes are correctly attached to
-//       device functions with external linkage.
-
-// Due to a current restriction on attribute lists not being applicable after a
-// __attribute__ specifier, SYCL_EXT_ONEAPI_FUNCTION_PROPERTY cannot currently
-// be used after SYCL_EXTERNAL.
-// TODO: Add test for SYCL_EXT_ONEAPI_FUNCTION_PROPERTY after SYCL_EXTERNAL when
-//       the above restriction is loosened.
+SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (device_has<aspect::fp16, aspect::atomic64>)) void Func2() {}
 
 int main() {
   queue Q;


### PR DESCRIPTION
In getLLVMLinkageForDeclarator, CUDA device functions are given internal linkage to allow improved IPO. The same optimizations would also be useful for SYCL. However, as multiple translation units are a possibility here, it cannot be done exactly the same way. There are a number of extra considerations that need to be made.

- If a device function or object is annotated with the SYCL_EXTERNAL macro, it may be called from a different module and its handling should not be touched.

- If a device function or object is not annotated with the SYCL_EXTERNAL macro, it may not be called from a different translation unit unless that other translation unit provides its own definition of it. As such, if other optimizations remove all references in the current module, the function or object itself can be removed, and other passes should be aware that it is legal to remove the function or object.

- If two kernels defined in different translation units call into the same non-kernel inline or template device function, these different copies of the device function would previously be merged together, and should continue to be.

The linkage that satisfies these criteria is linkonce_odr, so this commit marks functions and objects so, unless the sycl_kernel or sycl_device attributes are present which indicate that it must remain externally accessible.