### PR TITLE
[PI][UR] Report error from cuInit

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
@@ -73,7 +73,8 @@ urPlatformGet(uint32_t NumEntries, ur_platform_handle_t *phPlatforms,
     std::call_once(
         InitFlag,
         [](ur_result_t &Result) {
-          if (cuInit(0) != CUDA_SUCCESS) {
+          Result = UR_CHECK_ERROR(cuInit(0));
+          if (Result != UR_RESULT_SUCCESS) {
             NumPlatforms = 0;
             return;
           }


### PR DESCRIPTION
Currently if `cuInit` fails while getting platforms it returns UR_RESULT_SUCCESS. Instead we use `UR_CHECK_ERROR` to return the correct error code.