### PR TITLE
[CI][NFC] Remove dead code from sycl_detect_changes.yml

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -49,14 +49,9 @@ jobs:
               - 'sycl/!(test-e2e|doc)/**'
             ci:
               - .github/workflows/**
-              - devops/*/**
               # devops/* contains config files, including drivers versions.
               # Allow them to be tested in pre-commit.
-            drivers_and_configs: &drivers_and_configs
-              - devops/*
-            test_build:
-              - *sycl
-              - *drivers_and_configs
+              - devops/*/**
 
       - name: Set output
         id: result
@@ -69,6 +64,6 @@ jobs:
               return '${{ steps.changes.outputs.changes }}';
             }
             // Treat everything as changed for huge PRs.
-            return ["llvm", "llvm_spirv", "clang", "sycl_fusion", "xptifw", "libclc", "sycl", "ci", "drivers_and_configs", "test_build"];
+            return ["llvm", "llvm_spirv", "clang", "sycl_fusion", "xptifw", "libclc", "sycl", "ci"];
 
       - run: echo '${{ steps.result.outputs.result }}'


### PR DESCRIPTION
We've removed support for E2E tests on nightly compiler/image in pre-commit, so these aren't used anymore.