### PR TITLE
[SYCL][NFC] Clean-up includes in DPC++ headers

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -7,13 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+
 #include <CL/__spirv/spirv_types.hpp>
-#include <complex>
-#include <cstddef>
-#include <cstdint>
-#include <sycl/detail/defines.hpp>
+#include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/export.hpp>
-#include <sycl/detail/stl_type_traits.hpp>
 
 // Convergent attribute
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/CL/__spirv/spirv_types.hpp
+++ b/sycl/include/CL/__spirv/spirv_types.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include "sycl/half_type.hpp"
-#include <sycl/detail/defines.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/half_type.hpp>
 

--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -11,10 +11,6 @@
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
 
-#include <fstream>
-#include <istream>
-#include <string>
-
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -19,7 +19,6 @@
 #include <sycl/ext/oneapi/weak_object_base.hpp>
 #include <sycl/info/info_desc.hpp>
 #include <sycl/property_list.hpp>
-#include <sycl/stl.hpp>
 
 // 4.6.2 Context class
 

--- a/sycl/include/sycl/detail/aligned_allocator.hpp
+++ b/sycl/include/sycl/detail/aligned_allocator.hpp
@@ -11,11 +11,9 @@
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/os_util.hpp>
 
-#include <cstdlib>
-#include <cstring>
+#include <limits>
 #include <memory>
-#include <type_traits>
-#include <vector>
+#include <new>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -8,13 +8,13 @@
 
 #pragma once
 
-#include <sycl/detail/defines.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/export.hpp>
-#include <sycl/detail/pi.hpp>
-#include <sycl/detail/stl_type_traits.hpp>
+#include <sycl/detail/pi.h> // for pi_int32
 
-#include <cstdint>
+#include <array>
+#include <cassert>
+#include <memory>
 #include <string>
 
 // Default signature enables the passing of user code location information to

--- a/sycl/include/sycl/detail/common_info.hpp
+++ b/sycl/include/sycl/detail/common_info.hpp
@@ -8,7 +8,9 @@
 
 #pragma once
 #include <sycl/detail/export.hpp>
-#include <sycl/stl.hpp>
+
+#include <string>
+#include <vector>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/detail/util.hpp
+++ b/sycl/include/sycl/detail/util.hpp
@@ -11,10 +11,10 @@
 #ifndef __SYCL_DEVICE_ONLY
 
 #include <sycl/detail/defines.hpp>
-#include <sycl/stl.hpp>
 
 #include <cstring>
 #include <mutex>
+#include <vector>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -19,7 +19,6 @@
 #include <sycl/ext/oneapi/weak_object_base.hpp>
 #include <sycl/info/info_desc.hpp>
 #include <sycl/platform.hpp>
-#include <sycl/stl.hpp>
 
 #include <memory>
 #include <utility>

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -11,6 +11,7 @@
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
 
+#include <functional>
 #include <vector>
 
 // 4.6.1 Device selection class
@@ -20,6 +21,7 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
 // Forward declarations
 class device;
