### PR TITLE
[SYCL][CUDA] Update required min CUDA from 10.1 to 11.5

### DIFF
--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -173,7 +173,7 @@ the CUDA backend has Windows support; windows subsystem for
 linux (WSL) is not needed to build and run the CUDA backend.
 
 Enabling this flag requires an installation of at least
-[CUDA 10.2](https://developer.nvidia.com/cuda-10.2-download-archive) on
+[CUDA 11.5](https://developer.nvidia.com/cuda-11-5-0-download-archive) on
 the system, refer to
 [NVIDIA CUDA Installation Guide for Linux](https://docs.nvidia.com/cuda/cuda-installation-guide-linux/index.html)
 or

--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -4,7 +4,7 @@ message(STATUS "Including the PI API CUDA backend.")
  # we only require the CUDA driver API to be used
  # CUDA_CUDA_LIBRARY variable defines the path to libcuda.so, the CUDA Driver API library.
 
-find_package(CUDA 10.1 REQUIRED)
+find_package(CUDA 11.5 REQUIRED)
 
 # Make imported library global to use it within the project.
 add_library(cudadrv SHARED IMPORTED GLOBAL)

--- a/sycl/tools/sycl-trace/CMakeLists.txt
+++ b/sycl/tools/sycl-trace/CMakeLists.txt
@@ -99,7 +99,7 @@ add_dependencies(sycl_pi_trace_collector pi-pretty-printers)
 
 if(SYCL_BUILD_PI_CUDA)
 
-  find_package(CUDA 10.1 REQUIRED)
+  find_package(CUDA 11.5 REQUIRED)
 
   target_compile_definitions(cuda_trace_collector
     PRIVATE


### PR DESCRIPTION
Given the features used in unified runtime (specifically to images format to name a few), a min of 11.5 is ~~recommended~~ required