### PR TITLE
[CI] Allow llvmspirv_pulldown branch in pre-/post-commit triggers

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - sycl
     - sycl-devops-pr/**
+    - llvmspirv_pulldown
 
 jobs:
   # This job generates matrix of tests for SYCL End-to-End tests

--- a/.github/workflows/sycl_precommit_windows.yml
+++ b/.github/workflows/sycl_precommit_windows.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - sycl
     - sycl-devops-pr/**
+    - llvmspirv_pulldown
     # Do not run builds if changes are only in the following locations
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
For post-commit it would start the entire task whenever the branch is updated. For windows pre-commit it would allow the temporary workaround of creating a fake PR into that branch to trigger Windows pre-commit task (same as was done in #10434)

SYCL Nightly doesn't have "push:" trigger and it has a bug with pushing the containers even for branches that aren't "origin/sycl" so not changing it for now.