### PR TITLE
Guard "[IR] Remove LLVMPointerTo intrinsic type (NFC)" with INTEL_SYCL_OPAQUEPOINTER_READY

### DIFF
--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -128,6 +128,9 @@ namespace Intrinsic {
       TruncArgument,
       HalfVecArgument,
       SameVecWidthArgument,
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+      PtrToArgument,
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       PtrToElt,
       VecOfAnyPtrsToElt,
       VecElementArgument,
@@ -160,6 +163,9 @@ namespace Intrinsic {
       assert(Kind == Argument || Kind == ExtendArgument ||
              Kind == TruncArgument || Kind == HalfVecArgument ||
              Kind == SameVecWidthArgument ||
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+             Kind == PtrToArgument ||
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
              Kind == PtrToElt || Kind == VecElementArgument ||
              Kind == Subdivide2Argument || Kind == Subdivide4Argument ||
              Kind == VecOfBitcastsToInt);
@@ -168,6 +174,9 @@ namespace Intrinsic {
     ArgKind getArgumentKind() const {
       assert(Kind == Argument || Kind == ExtendArgument ||
              Kind == TruncArgument || Kind == HalfVecArgument ||
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+             Kind == PtrToArgument ||
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
              Kind == SameVecWidthArgument ||
              Kind == VecElementArgument || Kind == Subdivide2Argument ||
              Kind == Subdivide4Argument || Kind == VecOfBitcastsToInt);

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -294,6 +294,9 @@ def IIT_V1 : IIT_Vec<1, 28>;
 def IIT_VARARG : IIT_VT<isVoid, 29>;
 def IIT_HALF_VEC_ARG : IIT_Base<30>;
 def IIT_SAME_VEC_WIDTH_ARG : IIT_Base<31>;
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+def IIT_PTR_TO_ARG : IIT_Base<32>;
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 def IIT_PTR_TO_ELT : IIT_Base<33>;
 def IIT_VEC_OF_ANYPTRS_TO_ELT : IIT_Base<34>;
 def IIT_I128 : IIT_Int<128, 35>;
@@ -448,6 +451,9 @@ class LLVMScalarOrSameVectorWidth<int idx, LLVMType elty>
   ], elty.Sig);
 }
 
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+class LLVMPointerTo<int num> : LLVMMatchType<num, IIT_PTR_TO_ARG>;
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 class LLVMPointerToElt<int num> : LLVMMatchType<num, IIT_PTR_TO_ELT>;
 class LLVMAnyPointerToElt<int num>
   : LLVMMatchTypeNextArg<num, IIT_ANYPTR_TO_ELT>;


### PR DESCRIPTION
https://github.com/intel/llvm/commit/253a52988fe37887ba1f7741271d602083fe7dd7 Remove LLVMPointerTo intrinsic type
To fix build failure in vc-intrinsics-src , Guard it with INTEL_SYCL_OPAQUEPOINTER_READY : 
```
./sycl-web/builds/_deps/vc-intrinsics-src/GenXIntrinsics/lib/GenXIntrinsics/GenXIntrinsics.cpp:340:23: 
error: ‘PtrToArgument’ is not a member of ‘llvm::Intrinsic::IITDescriptor’
  340 |   case IITDescriptor::PtrToArgument: {
      |               
```