### PR TITLE
[SYCL-MLIR][NFC] Fix constexpr static function

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -673,7 +673,7 @@ public:
     }
 
     // Check we are not dealing with a default constructor
-    if constexpr (tag.hasDefaultConstructor()) {
+    if constexpr (TypeTag::hasDefaultConstructor()) {
       auto matcher = m_Zero();
       if (llvm::all_of(values, [&](Value value) {
             return matchPattern(value, matcher);


### PR DESCRIPTION
Fix compilation issues with Clang 10 by changing the invocation inside the `if constexpr` to static invocation.