### PR TITLE
[CI] Use separate repo cache for E2E tests checkout

### DIFF
--- a/.github/workflows/linux_single_e2e.yml
+++ b/.github/workflows/linux_single_e2e.yml
@@ -61,7 +61,9 @@ jobs:
       with:
         path: llvm
         ref: ${{ inputs.ref }}
-        cache_path: "/__w/repo_cache/"
+        # We run build and HIP E2E tests under different users on the same
+        # runners, so need to use distinct cache paths.
+        cache_path: "/__w/repo_cache_e2e/"
         merge: ${{ inputs.merge }}
     - name: Install drivers
       if: env.compute_runtime_tag != ''

--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -33,7 +33,6 @@ runs:
       else
         git clone https://github.com/${{ inputs.repository }}.git .
       fi
-      chown -R sycl:sycl ${{ inputs.cache_path }}/${{ inputs.repository }}
   - name: Checkout
     env:
       GIT_ALTERNATE_OBJECT_DIRECTORIES: ${{ inputs.cache_path }}/${{ inputs.repository }}/.git/objects


### PR DESCRIPTION
We run Build/E2E tasks under different users on our amdgpu runners resulting in errors reusing the same cache under both. Separate the caches to resolve those.