### PR TITLE
[SPIR-V][OpaquePointers] Temporary workaround for IGC issue.

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVRegularizeLLVM.cpp
@@ -359,10 +359,73 @@ bool SPIRVRegularizeLLVMBase::runRegularizeLLVM(Module &Module) {
   return true;
 }
 
+// This is a temporary workaround to deal with a graphics driver failure not
+// able to support the typed pointer reverse translation of
+// getelementptr i8, ptr @__spirv_Builtin* patterns. This replaces such
+// accesses with getelementptr i32, ptr @__spirv_Builtin instead.
+static void simplifyBuiltinVarAccesses(GlobalValue *GV) {
+  // IGC only supports:
+  // load GV
+  // load (addrspacecast GV)
+  // load (gep (addrspacecast GV))
+  // load (gep GV)
+  // Opaque pointers will cause the optimizer to use i8 geps, or to remove
+  // 0-index geps entirely (adding bitcasts to the result). Restore these to
+  // avoid bitcasts in the resulting IR.
+  if (GV->getContext().supportsTypedPointers())
+    return;
+
+  Type *Ty = GV->getValueType();
+  Type *ScalarTy = Ty->getScalarType();
+  SmallVector<Value *, 4> Users;
+  for (auto User : GV->users()) {
+    if (auto *LI = dyn_cast<LoadInst>(User)) {
+      if (LI->getType() != Ty)
+        Users.push_back(LI);
+    } else if (auto *GEP = dyn_cast<GEPOperator>(User)) {
+      if (GEP->getSourceElementType() != Ty)
+        Users.push_back(GEP);
+    }
+  }
+
+  Type *Int32Ty = Type::getInt32Ty(GV->getContext());
+  auto GetGep = [&](unsigned Offset) {
+    return ConstantExpr::getGetElementPtr(
+        Ty, GV,
+        ArrayRef<Constant *>(
+            {ConstantInt::get(Int32Ty, 0), ConstantInt::get(Int32Ty, Offset)}),
+        true, 0);
+  };
+
+  const DataLayout &DL = GV->getParent()->getDataLayout();
+  for (auto *User : Users) {
+    if (auto *LI = dyn_cast<LoadInst>(User)) {
+      LI->setOperand(0, GetGep(0));
+    } else if (auto *GEP = dyn_cast<GEPOperator>(User)) {
+      APInt Offset(64, 0);
+      GEP->accumulateConstantOffset(DL, Offset);
+      APInt Index;
+      uint64_t Remainder;
+      APInt::udivrem(Offset, ScalarTy->getScalarSizeInBits() / 8, Index,
+                     Remainder);
+      assert(Remainder == 0 && "Cannot handle misaligned access to builtins");
+      GEP->replaceAllUsesWith(GetGep(Index.getZExtValue()));
+      if (auto *Inst = dyn_cast<Instruction>(GEP))
+        Inst->eraseFromParent();
+    }
+  }
+}
+
 /// Remove entities not representable by SPIR-V
 bool SPIRVRegularizeLLVMBase::regularize() {
   eraseUselessFunctions(M);
   expandSYCLTypeUsing(M);
+
+  for (auto &GV : M->globals()) {
+    SPIRVBuiltinVariableKind Kind;
+    if (isSPIRVBuiltinVariable(&GV, &Kind))
+      simplifyBuiltinVarAccesses(&GV);
+  }
 
   for (auto I = M->begin(), E = M->end(); I != E;) {
     Function *F = &(*I++);


### PR DESCRIPTION
IGC has some issues with reverse translation of SPIR-V builtins resulting from code compiled with opaque pointers enabled. To enable opaque pointers to be enabled for offloaded code before the new driver version is propagated to CI, this change is temporarily necessary to ensure we have test coverage.