### PR TITLE
[SYCL][Doc] Bindless images proposal name fix

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_bindless_images.asciidoc
@@ -648,25 +648,25 @@ struct bindless_image_sampler {
   sycl::addressing_mode addressing;
   sycl::coordinate_normalization_mode coordinate;
   sycl::filtering_mode filtering;
-  sycl::filtering_mode mipmapFiltering;
-  float minMipmapLevelClamp;
-  float maxMipmapLevelClamp;
-  float maxAnisotropy;
+  sycl::filtering_mode mipmap_filtering;
+  float min_mipmap_level_clamp;
+  float max_mipmap_level_clamp;
+  float max_anisotropy;
 };
 
 }
 ```
 
-`mipmapFiltering` dictates the method in which sampling between mipmap 
+`mipmap_filtering` dictates the method in which sampling between mipmap 
 levels is performed.
 
-`minMipmapLevelClamp` defines the minimum mipmap level from which we can sample, 
-with the minimum value being 0.
+`min_mipmap_level_clamp` defines the minimum mipmap level from which we can 
+sample, with the minimum value being 0.
 
-`maxMipmapLevelClamp` defines the maximum mipmap level from which we can sample.
-This cannot value cannot be higher than the number of allocated levels.
+`max_mipmap_level_clamp` defines the maximum mipmap level from which we can 
+sample. This cannot value cannot be higher than the number of allocated levels.
 
-`maxAnisotropy` dictates the anisotropic ratio used when samplling the mipmap 
+`max_anisotropy` dictates the anisotropic ratio used when samplling the mipmap 
 with anisotropic filtering.
 
 === Explicit copies
@@ -1970,4 +1970,5 @@ These features still need to be handled:
                    Semantics.
 
                  - Updated code samples.
+|4.1|2023-07-21| - Made bindless image sampler member names snake-case
 |======================


### PR DESCRIPTION
Made the bindless image sampler member names snake case to match SYCL convention.