### PR TITLE
[SYCL] Disable `HostPtr` reuse when the pointer is read-only

### DIFF
--- a/sycl/source/detail/sycl_mem_obj_t.hpp
+++ b/sycl/source/detail/sycl_mem_obj_t.hpp
@@ -175,7 +175,7 @@ public:
   bool canReuseHostPtr(void *HostPtr, const size_t RequiredAlign) {
     bool Aligned =
         (reinterpret_cast<std::uintptr_t>(HostPtr) % RequiredAlign) == 0;
-    return Aligned || useHostPtr();
+    return !MHostPtrReadOnly && (Aligned || useHostPtr());
   }
 
   void handleHostData(void *HostPtr, const size_t RequiredAlign) {

--- a/sycl/test-e2e/Basic/host_write_back.cpp
+++ b/sycl/test-e2e/Basic/host_write_back.cpp
@@ -1,0 +1,37 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+static constexpr int N = 32;
+
+void testAccessor() {
+  std::vector<int> vec(N, 1);
+  {
+    buffer<int, 1> buf(static_cast<const int *>(vec.data()), range<1>{N});
+    queue q;
+    q.submit([&](handler &cgh) {
+      auto acc = buf.get_access<access_mode::read_write>(cgh);
+      cgh.parallel_for<class Kernel>({N}, [=](id<1> i) { acc[i] += 5; });
+    });
+  }
+  assert(vec[0] == 1);
+}
+
+void testHostAcessor() {
+  std::vector<int> vec(N, 1);
+  {
+    buffer<int, 1> buf(static_cast<const int *>(vec.data()), range<1>{N});
+    auto acc = buf.get_host_access();
+    acc[0] += 5;
+  }
+  assert(vec[0] == 1);
+}
+
+int main() {
+  testAccessor();
+  testHostAcessor();
+}


### PR DESCRIPTION
Mutable SYCL buffers can be initialized using a `const T* hostData`. This change ensures that these buffers allocate new memory so that their contents can be modified without changing the original host data. Fixes #10091.