### PR TITLE
[SYCL-MLIR] Raise `nd_range` constructor

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -89,6 +89,10 @@ private:
   std::size_t size;
 };
 
+static Type getEmptyBodyType(MLIRContext *ctx) {
+  return LLVM::LLVMVoidType::get(ctx);
+}
+
 /// Returns whether function \p demangled is a member of type \p targetType in
 /// namespace \p targetNamespace.
 static bool isMemberFunction(StringRef demangled, StringRef targetNamespace,
@@ -580,7 +584,7 @@ public:
         // for the analyses. However, leaving the body types empty leads to
         // problems when parsing an MLIR file containing such an accessor type
         // with empty body type list. Therefore, simply put !llvm.void for now.
-        LLVM::LLVMVoidType::get(constructor->getContext()));
+        getEmptyBodyType(constructor->getContext()));
   }
 
 private:
@@ -803,7 +807,7 @@ public:
     unsigned dimensions =
         cast<LLVM::LLVMArrayType>(at.getBody()[0]).getNumElements();
     return sycl::NdRangeType::get(type.getContext(), dimensions,
-                                  LLVM::LLVMVoidType::get(type.getContext()));
+                                  getEmptyBodyType(type.getContext()));
   }
 
 private:
@@ -1064,7 +1068,7 @@ RaiseNDRangeConstructor::getArgs(FunctionOpInterface func, LLVM::AllocaOp alloc,
     });
     // Build SYCL type. We do not care about the body.
     auto type = [&]() -> Type {
-      std::array<Type, 1> body{LLVM::LLVMVoidType::get(func->getContext())};
+      Type body = getEmptyBodyType(func->getContext());
       switch (iter.index()) {
       case 0:
       case 1:

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -29,6 +29,7 @@
 #include "llvm/Support/Debug.h"
 #include "llvm/Support/Regex.h"
 
+#include <llvm/ADT/STLExtras.h>
 #include <type_traits>
 
 namespace mlir {
@@ -786,11 +787,375 @@ private:
   llvm::Regex regex;
 };
 
+class NDRangeTypeTag {
+public:
+  using SYCLType = mlir::sycl::NdRangeType;
+
+  NDRangeTypeTag() : regex{"class.sycl::_V1::nd_range(\\.[0-9]+])?"} {}
+
+  const llvm::Regex &getTypeName() const { return regex; }
+
+  /// Translate an LLVM type to a SYCL type. Do not care about the body.
+  static sycl::NdRangeType translateLLVMType(Type type) {
+    auto st = cast<LLVM::LLVMStructType>(type);
+    auto rt = cast<LLVM::LLVMStructType>(st.getBody()[0]);
+    auto at = cast<LLVM::LLVMStructType>(rt.getBody()[0]);
+    unsigned dimensions =
+        cast<LLVM::LLVMArrayType>(at.getBody()[0]).getNumElements();
+    return sycl::NdRangeType::get(type.getContext(), dimensions,
+                                  /*body=*/ArrayRef<Type>());
+  }
+
+private:
+  llvm::Regex regex;
+};
+
 struct RaiseRangeConstructor
     : public RaiseArrayConstructorBasePattern<RangeTypeTag> {
   using RaiseArrayConstructorBasePattern<
       RangeTypeTag>::RaiseArrayConstructorBasePattern;
 };
+
+class RaiseNDRangeConstructor
+    : public OpInterfaceHostRaisePattern<FunctionOpInterface> {
+public:
+  using OpInterfaceHostRaisePattern<
+      FunctionOpInterface>::OpInterfaceHostRaisePattern;
+
+  LogicalResult matchAndRewrite(FunctionOpInterface op,
+                                PatternRewriter &rewriter) const final {
+    // Gather every alloca
+    SmallVector<LLVM::AllocaOp> allocas;
+    op.walk([&](LLVM::AllocaOp alloca) { allocas.push_back(alloca); });
+
+    // Try to raise constructors from allocas
+    bool changed = false;
+    for (LLVM::AllocaOp alloca : allocas) {
+      if (succeeded(raiseAlloca(op, alloca, rewriter)))
+        changed = true;
+    }
+
+    return success(changed);
+  }
+
+private:
+  /// Struct representing the initialzers of an nd_range
+  class Initializers {
+  public:
+    /// Create a new instance from alloca \p alloc. The nd_range to initialize
+    /// has \p dimensions dimensions.
+    static FailureOr<Initializers>
+    get(LLVM::AllocaOp alloc, const NDRangeTypeTag &tag, unsigned dimensions);
+
+    Initializers() = delete;
+
+    /// Return an ArrayRef containing the operations used to initialize the
+    /// nd_range or an error if it is bad formed.
+    FailureOr<ArrayRef<Operation *>> getGlobalSizeInitializers() const {
+      return shrunk(globalSizeInitializers);
+    }
+    FailureOr<ArrayRef<Operation *>> getLocalSizeInitializers() const {
+      return shrunk(localSizeInitializers);
+    }
+    FailureOr<ArrayRef<Operation *>> getOffsetInitializers() const {
+      return shrunk(offsetInitializers);
+    }
+
+  private:
+    static FailureOr<ArrayRef<Operation *>> shrunk(ArrayRef<Operation *> ops) {
+      // Find first null operation
+      auto end = llvm::find(ops, nullptr);
+      // Check no operation right of end is set
+      if (std::any_of(end, ops.end(), llvm::identity<Operation *>()))
+        return failure();
+      return ArrayRef<Operation *>(ops.begin(), end);
+    }
+
+    explicit Initializers(unsigned dimensions) : dimensions(dimensions) {
+      assert(0 < dimensions && dimensions <= 3 &&
+             "Invalid number of dimensions");
+      globalSizeInitializers.fill(nullptr);
+      localSizeInitializers.fill(nullptr);
+      offsetInitializers.fill(nullptr);
+    }
+
+    LogicalResult handle(LLVM::StoreOp store, LLVM::AllocaOp alloc,
+                         const NDRangeTypeTag &tag);
+    LogicalResult handle(LLVM::MemcpyOp memcpy, LLVM::AllocaOp alloc,
+                         const NDRangeTypeTag &tag);
+    LogicalResult handle(LLVM::GEPOp gep, LLVM::AllocaOp alloc,
+                         const NDRangeTypeTag &tag);
+
+    /// Returns whether this is a valid sequence of initializers
+    LogicalResult checkValidity() const;
+
+    /// Safely stores an operation. Will return failure if the setting cannot be
+    /// done safely.
+    LogicalResult set(std::size_t i, std::size_t j, Operation *op) {
+      if (i > 2 || j >= dimensions)
+        return failure();
+      auto &initializers = [&]() -> std::array<Operation *, 3> & {
+        switch (i) {
+        case 0:
+          return globalSizeInitializers;
+        case 1:
+          return localSizeInitializers;
+        case 2:
+          return offsetInitializers;
+        default:
+          llvm_unreachable("Invalid index");
+        }
+      }();
+      Operation *&ref = initializers[j];
+      if (ref)
+        return failure();
+      ref = op;
+      return success();
+    }
+
+    unsigned dimensions;
+    std::array<Operation *, 3> globalSizeInitializers;
+    std::array<Operation *, 3> localSizeInitializers;
+    std::array<Operation *, 3> offsetInitializers;
+  };
+
+  LogicalResult raiseAlloca(FunctionOpInterface func, LLVM::AllocaOp alloc,
+                            PatternRewriter &rewriter) const {
+    assert(alloc.getElemType().has_value() &&
+           "Expecting element type attribute for opaque alloca");
+
+    // Check whether the type allocated matches the expected type.
+    Type elemType = *alloc.getElemType();
+    if (!isClassType(elemType, tag.getTypeName()))
+      return failure();
+
+    // Get the constructed type early to check number of dimensions
+    OpBuilder::InsertionGuard IG(rewriter);
+    sycl::NdRangeType constructedType = tag.translateLLVMType(elemType);
+    FailureOr<std::array<Value, 3>> args =
+        getArgs(func, alloc, constructedType.getDimension(), rewriter);
+    if (failed(args))
+      return failure();
+
+    // Drop default offset initializer
+    ArrayRef<Value> argsRef(*args);
+    if (!argsRef[1])
+      argsRef = argsRef.drop_back(2);
+    else if (!argsRef.back())
+      argsRef = argsRef.drop_back();
+
+    rewriter.updateRootInPlace(func, [&] {
+      rewriter.create<sycl::SYCLHostConstructorOp>(
+          UnknownLoc::get(alloc.getContext()), alloc, argsRef,
+          TypeAttr::get(constructedType));
+    });
+
+    return success();
+  }
+
+  /// Returns the arguments to be passed to the sycl.host.constructor operation.
+  ///
+  /// Also sets rewriter to the correct insertion point.
+  FailureOr<std::array<Value, 3>> getArgs(FunctionOpInterface func,
+                                          LLVM::AllocaOp alloc,
+                                          unsigned dimensions,
+                                          PatternRewriter &rewriter) const;
+
+  NDRangeTypeTag tag;
+};
+
+LogicalResult RaiseNDRangeConstructor::Initializers::handle(
+    LLVM::StoreOp store, LLVM::AllocaOp alloc, const NDRangeTypeTag &) {
+  if (store.getAddr().getDefiningOp() == alloc)
+    return set(0, 0, store);
+  return success();
+}
+
+LogicalResult RaiseNDRangeConstructor::Initializers::handle(
+    LLVM::MemcpyOp memcpy, LLVM::AllocaOp alloc, const NDRangeTypeTag &) {
+  if (memcpy.getDst().getDefiningOp() == alloc)
+    return set(0, 0, memcpy);
+  return success();
+}
+
+LogicalResult RaiseNDRangeConstructor::Initializers::handle(
+    LLVM::GEPOp gep, LLVM::AllocaOp alloc, const NDRangeTypeTag &tag) {
+  assert(gep.getElemType().has_value() &&
+         "Expecting element type attribute for opaque alloca");
+
+  // In some cases we will find elemType = i8
+  if (!isClassType(*gep.getElemType(), tag.getTypeName()))
+    return failure();
+
+  auto memcpyUsers = llvm::make_filter_range(
+      getUsersOfType<LLVM::MemcpyOp>(gep),
+      [=](auto op) { return op.getDst().getDefiningOp() == gep; });
+  auto storeUsers =
+      llvm::make_filter_range(getUsersOfType<LLVM::StoreOp>(gep), [=](auto op) {
+        return op.getAddr().getDefiningOp() == gep;
+      });
+  constexpr auto isSingleton = [](auto range) {
+    return std::next(range.begin()) == range.end();
+  };
+  Operation *op;
+  if (memcpyUsers.empty()) {
+    if (storeUsers.empty())
+      return success();
+    if (!isSingleton(storeUsers))
+      return failure();
+    // Handle store
+    op = *storeUsers.begin();
+  } else if (storeUsers.empty()) {
+    if (!isSingleton(memcpyUsers))
+      return failure();
+    // Handle memcpy
+    op = *memcpyUsers.begin();
+  } else {
+    return failure();
+  }
+  assert(op && "Operation not set");
+  ArrayRef<int32_t> indices = gep.getRawConstantIndices();
+  std::size_t numIndices = indices.size();
+  if (numIndices != 2 && numIndices != 5)
+    return failure();
+  std::size_t componentIndex = indices[1];
+  std::size_t dimensionIndex = numIndices == 5 ? indices[4] : 0;
+  return set(componentIndex, dimensionIndex, op);
+}
+
+FailureOr<std::array<Value, 3>>
+RaiseNDRangeConstructor::getArgs(FunctionOpInterface func, LLVM::AllocaOp alloc,
+                                 unsigned dimensions,
+                                 PatternRewriter &rewriter) const {
+  FailureOr<Initializers> initializers =
+      Initializers::get(alloc, tag, dimensions);
+  if (failed(initializers))
+    return failure();
+
+  // If the id/range is not explicit, we need to reconstruct it
+  std::array<Value, 3> args;
+  std::array<ArrayRef<Operation *>, 3> ops{
+      *initializers->getGlobalSizeInitializers(),
+      *initializers->getLocalSizeInitializers(),
+      *initializers->getOffsetInitializers()};
+  llvm::transform(llvm::enumerate(ops), args.begin(), [&](auto iter) -> Value {
+    ArrayRef<Operation *> ops = iter.value();
+    // No offset or copy/move constructor cases
+    if (ops.empty())
+      return nullptr;
+    rewriter.setInsertionPointAfter(ops.back());
+    // llvm.intr.memcpy
+    if (auto memcpy = dyn_cast<LLVM::MemcpyOp>(ops[0])) {
+      assert(ops.size() == 1 && "Expecting a single argument when copying");
+      rewriter.eraseOp(memcpy);
+      return memcpy.getSrc();
+    }
+    // gep+store
+    assert(ops.size() == dimensions && "Expecting a value per dimension");
+    OpBuilder::InsertionGuard IG(rewriter);
+    rewriter.setInsertionPoint(alloc);
+    Type resultType = rewriter.getType<LLVM::LLVMPointerType>();
+    Type elementType = cast<LLVM::LLVMStructType>(*alloc.getElemType())
+                           .getBody()[iter.index()];
+    Location loc = ops[0]->getLoc();
+    SmallVector<Value> args;
+    llvm::transform(ops, std::back_inserter(args), [](Operation *op) {
+      return cast<LLVM::StoreOp>(op).getValue();
+    });
+    // Build SYCL type. We do not care about the body.
+    auto type = [&]() -> Type {
+      ArrayRef<Type> body;
+      switch (iter.index()) {
+      case 0:
+      case 1:
+        // Global or local size
+        return rewriter.getType<sycl::RangeType>(dimensions, body);
+      case 2:
+        // Offset
+        return rewriter.getType<sycl::IDType>(dimensions, body);
+      default:
+        llvm_unreachable("Invalid index");
+      }
+    }();
+    Value result;
+    rewriter.updateRootInPlace(func, [&] {
+      // Erase all stores
+      for (Operation *op : ops)
+        rewriter.eraseOp(op);
+      // Create new alloca
+      Value arraySize =
+          rewriter.create<LLVM::ConstantOp>(loc, rewriter.getI32Type(), 1);
+      result = rewriter.create<LLVM::AllocaOp>(loc, resultType, elementType,
+                                               arraySize);
+      // Construct it
+      rewriter.create<sycl::SYCLHostConstructorOp>(loc, result, args,
+                                                   TypeAttr::get(type));
+    });
+    return result;
+  });
+
+  return args;
+}
+
+FailureOr<RaiseNDRangeConstructor::Initializers>
+RaiseNDRangeConstructor::Initializers::get(LLVM::AllocaOp alloc,
+                                           const NDRangeTypeTag &tag,
+                                           unsigned dimensions) {
+  Initializers initializers(dimensions);
+  for (OpOperand user : alloc->getUsers()) {
+    LogicalResult result =
+        TypeSwitch<Operation *, LogicalResult>(user.getOwner())
+            .Case<LLVM::StoreOp, LLVM::MemcpyOp, LLVM::GEPOp>(
+                [&](auto op) { return initializers.handle(op, alloc, tag); })
+            .Default([](auto) { return success(); });
+    if (failed(result))
+      return result;
+  }
+  if (failed(initializers.checkValidity()))
+    return failure();
+  return initializers;
+}
+
+LogicalResult RaiseNDRangeConstructor::Initializers::checkValidity() const {
+  FailureOr<ArrayRef<Operation *>> failureOrGlobalSizeInit =
+      getGlobalSizeInitializers();
+  FailureOr<ArrayRef<Operation *>> failureOrLocalSizeInit =
+      getLocalSizeInitializers();
+  FailureOr<ArrayRef<Operation *>> failureOrOffsetInit =
+      getOffsetInitializers();
+  if (failed(failureOrGlobalSizeInit) || failed(failureOrLocalSizeInit) ||
+      failed(failureOrOffsetInit))
+    return failure();
+
+  ArrayRef<Operation *> globalSizeInit = *failureOrGlobalSizeInit;
+  ArrayRef<Operation *> localSizeInit = *failureOrLocalSizeInit;
+  ArrayRef<Operation *> offsetInit = *failureOrOffsetInit;
+
+  if (globalSizeInit.size() == 1 && isa<LLVM::MemcpyOp>(globalSizeInit[0]) &&
+      localSizeInit.empty() && offsetInit.empty())
+    return success();
+
+  // Check global and local size initialization
+  const auto checkInit = [=](ArrayRef<Operation *> ops) {
+    if (ops.empty())
+      return failure();
+    if (ops.size() == dimensions) {
+      if (dimensions == 1)
+        return success();
+      if (llvm::all_of(ops,
+                       [](Operation *op) { return isa<LLVM::StoreOp>(op); }))
+        return success();
+      // When initializing each component, we must be using store operations
+      return failure();
+    }
+    // Should be a memcpy
+    return success(ops.size() == 1 && isa<LLVM::MemcpyOp>(ops[0]));
+  };
+
+  return success(succeeded(checkInit(globalSizeInit)) &&
+                 succeeded(checkInit(localSizeInit)) &&
+                 (offsetInit.empty() || succeeded(checkInit(offsetInit))));
+}
 
 /// Raise constructs assigning a kernel name to a handler to
 /// `sycl.host.handler.set_kernel`.
@@ -1033,7 +1398,8 @@ void SYCLRaiseHostConstructsPass::runOnOperation() {
   // them.
   rewritePatterns.add<RaiseIDConstructor, RaiseRangeConstructor>(context,
                                                                  /*benefit=*/3);
-  // TODO: Add RaiseNDRangeConstructor with benefit=2
+  rewritePatterns.add<RaiseNDRangeConstructor>(context,
+                                               /*benefit=*/2);
   rewritePatterns.add<RaiseSetNDRange>(context, /*benefit=*/1);
 
   FrozenRewritePatternSet frozen(std::move(rewritePatterns));

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -803,7 +803,7 @@ public:
     unsigned dimensions =
         cast<LLVM::LLVMArrayType>(at.getBody()[0]).getNumElements();
     return sycl::NdRangeType::get(type.getContext(), dimensions,
-                                  /*body=*/ArrayRef<Type>());
+                                  LLVM::LLVMVoidType::get(type.getContext()));
   }
 
 private:
@@ -1064,7 +1064,7 @@ RaiseNDRangeConstructor::getArgs(FunctionOpInterface func, LLVM::AllocaOp alloc,
     });
     // Build SYCL type. We do not care about the body.
     auto type = [&]() -> Type {
-      ArrayRef<Type> body;
+      std::array<Type, 1> body{LLVM::LLVMVoidType::get(func->getContext())};
       switch (iter.index()) {
       case 0:
       case 1:

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -1143,15 +1143,11 @@ LogicalResult RaiseNDRangeConstructor::Initializers::checkValidity() const {
   const auto checkInit = [=](ArrayRef<Operation *> ops) {
     if (ops.empty())
       return failure();
-    if (ops.size() == dimensions) {
-      if (dimensions == 1)
-        return success();
-      if (llvm::all_of(ops,
-                       [](Operation *op) { return isa<LLVM::StoreOp>(op); }))
-        return success();
+    if (ops.size() == dimensions)
       // When initializing each component, we must be using store operations
-      return failure();
-    }
+      return success(dimensions == 1 || llvm::all_of(ops, [](Operation *op) {
+                       return isa<LLVM::StoreOp>(op);
+                     }));
     // Should be a memcpy
     return success(ops.size() == 1 && isa<LLVM::MemcpyOp>(ops[0]));
   };

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -372,3 +372,155 @@ llvm.func @raise_set_globalsize_offset(%handler: !llvm.ptr) {
   "llvm.intr.var.annotation"(%offset, %offsetStr, %offsetStr, %c0, %nullptr) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
   llvm.return
 }
+
+// -----
+
+// COM: Check we can raise nd_range copy constructor
+
+// CHECK-LABEL:   llvm.func @raise_nd_range_copy(
+// CHECK-SAME:                                   %[[VAL_0:.*]]: !llvm.ptr) {
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+llvm.func @raise_nd_range_copy(%other: !llvm.ptr) {
+  %c1 = llvm.mlir.constant (1 : i32) : i32
+  %false = llvm.mlir.constant (1 : i1) : i1
+  %len = llvm.mlir.constant (24 : i64) : i64
+  %nd = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)>)> : (i32) -> !llvm.ptr
+  "llvm.intr.memcpy"(%nd, %other, %len, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+  llvm.return
+}
+
+// -----
+
+// COM: Check we can raise nd_range constructor using memcpy
+
+// CHECK-LABEL:   llvm.func @raise_nd_range_memcpy(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                     %[[VAL_1:.*]]: !llvm.ptr) {
+// CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:       %[[VAL_4:.*]] = llvm.mlir.constant(true) : i1
+// CHECK-DAG:       %[[VAL_5:.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_nd_range_3_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)>
+// CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_7]], %[[VAL_2]], %[[VAL_5]], %[[VAL_4]]) : (!llvm.ptr, i8, i64, i1) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+llvm.func @raise_nd_range_memcpy(%globalSize: !llvm.ptr, %localSize: !llvm.ptr) {
+  %c0 = llvm.mlir.constant (0 : i8) : i8
+  %c1 = llvm.mlir.constant (1 : i32) : i32
+  %false = llvm.mlir.constant (1 : i1) : i1
+  %len = llvm.mlir.constant (24 : i64) : i64
+  %nd = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)> : (i32) -> !llvm.ptr
+  "llvm.intr.memcpy"(%nd, %globalSize, %len, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+  %ls_ref = llvm.getelementptr inbounds %nd[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)>
+  "llvm.intr.memcpy"(%ls_ref, %localSize, %len, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+  %off_ref = llvm.getelementptr inbounds %nd[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)>
+  "llvm.intr.memset"(%off_ref, %c0, %len, %false) : (!llvm.ptr, i8, i64, i1) -> ()
+  llvm.return
+}
+
+// -----
+
+// COM: Check we can raise nd_range constructor using memcpy and passing an offset
+
+// CHECK-LABEL:   llvm.func @raise_nd_range_memcpy_offset(
+// CHECK-SAME:                                            %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr) {
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_4]], %[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {type = !sycl_nd_range_3_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+llvm.func @raise_nd_range_memcpy_offset(%globalSize: !llvm.ptr, %localSize: !llvm.ptr, %offset: !llvm.ptr) {
+  %c1 = llvm.mlir.constant (1 : i32) : i32
+  %false = llvm.mlir.constant (1 : i1) : i1
+  %len = llvm.mlir.constant (24 : i64) : i64
+  %nd = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)> : (i32) -> !llvm.ptr
+  "llvm.intr.memcpy"(%nd, %globalSize, %len, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+  %ls_ref = llvm.getelementptr inbounds %nd[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)>
+  "llvm.intr.memcpy"(%ls_ref, %localSize, %len, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+  %off_ref = llvm.getelementptr inbounds %nd[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<3 x i64>)>)>)>
+  "llvm.intr.memcpy"(%off_ref, %offset, %len, %false) : (!llvm.ptr, !llvm.ptr, i64, i1) -> ()
+  llvm.return
+}
+
+// -----
+
+// COM: Check we can raise nd_range constructor using stores
+
+// CHECK-LABEL:   llvm.func @raise_nd_range_store(
+// CHECK-SAME:                                    %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64) {
+// CHECK-DAG:       %[[VAL_4:.*]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-DAG:       %[[VAL_5:.*]] = llvm.mlir.constant(true) : i1
+// CHECK-DAG:       %[[VAL_6:.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK-DAG:       %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_11]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+// CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_12]], %[[VAL_4]], %[[VAL_6]], %[[VAL_5]]) : (!llvm.ptr, i8, i64, i1) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+llvm.func @raise_nd_range_store(%g0: i64, %g1: i64, %l0: i64, %l1: i64) {
+  %c0 = llvm.mlir.constant (0 : i8) : i8
+  %false = llvm.mlir.constant (1 : i1) : i1
+  %len = llvm.mlir.constant (24 : i64) : i64
+  %c1 = llvm.mlir.constant (1 : i32) : i32
+  %nd = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+  llvm.store %g0, %nd : i64, !llvm.ptr
+  %g1_ref = llvm.getelementptr inbounds %nd[0, 0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %g1, %g1_ref : i64, !llvm.ptr
+  %l0_ref = llvm.getelementptr inbounds %nd[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %l0, %l0_ref : i64, !llvm.ptr
+  %l1_ref = llvm.getelementptr inbounds %nd[0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %l1, %l1_ref : i64, !llvm.ptr
+  %off_ref = llvm.getelementptr inbounds %nd[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  "llvm.intr.memset"(%off_ref, %c0, %len, %false) : (!llvm.ptr, i8, i64, i1) -> ()
+  llvm.return
+}
+
+// -----
+
+// COM: Check we can raise nd_range constructor using stores and passing an offset
+
+// CHECK-LABEL:   llvm.func @raise_nd_range_store_offset(
+// CHECK-SAME:                                           %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64, %[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64) {
+// CHECK-DAG:       %[[VAL_6:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_11]], %[[VAL_8]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+llvm.func @raise_nd_range_store_offset(%g0: i64, %g1: i64, %l0: i64, %l1: i64, %off0: i64, %off1: i64) {
+  %c1 = llvm.mlir.constant (1 : i32) : i32
+  %nd = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+  llvm.store %g0, %nd : i64, !llvm.ptr
+  %g1_ref = llvm.getelementptr inbounds %nd[0, 0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %g1, %g1_ref : i64, !llvm.ptr
+  %l0_ref = llvm.getelementptr inbounds %nd[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %l0, %l0_ref : i64, !llvm.ptr
+  %l1_ref = llvm.getelementptr inbounds %nd[0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %l1, %l1_ref : i64, !llvm.ptr
+  %off0_ref = llvm.getelementptr inbounds %nd[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %off0, %off0_ref : i64, !llvm.ptr
+  %off1_ref = llvm.getelementptr inbounds %nd[0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  llvm.store %off1, %off1_ref : i64, !llvm.ptr
+  llvm.return
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/failing_host_raising_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/failing_host_raising_constructors.cpp
@@ -1,0 +1,31 @@
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers -w | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers -w | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers -w | FileCheck %s
+// XFAIL: *
+
+// COM: We fail to detect 2-D nd_range constructor as the nd_range allocation is GEPed using an `i8` element type.
+
+// CHECK: sycl.host.constructor({{.*}}) {type = !sycl_nd_range_2_}
+
+#include <sycl/sycl.hpp>
+
+template <typename... Args>
+void keep(Args&&...);
+
+template <int Dimensions>
+void nd_range(sycl::range<Dimensions> globalSize,
+              sycl::range<Dimensions> localSize) {
+  sycl::nd_range<Dimensions> ndr(globalSize, localSize);
+  keep(ndr);
+}
+
+template <int Dimensions>
+void nd_range_offset(sycl::range<Dimensions> globalSize,
+                     sycl::range<Dimensions> localSize,
+                     sycl::id<Dimensions> offset) {
+  sycl::nd_range<Dimensions> ndr(globalSize, localSize, offset);
+  keep(ndr);
+}
+
+template void nd_range(sycl::range<2>, sycl::range<2>);
+template void nd_range_offset(sycl::range<2>, sycl::range<2>, sycl::id<2>);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_constructors.cpp
@@ -1,0 +1,175 @@
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers -w | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers -w | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers -w | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+template <typename... Args>
+void keep(Args&&...);
+
+template <int Dimensions>
+void nd_range(sycl::range<Dimensions> globalSize,
+              sycl::range<Dimensions> localSize) {
+  sycl::nd_range<Dimensions> ndr(globalSize, localSize);
+  keep(ndr);
+}
+
+template <int Dimensions>
+void nd_range_offset(sycl::range<Dimensions> globalSize,
+                     sycl::range<Dimensions> localSize,
+                     sycl::id<Dimensions> offset) {
+  sycl::nd_range<Dimensions> ndr(globalSize, localSize, offset);
+  keep(ndr);
+}
+
+template <int Dimensions>
+void nd_range_copy(const sycl::nd_range<Dimensions> &other) {
+  sycl::nd_range<Dimensions> ndr(other);
+  keep(ndr);
+}
+
+template <int Dimensions>
+void nd_range_move(sycl::nd_range<Dimensions> &&other) {
+  sycl::nd_range<Dimensions> ndr(std::move(other));
+  keep(ndr);
+}
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z8nd_rangeILi1EEvN4sycl3_V15rangeIXT_EEES3_(
+// CHECK-SAME:                                                                     %[[VAL_0:.*]]: i64,
+// CHECK-SAME:                                                                     %[[VAL_1:.*]]: i64)
+// CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[RANGE1:.*]]> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_5]], %[[VAL_0]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[RANGE1]]> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_1]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[ID1:.*]]> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_3]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[ND1:.*]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 24, %[[VAL_8]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_5]], %[[VAL_6]], %[[VAL_7]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi1EEEEEvDpOT_(%[[VAL_8]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 24, %[[VAL_8]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range(sycl::range<1>, sycl::range<1>);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z8nd_rangeILi3EEvN4sycl3_V15rangeIXT_EEES3_(
+// CHECK-SAME:                                                                     %[[VAL_0:.*]]: !llvm.ptr {{{.*}}},
+// CHECK-SAME:                                                                     %[[VAL_1:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(24 : i64) : i64
+// CHECK-DAG:       %[[VAL_4:.*]] = llvm.mlir.constant(false) : i1
+// CHECK-DAG:       %[[VAL_5:.*]] = llvm.mlir.constant(0 : i8) : i8
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[ND3:.*]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 72, %[[VAL_6]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_nd_range_3_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_6]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<[[ND3]]>
+// CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_7]], %[[VAL_5]], %[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, i8, i64, i1) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi3EEEEEvDpOT_(%[[VAL_6]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 72, %[[VAL_6]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range(sycl::range<3>, sycl::range<3>);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z15nd_range_offsetILi1EEvN4sycl3_V15rangeIXT_EEES3_NS1_2idIXT_EEE(
+// CHECK-SAME:                                                                                           %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64)
+// CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[RANGE1]]> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_5]], %[[VAL_0]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[RANGE1]]> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_1]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[ID1]]> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_2]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[ND1]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 24, %[[VAL_8]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_5]], %[[VAL_6]], %[[VAL_7]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi1EEEEEvDpOT_(%[[VAL_8]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 24, %[[VAL_8]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_offset(sycl::range<1>, sycl::range<1>, sycl::id<1>);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z15nd_range_offsetILi3EEvN4sycl3_V15rangeIXT_EEES3_NS1_2idIXT_EEE(
+// CHECK-SAME:                                                                                           %[[VAL_0:.*]]: !llvm.ptr {{{.*}}}, %[[VAL_1:.*]]: !llvm.ptr {{{.*}}}, %[[VAL_2:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[ND3]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 72, %[[VAL_4]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_4]], %[[VAL_0]], %[[VAL_1]], %[[VAL_2]]) {type = !sycl_nd_range_3_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi3EEEEEvDpOT_(%[[VAL_4]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 72, %[[VAL_4]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_offset(sycl::range<3>, sycl::range<3>, sycl::id<3>);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z13nd_range_copyILi1EEvRKN4sycl3_V18nd_rangeIXT_EEE(
+// CHECK-SAME:                                                                             %[[VAL_0:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<[[ND1]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 24, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi1EEEEEvDpOT_(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 24, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_copy(const sycl::nd_range<1> &);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z13nd_range_copyILi2EEvRKN4sycl3_V18nd_rangeIXT_EEE(
+// CHECK-SAME:                                                                             %[[VAL_0:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<[[ND2:.*]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 48, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi2EEEEEvDpOT_(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 48, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_copy(const sycl::nd_range<2> &);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z13nd_range_copyILi3EEvRKN4sycl3_V18nd_rangeIXT_EEE(
+// CHECK-SAME:                                                                             %[[VAL_0:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<[[ND3]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 72, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_3_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi3EEEEEvDpOT_(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 72, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_copy(const sycl::nd_range<3> &);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z13nd_range_moveILi1EEvON4sycl3_V18nd_rangeIXT_EEE(
+// CHECK-SAME:                                                                            %[[VAL_0:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<[[ND1]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 24, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi1EEEEEvDpOT_(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 24, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_move(sycl::nd_range<1> &&);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z13nd_range_moveILi2EEvON4sycl3_V18nd_rangeIXT_EEE(
+// CHECK-SAME:                                                                            %[[VAL_0:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<[[ND2]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 48, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi2EEEEEvDpOT_(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 48, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_move(sycl::nd_range<2> &&);
+
+// CHECK-LABEL:   llvm.func weak_odr @_Z13nd_range_moveILi3EEvON4sycl3_V18nd_rangeIXT_EEE(
+// CHECK-SAME:                                                                            %[[VAL_0:.*]]: !llvm.ptr {{{.*}}})
+// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<[[ND3]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:      llvm.intr.lifetime.start 72, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_2]], %[[VAL_0]]) {type = !sycl_nd_range_3_} : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi3EEEEEvDpOT_(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.intr.lifetime.end 72, %[[VAL_2]] : !llvm.ptr
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+template void nd_range_move(sycl::nd_range<3> &&);


### PR DESCRIPTION
Raise `nd_range` constructor to `sycl.host.constructor`. This may involve allocating each argument of the constructor if the `range` and `id` instances are optimized-away.