### PR TITLE
[SYCL-MLIR] SYCL 'accessor' analysis

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -73,6 +73,9 @@ public:
   const AccessorInformation join(const AccessorInformation &other,
                                  AliasAnalysis &aliasAnalysis) const;
 
+  AliasResult alias(const AccessorInformation &other,
+                       AliasAnalysis &aliasAnalysis) const;
+
 private:
   Value buffer;
 

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -41,8 +41,8 @@ public:
                       bool hasRange, llvm::ArrayRef<size_t> constRange,
                       bool hasOffset, llvm::ArrayRef<size_t> constOffset)
       : buffer{buf}, bufferInfo{bufInfo}, needRange{hasRange},
-        constantRange{constRange}, needOffset{hasOffset}, constantOffset{
-                                                              constOffset} {}
+        constantRange{constRange}, needOffset{hasOffset},
+        constantOffset{constOffset} {}
 
   bool hasKnownBuffer() const { return buffer != nullptr; }
 
@@ -74,7 +74,7 @@ public:
                                  AliasAnalysis &aliasAnalysis) const;
 
   AliasResult alias(const AccessorInformation &other,
-                       AliasAnalysis &aliasAnalysis) const;
+                    AliasAnalysis &aliasAnalysis) const;
 
 private:
   Value buffer;

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -14,7 +14,7 @@
 #ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
 #define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
 
-#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Polygeist/Analysis/DataFlowSolverWrapper.h"
 #include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/SYCLBufferAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
@@ -116,7 +116,7 @@ private:
 
   AnalysisManager &am;
 
