### PR TITLE
[SYCL][E2E] Disable a test that causes hangs on Linux GEN12

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp
@@ -1,4 +1,7 @@
-// Check that full compilation works:
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
+ // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../call_vadd_1d_loop_naive.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp
@@ -1,7 +1,7 @@
 // https://github.com/intel/llvm/issues/10369
 // UNSUPPORTED: gpu
 //
- // Check that full compilation works:
+// Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../call_vadd_1d_loop_naive.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //


### PR DESCRIPTION
Follow-up for #10409 that disabled
InvokeSimd/Regression//call_vadd_1d_loop_naive.cpp but missed InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp.

See also https://github.com/intel/llvm/issues/10369.