### PR TITLE
[SYCL][NFC] Define function in a header as inline

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -71,7 +71,7 @@ namespace detail {
 class queue_impl;
 
 #if __SYCL_USE_FALLBACK_ASSERT
-static event submitAssertCapture(queue &, event &, queue *,
+inline event submitAssertCapture(queue &, event &, queue *,
                                  const detail::code_location &);
 #endif
 } // namespace detail


### PR DESCRIPTION
To comply ODR.
