### PR TITLE
[SYCL][CUDA] Pass device from context in create queue.

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -1570,7 +1570,6 @@ inline pi_result piextQueueCreateWithNativeHandle(
   PI_ASSERT(Context, PI_ERROR_INVALID_CONTEXT);
   PI_ASSERT(NativeHandle, PI_ERROR_INVALID_VALUE);
   PI_ASSERT(Queue, PI_ERROR_INVALID_QUEUE);
-  PI_ASSERT(Device, PI_ERROR_INVALID_DEVICE);
 
   ur_context_handle_t UrContext =
       reinterpret_cast<ur_context_handle_t>(Context);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
@@ -243,6 +243,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
     ur_device_handle_t hDevice, const ur_queue_native_properties_t *pProperties,
     ur_queue_handle_t *phQueue) {
   (void)pProperties;
+  (void)hDevice;
 
   unsigned int CuFlags;
   CUstream CuStream = reinterpret_cast<CUstream>(hNativeQueue);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
@@ -246,7 +246,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
 
   unsigned int CuFlags;
   CUstream CuStream = reinterpret_cast<CUstream>(hNativeQueue);
-  UR_ASSERT(hContext->getDevice() == hDevice, UR_RESULT_ERROR_INVALID_DEVICE);
 
   auto Return = UR_CHECK_ERROR(cuStreamGetFlags(CuStream, &CuFlags));
 
@@ -266,7 +265,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   *phQueue = new ur_queue_handle_t_{std::move(ComputeCuStreams),
                                     std::move(TransferCuStreams),
                                     hContext,
-                                    hDevice,
+                                    hContext->getDevice(),
                                     CuFlags,
                                     Flags,
                                     /*backend_owns*/ false};


### PR DESCRIPTION
Recently in the switch to UR `urQueueCreateFromNativeHandle` changed the previous behaviour whereby a queue was created with a device taken as the default device from the context. It changed it so that the queue was created with the device argument instead. Since the sycl runtime always passes a nullptr for the device when programmers call `make_queue(nativeStream, context)`, this broke `make_queue`. This patch reverts to the previous behaviour before the switch from pi cuda to ur cuda.

Note that this should also fix `make_queue` for l0 which I also guess was broken due to the asserts meaning that this line was never reached: https://github.com/intel/llvm/blob/sycl/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp#L574. But I have not tested this.