### PR TITLE
[XPTI] New hash function and additional TBB dependency removal

### DIFF
--- a/xpti/include/xpti/xpti_data_types.h
+++ b/xpti/include/xpti/xpti_data_types.h
@@ -14,6 +14,57 @@
 #include <unordered_map>
 
 namespace xpti {
+/// @brief Hash generation helper
+/// @details The Universal ID concept in XPTI requires a good hashing function
+/// and this data type provides the necessary functionality for creating the
+/// Universal ID. This implementation is derived from the paper:
+/// "Strongly universal string hashing is fast" by Daniel Lemire and Owen Kaser
+/// and the corresponding Java implementation available in the blog 2018/08/15:
+///  https:// github.com/lemire/Code-used-on-Daniel-Lemire-s-blog/
+struct hash_t {
+  // Random 64-bit constants used in generating the hash
+  static const uint64_t a1 = 0x65d200ce55b19ad8L;
+  static const uint64_t b1 = 0x4f2162926e40c299L;
+  static const uint64_t c1 = 0x162dd799029970f8L;
+  static const uint64_t a2 = 0x68b665e6872bd1f4L;
+  static const uint64_t b2 = 0xb6cfcf9d79b51db2L;
+  static const uint64_t c2 = 0x7a2b92ae912898c2L;
+
+  // Ability to generate a 32-bit hash from a 64-bit value
+  uint32_t hash32_1(uint64_t x) const {
+    int low = (int)x;
+    int high = (int)(x >> 32);
+    return (int)((a1 * low + b1 * high + c1) >> 32);
+  }
+  // Ability to generate a different 32-bit hash from a 64-bit value
+  // Alows you combine two different hash values generated from the same 64-bit
+  // value to create a 64-bit hash
+  uint32_t hash32_2(uint64_t x) const {
+    int low = (int)x;
+    int high = (int)(x >> 32);
+    return (int)((a2 * low + b2 * high + c2) >> 32);
+  }
+
+  // Create a 64-bit hash from a 64-bit value
+  uint64_t hash64(uint64_t x) const {
+    int low = (int)x;
+    int high = (int)(x >> 32);
+    return ((a1 * low + b1 * high + c1) >> 32) |
+           ((a2 * low + b2 * high + c2) & 0xFFFFFFFF00000000L);
+  }
+
+  // Murmur hash that is a non-cryptographic has function for general hash
+  // based lookup implemented by Daniel Lemire to compare the fast hash with a
+  // standard hash function
+  uint64_t murmur64(uint64_t h) const {
+    h ^= h >> 33;
+    h *= 0xff51afd7ed558ccdL;
+    h ^= h >> 33;
+    h *= 0xc4ceb9fe1a85ec53L;
+    h ^= h >> 33;
+    return h;
+  }
+};
 /// @brief Universal ID data structure that is central to XPTI
 /// @details A given trace point is referred to by it its universal ID and this
 /// data structure has all the elements that are necessary to map to the code
@@ -31,11 +82,13 @@ struct uid_t {
   /// Contains the address of the kernel object or SYCL object references and
   /// only the lower 32-bits will be used to generate the hash
   uint64_t p3 = 0;
+  /// Hash generation helper
+  hash_t helper;
 
   uid_t() = default;
   /// Computes a hash that is a bijection between N^3 and N
   /// (x,y,z) |-> (x) + (x+y+1)/2 + (x+y+z+2)/3
-  uint64_t hash() const {
+  uint64_t old_hash() const {
     /// Use lower 32-bits of the address
     uint32_t v3 = (uint32_t)(p3 & 0x00000000ffffffff);
     /// Use p1 and p2 as is; since p1 and p2 upper 32-bits is built from string
@@ -44,6 +97,10 @@ struct uid_t {
     /// 64-bit accumulator.
     return (p1 + (p1 + p2 + 1) / 2 + (p1 + p2 + v3 + 2) / 3);
   }
+
+  /// New hash generation function that will take into account the absence of
+  /// code location information required to generate p1 and p2
+  uint64_t hash() const { return helper.hash64(p1) + helper.hash64(p2) + p3; }
 
   bool operator<(const uid_t &rhs) const {
     if (p1 < rhs.p1)
@@ -163,7 +220,7 @@ struct payload_t {
   /// Kernel/lambda/function address
   const void *code_ptr_va = nullptr;
   /// Internal bookkeeping slot - do not change.
-  uint64_t internal;
+  uint64_t internal = 0;
   /// Flags indicating whether string name, codepointer, source file and hash
   /// values are available
   uint64_t flags = 0;
@@ -259,8 +316,9 @@ struct payload_t {
     }
   }
 
-  int32_t name_sid() const { return (int32_t)(uid.p2 & 0x00000000ffffffff); }
-  int32_t stacktrace_sid() const { return (int32_t)(uid.p2 >> 32); }
+  int32_t name_sid() const { return (int32_t)(uid.p1 & 0x00000000ffffffff); }
+  // Will be deprecated during the next ABI breakage window
+  int32_t stacktrace_sid() const { return 0; }
   int32_t source_file_sid() const { return (int32_t)(uid.p1 >> 32); }
 };
 

--- a/xpti/include/xpti/xpti_data_types.h
+++ b/xpti/include/xpti/xpti_data_types.h
@@ -79,8 +79,12 @@ struct uid_t {
   /// dynamic stack walk is performed, the upper 32-bits contain the string ID
   /// of the caller->callee combination string.
   uint64_t p2 = 0;
-  /// Contains the address of the kernel object or SYCL object references and
-  /// only the lower 32-bits will be used to generate the hash
+  /// Previous implementations stored a reference to a SYCL object in p3 and
+  /// since such references are generally not available whn the payload and UID
+  /// are created, p3 will now contain a monotonically increasing 64-bit value
+  /// that is always considered unique. In the case payload information is
+  /// invalid (when NDEBUG is provided at compile time), the hash will return
+  /// the unique value in p3
   uint64_t p3 = 0;
   /// Hash generation helper
   hash_t helper;

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -18,9 +18,6 @@ if (NOT DEFINED XPTI_DIR) # don't overwrite if already set
   endif()
 endif()
 
-# Create a soft option for enabling the use of TBB
-option(XPTI_ENABLE_TBB "Enable TBB in the framework" OFF)
-
 option(XPTI_ENABLE_WERROR OFF)
 option(XPTI_BUILD_SAMPLES OFF)
 option(XPTI_BUILD_BENCHMARK OFF)

--- a/xptifw/basic_test/parallel_test.h
+++ b/xptifw/basic_test/parallel_test.h
@@ -1,0 +1,22 @@
+//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+#pragma once
+#include "external/BS_thread_pool.hpp"
+
+// Macro to parallelize a loop.
+#define PARALLEL_FOR(tp, func, lower, upper)                                   \
+  {                                                                            \
+    int NumWorkers = tp.get_thread_count();                                    \
+    int Step = (upper - lower + 1) / NumWorkers;                               \
+    for (int i = 0; i < NumWorkers; ++i) {                                     \
+      int Min = lower + i * Step;                                              \
+      int Max = std::min<int>((lower + (i + 1) * Step), upper);                \
+      auto Ret = tp.submit(func, Min, Max);                                    \
+    }                                                                          \
+    tp.wait_for_tasks();                                                       \
+  }

--- a/xptifw/basic_test/performance_tests.cpp
+++ b/xptifw/basic_test/performance_tests.cpp
@@ -16,26 +16,13 @@
 //
 // Copyright (c) 2023 Barak Shoshany. Licensed under the MIT license.
 #include "cl_processor.hpp"
-#include "external/BS_thread_pool.hpp"
+#include "parallel_test.h"
 #include "xpti/xpti_trace_framework.h"
 
 #include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <random>
-
-// Macro to parallelize a loop.
-#define PARALLEL_FOR(tp, func, lower, upper)                                   \
-  {                                                                            \
-    int NumWorkers = tp.get_thread_count();                                    \
-    int Step = (upper - lower + 1) / NumWorkers;                               \
-    for (int i = 0; i < NumWorkers; ++i) {                                     \
-      int Min = lower + i * Step;                                              \
-      int Max = std::min<int>((lower + (i + 1) * Step), upper);                \
-      auto Ret = tp.submit(func, Min, Max);                                    \
-    }                                                                          \
-    tp.wait_for_tasks();                                                       \
-  }
 
 namespace test {
 void registerCallbacks(uint8_t sid);

--- a/xptifw/unit_test/xpti_api_tests.cpp
+++ b/xptifw/unit_test/xpti_api_tests.cpp
@@ -82,7 +82,9 @@ TEST_F(xptiApiTest, xptiRegisterPayloadBadInput) {
   xpti::payload_t p;
 
   auto ID = xptiRegisterPayload(&p);
-  EXPECT_EQ(ID, xpti::invalid_uid);
+  // With the new change in Hash algorithm, an invalid payload will generate a
+  // 64-bit ID using the monotonically increasing value in uid.p3
+  EXPECT_NE(ID, xpti::invalid_uid);
 }
 
 TEST_F(xptiApiTest, xptiGetUniqueId) {

--- a/xptifw/unit_test/xpti_correctness_tests.cpp
+++ b/xptifw/unit_test/xpti_correctness_tests.cpp
@@ -571,19 +571,47 @@ TEST_F(xptiCorrectnessTest, xptiUniversalIDTest) {
   uint64_t instance;
   /// Simulates the specialization of a Kernel as used by MKL where
   /// the same kernel may be compiled multiple times
-  xpti::payload_t Payload("foo", "foo.cpp", 1, 0, (void *)&Id0);
+  xpti::payload_t Payload("foo", "foo.cpp", 1, 5,
+                          (void *)&Id0 /*Value will be ignored*/);
   auto Result = xptiMakeEvent("foo", &Payload, 0,
                               (xpti::trace_activity_type_t)1, &instance);
-  Id0.p1 = XPTI_PACK32_RET64(Payload.source_file_sid(), Payload.line_no);
-  Id0.p2 = XPTI_PACK32_RET64(0, Payload.name_sid());
-  Id0.p3 = (uint64_t)Payload.code_ptr_va;
-  xpti::payload_t P("foo", "foo.cpp", 1, 0, (void *)&Id1);
+  Id0.p1 = XPTI_PACK32_RET64(Payload.source_file_sid(), Payload.name_sid());
+  Id0.p2 = XPTI_PACK32_RET64(Payload.line_no, Payload.column_no);
+  Id0.p3 = 0;
+  xpti::payload_t P("foo", "foo.cpp", 1, 5,
+                    (void *)&Id1 /* Value will be ignored*/);
   auto Result1 =
       xptiMakeEvent("foo", &P, 0, (xpti::trace_activity_type_t)1, &instance);
-  Id1.p1 = XPTI_PACK32_RET64(P.source_file_sid(), P.line_no);
-  Id1.p2 = XPTI_PACK32_RET64(0, P.name_sid());
-  Id1.p3 = (uint64_t)P.code_ptr_va;
-  EXPECT_NE(Result, Result1);
+  Id1.p1 = XPTI_PACK32_RET64(P.source_file_sid(), P.name_sid());
+  Id1.p2 = XPTI_PACK32_RET64(P.line_no, P.column_no);
+  Id1.p3 = 0;
+  // Since codeptr value is ignored, Id0.p1 == Id1.p1 && Id0.p2 == Id1.p2
+  EXPECT_EQ(Result, Result1);
+  EXPECT_EQ(Id0.hash(), Id1.hash());
+}
+
+TEST_F(xptiCorrectnessTest, xptiUniversalIDNDEBUGTest) {
+  xpti::uid_t Id0, Id1;
+  uint64_t instance;
+
+  xpti::payload_t P1;
+  auto Result2 =
+      xptiMakeEvent("foo", &P1, 0, (xpti::trace_activity_type_t)1, &instance);
+  Id0.p1 = 0;
+  Id0.p2 = 0;
+  Id0.p3 = (uint64_t)(&P1);
+  xpti::payload_t P2; // Value will be ignored
+  auto Result3 =
+      xptiMakeEvent("foo", &P2, 0, (xpti::trace_activity_type_t)1, &instance);
+  Id1.p1 = 0;
+  Id1.p2 = 0;
+  Id1.p3 = (uint64_t)(&P2); // Value will be ignored
+  // Since codeptr value is ignored, Id0.p1 == Id1.p1 && Id0.p2 == Id1.p2
+  // and Id0.p3 !> Id1.p3 as these will have different monotonically increasing
+  // 64-bit values, the hash generated will be different. This will result in
+  // two different trace events; This is expected result when NDEBUG is used
+  // during compilation and conflicts are avoided with unique 64-bit values
+  EXPECT_NE(Result2, Result3);
   EXPECT_NE(Id0.hash(), Id1.hash());
 }
 
@@ -592,16 +620,17 @@ TEST_F(xptiCorrectnessTest, xptiUniversalIDRandomTest) {
   set<uint64_t> HashSet;
   random_device QRd;
   mt19937_64 Gen(QRd());
-  uniform_int_distribution<uint32_t> MStringID, MLineNo, MAddr;
+  uniform_int_distribution<uint32_t> MStringID, MLineNo, MColumnNo, MAddr;
 
   MStringID = uniform_int_distribution<uint32_t>(1, 1000000);
   MLineNo = uniform_int_distribution<uint32_t>(1, 200000);
+  MColumnNo = uniform_int_distribution<uint32_t>(1, 256);
   MAddr = uniform_int_distribution<uint32_t>(0x10000000, 0xffffffff);
 
   for (int i = 0; i < 1000000; ++i) {
     xpti::uid_t id;
-    id.p1 = XPTI_PACK32_RET64(MStringID(Gen), MLineNo(Gen));
-    id.p2 = XPTI_PACK32_RET64(0, MStringID(Gen));
+    id.p1 = XPTI_PACK32_RET64(MStringID(Gen), MStringID(Gen));
+    id.p2 = XPTI_PACK32_RET64(MLineNo(Gen), MColumnNo(Gen));
     id.p3 = (uint64_t)MAddr(Gen);
 
     uint64_t hash = id.hash();
@@ -611,13 +640,13 @@ TEST_F(xptiCorrectnessTest, xptiUniversalIDRandomTest) {
 
   xpti::uid_t id1, id2;
   uint32_t sid = MStringID(Gen), ln = MLineNo(Gen), kid = MStringID(Gen),
-           addr = MAddr(Gen);
-  id1.p1 = XPTI_PACK32_RET64(sid, ln);
-  id1.p2 = XPTI_PACK32_RET64(0, kid);
+           addr = MAddr(Gen), col = MColumnNo(Gen);
+  id1.p1 = XPTI_PACK32_RET64(sid, kid);
+  id1.p2 = XPTI_PACK32_RET64(ln, col);
   id1.p3 = (uint64_t)addr;
 
-  id2.p1 = XPTI_PACK32_RET64(sid, ln);
-  id2.p2 = XPTI_PACK32_RET64(0, kid);
+  id2.p1 = XPTI_PACK32_RET64(sid, kid);
+  id2.p2 = XPTI_PACK32_RET64(ln, col);
   id2.p3 = (uint64_t)addr;
 
   EXPECT_EQ(id1.hash(), id2.hash());
@@ -628,17 +657,18 @@ TEST_F(xptiCorrectnessTest, xptiUniversalIDMapTest) {
   map<xpti::uid_t, uint64_t> MapTest;
   random_device QRd;
   mt19937_64 Gen(QRd());
-  uniform_int_distribution<uint32_t> MStringID, MLineNo, MAddr;
+  uniform_int_distribution<uint32_t> MStringID, MLineNo, MColumnNo, MAddr;
 
   MStringID = uniform_int_distribution<uint32_t>(1, 1000000);
   MLineNo = uniform_int_distribution<uint32_t>(1, 200000);
+  MColumnNo = uniform_int_distribution<uint32_t>(1, 256);
   MAddr = uniform_int_distribution<uint32_t>(0x10000000, 0xffffffff);
 
   constexpr unsigned int Count = 100000;
   for (unsigned int i = 0; i < Count; ++i) {
     xpti::uid_t id;
-    id.p1 = XPTI_PACK32_RET64(MStringID(Gen), MLineNo(Gen));
-    id.p2 = XPTI_PACK32_RET64(0, MStringID(Gen));
+    id.p1 = XPTI_PACK32_RET64(MStringID(Gen), MStringID(Gen));
+    id.p2 = XPTI_PACK32_RET64(MLineNo(Gen), MColumnNo(Gen));
     id.p3 = (uint64_t)MAddr(Gen);
 
     uint64_t hash = id.hash();
@@ -663,17 +693,18 @@ TEST_F(xptiCorrectnessTest, xptiUniversalIDUnorderedMapTest) {
   unordered_map<xpti::uid_t, uint64_t> MapTest;
   random_device QRd;
   mt19937_64 Gen(QRd());
-  uniform_int_distribution<uint32_t> MStringID, MLineNo, MAddr;
+  uniform_int_distribution<uint32_t> MStringID, MLineNo, MColumnNo, MAddr;
 
   MStringID = uniform_int_distribution<uint32_t>(1, 1000000);
   MLineNo = uniform_int_distribution<uint32_t>(1, 200000);
+  MColumnNo = uniform_int_distribution<uint32_t>(1, 256);
   MAddr = uniform_int_distribution<uint32_t>(0x10000000, 0xffffffff);
 
   constexpr unsigned int Count = 100000;
   for (unsigned int i = 0; i < Count; ++i) {
     xpti::uid_t id;
-    id.p1 = XPTI_PACK32_RET64(MStringID(Gen), MLineNo(Gen));
-    id.p2 = XPTI_PACK32_RET64(0, MStringID(Gen));
+    id.p1 = XPTI_PACK32_RET64(MStringID(Gen), MStringID(Gen));
+    id.p2 = XPTI_PACK32_RET64(MLineNo(Gen), MColumnNo(Gen));
     id.p3 = (uint64_t)MAddr(Gen);
 
     uint64_t hash = id.hash();


### PR DESCRIPTION
Semantic and correctness testing of the XPTI framework relies on std::for_each parallel execution policy. However, this adds an install dependency of the TBB development package. To remove this inconvenience,  the semantic tests that used std::for_each have been modified to use the same thread pool functionality adopted by the performance tests. 

Other changes:
  + New hash function that no longer relies on codeptr field of the payload structure t to generate the hash, and will eliminate collisions for cases where codeptr information is not available and a null value has to be sent for this field. 
