### PR TITLE
[SYCL] Update validation of annotated_arg/annotated_ptr parameterization

### DIFF
--- a/sycl/include/sycl/ext/oneapi/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/annotated_arg/annotated_arg.hpp
@@ -76,6 +76,9 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
 public:
   static_assert(is_property_list<property_list_t>::value,
                 "Property list is invalid.");
+  static_assert(
+      validate_annotated_type<annotated_arg<T *, property_list_t>>::value,
+      "The property list contains invalid property.");
 
   annotated_arg() noexcept = default;
   annotated_arg(const annotated_arg &) = default;
@@ -178,8 +181,9 @@ public:
   static_assert(is_device_copyable_v<T>, "Type T must be device copyable.");
   static_assert(is_property_list<property_list_t>::value,
                 "Property list is invalid.");
-  static_assert(check_property_list<T, Props...>::value,
-                "The property list contains invalid property.");
+  static_assert(
+      validate_annotated_type<annotated_arg<T, property_list_t>>::value,
+      "The property list contains invalid property.");
 
   annotated_arg() noexcept = default;
   annotated_arg(const annotated_arg &) = default;

--- a/sycl/include/sycl/ext/oneapi/annotated_arg/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/annotated_arg/annotated_ptr.hpp
@@ -121,6 +121,9 @@ __SYCL_TYPE(annotated_ptr) annotated_ptr<T, detail::properties_t<Props...>> {
 public:
   static_assert(is_property_list<property_list_t>::value,
                 "Property list is invalid.");
+  static_assert(
+      validate_annotated_type<annotated_ptr<T, property_list_t>>::value,
+      "The property list contains invalid property.");
 
   annotated_ptr() noexcept = default;
   annotated_ptr(const annotated_ptr &) = default;


### PR DESCRIPTION
Update the validation of annotated_arg/annotated_pointer type parameterization as follows.  Given a parameterized `annotated_arg<T, PropertyList>` or `annotated_arg<T, PropertyList>`, validate the type from two aspects:
1.  For a given `T`, pointer-specific properties are not allowed if **T** is not pointer.  E.g., `buffer_location<N>` is not applicable for non pointers.
2.  For annotated_arg/annotated_ptr, each of them has its specific properties. E.g.  `alignment<N>` is only supported for anntoated_ptr,  while `restrict` is only supported for annotated_arg.  Therefore this PR each property in `PropertyList` must be supported for annotated_arg (or anntoated_ptr)