### PR TITLE
[SYCL][L0] Remove not needed mutex

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
@@ -73,13 +73,6 @@ struct _ur_ze_event_list_t {
   // of elements in the above arrays that are valid.
   uint32_t Length = {0};
 
-  // A mutex is needed for destroying the event list.
-  // Creation is already thread-safe because we only create the list
-  // when an event is initially created.  However, it might be
-  // possible to have multiple threads racing to destroy the list,
-  // so this will be used to make list destruction thread-safe.
-  ur_mutex UrZeEventListMutex;
-
   // Initialize this using the array of events in EventList, and retain
   // all the pi_events in the created data structure.
   // CurQueue is the pi_queue that the command with this event wait


### PR DESCRIPTION
collectEventsForReleaseAndDestroyPiZeEventList is the only
place where mutex is currently used.
This function is always called with event that own the
waitlist mutex taken.
Therefore the mutex is redundant and causes overhead.
With this change we save 2 mutex calls per event cleanup in
in-order-queue scenarios.
This means that when we clean while reaching the
ImmCmdListsEventCleanupThreshold, we save 2000 mutex
taking calls, which improves host overhead.

Once the mutex taking is removed, there are no other code
places where mutex is used, so removing it from codebase.

Signed-off-by: mmrozek <michal.mrozek@intel.com>