### PR TITLE
[SYCL] Small fix for accessor default constructor

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1396,7 +1396,7 @@ public:
             /*MemoryRange=*/{0, 0, 0},
             /*AccessMode=*/getAdjustedMode({}),
             /*SYCLMemObject=*/nullptr, /*Dims=*/0, /*ElemSize=*/0,
-            /*IsPlaceH=*/true,
+            /*IsPlaceH=*/false,
             /*OffsetInBytes=*/0, /*IsSubBuffer=*/false, /*PropertyList=*/{}){};
 
   template <typename, int, access_mode> friend class host_accessor;

--- a/sycl/test/basic_tests/accessor/accessor_default_ctor.cpp
+++ b/sycl/test/basic_tests/accessor/accessor_default_ctor.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
+// RUN: %t.out
 
 #include <sycl/sycl.hpp>
 
@@ -14,6 +15,7 @@ int main() {
   assert(B.get_multi_ptr<sycl::access::decorated::yes>() == nullptr);
   assert(B.get_multi_ptr<sycl::access::decorated::no>() == nullptr);
   assert(B.get_multi_ptr<sycl::access::decorated::legacy>() == nullptr);
+  assert(!B.is_placeholder());
 
   return 0;
 }


### PR DESCRIPTION
According to SYCL2020 default constructor for empty accessor shouldn't create a placeholder.