### PR TITLE
[SYCL][PI] Fix piextKernelSetArgPointer

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -2310,12 +2310,10 @@ inline pi_result piProgramRelease(pi_program Program) {
 }
 
 inline pi_result piextKernelSetArgPointer(pi_kernel Kernel, pi_uint32 ArgIndex,
-                                          size_t ArgSize,
-                                          const void *ArgValue) {
+                                          size_t, const void *ArgValue) {
   ur_kernel_handle_t UrKernel = reinterpret_cast<ur_kernel_handle_t>(Kernel);
 
-  HANDLE_ERRORS(
-      urKernelSetArgValue(UrKernel, ArgIndex, ArgSize, nullptr, ArgValue));
+  HANDLE_ERRORS(urKernelSetArgPointer(UrKernel, ArgIndex, nullptr, ArgValue));
 
   return PI_SUCCESS;
 }


### PR DESCRIPTION
Fix piextKernelSetArgPointer to forward the call to the correct UR entrypoint.