### PR TITLE
[SYCL][NFC] Clean-up usage of "static inline" functions

### DIFF
--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -190,7 +190,7 @@ namespace __spirv {
     }                                                                          \
   };                                                                           \
                                                                                \
-  template <int Dims, class DstT> static DstT init##POSTFIX() {                \
+  template <int Dims, class DstT> DstT init##POSTFIX() {                       \
     return InitSizesST##POSTFIX<Dims, DstT>::initSize();                       \
   }
 

--- a/sycl/include/sycl/atomic.hpp
+++ b/sycl/include/sycl/atomic.hpp
@@ -79,8 +79,7 @@ namespace detail {
 // Translate sycl::memory_order or __spv::MemorySemanticsMask::Flag
 // into std::memory_order
 // Only relaxed memory semantics are supported currently
-static inline std::memory_order
-getStdMemoryOrder(__spv::MemorySemanticsMask::Flag) {
+inline std::memory_order getStdMemoryOrder(__spv::MemorySemanticsMask::Flag) {
   return std::memory_order_relaxed;
 }
 } // namespace detail

--- a/sycl/include/sycl/atomic_fence.hpp
+++ b/sycl/include/sycl/atomic_fence.hpp
@@ -19,7 +19,7 @@
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
-static inline void atomic_fence(memory_order order, memory_scope scope) {
+inline void atomic_fence(memory_order order, memory_scope scope) {
 #ifdef __SYCL_DEVICE_ONLY__
   auto SPIRVOrder = detail::spirv::getMemorySemanticsMask(order);
   auto SPIRVScope = detail::spirv::getScope(scope);

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -156,7 +156,7 @@ namespace detail {
 
 __SYCL_EXPORT const char *stringifyErrorCode(pi_int32 error);
 
-static inline std::string codeToString(pi_int32 code) {
+inline std::string codeToString(pi_int32 code) {
   return std::string(std::to_string(code) + " (" + stringifyErrorCode(code) +
                      ")");
 }

--- a/sycl/include/sycl/detail/os_util.hpp
+++ b/sycl/include/sycl/detail/os_util.hpp
@@ -72,7 +72,7 @@ public:
   static int makeDir(const char *Dir);
 
   /// Checks if specified path is present
-  static inline bool isPathPresent(const std::string &Path) {
+  static bool isPathPresent(const std::string &Path) {
 #ifdef __SYCL_RT_OS_WINDOWS
     struct _stat Stat;
     return !_stat(Path.c_str(), &Stat);

--- a/sycl/include/sycl/ext/intel/esimd/detail/util.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/util.hpp
@@ -165,7 +165,7 @@ template <> struct word_type<uint> {
 
 // Utility for compile time loop unrolling.
 template <unsigned N> class ForHelper {
-  template <unsigned I, typename Action> static inline void repeat(Action A) {
+  template <unsigned I, typename Action> static void repeat(Action A) {
     if constexpr (I < N)
       A(I);
     if constexpr (I + 1 < N)
@@ -173,7 +173,7 @@ template <unsigned N> class ForHelper {
   }
 
 public:
-  template <typename Action> static inline void unroll(Action A) {
+  template <typename Action> static void unroll(Action A) {
     ForHelper::template repeat<0, Action>(A);
   }
 };

--- a/sycl/include/sycl/group.hpp
+++ b/sycl/include/sycl/group.hpp
@@ -32,7 +32,7 @@ namespace detail {
 class Builder;
 
 // Implements a barrier accross work items within a work group.
-static inline void workGroupBarrier() {
+inline void workGroupBarrier() {
 #ifdef __SYCL_DEVICE_ONLY__
   constexpr uint32_t flags =
       static_cast<uint32_t>(

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1358,7 +1358,7 @@ struct NDRangeReduction<
 };
 
 /// Computes the greatest power-of-two less than or equal to N.
-static inline size_t GreatestPowerOfTwo(size_t N) {
+inline size_t GreatestPowerOfTwo(size_t N) {
   if (N == 0)
     return 0;
 

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -224,7 +224,7 @@ inline unsigned append(char *Dst, const char *Src) {
   return Len;
 }
 
-static inline unsigned F2I32(float Val) {
+inline unsigned F2I32(float Val) {
   union {
     float FVal;
     unsigned I32Val;
@@ -233,7 +233,7 @@ static inline unsigned F2I32(float Val) {
   return Internal.I32Val;
 }
 
-static inline unsigned long long D2I64(double Val) {
+inline unsigned long long D2I64(double Val) {
   union {
     double DVal;
     unsigned long long I64Val;


### PR DESCRIPTION
For member functions inline which are defined in class scope inline is
implicit and can be dropped.
For free functions static causes compiler to duplicate the body of the
function when the function is not inlined and linked with another TU
defining the same function. Using inline in this case allows compiler to
merge definitions from different TU and avoid code bloat.
