### PR TITLE
[CI] Remove support for running E2E tests on nightly builds

### DIFF
--- a/.github/workflows/sycl_precommit_linux.yml
+++ b/.github/workflows/sycl_precommit_linux.yml
@@ -77,7 +77,6 @@ jobs:
     if: |
       always()
       && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
-      && contains(needs.detect_changes.outputs.filters, 'test_build')
       && !contains(needs.detect_changes.outputs.filters, 'ci')
     uses: ./.github/workflows/sycl_linux_build_and_test.yml
     secrets: inherit
@@ -91,14 +90,3 @@ jobs:
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
       check_filters: ${{ needs.detect_changes.outputs.filters }}
-
-  linux_e2e_on_nightly:
-    name: Linux SYCL E2E on Nightly
-    needs: [detect_changes]
-    if: |
-      !contains(needs.detect_changes.outputs.filters, 'test_build')
-      && !contains(needs.detect_changes.outputs.filters, 'ci')
-    uses: ./.github/workflows/linux_matrix_e2e_on_nightly.yml
-    secrets: inherit
-    with:
-      ref: ${{ github.event.pull_request.head.sha }}


### PR DESCRIPTION
It has to be opt-in and the feature needs redesign.