### PR TITLE
[SYCL-MLIR] Detect accessor range and offset

### DIFF
--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -105,25 +105,31 @@ llvm.func @raise_sub_buffer() -> !llvm.ptr attributes {personality = @__gxx_pers
 llvm.func @__gxx_personality_v0(...) -> i32
 
 // CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
-// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!llvm.void)>
+// CHECK:       !sycl_id_1_ = !sycl.id<[1], (!llvm.void)>
+// CHECK:       !sycl_range_1_ = !sycl.range<[1], (!llvm.void)>
+// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
 
 // CHECK-LABEL:   llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
-// CHECK:           %[[VAL_1:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor.5", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK:           sycl.host.constructor(%[[VAL_2]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           %[[VAL_1:.*]] = arith.constant 128 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 64 : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_6:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_7:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor.5", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK:           sycl.host.constructor(%[[VAL_4]], %[[VAL_3]], %[[VAL_5]], %[[VAL_6]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           sycl.host.constructor(%[[VAL_5]], %[[VAL_1]], %[[VAL_3]], %[[VAL_4]]) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_3]], %[[VAL_1]], %[[VAL_2]], %[[VAL_5]], %[[VAL_6]]) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb2
 // CHECK:         ^bb2:
-// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr
+// CHECK:           llvm.return %[[VAL_3]] : !llvm.ptr
 // CHECK:         }
 llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
   %0 = arith.constant 1 : i32
+  %range = arith.constant 128 : i64
+  %offset = arith.constant 64 : i64
   %1 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %2 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %0 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
@@ -136,7 +142,7 @@ llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_person
   %lp = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
   llvm.resume %lp : !llvm.struct<(ptr, i32)>
 ^bb1:
-  llvm.invoke @_ZN4sycl3_V18accessorIfLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2IfLi1ENS0_6detail17aligned_allocatorIfEEvEERNS0_6bufferIT_XT0_ET1_NSt9enable_ifIXaagtT0_Li0EleT0_Li3EEvE4typeEEERNS0_7handlerERKNS0_13property_listENSC_13code_locationE(%5, %1, %3, %4) to ^bb3 unwind ^bb2 : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.invoke @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE1ENS0_3ext6oneapi22accessor_property_listIJEEEEC2IiLi1ENS0_6detail17aligned_allocatorIiEEvEERNS0_6bufferIT_XT0_ET1_NSt9enable_ifIXaagtT0_Li0EleT0_Li3EEvE4typeEEENS0_5rangeILi1EEENS0_2idILi1EEERKNS0_13property_listENSC_13code_locationE(%5, %1, %range, %offset, %3, %4) to ^bb3 unwind ^bb2 : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
 ^bb2:
   %lp1 = llvm.landingpad cleanup : !llvm.struct<(ptr, i32)>
   llvm.resume %lp1 : !llvm.struct<(ptr, i32)>


### PR DESCRIPTION
During raising of the host code, detect whether a constructed accessor requires the range and offset parameter.