### PR TITLE
[SYCL][NFC] Add missing climits include

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -15,6 +15,8 @@
 #include <sycl/id.hpp>
 #include <sycl/marray.hpp>
 
+#include <climits>
+
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {


### PR DESCRIPTION
sub_group_mask.hpp uses CHAR_BIT defined in climits header