-  DataFlowSolver solver;
+  std::unique_ptr<DataFlowSolverWrapper> solver;
 
   bool initialized = false;
 

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -1,0 +1,130 @@
+//===- SYCLAccessorAnalysis.h - Analysis for sycl::accessor -----*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// This file contains an analysis to derive interesting properties about
+// sycl::accessor in SYCL host code.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
+#define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
+
+#include "mlir/Analysis/DataFlowFramework.h"
+#include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
+#include "mlir/Dialect/Polygeist/Analysis/SYCLBufferAnalysis.h"
+#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Pass/AnalysisManager.h"
+
+namespace mlir {
+namespace polygeist {
+
+/// YES indicates that the buffer is definitely a sub-buffer
+/// NO indicates that the buffer is definitely not a sub-buffer.
+/// MAYBE indicates that there are multiple constructions with different
+/// sub-buffer property or insufficient information is available.
+enum class SYCLAcessorAliasResult { YES, NO, MAYBE };
+
+/// Represents information about a `sycl::accessor` gathered from its
+/// construction.
+class AccessorInformation {
+public:
+  AccessorInformation() {}
+
+  AccessorInformation(Value buf, std::optional<BufferInformation> bufInfo,
+                      bool hasRange, llvm::ArrayRef<size_t> constRange,
+                      bool hasOffset, llvm::ArrayRef<size_t> constOffset)
+      : buffer{buf}, bufferInfo{bufInfo}, needRange{hasRange},
+        constantRange{constRange}, needOffset{hasOffset}, constantOffset{
+                                                              constOffset} {}
+
+  bool hasKnownBuffer() const { return buffer != nullptr; }
+
+  Value getBuffer() const { return buffer; }
+
+  bool hasBufferInformation() const { return bufferInfo.has_value(); }
+
+  const BufferInformation &getBufferInfo() const { return *bufferInfo; }
+
+  bool needsRange() const { return needRange; }
+
+  bool hasConstantRange() const { return !constantRange.empty(); }
+
+  const llvm::SmallVector<size_t, 3> &getConstantRange() const {
+    assert(hasConstantRange() && "Range not constant");
+    return constantRange;
+  }
+
+  bool needsOffset() const { return needOffset; }
+
+  bool hasConstantOffset() const { return !constantOffset.empty(); }
+
+  const llvm::SmallVector<size_t, 3> &getConstantOffset() const {
+    assert(hasConstantOffset() && "Offset not constant");
+    return constantOffset;
+  }
+
+  const AccessorInformation join(const AccessorInformation &other,
+                                 AliasAnalysis &aliasAnalysis) const;
+
+private:
+  Value buffer;
+
+  std::optional<BufferInformation> bufferInfo;
+
+  bool needRange;
+
+  llvm::SmallVector<size_t, 3> constantRange;
+
+  bool needOffset;
+
+  llvm::SmallVector<size_t, 3> constantOffset;
+
+  friend raw_ostream &operator<<(raw_ostream &, const AccessorInformation &);
+};
+
+/// Analysis to determine properties of interest about a `sycl::accessor` from
+/// its construction.
+class SYCLAccessorAnalysis {
+public:
+  SYCLAccessorAnalysis(Operation *op, AnalysisManager &am);
+
+  /// Consumers of the analysis must call this member function immediately after
+  /// construction and before requesting any information from the analysis.
+  SYCLAccessorAnalysis &initialize(bool useRelaxedAliasing = false);
+
+  std::optional<AccessorInformation>
+  getAccessorInformationFromConstruction(Operation *op, Value operand);
+
+private:
+  void initialize();
+
+  bool isConstructor(const Definition &def);
+
+  AccessorInformation getInformation(const Definition &def);
+
+  bool isHandler(Value value) const;
+
+  bool isAccessTag(Value value) const;
+
+  Operation *operation;
+
+  AnalysisManager &am;
+
+  DataFlowSolver solver;
+
+  bool initialized = false;
+
+  AliasAnalysis *aliasAnalysis;
+
+  SYCLIDAndRangeAnalysis idRangeAnalysis;
+};
+} // namespace polygeist
+} // namespace mlir
+
+#endif // MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -29,7 +29,7 @@ namespace polygeist {
 /// construction.
 class AccessorInformation {
 public:
-  AccessorInformation() {}
+  AccessorInformation() = default;
 
   AccessorInformation(Value buf, std::optional<BufferInformation> bufInfo,
                       bool hasRange, llvm::ArrayRef<size_t> constRange,
@@ -42,14 +42,20 @@ public:
   bool hasKnownBuffer() const { return buffer != nullptr; }
 
   /// Returns the underlying buffer of this accessor.
-  Value getBuffer() const { return buffer; }
+  Value getBuffer() const {
+    assert(hasKnownBuffer() && "Buffer unknown");
+    return buffer;
+  }
 
   /// Returns true if buffer information is available for the buffer underlying
   /// this accessor.
   bool hasBufferInformation() const { return bufferInfo.has_value(); }
 
   /// Returns the buffer information for the buffer underlying this accessor.
-  const BufferInformation &getBufferInfo() const { return *bufferInfo; }
+  const BufferInformation &getBufferInfo() const {
+    assert(hasBufferInformation() && "No buffer information available");
+    return *bufferInfo;
+  }
 
   /// Returns false if the range can be omitted for this accessor, true
   /// otherwise.

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -19,6 +19,7 @@
 #include "mlir/Dialect/Polygeist/Analysis/SYCLBufferAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Pass/AnalysisManager.h"
 
 namespace mlir {
@@ -108,9 +109,10 @@ private:
 
   AccessorInformation getInformation(const Definition &def);
 
-  bool isHandler(Value value) const;
-
-  bool isAccessTag(Value value) const;
+  template <typename OperandType>
+  std::optional<IDRangeInformation>
+  getOperandInfo(sycl::SYCLHostConstructorOp constructor, size_t possibleIndex1,
+                 size_t possibleIndex2);
 
   Operation *operation;
 
@@ -123,6 +125,8 @@ private:
   AliasAnalysis *aliasAnalysis;
 
   SYCLIDAndRangeAnalysis idRangeAnalysis;
+
+  SYCLBufferAnalysis bufferAnalysis;
 };
 } // namespace polygeist
 } // namespace mlir

--- a/polygeist/lib/Dialect/Polygeist/Analysis/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRPolygeistAnalysis
   MemoryAccessAnalysis.cpp
   ReachingDefinitionAnalysis.cpp
