### PR TITLE
[CI] Don't put devops/actions/* into the docker images

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -31,8 +31,6 @@ RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
 RUN usermod -aG video sycl
 RUN usermod -aG irc sycl
 
-COPY actions/cached_checkout /actions/cached_checkout
-COPY actions/cleanup /actions/cleanup
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 
 ENTRYPOINT ["/docker_entrypoint.sh"]


### PR DESCRIPTION
Those are not used after https://github.com/intel/llvm/pull/10314 and https://github.com/intel/llvm/pull/10387.