+enum class aspect;
 
 namespace ext::oneapi {
 class filter_selector;

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -16,7 +16,6 @@
 #include <sycl/detail/owner_less_base.hpp>
 #include <sycl/ext/oneapi/weak_object_base.hpp>
 #include <sycl/info/info_desc.hpp>
-#include <sycl/stl.hpp>
 
 #include <memory>
 

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -15,7 +15,6 @@
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/pi.h>
-#include <sycl/stl.hpp>
 
 #include <exception>
 

--- a/sycl/include/sycl/exception_list.hpp
+++ b/sycl/include/sycl/exception_list.hpp
@@ -13,9 +13,10 @@
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
-#include <sycl/stl.hpp>
 
 #include <cstddef>
+#include <functional>
+#include <vector>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -8,12 +8,13 @@
 
 #pragma once
 
-#include <memory>
-#include <vector>
-
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/property_list.hpp>
+
+#include <functional>
+#include <memory>
+#include <vector>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
@@ -11,6 +11,7 @@
 #if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 #include <sycl/detail/group_sort_impl.hpp>
 #include <sycl/ext/oneapi/experimental/builtins.hpp>
+#include <sycl/sycl_span.hpp>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -34,7 +34,6 @@
 #include <sycl/nd_range.hpp>
 #include <sycl/property_list.hpp>
 #include <sycl/sampler.hpp>
-#include <sycl/stl.hpp>
 #include <sycl/usm/usm_pointer_info.hpp>
 #ifdef __SYCL_NATIVE_CPU__
 #include <sycl/detail/native_cpu.hpp>

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -17,7 +17,6 @@
 #include <sycl/ext/oneapi/weak_object_base.hpp>
 #include <sycl/info/info_desc.hpp>
 #include <sycl/kernel_bundle_enums.hpp>
-#include <sycl/stl.hpp>
 
 #include <memory>
 

--- a/sycl/include/sycl/platform.hpp
+++ b/sycl/include/sycl/platform.hpp
@@ -17,10 +17,9 @@
 #include <sycl/detail/owner_less_base.hpp>
 #include <sycl/device_selector.hpp>
 #include <sycl/ext/oneapi/weak_object_base.hpp>
-#include <sycl/stl.hpp>
 
-// 4.6.2 Platform class
 #include <utility>
+
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 // TODO: make code thread-safe

--- a/sycl/include/sycl/properties/buffer_properties.hpp
+++ b/sycl/include/sycl/properties/buffer_properties.hpp
@@ -12,6 +12,8 @@
 #include <sycl/detail/property_helper.hpp>
 #include <sycl/properties/property_traits.hpp>
 
+#include <mutex>
+
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -9,31 +9,11 @@
 #pragma once
 
 #include <sycl/detail/assert_happened.hpp>
-#include <sycl/detail/backend_traits.hpp>
 #include <sycl/detail/common.hpp>
-#include <sycl/detail/export.hpp>
-#include <sycl/detail/info_desc_helpers.hpp>
-#include <sycl/detail/owner_less_base.hpp>
 #include <sycl/detail/service_kernel_names.hpp>
-#include <sycl/device.hpp>
 #include <sycl/device_selector.hpp>
-#include <sycl/event.hpp>
-#include <sycl/exception.hpp>
-#include <sycl/exception_list.hpp>
-#include <sycl/ext/oneapi/device_global/device_global.hpp>
-#include <sycl/ext/oneapi/weak_object_base.hpp>
 #include <sycl/handler.hpp>
-#include <sycl/info/info_desc.hpp>
 #include <sycl/property_list.hpp>
-#include <sycl/stl.hpp>
-
-// Explicitly request format macros
-#ifndef __STDC_FORMAT_MACROS
-#define __STDC_FORMAT_MACROS 1
-#endif
-#include <cinttypes>
-#include <type_traits>
-#include <utility>
 
 // having _TWO_ mid-param #ifdefs makes the functions very difficult to read.
 // Here we simplify the KernelFunc param is simplified to be
@@ -61,6 +41,7 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 // Forward declaration
 class context;
 class device;
+class event;
 class queue;
 
 template <backend BackendName, class SyclObjectT>
@@ -2282,8 +2263,29 @@ private:
                                const std::vector<event> &DepEvents);
 };
 
