### PR TITLE
[SYCL] Fix nextafter with half on host

### DIFF
--- a/sycl/test/regression/host_half_nextafter.cpp
+++ b/sycl/test/regression/host_half_nextafter.cpp
@@ -1,0 +1,30 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+//
+// Checks that sycl::nextafter with sycl::half on host correctly converts based
+// on half-precision.
+
+#include <sycl/sycl.hpp>
+
+void check(uint16_t x, uint16_t y, uint16_t ref) {
+  assert(sycl::nextafter(sycl::bit_cast<sycl::half>(x),
+                         sycl::bit_cast<sycl::half>(y)) ==
+         sycl::bit_cast<sycl::half>(ref));
+}
+
+int main() {
+  check(0x0, 0x0, 0x0);
+  check(0x1, 0x1, 0x1);
+  check(0x8001, 0x8001, 0x8001);
+  check(0x0, 0x1, 0x1);
+  check(0x8000, 0x8001, 0x8001);
+  check(0x0, 0x8001, 0x8001);
+  check(0x8000, 0x1, 0x1);
+  check(0x8001, 0x0, 0x0);
+  check(0x1, 0x8000, 0x8000);
+  check(0x8001, 0x1, 0x0);
+  check(0x1, 0x8001, 0x8000);
+
+  std::cout << "Passed!" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Currently the host-side implementation of sycl::nextafter with sycl::half uses the float variant of std::nextafter. However, due to the conversion between half and float, the result may be unexpected. Likewise, https://github.com/KhronosGroup/SYCL-Docs/pull/440 removes the reference to single-precision floating point results.