### PR TITLE
[SYCL][UR][L0] Correct default for SYCL_PI_LEVEL_ZERO_FILTER_EVENT_WAIT_LIST

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
@@ -57,7 +57,7 @@ const bool ReuseDiscardedEvents = [] {
 
 const bool FilterEventWaitList = [] {
   const char *Ret = std::getenv("SYCL_PI_LEVEL_ZERO_FILTER_EVENT_WAIT_LIST");
-  const bool RetVal = Ret ? std::stoi(Ret) : 1;
+  const bool RetVal = Ret ? std::stoi(Ret) : 0;
   return RetVal;
 }();
 


### PR DESCRIPTION
As previously committed in:

https://github.com/intel/llvm/commit/dbde93f8eb96d6c7b29e2386aac7a7cd64aef84d