### PR TITLE
[SYCL][UR][L0] Defer setting null and argPointer arguments

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -472,9 +472,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
     // The ArgValue may be a NULL pointer in which case a NULL value is used for
     // the kernel argument declared as a pointer to global or constant memory.
     char **ZeHandlePtr = nullptr;
-    if (Arg.Value) {
+    if (Arg.MemValue) {
       // TODO: Not sure of the implication of not passing a device pointer here
-      UR_CALL(Arg.Value->getZeHandlePtr(ZeHandlePtr, Arg.AccessMode));
+      UR_CALL(Arg.MemValue->getZeHandlePtr(ZeHandlePtr, Arg.AccessMode));
     }
     ZE2UR_CALL(zeKernelSetArgumentValue,
                (Kernel->ZeKernel, Arg.Index, Arg.Size, ZeHandlePtr));

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -469,6 +469,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
 
   // If there are any pending arguments set them now.
   for (auto &Arg : Kernel->PendingArguments) {
+    // if the argument has access_mode_t::unknown, then this is a
+    // regular pointer
+    if (Arg.AccessMode == ur_mem_handle_t_::access_mode_t::unknown) {
+      ZE2UR_CALL(zeKernelSetArgumentValue,
+                 (Kernel->ZeKernel, Arg.Index, Arg.Size, Arg.ArgValue));
+      continue;
+    }
+
     // The ArgValue may be a NULL pointer in which case a NULL value is used for
     // the kernel argument declared as a pointer to global or constant memory.
     char **ZeHandlePtr = nullptr;

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
@@ -83,7 +83,9 @@ struct ur_kernel_handle_t_ : _ur_object {
   struct ArgumentInfo {
     uint32_t Index;
     size_t Size;
+    // ArgValue contains a generic pointer argument
     void *ArgValue;
+    // MemValue contains a memory pointer argument
     ur_mem_handle_t_ *MemValue;
     ur_mem_handle_t_::access_mode_t AccessMode{ur_mem_handle_t_::unknown};
   };

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
@@ -83,8 +83,8 @@ struct ur_kernel_handle_t_ : _ur_object {
   struct ArgumentInfo {
     uint32_t Index;
     size_t Size;
-    // const ur_mem_handle_t_ *Value;
-    ur_mem_handle_t_ *Value;
+    void *ArgValue;
+    ur_mem_handle_t_ *MemValue;
     ur_mem_handle_t_::access_mode_t AccessMode{ur_mem_handle_t_::unknown};
   };
   // Arguments that still need to be set (with zeKernelSetArgumentValue)


### PR DESCRIPTION
- Reroute piextKernelSetArgPointer to urKernelSetArgPointer.
- In urKernelSetArgPointer, dont call urKernelSetArgValue but instead, push the argument and set it in urEnqueueKernelLaunch.
- This could potentially provide some benefits, as more calls to zeKernelSetArgumentValue are grouped together in urEnqueueKernelLaunch, reducing some overhead when going from SYCL runtime to UR and then to L0 on each separate piextKernelSetArgPointer.