### PR TITLE
Revert "[SYCL] Adds complex Literals support to sycl::experimental::complex"

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_complex.asciidoc
@@ -438,33 +438,6 @@ mathematical operation.
 |Compute the hyperbolic tangent of complex number x.
 |===
 
-
-=== Suffixes for complex number literals
-
-This proposal describes literal suffixes for constructing complex number literals.
-The suffixes `i` and `if` create complex numbers of the types `complex<double>` and `complex<float>` respectively, with their imaginary part denoted by the given literal number and the real part being zero.
-
-```C++
-namespace sycl {
-namespace ext {
-namespace oneapi {
-
-namespace literals {
-namespace complex_literals {
-constexpr complex<double> operator""i(long double x);
-constexpr complex<double> operator""i(unsigned long long x);
-
-constexpr complex<float> operator""if(long double x);
-constexpr complex<float> operator""if(unsigned long long x);
-} // namespace complex_literals
-} // namespace literals
-
-} // namespace oneapi
-} // namespace ext
-} // namespace sycl
-```
-
-
 == Implementation notes
 
 The complex mathematical operations can all be defined using SYCL built-ins.

--- a/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
@@ -979,27 +979,6 @@ tan(const complex<_Tp> &__x) {
   return complex<_Tp>(__z.imag(), -__z.real());
 }
 
-// Literal suffix for complex number literals [complex.literals]
-inline namespace literals {
-inline namespace complex_literals {
-constexpr complex<double> operator""i(long double __im) {
-  return {0.0, static_cast<double>(__im)};
-}
-
-constexpr complex<double> operator""i(unsigned long long __im) {
-  return {0.0, static_cast<double>(__im)};
-}
-
-constexpr complex<float> operator""if(long double __im) {
-  return {0.0f, static_cast<float>(__im)};
-}
-
-constexpr complex<float> operator""if(unsigned long long __im) {
-  return {0.0f, static_cast<float>(__im)};
-}
-} // namespace complex_literals
-} // namespace literals
-
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext

--- a/sycl/test/extensions/test_complex.cpp
+++ b/sycl/test/extensions/test_complex.cpp
@@ -186,16 +186,6 @@ void check_sycl_constructor_from_std() {
   }
 }
 
-// Check types for sycl complex constructed from literals
-void check_sycl_complex_literals() {
-  static_assert(
-      std::is_same_v<decltype(0.3if),
-                     sycl::ext::oneapi::experimental::complex<float>>);
-  static_assert(
-      std::is_same_v<decltype(0.3i),
-                     sycl::ext::oneapi::experimental::complex<double>>);
-}
-
 int main() {
   check_math_function_types();
   check_math_operator_types();
@@ -204,8 +194,6 @@ int main() {
 
   check_std_to_sycl_conversion();
   check_sycl_constructor_from_std();
-
-  check_sycl_complex_literals();
 
   return 0;
 }


### PR DESCRIPTION
Reverts intel/llvm#9819

As mentioned in the PR https://github.com/intel/llvm/pull/9867, this introduction of literal operators creates some issues due to literal operators receiving arguments as `long double` which are not supported on device code (and only works on host side); and our worries that users will try to use it and will not understand why it does not work.

Also, user-defined literal operators should be declared with a `_` prefix to not clash with the standard literal operators when `using namespace std::literals`.

Reverting this PR will facilitate the merge of the previously mentioned PR and have a place where the issues from this introduction are listed.

Regardless of this PR, we'd still like to have support for literal operators for complex, so if you (@abagusetty) could open up a new PR for re-introducing the literal operator if a solution can be found also to handle it in device code, that would be great!

@gmlueck @abagusetty 





