### PR TITLE
[SYCL-MLIR][Polygeist] Support bswap builtin lowering

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -1491,6 +1491,7 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
   };
   Optional<Value> V = std::nullopt;
   std::optional<mlir::Type> ElemTy = std::nullopt;
+
   switch (Expr->getBuiltinCallee()) {
   case clang::Builtin::BIceil: {
     VisitArgs();
@@ -1665,6 +1666,15 @@ MLIRScanner::emitBuiltinOps(clang::CallExpr *Expr) {
                                    /*isVolatile*/ false);
     V = Args[0];
     ElemTy = Builder.getI8Type();
+  } break;
+  case clang::Builtin::BI__builtin_bswap16:
+  case clang::Builtin::BI__builtin_bswap32:
+  case clang::Builtin::BI__builtin_bswap64:
+  case clang::Builtin::BI_byteswap_ushort:
+  case clang::Builtin::BI_byteswap_ulong:
+  case clang::Builtin::BI_byteswap_uint64: {
+    VisitArgs();
+    V = Builder.create<LLVM::ByteSwapOp>(Loc, Args[0]);
   } break;
   }
 

--- a/polygeist/tools/cgeist/Test/CMakeLists.txt
+++ b/polygeist/tools/cgeist/Test/CMakeLists.txt
@@ -14,6 +14,7 @@ list(APPEND MLIR_CLANG_TEST_DEPS
   FileCheck count not
   llvm-config 
   llvm-dis
+  llvm-as
   mlir-translate
   opt
   split-file

--- a/polygeist/tools/cgeist/Test/Verification/builtin.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/builtin.cpp
@@ -1,0 +1,13 @@
+// RUN: cgeist -O0 %s -w -o - -S --function=* | FileCheck %s
+
+// COM: Test bswap builtin lowering
+
+// CHECK:   func.func @_Z5bswap
+void bswap(unsigned short* s, unsigned int* i, unsigned long *l) {
+  // CHECK: llvm.intr.bswap({{.*}}) : (i16) -> i16
+  *s = __builtin_bswap16(*s);
+  // CHECK: llvm.intr.bswap({{.*}}) : (i32) -> i32
+  *i = __builtin_bswap32(*i);
+  // CHECK: llvm.intr.bswap({{.*}}) : (i64) -> i64
+  *l = __builtin_bswap64(*l);
+}


### PR DESCRIPTION
Lower __builtin_bswap* to the llvm ByteSwap op.