### PR TITLE
[SYCL-MLIR] Define `sycl.nd_range.constructor` canonicalization pattern

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -626,6 +626,7 @@ def SYCLNDRangeConstructorOp : SYCLConstructor<"nd_range"> {
                         ::mlir::MemoryEffects::Effect>> &effects);
   }];
   let hasVerifier = true;
+  let hasCanonicalizer = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 
+#include "mlir/Dialect/Affine/IR/AffineOps.h"
 #include "mlir/Dialect/SYCL/IR/SYCLAttributes.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -65,7 +66,7 @@ static bool isDefaultConstructedID(Value id) {
       // sycl.id.get should only be used when returning a scalar
       return !isa<MemRefType>(get.getRes().getType());
     return isa<SYCLNDRangeConstructorOp, SYCLIDConstructorOp, SYCLConstructorOp,
-               memref::LoadOp>(op);
+               affine::AffineLoadOp, memref::LoadOp>(op);
   });
 }
 

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -52,6 +52,61 @@ template <typename Ty> static Ty getMemRefElementType(Type ty) {
   return dyn_cast<Ty>(mt.getElementType());
 }
 
+/// Test \p id is default constructed and it is not modified.
+static bool isDefaultConstructedID(Value id) {
+  // Check it is default constructed
+  auto constructor = id.getDefiningOp<sycl::SYCLIDConstructorOp>();
+  if (!constructor || !constructor.getArgs().empty())
+    return false;
+
+  // Conservatively check it has not been modified after construction
+  return llvm::all_of(id.getUsers(), [=](Operation *op) {
+    if (auto get = dyn_cast<SYCLIDGetOp>(op))
+      // sycl.id.get should only be used when returning a scalar
+      return !isa<MemRefType>(get.getRes().getType());
+    return isa<SYCLNDRangeConstructorOp, SYCLIDConstructorOp, SYCLConstructorOp,
+               memref::LoadOp>(op);
+  });
+}
+
+namespace {
+/// Transform:
+/// ```
+/// %off = sycl.id.constructor() : () -> memref<?x!sycl_id_X_>
+/// sycl.nd_range.constructor(%gs, %ls, %off)
+///   : (memref<?x!sycl_range_X_>,
+///      memref<?x!sycl_range_X_>,
+///      memref<?x!sycl_id_X_>)
+///   -> memref<?x!sycl_nd_range_X_>
+/// ```
+/// To:
+/// ```
+/// sycl.nd_range.constructor(%gs, %ls)
+///   : (memref<?x!sycl_range_X_>, memref<?x!sycl_range_X_>)
+///   -> memref<?x!sycl_nd_range_X_>
+/// ```
+class SYCLNDRangeConstructorEraseDefaultOffset
+    : public OpRewritePattern<SYCLNDRangeConstructorOp> {
+public:
+  using OpRewritePattern<SYCLNDRangeConstructorOp>::OpRewritePattern;
+
+  LogicalResult match(SYCLNDRangeConstructorOp op) const final {
+    OperandRange args = op.getArgs();
+    return success(args.size() == offsetOperandIndex + 1 &&
+                   isDefaultConstructedID(args[offsetOperandIndex]));
+  }
+
+  void rewrite(SYCLNDRangeConstructorOp op,
+               PatternRewriter &rewriter) const final {
+    rewriter.updateRootInPlace(op,
+                               [=] { op->eraseOperand(offsetOperandIndex); });
+  }
+
+private:
+  constexpr static unsigned offsetOperandIndex = 2;
+};
+} // namespace
+
 bool SYCLCastOp::areCastCompatible(TypeRange Inputs, TypeRange Outputs) {
   if (Inputs.size() != 1 || Outputs.size() != 1)
     return false;
@@ -404,6 +459,11 @@ LogicalResult SYCLNDRangeConstructorOp::verify() {
     break;
   }
   return emitBadSignatureError(*this);
+}
+
+void SYCLNDRangeConstructorOp::getCanonicalizationPatterns(
+    RewritePatternSet &patterns, MLIRContext *context) {
+  patterns.add<SYCLNDRangeConstructorEraseDefaultOffset>(context);
 }
 
 void SYCLNDRangeConstructorOp::getEffects(

--- a/mlir-sycl/test/Dialect/SYCL/canonicalize.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/canonicalize.mlir
@@ -12,3 +12,34 @@ func.func @id_constructor_use_default() -> memref<?x!sycl_id_3_> {
       : (index, index, index) -> memref<?x!sycl_id_3_>
   func.return %id : memref<?x!sycl_id_3_>
 }
+
+// -----
+
+!sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
+!sycl_nd_range_3_ = !sycl.nd_range<[3], (!sycl_range_3_, !sycl_range_3_, !sycl_id_3_)>
+
+// CHECK-LABEL:   func.func @nd_constructor_drop_zero_offset(
+// CHECK-SAME:                                               %[[VAL_0:.*]]: memref<?x!sycl_range_3_>,
+// CHECK-SAME:                                               %[[VAL_1:.*]]: memref<?x!sycl_range_3_>) -> (memref<?x!sycl_nd_range_3_>, memref<?x!sycl_id_3_>, i64) {
+// CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 0 : i32
+// CHECK-NEXT:      %[[VAL_3:.*]] = sycl.id.constructor() : () -> memref<?x!sycl_id_3_>
+// CHECK-NEXT:      %[[VAL_4:.*]] = sycl.id.constructor(%[[VAL_3]]) : (memref<?x!sycl_id_3_>) -> memref<?x!sycl_id_3_>
+// CHECK-NEXT:      sycl.constructor @id(%[[VAL_4]], %[[VAL_3]]) {MangledFunctionName = @foo} : (memref<?x!sycl_id_3_>, memref<?x!sycl_id_3_>)
+// CHECK-NEXT:      %[[VAL_5:.*]] = sycl.id.get %[[VAL_3]]{{\[}}%[[VAL_2]]] : (memref<?x!sycl_id_3_>, i32) -> i64
+// CHECK-NEXT:      %[[VAL_6:.*]] = sycl.nd_range.constructor(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_range_3_>, memref<?x!sycl_range_3_>) -> memref<?x!sycl_nd_range_3_>
+// CHECK-NEXT:      return %[[VAL_6]], %[[VAL_4]], %[[VAL_5]] : memref<?x!sycl_nd_range_3_>, memref<?x!sycl_id_3_>, i64
+// CHECK-NEXT:    }
+func.func @nd_constructor_drop_zero_offset(
+    %globalSize: memref<?x!sycl_range_3_>, %localSize: memref<?x!sycl_range_3_>)
+    -> (memref<?x!sycl_nd_range_3_>, memref<?x!sycl_id_3_>, i64) {
+  %c0 = arith.constant 0 : i32
+  %offset = sycl.id.constructor() : () -> memref<?x!sycl_id_3_>
+  %cpy = sycl.id.constructor(%offset) : (memref<?x!sycl_id_3_>) -> memref<?x!sycl_id_3_>
+  sycl.constructor @id(%cpy, %offset) {MangledFunctionName=@foo} : (memref<?x!sycl_id_3_>, memref<?x!sycl_id_3_>)
+  %zero = sycl.id.get %offset[%c0] : (memref<?x!sycl_id_3_>, i32) -> i64
+  %nd = sycl.nd_range.constructor(%globalSize, %localSize, %offset)
+    : (memref<?x!sycl_range_3_>, memref<?x!sycl_range_3_>, memref<?x!sycl_id_3_>)
+    -> memref<?x!sycl_nd_range_3_>
+  func.return %nd, %cpy, %zero : memref<?x!sycl_nd_range_3_>, memref<?x!sycl_id_3_>, i64
+}


### PR DESCRIPTION
Define pattern dropping `offset` argument if it has been default constructed and not modified afterwards, i.e., transform the following pattern:

```mlir
%off = sycl.id.constructor() : () -> memref<?x!sycl_id_X_>
sycl.nd_range.constructor(%gs, %ls, %off)
  : (memref<?x!sycl_range_X_>,
     memref<?x!sycl_range_X_>,
     memref<?x!sycl_id_X_>)
  -> memref<?x!sycl_nd_range_X_>
```

into:

```mlir
sycl.nd_range.constructor(%gs, %ls)
  : (memref<?x!sycl_range_X_>, memref<?x!sycl_range_X_>)
  -> memref<?x!sycl_nd_range_X_>
```