### PR TITLE
[SYCL][NFC] Remove outdated .gitignore file for SYCL library

### DIFF
--- a/sycl/.gitignore
+++ b/sycl/.gitignore
@@ -1,2 +1,0 @@
-include/sycl/version.hpp
-include/sycl/feature_test.hpp


### PR DESCRIPTION
We used to generate two header files to source directory, so .gitignore
file protected developers from committing auto-generated files.
https://github.com/intel/llvm/commit/f3b5fad81fb3291737b3c3550e0dd41e032eda20
changed the directory for emitted files from source to build. Now we
don't need this .gitignore file anymore.
