### PR TITLE
[SYCL] Fix HIP plugin codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -43,8 +43,9 @@ sycl/plugins/unified_runtime/ @intel/dpcpp-l0-pi-reviewers
 # ESIMD CPU emulator plug-in
 sycl/plugins/esimd_emulator/ @intel/dpcpp-esimd-reviewers
 
-# CUDA plugin
+# CUDA and HIP plugins
 sycl/plugins/**/cuda/ @intel/llvm-reviewers-cuda
+sycl/plugins/**/hip/ @intel/llvm-reviewers-cuda
 
 # XPTI instrumentation utilities
 xpti/ @intel/llvm-reviewers-runtime


### PR DESCRIPTION
HIP plugin codeownership currently falls to L0 reviewers. A more appropriate group for owning this plugin is the CUDA plugin maintainers. In the future we can consider splitting the ownership or rename the CUDA reviewers group to encapsulate both.