### PR TITLE
[CUDA][UR] Cache the max local mem size

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -542,8 +542,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // OpenCL's "local memory" maps most closely to CUDA's "shared memory".
     // CUDA has its own definition of "local memory", which maps to OpenCL's
     // "private memory".
-    return ReturnValue(
-        static_cast<uint64_t>(hDevice->getDeviceMaxChosenLocalMem()));
+    if (hDevice->maxLocalMemSizeChosen()) {
+      return ReturnValue(
+          static_cast<uint64_t>(hDevice->getMaxChosenLocalMem()));
+    } else {
+      int LocalMemSize = 0;
+      detail::ur::assertion(
+          cuDeviceGetAttribute(&LocalMemSize,
+                               CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
+                               hDevice->get()) == CUDA_SUCCESS);
+      detail::ur::assertion(LocalMemSize >= 0);
+      return ReturnValue(static_cast<uint64_t>(LocalMemSize));
+    }
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
     int ECCEnabled = 0;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -543,7 +543,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // CUDA has its own definition of "local memory", which maps to OpenCL's
     // "private memory".
     return ReturnValue(
-        static_cast<uint64_t>(hDevice->getDeviceChosenMaxLocalMem));
+        static_cast<uint64_t>(hDevice->getDeviceMaxChosenLocalMem()));
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
     int ECCEnabled = 0;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -542,13 +542,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     // OpenCL's "local memory" maps most closely to CUDA's "shared memory".
     // CUDA has its own definition of "local memory", which maps to OpenCL's
     // "private memory".
-    int LocalMemSize = 0;
-    detail::ur::assertion(
-        cuDeviceGetAttribute(&LocalMemSize,
-                             CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK,
-                             hDevice->get()) == CUDA_SUCCESS);
-    detail::ur::assertion(LocalMemSize >= 0);
-    return ReturnValue(static_cast<uint64_t>(LocalMemSize));
+    return ReturnValue(
+        static_cast<uint64_t>(hDevice->getDeviceChosenMaxLocalMem));
   }
   case UR_DEVICE_INFO_ERROR_CORRECTION_SUPPORT: {
     int ECCEnabled = 0;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
@@ -25,8 +25,9 @@ private:
   int MaxBlockDimY{0};
   int MaxBlockDimZ{0};
   int MaxRegsPerBlock{0};
-  int DeviceMaxCapacityLocalMem{0};
-  int DeviceMaxChosenLocalMem{0};
+  int MaxCapacityLocalMem{0};
+  int MaxChosenLocalMem{0};
+  bool MaxLocalMemSizeChosen{false};
 
 public:
   ur_device_handle_t_(native_type cuDevice, CUcontext cuContext, CUevent evBase,
@@ -48,9 +49,10 @@ public:
 
     if (LocalMemSizePtr) {
       cuDeviceGetAttribute(
-          &DeviceMaxCapacityLocalMem,
+          &MaxCapacityLocalMem,
           CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, cuDevice);
-      DeviceMaxChosenLocalMem = std::atoi(LocalMemSizePtr);
+      MaxChosenLocalMem = std::atoi(LocalMemSizePtr);
+      MaxLocalMemSizeChosen = true;
     }
   };
 
@@ -86,13 +88,15 @@ public:
 
   size_t getMaxRegsPerBlock() const noexcept { return MaxRegsPerBlock; };
 
-  int getDeviceMaxCapacityLocalMem() const noexcept {
-    return DeviceMaxCapacityLocalMem;
+  int getMaxCapacityLocalMem() const noexcept {
+    return MaxCapacityLocalMem;
   };
 
-  int getDeviceMaxChosenLocalMem() const noexcept {
-    return DeviceMaxChosenLocalMem;
+  int getMaxChosenLocalMem() const noexcept {
+    return MaxChosenLocalMem;
   };
+
+  bool maxLocalMemSizeChosen() { return MaxLocalMemSizeChosen; };
 };
 
 int getAttribute(ur_device_handle_t Device, CUdevice_attribute Attribute);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
@@ -51,19 +51,10 @@ public:
           &DeviceMaxCapacityLocalMem,
           CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN, cuDevice);
       DeviceMaxChosenLocalMem = std::atoi(LocalMemSizePtr);
-      if (DeviceMaxChosenLocalMem < 0) {
-        setErrorMessage("Invalid value specified for "
-                        "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE",
-                        UR_RESULT_ERROR_ADAPTER_SPECIFIC);
-        return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
-      }
     }
-  }
-};
+  };
 
-~ur_device_handle_t_() {
-  cuDevicePrimaryCtxRelease(CuDevice);
-}
+  ~ur_device_handle_t_() { cuDevicePrimaryCtxRelease(CuDevice); }
 
   native_type get() const noexcept { return CuDevice; };
 
@@ -96,11 +87,11 @@ public:
   size_t getMaxRegsPerBlock() const noexcept { return MaxRegsPerBlock; };
 
   int getDeviceMaxCapacityLocalMem() const noexcept {
-    return DeviceMaxLocalMem;
+    return DeviceMaxCapacityLocalMem;
   };
 
   int getDeviceMaxChosenLocalMem() const noexcept {
-    return DeviceChosenMaxLocalMem;
+    return DeviceMaxChosenLocalMem;
   };
 };
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
@@ -88,13 +88,9 @@ public:
 
   size_t getMaxRegsPerBlock() const noexcept { return MaxRegsPerBlock; };
 
