### PR TITLE
[SYCL-MLIR] Define `sycl.host.submit` operation

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -228,7 +228,7 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
   let hasVerifier = 1;
 }
 
-def SYCLHostSubmit : SYCL_HostOp<"submit",
+def SYCLHostSubmitOp : SYCL_HostOp<"submit",
     [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
   let summary = "Submits a SYCL kernel.";
   let description = [{
@@ -244,12 +244,12 @@ def SYCLHostSubmit : SYCL_HostOp<"submit",
   }];
 
   let arguments = (ins
-    SymbolRefAttr:$kernel_name,
+    SymbolRefAttr:$c_g_f_name,
     Arg<LLVM_AnyPointer, "The queue", [MemWrite]>:$queue,
     Arg<LLVM_AnyPointer, "The event", [MemWrite]>:$event,
     Variadic<AnyType>:$args);
   let assemblyFormat = [{
-    $queue `(` (`[` $args^ `]`)? `` $kernel_name `)` `->` $event
+    $queue `(` (`[` $args^ `]`)? `` $c_g_f_name `)` `->` $event
       attr-dict `:` type(operands)
   }];
 }

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -238,13 +238,13 @@ def SYCLHostSubmitOp : SYCL_HostOp<"submit",
 
     Example:
     ```
-    sycl.host.submit %queue([%buff_a, %buff_b]@kernels::@k0) -> %event
+    sycl.host.submit %queue([%buff_a, %buff_b]@cgf_impl) -> %event
       : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
     ```
   }];
 
   let arguments = (ins
-    SymbolRefAttr:$c_g_f_name,
+    FlatSymbolRefAttr:$c_g_f_name,
     Arg<LLVM_AnyPointer, "The queue", [MemWrite]>:$queue,
     Arg<LLVM_AnyPointer, "The event", [MemWrite]>:$event,
     Variadic<AnyType>:$args);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -228,4 +228,30 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
   let hasVerifier = 1;
 }
 
+def SYCLHostSubmit : SYCL_HostOp<"submit",
+    [DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
+  let summary = "Submits a SYCL kernel.";
+  let description = [{
+    This operation represents the submission of a SYCL kernel
+    (`sycl::queue::submit`). In addition to the function implementing the CGF,
+    this operation receives the values captured (by reference) by this.
+
+    Example:
+    ```
+    sycl.host.submit %queue([%buff_a, %buff_b]@kernels::@k0) -> %event
+      : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
+    ```
+  }];
+
+  let arguments = (ins
+    SymbolRefAttr:$kernel_name,
+    Arg<LLVM_AnyPointer, "The queue", [MemWrite]>:$queue,
+    Arg<LLVM_AnyPointer, "The event", [MemWrite]>:$event,
+    Variadic<AnyType>:$args);
+  let assemblyFormat = [{
+    $queue `(` (`[` $args^ `]`)? `` $kernel_name `)` `->` $event
+      attr-dict `:` type(operands)
+  }];
+}
+
 #endif // SYCL_HOST_OPS

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -597,5 +597,10 @@ LogicalResult SYCLHostScheduleKernel::verify() {
   return verifyNdRange(*this, range, offset, ndRange);
 }
 
+LogicalResult
+SYCLHostSubmit::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
+}
+
 #define GET_OP_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOps.cpp.inc"

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 
 #include "mlir/Dialect/Affine/IR/AffineOps.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/SYCL/IR/SYCLAttributes.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/IR/BuiltinTypes.h"
@@ -598,8 +599,14 @@ LogicalResult SYCLHostScheduleKernel::verify() {
 }
 
 LogicalResult
