### PR TITLE
Revert "[NFC][SYCL] Remove assert related code when NDEBUG is set"

### DIFF
--- a/sycl/include/sycl/detail/assert_happened.hpp
+++ b/sycl/include/sycl/detail/assert_happened.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#ifndef NDEBUG
-
 #include <sycl/detail/defines_elementary.hpp>
 
 #include <cstdint>
@@ -44,5 +42,3 @@ struct AssertHappened {
 } // namespace detail
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
-
-#endif // NDEBUG

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -48,7 +48,8 @@
 #endif
 
 // Helper macro to identify if fallback assert is needed
-#if defined(SYCL_FALLBACK_ASSERT) && !defined(NDEBUG)
+// FIXME remove __NVPTX__ condition once devicelib supports CUDA
+#if defined(SYCL_FALLBACK_ASSERT)
 #define __SYCL_USE_FALLBACK_ASSERT SYCL_FALLBACK_ASSERT
 #else
 #define __SYCL_USE_FALLBACK_ASSERT 0
@@ -70,7 +71,7 @@ namespace detail {
 class queue_impl;
 
 #if __SYCL_USE_FALLBACK_ASSERT
-inline event submitAssertCapture(queue &, event &, queue *,
+static event submitAssertCapture(queue &, event &, queue *,
                                  const detail::code_location &);
 #endif
 } // namespace detail
@@ -2256,9 +2257,7 @@ private:
         ext::oneapi::experimental::detail::empty_properties_t{}, Rest...);
   }
 
-#ifndef NDEBUG
   buffer<detail::AssertHappened, 1> &getAssertHappenedBuffer();
-#endif // NDEBUG
 
   event memcpyToDeviceGlobal(void *DeviceGlobalPtr, const void *Src,
                              bool IsDeviceImageScope, size_t NumBytes,
@@ -2284,9 +2283,8 @@ namespace detail {
  * which it gets compiled and exported without any integration header and, thus,
  * with no proper KernelInfo instance.
  */
-inline event submitAssertCapture(queue &Self, event &Event,
-                                 queue *SecondaryQueue,
-                                 const detail::code_location &CodeLoc) {
+event submitAssertCapture(queue &Self, event &Event, queue *SecondaryQueue,
+                          const detail::code_location &CodeLoc) {
   using AHBufT = buffer<detail::AssertHappened, 1>;
 
   AHBufT &Buffer = Self.getAssertHappenedBuffer();

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -629,11 +629,9 @@ public:
   /// \return a native handle.
   pi_native_handle getNative(int32_t &NativeHandleDesc) const;
 
-#ifndef NDEBUG
   buffer<AssertHappened, 1> &getAssertHappenedBuffer() {
     return MAssertHappenedBuffer;
   }
-#endif // NDEBUG
 
   void registerStreamServiceEvent(const EventImplPtr &Event) {
     std::lock_guard<std::mutex> Lock(MMutex);

--- a/sycl/source/queue.cpp
+++ b/sycl/source/queue.cpp
@@ -230,11 +230,9 @@ pi_native_handle queue::getNative(int32_t &NativeHandleDesc) const {
   return impl->getNative(NativeHandleDesc);
 }
 
-#ifndef NDEBUG
 buffer<detail::AssertHappened, 1> &queue::getAssertHappenedBuffer() {
   return impl->getAssertHappenedBuffer();
 }
-#endif // NDEBUG
 
 event queue::memcpyToDeviceGlobal(void *DeviceGlobalPtr, const void *Src,
                                   bool IsDeviceImageScope, size_t NumBytes,


### PR DESCRIPTION
Reverts intel/llvm#10341

This change breaks post-commit checks in no-assertion configuration.
