### PR TITLE
[SYCL][E2E] Disable tests that fail on Linux GEN12 runners

### DIFF
--- a/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/api/replicate_smoke.cpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
 // UNSUPPORTED: gpu-intel-pvc
 // TODO: remove fno-fast-math option once the issue is investigated and the test
 // is fixed.

--- a/sycl/test-e2e/ESIMD/local_accessor_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_block_load_store.cpp
@@ -8,6 +8,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
 // TODO: Enable the test when GPU driver is ready/fixed.
 // XFAIL: opencl || windows || gpu-intel-pvc
 // TODO: add support for local_accessors to esimd_emulator.

--- a/sycl/test-e2e/ESIMD/local_accessor_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_gather_scatter.cpp
@@ -8,6 +8,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
 // TODO: Enable the test when GPU driver is ready/fixed.
 // XFAIL: opencl || windows || gpu-intel-pvc
 // TODO: add support for local_accessors to esimd_emulator.

--- a/sycl/test-e2e/ESIMD/local_accessor_gather_scatter_rgba.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_gather_scatter_rgba.cpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // TODO: Enable the test when GPU driver is ready/fixed.

--- a/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
 // UNSUPPORTED: cuda, hip
 // REQUIRES: gpu,linux
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Regression/commandlist/gpu.cpp
+++ b/sycl/test-e2e/Regression/commandlist/gpu.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/10369
+// UNSUPPORTED: gpu
+//
 // REQUIRES: gpu, linux
 
 // UNSUPPORTED: ze_debug


### PR DESCRIPTION
See also https://github.com/intel/llvm/issues/10369.