### PR TITLE
Add alias for simplifying certain properties use cases

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -87,56 +87,6 @@ static_assert(std::is_same_v<decltype(P3), decltype(P4)>); // The order properti
 
 ```
 
-The alias `sycl::ext::oneapi::experimental::properties_t` is defined for
-convenience and it is defined as follows:
-
-```c++
-namespace sycl::ext::oneapi::experimental {
-
-template <auto... Props> using properties_t = decltype(properties{Props...});
-
-} // namespace experimental::oneapi::ext::sycl
-```
-
-Use this alias in situations where you need to get the type of a `properties`
-object that consists of 1 or more compile time constant properties. For example
-consider the following toy examples:
-
-.Examples using decltype
-```c++
-
-// buffer_location and awidth are some compile time constant properties
-annotated_arg<int *, decltype(properties{buffer_location<1>, awidth<32>})> a;
-
-// protocol_avalon_mm and uses_ready<false> are some compile time constant
-// properties
-using Pipe = pipe<..., decltype(properties{protocol_avalon_mm,
-                                           uses_ready<false>})>;
-
-// device_image_scope and host_access_read_write are some compile time constant
-// properties
-device_global<int, decltype(properties{device_image_scope,
-                                       host_access_read_write})> global_obj;
-```
-
-Such use cases arise often with SYCL extensions that are built to utilize
-`properties`. The above can be simplified to:
-
-.Examples using properties_t
-```c++
-using namespace sycl::ext::oneapi::experimental;
-
-// buffer_location and awidth are compile time constant properties
-annotated_arg<int *, properties_t<buffer_location<1>, awidth<32>> a;
-
-using Pipe = pipe<..., properties_t<protocol_avalon, uses_ready<false>>>;
-
-// device_image_scope and host_access_read_write are some compile time constant
-// properties
-device_global<int, properties_t<device_image_scope, host_access_read_write>>
-  global_obj;
-```
-
 === Goals
 
 The goals of this extension are:
@@ -547,13 +497,45 @@ inline constexpr bool is_property_list_v;
 |===
 --
 
-
 === Type of `properties`
 
-The details of the `properties` template argument(s) are unspecified. In particular the sorting order of properties is unspecified.
+The details of the `properties` template argument(s) are unspecified. In
+particular the sorting order of properties is unspecified.
 
-The type of the property list can be written with `properties_t` or with
-`decltype`.
+The type of the property list can be written with with `decltype`.
+
+The following example shows how `decltype` is used to create a property list
+type containing the compile-time constant properties `bar` and `baz`:
+
+```c++
+using P1 = decltype(properties(baz<1>, bar));
+using P2 = decltype(properties(bar, baz<1>));
+// Succeeds, since the order of properties does not matter
+static_assert(std::is_same<P1, P2>::value);
+static_assert(P1::get_property<baz_key>().value == 1);
+```
+
+An empty property list can be created as follows:
+
+```c++
+using empty_property_list = decltype(properties());
+```
+
+
+=== `properties_t` : Getting type of `properties` with C++20 support
+
+The alias `sycl::ext::oneapi::experimental::properties_t` is supported only when
+C++20 features are enabled. It is defined as follows:
+
+```c++
+namespace sycl::ext::oneapi::experimental {
+
+template <auto... Props> using properties_t = decltype(properties{Props...});
+
+} // namespace experimental::oneapi::ext::sycl
+
+Use this alias in situations where you need to get the type of a `properties`
+object that consists of 1 or more compile time constant properties.
 
 The following example shows how `properties_t` is used to create a property list
 type containing the compile-time constant properties `bar` and `baz`:
@@ -572,6 +554,11 @@ An empty property list can be created as follows:
 using empty_property_list = properties_t<>;
 ```
 
+It is equivalent to using `decltype` directly:
+```c++
+static_assert(std::is_same_v<properties_t<sub_group_size<8>>,
+                             decltype(properties(sub_group_size<8>))>);
+```
 
 === Querying Properties in Device Code
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -87,10 +87,15 @@ static_assert(std::is_same_v<decltype(P3), decltype(P4)>); // The order properti
 
 ```
 
-The `properties_type` alias is defined as follows:
+The alias `sycl::ext::oneapi::experimental::properties_type` is defined for
+convenience and it is defined as follows:
 
 ```c++
+namespace sycl::ext::oneapi::experimental {
+
 template <auto... Props> using properties_set = decltype(properties{Props...});
+
+} // namespace experimental::oneapi::ext::sycl
 ```
 
 Use this alias in situations where you need to get the type of a `properties`
@@ -105,14 +110,13 @@ annotated_arg<int *, decltype(properties{buffer_location<1>, awidth<32>})> a;
 
 // protocol_avalon_mm and uses_ready<false> are some compile time constant
 // properties
