### PR TITLE
[SYCL][NFC] Move __SYCL_STRINGIFY definition from headers

### DIFF
--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -80,10 +80,5 @@
 #endif
 #endif
 
-// Stringify an argument to pass it in _Pragma directive below.
-#ifndef __SYCL_STRINGIFY
-#define __SYCL_STRINGIFY(x) #x
-#endif // __SYCL_STRINGIFY
-
 static_assert(__cplusplus >= 201703L,
               "DPCPP does not support C++ version earlier than C++17.");

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -24,6 +24,11 @@ namespace detail {
 #define SYCL_CONFIG_FILE_NAME "sycl.conf"
 #endif // SYCL_CONFIG_FILE_NAME
 
+// Stringify an argument to pass it in _Pragma directive below.
+#ifndef __SYCL_STRINGIFY
+#define __SYCL_STRINGIFY(x) #x
+#endif // __SYCL_STRINGIFY
+
 #define CONFIG(Name, MaxSize, CompileTimeDef)                                  \
   const char *SYCLConfigBase<Name>::MValueFromFile = nullptr;                  \
   char SYCLConfigBase<Name>::MStorage[MaxSize + 1];                            \


### PR DESCRIPTION
The only real use of the macro is in config.cpp file. The macro was used
in sycl/detail/common.hpp, but the use is commented out.
