### PR TITLE
[SYCL] Fix unreferenced parameters

### DIFF
--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
@@ -2045,10 +2045,7 @@ pi_result piextUSMGetMemAllocInfo(pi_context, const void *, pi_mem_alloc_info,
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piextUSMImport(const void *ptr, size_t size, pi_context context) {
-  (void)ptr;
-  (void)size;
-  (void)context;
+pi_result piextUSMImport(const void *, size_t, pi_context) {
   return PI_SUCCESS;
 }
 

--- a/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
+++ b/sycl/plugins/esimd_emulator/pi_esimd_emulator.cpp
@@ -2046,10 +2046,15 @@ pi_result piextUSMGetMemAllocInfo(pi_context, const void *, pi_mem_alloc_info,
 }
 
 pi_result piextUSMImport(const void *ptr, size_t size, pi_context context) {
+  (void)ptr;
+  (void)size;
+  (void)context;
   return PI_SUCCESS;
 }
 
 pi_result piextUSMRelease(const void *ptr, pi_context context) {
+  (void)ptr;
+  (void)context;
   return PI_SUCCESS;
 }
 

--- a/sycl/plugins/opencl/pi_opencl.cpp
+++ b/sycl/plugins/opencl/pi_opencl.cpp
@@ -2042,10 +2042,15 @@ pi_result piextUSMGetMemAllocInfo(pi_context context, const void *ptr,
 }
 
 pi_result piextUSMImport(const void *ptr, size_t size, pi_context context) {
+  std::ignore = ptr;
+  std::ignore = size;
+  std::ignore = context;
   return PI_SUCCESS;
 }
 
 pi_result piextUSMRelease(const void *ptr, pi_context context) {
+  std::ignore = ptr;
+  std::ignore = context;
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
This adds references to unused function parameters to avoid build errors.