-  int getMaxCapacityLocalMem() const noexcept {
-    return MaxCapacityLocalMem;
-  };
+  int getMaxCapacityLocalMem() const noexcept { return MaxCapacityLocalMem; };
 
-  int getMaxChosenLocalMem() const noexcept {
-    return MaxChosenLocalMem;
-  };
+  int getMaxChosenLocalMem() const noexcept { return MaxChosenLocalMem; };
 
   bool maxLocalMemSizeChosen() { return MaxLocalMemSizeChosen; };
 };

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -393,27 +393,24 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
       RetImplEvent->start();
     }
 
-    // Set local mem max size if env var is present
-    static const char *LocalMemSizePtr =
-        std::getenv("SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE");
-
-    if (LocalMemSizePtr) {
-      int DeviceMaxLocalMem = 0;
-      cuDeviceGetAttribute(
-          &DeviceMaxLocalMem,
-          CU_DEVICE_ATTRIBUTE_MAX_SHARED_MEMORY_PER_BLOCK_OPTIN,
-          hQueue->get_device()->get());
-
-      static const int EnvVal = std::atoi(LocalMemSizePtr);
-      if (EnvVal <= 0 || EnvVal > DeviceMaxLocalMem) {
-        setErrorMessage("Invalid value specified for "
-                        "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE",
-                        UR_RESULT_ERROR_ADAPTER_SPECIFIC);
-        return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
-      }
-      UR_CHECK_ERROR(cuFuncSetAttribute(
-          CuFunc, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES, EnvVal));
+    // Set up local memory requirements for kernel.
+    auto Device = hQueue->getContext()->getDevice();
+    if (LocalSize > Device->getDeviceMaxCapacityLocalMem()) {
+      setErrorMessage("Too much local memory allocated for device",
+                      UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
     }
+    if (LocalSize > Device->getDeviceMaxChosenLocalMem()) {
+      setErrorMessage(
+          "Local memory for kernel exceeds the amount requested using "
+          "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE. Try increasing the value for "
+          "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE.",
+          UR_RESULT_ERROR_ADAPTER_SPECIFIC);
+      return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
+    }
+    UR_CHECK_ERROR(cuFuncSetAttribute(
+        CuFunc, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
+        Device->getDeviceMaxChosenLocalMem()));
 
     Result = UR_CHECK_ERROR(cuLaunchKernel(
         CuFunc, BlocksPerGrid[0], BlocksPerGrid[1], BlocksPerGrid[2],

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -402,12 +402,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
                         UR_RESULT_ERROR_ADAPTER_SPECIFIC);
         return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
       }
-      if (LocalSize > Device->getDeviceMaxCapacityLocalMem()) {
+      if (LocalSize >
+          static_cast<uint32_t>(Device->getDeviceMaxCapacityLocalMem())) {
         setErrorMessage("Too much local memory allocated for device",
                         UR_RESULT_ERROR_ADAPTER_SPECIFIC);
         return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
       }
-      if (LocalSize > Device->getDeviceMaxChosenLocalMem()) {
+      if (LocalSize >
+          static_cast<uint32_t>(Device->getDeviceMaxChosenLocalMem())) {
         setErrorMessage(
             "Local memory for kernel exceeds the amount requested using "
             "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE. Try increasing the value for "

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -393,23 +393,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
       RetImplEvent->start();
     }
 
-    if (hQueue->getContext()->getDevice()->getDeviceMaxChosenLocalMem()) {
+    if (hQueue->getContext()->getDevice()->maxLocalMemSizeChosen()) {
       // Set up local memory requirements for kernel.
       auto Device = hQueue->getContext()->getDevice();
-      if (Device->getDeviceMaxChosenLocalMem() < 0) {
+      if (Device->getMaxChosenLocalMem() < 0) {
         setErrorMessage("Invalid value specified for "
                         "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE",
                         UR_RESULT_ERROR_ADAPTER_SPECIFIC);
         return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
       }
-      if (LocalSize >
-          static_cast<uint32_t>(Device->getDeviceMaxCapacityLocalMem())) {
+      if (LocalSize > static_cast<uint32_t>(Device->getMaxCapacityLocalMem())) {
         setErrorMessage("Too much local memory allocated for device",
                         UR_RESULT_ERROR_ADAPTER_SPECIFIC);
         return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
       }
-      if (LocalSize >
-          static_cast<uint32_t>(Device->getDeviceMaxChosenLocalMem())) {
+      if (LocalSize > static_cast<uint32_t>(Device->getMaxChosenLocalMem())) {
         setErrorMessage(
             "Local memory for kernel exceeds the amount requested using "
             "SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE. Try increasing the value for "
@@ -419,7 +417,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
       }
       UR_CHECK_ERROR(cuFuncSetAttribute(
           CuFunc, CU_FUNC_ATTRIBUTE_MAX_DYNAMIC_SHARED_SIZE_BYTES,
-          Device->getDeviceMaxChosenLocalMem()));
+          Device->getMaxChosenLocalMem()));
     }
 
     Result = UR_CHECK_ERROR(cuLaunchKernel(


### PR DESCRIPTION
Cache the max local mem size so that we can call less CUDA driver entry points at `urEnqueueKernelLaunch`. Also allows us to query the value set for `SYCL_PI_CUDA_MAX_LOCAL_MEM_SIZE` using `device.get_info<sycl::info::device::local_mem_size>()`