### PR TITLE
sycl-in-tree: Allow different patch in usm testcases

### DIFF
--- a/sycl/test-e2e/Tracing/usm/queue_copy_released_pointer.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_copy_released_pointer.cpp
@@ -15,7 +15,7 @@ int main() {
 
   try {
     // CHECK: [USM] Function uses unknown USM pointer (could be already released or not allocated as USM) as destination memory block
-    // CHECK: | memcpy location: function main at {{.*}}/queue_copy_released_pointer.cpp:[[# @LINE + 1 ]]
+    // CHECK: | memcpy location: function main at {{.*}}queue_copy_released_pointer.cpp:[[# @LINE + 1 ]]
     Q.copy(AllocSrc, AllocDst, 1);
     Q.wait();
   } catch (...) {

--- a/sycl/test-e2e/Tracing/usm/queue_single_task_nullptr.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_single_task_nullptr.cpp
@@ -11,7 +11,7 @@ int main() {
   unsigned int *AllocSrc = nullptr;
   try {
     // CHECK: [USM] Function uses nullptr as kernel parameter with index = 0.
-    // CHECK: | kernel location: function main at {{.*}}/queue_single_task_nullptr.cpp:[[# @LINE + 1 ]]
+    // CHECK: | kernel location: function main at {{.*}}queue_single_task_nullptr.cpp:[[# @LINE + 1 ]]
     Q.single_task([=]() {
       if (AllocSrc == nullptr)
         sycl::ext::oneapi::experimental::printf("nullptr");

--- a/sycl/test-e2e/Tracing/usm/queue_single_task_released_pointer.cpp
+++ b/sycl/test-e2e/Tracing/usm/queue_single_task_released_pointer.cpp
@@ -13,7 +13,7 @@ int main() {
 
   try {
     // CHECK: [USM] Function uses unknown USM pointer (could be already released or not allocated as USM) as kernel parameter with index = 0.
-    // CHECK: | kernel location: function main at {{.*}}/queue_single_task_released_pointer.cpp:[[# @LINE + 1 ]]
+    // CHECK: | kernel location: function main at {{.*}}queue_single_task_released_pointer.cpp:[[# @LINE + 1 ]]
     Q.single_task([=]() { *AllocSrc = 13; });
     Q.wait();
   } catch (...) {


### PR DESCRIPTION
We might get different path (eg: without /) in different test env
Remove the "/" to avoid noise.