+  SYCLAccessorAnalysis.cpp
   SYCLBufferAnalysis.cpp
   SYCLIDAndRangeAnalysis.cpp
   UniformityAnalysis.cpp

--- a/polygeist/lib/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.cpp
@@ -1,0 +1,207 @@
+//===- SYCLAccessorAnalysis.h - Analysis for sycl::buffer
+//-------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h"
+
+#include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
+#include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLDialect.h"
+#include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
+
+#define DEBUG_TYPE "sycl-accessor-analysis"
+
+namespace mlir {
+namespace polygeist {
+
+//===----------------------------------------------------------------------===//
+// AccessorInformation
+//===----------------------------------------------------------------------===//
+
+raw_ostream &operator<<(raw_ostream &os, const AccessorInformation &info) {
+  // TODO
+  return os;
+}
+
+const AccessorInformation
+AccessorInformation::join(const AccessorInformation &other,
+                          AliasAnalysis &aliasAnalysis) const {
+  // TODO
+}
+
+//===----------------------------------------------------------------------===//
+// SYCLAccessorAnalysis
+//===----------------------------------------------------------------------===//
+
+SYCLAccessorAnalysis::SYCLAccessorAnalysis(Operation *op, AnalysisManager &mgr)
+    : operation(op), am(mgr), idRangeAnalysis(op, mgr) {}
+
+SYCLAccessorAnalysis &
+SYCLAccessorAnalysis::initialize(bool useRelaxedAliasing) {
+
+  // Initialize the dataflow solver
+  aliasAnalysis = &am.getAnalysis<mlir::AliasAnalysis>();
+  aliasAnalysis->addAnalysisImplementation(
+      sycl::AliasAnalysis(useRelaxedAliasing));
+
+  // Populate the solver and run the analyses needed by this analysis.
+  solver.load<dataflow::DeadCodeAnalysis>();
+  solver.load<dataflow::SparseConstantPropagation>();
+  solver.load<ReachingDefinitionAnalysis>(*aliasAnalysis);
+
+  if (failed(solver.initializeAndRun(operation))) {
+    operation->emitError("Failed to run required dataflow analyses");
+    return *this;
+  }
+
+  idRangeAnalysis.initialize(useRelaxedAliasing);
+
+  initialized = true;
+
+  return *this;
+}
+
+std::optional<AccessorInformation>
+SYCLAccessorAnalysis::getAccessorInformationFromConstruction(Operation *op,
+                                                             Value operand) {
+  assert(initialized &&
+         "Analysis only available after successful initialization");
+  assert(isa<LLVM::LLVMPointerType>(operand.getType()) &&
+         "Expecting an LLVM pointer");
+
+  const polygeist::ReachingDefinition *reachingDef =
+      solver.lookupState<polygeist::ReachingDefinition>(op);
+  assert(reachingDef && "expected a reaching definition");
+
+  auto mods = reachingDef->getModifiers(operand);
+  if (!mods || mods->empty())
+    return std::nullopt;
+
+  if (!llvm::all_of(*mods,
+                    [&](const Definition &def) { return isConstructor(def); }))
+    return std::nullopt;
+
+  auto pMods = reachingDef->getPotentialModifiers(operand);
+  if (pMods) {
+    if (!llvm::all_of(
+            *pMods, [&](const Definition &def) { return isConstructor(def); }))
+      return std::nullopt;
+  }
+
+  bool first = true;
+  AccessorInformation info;
+  for (const Definition &def : *mods) {
+    if (first) {
+      info = getInformation(def);
+      first = false;
+    } else {
+      info = info.join(getInformation(def), *aliasAnalysis);
+      if (false /* TODO */)
+        // Early return: As soon as joining of the different information has led
+        // to an info with no fixed size and no definitive sub-buffer
+        // information, we can end the processing.
+        return info;
+    }
+  }
+
+  if (pMods) {
+    for (const Definition &def : *pMods) {
+      info = info.join(getInformation(def), *aliasAnalysis);
+      if (false /* TODO */)
+        // Early return: As soon as joining of the different information has led
+        // to an info with no fixed size and no definitive sub-buffer
+        // information, we can end the processing.
+        return info;
+    }
+  }
+
+  return info;
+}
+
+bool SYCLAccessorAnalysis::isConstructor(const Definition &def) {
+  if (!def.isOperation())
+    return false;
+
+  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
+  if (!constructor)
+    return false;
+
+  return isa<sycl::AccessorType>(constructor.getType().getValue());
+}
+
+AccessorInformation
+SYCLAccessorAnalysis::getInformation(const Definition &def) {
+  assert(def.isOperation() && "Expecting operation");
+
+  auto constructor = cast<sycl::SYCLHostConstructorOp>(def.getOperation());
+
+  // The default is true because we conservatively need to assume that the
+  // accessor uses those two fields, unless we can infer otherwise.
+  bool needsRange = true;
+  bool needsOffset = true;
+  SmallVector<size_t, 3> constRange;
+  SmallVector<size_t, 3> constOffset;
+  Value buffer = (constructor->getNumOperands() > 2)
+                     ? constructor->getOperand(1)
+                     : nullptr;
+
+  // Deduct two for the this pointer and the DPC++-specific code location
+  // argument.
+  switch (constructor->getNumOperands() - 2) {
+  case 0:
+  case 2:
+    needsRange = false;
+    needsOffset = false;
+    break;
+  case 3: {
+    needsOffset = false;
+    // The second parameter can either be a handler, a tag or a range.
+    Value secondArg = constructor->getOperand(2);
+    needsRange = !(isHandler(secondArg) || isAccessTag(secondArg));
+    if (needsRange) {
+      auto rangeInfo =
+          idRangeAnalysis
+              .getIDRangeInformationFromConstruction<sycl::RangeType>(
+                  constructor, secondArg);
+      if (rangeInfo && rangeInfo->isConstant())
+        constRange = rangeInfo->getConstantValues();
+    }
+    break;
+  }
+  case 4: {
+    // The second parameter can either be a handler or a range.
+    Value secondArg = constructor->getOperand(2);
+    // The third parameter can either be a tag, a range or an id.
+    Value thirdArg = constructor.getOperand(3);
+    if (isHandler(secondArg)) {
+      needsOffset = false;
+      if (isAccessTag(thirdArg)) {
+        needsRange = false;
+        break;
+      }
+      auto rangeInfo =
+          idRangeAnalysis
+              .getIDRangeInformationFromConstruction<sycl::RangeType>(
+                  constructor, thirdArg);
+      if (rangeInfo && rangeInfo->isConstant())
+        constRange = rangeInfo->getConstantValues();
+      break;
+    }
+  }
+  }
+  // TODO
+}
+
+bool SYCLAccessorAnalysis::isHandler(Value value) const { return false; }
+
+bool SYCLAccessorAnalysis::isAccessTag(Value value) const { return false; }
+
+} // namespace polygeist
+} // namespace mlir

