### PR TITLE
[NFC][SYCL] Fix DPC++ library "no-assert" build.

### DIFF
--- a/sycl/include/sycl/detail/assert_happened.hpp
+++ b/sycl/include/sycl/detail/assert_happened.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#ifndef NDEBUG
-
 #include <sycl/detail/defines_elementary.hpp>
 
 #include <cstdint>
@@ -44,5 +42,3 @@ struct AssertHappened {
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
-
-#endif // NDEBUG

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 
+#ifndef NDEBUG
 #include <sycl/detail/assert_happened.hpp>
+#endif
 #include <sycl/detail/backend_traits.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/export.hpp>


### PR DESCRIPTION
https://github.com/intel/llvm/pull/10341/ missed the include of
assert_happend.hpp to DPC++ library. We must be able to build user's
applications with enabled assertions and link it with DPC++ library
built with disabled assertions. `AssertHappened` sturct must be defined
for DPC++ library sources to support this use case.
