### PR TITLE
[SYCL-MLIR] Avoid empty body in accessor raising

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -573,8 +573,13 @@ public:
     // translation from C++ types to MLIR types, which is not available here.
     Type elemTy = LLVM::LLVMVoidType::get(constructor->getContext());
 
-    return sycl::AccessorType::get(constructor.getContext(), elemTy, dimensions,
-                                   accessMode, accessTarget, {});
+    return sycl::AccessorType::get(
+        constructor.getContext(), elemTy, dimensions, accessMode, accessTarget,
+        // On the host, the body type of the accessor currently has no relevance
+        // for the analyses. However, leaving the body types empty leads to
+        // problems when parsing an MLIR file containing such an accessor type
+        // with empty body type list. Therefore, simply put !llvm.void for now.
+        LLVM::LLVMVoidType::get(constructor->getContext()));
   }
 
 private:

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -104,7 +104,8 @@ llvm.func @raise_sub_buffer() -> !llvm.ptr attributes {personality = @__gxx_pers
 
 llvm.func @__gxx_personality_v0(...) -> i32
 
-// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], ()>
+// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
+// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!llvm.void)>
 
 // CHECK-LABEL:   llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32


### PR DESCRIPTION
On the host, the body type of the accessor currently has no relevance for the analyses. However, leaving the body types empty leads to problems when parsing an MLIR file containing such an accessor type with empty body type list. Therefore, simply put `!llvm.void` for now.