### PR TITLE
[SYCL][Matrix] Fix compilation failure in get_coord test cases.

### DIFF
--- a/sycl/test-e2e/Matrix/XMX8/get_coord_bf16_gemm.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/get_coord_bf16_gemm.cpp
@@ -16,7 +16,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 

--- a/sycl/test-e2e/Matrix/XMX8/get_coord_bf16_matA.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/get_coord_bf16_matA.cpp
@@ -16,7 +16,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 

--- a/sycl/test-e2e/Matrix/XMX8/get_coord_bf16_matB.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/get_coord_bf16_matB.cpp
@@ -16,7 +16,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 

--- a/sycl/test-e2e/Matrix/get_coord_bf16_gemm.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_bf16_gemm.cpp
@@ -16,8 +16,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-using namespace sycl::ext::intel;
-using namespace sycl::ext::oneapi;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 

--- a/sycl/test-e2e/Matrix/get_coord_bf16_matA.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_bf16_matA.cpp
@@ -16,8 +16,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-using namespace sycl::ext::intel;
-using namespace sycl::ext::oneapi;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 

--- a/sycl/test-e2e/Matrix/get_coord_bf16_matB.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_bf16_matB.cpp
@@ -16,8 +16,6 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-using namespace sycl::ext::intel;
-using namespace sycl::ext::oneapi;
 using namespace sycl::ext::oneapi::experimental::matrix;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 


### PR DESCRIPTION
get_coord test cases were failing due to a ambiguous use of `sub_group` type.  The reason was due to the use of extra namespaces that gave rise to the ambuity.