### PR TITLE
[CI] Treat PRs touching 500+ files as changing everything

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: [Linux, build]
     timeout-minutes: 3
     outputs:
-      filters: ${{ steps.changes.outputs.changes }}
+      filters: ${{ steps.result.outputs.result }}
     steps:
       - name: Check file changes
         uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50
@@ -59,3 +59,18 @@ jobs:
               - *drivers_and_configs
               # Temporary, until plugins are enabled in nightly image.
               - sycl/**
+
+      - name: Set output
+        id: result
+        uses: actions/github-script@v6
+        with:
+          script: |
+            console.log("Number of files changed:");
+            console.log(context.payload.pull_request.changed_files);
+            if (context.payload.pull_request.changed_files < 500) {
+              return '${{ steps.changes.outputs.changes }}';
+            }
+            // Treat everything as changed for huge PRs.
+            return ["llvm", "llvm_spirv", "clang", "sycl_fusion", "xptifw", "libclc", "sycl", "ci", "drivers_and_configs", "test_build"];
+
+      - run: echo '${{ steps.result.outputs.result }}'


### PR DESCRIPTION
Github APIs used by dorny/paths-filter limit the list of changed files so we can't reliable detect the changes when many files are changed. As such, treat those as changing everything. Note that 500 is much less than GH's limit which is around 3000.