-SYCLHostSubmit::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
+SYCLHostSubmitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
+  SymbolRefAttr symbol = getCGFNameAttr();
+  auto cgf =
+      symbolTable.lookupNearestSymbolFrom<LLVM::LLVMFuncOp>(*this, symbol);
+  if (!cgf)
+    return emitOpError("'")
+           << symbol << "' does not reference a valid CGF function";
+  return success();
 }
 
 #define GET_OP_CLASSES

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -600,7 +600,7 @@ LogicalResult SYCLHostScheduleKernel::verify() {
 
 LogicalResult
 SYCLHostSubmitOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  SymbolRefAttr symbol = getCGFNameAttr();
+  FlatSymbolRefAttr symbol = getCGFNameAttr();
   auto cgf =
       symbolTable.lookupNearestSymbolFrom<LLVM::LLVMFuncOp>(*this, symbol);
   if (!cgf)

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -148,3 +148,26 @@ func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.p
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
   func.return
 }
+
+// CHECK-LABEL:   func.func @submit_kernel(
+// CHECK-SAME:                             %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr, %[[VAL_3:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.submit %[[VAL_1]]({{\[}}%[[VAL_2]], %[[VAL_3]]]@kernels::@k0) -> %[[VAL_0]] : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
+// CHECK:           return
+// CHECK:         }
+func.func @submit_kernel(%event: !llvm.ptr, %queue: !llvm.ptr,
+                         %arg0: !llvm.ptr, %arg1 : !llvm.ptr) {
+  sycl.host.submit %queue([%arg0, %arg1]@kernels::@k0) -> %event
+    : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+// CHECK-LABEL:   func.func @submit_kernel_no_args(
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr,
+// CHECK-SAME:                                     %[[VAL_1:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.submit %[[VAL_1]](@kernels::@k0) -> %[[VAL_0]] : !llvm.ptr, !llvm.ptr
+// CHECK:           return
+// CHECK:         }
+func.func @submit_kernel_no_args(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  sycl.host.submit %queue(@kernels::@k0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -149,14 +149,16 @@ func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.p
   func.return
 }
 
+llvm.func @cgf()
+
 // CHECK-LABEL:   func.func @submit_kernel(
 // CHECK-SAME:                             %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr, %[[VAL_3:.*]]: !llvm.ptr) {
-// CHECK:           sycl.host.submit %[[VAL_1]]({{\[}}%[[VAL_2]], %[[VAL_3]]]@kernels::@k0) -> %[[VAL_0]] : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
+// CHECK:           sycl.host.submit %[[VAL_1]]({{\[}}%[[VAL_2]], %[[VAL_3]]]@cgf) -> %[[VAL_0]] : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
 // CHECK:           return
 // CHECK:         }
 func.func @submit_kernel(%event: !llvm.ptr, %queue: !llvm.ptr,
                          %arg0: !llvm.ptr, %arg1 : !llvm.ptr) {
-  sycl.host.submit %queue([%arg0, %arg1]@kernels::@k0) -> %event
+  sycl.host.submit %queue([%arg0, %arg1]@cgf) -> %event
     : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
   func.return
 }
@@ -164,10 +166,10 @@ func.func @submit_kernel(%event: !llvm.ptr, %queue: !llvm.ptr,
 // CHECK-LABEL:   func.func @submit_kernel_no_args(
 // CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                                     %[[VAL_1:.*]]: !llvm.ptr) {
-// CHECK:           sycl.host.submit %[[VAL_1]](@kernels::@k0) -> %[[VAL_0]] : !llvm.ptr, !llvm.ptr
+// CHECK:           sycl.host.submit %[[VAL_1]](@cgf) -> %[[VAL_0]] : !llvm.ptr, !llvm.ptr
 // CHECK:           return
 // CHECK:         }
 func.func @submit_kernel_no_args(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  sycl.host.submit %queue(@kernels::@k0) -> %event : !llvm.ptr, !llvm.ptr
+  sycl.host.submit %queue(@cgf) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -149,7 +149,9 @@ func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.p
   func.return
 }
 
-llvm.func @cgf()
+llvm.func internal @cgf(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+  llvm.return
+}
 
 // CHECK-LABEL:   func.func @submit_kernel(
 // CHECK-SAME:                             %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr, %[[VAL_3:.*]]: !llvm.ptr) {

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -613,3 +613,17 @@ gpu.module @kernels {
     gpu.return
   }
 }
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op '@kernels::@k0' does not reference a valid kernel}}
+  sycl.host.submit %queue(@kernels::@k0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+gpu.module @kernels {
+  gpu.func @k0() {
+    gpu.return
+  }
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -625,3 +625,64 @@ func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
 func.func @f0() {
   func.return
 }
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function to have internal linkage}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+llvm.func @f0(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
+  llvm.return
+}
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+llvm.func internal @f0(%arg0: !llvm.ptr, %arg1: i64) {
+  llvm.return
+}
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+llvm.func internal @f0(%arg0: !llvm.ptr) {
+  llvm.return
+}
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+llvm.func internal @f0(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> i64 {
+  %0 = llvm.mlir.constant(0 : i64) : i64
+  llvm.return %0 : i64
+}
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+llvm.func internal @f0(%arg0: !llvm.ptr, ...) {
+  llvm.return
+}

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -617,13 +617,11 @@ gpu.module @kernels {
 // -----
 
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@kernels::@k0' does not reference a valid CGF function}}
-  sycl.host.submit %queue(@kernels::@k0) -> %event : !llvm.ptr, !llvm.ptr
+  // expected-error @below {{'sycl.host.submit' op '@f0' does not reference a valid CGF function}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }
 
-gpu.module @kernels {
-  gpu.func @k0() {
-    gpu.return
-  }
+func.func @f0() {
+  func.return
 }

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -617,7 +617,7 @@ gpu.module @kernels {
 // -----
 
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@kernels::@k0' does not reference a valid kernel}}
+  // expected-error @below {{'sycl.host.submit' op '@kernels::@k0' does not reference a valid CGF function}}
   sycl.host.submit %queue(@kernels::@k0) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -629,7 +629,8 @@ func.func @f0() {
 // -----
 
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function to have internal linkage}}
+  // expected-error @below {{'sycl.host.submit' op expects CGF function to have internal linkage}}
+  // expected-note @below {{got: 'external'}}
   sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }
@@ -641,31 +642,43 @@ llvm.func @f0(%arg0: !llvm.ptr, %arg1: !llvm.ptr) {
 // -----
 
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  // expected-error @below {{'sycl.host.submit' op expects CGF function to not have variadic arguments}}
   sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }
 
-llvm.func internal @f0(%arg0: !llvm.ptr, %arg1: i64) {
+llvm.func internal @f0(%arg0: !llvm.ptr, ...) {
   llvm.return
 }
 
 // -----
 
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  // expected-error @below {{'sycl.host.submit' op incorrect number of operands for CGF}}
   sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }
 
-llvm.func internal @f0(%arg0: !llvm.ptr) {
+llvm.func internal @f0(%arg1: i64) {
   llvm.return
 }
 
 // -----
 
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
+  // expected-error @below {{'sycl.host.submit' op expecting CGF's operand type '!llvm.ptr', but got 'i64' for operand number 0}}
+  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
+  func.return
+}
+
+llvm.func internal @f0(%arg0: i64, %arg1: !llvm.ptr) {
+  llvm.return
+}
+
+// -----
+
+func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.submit' op expecting CGF's result type '!llvm.void', but got 'i64'}}
   sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
   func.return
 }
@@ -673,16 +686,4 @@ func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
 llvm.func internal @f0(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> i64 {
   %0 = llvm.mlir.constant(0 : i64) : i64
   llvm.return %0 : i64
-}
-
-// -----
-
-func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
-  // expected-error @below {{'sycl.host.submit' op '@f0' expects CGF function type to be (!llvm.ptr, !llvm.ptr) -> ()}}
-  sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr
-  func.return
-}
-
-llvm.func internal @f0(%arg0: !llvm.ptr, ...) {
-  llvm.return
 }


### PR DESCRIPTION
This operation represents the submission of a SYCL kernel (`sycl::queue::submit`). In addition to the function implementing the CGF, this operation receives the values captured (by reference) by this.

Example:

```mlir
sycl.host.submit %queue([%buff_a, %buff_b]@kernels::@k0) -> %event
  : !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr
```