### PR TITLE
[CI] Use self-hosted runner for containers builds

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -52,7 +52,7 @@ jobs:
 
   ubuntu2204_docker_build_push:
     if: github.repository == 'intel/llvm'
-    runs-on: ubuntu-22.04
+    runs-on: [Linux, build]
     needs: ubuntu2204_build_test
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
Github's runner doesn't have enough space to build nightly.build image.