### PR TITLE
[SYCL][NFC] Don't include the whole mp11 library

### DIFF
--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -10,7 +10,7 @@
 
 #include <sycl/detail/property_helper.hpp>
 #include <sycl/ext/oneapi/properties/property.hpp>
-#include <sycl/detail/boost/mp11.hpp>
+#include <sycl/detail/boost/mp11/algorithm.hpp>
 
 #include <tuple>
 

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include <sycl/detail/boost/mp11/algorithm.hpp>
 #include <sycl/detail/property_helper.hpp>
 #include <sycl/ext/oneapi/properties/property.hpp>
-#include <sycl/detail/boost/mp11/algorithm.hpp>
 
 #include <tuple>
 


### PR DESCRIPTION
Include only what you use i.e. algorithm in our case.
