### PR TITLE
[SYCL][NFC] Refactor includes in DPC++ headers

### DIFF
--- a/sycl/include/sycl/async_handler.hpp
+++ b/sycl/include/sycl/async_handler.hpp
@@ -1,4 +1,4 @@
-//===----------------------------------------------------------------------===//
+//===- async_handler.hpp --------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/include/sycl/async_handler.hpp
+++ b/sycl/include/sycl/async_handler.hpp
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/defines_elementary.hpp>
+
+#include <functional>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+
+// Forward declaration
+class exception_list;
+
+using async_handler = std::function<void(sycl::exception_list)>;
+}
+} // namespace sycl

--- a/sycl/include/sycl/async_handler.hpp
+++ b/sycl/include/sycl/async_handler.hpp
@@ -19,5 +19,5 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 class exception_list;
 
 using async_handler = std::function<void(sycl::exception_list)>;
-}
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
 } // namespace sycl

--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <sycl/detail/defines.hpp>
+#include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
 
 namespace sycl {

--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include <sycl/detail/defines_elementary.hpp>
-#include <sycl/detail/iostream_proxy.hpp>
+
+#include <ostream>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -16,8 +16,8 @@
 #include <sycl/exception.hpp>
 #include <sycl/ext/oneapi/accessor_property_list.hpp>
 #include <sycl/ext/oneapi/weak_object_base.hpp>
-#include <sycl/property_list.hpp>
 #include <sycl/id.hpp>
+#include <sycl/property_list.hpp>
 #include <sycl/range.hpp>
 #include <sycl/stl.hpp>
 

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -17,6 +17,7 @@
 #include <sycl/ext/oneapi/accessor_property_list.hpp>
 #include <sycl/ext/oneapi/weak_object_base.hpp>
 #include <sycl/property_list.hpp>
+#include <sycl/id.hpp>
 #include <sycl/range.hpp>
 #include <sycl/stl.hpp>
 

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -8,16 +8,11 @@
 
 #pragma once
 
-#include <sycl/detail/backend_traits.hpp>
-#include <sycl/detail/cl.h>
-#include <sycl/detail/common.hpp>
+#include <sycl/async_handler.hpp>
+#include <sycl/backend_types.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/detail/owner_less_base.hpp>
-#include <sycl/detail/stl_type_traits.hpp>
-#include <sycl/exception_list.hpp>
-#include <sycl/ext/oneapi/weak_object_base.hpp>
-#include <sycl/info/info_desc.hpp>
 #include <sycl/property_list.hpp>
 
 // 4.6.2 Context class
@@ -27,6 +22,7 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 // Forward declarations
 class device;
 class platform;
+
 namespace detail {
 class context_impl;
 }

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -231,6 +231,10 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
+  friend typename std::add_pointer_t<typename decltype(T::impl)::element_type>
+  detail::getRawSyclObjImpl(const T &SyclObject);
+
+  template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
 

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -231,10 +231,6 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
-  friend typename std::add_pointer_t<typename decltype(T::impl)::element_type>
-  detail::getRawSyclObjImpl(const T &SyclObject);
-
-  template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 };
 

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -259,41 +259,6 @@ inline std::string codeToString(pi_int32 code) {
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
 namespace detail {
-
-// Helper function for extracting implementation from SYCL's interface objects.
-// Note! This function relies on the fact that all SYCL interface classes
-// contain "impl" field that points to implementation object. "impl" field
-// should be accessible from this function.
-//
-// Note that due to a bug in MSVC compilers (including MSVC2019 v19.20), it
-// may not recognize the usage of this function in friend member declarations
-// if the template parameter name there is not equal to the name used here,
-// i.e. 'Obj'. For example, using 'Obj' here and 'T' in such declaration
-// would trigger that error in MSVC:
-//   template <class T>
-//   friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
-template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
-  assert(SyclObject.impl && "every constructor should create an impl");
-  return SyclObject.impl;
-}
-
-// Returns the raw pointer to the impl object of given face object. The caller
-// must make sure the returned pointer is not captured in a field or otherwise
-// stored - i.e. must live only as on-stack value.
-template <class T>
-typename std::add_pointer_t<typename decltype(T::impl)::element_type>
-getRawSyclObjImpl(const T &SyclObject) {
-  return SyclObject.impl.get();
-}
-
-// Helper function for creation SYCL interface objects from implementations.
-// Note! This function relies on the fact that all SYCL interface classes
-// contain "impl" field that points to implementation object. "impl" field
-// should be accessible from this function.
-template <class T> T createSyclObjFromImpl(decltype(T::impl) ImplObj) {
-  return T(ImplObj);
-}
-
 // Produces N-dimensional object of type T whose all components are initialized
 // to given integer value.
 template <int N, template <int> class T> struct InitializedVal {

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -33,6 +33,15 @@ template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
   return SyclObject.impl;
 }
 
+// Returns the raw pointer to the impl object of given face object. The caller
+// must make sure the returned pointer is not captured in a field or otherwise
+// stored - i.e. must live only as on-stack value.
+template <class T>
+typename std::add_pointer_t<typename decltype(T::impl)::element_type>
+getRawSyclObjImpl(const T &SyclObject) {
+  return SyclObject.impl.get();
+}
+
 // Helper function for creation SYCL interface objects from implementations.
 // Note! This function relies on the fact that all SYCL interface classes
 // contain "impl" field that points to implementation object. "impl" field

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -1,4 +1,4 @@
-//===----------------------------------------------------------------------===//
+//===- impl_utils.hpp -----------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -33,15 +33,6 @@ template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
   return SyclObject.impl;
 }
 
