### PR TITLE
[SYCL][test-e2e] Fix lit config for sycl-ls

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import copy
 import re
 import subprocess
 import tempfile
@@ -238,10 +239,14 @@ if config.dump_ir_supported:
 
 lit_config.note("Targeted devices: {}".format(', '.join(config.sycl_devices)))
 
+sycl_ls = FindTool('sycl-ls').resolve(llvm_config, config.llvm_tools_dir)
+if not sycl_ls:
+    lit_config.fatal("can't find `sycl-ls`")
+
 if len(config.sycl_devices) == 1 and config.sycl_devices[0] == 'all':
     devices = set()
-    sp = subprocess.getstatusoutput('sycl-ls')
-    for line in sp[1].split('\n'):
+    sp = subprocess.check_output(sycl_ls, text=True)
+    for line in sp.splitlines():
         (backend, device, _) = line[1:].split(':', 2)
         devices.add('{}:{}'.format(backend, device))
     config.sycl_devices = list(devices)
@@ -326,7 +331,7 @@ tools = [
   # behaviour.
   ToolSubst(r'\| \bnot\b', command=FindTool('not'),
     verbatim=True, unresolved='ignore'),
-  ToolSubst('sycl-ls', unresolved='ignore'),
+  ToolSubst('sycl-ls', command=sycl_ls, unresolved='ignore'),
 ] + feature_tools
 
 # Try and find each of these tools in the llvm tools directory or the PATH, in
@@ -383,19 +388,29 @@ for sycl_device in config.sycl_devices:
 # discovered already.
 config.sycl_dev_features = {}
 for sycl_device in config.sycl_devices:
-    cmd = 'env '
+    env = copy.copy(llvm_config.config.environment)
+    env['ONEAPI_DEVICE_SELECTOR'] = sycl_device
     if sycl_device.startswith('ext_oneapi_cuda:'):
-        cmd += 'SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 '
-    cmd += 'ONEAPI_DEVICE_SELECTOR={} sycl-ls --verbose'.format(sycl_device)
-    sp = subprocess.run((cmd), env=llvm_config.config.environment,
-                        shell=True, capture_output=True, text=True)
-    if sp.returncode != 0:
-        lit_config.error('Cannot list device aspects for {}\nstdout:\n{}\nstderr:\n{}'.format(
-            sycl_device, sp.stdout, sp.stderr))
+        env['SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT'] = '1'
+    # When using the ONEAPI_DEVICE_SELECTOR environment variable, sycl-ls
+    # prints warnings that might derail a user thinking something is wrong
+    # with their test run. It's just us filtering here, so silence them unless
+    # we get an exit status.
+    try:
+        sp = subprocess.run([sycl_ls, '--verbose'], env=env, text=True,
+                            capture_output=True)
+        sp.check_returncode()
+    except subprocess.CalledProcessError as e:
+        # capturing e allows us to see path resolution errors / system
+        # permissions errors etc
+        lit_config.fatal(f'Cannot list device aspects for {sycl_device}\n'
+                         f'{e}\n'
+                         f'stdout:{sp.stdout}\n'
+                         f'stderr:{sp.stderr}\n')
 
     dev_aspects = []
     dev_sg_sizes = []
-    for line in sp.stdout.split('\n'):
+    for line in sp.stdout.splitlines():
         if re.search(r'^ *Aspects *:', line):
             _, aspects_str = line.split(':', 1)
             dev_aspects.append(aspects_str.strip().split(' '))


### PR DESCRIPTION
If sycl-ls is not on `PATH`, the lit config will fail with this message:

  env: '1': No such file or directory

It's cryptic, and it's a result of trying to use the first part of the spawned subshell's "not found" message as the path to the binary. Also, `sycl-ls` is a hard requirement for the end to end tests to run at all so we should use the one we built, and if we can't find it, we bail out with `fatal`.

This patch then, does 3 things:
  1. Prefers the `sycl-ls` we should have just built; it's implicitly being tested here so we *need* it. If the user wants to use an out-of tree sycl-ls, then running lit directly gives them mechanism to do that
  2. Fix the error handling to fail early with clearer and more useful error messages
  3. Cleanup subprocess usage. We don't need to spawn a shell for these usages, and don't need to call out to `env` because there are better `subprocess` mechanisms