--- a/polygeist/lib/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.cpp
@@ -1,5 +1,4 @@
-//===- SYCLAccessorAnalysis.h - Analysis for sycl::buffer
-//-------------------===//
+//===- SYCLAccessorAnalysis.cpp - Analysis for sycl::accessor -------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/polygeist/test/lib/Dialect/Polygeist/CMakeLists.txt
+++ b/polygeist/test/lib/Dialect/Polygeist/CMakeLists.txt
@@ -1,5 +1,6 @@
 if(MLIR_INCLUDE_TESTS)
   add_mlir_library(MLIRPolygeistTestAnalysis
+    TestAccessorAnalysis.cpp
     TestBufferAnalysis.cpp
     TestIDAndRangeAnalysis.cpp
     TestMemoryAccessAnalysis.cpp

--- a/polygeist/test/lib/Dialect/Polygeist/TestAccessorAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestAccessorAnalysis.cpp
@@ -23,6 +23,9 @@ struct TestAccessorAnalysisPass
   void runOnOperation() override {
     Operation *op = getOperation();
     bool relaxedAliasing = true;
+    AliasAnalysis &aliasAnalysis = getAnalysis<mlir::AliasAnalysis>();
+    aliasAnalysis.addAnalysisImplementation(
+        sycl::AliasAnalysis(relaxedAliasing));
     auto &AccessorAnalysis =
         getAnalysis<polygeist::SYCLAccessorAnalysis>().initialize(
             relaxedAliasing);
@@ -41,6 +44,20 @@ struct TestAccessorAnalysisPass
         if (accResult) {
           llvm::errs().indent(2) << "accessor:\n";
           llvm::errs() << *accResult;
+
+          // Check aliasing with other operands.
+          for (size_t otherIdx = index + 1; otherIdx < op->getNumOperands();
+               ++otherIdx) {
+            auto otherResult =
+                AccessorAnalysis.getAccessorInformationFromConstruction(
+                    op, op->getOperand(otherIdx));
+
+            if (otherResult) {
+              auto aliasing = accResult->alias(*otherResult, aliasAnalysis);
+              llvm::errs().indent(2) << "Alias (op#" << index << " x op#"
+                                     << otherIdx << "): " << aliasing << "\n";
+            }
+          }
         }
       }
       return WalkResult::advance();

--- a/polygeist/test/lib/Dialect/Polygeist/TestAccessorAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestAccessorAnalysis.cpp
@@ -1,0 +1,59 @@
+//===------------- TestAccessorAnalysis.cpp -------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
+#include "mlir/Pass/Pass.h"
+
+using namespace mlir;
+
+namespace {
+
+struct TestAccessorAnalysisPass
+    : public PassWrapper<TestAccessorAnalysisPass, OperationPass<>> {
+  MLIR_DEFINE_EXPLICIT_INTERNAL_INLINE_TYPE_ID(TestAccessorAnalysisPass)
+
+  StringRef getArgument() const override { return "test-accessor-analysis"; }
+
+  void runOnOperation() override {
+    Operation *op = getOperation();
+    bool relaxedAliasing = true;
+    auto &AccessorAnalysis =
+        getAnalysis<polygeist::SYCLAccessorAnalysis>().initialize(
+            relaxedAliasing);
+
+    op->walk([&](Operation *op) {
+      auto tag = op->getAttrOfType<StringAttr>("tag");
+      if (!tag)
+        return WalkResult::skip();
+
+      llvm::errs() << "test_tag: " << tag.getValue() << ":\n";
+      for (auto [index, operand] : llvm::enumerate(op->getOperands())) {
+        llvm::errs().indent(2) << "operand #" << index << "\n";
+        auto accResult =
+            AccessorAnalysis.getAccessorInformationFromConstruction(op,
+                                                                    operand);
+        if (accResult) {
+          llvm::errs().indent(2) << "accessor:\n";
+          llvm::errs() << *accResult;
+        }
+      }
+      return WalkResult::advance();
+    });
+  };
+};
+
+} // namespace
+
+namespace mlir {
+namespace test {
+void registerTestAccessorAnalysisPass() {
+  PassRegistration<TestAccessorAnalysisPass>();
+}
+} // end namespace test
+} // end namespace mlir

--- a/polygeist/test/polygeist-opt/sycl/accessor-analysis.mlir
+++ b/polygeist/test/polygeist-opt/sycl/accessor-analysis.mlir
@@ -5,6 +5,7 @@ llvm.func @__gxx_personality_v0(...) -> i32
 !sycl_id_1_ = !sycl.id<[1], (i64)>
 !sycl_range_1_ = !sycl.range<[1], (i64)>
 !sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
 
 // CHECK-LABEL: test_tag: full_information:
 // CHECK:        operand #0
@@ -102,4 +103,161 @@ llvm.func @join_accessor(%arg0 : i1) -> !llvm.ptr attributes {personality = @__g
 ^bb3:
   %4 = llvm.load %acc {tag = "join_accessor"} : !llvm.ptr -> i32
   llvm.return %acc : !llvm.ptr
+}
+
+// COM: Test scenario: Two accessors on the same buffer, with no range
+// information available for the accesors should yield may-alias.
+// CHECK-LABEL: test_tag: alias_same_buffer_no_range_info:
+// CHECK:        Alias (op#1 x op#2): MayAlias
+llvm.func @alias_same_buffer_no_range_info() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %range1 = arith.constant 128 : i64
+  %offset1 = arith.constant 64 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %range2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %offset2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_no_range_info"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.return %acc1 : !llvm.ptr
+}
+
+
+// COM: Test scenario: Two accessors on the same buffer, with no range
+// information required for the accesors, should yield must-alias, as 
+// both accessor cover the whole buffer.
+// CHECK-LABEL: test_tag: alias_same_buffer_no_range_required:
+// CHECK:        Alias (op#1 x op#2): MustAlias
+llvm.func @alias_same_buffer_no_range_required() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %buf1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_no_range_required"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.return %acc1 : !llvm.ptr
+}
+
+
+// COM: Test scenario: Two accessors on the same buffer, with range
+// information available for the accesors and no overlap between them should
+// yield a no-alias.
+// CHECK-LABEL: test_tag: alias_same_buffer_no_overlap:
+// CHECK:        Alias (op#1 x op#2): NoAlias
+llvm.func @alias_same_buffer_no_overlap() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %range1 = arith.constant 128 : i64
+  %offset1 = arith.constant 0 : i64
+  %range2 = arith.constant 128 : i64
+  %offset2 = arith.constant 128 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_no_overlap"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.return %acc1 : !llvm.ptr
+}
+
+
+// COM: Test scenario: Two accessors on the same buffer, with range
+// information available for the accesors and the two accessors' access
+// range fully overlapping should yield must-alias.
+// CHECK-LABEL: test_tag: alias_same_buffer_full_overlap:
+// CHECK:        Alias (op#1 x op#2): MustAlias
+llvm.func @alias_same_buffer_full_overlap() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %range1 = arith.constant 128 : i64
+  %offset1 = arith.constant 0 : i64
+  %range2 = arith.constant 128 : i64
+  %offset2 = arith.constant 0 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_full_overlap"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.return %acc1 : !llvm.ptr
+}
+
+
+// COM: Test scenario: Two accessors on the two different buffers, with buffer
+// information available should yield a no-alias, as both buffers are not 
+// sub-buffers.
+// CHECK-LABEL: test_tag: alias_two_buffers_with_info:
+// CHECK:        Alias (op#1 x op#2): NoAlias
+llvm.func @alias_two_buffers_with_info() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %buf1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %buf2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%buf1, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%buf2, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %buf2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_two_buffers_with_info"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.return %acc1 : !llvm.ptr
+}
+
+
+// COM: Test scenario: Two accessors on the two different buffers, with no
+// buffer information available should yield a may-alias, as the buffers may
+// be sub-buffers.
+// CHECK-LABEL: test_tag: alias_two_buffers_no_info:
+// CHECK:        Alias (op#1 x op#2): MayAlias
+llvm.func @alias_two_buffers_no_info() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %buf1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %buf2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %buf2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_two_buffers_no_info"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.return %acc1 : !llvm.ptr
 }

