### PR TITLE
[GHA] Uplift Linux GPU RT version to 23.22.26516.18

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "23.17.26241.22",
-      "version": "23.17.26241.22",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/23.17.26241.22",
+      "github_tag": "23.22.26516.18",
+      "version": "23.22.26516.18",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/23.22.26516.18",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.13822.6",
-      "version": "1.0.13822.6",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.13822.6",
+      "github_tag": "igc-1.0.14062.11",
+      "version": "1.0.14062.11",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.14062.11",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.12.0",
-      "version": "v1.12.0",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.12.0",
+      "github_tag": "v1.13.1",
+      "version": "v1.13.1",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.13.1",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Scheduled drivers uplift