### PR TITLE
[SYCL][Doc]update design docs for intel_sycl_ptr_annotation builtin

### DIFF
--- a/sycl/doc/design/CompileTimeProperties.md
+++ b/sycl/doc/design/CompileTimeProperties.md
@@ -410,7 +410,7 @@ struct kernel{
 Illustrating this with properties from our previous example:
 
 ```
-struct kernel{
+struct kernel {
   int *ptr
 #ifdef __SYCL_DEVICE_ONLY__
   [[__sycl_detail__::add_ir_annotations_member(

--- a/sycl/doc/design/CompileTimeProperties.md
+++ b/sycl/doc/design/CompileTimeProperties.md
@@ -507,6 +507,7 @@ to perform these optimizations.
 
 
 ## Properties on a non-global pointer type variable
+
 Applying properties on a non-global pointer type variable can be done with
 `__bultin_intel_sycl_ptr_annotation` builtin function. Comparing to
 `add_ir_annotations_member`, this builtin function is more flexible as

--- a/sycl/doc/design/CompileTimeProperties.md
+++ b/sycl/doc/design/CompileTimeProperties.md
@@ -511,8 +511,7 @@ to perform these optimizations.
 Applying properties on a non-global pointer type variable can be done with
 `__bultin_intel_sycl_ptr_annotation` builtin function. Comparing to
 `add_ir_annotations_member`, this builtin function is more flexible as
-it can decorate any pointer variable in the kernel.
-
+it can decorate any pointer variable in a kernel.
 
 An example of this is the proposed `annotated_ptr` class.
 

--- a/sycl/doc/design/CompileTimeProperties.md
+++ b/sycl/doc/design/CompileTimeProperties.md
@@ -508,6 +508,7 @@ to perform these optimizations.
 
 ## Properties on a non-global pointer type variable
 
+
 Applying properties on a non-global pointer type variable can be done with
 `__bultin_intel_sycl_ptr_annotation` builtin function. Comparing to
 `add_ir_annotations_member`, this builtin function is more flexible as

--- a/sycl/doc/design/CompileTimeProperties.md
+++ b/sycl/doc/design/CompileTimeProperties.md
@@ -508,7 +508,10 @@ to perform these optimizations.
 
 ## Properties on a non-global pointer type variable
 Applying properties on a non-global pointer type variable can be done with
-`__bultin_intel_sycl_ptr_annotation` builtin function.
+`__bultin_intel_sycl_ptr_annotation` builtin function. Comparing to
+`add_ir_annotations_member`, this builtin function is more flexible as
+it can decorate any pointer variable in the kernel.
+
 
 An example of this is the proposed `annotated_ptr` class.
 
@@ -536,10 +539,10 @@ void foo(int *p) {
 }
 ```
 
-To precisely control the location we insert the annotation information for the targetted
+To precisely control the location of the annotation information for the targetted
 pointer defereference, We invoke a SYCL builtin in the header.  The builtin
-`__builtin_intel_sycl_ptr_annotation` decorates one of the pointer variables of the
-class, and the parameters to this builtin represent the properties.
+`__builtin_intel_sycl_ptr_annotation` decorates one of the pointer variables,
+and the parameters to this builtin represent the properties.
 
 ```
 namespace sycl::ext::oneapi {


### PR DESCRIPTION
Update the CompileTimeProperties design docs regarding a new builtin function "__builtin_intel_sycl_ptr_annotation "

This the implementation PR https://github.com/intel/llvm/pull/10267