### PR TITLE
[SYCL-MLIR] Support optional SYCL type attributes on `schedule_kernel`'s args

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -192,7 +192,10 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
     case, the `nd_range` attribute must be set.
 
     Pointer arguments can be annotated with the SYCL type of the entity they
-    refer to, e.g. an accessor.
+    refer to, e.g. an accessor. Internally, this information is stored in the
+    `sycl_types` type array attribute, sized to match the number of arguments.
+    If no such type annotation is available for an argument, the `None` type
+    shall be used as a placeholder.
 
     Note that due to the current focus on host-device optimizations for
     individual launches, this operation currently does not model the queue or

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -208,6 +208,7 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
     Optional<LLVM_AnyPointer>:$range,
     Optional<LLVM_AnyPointer>:$offset,
     Variadic<AnyType>:$args,
+    TypeArrayAttr:$sycl_types,
     UnitAttr:$nd_range);
   let builders = [
     OpBuilder<(ins "::mlir::SymbolRefAttr":$kernel_name,
@@ -219,20 +220,25 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
                    "::mlir::Value":$range,
                    "::mlir::ValueRange":$args,
                    "bool":$nd_range), [{
+      ::llvm::SmallVector<::mlir::Type> noneTypes(args.size(), $_builder.getNoneType());
+      auto syclTypes = $_builder.getTypeArrayAttr(noneTypes);
       auto ndRangeAttr = nd_range ? $_builder.getUnitAttr() : UnitAttr();
       build($_builder, $_state, kernel_name, range,
-            /*offset=*/Value(), args, ndRangeAttr);
+            /*offset=*/Value(), args, syclTypes, ndRangeAttr);
     }]>,
     OpBuilder<(ins "::mlir::SymbolRefAttr":$kernel_name,
                    "::mlir::Value":$range,
                    "::mlir::Value":$offset,
                    "::mlir::ValueRange":$args), [{
-      build($_builder, $_state, kernel_name, range, offset, args);
+      ::llvm::SmallVector<::mlir::Type> noneTypes(args.size(), $_builder.getNoneType());
+      auto syclTypes = $_builder.getTypeArrayAttr(noneTypes);
+      build($_builder, $_state, kernel_name, range, offset, args, syclTypes);
     }]>
   ];
   let assemblyFormat = [{
-    $kernel_name (`[` (`nd_range` $nd_range^):(```range`)? $range^ (`,` `offset` $offset^)? `]`)? `` (`(` $args^ `)`)?
-      attr-dict `:` functional-type(operands, results)
+    $kernel_name (`[` (`nd_range` $nd_range^):(```range`)? $range^ (`,` `offset` $offset^)? `]`)? ``
+    custom<ArgsWithSYCLTypes>($args, $sycl_types)
+    attr-dict `:` functional-type(operands, results)
   }];
   let hasVerifier = 1;
 }

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -191,6 +191,9 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
     case, an `id` pointer can be optionally given as the `offset`. In the former
     case, the `nd_range` attribute must be set.
 
+    Pointer arguments can be annotated with the SYCL type of the entity they
+    refer to, e.g. an accessor.
+
     Note that due to the current focus on host-device optimizations for
     individual launches, this operation currently does not model the queue or
     the command-group handler associated with the launch, nor does it observe or
