### PR TITLE
[SYCL][CUDA] Fix device creation from native handle

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -1090,7 +1090,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
   // We can't cast between ur_native_handle_t and CUdevice, so memcpy the bits
   // instead
   CUdevice CuDevice = 0;
-  memcpy(&CuDevice, hNativeDevice, sizeof(CUdevice));
+  memcpy(&CuDevice, &hNativeDevice, sizeof(CUdevice));
 
   auto IsDevice = [=](std::unique_ptr<ur_device_handle_t_> &Dev) {
     return Dev->get() == CuDevice;


### PR DESCRIPTION
In CUDA objects are represented as integers rather than opaque handles.
This patch fixes a segmentation fault when creating a device handle from
a native handle by avoiding dereferencing a pointer which should be
treated as an integer.