-using Pipe = pipe<class PipeID, int, decltype(properties{protocol_avalon_mm,
-                                                         uses_ready<false>})>;
+using Pipe = pipe<..., decltype(properties{protocol_avalon_mm,
+                                           uses_ready<false>})>;
 
 // device_image_scope and host_access_read_write are some compile time constant
 // properties
 device_global<int, decltype(properties{device_image_scope,
-                                       host_access_read_write})>
-    global_obj;
+                                       host_access_read_write})> global_obj;
 ```
 
 Such use cases arise often with SYCL extensions that are built to utilize
@@ -120,11 +124,12 @@ Such use cases arise often with SYCL extensions that are built to utilize
 
 .Examples using properties_type
 ```c++
+using namespace namespace experimental::oneapi::ext::sycl;
+
 // buffer_location and awidth are compile time constant properties
 annotated_arg<int *, properties_type<buffer_location<1>, awidth<32>> a;
 
-using Pipe = pipe<class PipeID, int, properties_type<protocol_avalon,
-                                                     uses_ready<false>>>;
+using Pipe = pipe<..., properties_type<protocol_avalon, uses_ready<false>>>;
 
 // device_image_scope and host_access_read_write are some compile time constant
 // properties

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -124,7 +124,7 @@ Such use cases arise often with SYCL extensions that are built to utilize
 
 .Examples using properties_type
 ```c++
-using namespace namespace experimental::oneapi::ext::sycl;
+using namespace sycl::ext::oneapi::experimental;
 
 // buffer_location and awidth are compile time constant properties
 annotated_arg<int *, properties_type<buffer_location<1>, awidth<32>> a;

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -87,13 +87,13 @@ static_assert(std::is_same_v<decltype(P3), decltype(P4)>); // The order properti
 
 ```
 
-The alias `sycl::ext::oneapi::experimental::properties_type` is defined for
+The alias `sycl::ext::oneapi::experimental::properties_t` is defined for
 convenience and it is defined as follows:
 
 ```c++
 namespace sycl::ext::oneapi::experimental {
 
-template <auto... Props> using properties_type = decltype(properties{Props...});
+template <auto... Props> using properties_t = decltype(properties{Props...});
 
 } // namespace experimental::oneapi::ext::sycl
 ```
