### PR TITLE
[SYCL][NFC] Remove explicit inline when implied.

### DIFF
--- a/sycl/include/std/experimental/simd.hpp
+++ b/sycl/include/std/experimental/simd.hpp
@@ -1589,7 +1589,7 @@ struct __abi_storage_kind : public std::false_type {};
 
 template <_StorageKind _K, int _Np>
 struct __abi_storage_kind<__simd_abi<_K, _Np>> : public std::true_type {
-  static inline constexpr _StorageKind value = _K;
+  static constexpr _StorageKind value = _K;
 };
 
 template <typename _Tp, class _Abi> struct __mask_element {

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -441,7 +441,7 @@ EnableIfGenericBroadcast<T> GroupBroadcast(Group g, T x,
 // Single happens-before means semantics should always apply to all spaces
 // Although consume is unsupported, forwarding to acquire is valid
 template <typename T>
-static inline constexpr
+static constexpr
     typename std::enable_if<std::is_same<T, sycl::memory_order>::value,
                             __spv::MemorySemanticsMask::Flag>::type
     getMemorySemanticsMask(T Order) {
@@ -470,7 +470,7 @@ static inline constexpr
       __spv::MemorySemanticsMask::CrossWorkgroupMemory);
 }
 
-static inline constexpr __spv::Scope::Flag getScope(memory_scope Scope) {
+static constexpr __spv::Scope::Flag getScope(memory_scope Scope) {
   switch (Scope) {
   case memory_scope::work_item:
     return __spv::Scope::Invocation;

--- a/sycl/include/sycl/ext/intel/esimd/detail/bfloat16_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/bfloat16_type_traits.hpp
@@ -30,8 +30,8 @@ template <> struct element_type_traits<bfloat16> {
   // operations to:
   using EnclosingCppT = float;
   // Can't map bfloat16 operations to opertations on RawT:
-  static inline constexpr bool use_native_cpp_ops = false;
-  static inline constexpr bool is_floating_point = true;
+  static constexpr bool use_native_cpp_ops = false;
+  static constexpr bool is_floating_point = true;
 };
 
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/elem_type_traits.hpp
@@ -135,11 +135,11 @@ template <class T, class SFINAE = void> struct element_type_traits {
   using EnclosingCppT = void;
   // Whether a value or clang vector value the raw element type can be used
   // directly as operand to std C++ operations.
-  static inline constexpr bool use_native_cpp_ops = true;
+  static constexpr bool use_native_cpp_ops = true;
   // W/A for MSVC compiler problems which thinks
   // std::is_floating_point_v<_Float16> is false; so require new element types
   // implementations to state "is floating point" trait explicitly
-  static inline constexpr bool is_floating_point = false;
+  static constexpr bool is_floating_point = false;
 };
 
 // Element type traits specialization for C++ standard element type.
@@ -147,8 +147,8 @@ template <class T>
 struct element_type_traits<T, std::enable_if_t<is_vectorizable_v<T>>> {
   using RawT = T;
   using EnclosingCppT = T;
-  static inline constexpr bool use_native_cpp_ops = true;
-  static inline constexpr bool is_floating_point = std::is_floating_point_v<T>;
+  static constexpr bool use_native_cpp_ops = true;
+  static constexpr bool is_floating_point = std::is_floating_point_v<T>;
 };
 
 // ------------------- Useful meta-functions and declarations

--- a/sycl/include/sycl/ext/intel/esimd/detail/half_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/half_type_traits.hpp
@@ -40,14 +40,14 @@ template <> struct element_type_traits<sycl::half> {
 #ifdef __SYCL_DEVICE_ONLY__
   // On device, operations on half are translated to operations on _Float16,
   // which is natively supported by the device compiler
-  static inline constexpr bool use_native_cpp_ops = true;
+  static constexpr bool use_native_cpp_ops = true;
 #else
   // On host, we can't use native Cpp '+', '-' etc. over uint16_t to emulate the
   // operations on half type.
-  static inline constexpr bool use_native_cpp_ops = false;
+  static constexpr bool use_native_cpp_ops = false;
 #endif // __SYCL_DEVICE_ONLY__
 
-  static inline constexpr bool is_floating_point = true;
+  static constexpr bool is_floating_point = true;
 };
 
 // ------------------- Type conversion traits

--- a/sycl/include/sycl/ext/intel/esimd/detail/region.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/region.hpp
@@ -95,20 +95,20 @@ template <typename Ty, int Size, int Stride>
 struct shape_type<region1d_t<Ty, Size, Stride>> {
   using element_type = Ty;
   using type = region1d_t<Ty, Size, Stride>;
-  static inline constexpr int length = type::length;
+  static constexpr int length = type::length;
 };
 
 template <typename Ty> struct shape_type<region1d_scalar_t<Ty>> {
   using element_type = Ty;
   using type = region1d_t<Ty, 1, 1>;
-  static inline constexpr int length = type::length;
+  static constexpr int length = type::length;
 };
 
 template <typename Ty, int SizeY, int StrideY, int SizeX, int StrideX>
 struct shape_type<region2d_t<Ty, SizeY, StrideY, SizeX, StrideX>> {
   using element_type = Ty;
   using type = region2d_t<Ty, SizeY, StrideY, SizeX, StrideX>;
-  static inline constexpr int length = type::length;
+  static constexpr int length = type::length;
 };
 
 // Forward the shape computation on the top region type.

--- a/sycl/include/sycl/ext/intel/esimd/detail/simd_mask_impl.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/simd_mask_impl.hpp
@@ -103,7 +103,7 @@ public:
 
 private:
   /// @cond ESIMD_DETAIL
-  static inline constexpr bool mask_size_ok_for_mem_io() {
+  static constexpr bool mask_size_ok_for_mem_io() {
     constexpr unsigned Sz = sizeof(element_type) * N;
     return (Sz >= OperandSize::OWORD) && (Sz % OperandSize::OWORD == 0) &&
            isPowerOf2(Sz / OperandSize::OWORD) &&

--- a/sycl/include/sycl/ext/intel/esimd/detail/sycl_util.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/sycl_util.hpp
@@ -44,8 +44,8 @@ using accessor_mode_cap_val_t = bool;
 
 // Denotes an accessor's capability - whether it can read or write.
 struct accessor_mode_cap {
-  static inline constexpr accessor_mode_cap_val_t can_read = false;
-  static inline constexpr accessor_mode_cap_val_t can_write = true;
+  static constexpr accessor_mode_cap_val_t can_read = false;
+  static constexpr accessor_mode_cap_val_t can_write = true;
 };
 
 template <sycl::access::mode Mode, accessor_mode_cap_val_t Cap>

--- a/sycl/include/sycl/ext/intel/esimd/detail/tfloat32_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/tfloat32_type_traits.hpp
@@ -28,8 +28,8 @@ template <> struct element_type_traits<tfloat32> {
   using RawT = unsigned int;
   using EnclosingCppT = float;
 
-  static inline constexpr bool use_native_cpp_ops = false;
-  static inline constexpr bool is_floating_point = true;
+  static constexpr bool use_native_cpp_ops = false;
+  static constexpr bool is_floating_point = true;
 };
 
 // ------------------- Type conversion traits

--- a/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types.hpp
@@ -230,23 +230,23 @@ template <typename T> using element_type_t = typename element_type<T>::type;
 // hence can't be used here).
 template <class T> struct simd_like_obj_info {
   using element_type = T;
-  static inline constexpr int vector_length = 0;
+  static constexpr int vector_length = 0;
 };
 
 template <class T, int N> struct simd_like_obj_info<simd<T, N>> {
   using element_type = T;
-  static inline constexpr int vector_length = N;
+  static constexpr int vector_length = N;
 };
 
 template <class T, int N> struct simd_like_obj_info<simd_mask_impl<T, N>> {
   using element_type = simd_mask_elem_type; // equals T
-  static inline constexpr int vector_length = N;
+  static constexpr int vector_length = N;
 };
 
 template <class BaseT, class RegionT>
 struct simd_like_obj_info<simd_view<BaseT, RegionT>> {
   using element_type = typename RegionT::element_type;
-  static inline constexpr int vector_length = RegionT::length;
+  static constexpr int vector_length = RegionT::length;
 };
 
 template <typename T>
@@ -272,7 +272,7 @@ std::enable_if_t<is_clang_vector_type_v<To> && is_clang_vector_type_v<From>, To>
 template <typename ToEltTy, typename FromEltTy, int FromN,
           typename = std::enable_if_t<is_vectorizable<ToEltTy>::value>>
 struct bitcast_helper {
-  static inline constexpr int nToElems() {
+  static constexpr int nToElems() {
     constexpr int R1 = sizeof(ToEltTy) / sizeof(FromEltTy);
     constexpr int R2 = sizeof(FromEltTy) / sizeof(ToEltTy);
     constexpr int ToN = (R2 > 0) ? (FromN * R2) : (FromN / R1);
@@ -323,10 +323,10 @@ private:
   using native_t =
       std::conditional_t<tr<T>::use_native_cpp_ops, typename tr<T>::RawT,
                          typename tr<T>::EnclosingCppT>;
-  static inline constexpr bool is_wr1 = is_wrapper_elem_type_v<T1>;
-  static inline constexpr bool is_wr2 = is_wrapper_elem_type_v<T2>;
-  static inline constexpr bool is_fp1 = is_generic_floating_point_v<T1>;
-  static inline constexpr bool is_fp2 = is_generic_floating_point_v<T2>;
+  static constexpr bool is_wr1 = is_wrapper_elem_type_v<T1>;
+  static constexpr bool is_wr2 = is_wrapper_elem_type_v<T2>;
+  static constexpr bool is_fp1 = is_generic_floating_point_v<T1>;
+  static constexpr bool is_fp2 = is_generic_floating_point_v<T2>;
 
 public:
   using type = std::conditional_t<

--- a/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/types_elementary.hpp
@@ -96,14 +96,14 @@ using vector_type_t = typename raw_vector_type<Ty, N>::type;
 struct invalid_element_type;
 
 template <class T> struct is_clang_vector_type : std::false_type {
-  static inline constexpr int length = 0;
+  static constexpr int length = 0;
   using element_type = invalid_element_type;
 };
 
 template <class T, int N>
 struct is_clang_vector_type<T __attribute__((ext_vector_type(N)))>
     : std::true_type {
-  static inline constexpr int length = N;
+  static constexpr int length = N;
   using element_type = T;
 };
 template <class T>

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -21,10 +21,10 @@ namespace ext::oneapi::experimental {
 namespace detail {
 // Trait for checking that all size_t values are non-zero.
 template <size_t... Xs> struct AllNonZero {
-  static inline constexpr bool value = true;
+  static constexpr bool value = true;
 };
 template <size_t X, size_t... Xs> struct AllNonZero<X, Xs...> {
-  static inline constexpr bool value = X > 0 && AllNonZero<Xs...>::value;
+  static constexpr bool value = X > 0 && AllNonZero<Xs...>::value;
 };
 } // namespace detail
 

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -207,7 +207,7 @@ template <char... Sizes> struct CharList {};
 
 // Helper for converting characters to a constexpr string.
 template <char... Chars> struct CharsToStr {
-  static inline constexpr const char value[] = {Chars..., '\0'};
+  static constexpr const char value[] = {Chars..., '\0'};
 };
 
 // Helper for converting a list of size_t values to a comma-separated string


### PR DESCRIPTION
`inline` is implicitly applied to constexpr functions and constexpr
static data members. This change aims to align the style across the
code, where implied inline is not spelled.