--- a/polygeist/test/polygeist-opt/sycl/accessor-analysis.mlir
+++ b/polygeist/test/polygeist-opt/sycl/accessor-analysis.mlir
@@ -1,0 +1,105 @@
+// RUN: polygeist-opt -split-input-file -test-accessor-analysis %s 2>&1 | FileCheck %s
+
+llvm.func @__gxx_personality_v0(...) -> i32
+
+!sycl_id_1_ = !sycl.id<[1], (i64)>
+!sycl_range_1_ = !sycl.range<[1], (i64)>
+!sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
+
+// CHECK-LABEL: test_tag: full_information:
+// CHECK:        operand #0
+// CHECK-NEXT:     accessor:
+// CHECK-NEXT:       Needs range: Yes
+// CHECK-NEXT:       Range: range{128}
+// CHECK-NEXT:       Needs offset: Yes
+// CHECK-NEXT:       Offset: id{64}
+// CHECK-NEXT:       Buffer: %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:       Buffer information:     Sub-Buffer: No
+// CHECK-NEXT:       Size: range{256}
+llvm.func @full_information() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %range = arith.constant 128 : i64
+  %offset = arith.constant 64 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+   sycl.host.constructor(%acc, %0, %range, %offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  %4 = llvm.load %acc {tag = "full_information"} : !llvm.ptr -> i32
+  llvm.return %acc : !llvm.ptr
+}
+
+// CHECK-LABEL: test_tag: no_information:
+// CHECK:        operand #0
+// CHECK-NEXT:     accessor:
+// CHECK-NEXT:       Needs range: Yes
+// CHECK-NEXT:       Range: <unknown>
+// CHECK-NEXT:       Needs offset: Yes
+// CHECK-NEXT:       Offset: <unknown>
+// CHECK-NEXT:       Buffer: %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+// CHECK-NEXT:       Buffer information: <unknown>
+llvm.func @no_information() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c256_i64 = arith.constant 256 : i64
+  %range = arith.constant 128 : i64
+  %offset = arith.constant 64 : i64
+  %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %4 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  sycl.host.constructor(%acc, %0, %1, %2, %3, %4) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb1
+^bb1:
+  %5 = llvm.load %acc {tag = "no_information"} : !llvm.ptr -> i32
+  llvm.return %acc : !llvm.ptr
+}
+
+// CHECK-LABEL: test_tag: join_accessor:
+// CHECK:        operand #0
+// CHECK-NEXT:     accessor:
+// CHECK-NEXT:       Needs range: Yes
+// CHECK-NEXT:       Range: <unknown>
+// CHECK-NEXT:       Needs offset: Yes
+// CHECK-NEXT:       Offset: <unknown>
+// CHECK-NEXT:       Buffer: <unknown>
+// CHECK-NEXT:       Buffer information:     Sub-Buffer: No
+// CHECK-NEXT:       Size: <unknown>
+llvm.func @join_accessor(%arg0 : i1) -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
+  %c1_i32 = arith.constant 1 : i32
+  %c64_i64 = arith.constant 64 : i64
+  %c128_i64 = arith.constant 128 : i64
+  %c256_i64 = arith.constant 256 : i64
+  %buf1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %buf2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::buffer", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc_range = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %acc_offset = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
+  llvm.cond_br %arg0, ^bb1, ^bb2
+^bb1:
+  sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%buf1, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc_range, %c128_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%acc_offset, %c64_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%acc, %buf1, %acc_range, %acc_offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb3
+^bb2:
+  sycl.host.constructor(%buf2, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc_range, %c64_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%acc_offset, %c128_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%acc, %buf2, %acc_range, %acc_offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  llvm.br ^bb3
+^bb3:
+  %4 = llvm.load %acc {tag = "join_accessor"} : !llvm.ptr -> i32
+  llvm.return %acc : !llvm.ptr
+}

--- a/polygeist/tools/polygeist-opt/polygeist-opt.cpp
+++ b/polygeist/tools/polygeist-opt/polygeist-opt.cpp
@@ -49,6 +49,7 @@ struct PtrElementModel
 
 namespace mlir {
 namespace test {
+void registerTestAccessorAnalysisPass();
 void registerTestBufferAnalysisPass();
 void registerTestIDAndRangeAnalysisPass();
 void registerTestMemoryAccessAnalysisPass();
@@ -59,6 +60,7 @@ void registerTestUniformityAnalysisPass();
 
 #ifdef MLIR_INCLUDE_TESTS
 void registerTestPasses() {
+  mlir::test::registerTestAccessorAnalysisPass();
   mlir::test::registerTestBufferAnalysisPass();
   mlir::test::registerTestIDAndRangeAnalysisPass();
   mlir::test::registerTestMemoryAccessAnalysisPass();


### PR DESCRIPTION
MLIR analysis to infer properties of interest about instances of `sycl:accessor` from their construction in host code.

This also includes the ability to query two accessor for their potential aliasing behavior.
