### PR TITLE
[SYCL-MLIR] Define `sycl.id.constructor` fold mechanism

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -722,6 +722,7 @@ def SYCLIDConstructorOp : SYCLConstructor<"id"> {
                         ::mlir::MemoryEffects::Effect>> &effects);
   }];
   let hasVerifier = true;
+  let hasFolder = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -11,6 +11,7 @@
 #include "mlir/Dialect/SYCL/IR/SYCLAttributes.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
+#include "mlir/IR/Matchers.h"
 #include "mlir/IR/OpImplementation.h"
 #include "mlir/Support/LLVM.h"
 #include "llvm/ADT/TypeSwitch.h"
@@ -277,6 +278,31 @@ LogicalResult SYCLIDConstructorOp::verify() {
       return checkSameDimensions(*this, type, MT);
   }
   return emitBadSignatureError(*this);
+}
+
+/// Fold:
+/// ```
+/// %c0 = arith.constant 0 : index
+/// sycl.id.constructor(%c0+) : (index+) -> memref<?x!sycl_id_X_>
+/// ```
+/// To:
+/// ```
+/// sycl.id.constructor() : () -> memref<?x!sycl_id_X_>
+/// ```
+OpFoldResult SYCLIDConstructorOp::fold(FoldAdaptor adaptor) {
+  mlir::OperandRange args = getArgs();
+  if (args.empty())
+    // Already dealing with the default constructor
+    return {};
+
+  // Check all arguments are a constant 0
+  auto isZero = m_Zero();
+  if (!llvm::all_of(args, [&](Value arg) { return matchPattern(arg, isZero); }))
+    return {};
+
+  // Erase arguments
+  (*this)->setOperands({});
+  return getId();
 }
 
 LogicalResult SYCLRangeConstructorOp::verify() {

--- a/mlir-sycl/test/Dialect/SYCL/canonicalize.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/canonicalize.mlir
@@ -1,0 +1,14 @@
+// RUN: sycl-mlir-opt %s -canonicalize --split-input-file | FileCheck %s
+
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+
+// CHECK-LABEL:   func.func @id_constructor_use_default() -> memref<?x!sycl_id_3_> {
+// CHECK-NEXT:      %[[VAL_0:.*]] = sycl.id.constructor() : () -> memref<?x!sycl_id_3_>
+// CHECK-NEXT:      return %[[VAL_0]] : memref<?x!sycl_id_3_>
+// CHECK-NEXT:    }
+func.func @id_constructor_use_default() -> memref<?x!sycl_id_3_> {
+  %c0 = arith.constant 0 : index
+  %id = sycl.id.constructor(%c0, %c0, %c0)
+      : (index, index, index) -> memref<?x!sycl_id_3_>
+  func.return %id : memref<?x!sycl_id_3_>
+}


### PR DESCRIPTION
Fold constructors receiving all constant 0 values (`sycl.id.constructor(%c0...) : (index...) -> ...`) to the default constructor (`sycl.id.constructor() : () -> ...`).