@@ -198,8 +201,8 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
 
     Example:
     ```
-    sycl.host.schedule_kernel @kernels::@k0[range %1](%2, %3)
-      : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    sycl.host.schedule_kernel @kernels::@k0[range %1]
+      (%2: !sycl_accessor_1_f32_rw_gb, %3) : (!llvm.ptr, !llvm.ptr, i32) -> ()
     ```
   }];
 

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -616,13 +616,13 @@ parseArgsWithSYCLTypes(mlir::OpAsmParser &parser,
     args.push_back(operand);
 
     Type type = builder.getNoneType();
-    if (parser.parseOptionalLParen()) {
+    if (parser.parseOptionalColon()) {
       // no type attribute
       types.push_back(type);
       return success();
     }
 
-    if (parser.parseType(type) || parser.parseRParen())
+    if (parser.parseType(type))
       return failure();
 
     types.push_back(type);
@@ -648,9 +648,8 @@ static void printArgsWithSYCLTypes(mlir::OpAsmPrinter &printer,
                           printer.printOperand(std::get<0>(it));
                           TypeAttr attr = std::get<1>(it);
                           if (!isa<NoneType>(attr.getValue())) {
-                            printer << " (";
+                            printer << ": ";
                             printer.printType(attr.getValue());
-                            printer << ')';
                           }
                         });
   printer << ')';

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -91,63 +91,66 @@ func.func @set_captured(%lambda: !llvm.ptr, %scalar_arg: i16, %struct_arg: !llvm
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_single_task(
-// CHECK-SAME:                                         %[[VAL_0:.*]]: i32,
-// CHECK-SAME:                                         %[[VAL_1:.*]]: i32) {
+// CHECK-SAME:                                           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: !llvm.ptr) {
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0 : () -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]]) : (i32) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]]) : (i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]] (!sycl_accessor_2_i32_r_gb)) : (i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_single_task(%arg0 : i32, %arg1 : i32) {
+func.func @schedule_kernel_single_task(%arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0 : () -> ()
   sycl.host.schedule_kernel @kernels::@k0(%arg0) : (i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1) : (i32, i32) -> ()
+  sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_nd_range(
-// CHECK-SAME:                                      %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                                      %[[VAL_1:.*]]: i32,
-// CHECK-SAME:                                      %[[VAL_2:.*]]: i32) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}nd_range %[[VAL_0]]] : (!llvm.ptr) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}nd_range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
+// CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]] : (!llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]] (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_nd_range(%nd_range: !llvm.ptr, %arg0 : i32, %arg1 : i32) {
+func.func @schedule_kernel_nd_range(%nd_range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range] : (!llvm.ptr) -> ()
   sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0) : (!llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_range(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                                   %[[VAL_1:.*]]: i32,
-// CHECK-SAME:                                   %[[VAL_2:.*]]: i32) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}range %[[VAL_0]]] : (!llvm.ptr) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]] : (!llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]] (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_range(%range: !llvm.ptr, %arg0 : i32, %arg1 : i32) {
+func.func @schedule_kernel_range(%range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0[range %range] : (!llvm.ptr) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0) : (!llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_range_with_offset(
-// CHECK-SAME:                                               %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}range %[[VAL_0]], offset %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0{{\[}}range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]] (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.ptr, %arg0 : i32, %arg1 : i32) {
+func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset] : (!llvm.ptr, !llvm.ptr) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -95,14 +95,14 @@ func.func @set_captured(%lambda: !llvm.ptr, %scalar_arg: i16, %struct_arg: !llvm
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0 : () -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]]) : (i32) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]]) : (i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]] (!sycl_accessor_2_i32_r_gb)) : (i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]: !sycl_accessor_2_i32_r_gb) : (i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_single_task(%arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0 : () -> ()
   sycl.host.schedule_kernel @kernels::@k0(%arg0) : (i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1) : (i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
@@ -111,14 +111,14 @@ func.func @schedule_kernel_single_task(%arg0: i32, %arg1: i32, %arg2: !llvm.ptr)
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]] : (!llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]] (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_nd_range(%nd_range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range] : (!llvm.ptr) -> ()
   sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0) : (!llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
@@ -127,14 +127,14 @@ func.func @schedule_kernel_nd_range(%nd_range: !llvm.ptr, %arg0: i32, %arg1: i32
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]] : (!llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]] (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_range(%range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0[range %range] : (!llvm.ptr) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0) : (!llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
@@ -143,14 +143,14 @@ func.func @schedule_kernel_range(%range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]] (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset] : (!llvm.ptr, !llvm.ptr) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2 (!sycl_accessor_2_i32_r_gb)) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -646,7 +646,7 @@ gpu.module @kernels {
 
 func.func @schedule_kernel_scalar_type_attribute(%arg0: i32) {
   // expected-error @below {{'sycl.host.schedule_kernel' op does not expect a type attribute for a non-pointer value}}
-  sycl.host.schedule_kernel @kernels::@k0(%arg0 (i32)) : (i32) -> ()
+  sycl.host.schedule_kernel @kernels::@k0(%arg0: i32) : (i32) -> ()
   func.return
 }
 
@@ -660,7 +660,7 @@ gpu.module @kernels {
 
 func.func @schedule_kernel_non_sycl_type_attribute(%arg0: !llvm.ptr) {
   // expected-error @below {{'sycl.host.schedule_kernel' op expects the type attribute to reference a SYCL type}}
-  sycl.host.schedule_kernel @kernels::@k0(%arg0 (i32)) : (!llvm.ptr) -> ()
+  sycl.host.schedule_kernel @kernels::@k0(%arg0: i32) : (!llvm.ptr) -> ()
   func.return
 }
 

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -630,6 +630,48 @@ gpu.module @kernels {
 
 // -----
 
+func.func @schedule_kernel_inconsistent_type_attributes(%arg0: i32) {
+  // expected-error @below {{'sycl.host.schedule_kernel' op has inconsistent SYCL type attributes}}
+  "sycl.host.schedule_kernel"(%arg0) {kernel_name = @kernels::@k0, operand_segment_sizes = array<i32: 0, 0, 1>, sycl_types = [none, none]} : (i32) -> ()
+  func.return
+}
+
+gpu.module @kernels {
+  gpu.func @k0() kernel {
+    gpu.return
+  }
+}
+
+// -----
+
+func.func @schedule_kernel_scalar_type_attribute(%arg0: i32) {
+  // expected-error @below {{'sycl.host.schedule_kernel' op does not expect a type attribute for a non-pointer value}}
+  sycl.host.schedule_kernel @kernels::@k0(%arg0 (i32)) : (i32) -> ()
+  func.return
+}
+
+gpu.module @kernels {
+  gpu.func @k0() kernel {
+    gpu.return
+  }
+}
+
+// -----
+
+func.func @schedule_kernel_non_sycl_type_attribute(%arg0: !llvm.ptr) {
+  // expected-error @below {{'sycl.host.schedule_kernel' op expects the type attribute to reference a SYCL type}}
+  sycl.host.schedule_kernel @kernels::@k0(%arg0 (i32)) : (!llvm.ptr) -> ()
+  func.return
+}
+
+gpu.module @kernels {
+  gpu.func @k0() kernel {
+    gpu.return
+  }
+}
+
+// -----
+
 func.func @f(%event: !llvm.ptr, %queue: !llvm.ptr) {
   // expected-error @below {{'sycl.host.submit' op '@f0' does not reference a valid CGF function}}
   sycl.host.submit %queue(@f0) -> %event : !llvm.ptr, !llvm.ptr


### PR DESCRIPTION
Rationale for annotating the argument list rather than the op's functional type: The optionality of `$range` and `$offset` prevents the use of a custom directive, hence we would need a complete custom parser/printer for the op.