### PR TITLE
[SYCL][UR] Remove UR_L0_TRACE

### DIFF
--- a/sycl/plugins/unified_runtime/ur/ur.cpp
+++ b/sycl/plugins/unified_runtime/ur/ur.cpp
@@ -12,9 +12,8 @@
 
 // Controls tracing UR calls from within the UR itself.
 bool PrintTrace = [] {
-  const char *UrRet = std::getenv("UR_L0_TRACE");
   const char *PiRet = std::getenv("SYCL_PI_TRACE");
-  const char *Trace = UrRet ? UrRet : (PiRet ? PiRet : nullptr);
+  const char *Trace = PiRet ? PiRet : nullptr;
   const int TraceValue = Trace ? std::stoi(Trace) : 0;
   if (TraceValue == -1 || TraceValue == 2) { // Means print all traces
     return true;


### PR DESCRIPTION
It shadows SYCL_PI_TRACE, so not needed.Tracing at UR level would eventually move to an official UR environment variable,

Resolves: #10178