### PR TITLE
[CI] Remove last usage of "cp -r /actions"

### DIFF
--- a/devops/actions/khronos_cts_test/action.yml
+++ b/devops/actions/khronos_cts_test/action.yml
@@ -25,14 +25,17 @@ post-if: false
 runs:
   using: "composite"
   steps:
+  - uses: actions/checkout@v3
+    with:
+      sparse-checkout: |
+        devops/actions
   - run: |
-      cp -r /actions .
       git config --global --add safe.directory /__w/repo_cache/KhronosGroup/SYCL-CTS
     shell: bash
   - run: apt update && apt install -yqq opencl-headers ocl-icd-opencl-dev
     shell: bash
   - name: Checkout SYCL CTS
-    uses: ./actions/cached_checkout
+    uses: ./devops/actions/cached_checkout
     with:
       path: khronos_sycl_cts
       repository: 'KhronosGroup/SYCL-CTS'


### PR DESCRIPTION
Most uses were replaced in https://github.com/intel/llvm/pull/10314 but khronos_ct_test/action.yml was missed because it's not enabled anywhere.