### PR TITLE
[CI] Don't use LIT_FILTER_OUT in sycl_linux_gen12_exp.yml

### DIFF
--- a/.github/workflows/sycl_linux_gen12_exp.yml
+++ b/.github/workflows/sycl_linux_gen12_exp.yml
@@ -1,13 +1,11 @@
 name: Experiment with Linux GEN12 runners
-run-name: Linux GEN12 ${{ inputs.lit_filter }} / no ${{ inputs.lit_filter_out}} on ${{ inputs.devices }}
+run-name: Linux GEN12 ${{ inputs.env }} on ${{ inputs.devices }}
 
 on:
   workflow_dispatch:
     inputs:
-      lit_filter:
-        required: false
-      lit_filter_out:
-        required: false
+      env:
+        default: '{"LIT_FILTER":""}'
       devices:
         default: 'ext_oneapi_level_zero:gpu'
 
@@ -22,4 +20,4 @@ jobs:
       target_devices: ${{ inputs.devices }}
       ref: ${{ github.sha }}
 
-      env: '{"LIT_FILTER":"${{ inputs.lit_filter }}","LIT_FILTER_OUT":"${{ inputs.lit_filter_out }}"}'
+      env: ${{ inputs.env }}


### PR DESCRIPTION
Empty value in the variable matches everything and results in no tests being run. Instead, change the input parameter to `env` and use default value to make its update easier.