@@ -122,18 +122,18 @@ device_global<int, decltype(properties{device_image_scope,
 Such use cases arise often with SYCL extensions that are built to utilize
 `properties`. The above can be simplified to:
 
-.Examples using properties_type
+.Examples using properties_t
 ```c++
 using namespace sycl::ext::oneapi::experimental;
 
 // buffer_location and awidth are compile time constant properties
-annotated_arg<int *, properties_type<buffer_location<1>, awidth<32>> a;
+annotated_arg<int *, properties_t<buffer_location<1>, awidth<32>> a;
 
-using Pipe = pipe<..., properties_type<protocol_avalon, uses_ready<false>>>;
+using Pipe = pipe<..., properties_t<protocol_avalon, uses_ready<false>>>;
 
 // device_image_scope and host_access_read_write are some compile time constant
 // properties
-device_global<int, properties_type<device_image_scope, host_access_read_write>>
+device_global<int, properties_t<device_image_scope, host_access_read_write>>
   global_obj;
 ```
 
@@ -549,21 +549,25 @@ inline constexpr bool is_property_list_v;
 === Type of `properties`
 
 The details of the `properties` template argument(s) are unspecified. In particular the sorting order of properties is unspecified.
-The type of the property list can be written with `decltype`.
 
-The following example shows how `decltype` is used to create a property list type containing the compile-time constant properties `bar` and `baz`:
+The type of the property list can be written with `properties_t` or with
+`decltype`.
+
+The following example shows how `properties_t` is used to create a property list
+type containing the compile-time constant properties `bar` and `baz`:
 
 ```c++
-using P1 = properties_type<baz<1>, bar>;
-using P2 = properties_type<bar, baz<1>>;
-static_assert(std::is_same<P1, P2>::value); // Succeeds, since the order of properties does not matter
+using P1 = properties_t<baz<1>, bar>;
+using P2 = properties_t<bar, baz<1>>;
+// Succeeds, since the order of properties does not matter
+static_assert(std::is_same<P1, P2>::value);
 static_assert(P1::get_property<baz_key>().value == 1);
 ```
 
 An empty property list can be created as follows:
 
 ```c++
-using empty_property_list = decltype(properties());
+using empty_property_list = properties_t<>;
 ```
 
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -59,7 +59,7 @@ The handling of runtime properties in `properties` departs from that of `sycl::p
 
 [NOTE]
 ====
-Due to type deduction, users should usually not need to specify the template parameters of `properties` directly. In cases the type is needed, `decltype` should be used.
+Due to type deduction, users should usually not need to specify the template parameters of `properties` directly. In cases where the type is needed, `decltype` should be used.
 ====
 
 A property list that has the compile-time constant property `foo` can be created as follows:
@@ -80,9 +80,56 @@ properties P1{bar};
 properties P2{bar, foo{argv[0]}};
 properties P3{bar, baz};
 properties P4{baz, bar};
+
 static_assert(!std::is_same_v<decltype(P1), decltype(P2)>); // P1 and P2 contain different properties
 static_assert(!std::is_same_v<decltype(P1), decltype(P3)>); // P1 and P3 contain different properties
 static_assert(std::is_same_v<decltype(P3), decltype(P4)>); // The order properties are specified doesn't change the type
+
+```
+
+The `properties_type` alias is defined as follows:
+
+```c++
+template <auto... Props> using properties_set = decltype(properties{Props...});
+```
+
+Use this alias in situations where you need to get the type of a `properties`
+object that consists of 1 or more compile time constant properties. For example
+consider the following toy examples:
+
+.Examples using decltype
+```c++
+
+// buffer_location and awidth are some compile time constant properties
+annotated_arg<int *, decltype(properties{buffer_location<1>, awidth<32>})> a;
+
+// protocol_avalon_mm and uses_ready<false> are some compile time constant
+// properties
+using Pipe = pipe<class PipeID, int, decltype(properties{protocol_avalon_mm,
+                                                         uses_ready<false>})>;
+
+// device_image_scope and host_access_read_write are some compile time constant
+// properties
+device_global<int, decltype(properties{device_image_scope,
+                                       host_access_read_write})>
+    global_obj;
+```
+
+Such use cases arise often with SYCL extensions that are built to utilize
+`properties`. The above can be simplified to:
+
+.Examples using properties_type
+```c++
+// buffer_location and awidth are compile time constant properties
+annotated_arg<int *, properties_type<buffer_location<1>, awidth<32>> a;
+
+using Pipe = pipe<class PipeID, int, properties_type<protocol_avalon,
+                                                     uses_ready<false>>>;
+
+// device_image_scope and host_access_read_write are some compile time constant
+// properties
+device_global<int, properties_type<device_image_scope, host_access_read_write>>
+  global_obj;
 ```
 
 === Goals
@@ -502,8 +549,8 @@ The type of the property list can be written with `decltype`.
 The following example shows how `decltype` is used to create a property list type containing the compile-time constant properties `bar` and `baz`:
 
 ```c++
-using P1 = decltype(properties(baz<1>, bar));
-using P2 = decltype(properties(bar, baz<1>));
+using P1 = properties_type<baz<1>, bar>;
+using P2 = properties_type<bar, baz<1>>;
 static_assert(std::is_same<P1, P2>::value); // Succeeds, since the order of properties does not matter
 static_assert(P1::get_property<baz_key>().value == 1);
 ```

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -648,7 +648,7 @@ using f = decltype(P8.get_property<foo_types_key>());
 using t1 = f::first_t;
 using t2 = f::second_t;
 using t3 = f::third_t;
-static_assert(std::is_same_v<t1, float);
+static_assert(std::is_same_v<t1, float>);
 static_assert(std::is_same_v<t2, int>);
 static_assert(std::is_same_v<t3, bool>);
 ```

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -93,7 +93,7 @@ convenience and it is defined as follows:
 ```c++
 namespace sycl::ext::oneapi::experimental {
 
-template <auto... Props> using properties_set = decltype(properties{Props...});
+template <auto... Props> using properties_type = decltype(properties{Props...});
 
 } // namespace experimental::oneapi::ext::sycl
 ```

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -247,6 +247,7 @@ template<typename... Ts>
 inline constexpr boo_key::value_t<Ts...> boo;
 
 } // namespace experimental::oneapi::ext::sycl
+```
 
 === Property traits
 
@@ -255,7 +256,8 @@ All runtime and compile-time-constant properties must have a specialization of
 `std::true_type`, and they must have a specialization of `is_property_key_of`
 and `is_property_value_of`
 that inherits from `std::true_type` for each SYCL runtime class that the
-property can be applied to. All have a base case which inherits from `std::false_type`.
+property can be applied to. All have a base case which inherits from
+`std::false_type`.
 
 ```c++
 namespace sycl::ext::oneapi::experimental {


### PR DESCRIPTION
The PR introduces the alias `sycl::ext::oneapi::experimental::properties_t` that can help simplify the syntax needed to use `sycl::ext::oneapi::experimental::properties` with various SYCL extensions that leverage properties like:
- `sycl::ext::oneapi::experimental::annotated_arg`
- `sycl::ext::oneapi::experimental::annotated_ptr`
- `sycl::ext::oneapi::experimental::device_globals`
- `sycl::ext::intel::experimental::pipes`

The alias allows replacing `decltype(properties{...})` with `properties_t<...>`.

I am looking for feedback on the approach. I still need to go through the extension and see if more cases can be simplified and/or a better alias can be built.