### PR TITLE
[CI][NFC] Remove idle build artifact suffix.

### DIFF
--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -20,7 +20,7 @@ jobs:
     secrets: inherit
     with:
       build_cache_root: "/__w/"
-      build_artifact_suffix: default-2204
+      build_artifact_suffix: default
       build_configure_extra_args: '--hip --cuda --enable-esimd-emulator'
       merge_ref: ''
       retention-days: 90
@@ -35,7 +35,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_cache_suffix: opaque_pointers
-      build_artifact_suffix: opaque_pointers-2204
+      build_artifact_suffix: opaque_pointers
       build_configure_extra_args: "--hip --cuda --enable-esimd-emulator --cmake-opt=-DSPIRV_ENABLE_OPAQUE_POINTERS=TRUE"
       merge_ref: ''
 
@@ -56,7 +56,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3
       with:
-        name: sycl_linux_default-2204
+        name: sycl_linux_default
         path: devops/
     - name: Build and Push Container (with drivers)
       uses: ./devops/actions/build_container


### PR DESCRIPTION
This effectively reverts changes made by
8d07b4de7c1dc867c647d751eb2ed532835299fd. The suffix was added to handle
collision between two jobs producing build artifacts. The job causing
this conflict was removed by 5504c74a5a58974844cbc2ebf2d46451614b9dca,
so suffix is not needed anymore.