-// Returns the raw pointer to the impl object of given face object. The caller
-// must make sure the returned pointer is not captured in a field or otherwise
-// stored - i.e. must live only as on-stack value.
-template <class T>
-typename std::add_pointer_t<typename decltype(T::impl)::element_type>
-getRawSyclObjImpl(const T &SyclObject) {
-  return SyclObject.impl.get();
-}
-
 // Helper function for creation SYCL interface objects from implementations.
 // Note! This function relies on the fact that all SYCL interface classes
 // contain "impl" field that points to implementation object. "impl" field

--- a/sycl/include/sycl/detail/impl_utils.hpp
+++ b/sycl/include/sycl/detail/impl_utils.hpp
@@ -1,0 +1,55 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/defines_elementary.hpp>
+
+#include <cassert>
+
+namespace sycl {
+__SYCL_INLINE_VER_NAMESPACE(_V1) {
+namespace detail {
+
+// Helper function for extracting implementation from SYCL's interface objects.
+// Note! This function relies on the fact that all SYCL interface classes
+// contain "impl" field that points to implementation object. "impl" field
+// should be accessible from this function.
+//
+// Note that due to a bug in MSVC compilers (including MSVC2019 v19.20), it
+// may not recognize the usage of this function in friend member declarations
+// if the template parameter name there is not equal to the name used here,
+// i.e. 'Obj'. For example, using 'Obj' here and 'T' in such declaration
+// would trigger that error in MSVC:
+//   template <class T>
+//   friend decltype(T::impl) detail::getSyclObjImpl(const T &SyclObject);
+template <class Obj> decltype(Obj::impl) getSyclObjImpl(const Obj &SyclObject) {
+  assert(SyclObject.impl && "every constructor should create an impl");
+  return SyclObject.impl;
+}
+
+// Returns the raw pointer to the impl object of given face object. The caller
+// must make sure the returned pointer is not captured in a field or otherwise
+// stored - i.e. must live only as on-stack value.
+template <class T>
+typename std::add_pointer_t<typename decltype(T::impl)::element_type>
+getRawSyclObjImpl(const T &SyclObject) {
+  return SyclObject.impl.get();
+}
+
+// Helper function for creation SYCL interface objects from implementations.
+// Note! This function relies on the fact that all SYCL interface classes
+// contain "impl" field that points to implementation object. "impl" field
+// should be accessible from this function.
+template <class T> T createSyclObjFromImpl(decltype(T::impl) ImplObj) {
+  return T(ImplObj);
+}
+
+} // namespace detail
+} // __SYCL_INLINE_VER_NAMESPACE(_V1)
+} // namespace sycl

--- a/sycl/include/sycl/detail/info_desc_helpers.hpp
+++ b/sycl/include/sycl/detail/info_desc_helpers.hpp
@@ -9,7 +9,8 @@
 #pragma once
 
 #include <sycl/aspects.hpp>
