### PR TITLE
[CI] Enable HIP/CUDA/ESIMD plugins in nightly build, 2nd attempt

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -57,8 +57,6 @@ jobs:
             test_build:
               - *sycl
               - *drivers_and_configs
-              # Temporary, until plugins are enabled in nightly image.
-              - sycl/**
 
       - name: Set output
         id: result

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -11,9 +11,7 @@ jobs:
     name: Generate Test Matrix
     uses: ./.github/workflows/sycl_gen_test_matrix.yml
     with:
-      # Restore once plugins are enabled in the build.
-      # lts_config: "hip_amdgpu;ocl_gen12;ocl_x64;l0_gen12;esimd_emu;cuda_aws;win_l0_gen12"
-      lts_config: "ocl_gen12;ocl_x64;l0_gen12;win_l0_gen12"
+      lts_config: "hip_amdgpu;ocl_gen12;ocl_x64;l0_gen12;esimd_emu;cuda_aws;win_l0_gen12"
 
   ubuntu2204_build_test:
     if: github.repository == 'intel/llvm'
@@ -23,11 +21,11 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default-2204
+      build_configure_extra_args: '--hip --cuda --enable-esimd-emulator'
       merge_ref: ''
       retention-days: 90
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
       lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
-      build_configure_extra_args: ''
 
   ubuntu2204_opaque_pointers_build_test:
     if: github.repository == 'intel/llvm'


### PR DESCRIPTION
This effectively reverts commit 5c10c73b1174afe887a282e6f650d364d51b6b40.