### PR TITLE
[SYCL] [L0] Fix for unreferenced parameters.

### DIFF
--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -2042,10 +2042,15 @@ pi_result piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
 }
 
 pi_result piextUSMImport(const void *ptr, size_t size, pi_context context) {
+  std::ignore = ptr;
+  std::ignore = size;
+  std::ignore = context;
   return PI_SUCCESS;
 }
 
 pi_result piextUSMRelease(const void *ptr, pi_context context) {
+  std::ignore = ptr;
+  std::ignore = context;
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
This adds references to unused function parameters to avoid build errors.