### PR TITLE
[SYCL][NATIVECPU] Refactor from PI plugin to UR adapter

### DIFF
--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -24,6 +24,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/queue.hpp"
     "../unified_runtime/ur/adapters/native_cpu/sampler.cpp"
     "../unified_runtime/ur/adapters/native_cpu/runtime.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/usm.cpp"
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
   LIBRARIES

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -21,6 +21,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/program.hpp"
     "../unified_runtime/ur/adapters/native_cpu/queue.cpp"
     "../unified_runtime/ur/adapters/native_cpu/queue.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/sampler.cpp"
     "../unified_runtime/ur/adapters/native_cpu/runtime.cpp"
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -27,6 +27,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/runtime.cpp"
     "../unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp"
     "../unified_runtime/ur/adapters/native_cpu/usm.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp"
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
   LIBRARIES

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -10,6 +10,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/context.hpp"
     "../unified_runtime/ur/adapters/native_cpu/device.cpp"
     "../unified_runtime/ur/adapters/native_cpu/device.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/enqueue.cpp"
     "../unified_runtime/ur/adapters/native_cpu/event.cpp"
     "../unified_runtime/ur/adapters/native_cpu/kernel.cpp"
     "../unified_runtime/ur/adapters/native_cpu/kernel.hpp"

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -5,6 +5,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/pi2ur.cpp"
     "../unified_runtime/ur/ur.hpp"
     "../unified_runtime/ur/ur.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/common.cpp"
     "../unified_runtime/ur/adapters/native_cpu/common.hpp"
     "../unified_runtime/ur/adapters/native_cpu/context.cpp"
     "../unified_runtime/ur/adapters/native_cpu/context.hpp"
@@ -24,6 +25,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/queue.hpp"
     "../unified_runtime/ur/adapters/native_cpu/sampler.cpp"
     "../unified_runtime/ur/adapters/native_cpu/runtime.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp"
     "../unified_runtime/ur/adapters/native_cpu/usm.cpp"
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -10,6 +10,7 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/context.hpp"
     "../unified_runtime/ur/adapters/native_cpu/device.cpp"
     "../unified_runtime/ur/adapters/native_cpu/device.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/event.cpp"
     "../unified_runtime/ur/adapters/native_cpu/kernel.cpp"
     "../unified_runtime/ur/adapters/native_cpu/kernel.hpp"
     "../unified_runtime/ur/adapters/native_cpu/memory.cpp"

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -10,6 +10,8 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/context.hpp"
     "../unified_runtime/ur/adapters/native_cpu/device.cpp"
     "../unified_runtime/ur/adapters/native_cpu/device.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/kernel.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/kernel.hpp"
     "../unified_runtime/ur/adapters/native_cpu/memory.cpp"
     "../unified_runtime/ur/adapters/native_cpu/memory.hpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.cpp"

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -1,6 +1,18 @@
 add_sycl_plugin(native_cpu
   SOURCES
-    pi_native_cpu.cpp
+    "pi_native_cpu.cpp"
+
+    "../unified_runtime/pi2ur.hpp"
+    "../unified_runtime/pi2ur.cpp"
+    "../unified_runtime/ur/ur.hpp"
+    "../unified_runtime/ur/ur.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/common.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/context.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/context.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/device.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/device.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/platform.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/platform.hpp"
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR} 
     ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -1,5 +1,4 @@
-add_sycl_plugin(
-  native_cpu
+add_sycl_plugin(native_cpu
   SOURCES
     "pi_native_cpu.cpp"
     "../unified_runtime/pi2ur.hpp"
@@ -15,11 +14,14 @@ add_sycl_plugin(
     "../unified_runtime/ur/adapters/native_cpu/memory.hpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.cpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/program.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/program.hpp"
     "../unified_runtime/ur/adapters/native_cpu/queue.cpp"
     "../unified_runtime/ur/adapters/native_cpu/queue.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/runtime.cpp"
   INCLUDE_DIRS
-  ${CMAKE_CURRENT_SOURCE_DIR}
-  ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
+    ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
   LIBRARIES
-  sycl
-  UnifiedRuntime-Headers)
+    sycl
+    UnifiedRuntime-Headers
+)

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -3,6 +3,8 @@ add_sycl_plugin(native_cpu
     pi_native_cpu.cpp
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR} 
+    ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
   LIBRARIES
     sycl
+    UnifiedRuntime-Headers
 )

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -13,6 +13,8 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/device.hpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.cpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/queue.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/queue.hpp"
   INCLUDE_DIRS
     ${CMAKE_CURRENT_SOURCE_DIR} 
     ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime

--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -1,7 +1,7 @@
-add_sycl_plugin(native_cpu
+add_sycl_plugin(
+  native_cpu
   SOURCES
     "pi_native_cpu.cpp"
-
     "../unified_runtime/pi2ur.hpp"
     "../unified_runtime/pi2ur.cpp"
     "../unified_runtime/ur/ur.hpp"
@@ -11,14 +11,15 @@ add_sycl_plugin(native_cpu
     "../unified_runtime/ur/adapters/native_cpu/context.hpp"
     "../unified_runtime/ur/adapters/native_cpu/device.cpp"
     "../unified_runtime/ur/adapters/native_cpu/device.hpp"
+    "../unified_runtime/ur/adapters/native_cpu/memory.cpp"
+    "../unified_runtime/ur/adapters/native_cpu/memory.hpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.cpp"
     "../unified_runtime/ur/adapters/native_cpu/platform.hpp"
     "../unified_runtime/ur/adapters/native_cpu/queue.cpp"
     "../unified_runtime/ur/adapters/native_cpu/queue.hpp"
   INCLUDE_DIRS
-    ${CMAKE_CURRENT_SOURCE_DIR} 
-    ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
+  ${CMAKE_CURRENT_SOURCE_DIR}
+  ${CMAKE_CURRENT_SOURCE_DIR}/../unified_runtime
   LIBRARIES
-    sycl
-    UnifiedRuntime-Headers
-)
+  sycl
+  UnifiedRuntime-Headers)

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -11,24 +11,6 @@
 static bool PrintPiTrace = true;
 
 extern "C" {
-#define DIE_NO_IMPLEMENTATION                                                  \
-  if (PrintPiTrace) {                                                          \
-    std::cerr << "Not Implemented : " << __FUNCTION__                          \
-              << " - File : " << __FILE__;                                     \
-    std::cerr << " / Line : " << __LINE__ << std::endl;                        \
-  }                                                                            \
-  return PI_ERROR_INVALID_OPERATION;
-
-pi_result piextEnablePeerAccess(pi_device, pi_device) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piextDisablePeerAccess(pi_device, pi_device) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextPeerAccessGetInfo(pi_device, pi_device, pi_peer_attr, size_t,
-                                 void *, size_t *) {
-  DIE_NO_IMPLEMENTATION;
-}
 
 pi_result piPluginInit(pi_plugin *PluginInit) {
 
@@ -87,7 +69,6 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
 
   // Program
   _PI_CL(piProgramCreate, pi2ur::piProgramCreate)
-  _PI_CL(piclProgramCreateWithSource, pi2ur::piclProgramCreateWithSource)
   _PI_CL(piProgramCreateWithBinary, pi2ur::piProgramCreateWithBinary)
   _PI_CL(piProgramGetInfo, pi2ur::piProgramGetInfo)
   _PI_CL(piProgramCompile, pi2ur::piProgramCompile)
@@ -139,7 +120,6 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
 
   // Queue commands
   _PI_CL(piEnqueueKernelLaunch, pi2ur::piEnqueueKernelLaunch)
-  _PI_CL(piEnqueueNativeKernel, pi2ur::piEnqueueNativeKernel)
   _PI_CL(piEnqueueEventsWait, pi2ur::piEnqueueEventsWait)
   _PI_CL(piEnqueueEventsWaitWithBarrier, pi2ur::piEnqueueEventsWaitWithBarrier)
   _PI_CL(piEnqueueMemBufferRead, pi2ur::piEnqueueMemBufferRead)
@@ -181,9 +161,9 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piPluginGetLastError, pi2ur::piPluginGetLastError)
 
   // P2P Access
-  _PI_CL(piextEnablePeerAccess, piextEnablePeerAccess)
-  _PI_CL(piextDisablePeerAccess, piextDisablePeerAccess)
-  _PI_CL(piextPeerAccessGetInfo, piextPeerAccessGetInfo)
+  _PI_CL(piextEnablePeerAccess, pi2ur::piextEnablePeerAccess)
+  _PI_CL(piextDisablePeerAccess, pi2ur::piextDisablePeerAccess)
+  _PI_CL(piextPeerAccessGetInfo, pi2ur::piextPeerAccessGetInfo)
 
   // Runtime
   _PI_CL(piTearDown, pi2ur::piTearDown)

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -10,12 +10,6 @@
 
 static bool PrintPiTrace = true;
 
-struct _pi_object {
-  _pi_object() : RefCount{1} {}
-
-  std::atomic<pi_uint32> RefCount;
-};
-
 // taken from pi_cuda.cpp
 template <typename T, typename Assign>
 pi_result getInfoImpl(size_t param_value_size, void *param_value,
@@ -122,42 +116,6 @@ pi_result piextPlatformCreateWithNativeHandle(pi_native_handle, pi_platform *) {
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piEventCreate(pi_context, pi_event *) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piEventGetInfo(pi_event, pi_event_info, size_t, void *, size_t *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEventGetProfilingInfo(pi_event Event, pi_profiling_info ParamName,
-                                  size_t ParamValueSize, void *ParamValue,
-                                  size_t *ParamValueSizeRet) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEventsWait(pi_uint32 NumEvents, const pi_event *EventList) {
-  // Todo: currently we do everything synchronously so this is a no-op
-  return PI_SUCCESS;
-}
-
-pi_result piEventSetCallback(pi_event, pi_int32,
-                             void (*)(pi_event, pi_int32, void *), void *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEventSetStatus(pi_event, pi_int32) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piEventRetain(pi_event Event) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piEventRelease(pi_event Event) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piextEventGetNativeHandle(pi_event, pi_native_handle *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextEventCreateWithNativeHandle(pi_native_handle, pi_context, bool,
-                                           pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
 pi_result piSamplerCreate(pi_context, const pi_sampler_properties *,
                           pi_sampler *) {
   DIE_NO_IMPLEMENTATION;
@@ -668,21 +626,24 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextKernelSetArgSampler, pi2ur::piextKernelSetArgSampler)
 
   // Event
-  _PI_CL(piEventCreate, piEventCreate)
-  _PI_CL(piEventGetInfo, piEventGetInfo)
-  _PI_CL(piEventGetProfilingInfo, piEventGetProfilingInfo)
-  _PI_CL(piEventsWait, piEventsWait)
-  _PI_CL(piEventSetCallback, piEventSetCallback)
-  _PI_CL(piEventSetStatus, piEventSetStatus)
-  _PI_CL(piEventRetain, piEventRetain)
-  _PI_CL(piEventRelease, piEventRelease)
-  _PI_CL(piextEventGetNativeHandle, piextEventGetNativeHandle)
-  _PI_CL(piextEventCreateWithNativeHandle, piextEventCreateWithNativeHandle)
+  _PI_CL(piEventCreate, pi2ur::piEventCreate)
+  _PI_CL(piEventGetInfo, pi2ur::piEventGetInfo)
+  _PI_CL(piEventGetProfilingInfo, pi2ur::piEventGetProfilingInfo)
+  _PI_CL(piEventsWait, pi2ur::piEventsWait)
+  _PI_CL(piEventSetCallback, pi2ur::piEventSetCallback)
+  _PI_CL(piEventSetStatus, pi2ur::piEventSetStatus)
+  _PI_CL(piEventRetain, pi2ur::piEventRetain)
+  _PI_CL(piEventRelease, pi2ur::piEventRelease)
+  _PI_CL(piextEventGetNativeHandle, pi2ur::piextEventGetNativeHandle)
+  _PI_CL(piextEventCreateWithNativeHandle,
+         pi2ur::piextEventCreateWithNativeHandle)
+
   // Sampler
   _PI_CL(piSamplerCreate, piSamplerCreate)
   _PI_CL(piSamplerGetInfo, piSamplerGetInfo)
   _PI_CL(piSamplerRetain, piSamplerRetain)
   _PI_CL(piSamplerRelease, piSamplerRelease)
+
   // Queue commands
   _PI_CL(piEnqueueKernelLaunch, piEnqueueKernelLaunch)
   _PI_CL(piEnqueueNativeKernel, piEnqueueNativeKernel)
@@ -715,6 +676,7 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextUSMEnqueueMemset2D, piextUSMEnqueueMemset2D)
   _PI_CL(piextUSMEnqueueMemcpy2D, piextUSMEnqueueMemcpy2D)
   _PI_CL(piextUSMGetMemAllocInfo, piextUSMGetMemAllocInfo)
+
   // Device global variable
   _PI_CL(piextEnqueueDeviceGlobalVariableWrite,
          piextEnqueueDeviceGlobalVariableWrite)

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -159,39 +159,6 @@ pi_result piextPlatformCreateWithNativeHandle(pi_native_handle, pi_platform *) {
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piQueueCreate(pi_context Context, pi_device Device,
-                        pi_queue_properties Properties, pi_queue *Queue) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piQueueGetInfo(pi_queue, pi_queue_info, size_t, void *, size_t *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piQueueRetain(pi_queue Queue) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piQueueRelease(pi_queue Queue) {
-  // Todo: is it fine as a no-op?
-  return PI_SUCCESS;
-}
-
-pi_result piQueueFinish(pi_queue) {
-  // Todo: is it fine as a no-op?
-  return PI_SUCCESS;
-}
-
-pi_result piQueueFlush(pi_queue) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piextQueueGetNativeHandle(pi_queue, pi_native_handle *, int32_t *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextQueueCreateWithNativeHandle(pi_native_handle, int32_t,
-                                           pi_context, pi_device, bool,
-                                           pi_queue_properties *, pi_queue *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
 pi_result piMemBufferCreate(pi_context Context, pi_mem_flags Flags, size_t Size,
                             void *HostPtr, pi_mem *RetMem,
                             const pi_mem_properties *properties) {
@@ -966,9 +933,6 @@ pi_result piTearDown(void *) {
 }
 
 pi_result piPluginInit(pi_plugin *PluginInit) {
-#define _PI_API(api)                                                           \
-  (PluginInit->PiFunctionTable).api = (decltype(&::api))(&api);
-#include <sycl/detail/pi.def>
 
 #define _PI_CL(pi_api, native_cpu_api)                                         \
   (PluginInit->PiFunctionTable).pi_api = (decltype(&::pi_api))(&native_cpu_api);
@@ -998,6 +962,121 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextContextGetNativeHandle, pi2ur::piextContextGetNativeHandle)
   _PI_CL(piextContextCreateWithNativeHandle,
          pi2ur::piextContextCreateWithNativeHandle)
+  // Queue
+  _PI_CL(piQueueCreate, pi2ur::piQueueCreate)
+  _PI_CL(piextQueueCreate, pi2ur::piextQueueCreate)
+  _PI_CL(piQueueGetInfo, pi2ur::piQueueGetInfo)
+  _PI_CL(piQueueFinish, pi2ur::piQueueFinish)
+  _PI_CL(piQueueFlush, pi2ur::piQueueFlush)
+  _PI_CL(piQueueRetain, pi2ur::piQueueRetain)
+  _PI_CL(piQueueRelease, pi2ur::piQueueRelease)
+  _PI_CL(piextQueueGetNativeHandle, pi2ur::piextQueueGetNativeHandle)
+  _PI_CL(piextQueueCreateWithNativeHandle,
+         pi2ur::piextQueueCreateWithNativeHandle)
+
+  // Memory
+  _PI_CL(piMemBufferCreate, piMemBufferCreate)
+  _PI_CL(piMemImageCreate, piMemImageCreate)
+  _PI_CL(piMemGetInfo, piMemGetInfo)
+  _PI_CL(piMemImageGetInfo, piMemImageGetInfo)
+  _PI_CL(piMemRetain, piMemRetain)
+  _PI_CL(piMemRelease, piMemRelease)
+  _PI_CL(piMemBufferPartition, piMemBufferPartition)
+  _PI_CL(piextMemGetNativeHandle, piextMemGetNativeHandle)
+  _PI_CL(piextMemCreateWithNativeHandle, piextMemCreateWithNativeHandle)
+
+  // Program
+  _PI_CL(piProgramCreate, piProgramCreate)
+  _PI_CL(piclProgramCreateWithSource, piclProgramCreateWithSource)
+  _PI_CL(piProgramCreateWithBinary, piProgramCreateWithBinary)
+  _PI_CL(piProgramGetInfo, piProgramGetInfo)
+  _PI_CL(piProgramCompile, piProgramCompile)
+  _PI_CL(piProgramBuild, piProgramBuild)
+  _PI_CL(piProgramLink, piProgramLink)
+  _PI_CL(piProgramGetBuildInfo, piProgramGetBuildInfo)
+  _PI_CL(piProgramRetain, piProgramRetain)
+  _PI_CL(piProgramRelease, piProgramRelease)
+  _PI_CL(piextProgramGetNativeHandle, piextProgramGetNativeHandle)
+  _PI_CL(piextProgramCreateWithNativeHandle, piextProgramCreateWithNativeHandle)
+  _PI_CL(piextProgramSetSpecializationConstant,
+         piextProgramSetSpecializationConstant)
+  // Kernel
+  _PI_CL(piKernelCreate, piKernelCreate)
+  _PI_CL(piKernelSetArg, piKernelSetArg)
+  _PI_CL(piKernelGetInfo, piKernelGetInfo)
+  _PI_CL(piKernelGetGroupInfo, piKernelGetGroupInfo)
+  _PI_CL(piKernelGetSubGroupInfo, piKernelGetSubGroupInfo)
+  _PI_CL(piKernelRetain, piKernelRetain)
+  _PI_CL(piKernelRelease, piKernelRelease)
+  _PI_CL(piextKernelGetNativeHandle, piextKernelGetNativeHandle)
+  _PI_CL(piKernelSetExecInfo, piKernelSetExecInfo)
+  _PI_CL(piextKernelSetArgPointer, piextKernelSetArgPointer)
+  _PI_CL(piextKernelCreateWithNativeHandle, piextKernelCreateWithNativeHandle)
+
+  // Event
+  _PI_CL(piEventCreate, piEventCreate)
+  _PI_CL(piEventGetInfo, piEventGetInfo)
+  _PI_CL(piEventGetProfilingInfo, piEventGetProfilingInfo)
+  _PI_CL(piEventsWait, piEventsWait)
+  _PI_CL(piEventSetCallback, piEventSetCallback)
+  _PI_CL(piEventSetStatus, piEventSetStatus)
+  _PI_CL(piEventRetain, piEventRetain)
+  _PI_CL(piEventRelease, piEventRelease)
+  _PI_CL(piextEventGetNativeHandle, piextEventGetNativeHandle)
+  _PI_CL(piextEventCreateWithNativeHandle, piextEventCreateWithNativeHandle)
+  // Sampler
+  _PI_CL(piSamplerCreate, piSamplerCreate)
+  _PI_CL(piSamplerGetInfo, piSamplerGetInfo)
+  _PI_CL(piSamplerRetain, piSamplerRetain)
+  _PI_CL(piSamplerRelease, piSamplerRelease)
+  // Queue commands
+  _PI_CL(piEnqueueKernelLaunch, piEnqueueKernelLaunch)
+  _PI_CL(piEnqueueNativeKernel, piEnqueueNativeKernel)
+  _PI_CL(piEnqueueEventsWait, piEnqueueEventsWait)
+  _PI_CL(piEnqueueEventsWaitWithBarrier, piEnqueueEventsWaitWithBarrier)
+  _PI_CL(piEnqueueMemBufferRead, piEnqueueMemBufferRead)
+  _PI_CL(piEnqueueMemBufferReadRect, piEnqueueMemBufferReadRect)
+  _PI_CL(piEnqueueMemBufferWrite, piEnqueueMemBufferWrite)
+  _PI_CL(piEnqueueMemBufferWriteRect, piEnqueueMemBufferWriteRect)
+  _PI_CL(piEnqueueMemBufferCopy, piEnqueueMemBufferCopy)
+  _PI_CL(piEnqueueMemBufferCopyRect, piEnqueueMemBufferCopyRect)
+  _PI_CL(piEnqueueMemBufferFill, piEnqueueMemBufferFill)
+  _PI_CL(piEnqueueMemImageRead, piEnqueueMemImageRead)
+  _PI_CL(piEnqueueMemImageWrite, piEnqueueMemImageWrite)
+  _PI_CL(piEnqueueMemImageCopy, piEnqueueMemImageCopy)
+  _PI_CL(piEnqueueMemImageFill, piEnqueueMemImageFill)
+  _PI_CL(piEnqueueMemBufferMap, piEnqueueMemBufferMap)
+  _PI_CL(piEnqueueMemUnmap, piEnqueueMemUnmap)
+
+  // USM
+  _PI_CL(piextUSMHostAlloc, piextUSMHostAlloc)
+  _PI_CL(piextUSMDeviceAlloc, piextUSMDeviceAlloc)
+  _PI_CL(piextUSMSharedAlloc, piextUSMSharedAlloc)
+  _PI_CL(piextUSMFree, piextUSMFree)
+  _PI_CL(piextUSMEnqueueMemset, piextUSMEnqueueMemset)
+  _PI_CL(piextUSMEnqueueMemcpy, piextUSMEnqueueMemcpy)
+  _PI_CL(piextUSMEnqueuePrefetch, piextUSMEnqueuePrefetch)
+  _PI_CL(piextUSMEnqueueMemAdvise, piextUSMEnqueueMemAdvise)
+  _PI_CL(piextUSMEnqueueFill2D, piextUSMEnqueueFill2D)
+  _PI_CL(piextUSMEnqueueMemset2D, piextUSMEnqueueMemset2D)
+  _PI_CL(piextUSMEnqueueMemcpy2D, piextUSMEnqueueMemcpy2D)
+  _PI_CL(piextUSMGetMemAllocInfo, piextUSMGetMemAllocInfo)
+  // Device global variable
+  _PI_CL(piextEnqueueDeviceGlobalVariableWrite,
+         piextEnqueueDeviceGlobalVariableWrite)
+  _PI_CL(piextEnqueueDeviceGlobalVariableRead,
+         piextEnqueueDeviceGlobalVariableRead)
+
+  // Host Pipe
+  _PI_CL(piextEnqueueReadHostPipe, piextEnqueueReadHostPipe)
+  _PI_CL(piextEnqueueWriteHostPipe, piextEnqueueWriteHostPipe)
+
+  _PI_CL(piextKernelSetArgMemObj, piextKernelSetArgMemObj)
+  _PI_CL(piextKernelSetArgSampler, piextKernelSetArgSampler)
+  _PI_CL(piPluginGetLastError, piPluginGetLastError)
+  _PI_CL(piTearDown, piTearDown)
+  _PI_CL(piGetDeviceAndHostTimer, piGetDeviceAndHostTimer)
+  _PI_CL(piPluginGetBackendOption, piPluginGetBackendOption)
 
 #undef _PI_CL
   return PI_SUCCESS;

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -54,33 +54,6 @@ pi_result getInfoArray(size_t array_length, size_t param_value_size,
                      array_length * sizeof(T), memcpy);
 }
 
-sycl::detail::NDRDescT getNDRDesc(pi_uint32 WorkDim,
-                                  const size_t *GlobalWorkOffset,
-                                  const size_t *GlobalWorkSize,
-                                  const size_t *LocalWorkSize) {
-  // Todo: we flip indexes here, I'm not sure we should, if we don't we need to
-  // un-flip them in the spirv builtins definitions as well
-  sycl::detail::NDRDescT Res;
-  switch (WorkDim) {
-  case 1:
-    Res.set<1>(sycl::nd_range<1>({GlobalWorkSize[0]}, {LocalWorkSize[0]},
-                                 {GlobalWorkOffset[0]}));
-    break;
-  case 2:
-    Res.set<2>(sycl::nd_range<2>({GlobalWorkSize[0], GlobalWorkSize[1]},
-                                 {LocalWorkSize[0], LocalWorkSize[1]},
-                                 {GlobalWorkOffset[0], GlobalWorkOffset[1]}));
-    break;
-  case 3:
-    Res.set<3>(sycl::nd_range<3>(
-        {GlobalWorkSize[0], GlobalWorkSize[1], GlobalWorkSize[2]},
-        {LocalWorkSize[0], LocalWorkSize[1], LocalWorkSize[2]},
-        {GlobalWorkOffset[0], GlobalWorkOffset[1], GlobalWorkOffset[2]}));
-    break;
-  }
-  return Res;
-}
-
 extern "C" {
 #define DIE_NO_IMPLEMENTATION                                                  \
   if (PrintPiTrace) {                                                          \
@@ -107,170 +80,6 @@ extern "C" {
                 << std::endl;                                                  \
     }                                                                          \
     return PI_ERROR_INVALID_OPERATION;
-
-pi_result piextPlatformGetNativeHandle(pi_platform, pi_native_handle *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextPlatformCreateWithNativeHandle(pi_native_handle, pi_platform *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueEventsWait(pi_queue, pi_uint32, const pi_event *,
-                              pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueEventsWaitWithBarrier(pi_queue, pi_uint32, const pi_event *,
-                                         pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemBufferRead(pi_queue Queue, pi_mem Src,
-                                 pi_bool BlockingRead, size_t Offset,
-                                 size_t Size, void *Dst,
-                                 pi_uint32 NumEventsInWaitList,
-                                 const pi_event *EventWaitList,
-                                 pi_event *Event) {
-  // TODO: is it ok to have this as no-op?
-  return PI_SUCCESS;
-}
-
-pi_result piEnqueueMemBufferReadRect(pi_queue, pi_mem, pi_bool,
-                                     pi_buff_rect_offset, pi_buff_rect_offset,
-                                     pi_buff_rect_region, size_t, size_t,
-                                     size_t, size_t, void *, pi_uint32,
-                                     const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemBufferWrite(pi_queue, pi_mem, pi_bool, size_t, size_t,
-                                  const void *, pi_uint32, const pi_event *,
-                                  pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemBufferWriteRect(pi_queue, pi_mem, pi_bool,
-                                      pi_buff_rect_offset, pi_buff_rect_offset,
-                                      pi_buff_rect_region, size_t, size_t,
-                                      size_t, size_t, const void *, pi_uint32,
-                                      const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemBufferCopy(pi_queue, pi_mem, pi_mem, size_t, size_t,
-                                 size_t, pi_uint32, const pi_event *,
-                                 pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemBufferCopyRect(pi_queue, pi_mem, pi_mem,
-                                     pi_buff_rect_offset, pi_buff_rect_offset,
-                                     pi_buff_rect_region, size_t, size_t,
-                                     size_t, size_t, pi_uint32,
-                                     const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemBufferFill(pi_queue, pi_mem buffer, const void *pattern,
-                                 size_t pattern_size, size_t offset,
-                                 size_t size, pi_uint32, const pi_event *,
-                                 pi_event *) {
-  // Todo: error checking
-  // Todo: handle async
-  void *startingPtr = buffer->_mem + offset;
-  unsigned steps = size / pattern_size;
-  for (unsigned i = 0; i < steps; i++) {
-    memcpy(static_cast<int8_t *>(startingPtr) + i * pattern_size, pattern,
-           pattern_size);
-  }
-  return PI_SUCCESS;
-}
-
-pi_result piEnqueueMemBufferMap(pi_queue, pi_mem buffer, pi_bool, pi_map_flags,
-                                size_t offset, size_t size, pi_uint32,
-                                const pi_event *, pi_event *, void **ret_map) {
-  // Todo: add proper error checking
-  *ret_map = buffer->_mem + offset;
-  return PI_SUCCESS;
-}
-
-pi_result piEnqueueMemUnmap(pi_queue, pi_mem mem_obj, void *mapped_ptr,
-                            pi_uint32, const pi_event *, pi_event *) {
-  // Todo: no-op?
-  return PI_SUCCESS;
-}
-
-pi_result piEnqueueMemImageRead(pi_queue CommandQueue, pi_mem Image,
-                                pi_bool BlockingRead, pi_image_offset Origin,
-                                pi_image_region Region, size_t RowPitch,
-                                size_t SlicePitch, void *Ptr,
-                                pi_uint32 NumEventsInWaitList,
-                                const pi_event *EventWaitList,
-                                pi_event *Event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemImageWrite(pi_queue, pi_mem, pi_bool, pi_image_offset,
-                                 pi_image_region, size_t, size_t, const void *,
-                                 pi_uint32, const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemImageCopy(pi_queue, pi_mem, pi_mem, pi_image_offset,
-                                pi_image_offset, pi_image_region, pi_uint32,
-                                const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piEnqueueMemImageFill(pi_queue, pi_mem, const void *, const size_t *,
-                                const size_t *, pi_uint32, const pi_event *,
-                                pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result
-piEnqueueKernelLaunch(pi_queue Queue, pi_kernel Kernel, pi_uint32 WorkDim,
-                      const size_t *GlobalWorkOffset,
-                      const size_t *GlobalWorkSize, const size_t *LocalWorkSize,
-                      pi_uint32 NumEventsInWaitList,
-                      const pi_event *EventWaitList, pi_event *Event) {
-  // TODO: add proper error checking
-  // TODO: add proper event dep management
-  sycl::detail::NDRDescT ndr =
-      getNDRDesc(WorkDim, GlobalWorkOffset, GlobalWorkSize, LocalWorkSize);
-  __nativecpu_state state(ndr.GlobalSize[0], ndr.GlobalSize[1],
-                          ndr.GlobalSize[2], ndr.LocalSize[0], ndr.LocalSize[1],
-                          ndr.LocalSize[2], ndr.GlobalOffset[0],
-                          ndr.GlobalOffset[1], ndr.GlobalOffset[2]);
-  auto numWG0 = ndr.GlobalSize[0] / ndr.LocalSize[0];
-  auto numWG1 = ndr.GlobalSize[1] / ndr.LocalSize[1];
-  auto numWG2 = ndr.GlobalSize[2] / ndr.LocalSize[2];
-  for (unsigned g2 = 0; g2 < numWG2; g2++) {
-    for (unsigned g1 = 0; g1 < numWG1; g1++) {
-      for (unsigned g0 = 0; g0 < numWG0; g0++) {
-        for (unsigned local2 = 0; local2 < ndr.LocalSize[2]; local2++) {
-          for (unsigned local1 = 0; local1 < ndr.LocalSize[1]; local1++) {
-            for (unsigned local0 = 0; local0 < ndr.LocalSize[0]; local0++) {
-              state.update(g0, g1, g2, local0, local1, local2);
-              Kernel->_subhandler(Kernel->_args.data(), &state);
-            }
-          }
-        }
-      }
-    }
-  }
-  // Todo: we should avoid calling clear here by avoiding using push_back
-  // in setKernelArgs.
-  Kernel->_args.clear();
-  return PI_SUCCESS;
-}
-
-pi_result piEnqueueNativeKernel(pi_queue, void (*)(void *), void *, size_t,
-                                pi_uint32, const pi_mem *, const void **,
-                                pi_uint32, const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
 
 pi_result piextUSMHostAlloc(void **result_ptr, pi_context,
                             pi_usm_mem_properties *, size_t size, pi_uint32) {
@@ -335,35 +144,6 @@ pi_result piextUSMEnqueuePrefetch(pi_queue, const void *, size_t,
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piextPluginGetOpaqueData(void *, void **OpaqueDataReturn) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextQueueCreate(pi_context context, pi_device device,
-                           pi_queue_properties *properties, pi_queue *queue) {
-  CONTINUE_NO_IMPLEMENTATION;
-}
-
-pi_result piextEnqueueWriteHostPipe(pi_queue queue, pi_program program,
-                                    const char *pipe_symbol, pi_bool blocking,
-                                    void *ptr, size_t size,
-                                    pi_uint32 num_events_in_waitlist,
-                                    const pi_event *events_waitlist,
-                                    pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextEnqueueReadHostPipe(pi_queue queue, pi_program program,
-                                   const char *pipe_symbol, pi_bool blocking,
-                                   void *ptr, size_t size,
-                                   pi_uint32 num_events_in_waitlist,
-                                   const pi_event *events_waitlist,
-                                   pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piPluginGetLastError(char **message) { DIE_NO_IMPLEMENTATION; }
-
 pi_result piextUSMEnqueueMemcpy2D(pi_queue queue, pi_bool blocking,
                                   void *dst_ptr, size_t dst_pitch,
                                   const void *src_ptr, size_t src_pitch,
@@ -374,50 +154,11 @@ pi_result piextUSMEnqueueMemcpy2D(pi_queue queue, pi_bool blocking,
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piextEnqueueDeviceGlobalVariableWrite(
-    pi_queue queue, pi_program program, const char *name,
-    pi_bool blocking_write, size_t count, size_t offset, const void *src,
-    pi_uint32 num_events_in_wait_list, const pi_event *event_wait_list,
-    pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextEnqueueDeviceGlobalVariableRead(
-    pi_queue queue, pi_program program, const char *name, pi_bool blocking_read,
-    size_t count, size_t offset, void *dst, pi_uint32 num_events_in_wait_list,
-    const pi_event *event_wait_list, pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
 pi_result piextUSMEnqueueMemset2D(pi_queue queue, void *ptr, size_t pitch,
                                   int value, size_t width, size_t height,
                                   pi_uint32 num_events_in_waitlist,
                                   const pi_event *events_waitlist,
                                   pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piGetDeviceAndHostTimer(pi_device Device, uint64_t *DeviceTime,
-                                  uint64_t *HostTime) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextQueueGetNativeHandle2(pi_queue queue,
-                                     pi_native_handle *nativeHandle,
-                                     int32_t *nativeHandleDesc) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextQueueCreate2(pi_context context, pi_device device,
-                            pi_queue_properties *properties, pi_queue *queue) {
-  // Todo: is it fine as a no-op?
-  return PI_SUCCESS;
-}
-
-pi_result piextQueueCreateWithNativeHandle2(
-    pi_native_handle nativeHandle, int32_t nativeHandleDesc, pi_context context,
-    pi_device device, bool pluginOwnsNativeHandle,
-    pi_queue_properties *Properties, pi_queue *queue) {
   DIE_NO_IMPLEMENTATION;
 }
 
@@ -542,11 +283,12 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piDeviceRetain, pi2ur::piDeviceRetain)
   _PI_CL(piDeviceRelease, pi2ur::piDeviceRelease)
   _PI_CL(piextDeviceSelectBinary, pi2ur::piextDeviceSelectBinary)
-  // TODO: uncomment when program is fully ported
   _PI_CL(piextGetDeviceFunctionPointer, pi2ur::piextGetDeviceFunctionPointer)
   _PI_CL(piextDeviceGetNativeHandle, pi2ur::piextDeviceGetNativeHandle)
   _PI_CL(piextDeviceCreateWithNativeHandle,
          pi2ur::piextDeviceCreateWithNativeHandle)
+  _PI_CL(piGetDeviceAndHostTimer, pi2ur::piGetDeviceAndHostTimer)
+
   // Context
   _PI_CL(piextContextSetExtendedDeleter, pi2ur::piextContextSetExtendedDeleter)
   _PI_CL(piContextCreate, pi2ur::piContextCreate)
@@ -595,6 +337,7 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
          pi2ur::piextProgramCreateWithNativeHandle)
   _PI_CL(piextProgramSetSpecializationConstant,
          pi2ur::piextProgramSetSpecializationConstant)
+
   // Kernel
   _PI_CL(piKernelCreate, pi2ur::piKernelCreate)
   _PI_CL(piKernelSetArg, pi2ur::piKernelSetArg)
@@ -631,51 +374,47 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piSamplerRelease, pi2ur::piSamplerRelease)
 
   // Queue commands
-  _PI_CL(piEnqueueKernelLaunch, piEnqueueKernelLaunch)
-  _PI_CL(piEnqueueNativeKernel, piEnqueueNativeKernel)
-  _PI_CL(piEnqueueEventsWait, piEnqueueEventsWait)
-  _PI_CL(piEnqueueEventsWaitWithBarrier, piEnqueueEventsWaitWithBarrier)
-  _PI_CL(piEnqueueMemBufferRead, piEnqueueMemBufferRead)
-  _PI_CL(piEnqueueMemBufferReadRect, piEnqueueMemBufferReadRect)
-  _PI_CL(piEnqueueMemBufferWrite, piEnqueueMemBufferWrite)
-  _PI_CL(piEnqueueMemBufferWriteRect, piEnqueueMemBufferWriteRect)
-  _PI_CL(piEnqueueMemBufferCopy, piEnqueueMemBufferCopy)
-  _PI_CL(piEnqueueMemBufferCopyRect, piEnqueueMemBufferCopyRect)
-  _PI_CL(piEnqueueMemBufferFill, piEnqueueMemBufferFill)
-  _PI_CL(piEnqueueMemImageRead, piEnqueueMemImageRead)
-  _PI_CL(piEnqueueMemImageWrite, piEnqueueMemImageWrite)
-  _PI_CL(piEnqueueMemImageCopy, piEnqueueMemImageCopy)
-  _PI_CL(piEnqueueMemImageFill, piEnqueueMemImageFill)
-  _PI_CL(piEnqueueMemBufferMap, piEnqueueMemBufferMap)
-  _PI_CL(piEnqueueMemUnmap, piEnqueueMemUnmap)
+  _PI_CL(piEnqueueKernelLaunch, pi2ur::piEnqueueKernelLaunch)
+  _PI_CL(piEnqueueNativeKernel, pi2ur::piEnqueueNativeKernel)
+  _PI_CL(piEnqueueEventsWait, pi2ur::piEnqueueEventsWait)
+  _PI_CL(piEnqueueEventsWaitWithBarrier, pi2ur::piEnqueueEventsWaitWithBarrier)
+  _PI_CL(piEnqueueMemBufferRead, pi2ur::piEnqueueMemBufferRead)
+  _PI_CL(piEnqueueMemBufferReadRect, pi2ur::piEnqueueMemBufferReadRect)
+  _PI_CL(piEnqueueMemBufferWrite, pi2ur::piEnqueueMemBufferWrite)
+  _PI_CL(piEnqueueMemBufferWriteRect, pi2ur::piEnqueueMemBufferWriteRect)
+  _PI_CL(piEnqueueMemBufferCopy, pi2ur::piEnqueueMemBufferCopy)
+  _PI_CL(piEnqueueMemBufferCopyRect, pi2ur::piEnqueueMemBufferCopyRect)
+  _PI_CL(piEnqueueMemBufferFill, pi2ur::piEnqueueMemBufferFill)
+  _PI_CL(piEnqueueMemImageRead, pi2ur::piEnqueueMemImageRead)
+  _PI_CL(piEnqueueMemImageWrite, pi2ur::piEnqueueMemImageWrite)
+  _PI_CL(piEnqueueMemImageCopy, pi2ur::piEnqueueMemImageCopy)
+  _PI_CL(piEnqueueMemImageFill, pi2ur::piEnqueueMemImageFill)
+  _PI_CL(piEnqueueMemBufferMap, pi2ur::piEnqueueMemBufferMap)
+  _PI_CL(piEnqueueMemUnmap, pi2ur::piEnqueueMemUnmap)
+  // Device global variable
+  _PI_CL(piextEnqueueDeviceGlobalVariableWrite,
+         pi2ur::piextEnqueueDeviceGlobalVariableWrite)
+  _PI_CL(piextEnqueueDeviceGlobalVariableRead,
+         pi2ur::piextEnqueueDeviceGlobalVariableRead)
+  // Host Pipe
+  _PI_CL(piextEnqueueReadHostPipe, pi2ur::piextEnqueueReadHostPipe)
+  _PI_CL(piextEnqueueWriteHostPipe, pi2ur::piextEnqueueWriteHostPipe)
 
   // USM
   _PI_CL(piextUSMHostAlloc, piextUSMHostAlloc)
   _PI_CL(piextUSMDeviceAlloc, piextUSMDeviceAlloc)
   _PI_CL(piextUSMSharedAlloc, piextUSMSharedAlloc)
   _PI_CL(piextUSMFree, piextUSMFree)
-  _PI_CL(piextUSMEnqueueMemset, piextUSMEnqueueMemset)
-  _PI_CL(piextUSMEnqueueMemcpy, piextUSMEnqueueMemcpy)
-  _PI_CL(piextUSMEnqueuePrefetch, piextUSMEnqueuePrefetch)
-  _PI_CL(piextUSMEnqueueMemAdvise, piextUSMEnqueueMemAdvise)
-  _PI_CL(piextUSMEnqueueFill2D, piextUSMEnqueueFill2D)
-  _PI_CL(piextUSMEnqueueMemset2D, piextUSMEnqueueMemset2D)
-  _PI_CL(piextUSMEnqueueMemcpy2D, piextUSMEnqueueMemcpy2D)
+  _PI_CL(piextUSMEnqueueMemset, pi2ur::piextUSMEnqueueMemset)
+  _PI_CL(piextUSMEnqueueMemcpy, pi2ur::piextUSMEnqueueMemcpy)
+  _PI_CL(piextUSMEnqueuePrefetch, pi2ur::piextUSMEnqueuePrefetch)
+  _PI_CL(piextUSMEnqueueMemAdvise, pi2ur::piextUSMEnqueueMemAdvise)
+  _PI_CL(piextUSMEnqueueFill2D, pi2ur::piextUSMEnqueueFill2D)
+  _PI_CL(piextUSMEnqueueMemset2D, pi2ur::piextUSMEnqueueMemset2D)
+  _PI_CL(piextUSMEnqueueMemcpy2D, pi2ur::piextUSMEnqueueMemcpy2D)
   _PI_CL(piextUSMGetMemAllocInfo, piextUSMGetMemAllocInfo)
 
-  // Device global variable
-  _PI_CL(piextEnqueueDeviceGlobalVariableWrite,
-         piextEnqueueDeviceGlobalVariableWrite)
-  _PI_CL(piextEnqueueDeviceGlobalVariableRead,
-         piextEnqueueDeviceGlobalVariableRead)
-
-  // Host Pipe
-  _PI_CL(piextEnqueueReadHostPipe, piextEnqueueReadHostPipe)
-  _PI_CL(piextEnqueueWriteHostPipe, piextEnqueueWriteHostPipe)
-
-  _PI_CL(piPluginGetLastError, piPluginGetLastError)
-
-  _PI_CL(piGetDeviceAndHostTimer, piGetDeviceAndHostTimer)
+  _PI_CL(piPluginGetLastError, pi2ur::piPluginGetLastError)
 
   // P2P Access
   _PI_CL(piextEnablePeerAccess, piextEnablePeerAccess)

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -116,20 +116,6 @@ pi_result piextPlatformCreateWithNativeHandle(pi_native_handle, pi_platform *) {
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piSamplerCreate(pi_context, const pi_sampler_properties *,
-                          pi_sampler *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piSamplerGetInfo(pi_sampler, pi_sampler_info, size_t, void *,
-                           size_t *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piSamplerRetain(pi_sampler) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piSamplerRelease(pi_sampler) { DIE_NO_IMPLEMENTATION; }
-
 pi_result piEnqueueEventsWait(pi_queue, pi_uint32, const pi_event *,
                               pi_event *) {
   DIE_NO_IMPLEMENTATION;
@@ -639,10 +625,10 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
          pi2ur::piextEventCreateWithNativeHandle)
 
   // Sampler
-  _PI_CL(piSamplerCreate, piSamplerCreate)
-  _PI_CL(piSamplerGetInfo, piSamplerGetInfo)
-  _PI_CL(piSamplerRetain, piSamplerRetain)
-  _PI_CL(piSamplerRelease, piSamplerRelease)
+  _PI_CL(piSamplerCreate, pi2ur::piSamplerCreate)
+  _PI_CL(piSamplerGetInfo, pi2ur::piSamplerGetInfo)
+  _PI_CL(piSamplerRetain, pi2ur::piSamplerRetain)
+  _PI_CL(piSamplerRelease, pi2ur::piSamplerRelease)
 
   // Queue commands
   _PI_CL(piEnqueueKernelLaunch, piEnqueueKernelLaunch)

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -16,11 +16,6 @@ struct _pi_object {
   std::atomic<pi_uint32> RefCount;
 };
 
-struct _pi_program : _pi_object {
-  _pi_context *_ctx;
-  const unsigned char *_ptr;
-};
-
 using nativecpu_kernel_t = void(const sycl::detail::NativeCPUArgDesc *,
                                 __nativecpu_state *);
 using nativecpu_ptr_t = nativecpu_kernel_t *;
@@ -134,111 +129,6 @@ pi_result piextPlatformGetNativeHandle(pi_platform, pi_native_handle *) {
 }
 
 pi_result piextPlatformCreateWithNativeHandle(pi_native_handle, pi_platform *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piProgramCreate(pi_context, const void *, size_t, pi_program *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piProgramCreateWithBinary(pi_context context, pi_uint32,
-                                    const pi_device *, const size_t *,
-                                    const unsigned char **binaries, size_t,
-                                    const pi_device_binary_property *,
-                                    pi_int32 *, pi_program *program) {
-  // Todo: proper error checking
-  assert(binaries);
-  auto p = new _pi_program();
-  p->_ptr = binaries[0];
-  p->_ctx = context;
-  *program = p;
-  return PI_SUCCESS;
-}
-
-pi_result piclProgramCreateWithBinary(pi_context, pi_uint32, const pi_device *,
-                                      const size_t *, const unsigned char **,
-                                      pi_int32 *, pi_program *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piclProgramCreateWithSource(pi_context, pi_uint32, const char **,
-                                      const size_t *, pi_program *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piProgramGetInfo(pi_program program, pi_program_info param_name,
-                           size_t param_value_size, void *param_value,
-                           size_t *param_value_size_ret) {
-  assert(program != nullptr);
-
-  switch (param_name) {
-  case PI_PROGRAM_INFO_REFERENCE_COUNT:
-    return getInfo(param_value_size, param_value, param_value_size_ret,
-                   &program->RefCount);
-  case PI_PROGRAM_INFO_CONTEXT:
-    return getInfo(param_value_size, param_value, param_value_size_ret,
-                   nullptr);
-  case PI_PROGRAM_INFO_NUM_DEVICES:
-    return getInfo(param_value_size, param_value, param_value_size_ret, 1u);
-  case PI_PROGRAM_INFO_DEVICES:
-    return getInfoArray(1, param_value_size, param_value, param_value_size_ret,
-                        program->_ctx->Device);
-  case PI_PROGRAM_INFO_SOURCE:
-    return getInfo(param_value_size, param_value, param_value_size_ret,
-                   nullptr);
-  case PI_PROGRAM_INFO_BINARY_SIZES:
-    return getInfoArray(1, param_value_size, param_value, param_value_size_ret,
-                        "foo");
-  case PI_PROGRAM_INFO_BINARIES:
-    return getInfoArray(1, param_value_size, param_value, param_value_size_ret,
-                        "foo");
-  case PI_PROGRAM_INFO_KERNEL_NAMES: {
-    return getInfo(param_value_size, param_value, param_value_size_ret, "foo");
-  }
-  default:
-    __SYCL_PI_HANDLE_UNKNOWN_PARAM_NAME(param_name);
-  }
-  sycl::detail::pi::die("Program info request not implemented");
-  return {};
-}
-
-pi_result piProgramLink(pi_context, pi_uint32, const pi_device *, const char *,
-                        pi_uint32, const pi_program *,
-                        void (*)(pi_program, void *), void *, pi_program *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piProgramCompile(pi_program, pi_uint32, const pi_device *,
-                           const char *, pi_uint32, const pi_program *,
-                           const char **, void (*)(pi_program, void *),
-                           void *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piProgramBuild(pi_program, pi_uint32, const pi_device *, const char *,
-                         void (*)(pi_program, void *), void *) {
-  return PI_SUCCESS;
-}
-
-pi_result piProgramGetBuildInfo(pi_program, pi_device,
-                                pi_program_build_info param_name, size_t,
-                                void *, size_t *) {
-  CONTINUE_NO_IMPLEMENTATION;
-}
-
-pi_result piProgramRetain(pi_program) { DIE_NO_IMPLEMENTATION; }
-
-pi_result piProgramRelease(pi_program program) {
-  delete program;
-  return PI_SUCCESS;
-}
-
-pi_result piextProgramGetNativeHandle(pi_program, pi_native_handle *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextProgramCreateWithNativeHandle(pi_native_handle, pi_context, bool,
-                                             pi_program *) {
   DIE_NO_IMPLEMENTATION;
 }
 
@@ -562,11 +452,6 @@ pi_result piEnqueueNativeKernel(pi_queue, void (*)(void *), void *, size_t,
   DIE_NO_IMPLEMENTATION;
 }
 
-pi_result piextGetDeviceFunctionPointer(pi_device, pi_program, const char *,
-                                        pi_uint64 *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
 pi_result piextUSMHostAlloc(void **result_ptr, pi_context,
                             pi_usm_mem_properties *, size_t size, pi_uint32) {
   // Todo: check properties and alignment.
@@ -638,11 +523,6 @@ pi_result piKernelSetExecInfo(pi_kernel, pi_kernel_exec_info, size_t,
   return PI_SUCCESS;
 }
 
-pi_result piextProgramSetSpecializationConstant(pi_program, pi_uint32, size_t,
-                                                const void *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
 pi_result piextUSMEnqueuePrefetch(pi_queue, const void *, size_t,
                                   pi_usm_migration_flags, pi_uint32,
                                   const pi_event *, pi_event *) {
@@ -701,12 +581,6 @@ pi_result piextEnqueueDeviceGlobalVariableRead(
     size_t count, size_t offset, void *dst, pi_uint32 num_events_in_wait_list,
     const pi_event *event_wait_list, pi_event *event) {
   DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piPluginGetBackendOption(pi_platform platform,
-                                   const char *frontend_option,
-                                   const char **backend_option) {
-  CONTINUE_NO_IMPLEMENTATION;
 }
 
 pi_result piextUSMEnqueueMemset2D(pi_queue queue, void *ptr, size_t pitch,
@@ -853,6 +727,8 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   // Platform
   _PI_CL(piPlatformsGet, pi2ur::piPlatformsGet)
   _PI_CL(piPlatformGetInfo, pi2ur::piPlatformGetInfo)
+  _PI_CL(piPluginGetBackendOption, pi2ur::piPluginGetBackendOption)
+
   // Device
   _PI_CL(piDevicesGet, pi2ur::piDevicesGet)
   _PI_CL(piDeviceGetInfo, pi2ur::piDeviceGetInfo)
@@ -861,8 +737,7 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piDeviceRelease, pi2ur::piDeviceRelease)
   _PI_CL(piextDeviceSelectBinary, pi2ur::piextDeviceSelectBinary)
   // TODO: uncomment when program is fully ported
-  //  _PI_CL(piextGetDeviceFunctionPointer,
-  //  pi2ur::piextGetDeviceFunctionPointer)
+  _PI_CL(piextGetDeviceFunctionPointer, pi2ur::piextGetDeviceFunctionPointer)
   _PI_CL(piextDeviceGetNativeHandle, pi2ur::piextDeviceGetNativeHandle)
   _PI_CL(piextDeviceCreateWithNativeHandle,
          pi2ur::piextDeviceCreateWithNativeHandle)
@@ -899,20 +774,21 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextMemCreateWithNativeHandle, pi2ur::piextMemCreateWithNativeHandle)
 
   // Program
-  _PI_CL(piProgramCreate, piProgramCreate)
-  _PI_CL(piclProgramCreateWithSource, piclProgramCreateWithSource)
-  _PI_CL(piProgramCreateWithBinary, piProgramCreateWithBinary)
-  _PI_CL(piProgramGetInfo, piProgramGetInfo)
-  _PI_CL(piProgramCompile, piProgramCompile)
-  _PI_CL(piProgramBuild, piProgramBuild)
-  _PI_CL(piProgramLink, piProgramLink)
-  _PI_CL(piProgramGetBuildInfo, piProgramGetBuildInfo)
-  _PI_CL(piProgramRetain, piProgramRetain)
-  _PI_CL(piProgramRelease, piProgramRelease)
-  _PI_CL(piextProgramGetNativeHandle, piextProgramGetNativeHandle)
-  _PI_CL(piextProgramCreateWithNativeHandle, piextProgramCreateWithNativeHandle)
+  _PI_CL(piProgramCreate, pi2ur::piProgramCreate)
+  _PI_CL(piclProgramCreateWithSource, pi2ur::piclProgramCreateWithSource)
+  _PI_CL(piProgramCreateWithBinary, pi2ur::piProgramCreateWithBinary)
+  _PI_CL(piProgramGetInfo, pi2ur::piProgramGetInfo)
+  _PI_CL(piProgramCompile, pi2ur::piProgramCompile)
+  _PI_CL(piProgramBuild, pi2ur::piProgramBuild)
+  _PI_CL(piProgramLink, pi2ur::piProgramLink)
+  _PI_CL(piProgramGetBuildInfo, pi2ur::piProgramGetBuildInfo)
+  _PI_CL(piProgramRetain, pi2ur::piProgramRetain)
+  _PI_CL(piProgramRelease, pi2ur::piProgramRelease)
+  _PI_CL(piextProgramGetNativeHandle, pi2ur::piextProgramGetNativeHandle)
+  _PI_CL(piextProgramCreateWithNativeHandle,
+         pi2ur::piextProgramCreateWithNativeHandle)
   _PI_CL(piextProgramSetSpecializationConstant,
-         piextProgramSetSpecializationConstant)
+         pi2ur::piextProgramSetSpecializationConstant)
   // Kernel
   _PI_CL(piKernelCreate, piKernelCreate)
   _PI_CL(piKernelSetArg, piKernelSetArg)
@@ -987,9 +863,16 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextKernelSetArgMemObj, piextKernelSetArgMemObj)
   _PI_CL(piextKernelSetArgSampler, piextKernelSetArgSampler)
   _PI_CL(piPluginGetLastError, piPluginGetLastError)
-  _PI_CL(piTearDown, piTearDown)
+
   _PI_CL(piGetDeviceAndHostTimer, piGetDeviceAndHostTimer)
-  _PI_CL(piPluginGetBackendOption, piPluginGetBackendOption)
+
+  // P2P Access
+  _PI_CL(piextEnablePeerAccess, piextEnablePeerAccess)
+  _PI_CL(piextDisablePeerAccess, piextDisablePeerAccess)
+  _PI_CL(piextPeerAccessGetInfo, piextPeerAccessGetInfo)
+
+  // Runtime
+  _PI_CL(piTearDown, pi2ur::piTearDown)
 
 #undef _PI_CL
   return PI_SUCCESS;

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -1,10 +1,10 @@
-#include <atomic>
-#include <cstdint>
-#include <cstring>
-#include <iostream>
-#include <sycl/detail/cg_types.hpp> // NDRDescT
-#include <sycl/detail/native_cpu.hpp>
-#include <sycl/detail/pi.h>
+//==---------- pi_native_cpu.cpp - Native CPU Plugin -----------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
 
 #include "pi_native_cpu.hpp"
 

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -8,8 +8,6 @@
 
 #include "pi_native_cpu.hpp"
 
-static bool PrintPiTrace = true;
-
 extern "C" {
 
 pi_result piPluginInit(pi_plugin *PluginInit) {

--- a/sycl/plugins/native_cpu/pi_native_cpu.cpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.cpp
@@ -10,50 +10,6 @@
 
 static bool PrintPiTrace = true;
 
-// taken from pi_cuda.cpp
-template <typename T, typename Assign>
-pi_result getInfoImpl(size_t param_value_size, void *param_value,
-                      size_t *param_value_size_ret, T value, size_t value_size,
-                      Assign &&assign_func) {
-
-  if (param_value != nullptr) {
-    if (param_value_size < value_size) {
-      return PI_ERROR_INVALID_VALUE;
-    }
-
-    assign_func(param_value, value, value_size);
-  }
-
-  if (param_value_size_ret != nullptr) {
-    *param_value_size_ret = value_size;
-  }
-
-  return PI_SUCCESS;
-}
-
-template <typename T>
-pi_result getInfo(size_t param_value_size, void *param_value,
-                  size_t *param_value_size_ret, T value) {
-
-  auto assignment = [](void *param_value, T value, size_t value_size) {
-    // Ignore unused parameter
-    (void)value_size;
-
-    *static_cast<T *>(param_value) = value;
-  };
-
-  return getInfoImpl(param_value_size, param_value, param_value_size_ret, value,
-                     sizeof(T), assignment);
-}
-
-template <typename T>
-pi_result getInfoArray(size_t array_length, size_t param_value_size,
-                       void *param_value, size_t *param_value_size_ret,
-                       T *value) {
-  return getInfoImpl(param_value_size, param_value, param_value_size_ret, value,
-                     array_length * sizeof(T), memcpy);
-}
-
 extern "C" {
 #define DIE_NO_IMPLEMENTATION                                                  \
   if (PrintPiTrace) {                                                          \
@@ -62,193 +18,6 @@ extern "C" {
     std::cerr << " / Line : " << __LINE__ << std::endl;                        \
   }                                                                            \
   return PI_ERROR_INVALID_OPERATION;
-
-#define CONTINUE_NO_IMPLEMENTATION                                             \
-  if (PrintPiTrace) {                                                          \
-    std::cerr << "Warning : Not Implemented : " << __FUNCTION__                \
-              << " - File : " << __FILE__;                                     \
-    std::cerr << " / Line : " << __LINE__ << std::endl;                        \
-  }                                                                            \
-  return PI_SUCCESS;
-
-#define CASE_PI_UNSUPPORTED(not_supported)                                     \
-  case not_supported:                                                          \
-    if (PrintPiTrace) {                                                        \
-      std::cerr << std::endl                                                   \
-                << "Unsupported PI case : " << #not_supported << " in "        \
-                << __FUNCTION__ << ":" << __LINE__ << "(" << __FILE__ << ")"   \
-                << std::endl;                                                  \
-    }                                                                          \
-    return PI_ERROR_INVALID_OPERATION;
-
-pi_result piextUSMHostAlloc(void **result_ptr, pi_context,
-                            pi_usm_mem_properties *, size_t size, pi_uint32) {
-  // Todo: check properties and alignment.
-  // Todo: error checking.
-  *result_ptr = malloc(size);
-  return PI_SUCCESS;
-}
-
-pi_result piextUSMDeviceAlloc(void **ResultPtr, pi_context, pi_device,
-                              pi_usm_mem_properties *, size_t Size, pi_uint32) {
-  // Todo: check properties and alignment.
-  // Todo: error checking.
-  *ResultPtr = malloc(Size);
-  return PI_SUCCESS;
-}
-
-pi_result piextUSMSharedAlloc(void **ResultPtr, pi_context Context,
-                              pi_device Device,
-                              pi_usm_mem_properties *Properties, size_t Size,
-                              pi_uint32 Alignment) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextUSMFree(pi_context, void *Ptr) {
-  // Todo: error checking
-  free(Ptr);
-  return PI_SUCCESS;
-}
-
-pi_result piextUSMEnqueueMemset(pi_queue, void *ptr, pi_int32 value,
-                                size_t count, pi_uint32, const pi_event *,
-                                pi_event *) {
-  // Todo: event dependency
-  // Todo: error checking.
-  memset(ptr, value, count);
-  return PI_SUCCESS;
-}
-
-pi_result piextUSMEnqueueMemcpy(pi_queue, pi_bool, void *dest, const void *src,
-                                size_t len, pi_uint32, const pi_event *,
-                                pi_event *) {
-  // Todo: event dependency
-  // Todo: error checking
-  memcpy(dest, src, len);
-  return PI_SUCCESS;
-}
-
-pi_result piextUSMEnqueueMemAdvise(pi_queue, const void *, size_t,
-                                   pi_mem_advice, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextUSMGetMemAllocInfo(pi_context, const void *, pi_mem_alloc_info,
-                                  size_t, void *, size_t *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextUSMEnqueuePrefetch(pi_queue, const void *, size_t,
-                                  pi_usm_migration_flags, pi_uint32,
-                                  const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextUSMEnqueueMemcpy2D(pi_queue queue, pi_bool blocking,
-                                  void *dst_ptr, size_t dst_pitch,
-                                  const void *src_ptr, size_t src_pitch,
-                                  size_t width, size_t height,
-                                  pi_uint32 num_events_in_waitlist,
-                                  const pi_event *events_waitlist,
-                                  pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextUSMEnqueueMemset2D(pi_queue queue, void *ptr, size_t pitch,
-                                  int value, size_t width, size_t height,
-                                  pi_uint32 num_events_in_waitlist,
-                                  const pi_event *events_waitlist,
-                                  pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextUSMEnqueueFill2D(pi_queue queue, void *ptr, size_t pitch,
-                                size_t pattern_size, const void *pattern,
-                                size_t width, size_t height,
-                                pi_uint32 num_events_in_waitlist,
-                                const pi_event *events_waitlist,
-                                pi_event *event) {
-  DIE_NO_IMPLEMENTATION;
-}
-pi_result piextCommandBufferCreate(pi_context, pi_device,
-                                   const pi_ext_command_buffer_desc *,
-                                   pi_ext_command_buffer *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferRetain(pi_ext_command_buffer) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferRelease(pi_ext_command_buffer) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferFinalize(pi_ext_command_buffer) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferNDRangeKernel(pi_ext_command_buffer, pi_kernel,
-                                          pi_uint32, const size_t *,
-                                          const size_t *, const size_t *,
-                                          pi_uint32, const pi_ext_sync_point *,
-                                          pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemcpyUSM(pi_ext_command_buffer, void *,
-                                      const void *, size_t, pi_uint32,
-                                      const pi_ext_sync_point *,
-                                      pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemBufferCopy(pi_ext_command_buffer, pi_mem, pi_mem,
-                                          size_t, size_t, size_t, pi_uint32,
-                                          const pi_ext_sync_point *,
-                                          pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemBufferCopyRect(
-    pi_ext_command_buffer, pi_mem, pi_mem, pi_buff_rect_offset,
-    pi_buff_rect_offset, pi_buff_rect_region, size_t, size_t, size_t, size_t,
-    pi_uint32, const pi_ext_sync_point *, pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemBufferRead(pi_ext_command_buffer, pi_mem, size_t,
-                                          size_t, void *, pi_uint32,
-                                          const pi_ext_sync_point *,
-                                          pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemBufferReadRect(
-    pi_ext_command_buffer, pi_mem, pi_buff_rect_offset, pi_buff_rect_offset,
-    pi_buff_rect_region, size_t, size_t, size_t, size_t, void *, pi_uint32,
-    const pi_ext_sync_point *, pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemBufferWrite(pi_ext_command_buffer, pi_mem,
-                                           size_t, size_t, const void *,
-                                           pi_uint32, const pi_ext_sync_point *,
-                                           pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextCommandBufferMemBufferWriteRect(
-    pi_ext_command_buffer, pi_mem, pi_buff_rect_offset, pi_buff_rect_offset,
-    pi_buff_rect_region, size_t, size_t, size_t, size_t, const void *,
-    pi_uint32, const pi_ext_sync_point *, pi_ext_sync_point *) {
-  DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piextEnqueueCommandBuffer(pi_ext_command_buffer, pi_queue, pi_uint32,
-                                    const pi_event *, pi_event *) {
-  DIE_NO_IMPLEMENTATION;
-}
 
 pi_result piextEnablePeerAccess(pi_device, pi_device) { DIE_NO_IMPLEMENTATION; }
 
@@ -259,11 +28,6 @@ pi_result piextDisablePeerAccess(pi_device, pi_device) {
 pi_result piextPeerAccessGetInfo(pi_device, pi_device, pi_peer_attr, size_t,
                                  void *, size_t *) {
   DIE_NO_IMPLEMENTATION;
-}
-
-pi_result piTearDown(void *) {
-  // Todo: is it fine as a no-op?
-  return PI_SUCCESS;
 }
 
 pi_result piPluginInit(pi_plugin *PluginInit) {
@@ -401,10 +165,10 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextEnqueueWriteHostPipe, pi2ur::piextEnqueueWriteHostPipe)
 
   // USM
-  _PI_CL(piextUSMHostAlloc, piextUSMHostAlloc)
-  _PI_CL(piextUSMDeviceAlloc, piextUSMDeviceAlloc)
-  _PI_CL(piextUSMSharedAlloc, piextUSMSharedAlloc)
-  _PI_CL(piextUSMFree, piextUSMFree)
+  _PI_CL(piextUSMHostAlloc, pi2ur::piextUSMHostAlloc)
+  _PI_CL(piextUSMDeviceAlloc, pi2ur::piextUSMDeviceAlloc)
+  _PI_CL(piextUSMSharedAlloc, pi2ur::piextUSMSharedAlloc)
+  _PI_CL(piextUSMFree, pi2ur::piextUSMFree)
   _PI_CL(piextUSMEnqueueMemset, pi2ur::piextUSMEnqueueMemset)
   _PI_CL(piextUSMEnqueueMemcpy, pi2ur::piextUSMEnqueueMemcpy)
   _PI_CL(piextUSMEnqueuePrefetch, pi2ur::piextUSMEnqueuePrefetch)
@@ -412,7 +176,7 @@ pi_result piPluginInit(pi_plugin *PluginInit) {
   _PI_CL(piextUSMEnqueueFill2D, pi2ur::piextUSMEnqueueFill2D)
   _PI_CL(piextUSMEnqueueMemset2D, pi2ur::piextUSMEnqueueMemset2D)
   _PI_CL(piextUSMEnqueueMemcpy2D, pi2ur::piextUSMEnqueueMemcpy2D)
-  _PI_CL(piextUSMGetMemAllocInfo, piextUSMGetMemAllocInfo)
+  _PI_CL(piextUSMGetMemAllocInfo, pi2ur::piextUSMGetMemAllocInfo)
 
   _PI_CL(piPluginGetLastError, pi2ur::piPluginGetLastError)
 

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -1,0 +1,16 @@
+//===-- pi_native_cpu.hpp - Native CPU Plugin
+//-----------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <pi2ur.hpp>
+
+#include <ur/adapters/native_cpu/platform.hpp>
+
+struct _pi_platform : ur_platform_handle_t_ {
+  using ur_platform_handle_t_::ur_platform_handle_t_;
+};

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -10,19 +10,24 @@
 
 #include <ur/adapters/native_cpu/context.hpp>
 #include <ur/adapters/native_cpu/device.hpp>
+#include <ur/adapters/native_cpu/memory.hpp>
 #include <ur/adapters/native_cpu/platform.hpp>
 #include <ur/adapters/native_cpu/queue.hpp>
 
-struct _pi_platform : ur_platform_handle_t_ {
-  using ur_platform_handle_t_::ur_platform_handle_t_;
+struct _pi_context : ur_context_handle_t_ {
+  using ur_context_handle_t_::ur_context_handle_t_;
 };
 
 struct _pi_device : ur_device_handle_t_ {
   using ur_device_handle_t_::ur_device_handle_t_;
 };
 
-struct _pi_context : ur_context_handle_t_ {
-  using ur_context_handle_t_::ur_context_handle_t_;
+struct _pi_mem : ur_mem_handle_t_ {
+  using ur_mem_handle_t_::ur_mem_handle_t_;
+};
+
+struct _pi_platform : ur_platform_handle_t_ {
+  using ur_platform_handle_t_::ur_platform_handle_t_;
 };
 
 struct _pi_queue : ur_queue_handle_t_ {

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -14,3 +14,7 @@
 struct _pi_platform : ur_platform_handle_t_ {
   using ur_platform_handle_t_::ur_platform_handle_t_;
 };
+
+struct _pi_device : ur_device_handle_t_ {
+  using ur_device_handle_t_::ur_device_handle_t_;
+};

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -10,6 +10,7 @@
 
 #include <ur/adapters/native_cpu/context.hpp>
 #include <ur/adapters/native_cpu/device.hpp>
+#include <ur/adapters/native_cpu/kernel.hpp>
 #include <ur/adapters/native_cpu/memory.hpp>
 #include <ur/adapters/native_cpu/platform.hpp>
 #include <ur/adapters/native_cpu/program.hpp>
@@ -23,6 +24,10 @@ struct _pi_device : ur_device_handle_t_ {
   using ur_device_handle_t_::ur_device_handle_t_;
 };
 
+struct _pi_kernel : ur_kernel_handle_t_ {
+  using ur_kernel_handle_t_::ur_kernel_handle_t_;
+};
+
 struct _pi_mem : ur_mem_handle_t_ {
   using ur_mem_handle_t_::ur_mem_handle_t_;
 };
@@ -31,10 +36,10 @@ struct _pi_platform : ur_platform_handle_t_ {
   using ur_platform_handle_t_::ur_platform_handle_t_;
 };
 
-struct _pi_queue : ur_queue_handle_t_ {
-  using ur_queue_handle_t_::ur_queue_handle_t_;
-};
-
 struct _pi_program : ur_program_handle_t_ {
   using ur_program_handle_t_::ur_program_handle_t_;
+};
+
+struct _pi_queue : ur_queue_handle_t_ {
+  using ur_queue_handle_t_::ur_queue_handle_t_;
 };

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -12,6 +12,7 @@
 #include <ur/adapters/native_cpu/device.hpp>
 #include <ur/adapters/native_cpu/memory.hpp>
 #include <ur/adapters/native_cpu/platform.hpp>
+#include <ur/adapters/native_cpu/program.hpp>
 #include <ur/adapters/native_cpu/queue.hpp>
 
 struct _pi_context : ur_context_handle_t_ {
@@ -32,4 +33,8 @@ struct _pi_platform : ur_platform_handle_t_ {
 
 struct _pi_queue : ur_queue_handle_t_ {
   using ur_queue_handle_t_::ur_queue_handle_t_;
+};
+
+struct _pi_program : ur_program_handle_t_ {
+  using ur_program_handle_t_::ur_program_handle_t_;
 };

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -11,6 +11,7 @@
 #include <ur/adapters/native_cpu/context.hpp>
 #include <ur/adapters/native_cpu/device.hpp>
 #include <ur/adapters/native_cpu/platform.hpp>
+#include <ur/adapters/native_cpu/queue.hpp>
 
 struct _pi_platform : ur_platform_handle_t_ {
   using ur_platform_handle_t_::ur_platform_handle_t_;
@@ -22,4 +23,8 @@ struct _pi_device : ur_device_handle_t_ {
 
 struct _pi_context : ur_context_handle_t_ {
   using ur_context_handle_t_::ur_context_handle_t_;
+};
+
+struct _pi_queue : ur_queue_handle_t_ {
+  using ur_queue_handle_t_::ur_queue_handle_t_;
 };

--- a/sycl/plugins/native_cpu/pi_native_cpu.hpp
+++ b/sycl/plugins/native_cpu/pi_native_cpu.hpp
@@ -1,5 +1,4 @@
-//===-- pi_native_cpu.hpp - Native CPU Plugin
-//-----------------------------------------===//
+//===------ pi_native_cpu.hpp - Native CPU Plugin -------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -9,6 +8,8 @@
 
 #include <pi2ur.hpp>
 
+#include <ur/adapters/native_cpu/context.hpp>
+#include <ur/adapters/native_cpu/device.hpp>
 #include <ur/adapters/native_cpu/platform.hpp>
 
 struct _pi_platform : ur_platform_handle_t_ {
@@ -17,4 +18,8 @@ struct _pi_platform : ur_platform_handle_t_ {
 
 struct _pi_device : ur_device_handle_t_ {
   using ur_device_handle_t_::ur_device_handle_t_;
+};
+
+struct _pi_context : ur_context_handle_t_ {
+  using ur_context_handle_t_::ur_context_handle_t_;
 };

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -259,6 +259,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/program.hpp"
       "ur/adapters/native_cpu/queue.cpp"
       "ur/adapters/native_cpu/queue.hpp"
+      "ur/adapters/native_cpu/sampler.cpp"
       "ur/adapters/native_cpu/runtime.cpp"
     INCLUDE_DIRS
       ${sycl_inc_dir}

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -237,6 +237,27 @@ if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
   endif()
 endif()
 
+if ("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+  add_sycl_library("ur_adapter_native_cpu" SHARED
+    SOURCES
+      "ur/ur.cpp"
+      "ur/ur.hpp"
+      "ur/adapters/native_cpu/common.hpp"
+      "ur/adapters/native_cpu/platform.cpp"
+      "ur/adapters/native_cpu/platform.hpp"
+    INCLUDE_DIRS
+      ${sycl_inc_dir}
+    LIBRARIES
+      UnifiedRuntime-Headers
+      Threads::Threads
+  )
+
+  set_target_properties("ur_adapter_native_cpu" PROPERTIES
+    VERSION "0.0.0"
+    SOVERSION "0"
+  )
+endif()
+
 if (TARGET UnifiedRuntimeLoader)
   set_target_properties(hello_world PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
   # Install the UR loader.

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -243,8 +243,14 @@ if ("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/ur.cpp"
       "ur/ur.hpp"
       "ur/adapters/native_cpu/common.hpp"
+      "ur/adapters/native_cpu/context.cpp"
+      "ur/adapters/native_cpu/context.hpp"
+      "ur/adapters/native_cpu/device.cpp"
+      "ur/adapters/native_cpu/device.hpp"
       "ur/adapters/native_cpu/platform.cpp"
       "ur/adapters/native_cpu/platform.hpp"
+      "ur/adapters/native_cpu/queue.cpp"
+      "ur/adapters/native_cpu/queue.hpp"
     INCLUDE_DIRS
       ${sycl_inc_dir}
     LIBRARIES

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -1,20 +1,19 @@
 # PI Unified Runtime plugin library
 #
-if(NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED
-                                          UNIFIED_RUNTIME_INCLUDE_DIR)
+if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_DIR)
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
   set(UNIFIED_RUNTIME_TAG 3c6f02c7a76a0448a83932d93c2dbeff25af70aa)
 
   message(STATUS "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO}")
-  FetchContent_Declare(
-    unified-runtime
-    GIT_REPOSITORY ${UNIFIED_RUNTIME_REPO}
-    GIT_TAG ${UNIFIED_RUNTIME_TAG})
+  FetchContent_Declare(unified-runtime
+    GIT_REPOSITORY    ${UNIFIED_RUNTIME_REPO}
+    GIT_TAG           ${UNIFIED_RUNTIME_TAG}
+  )
 
-  # Disable errors from warnings while building the UR. And remember origin
-  # flags before doing that.
+  # Disable errors from warnings while building the UR.
+  # And remember origin flags before doing that.
   set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
   if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX-")
@@ -30,9 +29,7 @@ if(NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED
   endif()
 
   # No need to build tests from unified-runtime
-  set(UR_BUILD_TESTS
-      "0"
-      CACHE STRING "0")
+  set(UR_BUILD_TESTS "0" CACHE STRING "0")
 
   FetchContent_GetProperties(unified-runtime)
   FetchContent_MakeAvailable(unified-runtime)
@@ -43,20 +40,21 @@ if(NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED
   add_library(UnifiedRuntimeLoader ALIAS ur_loader)
 
   set(UNIFIED_RUNTIME_SOURCE_DIR
-      ${unified-runtime_SOURCE_DIR}
-      CACHE PATH "Path to Unified Runtime Headers")
+    ${unified-runtime_SOURCE_DIR} CACHE PATH "Path to Unified Runtime Headers")
   set(UNIFIED_RUNTIME_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/include")
 endif()
 
-add_library(UnifiedRuntime-Headers INTERFACE)
+
+add_library (UnifiedRuntime-Headers INTERFACE)
 
 target_include_directories(UnifiedRuntime-Headers
-                           INTERFACE "${UNIFIED_RUNTIME_INCLUDE_DIR}")
+  INTERFACE
+    "${UNIFIED_RUNTIME_INCLUDE_DIR}"
+)
 
 find_package(Threads REQUIRED)
 
-add_sycl_plugin(
-  unified_runtime
+add_sycl_plugin(unified_runtime
   SOURCES
     # These are short-term shared with Unified Runtime
     # The two plugins define a few things differrently so must
@@ -77,9 +75,7 @@ add_sycl_plugin(
 )
 
 # Build level zero adapter
-add_sycl_library(
-  "ur_adapter_level_zero"
-  SHARED
+add_sycl_library("ur_adapter_level_zero" SHARED
   SOURCES
     "ur/ur.hpp"
     "ur/ur.cpp"
@@ -118,21 +114,22 @@ add_sycl_library(
     "ur/adapters/level_zero/usm.cpp"
     "ur/adapters/level_zero/usm_p2p.cpp"
   INCLUDE_DIRS
-  ${sycl_inc_dir}
+    ${sycl_inc_dir}
   LIBRARIES
-  UnifiedRuntime-Headers
-  LevelZeroLoader-Headers
-  LevelZeroLoader
-  Threads::Threads)
+    UnifiedRuntime-Headers
+    LevelZeroLoader-Headers
+    LevelZeroLoader
+    Threads::Threads
+)
 
-set_target_properties("ur_adapter_level_zero" PROPERTIES VERSION "0.0.0"
-                                                         SOVERSION "0")
+set_target_properties("ur_adapter_level_zero" PROPERTIES
+    VERSION "0.0.0"
+    SOVERSION "0"
+)
 
-if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
   # Build CUDA adapter
-  add_sycl_library(
-    "ur_adapter_cuda"
-    SHARED
+  add_sycl_library("ur_adapter_cuda" SHARED
     SOURCES
       "ur/ur.hpp"
       "ur/ur.cpp"
@@ -168,14 +165,17 @@ if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/cuda/command_buffer.cpp"
       "ur/adapters/cuda/usm_p2p.cpp"
     INCLUDE_DIRS
-    ${sycl_inc_dir}
+      ${sycl_inc_dir}
     LIBRARIES
-    UnifiedRuntime-Headers
-    Threads::Threads
-    cudadrv)
+      UnifiedRuntime-Headers
+      Threads::Threads
+      cudadrv
+  )
 
-  set_target_properties("ur_adapter_cuda" PROPERTIES VERSION "0.0.0" SOVERSION
-                                                                     "0")
+  set_target_properties("ur_adapter_cuda" PROPERTIES
+    VERSION "0.0.0"
+    SOVERSION "0"
+  )
 endif()
 
 if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
@@ -239,9 +239,7 @@ if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
 endif()
 
 if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
-  add_sycl_library(
-    "ur_adapter_native_cpu"
-    SHARED
+  add_sycl_library("ur_adapter_native_cpu" SHARED
     SOURCES
       "ur/ur.cpp"
       "ur/ur.hpp"
@@ -254,34 +252,41 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/memory.hpp"
       "ur/adapters/native_cpu/platform.cpp"
       "ur/adapters/native_cpu/platform.hpp"
+      "ur/adapters/native_cpu/program.cpp"
+      "ur/adapters/native_cpu/program.hpp"
       "ur/adapters/native_cpu/queue.cpp"
       "ur/adapters/native_cpu/queue.hpp"
+      "ur/adapters/native_cpu/runtime.cpp"
     INCLUDE_DIRS
-    ${sycl_inc_dir}
+      ${sycl_inc_dir}
     LIBRARIES
-    UnifiedRuntime-Headers
-    Threads::Threads)
+      UnifiedRuntime-Headers
+      Threads::Threads
+  )
 
-  set_target_properties("ur_adapter_native_cpu" PROPERTIES VERSION "0.0.0"
-                                                           SOVERSION "0")
+  set_target_properties("ur_adapter_native_cpu" PROPERTIES 
+    VERSION "0.0.0"                                                         
+    SOVERSION "0"
+  )
 endif()
 
-if(TARGET UnifiedRuntimeLoader)
-  set_target_properties(hello_world PROPERTIES EXCLUDE_FROM_ALL 1
-                                               EXCLUDE_FROM_DEFAULT_BUILD 1)
-  # Install the UR loader. TODO: this is piggy-backing on the existing target
-  # component level-zero-sycl-dev When UR is moved to its separate repo perhaps
-  # we should introduce new component, e.g. unified-runtime-sycl-dev.
-  install(
-    TARGETS ur_loader
+
+if (TARGET UnifiedRuntimeLoader)
+  set_target_properties(hello_world PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
+  # Install the UR loader.
+  # TODO: this is piggy-backing on the existing target component level-zero-sycl-dev
+  # When UR is moved to its separate repo perhaps we should introduce new component,
+  # e.g. unified-runtime-sycl-dev.
+  install(TARGETS ur_loader
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
-    RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev)
+    RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev
+  )
 endif()
 
 # Install the UR adapters too
-install(
-  TARGETS ur_adapter_level_zero
+install(TARGETS ur_adapter_level_zero
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
-  RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev)
+  RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev
+)

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -265,6 +265,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/runtime.cpp"
       "ur/adapters/native_cpu/ur_interface_loader.cpp"
       "ur/adapters/native_cpu/usm.cpp"
+      "ur/adapters/native_cpu/usm_p2p.cpp"
     INCLUDE_DIRS
       ${sycl_inc_dir}
     LIBRARIES

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -180,8 +180,7 @@ endif()
 
 if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
   # Build HIP adapter
-  add_sycl_library(
-    "ur_adapter_hip" SHARED 
+  add_sycl_library("ur_adapter_hip" SHARED 
     SOURCES
       "ur/ur.hpp"
       "ur/ur.cpp"

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -248,6 +248,8 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/context.hpp"
       "ur/adapters/native_cpu/device.cpp"
       "ur/adapters/native_cpu/device.hpp"
+      "ur/adapters/native_cpu/kernel.cpp"
+      "ur/adapters/native_cpu/kernel.hpp"
       "ur/adapters/native_cpu/memory.cpp"
       "ur/adapters/native_cpu/memory.hpp"
       "ur/adapters/native_cpu/platform.cpp"

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -262,6 +262,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/queue.hpp"
       "ur/adapters/native_cpu/sampler.cpp"
       "ur/adapters/native_cpu/runtime.cpp"
+      "ur/adapters/native_cpu/usm.cpp"
     INCLUDE_DIRS
       ${sycl_inc_dir}
     LIBRARIES

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -248,6 +248,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/context.hpp"
       "ur/adapters/native_cpu/device.cpp"
       "ur/adapters/native_cpu/device.hpp"
+      "ur/adapters/native_cpu/event.cpp"
       "ur/adapters/native_cpu/kernel.cpp"
       "ur/adapters/native_cpu/kernel.hpp"
       "ur/adapters/native_cpu/memory.cpp"

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -1,19 +1,20 @@
 # PI Unified Runtime plugin library
 #
-if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_DIR)
+if(NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED
+                                          UNIFIED_RUNTIME_INCLUDE_DIR)
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
   set(UNIFIED_RUNTIME_TAG 3c6f02c7a76a0448a83932d93c2dbeff25af70aa)
 
   message(STATUS "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO}")
-  FetchContent_Declare(unified-runtime
-    GIT_REPOSITORY    ${UNIFIED_RUNTIME_REPO}
-    GIT_TAG           ${UNIFIED_RUNTIME_TAG}
-  )
+  FetchContent_Declare(
+    unified-runtime
+    GIT_REPOSITORY ${UNIFIED_RUNTIME_REPO}
+    GIT_TAG ${UNIFIED_RUNTIME_TAG})
 
-  # Disable errors from warnings while building the UR.
-  # And remember origin flags before doing that.
+  # Disable errors from warnings while building the UR. And remember origin
+  # flags before doing that.
   set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
   if(WIN32)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /WX-")
@@ -29,7 +30,9 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
   endif()
 
   # No need to build tests from unified-runtime
-  set(UR_BUILD_TESTS "0" CACHE STRING "0")
+  set(UR_BUILD_TESTS
+      "0"
+      CACHE STRING "0")
 
   FetchContent_GetProperties(unified-runtime)
   FetchContent_MakeAvailable(unified-runtime)
@@ -40,21 +43,20 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
   add_library(UnifiedRuntimeLoader ALIAS ur_loader)
 
   set(UNIFIED_RUNTIME_SOURCE_DIR
-    ${unified-runtime_SOURCE_DIR} CACHE PATH "Path to Unified Runtime Headers")
+      ${unified-runtime_SOURCE_DIR}
+      CACHE PATH "Path to Unified Runtime Headers")
   set(UNIFIED_RUNTIME_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/include")
 endif()
 
-
-add_library (UnifiedRuntime-Headers INTERFACE)
+add_library(UnifiedRuntime-Headers INTERFACE)
 
 target_include_directories(UnifiedRuntime-Headers
-  INTERFACE
-    "${UNIFIED_RUNTIME_INCLUDE_DIR}"
-)
+                           INTERFACE "${UNIFIED_RUNTIME_INCLUDE_DIR}")
 
 find_package(Threads REQUIRED)
 
-add_sycl_plugin(unified_runtime
+add_sycl_plugin(
+  unified_runtime
   SOURCES
     # These are short-term shared with Unified Runtime
     # The two plugins define a few things differrently so must
@@ -75,7 +77,9 @@ add_sycl_plugin(unified_runtime
 )
 
 # Build level zero adapter
-add_sycl_library("ur_adapter_level_zero" SHARED
+add_sycl_library(
+  "ur_adapter_level_zero"
+  SHARED
   SOURCES
     "ur/ur.hpp"
     "ur/ur.cpp"
@@ -114,22 +118,21 @@ add_sycl_library("ur_adapter_level_zero" SHARED
     "ur/adapters/level_zero/usm.cpp"
     "ur/adapters/level_zero/usm_p2p.cpp"
   INCLUDE_DIRS
-    ${sycl_inc_dir}
+  ${sycl_inc_dir}
   LIBRARIES
-    UnifiedRuntime-Headers
-    LevelZeroLoader-Headers
-    LevelZeroLoader
-    Threads::Threads
-)
+  UnifiedRuntime-Headers
+  LevelZeroLoader-Headers
+  LevelZeroLoader
+  Threads::Threads)
 
-set_target_properties("ur_adapter_level_zero" PROPERTIES
-    VERSION "0.0.0"
-    SOVERSION "0"
-)
+set_target_properties("ur_adapter_level_zero" PROPERTIES VERSION "0.0.0"
+                                                         SOVERSION "0")
 
-if ("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
   # Build CUDA adapter
-  add_sycl_library("ur_adapter_cuda" SHARED
+  add_sycl_library(
+    "ur_adapter_cuda"
+    SHARED
     SOURCES
       "ur/ur.hpp"
       "ur/ur.cpp"
@@ -165,22 +168,20 @@ if ("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/cuda/command_buffer.cpp"
       "ur/adapters/cuda/usm_p2p.cpp"
     INCLUDE_DIRS
-      ${sycl_inc_dir}
+    ${sycl_inc_dir}
     LIBRARIES
-      UnifiedRuntime-Headers
-      Threads::Threads
-      cudadrv
-  )
+    UnifiedRuntime-Headers
+    Threads::Threads
+    cudadrv)
 
-  set_target_properties("ur_adapter_cuda" PROPERTIES
-    VERSION "0.0.0"
-    SOVERSION "0"
-  )
+  set_target_properties("ur_adapter_cuda" PROPERTIES VERSION "0.0.0" SOVERSION
+                                                                     "0")
 endif()
 
 if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
   # Build HIP adapter
-  add_sycl_library("ur_adapter_hip" SHARED 
+  add_sycl_library(
+    "ur_adapter_hip" SHARED 
     SOURCES
       "ur/ur.hpp"
       "ur/ur.cpp"
@@ -237,8 +238,10 @@ if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
   endif()
 endif()
 
-if ("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
-  add_sycl_library("ur_adapter_native_cpu" SHARED
+if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+  add_sycl_library(
+    "ur_adapter_native_cpu"
+    SHARED
     SOURCES
       "ur/ur.cpp"
       "ur/ur.hpp"
@@ -247,39 +250,38 @@ if ("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/context.hpp"
       "ur/adapters/native_cpu/device.cpp"
       "ur/adapters/native_cpu/device.hpp"
+      "ur/adapters/native_cpu/memory.cpp"
+      "ur/adapters/native_cpu/memory.hpp"
       "ur/adapters/native_cpu/platform.cpp"
       "ur/adapters/native_cpu/platform.hpp"
       "ur/adapters/native_cpu/queue.cpp"
       "ur/adapters/native_cpu/queue.hpp"
     INCLUDE_DIRS
-      ${sycl_inc_dir}
+    ${sycl_inc_dir}
     LIBRARIES
-      UnifiedRuntime-Headers
-      Threads::Threads
-  )
+    UnifiedRuntime-Headers
+    Threads::Threads)
 
-  set_target_properties("ur_adapter_native_cpu" PROPERTIES
-    VERSION "0.0.0"
-    SOVERSION "0"
-  )
+  set_target_properties("ur_adapter_native_cpu" PROPERTIES VERSION "0.0.0"
+                                                           SOVERSION "0")
 endif()
 
-if (TARGET UnifiedRuntimeLoader)
-  set_target_properties(hello_world PROPERTIES EXCLUDE_FROM_ALL 1 EXCLUDE_FROM_DEFAULT_BUILD 1)
-  # Install the UR loader.
-  # TODO: this is piggy-backing on the existing target component level-zero-sycl-dev
-  # When UR is moved to its separate repo perhaps we should introduce new component,
-  # e.g. unified-runtime-sycl-dev.
-  install(TARGETS ur_loader
+if(TARGET UnifiedRuntimeLoader)
+  set_target_properties(hello_world PROPERTIES EXCLUDE_FROM_ALL 1
+                                               EXCLUDE_FROM_DEFAULT_BUILD 1)
+  # Install the UR loader. TODO: this is piggy-backing on the existing target
+  # component level-zero-sycl-dev When UR is moved to its separate repo perhaps
+  # we should introduce new component, e.g. unified-runtime-sycl-dev.
+  install(
+    TARGETS ur_loader
     LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
     ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
-    RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev
-  )
+    RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev)
 endif()
 
 # Install the UR adapters too
-install(TARGETS ur_adapter_level_zero
+install(
+  TARGETS ur_adapter_level_zero
   LIBRARY DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
   ARCHIVE DESTINATION "lib${LLVM_LIBDIR_SUFFIX}" COMPONENT level-zero-sycl-dev
-  RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev
-)
+  RUNTIME DESTINATION "bin" COMPONENT level-zero-sycl-dev)

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -248,6 +248,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/context.hpp"
       "ur/adapters/native_cpu/device.cpp"
       "ur/adapters/native_cpu/device.hpp"
+      "ur/adapters/native_cpu/enqueue.cpp"
       "ur/adapters/native_cpu/event.cpp"
       "ur/adapters/native_cpu/kernel.cpp"
       "ur/adapters/native_cpu/kernel.hpp"
@@ -266,6 +267,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
     LIBRARIES
       UnifiedRuntime-Headers
       Threads::Threads
+      sycl
   )
 
   set_target_properties("ur_adapter_native_cpu" PROPERTIES 

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -243,6 +243,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
     SOURCES
       "ur/ur.cpp"
       "ur/ur.hpp"
+      "ur/adapters/native_cpu/common.cpp"
       "ur/adapters/native_cpu/common.hpp"
       "ur/adapters/native_cpu/context.cpp"
       "ur/adapters/native_cpu/context.hpp"
@@ -262,6 +263,7 @@ if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/native_cpu/queue.hpp"
       "ur/adapters/native_cpu/sampler.cpp"
       "ur/adapters/native_cpu/runtime.cpp"
+      "ur/adapters/native_cpu/ur_interface_loader.cpp"
       "ur/adapters/native_cpu/usm.cpp"
     INCLUDE_DIRS
       ${sycl_inc_dir}

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -308,6 +308,8 @@ inline pi_result ur2piPlatformInfoValue(ur_platform_info_t ParamName,
         return PI_EXT_PLATFORM_BACKEND_CUDA;
       case UR_PLATFORM_BACKEND_HIP:
         return PI_EXT_PLATFORM_BACKEND_HIP;
+      case UR_PLATFORM_BACKEND_NATIVE_CPU:
+        return PI_EXT_PLATFORM_BACKEND_NATIVE_CPU;
       default:
         die("UR_PLATFORM_INFO_BACKEND: unhandled value");
       }

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
@@ -356,6 +356,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
   std::ignore = hProgram;
   std::ignore = pProperties;
   std::ignore = phKernel;
+
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
@@ -356,7 +356,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
   std::ignore = hProgram;
   std::ignore = pProperties;
   std::ignore = phKernel;
-
   return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.cpp
@@ -1,0 +1,28 @@
+//===---------------- common.cpp - Native CPU Adapter ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common.hpp"
+
+// Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
+thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
+thread_local char ErrorMessage[MaxMessageSize];
+
+// Utility function for setting a message and warning
+[[maybe_unused]] void setErrorMessage(const char *pMessage,
+                                      ur_result_t ErrorCode) {
+  assert(strlen(pMessage) <= MaxMessageSize);
+  strcpy(ErrorMessage, pMessage);
+  ErrorMessageCode = ErrorCode;
+}
+
+ur_result_t urGetLastResult(ur_platform_handle_t, const char **ppMessage) {
+  *ppMessage = &ErrorMessage[0];
+  return ErrorMessageCode;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.cpp
@@ -8,7 +8,8 @@
 
 #include "common.hpp"
 
-// Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR
+// Global variables for UR_RESULT_ADAPTER_SPECIFIC_ERROR
+// See urGetLastResult
 thread_local ur_result_t ErrorMessageCode = UR_RESULT_SUCCESS;
 thread_local char ErrorMessage[MaxMessageSize];
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.cpp
@@ -6,8 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-#pragma once
-
 #include "common.hpp"
 
 // Global variables for ZER_EXT_RESULT_ADAPTER_SPECIFIC_ERROR

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
@@ -27,11 +27,11 @@
   }                                                                            \
   return UR_RESULT_SUCCESS;
 
-#define CASE_PI_UNSUPPORTED(not_supported)                                     \
+#define CASE_UR_UNSUPPORTED(not_supported)                                     \
   case not_supported:                                                          \
     if (PrintTrace) {                                                          \
       std::cerr << std::endl                                                   \
-                << "Unsupported PI case : " << #not_supported << " in "        \
+                << "Unsupported UR case : " << #not_supported << " in "        \
                 << __FUNCTION__ << ":" << __LINE__ << "(" << __FILE__ << ")"   \
                 << std::endl;                                                  \
     }                                                                          \

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
@@ -10,6 +10,11 @@
 
 #include "ur/ur.hpp"
 
+constexpr size_t MaxMessageSize = 256;
+
+extern thread_local ur_result_t ErrorMessageCode;
+extern thread_local char ErrorMessage[MaxMessageSize];
+
 #define DIE_NO_IMPLEMENTATION                                                  \
   if (PrintTrace) {                                                            \
     std::cerr << "Not Implemented : " << __FUNCTION__                          \

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
@@ -1,0 +1,38 @@
+
+//===----------- common.cpp - Native CPU Adapter ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#pragma once
+
+#include "ur/ur.hpp"
+
+#define DIE_NO_IMPLEMENTATION                                                  \
+  if (PrintTrace) {                                                            \
+    std::cerr << "Not Implemented : " << __FUNCTION__                          \
+              << " - File : " << __FILE__;                                     \
+    std::cerr << " / Line : " << __LINE__ << std::endl;                        \
+  }                                                                            \
+  return UR_RESULT_ERROR_INVALID_OPERATION;
+
+#define CONTINUE_NO_IMPLEMENTATION                                             \
+  if (PrintTrace) {                                                            \
+    std::cerr << "Warning : Not Implemented : " << __FUNCTION__                \
+              << " - File : " << __FILE__;                                     \
+    std::cerr << " / Line : " << __LINE__ << std::endl;                        \
+  }                                                                            \
+  return UR_RESULT_SUCCESS;
+
+#define CASE_PI_UNSUPPORTED(not_supported)                                     \
+  case not_supported:                                                          \
+    if (PrintTrace) {                                                          \
+      std::cerr << std::endl                                                   \
+                << "Unsupported PI case : " << #not_supported << " in "        \
+                << __FUNCTION__ << ":" << __LINE__ << "(" << __FILE__ << ")"   \
+                << std::endl;                                                  \
+    }                                                                          \
+    return UR_RESULT_ERROR_INVALID_OPERATION;

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
@@ -1,4 +1,3 @@
-
 //===----------- common.cpp - Native CPU Adapter ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -17,7 +16,7 @@
               << " - File : " << __FILE__;                                     \
     std::cerr << " / Line : " << __LINE__ << std::endl;                        \
   }                                                                            \
-  return UR_RESULT_ERROR_INVALID_OPERATION;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
 
 #define CONTINUE_NO_IMPLEMENTATION                                             \
   if (PrintTrace) {                                                            \
@@ -35,4 +34,4 @@
                 << __FUNCTION__ << ":" << __LINE__ << "(" << __FILE__ << ")"   \
                 << std::endl;                                                  \
     }                                                                          \
-    return UR_RESULT_ERROR_INVALID_OPERATION;
+    return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
@@ -26,9 +26,8 @@ urContextCreate(uint32_t DeviceCount, const ur_device_handle_t *phDevices,
   assert(DeviceCount == 1);
 
   // TODO: Proper error checking.
-  auto ctx = std::unique_ptr<ur_context_handle_t_>(
-      new ur_context_handle_t_(*phDevices));
-  *phContext = ctx.release();
+  auto ctx = new ur_context_handle_t_(*phDevices);
+  *phContext = ctx;
   return UR_RESULT_SUCCESS;
 }
 
@@ -40,7 +39,7 @@ urContextRetain(ur_context_handle_t hContext) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  std::unique_ptr<ur_context_handle_t_> Context{hContext};
+  delete hContext;
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
@@ -1,0 +1,113 @@
+//===--------- context.cpp - Native CPU Adapter ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <memory>
+#include <tuple>
+
+#include "ur/ur.hpp"
+#include "ur_api.h"
+
+#include "common.hpp"
+#include "context.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextCreate(uint32_t DeviceCount, const ur_device_handle_t *phDevices,
+                const ur_context_properties_t *pProperties,
+                ur_context_handle_t *phContext) {
+  std::ignore = pProperties;
+  UR_ASSERT(phDevices, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(phContext, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  assert(DeviceCount == 1);
+
+  // TODO: Proper error checking.
+  auto ctx = std::unique_ptr<ur_context_handle_t_>(
+      new ur_context_handle_t_(*phDevices));
+  *phContext = ctx.release();
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextRetain(ur_context_handle_t hContext) {
+  std::ignore = hContext;
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextRelease(ur_context_handle_t hContext) {
+  // TODO: is it fine as a no-op?
+  std::ignore = hContext;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
+                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+
+  UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  UrReturnHelper returnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_CONTEXT_INFO_NUM_DEVICES:
+    return returnValue(1);
+  case UR_CONTEXT_INFO_DEVICES:
+    return returnValue(nullptr);
+  case UR_CONTEXT_INFO_REFERENCE_COUNT:
+    return returnValue(nullptr);
+  case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
+    return returnValue(true);
+  case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT:
+    // case UR_CONTEXT_INFO_USM_MEMSET2D_SUPPORT:
+    // 2D USM operations currently not supported.
+    return returnValue(false);
+  case UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES:
+  case UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES:
+  case UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES:
+  case UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES: {
+    // These queries should be dealt with in context_impl.cpp by calling the
+    // queries of each device separately and building the intersection set.
+    // setErrorMessage("These queries should have never come here.",
+    //               PI_ERROR_INVALID_ARG_VALUE);
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+  }
+  default:
+    return UR_RESULT_ERROR_INVALID_ENUMERATION;
+  }
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urContextGetNativeHandle(
+    ur_context_handle_t hContext, ur_native_handle_t *phNativeContext) {
+  std::ignore = hContext;
+  std::ignore = phNativeContext;
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urContextCreateWithNativeHandle(
+    ur_native_handle_t hNativeContext, uint32_t numDevices,
+    const ur_device_handle_t *phDevices,
+    const ur_context_native_properties_t *pProperties,
+    ur_context_handle_t *phContext) {
+  std::ignore = hNativeContext;
+  std::ignore = numDevices;
+  std::ignore = phDevices;
+  std::ignore = pProperties;
+  std::ignore = phContext;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urContextSetExtendedDeleter(
+    ur_context_handle_t hContext, ur_context_extended_deleter_t pfnDeleter,
+    void *pUserData) {
+  std::ignore = hContext;
+  std::ignore = pfnDeleter;
+  std::ignore = pUserData;
+
+  DIE_NO_IMPLEMENTATION
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
@@ -40,7 +40,6 @@ urContextRetain(ur_context_handle_t hContext) {
 
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
-  // TODO: is it fine as a no-op?
   std::unique_ptr<ur_context_handle_t_> Context{hContext};
   return UR_RESULT_SUCCESS;
 }
@@ -57,7 +56,7 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_NUM_DEVICES:
     return returnValue(1);
   case UR_CONTEXT_INFO_DEVICES:
-    return returnValue(nullptr);
+    return returnValue(hContext->_device);
   case UR_CONTEXT_INFO_REFERENCE_COUNT:
     return returnValue(nullptr);
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
@@ -70,10 +69,6 @@ urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
   case UR_CONTEXT_INFO_ATOMIC_MEMORY_SCOPE_CAPABILITIES:
   case UR_CONTEXT_INFO_ATOMIC_FENCE_ORDER_CAPABILITIES:
   case UR_CONTEXT_INFO_ATOMIC_FENCE_SCOPE_CAPABILITIES: {
-    // These queries should be dealt with in context_impl.cpp by calling the
-    // queries of each device separately and building the intersection set.
-    // setErrorMessage("These queries should have never come here.",
-    //               PI_ERROR_INVALID_ARG_VALUE);
     return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
   default:

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
@@ -41,7 +41,7 @@ urContextRetain(ur_context_handle_t hContext) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextRelease(ur_context_handle_t hContext) {
   // TODO: is it fine as a no-op?
-  std::ignore = hContext;
+  std::unique_ptr<ur_context_handle_t_> Context{hContext};
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===-----------------------------------------------------------------===//
+
 #pragma once
 
 #include <ur_api.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
@@ -13,7 +13,7 @@
 #include "device.hpp"
 
 struct ur_context_handle_t_ {
-  ur_context_handle_t_(ur_device_handle_t_ *phDevices) : Device{phDevices} {}
+  ur_context_handle_t_(ur_device_handle_t_ *phDevices) : _device{phDevices} {}
 
-  ur_device_handle_t Device;
+  ur_device_handle_t _device;
 };

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
@@ -1,0 +1,18 @@
+//===--------- context.hpp - Native CPU Adapter ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+#pragma once
+
+#include <ur_api.h>
+
+#include "device.hpp"
+
+struct ur_context_handle_t_ {
+  ur_context_handle_t_(ur_device_handle_t_ *phDevices) : Device{phDevices} {}
+
+  ur_device_handle_t Device;
+};

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -19,7 +19,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
 
   const bool AskingForAll = DeviceType == UR_DEVICE_TYPE_ALL;
   const bool AskingForDefault = DeviceType == UR_DEVICE_TYPE_DEFAULT;
-  const bool AskingForCPU = DeviceType == UR_DEVICE_TYPE_GPU;
+  const bool AskingForCPU = DeviceType == UR_DEVICE_TYPE_CPU;
   const bool ValidDeviceType = AskingForDefault || AskingForAll || AskingForCPU;
   uint32_t DeviceCount = ValidDeviceType ? 1 : 0;
 
@@ -39,7 +39,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
   }
 
   if (DeviceCount == 0) {
-    /// No GPU entry to fill 'Device' array
+    /// No CPU entry to fill 'Device' array
     return UR_RESULT_SUCCESS;
   }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -17,7 +17,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
                                                 uint32_t *pNumDevices) {
   UR_ASSERT(hPlatform, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
 
-  uint32_t DeviceCount = (DeviceType & UR_DEVICE_TYPE_CPU) ? 1 : 0;
+  const bool AskingForAll = DeviceType == UR_DEVICE_TYPE_ALL;
+  const bool AskingForDefault = DeviceType == UR_DEVICE_TYPE_DEFAULT;
+  const bool AskingForCPU = DeviceType == UR_DEVICE_TYPE_GPU;
+  const bool ValidDeviceType = AskingForDefault || AskingForAll || AskingForCPU;
+  uint32_t DeviceCount = ValidDeviceType ? 1 : 0;
 
   if (pNumDevices) {
     *pNumDevices = DeviceCount;
@@ -53,9 +57,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
                                                     size_t *pPropSizeRet) {
   UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
-
-  // TODO(alcpz): uncomment when context is finished (????)
-  // ScopedContext Active(hDevice->getContext());
 
   switch (propName) {
   case UR_DEVICE_INFO_TYPE:

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -94,8 +94,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(uint32_t{256});
   case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:
     return ReturnValue(uint32_t{0});
-  case UR_DEVICE_INFO_PARTITION_PROPERTIES:
-    return ReturnValue(ur_device_partition_property_t{0});
+  case UR_DEVICE_INFO_SUPPORTED_PARTITIONS:
+    return ReturnValue(ur_device_partition_properties_t{});
   case UR_DEVICE_INFO_VENDOR_ID:
     // '0x8086' : 'Intel HD graphics vendor ID'
     return ReturnValue(uint32_t{0x8086});
@@ -112,7 +112,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
     return ReturnValue(uint32_t{3});
   case UR_DEVICE_INFO_PARTITION_TYPE:
-    return ReturnValue(ur_device_partition_property_t{0});
+    return ReturnValue(ur_device_partition_property_t{});
   case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
     return ReturnValue("");
   case UR_DEVICE_INFO_QUEUE_PROPERTIES:
@@ -274,7 +274,7 @@ urDeviceRelease(ur_device_handle_t hDevice) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
     ur_device_handle_t hDevice,
-    const ur_device_partition_property_t *pProperties, uint32_t NumDevices,
+    const ur_device_partition_properties_t *pProperties, uint32_t NumDevices,
     ur_device_handle_t *phSubDevices, uint32_t *pNumDevicesRet) {
   std::ignore = hDevice;
   std::ignore = NumDevices;

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -1,0 +1,300 @@
+//===--------- device.cpp - NATIVE CPU Adapter ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <ur_api.h>
+
+#include "platform.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceGet(ur_platform_handle_t hPlatform,
+                                                ur_device_type_t DeviceType,
+                                                uint32_t NumEntries,
+                                                ur_device_handle_t *phDevices,
+                                                uint32_t *pNumDevices) {
+  UR_ASSERT(hPlatform, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  uint32_t DeviceCount = (DeviceType & UR_DEVICE_TYPE_CPU) ? 1 : 0;
+
+  if (pNumDevices) {
+    *pNumDevices = DeviceCount;
+  }
+
+  if (NumEntries == 0) {
+    /// Runtime queries number of devices
+    if (phDevices != nullptr) {
+      if (PrintTrace) {
+        std::cerr << "Invalid Arguments for urDevicesGet\n";
+      }
+      return UR_RESULT_ERROR_INVALID_VALUE;
+    }
+    return UR_RESULT_SUCCESS;
+  }
+
+  if (DeviceCount == 0) {
+    /// No GPU entry to fill 'Device' array
+    return UR_RESULT_SUCCESS;
+  }
+
+  if (phDevices) {
+    phDevices[0] = &hPlatform->TheDevice;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
+                                                    ur_device_info_t propName,
+                                                    size_t propSize,
+                                                    void *pPropValue,
+                                                    size_t *pPropSizeRet) {
+  UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
+
+  // TODO(alcpz): uncomment when context is finished (????)
+  // ScopedContext Active(hDevice->getContext());
+
+  switch (propName) {
+  case UR_DEVICE_INFO_TYPE:
+    return ReturnValue(UR_DEVICE_TYPE_CPU);
+  case UR_DEVICE_INFO_PARENT_DEVICE:
+    return ReturnValue(nullptr);
+  case UR_DEVICE_INFO_PLATFORM:
+    return ReturnValue(hDevice->Platform);
+  case UR_DEVICE_INFO_NAME:
+    return ReturnValue("SYCL Native CPU");
+  case UR_DEVICE_INFO_IMAGE_SUPPORTED:
+    return ReturnValue(bool{false});
+  case UR_DEVICE_INFO_DRIVER_VERSION:
+    return ReturnValue("0.0.0");
+  case UR_DEVICE_INFO_VENDOR:
+    return ReturnValue("Intel(R) Corporation");
+  case UR_DEVICE_INFO_IMAGE2D_MAX_WIDTH:
+    return ReturnValue(size_t{8192});
+  case UR_DEVICE_INFO_IMAGE2D_MAX_HEIGHT:
+    return ReturnValue(size_t{8192});
+  case UR_DEVICE_INFO_HOST_UNIFIED_MEMORY:
+    return ReturnValue(bool{1});
+  case UR_DEVICE_INFO_EXTENSIONS:
+    // TODO : Populate return string accordingly - e.g. cl_khr_fp16,
+    // cl_khr_fp64, cl_khr_int64_base_atomics,
+    // cl_khr_int64_extended_atomics
+    return ReturnValue("");
+  case UR_DEVICE_INFO_VERSION:
+    return ReturnValue("0.1");
+  case UR_DEVICE_INFO_COMPILER_AVAILABLE:
+    return ReturnValue(bool{false});
+  case UR_DEVICE_INFO_LINKER_AVAILABLE:
+    return ReturnValue(bool{false});
+  case UR_DEVICE_INFO_MAX_COMPUTE_UNITS:
+    return ReturnValue(uint32_t{256});
+  case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:
+    return ReturnValue(uint32_t{0});
+  case UR_DEVICE_INFO_PARTITION_PROPERTIES:
+    return ReturnValue(ur_device_partition_property_t{0});
+  case UR_DEVICE_INFO_VENDOR_ID:
+    // '0x8086' : 'Intel HD graphics vendor ID'
+    return ReturnValue(uint32_t{0x8086});
+  case UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE:
+    return ReturnValue(size_t{256});
+  case UR_DEVICE_INFO_MEM_BASE_ADDR_ALIGN:
+    // Imported from level_zero
+    return ReturnValue(uint32_t{8});
+  case UR_DEVICE_INFO_IMAGE3D_MAX_WIDTH:
+  case UR_DEVICE_INFO_IMAGE3D_MAX_HEIGHT:
+  case UR_DEVICE_INFO_IMAGE3D_MAX_DEPTH:
+    // Default minimum values required by the SYCL specification.
+    return ReturnValue(size_t{2048});
+  case UR_DEVICE_INFO_MAX_WORK_ITEM_DIMENSIONS:
+    return ReturnValue(uint32_t{3});
+  case UR_DEVICE_INFO_PARTITION_TYPE:
+    return ReturnValue(ur_device_partition_property_t{0});
+  case UR_EXT_DEVICE_INFO_OPENCL_C_VERSION:
+    return ReturnValue("");
+  case UR_DEVICE_INFO_QUEUE_PROPERTIES:
+    return ReturnValue(ur_queue_properties_t{});
+  case UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES: {
+    struct {
+      size_t Arr[3];
+    } MaxGroupSize = {{256, 256, 1}};
+    return ReturnValue(MaxGroupSize);
+  }
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_CHAR:
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_SHORT:
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_INT:
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_LONG:
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_FLOAT:
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_DOUBLE:
+  case UR_DEVICE_INFO_PREFERRED_VECTOR_WIDTH_HALF:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_CHAR:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_SHORT:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_INT:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_LONG:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_FLOAT:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_DOUBLE:
+  case UR_DEVICE_INFO_NATIVE_VECTOR_WIDTH_HALF:
+    return ReturnValue(uint32_t{1});
+
+  // Imported from level_zero
+  case UR_DEVICE_INFO_USM_HOST_SUPPORT:
+  case UR_DEVICE_INFO_USM_DEVICE_SUPPORT:
+  case UR_DEVICE_INFO_USM_SINGLE_SHARED_SUPPORT:
+  case UR_DEVICE_INFO_USM_CROSS_SHARED_SUPPORT:
+  case UR_DEVICE_INFO_USM_SYSTEM_SHARED_SUPPORT: {
+    uint64_t Supported = 0;
+    // TODO[1.0]: how to query for USM support now?
+    if (true) {
+      // TODO: Use ze_memory_access_capabilities_t
+      Supported = UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ACCESS |
+                  UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_ACCESS |
+                  UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_CONCURRENT_ACCESS |
+                  UR_DEVICE_USM_ACCESS_CAPABILITY_FLAG_ATOMIC_CONCURRENT_ACCESS;
+    }
+    return ReturnValue(Supported);
+  }
+  case UR_DEVICE_INFO_ADDRESS_BITS:
+    return ReturnValue(
+        uint32_t{sizeof(void *) * std::numeric_limits<unsigned char>::digits});
+  case UR_DEVICE_INFO_MAX_CLOCK_FREQUENCY:
+    return ReturnValue(uint32_t{1000});
+  case UR_DEVICE_INFO_ENDIAN_LITTLE:
+    return ReturnValue(bool{true});
+  case UR_DEVICE_INFO_AVAILABLE:
+    return ReturnValue(bool{true});
+  case UR_DEVICE_INFO_MAX_READ_IMAGE_ARGS:
+  case UR_DEVICE_INFO_MAX_WRITE_IMAGE_ARGS:
+    /// TODO : Check
+    return ReturnValue(uint32_t{0});
+  case UR_DEVICE_INFO_IMAGE_MAX_ARRAY_SIZE:
+    /// TODO : Check
+    return ReturnValue(size_t{0});
+  case UR_DEVICE_INFO_MAX_PARAMETER_SIZE:
+    /// TODO : Check
+    return ReturnValue(size_t{32});
+  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_TYPE:
+    return ReturnValue(UR_DEVICE_MEM_CACHE_TYPE_READ_WRITE_CACHE);
+  case UR_DEVICE_INFO_GLOBAL_MEM_CACHELINE_SIZE:
+    // TODO : CHECK
+    return ReturnValue(uint32_t{64});
+  case UR_DEVICE_INFO_GLOBAL_MEM_CACHE_SIZE:
+    // TODO : CHECK
+    return ReturnValue(uint64_t{0});
+  case UR_DEVICE_INFO_GLOBAL_MEM_SIZE:
+    // TODO : CHECK
+    return ReturnValue(uint64_t{0});
+  case UR_DEVICE_INFO_MAX_CONSTANT_BUFFER_SIZE:
+    // TODO : CHECK
+    return ReturnValue(uint64_t{0});
+  case UR_DEVICE_INFO_MAX_CONSTANT_ARGS:
+    // TODO : CHECK
+    return ReturnValue(uint32_t{64});
+  case UR_DEVICE_INFO_LOCAL_MEM_TYPE:
+    // TODO : CHECK
+    return ReturnValue(UR_DEVICE_LOCAL_MEM_TYPE_LOCAL);
+  case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT:
+    return ReturnValue(bool{false});
+  case UR_DEVICE_INFO_PROFILING_TIMER_RESOLUTION:
+    // TODO : CHECK
+    return ReturnValue(size_t{0});
+  case UR_DEVICE_INFO_BUILT_IN_KERNELS:
+    // TODO : CHECK
+    return ReturnValue("");
+  case UR_DEVICE_INFO_PRINTF_BUFFER_SIZE:
+    // TODO : CHECK
+    return ReturnValue(size_t{1024});
+  case UR_DEVICE_INFO_PREFERRED_INTEROP_USER_SYNC:
+    return ReturnValue(bool{false});
+  case UR_DEVICE_INFO_PARTITION_AFFINITY_DOMAIN:
+    return ReturnValue(ur_device_affinity_domain_flags_t{0});
+  case UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE:
+    // TODO : CHECK
+    return ReturnValue(uint64_t{0});
+  case UR_DEVICE_INFO_EXECUTION_CAPABILITIES:
+    // TODO : CHECK
+    return ReturnValue(ur_device_exec_capability_flags_t{
+        UR_DEVICE_EXEC_CAPABILITY_FLAG_KERNEL});
+  case UR_DEVICE_INFO_PROFILE:
+    return ReturnValue("FULL_PROFILE");
+  case UR_DEVICE_INFO_REFERENCE_COUNT:
+    // TODO : CHECK
+    return ReturnValue(uint32_t{0});
+  case UR_DEVICE_INFO_BUILD_ON_SUBDEVICE:
+    return ReturnValue(bool{0});
+  case UR_DEVICE_INFO_ATOMIC_64:
+    return ReturnValue(bool{0});
+  case UR_DEVICE_INFO_BFLOAT16:
+    return ReturnValue(bool{0});
+  case UR_DEVICE_INFO_MEM_CHANNEL_SUPPORT:
+    return ReturnValue(bool{0});
+  case UR_DEVICE_INFO_IMAGE_SRGB:
+    return ReturnValue(bool{0});
+  case UR_DEVICE_INFO_SUB_GROUP_SIZES_INTEL:
+    return ReturnValue(uint32_t{1});
+  case UR_DEVICE_INFO_GPU_EU_COUNT:
+  case UR_DEVICE_INFO_PCI_ADDRESS:
+  case UR_DEVICE_INFO_GPU_EU_SLICES:
+  case UR_DEVICE_INFO_GPU_EU_COUNT_PER_SUBSLICE:
+  case UR_DEVICE_INFO_GPU_SUBSLICES_PER_SLICE:
+  case UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH:
+  case UR_DEVICE_INFO_GPU_HW_THREADS_PER_EU:
+  case UR_DEVICE_INFO_UUID:
+  case UR_DEVICE_INFO_DEVICE_ID:
+  case UR_DEVICE_INFO_MAX_NUM_SUB_GROUPS:
+  case UR_DEVICE_INFO_SUB_GROUP_INDEPENDENT_FORWARD_PROGRESS:
+  case UR_DEVICE_INFO_IL_VERSION:
+  case UR_DEVICE_INFO_MAX_WORK_GROUPS_3D:
+  case UR_DEVICE_INFO_MEMORY_CLOCK_RATE:
+  case UR_DEVICE_INFO_MEMORY_BUS_WIDTH:
+    return UR_RESULT_ERROR_INVALID_VALUE;
+
+    CASE_UR_UNSUPPORTED(UR_DEVICE_INFO_MAX_MEMORY_BANDWIDTH);
+
+  default:
+    DIE_NO_IMPLEMENTATION;
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceRetain(ur_device_handle_t hDevice) {
+  UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE)
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urDeviceRelease(ur_device_handle_t hDevice) {
+  UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE)
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urDevicePartition(ur_device_handle_t hDevice,
+                  const ur_device_partition_property_t *pProperties,
+                  uint32_t NumDevices, ur_device_handle_t *phSubDevices,
+                  uint32_t *pNumDevicesRet){DIE_NO_IMPLEMENTATION}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+    urDeviceGetNativeHandle(ur_device_handle_t hDevice,
+                            ur_native_handle_t *phNativeDevice){
+        DIE_NO_IMPLEMENTATION}
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
+    ur_native_handle_t hNativeDevice, ur_platform_handle_t hPlatform,
+    const ur_device_native_properties_t *pProperties,
+    ur_device_handle_t *phDevice){DIE_NO_IMPLEMENTATION}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+    urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
+                                uint64_t *pDeviceTimestamp,
+                                uint64_t *pHostTimestamp){DIE_NO_IMPLEMENTATION}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+    urDeviceSelectBinary(ur_device_handle_t hDevice,
+                         const ur_device_binary_t *pBinaries,
+                         uint32_t NumBinaries, uint32_t *pSelectedBinary) {
+  CONTINUE_NO_IMPLEMENTATION
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -95,6 +95,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:
     return ReturnValue(uint32_t{0});
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS:
+    // TODO: Ensure this property is tested correctly
     // Taken from CUDA ur adapter
     if (pPropSizeRet) {
       *pPropSizeRet = 0;

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -272,30 +272,56 @@ urDeviceRelease(ur_device_handle_t hDevice) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL
-urDevicePartition(ur_device_handle_t hDevice,
-                  const ur_device_partition_property_t *pProperties,
-                  uint32_t NumDevices, ur_device_handle_t *phSubDevices,
-                  uint32_t *pNumDevicesRet){DIE_NO_IMPLEMENTATION}
+UR_APIEXPORT ur_result_t UR_APICALL urDevicePartition(
+    ur_device_handle_t hDevice,
+    const ur_device_partition_property_t *pProperties, uint32_t NumDevices,
+    ur_device_handle_t *phSubDevices, uint32_t *pNumDevicesRet) {
+  std::ignore = hDevice;
+  std::ignore = NumDevices;
+  std::ignore = pProperties;
+  std::ignore = phSubDevices;
+  std::ignore = pNumDevicesRet;
 
-UR_APIEXPORT ur_result_t UR_APICALL
-    urDeviceGetNativeHandle(ur_device_handle_t hDevice,
-                            ur_native_handle_t *phNativeDevice){
-        DIE_NO_IMPLEMENTATION}
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetNativeHandle(
+    ur_device_handle_t hDevice, ur_native_handle_t *phNativeDevice) {
+  std::ignore = hDevice;
+  std::ignore = phNativeDevice;
+
+  DIE_NO_IMPLEMENTATION
+}
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
     ur_native_handle_t hNativeDevice, ur_platform_handle_t hPlatform,
     const ur_device_native_properties_t *pProperties,
-    ur_device_handle_t *phDevice){DIE_NO_IMPLEMENTATION}
+    ur_device_handle_t *phDevice) {
+  std::ignore = hNativeDevice;
+  std::ignore = hPlatform;
+  std::ignore = pProperties;
+  std::ignore = phDevice;
 
-UR_APIEXPORT ur_result_t UR_APICALL
-    urDeviceGetGlobalTimestamps(ur_device_handle_t hDevice,
-                                uint64_t *pDeviceTimestamp,
-                                uint64_t *pHostTimestamp){DIE_NO_IMPLEMENTATION}
+  DIE_NO_IMPLEMENTATION;
+}
 
-UR_APIEXPORT ur_result_t UR_APICALL
-    urDeviceSelectBinary(ur_device_handle_t hDevice,
-                         const ur_device_binary_t *pBinaries,
-                         uint32_t NumBinaries, uint32_t *pSelectedBinary) {
-  CONTINUE_NO_IMPLEMENTATION
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
+    ur_device_handle_t hDevice, uint64_t *pDeviceTimestamp,
+    uint64_t *pHostTimestamp) {
+  std::ignore = hDevice;
+  std::ignore = pDeviceTimestamp;
+  std::ignore = pHostTimestamp;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(
+    ur_device_handle_t hDevice, const ur_device_binary_t *pBinaries,
+    uint32_t NumBinaries, uint32_t *pSelectedBinary) {
+  std::ignore = hDevice;
+  std::ignore = pBinaries;
+  std::ignore = NumBinaries;
+  std::ignore = pSelectedBinary;
+
+  CONTINUE_NO_IMPLEMENTATION;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -95,7 +95,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   case UR_DEVICE_INFO_PARTITION_MAX_SUB_DEVICES:
     return ReturnValue(uint32_t{0});
   case UR_DEVICE_INFO_SUPPORTED_PARTITIONS:
-    return ReturnValue(ur_device_partition_properties_t{});
+    // Taken from CUDA ur adapter
+    if (pPropSizeRet) {
+      *pPropSizeRet = 0;
+    }
+    return UR_RESULT_SUCCESS;
   case UR_DEVICE_INFO_VENDOR_ID:
     // '0x8086' : 'Intel HD graphics vendor ID'
     return ReturnValue(uint32_t{0x8086});

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.hpp
@@ -1,18 +1,16 @@
-//===--------- platform.hpp - Native CPU Adapter ---------------------===//
+//===--------- device.hpp - Native CPU Adapter 0----------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===-----------------------------------------------------------------===//
-
 #pragma once
 
 #include <ur/ur.hpp>
 
-#include "common.hpp"
-#include "device.hpp"
+struct ur_device_handle_t_ {
+  ur_device_handle_t_(ur_platform_handle_t ArgPlt) : Platform(ArgPlt) {}
 
-struct ur_platform_handle_t_ {
-  ur_device_handle_t_ TheDevice{this};
+  ur_platform_handle_t Platform;
 };

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===-----------------------------------------------------------------===//
+
 #pragma once
 
 #include <ur/ur.hpp>

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/enqueue.cpp
@@ -1,0 +1,535 @@
+//===----------- enqueue.cpp - NATIVE CPU Adapter -------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/detail/cg_types.hpp>
+
+#include "ur_api.h"
+
+#include "common.hpp"
+#include "kernel.hpp"
+#include "memory.hpp"
+
+sycl::detail::NDRDescT getNDRDesc(uint32_t WorkDim,
+                                  const size_t *GlobalWorkOffset,
+                                  const size_t *GlobalWorkSize,
+                                  const size_t *LocalWorkSize) {
+  // Todo: we flip indexes here, I'm not sure we should, if we don't we need to
+  // un-flip them in the spirv builtins definitions as well
+  sycl::detail::NDRDescT Res;
+  switch (WorkDim) {
+  case 1:
+    Res.set<1>(sycl::nd_range<1>({GlobalWorkSize[0]}, {LocalWorkSize[0]},
+                                 {GlobalWorkOffset[0]}));
+    break;
+  case 2:
+    Res.set<2>(sycl::nd_range<2>({GlobalWorkSize[0], GlobalWorkSize[1]},
+                                 {LocalWorkSize[0], LocalWorkSize[1]},
+                                 {GlobalWorkOffset[0], GlobalWorkOffset[1]}));
+    break;
+  case 3:
+    Res.set<3>(sycl::nd_range<3>(
+        {GlobalWorkSize[0], GlobalWorkSize[1], GlobalWorkSize[2]},
+        {LocalWorkSize[0], LocalWorkSize[1], LocalWorkSize[2]},
+        {GlobalWorkOffset[0], GlobalWorkOffset[1], GlobalWorkOffset[2]}));
+    break;
+  }
+  return Res;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
+    ur_queue_handle_t hQueue, ur_kernel_handle_t hKernel, uint32_t workDim,
+    const size_t *pGlobalWorkOffset, const size_t *pGlobalWorkSize,
+    const size_t *pLocalWorkSize, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  UR_ASSERT(hQueue, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(pGlobalWorkOffset, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(workDim > 0, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
+  UR_ASSERT(workDim < 4, UR_RESULT_ERROR_INVALID_WORK_DIMENSION);
+
+  if (*pGlobalWorkSize == 0) {
+    DIE_NO_IMPLEMENTATION;
+  }
+
+  // TODO: add proper error checking
+  // TODO: add proper event dep management
+  sycl::detail::NDRDescT ndr =
+      getNDRDesc(workDim, pGlobalWorkOffset, pGlobalWorkSize, pLocalWorkSize);
+
+  __nativecpu_state state(ndr.GlobalSize[0], ndr.GlobalSize[1],
+                          ndr.GlobalSize[2], ndr.LocalSize[0], ndr.LocalSize[1],
+                          ndr.LocalSize[2], ndr.GlobalOffset[0],
+                          ndr.GlobalOffset[1], ndr.GlobalOffset[2]);
+
+  auto numWG0 = ndr.GlobalSize[0] / ndr.LocalSize[0];
+  auto numWG1 = ndr.GlobalSize[1] / ndr.LocalSize[1];
+  auto numWG2 = ndr.GlobalSize[2] / ndr.LocalSize[2];
+  for (unsigned g2 = 0; g2 < numWG2; g2++) {
+    for (unsigned g1 = 0; g1 < numWG1; g1++) {
+      for (unsigned g0 = 0; g0 < numWG0; g0++) {
+        for (unsigned local2 = 0; local2 < ndr.LocalSize[2]; local2++) {
+          for (unsigned local1 = 0; local1 < ndr.LocalSize[1]; local1++) {
+            for (unsigned local0 = 0; local0 < ndr.LocalSize[0]; local0++) {
+              state.update(g0, g1, g2, local0, local1, local2);
+              hKernel->_subhandler(hKernel->_args.data(), &state);
+            }
+          }
+        }
+      }
+    }
+  }
+  // TODO: we should avoid calling clear here by avoiding using push_back
+  // in setKernelArgs.
+  hKernel->_args.clear();
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(
+    ur_queue_handle_t hQueue, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
+    ur_queue_handle_t hQueue, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferRead(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingRead,
+    size_t offset, size_t size, void *pDst, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hBuffer;
+  std::ignore = blockingRead;
+  std::ignore = offset;
+  std::ignore = size;
+  std::ignore = pDst;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  // TODO: is it ok to have this as no-op?
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWrite(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingWrite,
+    size_t offset, size_t size, const void *pSrc, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hBuffer;
+  std::ignore = blockingWrite;
+  std::ignore = offset;
+  std::ignore = size;
+  std::ignore = pSrc;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingRead,
+    ur_rect_offset_t bufferOrigin, ur_rect_offset_t hostOrigin,
+    ur_rect_region_t region, size_t bufferRowPitch, size_t bufferSlicePitch,
+    size_t hostRowPitch, size_t hostSlicePitch, void *pDst,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hBuffer;
+  std::ignore = blockingRead;
+  std::ignore = bufferOrigin;
+  std::ignore = hostOrigin;
+  std::ignore = region;
+  std::ignore = bufferRowPitch;
+  std::ignore = bufferSlicePitch;
+  std::ignore = hostRowPitch;
+  std::ignore = hostSlicePitch;
+  std::ignore = pDst;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingWrite,
+    ur_rect_offset_t bufferOrigin, ur_rect_offset_t hostOrigin,
+    ur_rect_region_t region, size_t bufferRowPitch, size_t bufferSlicePitch,
+    size_t hostRowPitch, size_t hostSlicePitch, void *pSrc,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hBuffer;
+  std::ignore = blockingWrite;
+  std::ignore = bufferOrigin;
+  std::ignore = hostOrigin;
+  std::ignore = region;
+  std::ignore = bufferRowPitch;
+  std::ignore = bufferSlicePitch;
+  std::ignore = hostRowPitch;
+  std::ignore = hostSlicePitch;
+  std::ignore = pSrc;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBufferSrc,
+    ur_mem_handle_t hBufferDst, size_t srcOffset, size_t dstOffset, size_t size,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hBufferSrc;
+  std::ignore = hBufferDst;
+  std::ignore = srcOffset;
+  std::ignore = dstOffset;
+  std::ignore = size;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopyRect(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBufferSrc,
+    ur_mem_handle_t hBufferDst, ur_rect_offset_t srcOrigin,
+    ur_rect_offset_t dstOrigin, ur_rect_region_t region, size_t srcRowPitch,
+    size_t srcSlicePitch, size_t dstRowPitch, size_t dstSlicePitch,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hBufferSrc;
+  std::ignore = hBufferDst;
+  std::ignore = srcOrigin;
+  std::ignore = dstOrigin;
+  std::ignore = region;
+  std::ignore = srcRowPitch;
+  std::ignore = srcSlicePitch;
+  std::ignore = dstRowPitch;
+  std::ignore = dstSlicePitch;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEvent;
+  std::ignore = phEventWaitList;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, const void *pPattern,
+    size_t patternSize, size_t offset, size_t size,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  UR_ASSERT(hQueue, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  // TODO: error checking
+  // TODO: handle async
+  void *startingPtr = hBuffer->_mem + offset;
+  unsigned steps = size / patternSize;
+  for (unsigned i = 0; i < steps; i++) {
+    memcpy(static_cast<int8_t *>(startingPtr) + i * patternSize, pPattern,
+           patternSize);
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingRead,
+    ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
+    size_t slicePitch, void *pDst, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hImage;
+  std::ignore = blockingRead;
+  std::ignore = origin;
+  std::ignore = region;
+  std::ignore = rowPitch;
+  std::ignore = slicePitch;
+  std::ignore = pDst;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hImage, bool blockingWrite,
+    ur_rect_offset_t origin, ur_rect_region_t region, size_t rowPitch,
+    size_t slicePitch, void *pSrc, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hImage;
+  std::ignore = blockingWrite;
+  std::ignore = origin;
+  std::ignore = region;
+  std::ignore = rowPitch;
+  std::ignore = slicePitch;
+  std::ignore = pSrc;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hImageSrc,
+    ur_mem_handle_t hImageDst, ur_rect_offset_t srcOrigin,
+    ur_rect_offset_t dstOrigin, ur_rect_region_t region,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hImageSrc;
+  std::ignore = hImageDst;
+  std::ignore = srcOrigin;
+  std::ignore = dstOrigin;
+  std::ignore = region;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferMap(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hBuffer, bool blockingMap,
+    ur_map_flags_t mapFlags, size_t offset, size_t size,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent, void **ppRetMap) {
+  std::ignore = hQueue;
+  std::ignore = blockingMap;
+  std::ignore = mapFlags;
+  std::ignore = size;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  *ppRetMap = hBuffer->_mem + offset;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemUnmap(
+    ur_queue_handle_t hQueue, ur_mem_handle_t hMem, void *pMappedPtr,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hMem;
+  std::ignore = pMappedPtr;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill(
+    ur_queue_handle_t hQueue, void *ptr, size_t patternSize,
+    const void *pPattern, size_t size, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  UR_ASSERT(ptr, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(pPattern, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(size % patternSize == 0 || patternSize > size,
+            UR_RESULT_ERROR_INVALID_SIZE);
+
+  memset(ptr, *static_cast<const uint8_t *>(pPattern), size * patternSize);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
+    ur_queue_handle_t hQueue, bool blocking, void *pDst, const void *pSrc,
+    size_t size, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = blocking;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  UR_ASSERT(hQueue, UR_RESULT_ERROR_INVALID_QUEUE);
+  UR_ASSERT(pDst, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(pSrc, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  memcpy(pDst, pSrc, size);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
+    ur_queue_handle_t hQueue, const void *pMem, size_t size,
+    ur_usm_migration_flags_t flags, uint32_t numEventsInWaitList,
+    const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = pMem;
+  std::ignore = size;
+  std::ignore = flags;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urEnqueueUSMAdvise(ur_queue_handle_t hQueue, const void *pMem, size_t size,
+                   ur_usm_advice_flags_t advice, ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = pMem;
+  std::ignore = size;
+  std::ignore = advice;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMFill2D(
+    ur_queue_handle_t hQueue, void *pMem, size_t pitch, size_t patternSize,
+    const void *pPattern, size_t width, size_t height,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = pMem;
+  std::ignore = pitch;
+  std::ignore = patternSize;
+  std::ignore = pPattern;
+  std::ignore = width;
+  std::ignore = height;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
+    ur_queue_handle_t hQueue, bool blocking, void *pDst, size_t dstPitch,
+    const void *pSrc, size_t srcPitch, size_t width, size_t height,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = blocking;
+  std::ignore = pDst;
+  std::ignore = dstPitch;
+  std::ignore = pSrc;
+  std::ignore = srcPitch;
+  std::ignore = width;
+  std::ignore = height;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
+    ur_queue_handle_t hQueue, ur_program_handle_t hProgram, const char *name,
+    bool blockingWrite, size_t count, size_t offset, const void *pSrc,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hProgram;
+  std::ignore = name;
+  std::ignore = blockingWrite;
+  std::ignore = count;
+  std::ignore = offset;
+  std::ignore = pSrc;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
+    ur_queue_handle_t hQueue, ur_program_handle_t hProgram, const char *name,
+    bool blockingRead, size_t count, size_t offset, void *pDst,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hProgram;
+  std::ignore = name;
+  std::ignore = blockingRead;
+  std::ignore = count;
+  std::ignore = offset;
+  std::ignore = pDst;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueReadHostPipe(
+    ur_queue_handle_t hQueue, ur_program_handle_t hProgram,
+    const char *pipe_symbol, bool blocking, void *pDst, size_t size,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hProgram;
+  std::ignore = pipe_symbol;
+  std::ignore = blocking;
+  std::ignore = pDst;
+  std::ignore = size;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEnqueueWriteHostPipe(
+    ur_queue_handle_t hQueue, ur_program_handle_t hProgram,
+    const char *pipe_symbol, bool blocking, void *pSrc, size_t size,
+    uint32_t numEventsInWaitList, const ur_event_handle_t *phEventWaitList,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hQueue;
+  std::ignore = hProgram;
+  std::ignore = pipe_symbol;
+  std::ignore = blocking;
+  std::ignore = pSrc;
+  std::ignore = size;
+  std::ignore = numEventsInWaitList;
+  std::ignore = phEventWaitList;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/event.cpp
@@ -1,0 +1,87 @@
+//===--------- event.cpp - NATIVE CPU Adapter ----------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+#include "common.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventGetInfo(ur_event_handle_t hEvent,
+                                                   ur_event_info_t propName,
+                                                   size_t propSize,
+                                                   void *pPropValue,
+                                                   size_t *pPropSizeRet) {
+  std::ignore = hEvent;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventGetProfilingInfo(
+    ur_event_handle_t hEvent, ur_profiling_info_t propName, size_t propSize,
+    void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hEvent;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventWait(uint32_t numEvents, const ur_event_handle_t *phEventWaitList) {
+  std::ignore = numEvents;
+  std::ignore = phEventWaitList;
+  // TODO: currently we do everything synchronously so this is a no-op
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventRetain(ur_event_handle_t hEvent) {
+  std::ignore = hEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventRelease(ur_event_handle_t hEvent) {
+  std::ignore = hEvent;
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventGetNativeHandle(
+    ur_event_handle_t hEvent, ur_native_handle_t *phNativeEvent) {
+  std::ignore = hEvent;
+  std::ignore = phNativeEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urEventCreateWithNativeHandle(
+    ur_native_handle_t hNativeEvent, ur_context_handle_t hContext,
+    const ur_event_native_properties_t *pProperties,
+    ur_event_handle_t *phEvent) {
+  std::ignore = hNativeEvent;
+  std::ignore = hContext;
+  std::ignore = pProperties;
+  std::ignore = phEvent;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urEventSetCallback(ur_event_handle_t hEvent, ur_execution_info_t execStatus,
+                   ur_event_callback_t pfnNotify, void *pUserData) {
+  std::ignore = hEvent;
+  std::ignore = execStatus;
+  std::ignore = pfnNotify;
+  std::ignore = pUserData;
+
+  DIE_NO_IMPLEMENTATION;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.cpp
@@ -139,10 +139,13 @@ urKernelRelease(ur_kernel_handle_t hKernel) {
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgPointer(
-    ur_kernel_handle_t hKernel, uint32_t argIndex, const void *pArgValue) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArgPointer(ur_kernel_handle_t hKernel, uint32_t argIndex,
+                      const ur_kernel_arg_pointer_properties_t *pProperties,
+                      const void *pArgValue) {
   // TODO: out_of_order args?
   std::ignore = argIndex;
+  std::ignore = pProperties;
 
   UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
   UR_ASSERT(pArgValue, UR_RESULT_ERROR_INVALID_NULL_POINTER);

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.cpp
@@ -1,0 +1,233 @@
+//===--------------- kernel.cpp - Native CPU Adapter ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+#include "common.hpp"
+#include "kernel.hpp"
+#include "memory.hpp"
+#include "program.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
+               ur_kernel_handle_t *phKernel) {
+  UR_ASSERT(hProgram, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(pKernelName, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  auto f = reinterpret_cast<nativecpu_ptr_t>(hProgram->_ptr);
+  auto kernel = new ur_kernel_handle_t_(pKernelName, *f);
+
+  *phKernel = kernel;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
+    ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
+    const ur_kernel_arg_value_properties_t *pProperties,
+    const void *pArgValue) {
+  // Todo: error checking
+  // Todo: I think that the opencl spec (and therefore the pi spec mandates that
+  // arg is copied (this is why it is defined as const void*, I guess we should
+  // do it
+  // TODO: can args arrive out of order?
+  std::ignore = argIndex;
+  std::ignore = pProperties;
+
+  UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(argSize, UR_RESULT_ERROR_INVALID_KERNEL_ARGUMENT_SIZE);
+
+  hKernel->_args.emplace_back(const_cast<void *>(pArgValue));
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgLocal(
+    ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize) {
+  std::ignore = hKernel;
+  std::ignore = argIndex;
+  std::ignore = argSize;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelGetInfo(ur_kernel_handle_t hKernel,
+                                                    ur_kernel_info_t propName,
+                                                    size_t propSize,
+                                                    void *pPropValue,
+                                                    size_t *pPropSizeRet) {
+  std::ignore = hKernel;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+                     ur_kernel_group_info_t propName, size_t propSize,
+                     void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hDevice;
+
+  UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  UrReturnHelper returnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_KERNEL_GROUP_INFO_GLOBAL_WORK_SIZE: {
+    size_t global_work_size[3] = {0, 0, 0};
+    return returnValue(global_work_size, 3);
+  }
+  case UR_KERNEL_GROUP_INFO_WORK_GROUP_SIZE: {
+    size_t max_threads = 0;
+    return returnValue(max_threads);
+  }
+  case UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE: {
+    size_t group_size[3] = {1, 1, 1};
+    return returnValue(group_size, 3);
+  }
+  case UR_KERNEL_GROUP_INFO_LOCAL_MEM_SIZE: {
+    int bytes = 0;
+    return returnValue(static_cast<uint64_t>(bytes));
+  }
+  case UR_KERNEL_GROUP_INFO_PREFERRED_WORK_GROUP_SIZE_MULTIPLE: {
+    int warpSize = 0;
+    return returnValue(static_cast<size_t>(warpSize));
+  }
+  case UR_KERNEL_GROUP_INFO_PRIVATE_MEM_SIZE: {
+    int bytes = 0;
+    return returnValue(static_cast<uint64_t>(bytes));
+  }
+
+  default:
+    break;
+  }
+
+  return UR_RESULT_ERROR_INVALID_ENUMERATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelGetSubGroupInfo(ur_kernel_handle_t hKernel, ur_device_handle_t hDevice,
+                        ur_kernel_sub_group_info_t propName, size_t propSize,
+                        void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hKernel;
+  std::ignore = hDevice;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelRetain(ur_kernel_handle_t hKernel) {
+  std::ignore = hKernel;
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelRelease(ur_kernel_handle_t hKernel) {
+  delete hKernel;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgPointer(
+    ur_kernel_handle_t hKernel, uint32_t argIndex, const void *pArgValue) {
+  // TODO: out_of_order args?
+  std::ignore = argIndex;
+
+  UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(pArgValue, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  auto ptrToPtr = reinterpret_cast<const intptr_t *>(pArgValue);
+  auto derefPtr = reinterpret_cast<void *>(*ptrToPtr);
+  hKernel->_args.push_back(derefPtr);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
+    ur_kernel_handle_t hKernel, ur_kernel_exec_info_t propName, size_t propSize,
+    const ur_kernel_exec_info_properties_t *pProperties,
+    const void *pPropValue) {
+  std::ignore = hKernel;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pProperties;
+  std::ignore = pPropValue;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArgSampler(ur_kernel_handle_t hKernel, uint32_t argIndex,
+                      const ur_kernel_arg_sampler_properties_t *pProperties,
+                      ur_sampler_handle_t hArgValue) {
+  std::ignore = hKernel;
+  std::ignore = argIndex;
+  std::ignore = pProperties;
+  std::ignore = hArgValue;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urKernelSetArgMemObj(ur_kernel_handle_t hKernel, uint32_t argIndex,
+                     const ur_kernel_arg_mem_obj_properties_t *pProperties,
+                     ur_mem_handle_t hArgValue) {
+  // TODO: out_of_order args?
+  std::ignore = argIndex;
+  std::ignore = pProperties;
+
+  UR_ASSERT(hKernel, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  // Taken from ur/adapters/cuda/kernel.cpp
+  // zero-sized buffers are expected to be null.
+  if (hArgValue == nullptr) {
+    hKernel->_args.emplace_back(nullptr);
+    return UR_RESULT_SUCCESS;
+  }
+
+  hKernel->_args.emplace_back(hArgValue->_mem);
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelSetSpecializationConstants(
+    ur_kernel_handle_t hKernel, uint32_t count,
+    const ur_specialization_constant_info_t *pSpecConstants) {
+  std::ignore = hKernel;
+  std::ignore = count;
+  std::ignore = pSpecConstants;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelGetNativeHandle(
+    ur_kernel_handle_t hKernel, ur_native_handle_t *phNativeKernel) {
+  std::ignore = hKernel;
+  std::ignore = phNativeKernel;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urKernelCreateWithNativeHandle(
+    ur_native_handle_t hNativeKernel, ur_context_handle_t hContext,
+    ur_program_handle_t hProgram,
+    const ur_kernel_native_properties_t *pProperties,
+    ur_kernel_handle_t *phKernel) {
+  std::ignore = hNativeKernel;
+  std::ignore = hContext;
+  std::ignore = hProgram;
+  std::ignore = pProperties;
+  std::ignore = phKernel;
+
+  DIE_NO_IMPLEMENTATION
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.cpp
@@ -48,10 +48,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgLocal(
-    ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize) {
+    ur_kernel_handle_t hKernel, uint32_t argIndex, size_t argSize,
+    const ur_kernel_arg_local_properties_t *pProperties) {
   std::ignore = hKernel;
   std::ignore = argIndex;
   std::ignore = argSize;
+  std::ignore = pProperties;
 
   DIE_NO_IMPLEMENTATION
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/kernel.hpp
@@ -1,0 +1,27 @@
+//===--------------- kernel.hpp - Native CPU Adapter ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/native_cpu.hpp>
+#include <ur_api.h>
+
+using nativecpu_kernel_t = void(const sycl::detail::NativeCPUArgDesc *,
+                                __nativecpu_state *);
+using nativecpu_ptr_t = nativecpu_kernel_t *;
+using nativecpu_task_t = std::function<nativecpu_kernel_t>;
+
+struct ur_kernel_handle_t_ {
+
+  ur_kernel_handle_t_(const char *name, nativecpu_task_t subhandler)
+      : _name{name}, _subhandler{subhandler} {}
+
+  const char *_name;
+  nativecpu_task_t _subhandler;
+  std::vector<sycl::detail::NativeCPUArgDesc> _args;
+};

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/memory.cpp
@@ -1,0 +1,153 @@
+//===-------------- memory.cpp - Native CPU Adapter -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "memory.hpp"
+#include "common.hpp"
+#include "ur_api.h"
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
+    ur_context_handle_t hContext, ur_mem_flags_t flags,
+    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
+    void *pHost, ur_mem_handle_t *phMem) {
+  std::ignore = hContext;
+  std::ignore = flags;
+  std::ignore = pImageFormat;
+  std::ignore = pImageDesc;
+  std::ignore = pHost;
+  std::ignore = phMem;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
+    ur_context_handle_t hContext, ur_mem_flags_t flags, size_t size,
+    const ur_buffer_properties_t *pProperties, ur_mem_handle_t *phBuffer) {
+
+  // TODO: add proper error checking and double check flag semantics
+  // TODO: support UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER flag
+
+  UR_ASSERT(phBuffer, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  UR_ASSERT((flags & UR_MEM_FLAGS_MASK) == 0,
+            UR_RESULT_ERROR_INVALID_ENUMERATION);
+  if (flags &
+      (UR_MEM_FLAG_USE_HOST_POINTER | UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER)) {
+    UR_ASSERT(pProperties && pProperties->pHost,
+              UR_RESULT_ERROR_INVALID_HOST_PTR);
+  }
+
+  UR_ASSERT(size != 0, UR_RESULT_ERROR_INVALID_BUFFER_SIZE);
+
+  const bool useHostPtr = flags & UR_MEM_FLAG_USE_HOST_POINTER;
+  const bool copyHostPtr = flags & UR_MEM_FLAG_USE_HOST_POINTER;
+
+  ur_mem_handle_t_ *retMem;
+
+  if (useHostPtr) {
+    retMem = new ur_mem_handle_t_(pProperties->pHost);
+  } else if (copyHostPtr) {
+    retMem = new ur_mem_handle_t_(pProperties->pHost, size);
+  } else {
+    retMem = new ur_mem_handle_t_(size);
+  }
+
+  *phBuffer = retMem;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemRetain(ur_mem_handle_t hMem) {
+  std::ignore = hMem;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
+  UR_ASSERT(hMem, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  hMem->decrementRefCount();
+  if (hMem->_refCount > 0) {
+    return UR_RESULT_SUCCESS;
+  }
+
+  delete hMem;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemBufferPartition(
+    ur_mem_handle_t hBuffer, ur_mem_flags_t flags,
+    ur_buffer_create_type_t bufferCreateType, const ur_buffer_region_t *pRegion,
+    ur_mem_handle_t *phMem) {
+  std::ignore = hBuffer;
+  std::ignore = flags;
+  std::ignore = bufferCreateType;
+  std::ignore = pRegion;
+  std::ignore = phMem;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urMemGetNativeHandle(ur_mem_handle_t hMem, ur_native_handle_t *phNativeMem) {
+  std::ignore = hMem;
+  std::ignore = phNativeMem;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreateWithNativeHandle(
+    ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
+    const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {
+  std::ignore = hNativeMem;
+  std::ignore = hContext;
+  std::ignore = pProperties;
+  std::ignore = phMem;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreateWithNativeHandle(
+    ur_native_handle_t hNativeMem, ur_context_handle_t hContext,
+    const ur_image_format_t *pImageFormat, const ur_image_desc_t *pImageDesc,
+    const ur_mem_native_properties_t *pProperties, ur_mem_handle_t *phMem) {
+  std::ignore = hNativeMem;
+  std::ignore = hContext;
+  std::ignore = pImageFormat;
+  std::ignore = pImageDesc;
+  std::ignore = pProperties;
+  std::ignore = phMem;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemGetInfo(ur_mem_handle_t hMemory,
+                                                 ur_mem_info_t propName,
+                                                 size_t propSize,
+                                                 void *pPropValue,
+                                                 size_t *pPropSizeRet) {
+  std::ignore = hMemory;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(ur_mem_handle_t hMemory,
+                                                      ur_image_info_t propName,
+                                                      size_t propSize,
+                                                      void *pPropValue,
+                                                      size_t *pPropSizeRet) {
+  std::ignore = hMemory;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/memory.hpp
@@ -1,0 +1,38 @@
+//===-------------- memory.hpp - Native CPU Adapter -----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <atomic>
+#include <cstdlib>
+#include <cstring>
+
+struct ur_mem_handle_t_ {
+  ur_mem_handle_t_(size_t Size)
+      : _mem{static_cast<char *>(malloc(Size))}, _ownsMem{true}, _refCount{1} {}
+
+  ur_mem_handle_t_(void *HostPtr, size_t Size)
+      : _mem{static_cast<char *>(malloc(Size))}, _ownsMem{true}, _refCount{1} {
+    memcpy(_mem, HostPtr, Size);
+  }
+
+  ur_mem_handle_t_(void *HostPtr)
+      : _mem{static_cast<char *>(HostPtr)}, _ownsMem{false}, _refCount{1} {}
+
+  ~ur_mem_handle_t_() {
+    if (_ownsMem) {
+      free(_mem);
+    }
+  }
+
+  void decrementRefCount() noexcept { _refCount--; }
+
+  char *_mem;
+  bool _ownsMem;
+  std::atomic_uint32_t _refCount;
+};

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -1,0 +1,101 @@
+//===--------- platform.cpp - Native CPU Adapter ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#include "platform.hpp"
+#include "common.hpp"
+
+#include "ur/ur.hpp"
+#include "ur_api.h"
+
+#include <iostream>
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGet(uint32_t NumEntries, ur_platform_handle_t *phPlatforms,
+              uint32_t *pNumPlatforms) {
+
+  UR_ASSERT(pNumPlatforms || phPlatforms, UR_RESULT_ERROR_INVALID_VALUE);
+
+  if (pNumPlatforms) {
+    *pNumPlatforms = 1;
+  }
+
+  if (NumEntries == 0) {
+    if (phPlatforms != nullptr) {
+      if (PrintTrace) {
+        std::cerr << "Invalid argument combination for piPlatformsGet\n";
+      }
+      return UR_RESULT_ERROR_INVALID_VALUE;
+    }
+    return UR_RESULT_SUCCESS;
+  }
+  if (phPlatforms && NumEntries > 0) {
+    static ur_platform_handle_t_ ThePlatform;
+    *phPlatforms = &ThePlatform;
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
+                  size_t propSize, void *pParamValue, size_t *pSizeRet) {
+
+  if (hPlatform == nullptr) {
+    return UR_RESULT_ERROR_INVALID_PLATFORM;
+  }
+  UrReturnHelper ReturnValue(propSize, pParamValue, pSizeRet);
+
+  const ur_platform_backend_t UR_PLATFORM_BACKEND_NATIVE_CPU =
+      static_cast<ur_platform_backend_t>(UR_PLATFORM_BACKEND_HIP + 1);
+
+  switch (propName) {
+  case UR_PLATFORM_INFO_NAME:
+    return ReturnValue("SYCL_NATIVE_CPU");
+
+  case UR_PLATFORM_INFO_VENDOR_NAME:
+    return ReturnValue("tbd");
+
+  case UR_PLATFORM_INFO_VERSION:
+    return ReturnValue("0.1");
+
+  case UR_PLATFORM_INFO_PROFILE:
+    return ReturnValue("FULL_PROFILE");
+
+  case UR_PLATFORM_INFO_EXTENSIONS:
+    return ReturnValue("");
+
+  case UR_PLATFORM_INFO_BACKEND:
+    // TODO(alcpz): PR with this enum value at
+    // https://github.com/oneapi-src/unified-runtime
+    return ReturnValue(UR_PLATFORM_BACKEND_NATIVE_CPU);
+  default:
+    DIE_NO_IMPLEMENTATION;
+  }
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urInit(ur_device_init_flags_t) {
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urTearDown(void *) {
+  return UR_RESULT_SUCCESS;
+}
+
+// TODO
+UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
+    ur_platform_handle_t hPlatform, const char *pFrontendOption,
+    const char **ppPlatformOption) {
+  std::ignore = hPlatform;
+  if (pFrontendOption == nullptr) {
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+  }
+
+  std::ignore = ppPlatformOption;
+  return UR_RESULT_SUCCESS;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -49,9 +49,6 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
   }
   UrReturnHelper ReturnValue(propSize, pParamValue, pSizeRet);
 
-  const ur_platform_backend_t UR_PLATFORM_BACKEND_NATIVE_CPU =
-      static_cast<ur_platform_backend_t>(UR_PLATFORM_BACKEND_HIP + 1);
-
   switch (propName) {
   case UR_PLATFORM_INFO_NAME:
     return ReturnValue("SYCL_NATIVE_CPU");

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -76,23 +76,13 @@ urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
   return UR_RESULT_SUCCESS;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urInit(ur_device_init_flags_t) {
-  return UR_RESULT_SUCCESS;
-}
-
-UR_APIEXPORT ur_result_t UR_APICALL urTearDown(void *) {
-  return UR_RESULT_SUCCESS;
-}
-
-// TODO
 UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
     ur_platform_handle_t hPlatform, const char *pFrontendOption,
     const char **ppPlatformOption) {
   std::ignore = hPlatform;
-  if (pFrontendOption == nullptr) {
-    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
-  }
-
+  std::ignore = pFrontendOption;
   std::ignore = ppPlatformOption;
-  return UR_RESULT_SUCCESS;
+
+  // Equivalent to piPluginGetBackendOption
+  CONTINUE_NO_IMPLEMENTATION
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -40,6 +40,15 @@ urPlatformGet(uint32_t NumEntries, ur_platform_handle_t *phPlatforms,
   return UR_RESULT_SUCCESS;
 }
 
+UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetApiVersion(
+    ur_platform_handle_t hDriver, ur_api_version_t *pVersion) {
+  UR_ASSERT(hDriver, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(pVersion, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  *pVersion = UR_API_VERSION_CURRENT;
+  return UR_RESULT_SUCCESS;
+}
+
 UR_APIEXPORT ur_result_t UR_APICALL
 urPlatformGetInfo(ur_platform_handle_t hPlatform, ur_platform_info_t propName,
                   size_t propSize, void *pParamValue, size_t *pSizeRet) {

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -27,7 +27,7 @@ urPlatformGet(uint32_t NumEntries, ur_platform_handle_t *phPlatforms,
   if (NumEntries == 0) {
     if (phPlatforms != nullptr) {
       if (PrintTrace) {
-        std::cerr << "Invalid argument combination for piPlatformsGet\n";
+        std::cerr << "Invalid argument combination for urPlatformsGet\n";
       }
       return UR_RESULT_ERROR_INVALID_VALUE;
     }
@@ -92,6 +92,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetBackendOption(
   std::ignore = pFrontendOption;
   std::ignore = ppPlatformOption;
 
-  // Equivalent to piPluginGetBackendOption
-  CONTINUE_NO_IMPLEMENTATION
+  CONTINUE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urPlatformCreateWithNativeHandle(
+    ur_native_handle_t hNativePlatform,
+    const ur_platform_native_properties_t *pProperties,
+    ur_platform_handle_t *phPlatform) {
+  std::ignore = hNativePlatform;
+  std::ignore = pProperties;
+  std::ignore = phPlatform;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urPlatformGetNativeHandle(
+    ur_platform_handle_t hPlatform, ur_native_handle_t *phNativePlatform) {
+  std::ignore = hPlatform;
+  std::ignore = phNativePlatform;
+
+  DIE_NO_IMPLEMENTATION;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.hpp
@@ -1,0 +1,18 @@
+//===--------- platform.hpp - Native CPU Adapter ---------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#pragma once
+
+#include <ur/ur.hpp>
+
+#include "common.hpp"
+
+struct ur_platform_handle_t_ {
+  // TODO Device handle_t_
+  //  ur_device_handle_t_ TheDevice{this};
+};

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.cpp
@@ -1,0 +1,179 @@
+//===--------- program.cpp - Native CPU Adapter ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+#include "common.hpp"
+#include "program.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramCreateWithIL(ur_context_handle_t hContext, const void *pIL,
+                      size_t length, const ur_program_properties_t *pProperties,
+                      ur_program_handle_t *phProgram) {
+  std::ignore = hContext;
+  std::ignore = pIL;
+  std::ignore = length;
+  std::ignore = pProperties;
+  std::ignore = phProgram;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithBinary(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice, size_t size,
+    const uint8_t *pBinary, const ur_program_properties_t *pProperties,
+    ur_program_handle_t *phProgram) {
+  std::ignore = size;
+  std::ignore = pProperties;
+
+  UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(hDevice, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+  UR_ASSERT(phProgram, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  UR_ASSERT(pBinary != nullptr, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  auto hProgram = new ur_program_handle_t_(
+      hContext, reinterpret_cast<const unsigned char *>(pBinary));
+
+  *phProgram = hProgram;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(ur_context_handle_t hContext,
+                                                   ur_program_handle_t hProgram,
+                                                   const char *pOptions) {
+  std::ignore = hContext;
+  std::ignore = hProgram;
+  std::ignore = pOptions;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramCompile(ur_context_handle_t hContext, ur_program_handle_t hProgram,
+                 const char *pOptions) {
+  std::ignore = hContext;
+  std::ignore = hProgram;
+  std::ignore = pOptions;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramLink(ur_context_handle_t hContext, uint32_t count,
+              const ur_program_handle_t *phPrograms, const char *pOptions,
+              ur_program_handle_t *phProgram) {
+  std::ignore = hContext;
+  std::ignore = count;
+  std::ignore = phPrograms;
+  std::ignore = pOptions;
+  std::ignore = phProgram;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramRetain(ur_program_handle_t hProgram) {
+  std::ignore = hProgram;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramRelease(ur_program_handle_t hProgram) {
+  delete hProgram;
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
+    ur_device_handle_t hDevice, ur_program_handle_t hProgram,
+    const char *pFunctionName, void **ppFunctionPointer) {
+  std::ignore = hDevice;
+  std::ignore = hProgram;
+  std::ignore = pFunctionName;
+  std::ignore = ppFunctionPointer;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
+                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  UR_ASSERT(hProgram, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
+
+  UrReturnHelper returnValue(propSize, pPropValue, pPropSizeRet);
+
+  switch (propName) {
+  case UR_PROGRAM_INFO_REFERENCE_COUNT:
+    return returnValue(hProgram->getReferenceCount());
+  case UR_PROGRAM_INFO_CONTEXT:
+    return returnValue(nullptr);
+  case UR_PROGRAM_INFO_NUM_DEVICES:
+    return returnValue(1u);
+  case UR_PROGRAM_INFO_DEVICES:
+    return returnValue(hProgram->_ctx->_device);
+  case UR_PROGRAM_INFO_SOURCE:
+    return returnValue(nullptr);
+  case UR_PROGRAM_INFO_BINARY_SIZES:
+    return returnValue("foo");
+  case UR_PROGRAM_INFO_BINARIES:
+    return returnValue("foo");
+  case UR_PROGRAM_INFO_KERNEL_NAMES: {
+    return returnValue("foo");
+  }
+  default:
+    break;
+  }
+
+  return UR_RESULT_ERROR_INVALID_ENUMERATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t hDevice,
+                      ur_program_build_info_t propName, size_t propSize,
+                      void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hProgram;
+  std::ignore = hDevice;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  CONTINUE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
+    ur_program_handle_t hProgram, uint32_t count,
+    const ur_specialization_constant_info_t *pSpecConstants) {
+  std::ignore = hProgram;
+  std::ignore = count;
+  std::ignore = pSpecConstants;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramGetNativeHandle(
+    ur_program_handle_t hProgram, ur_native_handle_t *phNativeProgram) {
+  std::ignore = hProgram;
+  std::ignore = phNativeProgram;
+
+  DIE_NO_IMPLEMENTATION
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urProgramCreateWithNativeHandle(
+    ur_native_handle_t hNativeProgram, ur_context_handle_t hContext,
+    const ur_program_native_properties_t *pProperties,
+    ur_program_handle_t *phProgram) {
+  std::ignore = hNativeProgram;
+  std::ignore = hContext;
+  std::ignore = pProperties;
+  std::ignore = phProgram;
+
+  DIE_NO_IMPLEMENTATION
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.hpp
@@ -19,6 +19,6 @@ struct ur_program_handle_t_ {
   uint32_t getReferenceCount() const noexcept { return _refCount; }
 
   ur_context_handle_t _ctx;
-  std::atomic_uint32_t _refCount;
   const unsigned char *_ptr;
+  std::atomic_uint32_t _refCount;
 };

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.hpp
@@ -1,0 +1,24 @@
+//===--------- program.hpp - Native CPU Adapter ----------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
+#pragma once
+
+#include <ur_api.h>
+
+#include "context.hpp"
+
+struct ur_program_handle_t_ {
+  ur_program_handle_t_(ur_context_handle_t ctx, const unsigned char *pBinary)
+      : _ctx{ctx}, _ptr{pBinary}, _refCount{1} {}
+
+  uint32_t getReferenceCount() const noexcept { return _refCount; }
+
+  ur_context_handle_t _ctx;
+  std::atomic_uint32_t _refCount;
+  const unsigned char *_ptr;
+};

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.cpp
@@ -1,0 +1,85 @@
+//===----------- queue.cpp - Native CPU Adapter ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "queue.hpp"
+#include "common.hpp"
+
+#include "ur/ur.hpp"
+#include "ur_api.h"
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,
+                                                   ur_queue_info_t propName,
+                                                   size_t propSize,
+                                                   void *pPropValue,
+                                                   size_t *pPropSizeRet) {
+  std::ignore = hQueue;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    const ur_queue_properties_t *pProperties, ur_queue_handle_t *phQueue) {
+  std::ignore = hContext;
+  std::ignore = hDevice;
+  std::ignore = pProperties;
+  std::ignore = phQueue;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
+  std::ignore = hQueue;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
+  std::ignore = hQueue;
+  // TODO: is this fine as no-op?
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urQueueGetNativeHandle(ur_queue_handle_t hQueue, ur_queue_native_desc_t *pDesc,
+                       ur_native_handle_t *phNativeQueue) {
+  std::ignore = hQueue;
+  std::ignore = pDesc;
+  std::ignore = phNativeQueue;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
+    ur_native_handle_t hNativeQueue, ur_context_handle_t hContext,
+    ur_device_handle_t hDevice, const ur_queue_native_properties_t *pProperties,
+    ur_queue_handle_t *phQueue) {
+  std::ignore = hNativeQueue;
+  std::ignore = hContext;
+  std::ignore = hDevice;
+  std::ignore = pProperties;
+  std::ignore = phQueue;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
+  std::ignore = hQueue;
+  // TODO: is this fine as no-op?
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urQueueFlush(ur_queue_handle_t hQueue) {
+  std::ignore = hQueue;
+
+  DIE_NO_IMPLEMENTATION;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.cpp
@@ -32,9 +32,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
   std::ignore = hContext;
   std::ignore = hDevice;
   std::ignore = pProperties;
-  std::ignore = phQueue;
 
-  DIE_NO_IMPLEMENTATION;
+  auto Queue = new ur_queue_handle_t_();
+  *phQueue = Queue;
+
+  CONTINUE_NO_IMPLEMENTATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
@@ -44,8 +46,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  std::ignore = hQueue;
   // TODO: is this fine as no-op?
+  delete hQueue;
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.cpp
@@ -46,7 +46,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueRetain(ur_queue_handle_t hQueue) {
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueRelease(ur_queue_handle_t hQueue) {
-  // TODO: is this fine as no-op?
   delete hQueue;
   return UR_RESULT_SUCCESS;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/queue.hpp
@@ -1,0 +1,10 @@
+//===----------- queue.hpp - Native CPU Adapter ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+struct ur_queue_handle_t_ {};

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/runtime.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/runtime.cpp
@@ -1,0 +1,17 @@
+//===---------------- runtime.cpp - Native CPU Adapter --------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+UR_APIEXPORT ur_result_t UR_APICALL urInit(ur_device_init_flags_t) {
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urTearDown(void *) {
+  return UR_RESULT_SUCCESS;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/sampler.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/sampler.cpp
@@ -1,0 +1,67 @@
+//===--------- sampler.cpp - NATIVE CPU Adapter ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+#include "common.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerCreate(ur_context_handle_t hContext, const ur_sampler_desc_t *pDesc,
+                ur_sampler_handle_t *phSampler) {
+  std::ignore = hContext;
+  std::ignore = pDesc;
+  std::ignore = phSampler;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerRetain(ur_sampler_handle_t hSampler) {
+  std::ignore = hSampler;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerRelease(ur_sampler_handle_t hSampler) {
+  std::ignore = hSampler;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urSamplerGetInfo(ur_sampler_handle_t hSampler, ur_sampler_info_t propName,
+                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hSampler;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ur_native_handle_t *phNativeSampler) {
+  std::ignore = hSampler;
+  std::ignore = phNativeSampler;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ur_context_handle_t hContext,
+    const ur_sampler_native_properties_t *pProperties,
+    ur_sampler_handle_t *phSampler) {
+  std::ignore = hNativeSampler;
+  std::ignore = hContext;
+  std::ignore = pProperties;
+  std::ignore = phSampler;
+
+  DIE_NO_IMPLEMENTATION;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp
@@ -26,9 +26,7 @@ ur_result_t validateProcInputs(ur_api_version_t version, void *pDdiTable) {
 }
 } // namespace
 
-#if defined(__cplusplus)
 extern "C" {
-#endif
 
 UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
     ur_api_version_t version, ur_platform_dditable_t *pDdiTable) {
@@ -36,11 +34,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urPlatformCreateWithNativeHandle;
   pDdiTable->pfnGet = urPlatformGet;
   pDdiTable->pfnGetApiVersion = urPlatformGetApiVersion;
   pDdiTable->pfnGetInfo = urPlatformGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urPlatformGetNativeHandle;
   pDdiTable->pfnGetBackendOption = urPlatformGetBackendOption;
   return UR_RESULT_SUCCESS;
 }
@@ -115,13 +113,13 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
   pDdiTable->pfnGetSubGroupInfo = urKernelGetSubGroupInfo;
   pDdiTable->pfnRelease = urKernelRelease;
   pDdiTable->pfnRetain = urKernelRetain;
-  pDdiTable->pfnSetArgLocal = nullptr;
+  pDdiTable->pfnSetArgLocal = urKernelSetArgLocal;
   pDdiTable->pfnSetArgMemObj = urKernelSetArgMemObj;
   pDdiTable->pfnSetArgPointer = urKernelSetArgPointer;
   pDdiTable->pfnSetArgSampler = urKernelSetArgSampler;
   pDdiTable->pfnSetArgValue = urKernelSetArgValue;
   pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
-  pDdiTable->pfnSetSpecializationConstants = nullptr;
+  pDdiTable->pfnSetSpecializationConstants = urKernelSetSpecializationConstants;
   return UR_RESULT_SUCCESS;
 }
 
@@ -132,9 +130,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
     return result;
   }
   pDdiTable->pfnCreate = urSamplerCreate;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urSamplerCreateWithNativeHandle;
   pDdiTable->pfnGetInfo = urSamplerGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urSamplerGetNativeHandle;
   pDdiTable->pfnRelease = urSamplerRelease;
   pDdiTable->pfnRetain = urSamplerRetain;
   return UR_RESULT_SUCCESS;
@@ -232,10 +230,10 @@ urGetUSMProcAddrTable(ur_api_version_t version, ur_usm_dditable_t *pDdiTable) {
   pDdiTable->pfnFree = urUSMFree;
   pDdiTable->pfnGetMemAllocInfo = urUSMGetMemAllocInfo;
   pDdiTable->pfnHostAlloc = urUSMHostAlloc;
-  pDdiTable->pfnPoolCreate = nullptr;
-  pDdiTable->pfnPoolRetain = nullptr;
-  pDdiTable->pfnPoolRelease = nullptr;
-  pDdiTable->pfnPoolGetInfo = nullptr;
+  pDdiTable->pfnPoolCreate = urUSMPoolCreate;
+  pDdiTable->pfnPoolRetain = urUSMPoolRetain;
+  pDdiTable->pfnPoolRelease = urUSMPoolRelease;
+  pDdiTable->pfnPoolGetInfo = urUSMPoolGetInfo;
   pDdiTable->pfnSharedAlloc = urUSMSharedAlloc;
   return UR_RESULT_SUCCESS;
 }
@@ -273,6 +271,4 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
   return retVal;
 }
 
-#if defined(__cplusplus)
 } // extern "C"
-#endif

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp
@@ -1,0 +1,264 @@
+//===----------- ur_interface_loader.cpp - Native CPU Plugin  -------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <ur_api.h>
+#include <ur_ddi.h>
+
+namespace {
+
+// TODO - this is a duplicate of what is in the L0 plugin
+// We should move this to somewhere common
+ur_result_t validateProcInputs(ur_api_version_t version, void *pDdiTable) {
+  if (pDdiTable == nullptr) {
+    return UR_RESULT_ERROR_INVALID_NULL_POINTER;
+  }
+  // Pre 1.0 we enforce that loader and adapter must have the same version.
+  // Post 1.0 only a major version match should be required.
+  if (version != UR_API_VERSION_CURRENT) {
+    return UR_RESULT_ERROR_UNSUPPORTED_VERSION;
+  }
+  return UR_RESULT_SUCCESS;
+}
+} // namespace
+
+#if defined(__cplusplus)
+extern "C" {
+#endif
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
+    ur_api_version_t version, ur_platform_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnGet = urPlatformGet;
+  pDdiTable->pfnGetApiVersion = urPlatformGetApiVersion;
+  pDdiTable->pfnGetInfo = urPlatformGetInfo;
+  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetBackendOption = urPlatformGetBackendOption;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetContextProcAddrTable(
+    ur_api_version_t version, ur_context_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreate = urContextCreate;
+  pDdiTable->pfnCreateWithNativeHandle = urContextCreateWithNativeHandle;
+  pDdiTable->pfnGetInfo = urContextGetInfo;
+  pDdiTable->pfnGetNativeHandle = urContextGetNativeHandle;
+  pDdiTable->pfnRelease = urContextRelease;
+  pDdiTable->pfnRetain = urContextRetain;
+  pDdiTable->pfnSetExtendedDeleter = urContextSetExtendedDeleter;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEventProcAddrTable(
+    ur_api_version_t version, ur_event_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreateWithNativeHandle = urEventCreateWithNativeHandle;
+  pDdiTable->pfnGetInfo = urEventGetInfo;
+  pDdiTable->pfnGetNativeHandle = urEventGetNativeHandle;
+  pDdiTable->pfnGetProfilingInfo = urEventGetProfilingInfo;
+  pDdiTable->pfnRelease = urEventRelease;
+  pDdiTable->pfnRetain = urEventRetain;
+  pDdiTable->pfnSetCallback = urEventSetCallback;
+  pDdiTable->pfnWait = urEventWait;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetProgramProcAddrTable(
+    ur_api_version_t version, ur_program_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnBuild = urProgramBuild;
+  pDdiTable->pfnCompile = urProgramCompile;
+  pDdiTable->pfnCreateWithBinary = urProgramCreateWithBinary;
+  pDdiTable->pfnCreateWithIL = urProgramCreateWithIL;
+  pDdiTable->pfnCreateWithNativeHandle = urProgramCreateWithNativeHandle;
+  pDdiTable->pfnGetBuildInfo = urProgramGetBuildInfo;
+  pDdiTable->pfnGetFunctionPointer = urProgramGetFunctionPointer;
+  pDdiTable->pfnGetInfo = urProgramGetInfo;
+  pDdiTable->pfnGetNativeHandle = urProgramGetNativeHandle;
+  pDdiTable->pfnLink = urProgramLink;
+  pDdiTable->pfnRelease = urProgramRelease;
+  pDdiTable->pfnRetain = urProgramRetain;
+  pDdiTable->pfnSetSpecializationConstants =
+      urProgramSetSpecializationConstants;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
+    ur_api_version_t version, ur_kernel_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreate = urKernelCreate;
+  pDdiTable->pfnCreateWithNativeHandle = urKernelCreateWithNativeHandle;
+  pDdiTable->pfnGetGroupInfo = urKernelGetGroupInfo;
+  pDdiTable->pfnGetInfo = urKernelGetInfo;
+  pDdiTable->pfnGetNativeHandle = urKernelGetNativeHandle;
+  pDdiTable->pfnGetSubGroupInfo = urKernelGetSubGroupInfo;
+  pDdiTable->pfnRelease = urKernelRelease;
+  pDdiTable->pfnRetain = urKernelRetain;
+  pDdiTable->pfnSetArgLocal = nullptr;
+  pDdiTable->pfnSetArgMemObj = urKernelSetArgMemObj;
+  pDdiTable->pfnSetArgPointer = urKernelSetArgPointer;
+  pDdiTable->pfnSetArgSampler = urKernelSetArgSampler;
+  pDdiTable->pfnSetArgValue = urKernelSetArgValue;
+  pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
+  pDdiTable->pfnSetSpecializationConstants = nullptr;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
+    ur_api_version_t version, ur_sampler_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreate = urSamplerCreate;
+  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnGetInfo = urSamplerGetInfo;
+  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnRelease = urSamplerRelease;
+  pDdiTable->pfnRetain = urSamplerRetain;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetMemProcAddrTable(ur_api_version_t version, ur_mem_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnBufferCreate = urMemBufferCreate;
+  pDdiTable->pfnBufferPartition = urMemBufferPartition;
+  pDdiTable->pfnBufferCreateWithNativeHandle =
+      urMemBufferCreateWithNativeHandle;
+  pDdiTable->pfnImageCreateWithNativeHandle = urMemImageCreateWithNativeHandle;
+  pDdiTable->pfnGetInfo = urMemGetInfo;
+  pDdiTable->pfnGetNativeHandle = urMemGetNativeHandle;
+  pDdiTable->pfnImageCreate = urMemImageCreate;
+  pDdiTable->pfnImageGetInfo = urMemImageGetInfo;
+  pDdiTable->pfnRelease = urMemRelease;
+  pDdiTable->pfnRetain = urMemRetain;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetEnqueueProcAddrTable(
+    ur_api_version_t version, ur_enqueue_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnDeviceGlobalVariableRead = urEnqueueDeviceGlobalVariableRead;
+  pDdiTable->pfnDeviceGlobalVariableWrite = urEnqueueDeviceGlobalVariableWrite;
+  pDdiTable->pfnEventsWait = urEnqueueEventsWait;
+  pDdiTable->pfnEventsWaitWithBarrier = urEnqueueEventsWaitWithBarrier;
+  pDdiTable->pfnKernelLaunch = urEnqueueKernelLaunch;
+  pDdiTable->pfnMemBufferCopy = urEnqueueMemBufferCopy;
+  pDdiTable->pfnMemBufferCopyRect = urEnqueueMemBufferCopyRect;
+  pDdiTable->pfnMemBufferFill = urEnqueueMemBufferFill;
+  pDdiTable->pfnMemBufferMap = urEnqueueMemBufferMap;
+  pDdiTable->pfnMemBufferRead = urEnqueueMemBufferRead;
+  pDdiTable->pfnMemBufferReadRect = urEnqueueMemBufferReadRect;
+  pDdiTable->pfnMemBufferWrite = urEnqueueMemBufferWrite;
+  pDdiTable->pfnMemBufferWriteRect = urEnqueueMemBufferWriteRect;
+  pDdiTable->pfnMemImageCopy = urEnqueueMemImageCopy;
+  pDdiTable->pfnMemImageRead = urEnqueueMemImageRead;
+  pDdiTable->pfnMemImageWrite = urEnqueueMemImageWrite;
+  pDdiTable->pfnMemUnmap = urEnqueueMemUnmap;
+  pDdiTable->pfnUSMFill2D = urEnqueueUSMFill2D;
+  pDdiTable->pfnUSMFill = urEnqueueUSMFill;
+  pDdiTable->pfnUSMAdvise = urEnqueueUSMAdvise;
+  pDdiTable->pfnUSMMemcpy2D = urEnqueueUSMMemcpy2D;
+  pDdiTable->pfnUSMMemcpy = urEnqueueUSMMemcpy;
+  pDdiTable->pfnUSMPrefetch = urEnqueueUSMPrefetch;
+  pDdiTable->pfnReadHostPipe = urEnqueueReadHostPipe;
+  pDdiTable->pfnWriteHostPipe = urEnqueueWriteHostPipe;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
+    ur_api_version_t version, ur_global_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnGetLastResult = urGetLastResult;
+  pDdiTable->pfnInit = urInit;
+  pDdiTable->pfnTearDown = urTearDown;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetQueueProcAddrTable(
+    ur_api_version_t version, ur_queue_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreate = urQueueCreate;
+  pDdiTable->pfnCreateWithNativeHandle = urQueueCreateWithNativeHandle;
+  pDdiTable->pfnFinish = urQueueFinish;
+  pDdiTable->pfnFlush = urQueueFlush;
+  pDdiTable->pfnGetInfo = urQueueGetInfo;
+  pDdiTable->pfnGetNativeHandle = urQueueGetNativeHandle;
+  pDdiTable->pfnRelease = urQueueRelease;
+  pDdiTable->pfnRetain = urQueueRetain;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL
+urGetUSMProcAddrTable(ur_api_version_t version, ur_usm_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnDeviceAlloc = urUSMDeviceAlloc;
+  pDdiTable->pfnFree = urUSMFree;
+  pDdiTable->pfnGetMemAllocInfo = urUSMGetMemAllocInfo;
+  pDdiTable->pfnHostAlloc = urUSMHostAlloc;
+  pDdiTable->pfnPoolCreate = nullptr;
+  pDdiTable->pfnPoolRetain = nullptr;
+  pDdiTable->pfnPoolRelease = nullptr;
+  pDdiTable->pfnPoolGetInfo = nullptr;
+  pDdiTable->pfnSharedAlloc = urUSMSharedAlloc;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
+    ur_api_version_t version, ur_device_dditable_t *pDdiTable) {
+  auto result = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != result) {
+    return result;
+  }
+  pDdiTable->pfnCreateWithNativeHandle = urDeviceCreateWithNativeHandle;
+  pDdiTable->pfnGet = urDeviceGet;
+  pDdiTable->pfnGetGlobalTimestamps = urDeviceGetGlobalTimestamps;
+  pDdiTable->pfnGetInfo = urDeviceGetInfo;
+  pDdiTable->pfnGetNativeHandle = urDeviceGetNativeHandle;
+  pDdiTable->pfnPartition = urDevicePartition;
+  pDdiTable->pfnRelease = urDeviceRelease;
+  pDdiTable->pfnRetain = urDeviceRetain;
+  pDdiTable->pfnSelectBinary = urDeviceSelectBinary;
+  return UR_RESULT_SUCCESS;
+}
+
+#if defined(__cplusplus)
+} // extern "C"
+#endif

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/ur_interface_loader.cpp
@@ -200,7 +200,6 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetGlobalProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnGetLastResult = urGetLastResult;
   pDdiTable->pfnInit = urInit;
   pDdiTable->pfnTearDown = urTearDown;
   return UR_RESULT_SUCCESS;
@@ -257,6 +256,21 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetDeviceProcAddrTable(
   pDdiTable->pfnRetain = urDeviceRetain;
   pDdiTable->pfnSelectBinary = urDeviceSelectBinary;
   return UR_RESULT_SUCCESS;
+}
+
+// TODO: CommandBuffer
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
+    ur_api_version_t version, ur_usm_p2p_exp_dditable_t *pDdiTable) {
+  auto retVal = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != retVal) {
+    return retVal;
+  }
+  pDdiTable->pfnEnablePeerAccessExp = urUsmP2PEnablePeerAccessExp;
+  pDdiTable->pfnDisablePeerAccessExp = urUsmP2PDisablePeerAccessExp;
+  pDdiTable->pfnPeerAccessGetInfoExp = urUsmP2PPeerAccessGetInfoExp;
+
+  return retVal;
 }
 
 #if defined(__cplusplus)

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm.cpp
@@ -1,0 +1,120 @@
+//===------------- usm.cpp - NATIVE CPU Adapter ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "ur_api.h"
+
+#include "common.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMHostAlloc(ur_context_handle_t hContext, const ur_usm_desc_t *pUSMDesc,
+               ur_usm_pool_handle_t pool, size_t size, void **ppMem) {
+  std::ignore = hContext;
+  std::ignore = pUSMDesc;
+  std::ignore = pool;
+
+  UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  // TODO: Check Max size when UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE is implemented
+  UR_ASSERT(size > 0, UR_RESULT_ERROR_INVALID_USM_SIZE);
+
+  *ppMem = malloc(size);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMDeviceAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
+                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
+                 size_t size, void **ppMem) {
+  std::ignore = hContext;
+  std::ignore = hDevice;
+  std::ignore = pUSMDesc;
+  std::ignore = pool;
+
+  UR_ASSERT(ppMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+  // TODO: Check Max size when UR_DEVICE_INFO_MAX_MEM_ALLOC_SIZE is implemented
+  UR_ASSERT(size > 0, UR_RESULT_ERROR_INVALID_USM_SIZE);
+
+  *ppMem = malloc(size);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMSharedAlloc(ur_context_handle_t hContext, ur_device_handle_t hDevice,
+                 const ur_usm_desc_t *pUSMDesc, ur_usm_pool_handle_t pool,
+                 size_t size, void **ppMem) {
+  std::ignore = hContext;
+  std::ignore = hDevice;
+  std::ignore = pUSMDesc;
+  std::ignore = pool;
+  std::ignore = size;
+  std::ignore = ppMem;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t hContext,
+                                              void *pMem) {
+  std::ignore = hContext;
+
+  UR_ASSERT(pMem, UR_RESULT_ERROR_INVALID_NULL_POINTER);
+
+  free(pMem);
+
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
+                     ur_usm_alloc_info_t propName, size_t propSize,
+                     void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hContext;
+  std::ignore = pMem;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMPoolCreate(ur_context_handle_t hContext, ur_usm_pool_desc_t *pPoolDesc,
+                ur_usm_pool_handle_t *ppPool) {
+  std::ignore = hContext;
+  std::ignore = pPoolDesc;
+  std::ignore = ppPool;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMPoolRetain(ur_usm_pool_handle_t pPool) {
+  std::ignore = pPool;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMPoolRelease(ur_usm_pool_handle_t pPool) {
+  std::ignore = pPool;
+
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUSMPoolGetInfo(ur_usm_pool_handle_t hPool, ur_usm_pool_info_t propName,
+                 size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hPool;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+
+  DIE_NO_IMPLEMENTATION;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp
@@ -1,0 +1,25 @@
+//===--------- usm_p2p.cpp - Native CPU Adapter ------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-------------------------------------------------------------------===//
+
+#include "common.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUsmP2PEnablePeerAccessExp(ur_device_handle_t, ur_device_handle_t) {
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urUsmP2PDisablePeerAccessExp(ur_device_handle_t, ur_device_handle_t) {
+  DIE_NO_IMPLEMENTATION;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
+    ur_device_handle_t, ur_device_handle_t, ur_exp_peer_info_t, size_t propSize,
+    void *pPropValue, size_t *pPropSizeRet) {
+  DIE_NO_IMPLEMENTATION;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp
@@ -18,8 +18,8 @@ urUsmP2PDisablePeerAccessExp(ur_device_handle_t, ur_device_handle_t) {
   DIE_NO_IMPLEMENTATION;
 }
 
-UR_APIEXPORT ur_result_t UR_APICALL urUsmP2PPeerAccessGetInfoExp(
-    ur_device_handle_t, ur_device_handle_t, ur_exp_peer_info_t, size_t propSize,
-    void *pPropValue, size_t *pPropSizeRet) {
+UR_APIEXPORT ur_result_t UR_APICALL
+urUsmP2PPeerAccessGetInfoExp(ur_device_handle_t, ur_device_handle_t,
+                             ur_exp_peer_info_t, size_t, void *, size_t *) {
   DIE_NO_IMPLEMENTATION;
 }


### PR DESCRIPTION
This PR refactors the current SYCL Native CPU Implementation as a Unified Runtime adapter.
No new functionalities are added.

Contents of this PR:
- Native CPU implementation divided in multiple source files at `sycl/plugins/unified_runtime/ur/adapters/native_cpu`
- Native CPU PI plugin is now implemented through the `pi2ur.hpp` interface
- _pi_* classes have now an equivalent ur_* class
- `UR_PLATFORM_BACKEND_NATIVE_CPU` value added to `ur2piPlatformInfoValue`