-namespace detail {
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl
+
+namespace std {
+template <> struct hash<sycl::queue> {
+  size_t operator()(const sycl::queue &Q) const {
+    return std::hash<std::shared_ptr<sycl::detail::queue_impl>>()(
+        sycl::detail::getSyclObjImpl(Q));
+  }
+};
+} // namespace std
+
 #if __SYCL_USE_FALLBACK_ASSERT
+// Explicitly request format macros
+#ifndef __STDC_FORMAT_MACROS
+#define __STDC_FORMAT_MACROS 1
+#endif
+#include <cinttypes>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+
+namespace detail {
 #define __SYCL_ASSERT_START 1
 /**
  * Submit copy task for assert failure flag and host-task to check the flag
@@ -2363,19 +2365,10 @@ event submitAssertCapture(queue &Self, event &Event, queue *SecondaryQueue,
   return CheckerEv;
 }
 #undef __SYCL_ASSERT_START
-#endif // __SYCL_USE_FALLBACK_ASSERT
 } // namespace detail
 
 } // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl
-
-namespace std {
-template <> struct hash<sycl::queue> {
-  size_t operator()(const sycl::queue &Q) const {
-    return std::hash<std::shared_ptr<sycl::detail::queue_impl>>()(
-        sycl::detail::getSyclObjImpl(Q));
-  }
-};
-} // namespace std
+#endif // __SYCL_USE_FALLBACK_ASSERT
 
 #undef __SYCL_USE_FALLBACK_ASSERT

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -20,6 +20,7 @@
 #include <sycl/kernel.hpp>
 #include <sycl/known_identity.hpp>
 #include <sycl/properties/reduction_properties.hpp>
+#include <sycl/sycl_span.hpp>
 #include <sycl/usm.hpp>
 
 #include <optional>

--- a/sycl/include/sycl/stl.hpp
+++ b/sycl/include/sycl/stl.hpp
@@ -10,17 +10,9 @@
 
 // 4.5 C++ Standard library classes required for the interface
 
-#include <sycl/bit_cast.hpp>
-#include <sycl/detail/defines.hpp>
-#include <sycl/sycl_span.hpp>
+#include <sycl/detail/defines_elementary.hpp>
 
-#include <exception>
-#include <functional>
 #include <memory>
-#include <mutex>
-#include <string>
-#include <string_view>
-#include <vector>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/source/detail/os_util.cpp
+++ b/sycl/source/detail/os_util.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 #include <sycl/detail/os_util.hpp>
-#include <sycl/exception.hpp>
 
 #include <cassert>
+#include <limits>
 
 #if defined(__SYCL_RT_OS_LINUX)
 

--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -12,6 +12,7 @@
 #include <detail/program_manager/program_manager.hpp>
 
 #include <cstdio>
+#include <fstream>
 #include <optional>
 
 #if defined(__SYCL_RT_OS_POSIX_SUPPORT)

--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -13,6 +13,7 @@
 #include <sycl/detail/export.hpp>
 #include <sycl/property_list.hpp>
 
+#include <mutex>
 #include <unordered_map>
 
 namespace sycl {

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -9,6 +9,7 @@
 #include <detail/config.hpp>
 #include <gtest/gtest.h>
 #include <regex>
+#include <fstream>
 
 TEST(ConfigTests, CheckConfigProcessing) {
 #ifdef _WIN32

--- a/sycl/unittests/config/ConfigTests.cpp
+++ b/sycl/unittests/config/ConfigTests.cpp
@@ -7,9 +7,11 @@
 //===----------------------------------------------------------------------===//
 
 #include <detail/config.hpp>
+
 #include <gtest/gtest.h>
-#include <regex>
+
 #include <fstream>
+#include <regex>
 
 TEST(ConfigTests, CheckConfigProcessing) {
 #ifdef _WIN32

--- a/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
+++ b/sycl/unittests/kernel-and-program/PersistentDeviceCodeCache.cpp
@@ -9,14 +9,16 @@
 // Detailed description of the tests cases can be seen per test function.
 #include "../thread_safety/ThreadUtils.h"
 #include "detail/persistent_device_code_cache.hpp"
-#include <cstdio>
 #include <detail/device_binary_image.hpp>
 #include <gtest/gtest.h>
 #include <helpers/PiMock.hpp>
 #include <llvm/Support/FileSystem.h>
-#include <optional>
 #include <sycl/detail/os_util.hpp>
 #include <sycl/sycl.hpp>
+
+#include <cstdio>
+#include <fstream>
+#include <optional>
 #include <vector>
 
 #define ASSERT_NO_ERROR(x)                                                     \


### PR DESCRIPTION
I tried to remove as much as possible unnecessary includes from sycl/queue.hpp. While I was looking at the headers included into queue.hpp, I cleaned-up their includes as well. For instance, I noticed that we abuse stl.hpp file, which is intended to extend STL functionality rather than to be a common file to include a bunch of STL headers.

Another thing we should do in the future is to re-organize the "info descriptors" header, which today includes descriptors for all SYCL classes. For instance, there is not possible to include only device info descriptors. 