### PR TITLE
[SYCL-MLIR] Raise `sycl.handler.set_nd_range` constructs

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -26,6 +26,12 @@ class SYCL_HostOp<string mnemonic, list<Trait> traits = []> :
     SYCL_Op<"host." # mnemonic, traits>;
 
 ////////////////////////////////////////////////////////////////////////////////
+// TRAIT DECLARATIONS
+////////////////////////////////////////////////////////////////////////////////
+
+def SYCLHostHandlerOp : SYCLOpTrait<"SYCLHostHandlerOp">;
+
+////////////////////////////////////////////////////////////////////////////////
 // OPERATIONS
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -96,7 +102,7 @@ def SYCLHostGetKernelOp
 
 def SYCLHostHandlerSetKernel
     : SYCL_HostOp<"handler.set_kernel",
-        [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+        [SYCLHostHandlerOp, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = [{
     Operation assigning a kernel to a `sycl::handler`, thus pairing the handler
     and the kernel being launched.
@@ -107,7 +113,8 @@ def SYCLHostHandlerSetKernel
   }];
 }
 
-def SYCLHostHandlerSetNDRange : SYCL_HostOp<"handler.set_nd_range"> {
+def SYCLHostHandlerSetNDRange
+    : SYCL_HostOp<"handler.set_nd_range", [SYCLHostHandlerOp]> {
   let summary = [{
     Operation assigning an nd-range to a `sycl::handler`, setting the nd-range
     of the kernel to be launched.

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostTraits.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostTraits.h
@@ -15,7 +15,8 @@ namespace mlir {
 namespace sycl {
 LogicalResult verifySYCLHandlerOpTrait(Operation *Op);
 
-/// This interface marks operations that represent a SYCL math function.
+/// This interface marks operations that receive a pointer to a sycl::handler as
+/// a first argument.
 template <typename ConcreteType>
 class SYCLHostHandlerOp
     : public OpTrait::TraitBase<ConcreteType, SYCLHostHandlerOp> {
@@ -27,4 +28,4 @@ public:
 } // namespace sycl
 } // namespace mlir
 
-#endif // MLIR_DIALECT_SYCL_IR_SYCLTRAITS_H
+#endif // MLIR_DIALECT_SYCL_IR_SYCLHOSTTRAITS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostTraits.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostTraits.h
@@ -1,0 +1,30 @@
+//===--- SYCLHostTraits.h -------------------------------------------------===//
+//
+// MLIR-SYCL is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_SYCL_IR_SYCLHOSTTRAITS_H
+#define MLIR_DIALECT_SYCL_IR_SYCLHOSTTRAITS_H
+
+#include "mlir/IR/OpDefinition.h"
+
+namespace mlir {
+namespace sycl {
+LogicalResult verifySYCLHandlerOpTrait(Operation *Op);
+
+/// This interface marks operations that represent a SYCL math function.
+template <typename ConcreteType>
+class SYCLHostHandlerOp
+    : public OpTrait::TraitBase<ConcreteType, SYCLHostHandlerOp> {
+public:
+  static LogicalResult verifyTrait(Operation *op) {
+    return verifySYCLHandlerOpTrait(op);
+  }
+};
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_DIALECT_SYCL_IR_SYCLTRAITS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -9,6 +9,7 @@
 #ifndef MLIR_DIALECT_SYCL_IR_SYCLOPS_H
 #define MLIR_DIALECT_SYCL_IR_SYCLOPS_H
 
+#include "mlir/Dialect/SYCL/IR/SYCLHostTraits.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTraits.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 

--- a/mlir-sycl/lib/Dialect/SYCL/IR/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/CMakeLists.txt
@@ -35,6 +35,7 @@ add_mlir_dialect_library(MLIRSYCLDialect
   SYCLAttributes.cpp
   SYCLDialect.cpp
   SYCLHostOps.cpp
+  SYCLHostTraits.cpp
   SYCLMethodOpInterface.cpp
   SYCLOps.cpp
   SYCLTraits.cpp

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostTraits.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostTraits.cpp
@@ -15,7 +15,7 @@ using namespace mlir::sycl;
 
 LogicalResult mlir::sycl::verifySYCLHandlerOpTrait(Operation *op) {
   if (op->getNumOperands() == 0)
-    return op->emitOpError("requires at least an operand");
+    return op->emitOpError("requires at least one operand");
   if (!isa<LLVM::LLVMPointerType>(op->getOperand(0).getType()))
     return op->emitOpError("requires the first argument to be a pointer");
   return success();

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostTraits.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostTraits.cpp
@@ -1,0 +1,19 @@
+//===--- SYCLHostTraits.cpp -----------------------------------------------===//
+//
+// MLIR-SYCL is under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/SYCL/IR/SYCLHostTraits.h"
+
+#include "mlir/Dialect/LLVMIR/LLVMTypes.h"
+
+using namespace mlir;
+using namespace mlir::sycl;
+
+LogicalResult mlir::sycl::verifySYCLHandlerOpTrait(Operation *op) {
+  return success(op->getNumOperands() >= 1 &&
+                 isa<LLVM::LLVMPointerType>(op->getOperand(0).getType()));
+}

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostTraits.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLHostTraits.cpp
@@ -14,6 +14,9 @@ using namespace mlir;
 using namespace mlir::sycl;
 
 LogicalResult mlir::sycl::verifySYCLHandlerOpTrait(Operation *op) {
-  return success(op->getNumOperands() >= 1 &&
-                 isa<LLVM::LLVMPointerType>(op->getOperand(0).getType()));
+  if (op->getNumOperands() == 0)
+    return op->emitOpError("requires at least an operand");
+  if (!isa<LLVM::LLVMPointerType>(op->getOperand(0).getType()))
+    return op->emitOpError("requires the first argument to be a pointer");
+  return success();
 }

--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -194,7 +194,7 @@ def LICM : Pass<"licm"> {
 def SYCLRaiseHostConstructs : Pass<"sycl-raise-host"> {
   let summary = "Raise relevant sequences of host code to SYCL dialect operations";
   // TODO: Description
-  let dependentDialects = ["sycl::SYCLDialect"];
+  let dependentDialects = ["arith::ArithDialect", "sycl::SYCLDialect"];
   let constructor = "mlir::polygeist::createSYCLHostRaisingPass()";
   let options = RewritePassUtils.options;
   // TODO: Statistics

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -24,6 +24,7 @@
 #include "mlir/Dialect/Polygeist/Utils/Utils.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
+#include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Regex.h"
@@ -58,6 +59,7 @@ public:
 //===----------------------------------------------------------------------===//
 
 constexpr StringLiteral stdNamespace = "std";
+constexpr StringLiteral syclNamespace = "sycl";
 
 /// Class holding results of calling `llvm::ItaniumPartialDemangler` member
 /// functions.
@@ -140,6 +142,15 @@ static LogicalResult partialDemangle(llvm::ItaniumPartialDemangler &demangler,
   return callable ? partialDemangle(demangler, callable) : failure();
 }
 
+/// Calls `partialDemangle` on \p demangler using the name of the function \p
+/// op.
+static LogicalResult partialDemangle(llvm::ItaniumPartialDemangler &demangler,
+                                     FunctionOpInterface op) {
+  // Get the symbol
+  auto symbol = dyn_cast<SymbolOpInterface>(*op);
+  return failure(!symbol || demangler.partialDemangle(symbol.getName().data()));
+}
+
 template <typename T> static auto getUsersOfType(Value value) {
   constexpr auto filter = [](const OpOperand &operand) -> bool {
     return isa<T>(operand.getOwner());
@@ -162,6 +173,92 @@ static bool isClassType(Type type, StringRef className) {
 static bool isClassType(Type type, const llvm::Regex &regex) {
   auto st = dyn_cast<LLVM::LLVMStructType>(type);
   return st && st.isIdentified() && regex.match(st.getName());
+}
+
+/// Check \p op is a member of class \p className and return the first (this)
+/// argument.
+static Value getThisArgument(FunctionOpInterface op, StringRef className) {
+  llvm::ItaniumPartialDemangler demangler;
+  if (!(succeeded(partialDemangle(demangler, op)) && demangler.isFunction() &&
+        isMemberFunction(demangler, syclNamespace, className)))
+    return nullptr;
+
+  assert(op.getNumArguments() > 0 &&
+         "A non-static member function must have at least one argument");
+  Value firstArg = op.getArgument(0);
+  assert(isa<LLVM::LLVMPointerType>(firstArg.getType()) &&
+         "Expecting this argument to be a pointer");
+  return firstArg;
+}
+
+static FailureOr<StringRef> getStringValue(LLVM::GlobalOp op) {
+  // Check the operation has a value
+  std::optional<Attribute> attr = op.getValue();
+  if (!attr)
+    return failure();
+
+  // Check it is a string
+  auto strAttr = dyn_cast<StringAttr>(*attr);
+  if (!strAttr)
+    return failure();
+
+  // Drop the trailing `0` character
+  return strAttr.getValue().drop_back();
+}
+
+static FailureOr<StringRef> getAnnotation(LLVM::VarAnnotation annotation) {
+  auto addressofOp =
+      annotation.getAnnotation().getDefiningOp<LLVM::AddressOfOp>();
+  if (!addressofOp)
+    return failure();
+
+  SymbolTableCollection symbolTable;
+  auto global = symbolTable.lookupNearestSymbolFrom<LLVM::GlobalOp>(
+      addressofOp, addressofOp.getGlobalNameAttr());
+  return global ? getStringValue(global) : FailureOr<StringRef>(failure());
+}
+
+/// Return the constructor reponsible of the construction of \p value.
+static sycl::SYCLHostConstructorOp getConstructor(Value value) {
+  // TODO: Implement using ReachingDefinionAnalysis after testing with non
+  // structured control flow.
+  constexpr auto canOmitOperation = [](Operation *op) {
+    return isa<sycl::SYCLDialect>(op->getDialect()) ||
+           isa<LLVM::VarAnnotation, LLVM::LifetimeEndOp, LLVM::LifetimeStartOp>(
+               op);
+  };
+
+  sycl::SYCLHostConstructorOp constructor;
+  for (const OpOperand &operand : value.getUses()) {
+    Operation *op = operand.getOwner();
+    if (auto c = dyn_cast<sycl::SYCLHostConstructorOp>(op)) {
+      if (constructor)
+        return nullptr;
+      constructor = c;
+      continue;
+    }
+    if (!canOmitOperation(op))
+      return nullptr;
+  }
+  return constructor;
+}
+
+static Value getHandler(FunctionOpInterface op) {
+  Value handler;
+  // First search for any operation known to receive a pointer to a handler
+  if (op.walk([&](Operation *setKernel) {
+          if (!setKernel->hasTrait<sycl::SYCLHostHandlerOp>())
+            return WalkResult::advance();
+          Value h = setKernel->getOperand(0);
+          if (handler && handler != h)
+            return WalkResult::interrupt();
+          handler = h;
+          return WalkResult::advance();
+        }).wasInterrupted())
+    return nullptr;
+  if (!handler)
+    handler = getThisArgument(op, "handler");
+  return handler;
 }
 
 namespace {
@@ -270,23 +367,14 @@ private:
   /// searching.
   static std::optional<SymbolRefAttr>
   getKernelRef(LLVM::GlobalOp op, SymbolTableCollection &symbolTable) {
-    // Check the operation has a value
-    std::optional<Attribute> attr = op.getValue();
-    if (!attr)
+    FailureOr<StringRef> name = getStringValue(op);
+    if (failed(name))
       return std::nullopt;
-
-    // Check it is a string
-    auto strAttr = dyn_cast<StringAttr>(*attr);
-    if (!strAttr)
-      return std::nullopt;
-
-    // Drop the trailing `0` character
-    StringRef name = strAttr.getValue().drop_back();
 
     // Search the `gpu.func` in the device module
     auto ref =
         SymbolRefAttr::get(op->getContext(), DeviceModuleName,
-                           FlatSymbolRefAttr::get(op->getContext(), name));
+                           FlatSymbolRefAttr::get(op->getContext(), *name));
     auto kernel = symbolTable.lookupNearestSymbolFrom<gpu::GPUFuncOp>(op, ref);
 
     // If it was found and it is a kernel, return the reference
@@ -778,6 +866,136 @@ private:
                : Value();
   }
 };
+
+struct RaiseSetNDRange
+    : public OpInterfaceHostRaisePattern<FunctionOpInterface> {
+  using OpInterfaceHostRaisePattern<
+      FunctionOpInterface>::OpInterfaceHostRaisePattern;
+
+  LogicalResult matchAndRewrite(FunctionOpInterface op,
+                                PatternRewriter &rewriter) const final {
+    // Only handle functions with body
+    if (op.isExternal())
+      return failure();
+
+    // The function must be a sycl::handler member
+    Value handler = getHandler(op);
+    if (!handler)
+      return failure();
+
+    // Annotated values constructors
+    SmallVector<sycl::SYCLHostConstructorOp> constructors;
+    // Annotations
+    SmallVector<LLVM::VarAnnotation> annotations;
+
+    // We will fill the constructors and annotations vectors
+    const auto getConstructors = [&](LLVM::VarAnnotation annotation) {
+      // Check the annotation is correct
+      FailureOr<StringRef> failureOrAnnotationStr = getAnnotation(annotation);
+      if (failed(failureOrAnnotationStr))
+        return WalkResult::advance();
+
+      StringRef annotationStr = *failureOrAnnotationStr;
+      if (!(annotationStr == "nd_range" || annotationStr == "offset" ||
+            annotationStr == "range"))
+        return WalkResult::advance();
+
+      // Get value's constructor
+      Value value = annotation.getVal();
+      sycl::SYCLHostConstructorOp constructor = getConstructor(value);
+      if (!constructor)
+        return WalkResult::interrupt();
+
+      assert((TypeSwitch<Type, bool>(constructor.getType().getValue())
+                  .Case<sycl::NdRangeType>(
+                      [=](auto) { return annotationStr == "nd_range"; })
+                  .Case<sycl::IDType>(
+                      [=](auto) { return annotationStr == "offset"; })
+                  .Case<sycl::RangeType>(
+                      [=](auto) { return annotationStr == "range"; })
+                  .Default(false)) &&
+             "Invalid constructor type");
+
+      constructors.push_back(constructor);
+      annotations.push_back(annotation);
+
+      return WalkResult::advance();
+    };
+    if (op.walk(getConstructors).wasInterrupted() || constructors.empty())
+      return failure();
+
+    // We will introduce the operation after the last annotation
+    OpBuilder::InsertionGuard ig(rewriter);
+    rewriter.setInsertionPointAfter(annotations.back());
+    Location loc = annotations.back().getLoc();
+
+    // Remove annotations, no longer needed
+    // Also prevent infinite recursion
+    rewriter.updateRootInPlace(op, [&] {
+      for (LLVM::VarAnnotation annotation : annotations)
+        rewriter.eraseOp(annotation);
+    });
+
+    assert((constructors.size() < 3 &&
+            isa<sycl::NdRangeType, sycl::RangeType>(
+                constructors.front().getType().getValue()) &&
+            (constructors.size() == 1 ||
+             (isa<sycl::RangeType>(constructors.front().getType().getValue()) &&
+              isa<sycl::IDType>(constructors.back().getType().getValue())))) &&
+           "Expecting nd-range or global size+[offset] combination");
+
+    // TODO: nd_range constructor receives pointers to structs, so we are not
+    // able to handle this yet.
+    if (isa<sycl::NdRangeType>(constructors.front().getType().getValue()))
+      return failure();
+
+    SmallVector<Value> arguments;
+    {
+      OpBuilder::InsertionGuard ig(rewriter);
+      llvm::transform(
+          constructors, std::back_inserter(arguments),
+          [&](sycl::SYCLHostConstructorOp constructor) -> Value {
+            // Insert sycl.X.constructor right after sycl.host.constructor
+            rewriter.setInsertionPoint(constructor);
+            Location loc = constructor.getLoc();
+            Type type = constructor.getType().getValue();
+            auto mt = MemRefType::get(1, type);
+            return TypeSwitch<Type, Value>(type)
+                .Case<sycl::RangeType, sycl::IDType>([&](auto t) {
+                  Value v;
+                  rewriter.updateRootInPlace(op, [&] {
+                    SmallVector<Value> args;
+                    auto indexType = rewriter.getIndexType();
+                    // Cast each argument from iX to index
+                    llvm::transform(
+                        constructor.getArgs(), std::back_inserter(args),
+                        [&](Value arg) {
+                          assert(isa<IntegerType>(arg.getType()) &&
+                                 "Expecting integer type");
+                          return rewriter.create<arith::IndexCastOp>(
+                              loc, indexType, arg);
+                        });
+                    // Create the required constructor operation depending on
+                    // the type
+                    using OpTy = std::conditional_t<
+                        std::is_same_v<decltype(t), sycl::RangeType>,
+                        sycl::SYCLRangeConstructorOp,
+                        sycl::SYCLIDConstructorOp>;
+                    v = rewriter.create<OpTy>(loc, mt, args);
+                  });
+                  return v;
+                });
+          });
+    }
+
+    // Finally insert sycl.host.handler.set_nd_range after the last annotation
+    rewriter.updateRootInPlace(op, [&] {
+      rewriter.create<sycl::SYCLHostHandlerSetNDRange>(loc, handler, arguments);
+    });
+
+    return success();
+  }
+};
 } // namespace
 
 //===----------------------------------------------------------------------===//
@@ -789,13 +1007,22 @@ void SYCLRaiseHostConstructsPass::runOnOperation() {
   MLIRContext *context = &getContext();
 
   RewritePatternSet rewritePatterns{context};
-  rewritePatterns.add<RaiseKernelName, BufferInvokeConstructorPattern,
-                      AccessorInvokeConstructorPattern, RaiseIDConstructor,
-                      RaiseRangeConstructor>(context);
+  rewritePatterns
+      .add<BufferInvokeConstructorPattern, AccessorInvokeConstructorPattern>(
+          context);
 
   // RaiseKernelName should be prioritized, as RaiseSetKernel depends on that.
   rewritePatterns.add<RaiseKernelName>(context, /*benefit=*/2);
   rewritePatterns.add<RaiseSetKernel>(context, /*benefit=*/1);
+
+  // Raising of some constructors (id, range and nd_range) should be
+  // prioritized, as RaiseSetNDRange depends on those. Also, raising of id and
+  // range constructors should be prioritized, as nd_range constructor uses
+  // them.
+  rewritePatterns.add<RaiseIDConstructor, RaiseRangeConstructor>(context,
+                                                                 /*benefit=*/3);
+  // TODO: Add RaiseNDRangeConstructor with benefit=2
+  rewritePatterns.add<RaiseSetNDRange>(context, /*benefit=*/1);
 
   FrozenRewritePatternSet frozen(std::move(rewritePatterns));
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -179,9 +179,9 @@ static bool isClassType(Type type, const llvm::Regex &regex) {
 /// argument.
 static Value getThisArgument(FunctionOpInterface op, StringRef className) {
   llvm::ItaniumPartialDemangler demangler;
-  if (!(succeeded(partialDemangle(demangler, op)) && demangler.isFunction() &&
-        isMemberFunction(demangler, syclNamespace, className) &&
-        op.getNumArguments() > 0))
+  if (failed(partialDemangle(demangler, op)) || !demangler.isFunction() ||
+      !isMemberFunction(demangler, syclNamespace, className) ||
+      op.getNumArguments() == 0)
     return nullptr;
 
   Value firstArg = op.getArgument(0);
@@ -932,7 +932,7 @@ public:
     Location loc = annotations.back().getLoc();
 
     // Remove annotations, no longer needed
-    // Also prevent infinite recursion
+    // Also prevents infinite recursion
     rewriter.updateRootInPlace(op, [&] {
       for (LLVM::VarAnnotation annotation : annotations)
         rewriter.eraseOp(annotation);

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -218,7 +218,9 @@ static FailureOr<StringRef> getAnnotation(LLVM::VarAnnotation annotation) {
   return global ? getStringValue(global) : FailureOr<StringRef>(failure());
 }
 
-/// Return the constructor reponsible of the construction of \p value.
+/// Return the constructor responsible of the construction of \p value.
+///
+/// Returns an empty instance if conflicting users are found.
 static sycl::SYCLHostConstructorOp getConstructor(Value value) {
   // TODO: Implement using ReachingDefinionAnalysis after testing with non
   // structured control flow.

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -292,12 +292,21 @@ gpu.module @device_functions {
 llvm.mlir.global private unnamed_addr constant @range_str("range\00")
     {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
 
-// CHECK-LABEL:   llvm.func @raise_set_nd_range(
-// CHECK-SAME:                                  %[[VAL_0:.*]]: !llvm.ptr) {
+// COM: Check we can raise parallel_for(globalSize, kernel) to sycl.host.handler.set_nd_range
+
+// CHECK-LABEL:   llvm.func @raise_set_globalsize(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: !llvm.ptr) {
 // CHECK-DAG:       %[[VAL_1:.*]] = arith.constant 512 : index
-// CHECK:           %[[VAL_5:.*]] = sycl.range.constructor(%[[VAL_1]]) : (index) -> memref<1x!sycl_range_1_>
-// CHECK:           sycl.host.handler.set_nd_range %[[VAL_0]] -> %[[VAL_5]] : !llvm.ptr, memref<1x!sycl_range_1_>
-llvm.func @raise_set_nd_range(%handler: !llvm.ptr) {
+// CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(512 : i64) : i64
+// CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:      sycl.host.handler.set_kernel %[[VAL_0]] -> @device_functions::@foo : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.range.constructor(%[[VAL_1]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_4]], %[[VAL_2]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      sycl.host.handler.set_nd_range %[[VAL_0]] -> %[[VAL_5]] : !llvm.ptr, memref<1x!sycl_range_1_>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+llvm.func @raise_set_globalsize(%handler: !llvm.ptr) {
   %c0 = llvm.mlir.constant (0 : i32) : i32
   %c1 = llvm.mlir.constant (1 : i64) : i64
   sycl.host.handler.set_kernel %handler -> @device_functions::@foo : !llvm.ptr
@@ -307,5 +316,58 @@ llvm.func @raise_set_nd_range(%handler: !llvm.ptr) {
   sycl.host.constructor(%range, %c512) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   %str = llvm.mlir.addressof @range_str : !llvm.ptr
   "llvm.intr.var.annotation"(%range, %str, %str, %c0, %nullptr) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
+  llvm.return
+}
+
+// -----
+
+!sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
+
+gpu.module @device_functions {
+  gpu.func @foo() kernel {
+    gpu.return
+  }
+}
+
+llvm.mlir.global private unnamed_addr constant @range_str("range\00")
+    {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+llvm.mlir.global private unnamed_addr constant @offset_str("offset\00")
+    {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
+
+// COM: Check we can raise parallel_for(globalSize, offset, kernel) to sycl.host.handler.set_nd_range
+
+// CHECK-LABEL:   llvm.func @raise_set_globalsize_offset(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: !llvm.ptr) {
+// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 512 : index
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 100 : index
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(512 : i64) : i64
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(100 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(1 : i64) : i64
+// CHECK-NEXT:      sycl.host.handler.set_kernel %[[VAL_0]] -> @device_functions::@foo : !llvm.ptr
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = sycl.range.constructor(%[[VAL_1]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_3]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_9:.*]] = sycl.id.constructor(%[[VAL_2]]) : (index) -> memref<1x!sycl_id_1_>
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_4]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      sycl.host.handler.set_nd_range %[[VAL_0]] -> %[[VAL_7]], %[[VAL_9]] : !llvm.ptr, memref<1x!sycl_range_1_>, memref<1x!sycl_id_1_>
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+llvm.func @raise_set_globalsize_offset(%handler: !llvm.ptr) {
+  %c0 = llvm.mlir.constant (0 : i32) : i32
+  %c1 = llvm.mlir.constant (1 : i64) : i64
+  sycl.host.handler.set_kernel %handler -> @device_functions::@foo : !llvm.ptr
+  %c100 = llvm.mlir.constant (100 : i64) : i64
+  %c512 = llvm.mlir.constant (512 : i64) : i64
+  %nullptr = llvm.mlir.null : !llvm.ptr
+  %range = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+  sycl.host.constructor(%range, %c512) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  %offset = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i64) -> !llvm.ptr
+  sycl.host.constructor(%offset, %c100) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+  %rangeStr = llvm.mlir.addressof @range_str : !llvm.ptr
+  %offsetStr = llvm.mlir.addressof @offset_str : !llvm.ptr
+  "llvm.intr.var.annotation"(%range, %rangeStr, %rangeStr, %c0, %nullptr) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
+  "llvm.intr.var.annotation"(%offset, %offsetStr, %offsetStr, %c0, %nullptr) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
   llvm.return
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
@@ -29,7 +29,7 @@ class KernelName;
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
-// COM: Check we can detect nd-range assignment
+// COM: Check we can detect nd-range assignment with a scalar argument
 
 // CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
 // CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> %[[G_SIZE]] : !llvm.ptr, memref<1x!sycl_range_1_>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
@@ -24,20 +24,20 @@ class KernelName;
 // COM: Check we can detect accessors construction
 
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
-// CHECK:         %[[N:.*]] = llvm.mlir.constant(1024 : i64) : i64
-// CHECK:         %[[RANGE_STR_ADDR:.*]] = llvm.mlir.addressof @[[RANGE_STR]] : !llvm.ptr
-// CHECK:         %[[KERNEL_STR_ADDR:.*]] = llvm.mlir.addressof @[[KERNEL_STR]] : !llvm.ptr
+// CHECK-DAG:     %[[N:.*]] = arith.constant 1024 : index
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:         sycl.host.constructor(%[[RANGE:.*]], %[[N]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-// CHECK:         "llvm.intr.var.annotation"(%[[RANGE]], %[[RANGE_STR_ADDR]], %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
-// CHECK:         "llvm.intr.var.annotation"(%{{.*}}, %[[KERNEL_STR_ADDR]], %{{.*}}, %{{.*}}, %{{.*}}) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
+
+// COM: Check we can detect nd-range assignment
+
+// CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> %[[G_SIZE]] : !llvm.ptr, memref<1x!sycl_range_1_>
 
 // COM: Check we can detect kernel assignment to a sycl::handler:
 
-// CHECK-DAG: sycl.host.handler.set_kernel %{{.*}} -> @device_functions::@_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE : !llvm.ptr
-// CHECK-DAG: sycl.host.handler.set_kernel %{{.*}} -> @device_functions::@_ZTS10KernelName : !llvm.ptr
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE : !llvm.ptr
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTS10KernelName : !llvm.ptr
 
 int main() {
   constexpr std::size_t N = 1024;
@@ -57,4 +57,3 @@ int main() {
 	     });
   }
 }
-

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
@@ -1,0 +1,67 @@
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// XFAIL: *
+
+// COM: Failing because we cannot raise nd-range constructor
+
+#include <sycl/sycl.hpp>
+
+std::vector<float> init(std::size_t);
+
+class KernelName;
+
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[RANGE_STR:.*]]("range\00")
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[KERNEL_STR:.*]]("kernel\00")
+
+// CHECK-DAG: gpu.func @_ZTS10KernelName
+// CHECK-DAG: gpu.func @_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE
+
+// COM: Check we can detect buffers contruction
+
+// CHECK-LABEL: llvm.func @main
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+
+// COM: Check we can detect accessors construction
+
+// CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
+// CHECK-DAG:     %[[N:.*]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[M:.*]] = arith.constant 512 : index
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+// COM: Check we can detect nd-range assignment
+
+// CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK:         %[[L_SIZE:.*]] = sycl.range.constructor(%[[M]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK:         %[[ND_RANGE:.*]] = sycl.nd_range.constructor(%[[G_SIZE]], %[[L_SIZE]]) : (memref<1x!sycl_range_1_>, memref<1x!sycl_range_1_>) -> memref<1x!sycl_nd_range_1_>
+// CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> %[[ND_RANGE]] : !llvm.ptr, memref<1x!sycl_nd_range_1_>
+
+// COM: Check we can detect kernel assignment to a sycl::handler:
+
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE : !llvm.ptr
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTS10KernelName : !llvm.ptr
+
+int main() {
+  constexpr std::size_t N = 1024;
+  constexpr std::size_t L = 512;
+  const std::vector<float> a = init(N);
+  const std::vector<float> b = init(N);
+  std::vector<float> c(N);
+  sycl::queue q;
+  {
+    sycl::buffer<float> buff_a(a);
+    sycl::buffer<float> buff_b(b);
+    sycl::buffer<float> buff_c(c);
+    q.submit([&](sycl::handler &cgh) {
+	       sycl::accessor acc_a(buff_a, cgh, sycl::read_only);
+	       sycl::accessor acc_b(buff_b, cgh, sycl::read_only);
+	       sycl::accessor acc_c(buff_c, cgh, sycl::write_only, sycl::no_init);
+	       cgh.parallel_for<KernelName>(sycl::nd_range<1>{{N}, {L}},
+					    [=](sycl::item<1> i) { acc_c[i] = acc_a[i] + acc_b[i]; });
+	     });
+  }
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
@@ -33,7 +33,7 @@ class KernelName;
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
-// COM: Check we can detect nd-range assignment
+// COM: Check we can detect nd-range assignment with an nd_range argument
 
 // CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
 // CHECK:         %[[L_SIZE:.*]] = sycl.range.constructor(%[[M]]) : (index) -> memref<1x!sycl_range_1_>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
@@ -24,14 +24,13 @@ class KernelName;
 // COM: Check we can detect accessors construction
 
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
-// CHECK-DAG:     %[[N:.*]] = llvm.mlir.constant(1024 : i64) : i64
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect nd-range assignment
 
-// CHECK:         %[[N]] = arith.index_cast %{{.*}} : i64 to index
+// CHECK:         %[[N:.*]] = arith.index_cast %{{.*}} : i64 to index
 // CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
 // CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> %[[G_SIZE]] : !llvm.ptr, memref<1x!sycl_range_1_>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
@@ -1,0 +1,61 @@
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+std::vector<float> init(std::size_t);
+
+class KernelName;
+
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[RANGE_STR:.*]]("range\00")
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[KERNEL_STR:.*]]("kernel\00")
+
+// CHECK-DAG: gpu.func @_ZTS10KernelName
+// CHECK-DAG: gpu.func @_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE
+
+// COM: Check we can detect buffers contruction
+
+// CHECK-LABEL: llvm.func @main
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+
+// COM: Check we can detect accessors construction
+
+// CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
+// CHECK-DAG:     %[[N:.*]] = llvm.mlir.constant(1024 : i64) : i64
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+// COM: Check we can detect nd-range assignment
+
+// CHECK:         %[[N]] = arith.index_cast %{{.*}} : i64 to index
+// CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> %[[G_SIZE]] : !llvm.ptr, memref<1x!sycl_range_1_>
+
+// COM: Check we can detect kernel assignment to a sycl::handler:
+
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE : !llvm.ptr
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTS10KernelName : !llvm.ptr
+
+int main() {
+  constexpr std::size_t N = 1024;
+  const sycl::range<1> range(N);
+  const std::vector<float> a = init(N);
+  const std::vector<float> b = init(N);
+  std::vector<float> c(N);
+  sycl::queue q;
+  {
+    sycl::buffer<float> buff_a(a);
+    sycl::buffer<float> buff_b(b);
+    sycl::buffer<float> buff_c(c);
+    q.submit([&](sycl::handler &cgh) {
+	       sycl::accessor acc_a(buff_a, cgh, sycl::read_only);
+	       sycl::accessor acc_b(buff_b, cgh, sycl::read_only);
+	       sycl::accessor acc_c(buff_c, cgh, sycl::write_only, sycl::no_init);
+	       cgh.parallel_for<KernelName>(range, [=](sycl::id<1> i) { acc_c[i] = acc_a[i] + acc_b[i]; });
+	     });
+  }
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
@@ -28,7 +28,7 @@ class KernelName;
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
-// COM: Check we can detect nd-range assignment
+// COM: Check we can detect nd-range assignment with a range argument
 
 // CHECK:         %[[N:.*]] = arith.index_cast %{{.*}} : i64 to index
 // CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
@@ -34,7 +34,7 @@ class KernelName;
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
-// COM: Check we can detect nd-range assignment
+// COM: Check we can detect nd-range assignment with range and offset arguments
 
 // CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
 // CHECK:         %[[OFFSET:.*]] = sycl.id.constructor(%[[N]]) : (index) -> memref<1x!sycl_id_1_>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
@@ -1,0 +1,67 @@
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// XFAIL: *
+
+// COM: Failing because we cannot detect range/id constructor when raising set_nd_range.
+// COM:  Using ReachingDefinitionAnalysis would fix this.
+
+#include <sycl/sycl.hpp>
+
+std::vector<float> init(std::size_t);
+
+class KernelName;
+
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[RANGE_STR:.*]]("range\00")
+// CHECK-DAG: llvm.mlir.global private unnamed_addr constant @[[KERNEL_STR:.*]]("kernel\00")
+
+// CHECK-DAG: gpu.func @_ZTS10KernelName
+// CHECK-DAG: gpu.func @_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE
+
+// COM: Check we can detect buffers contruction
+
+// CHECK-LABEL: llvm.func @main
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:         sycl.host.constructor({{.*}}) {type = !sycl.buffer<[1, !llvm.void]>}  : (!llvm.ptr, !llvm.ptr, i64, !llvm.ptr, !llvm.ptr) -> ()
+
+// COM: Check we can detect accessors construction
+
+// CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
+// CHECK-DAG:     %[[N:.*]] = arith.constant 1024 : index
+// CHECK-DAG:     %[[OFFSET:.*]] = arith.constant 2 : index
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+
+// COM: Check we can detect nd-range assignment
+
+// CHECK:         %[[G_SIZE:.*]] = sycl.range.constructor(%[[N]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK:         %[[OFFSET:.*]] = sycl.id.constructor(%[[N]]) : (index) -> memref<1x!sycl_id_1_>
+// CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> %[[G_SIZE]], %[[OFFSET]] : !llvm.ptr, memref<1x!sycl_range_1_>, memref<1x!sycl_id_1_>
+
+// COM: Check we can detect kernel assignment to a sycl::handler:
+
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTSN4sycl3_V16detail19__pf_kernel_wrapperI10KernelNameEE : !llvm.ptr
+// CHECK-DAG: sycl.host.handler.set_kernel %[[HANDLER]] -> @device_functions::@_ZTS10KernelName : !llvm.ptr
+
+int main() {
+  constexpr std::size_t N = 1024;
+  constexpr std::size_t Offset = 2;
+  const std::vector<float> a = init(N);
+  const std::vector<float> b = init(N);
+  std::vector<float> c(N);
+  sycl::queue q;
+  {
+    sycl::buffer<float> buff_a(a);
+    sycl::buffer<float> buff_b(b);
+    sycl::buffer<float> buff_c(c);
+    q.submit([&](sycl::handler &cgh) {
+	       sycl::accessor acc_a(buff_a, cgh, sycl::read_only);
+	       sycl::accessor acc_b(buff_b, cgh, sycl::read_only);
+	       sycl::accessor acc_c(buff_c, cgh, sycl::write_only, sycl::no_init);
+	       cgh.parallel_for<KernelName>(sycl::range<1>(N), sycl::id<1>(Offset),
+					    [=](sycl::id<1> i) { acc_c[i] = acc_a[i] + acc_b[i]; });
+	     });
+  }
+}


### PR DESCRIPTION
Detect arguments specifying the nd-range of a `parallel_for` invocation.

Raising of calls receiving an `nd_range` fail to be raised as we are not yet raising such constructors. Raising of calls receiving both the global size and an offset fail because we cannot detect the constructor. We will need to implement a pattern raising `nd_range` constructors to fix the former and use `ReachingDefinitionAnalysis` in the pattern implemented by this commit to fix the later.

We also define the `SYCLHostHandlerOp` to be able to find `sycl::handler` instances in a function easily.