### PR TITLE
[CI] Fix merge commit for build/e2e-tests in pre-commit

### DIFF
--- a/.github/workflows/sycl_precommit.yml
+++ b/.github/workflows/sycl_precommit.yml
@@ -82,6 +82,7 @@ jobs:
     secrets: inherit
     with:
       build_ref: ${{ github.event.pull_request.head.sha }}
+      merge_ref: ${{ github.event.pull_request.base.sha }}
       build_cache_root: "/__w/"
       build_cache_size: "8G"
       build_artifact_suffix: "default"

--- a/devops/actions/cached_checkout/action.yml
+++ b/devops/actions/cached_checkout/action.yml
@@ -61,7 +61,7 @@ runs:
       git fetch origin $DEFAULT_BRANCH
       echo "FETCHED:"
       git log -1 origin/$DEFAULT_BRANCH
-      echo "Merging it into the current workspace"
+      echo "Merging ${{ inputs.merge_ref }} into the current workspace"
       # Set fake identity to fulfil git requirements
       git config --local user.email "actions@github.com"
       git config --local user.name "GitHub Actions"


### PR DESCRIPTION
By default cached_checkout merges latest origin/sycl resulting in race condition between Build/E2E tasks. Fix it by setting it to the same specific commit hash (target branch head at the task start).