-#include <sycl/detail/pi.hpp>
+#include <sycl/detail/pi.h>
+#include <sycl/id.hpp>
 #include <sycl/info/info_desc.hpp>
 
 namespace sycl {

--- a/sycl/include/sycl/detail/owner_less_base.hpp
+++ b/sycl/include/sycl/detail/owner_less_base.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
-#include <sycl/detail/common.hpp>
 #include <sycl/detail/defines_elementary.hpp>
+#include <sycl/detail/impl_utils.hpp>
 #include <sycl/ext/oneapi/weak_object_base.hpp>
 
 namespace sycl {

--- a/sycl/include/sycl/detail/property_helper.hpp
+++ b/sycl/include/sycl/detail/property_helper.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include <sycl/detail/common.hpp>
+#include <sycl/detail/defines_elementary.hpp>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {

--- a/sycl/include/sycl/detail/property_list_base.hpp
+++ b/sycl/include/sycl/detail/property_list_base.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
-#include <sycl/detail/common.hpp>
 #include <sycl/detail/property_helper.hpp>
 #include <sycl/detail/stl_type_traits.hpp>
+#include <sycl/exception.hpp>
 
 #include <bitset>
 #include <memory>

--- a/sycl/include/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/sycl/detail/stl_type_traits.hpp
@@ -8,9 +8,9 @@
 
 #pragma once
 
+#include <sycl/detail/defines_elementary.hpp>
+
 #include <iterator>
-#include <memory>
-#include <sycl/detail/defines.hpp>
 #include <type_traits>
 
 namespace sycl {

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -278,6 +278,10 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
+  friend typename std::add_pointer_t<typename decltype(T::impl)::element_type>
+  detail::getRawSyclObjImpl(const T &SyclObject);
+
+  template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
   template <backend BackendName, class SyclObjectT>

--- a/sycl/include/sycl/device.hpp
+++ b/sycl/include/sycl/device.hpp
@@ -278,10 +278,6 @@ private:
   friend decltype(Obj::impl) detail::getSyclObjImpl(const Obj &SyclObject);
 
   template <class T>
-  friend typename std::add_pointer_t<typename decltype(T::impl)::element_type>
-  detail::getRawSyclObjImpl(const T &SyclObject);
-
-  template <class T>
   friend T detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
 
   template <backend BackendName, class SyclObjectT>

--- a/sycl/include/sycl/device_selector.hpp
+++ b/sycl/include/sycl/device_selector.hpp
@@ -21,6 +21,7 @@ __SYCL_INLINE_VER_NAMESPACE(_V1) {
 
 // Forward declarations
 class device;
+class context;
 enum class aspect;
 
 namespace ext::oneapi {

--- a/sycl/include/sycl/exception_list.hpp
+++ b/sycl/include/sycl/exception_list.hpp
@@ -10,6 +10,7 @@
 
 // 4.9.2 Exception Class Interface
 
+#include <sycl/async_handler.hpp>
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
@@ -51,8 +52,6 @@ private:
   void Clear() noexcept;
   std::vector<std::exception_ptr> MList;
 };
-
-using async_handler = std::function<void(sycl::exception_list)>;
 
 namespace detail {
 // Default implementation of async_handler used by queue and context when no

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -1,4 +1,4 @@
-//===----------------------------------------------------------------------===//
+//===- device_architecture.hpp --------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/device_architecture.hpp
@@ -1,3 +1,11 @@
+//===----------------------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
 #pragma once
 
 #include <sycl/detail/defines_elementary.hpp>

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -9,8 +9,8 @@
 #pragma once
 
 #include <sycl/detail/common.hpp>
-#include <sycl/detail/impl_utils.hpp>
 #include <sycl/detail/defines_elementary.hpp>
+#include <sycl/detail/impl_utils.hpp>
 #include <sycl/property_list.hpp>
 
 #include <functional>

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sycl/detail/common.hpp>
+#include <sycl/detail/impl_utils.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/property_list.hpp>
 

--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -9,10 +9,9 @@
 #pragma once
 
 #include <sycl/aspects.hpp>
-#include <sycl/detail/common.hpp>
-#include <sycl/detail/pi.hpp>
+#include <sycl/detail/pi.h>
 #include <sycl/ext/oneapi/experimental/device_architecture.hpp>
-#include <sycl/id.hpp>
+#include <sycl/range.hpp>
 
 namespace sycl {
 __SYCL_INLINE_VER_NAMESPACE(_V1) {
@@ -21,6 +20,7 @@ class device;
 class platform;
 class kernel_id;
 enum class memory_scope;
+enum class memory_order;
 
 // TODO: stop using OpenCL directly, use PI.
 namespace info {

--- a/sycl/include/sycl/property_list.hpp
+++ b/sycl/include/sycl/property_list.hpp
@@ -8,7 +8,6 @@
 
 #pragma once
 
-#include <sycl/detail/common.hpp>
 #include <sycl/detail/property_list_base.hpp>
 #include <sycl/properties/property_traits.hpp>
 

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -9,9 +9,9 @@
 #pragma once
 
 #include <sycl/detail/assert_happened.hpp>
-#include <sycl/detail/common.hpp>
 #include <sycl/detail/service_kernel_names.hpp>
 #include <sycl/device_selector.hpp>
+#include <sycl/exception_list.hpp>
 #include <sycl/handler.hpp>
 #include <sycl/property_list.hpp>
 

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -13,6 +13,7 @@
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/device_filter.hpp>
 #include <sycl/detail/pi.hpp>
+#include <sycl/exception.hpp>
 #include <sycl/info/info_desc.hpp>
 
 #include <algorithm>

--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <sycl/detail/defines.hpp>
-#include <sycl/detail/pi.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
+#include <sycl/detail/pi.hpp>
 
 #include <dlfcn.h>
 #include <string>

--- a/sycl/source/detail/posix_pi.cpp
+++ b/sycl/source/detail/posix_pi.cpp
@@ -8,6 +8,7 @@
 
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/pi.hpp>
+#include <sycl/detail/iostream_proxy.hpp>
 
 #include <dlfcn.h>
 #include <string>

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -114,9 +114,8 @@ ProgramManager::getDeviceImage(const std::string &KernelName,
                                bool JITCompilationIsRequired) {
   if (DbgProgMgr > 0)
     std::cerr << ">>> ProgramManager::getDeviceImage(\"" << KernelName << "\", "
-              << getSyclObjImpl(Context).get() << ", "
-              << getSyclObjImpl(Device).get() << ", "
-              << JITCompilationIsRequired << ")\n";
+              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
+              << ", " << JITCompilationIsRequired << ")\n";
 
   KernelSetId KSId = getKernelSetId(KernelName);
   return getDeviceImage(KSId, Context, Device, JITCompilationIsRequired);
@@ -283,8 +282,8 @@ ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
                                 const context &Context, const device &Device) {
   if (DbgProgMgr > 0)
     std::cerr << ">>> ProgramManager::createPIProgram(" << &Img << ", "
-              << getSyclObjImpl(Context).get() << ", "
-              << getSyclObjImpl(Device).get() << ")\n";
+              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
+              << ")\n";
   const pi_device_binary_struct &RawImg = Img.getRawData();
 
   // perform minimal sanity checks on the device image and the descriptor
@@ -719,7 +718,7 @@ sycl::detail::pi::PiProgram ProgramManager::getBuiltPIProgram(
 
     ProgramPtr BuiltProgram =
         build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
-              getSyclObjImpl(Device).get()->getHandleRef(), DeviceLibReqMask);
+              getRawSyclObjImpl(Device)->getHandleRef(), DeviceLibReqMask);
 
     emitBuiltProgramInfo(BuiltProgram.get(), ContextImpl);
 
@@ -1054,9 +1053,8 @@ ProgramManager::getDeviceImage(KernelSetId KSId, const context &Context,
                                bool JITCompilationIsRequired) {
   if (DbgProgMgr > 0) {
     std::cerr << ">>> ProgramManager::getDeviceImage(\"" << KSId << "\", "
-              << getSyclObjImpl(Context).get() << ", "
-              << getSyclObjImpl(Device).get() << ", "
-              << JITCompilationIsRequired << ")\n";
+              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
+              << ", " << JITCompilationIsRequired << ")\n";
 
     std::cerr << "available device images:\n";
     debugPrintBinaryImages();
@@ -2334,7 +2332,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
     ProgramPtr BuiltProgram =
         build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
-              getSyclObjImpl(Devs[0]).get()->getHandleRef(), DeviceLibReqMask);
+              getRawSyclObjImpl(Devs[0])->getHandleRef(), DeviceLibReqMask);
 
     emitBuiltProgramInfo(BuiltProgram.get(), ContextImpl);
 
@@ -2355,7 +2353,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
   uint32_t ImgId = Img.getImageID();
   const sycl::detail::pi::PiDevice PiDevice =
-      getSyclObjImpl(Devs[0]).get()->getHandleRef();
+      getRawSyclObjImpl(Devs[0])->getHandleRef();
   auto CacheKey =
       std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
                      std::make_pair(PiDevice, CompileOpts + LinkOpts));
@@ -2388,7 +2386,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
   // call to getOrBuild, so starting with "1"
   for (size_t Idx = 1; Idx < Devs.size(); ++Idx) {
     const sycl::detail::pi::PiDevice PiDeviceAdd =
-        getSyclObjImpl(Devs[Idx]).get()->getHandleRef();
+        getRawSyclObjImpl(Devs[Idx])->getHandleRef();
 
     // Change device in the cache key to reduce copying of spec const data.
     CacheKey.second.first = PiDeviceAdd;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -114,8 +114,9 @@ ProgramManager::getDeviceImage(const std::string &KernelName,
                                bool JITCompilationIsRequired) {
   if (DbgProgMgr > 0)
     std::cerr << ">>> ProgramManager::getDeviceImage(\"" << KernelName << "\", "
-              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
-              << ", " << JITCompilationIsRequired << ")\n";
+              << getSyclObjImpl(Context).get() << ", "
+              << getSyclObjImpl(Device).get() << ", "
+              << JITCompilationIsRequired << ")\n";
 
   KernelSetId KSId = getKernelSetId(KernelName);
   return getDeviceImage(KSId, Context, Device, JITCompilationIsRequired);
@@ -282,8 +283,8 @@ ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
                                 const context &Context, const device &Device) {
   if (DbgProgMgr > 0)
     std::cerr << ">>> ProgramManager::createPIProgram(" << &Img << ", "
-              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
-              << ")\n";
+              << getSyclObjImpl(Context).get() << ", "
+              << getSyclObjImpl(Device).get() << ")\n";
   const pi_device_binary_struct &RawImg = Img.getRawData();
 
   // perform minimal sanity checks on the device image and the descriptor
@@ -718,7 +719,7 @@ sycl::detail::pi::PiProgram ProgramManager::getBuiltPIProgram(
 
     ProgramPtr BuiltProgram =
         build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
-              getRawSyclObjImpl(Device)->getHandleRef(), DeviceLibReqMask);
+              getSyclObjImpl(Device).get()->getHandleRef(), DeviceLibReqMask);
 
     emitBuiltProgramInfo(BuiltProgram.get(), ContextImpl);
 
@@ -1053,8 +1054,9 @@ ProgramManager::getDeviceImage(KernelSetId KSId, const context &Context,
                                bool JITCompilationIsRequired) {
   if (DbgProgMgr > 0) {
     std::cerr << ">>> ProgramManager::getDeviceImage(\"" << KSId << "\", "
-              << getRawSyclObjImpl(Context) << ", " << getRawSyclObjImpl(Device)
-              << ", " << JITCompilationIsRequired << ")\n";
+              << getSyclObjImpl(Context).get() << ", "
+              << getSyclObjImpl(Device).get() << ", "
+              << JITCompilationIsRequired << ")\n";
 
     std::cerr << "available device images:\n";
     debugPrintBinaryImages();
@@ -2332,7 +2334,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
     ProgramPtr BuiltProgram =
         build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
-              getRawSyclObjImpl(Devs[0])->getHandleRef(), DeviceLibReqMask);
+              getSyclObjImpl(Devs[0]).get()->getHandleRef(), DeviceLibReqMask);
 
     emitBuiltProgramInfo(BuiltProgram.get(), ContextImpl);
 
@@ -2353,7 +2355,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
   uint32_t ImgId = Img.getImageID();
   const sycl::detail::pi::PiDevice PiDevice =
-      getRawSyclObjImpl(Devs[0])->getHandleRef();
+      getSyclObjImpl(Devs[0]).get()->getHandleRef();
   auto CacheKey =
       std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
                      std::make_pair(PiDevice, CompileOpts + LinkOpts));
@@ -2386,7 +2388,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
   // call to getOrBuild, so starting with "1"
   for (size_t Idx = 1; Idx < Devs.size(); ++Idx) {
     const sycl::detail::pi::PiDevice PiDeviceAdd =
-        getRawSyclObjImpl(Devs[Idx])->getHandleRef();
+        getSyclObjImpl(Devs[Idx]).get()->getHandleRef();
 
     // Change device in the cache key to reduce copying of spec const data.
     CacheKey.second.first = PiDeviceAdd;

--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -11,6 +11,7 @@
 #include <CL/__spirv/spirv_types.hpp>
 #include <sycl/context.hpp>
 #include <sycl/detail/export.hpp>
+#include <sycl/detail/pi.hpp>
 #include <sycl/property_list.hpp>
 
 #include <mutex>

--- a/sycl/source/detail/sycl_mem_obj_t.hpp
+++ b/sycl/source/detail/sycl_mem_obj_t.hpp
@@ -17,7 +17,7 @@
 #include <sycl/properties/buffer_properties.hpp>
 #include <sycl/properties/image_properties.hpp>
 #include <sycl/property_list.hpp>
-#include <sycl/stl.hpp>
+#include <sycl/range.hpp>
 
 #include <cstring>
 #include <memory>


### PR DESCRIPTION
The main goal of this refactoring is to reduce amount of includes to the context.hpp header.

Two new includes are added:
1. sycl/include/sycl/detail/impl_utils.hpp is intended to replace sycl/include/sycl/detail/common.hpp when only interopability with "impl" class is needed. common.hpp include is overloaded with a bunch of other functionality.
2. sycl/include/sycl/async_handler.hpp separates async_handler definiton from exception.hpp.