### PR TITLE
[CI] Remove unused/always default inputs in *build_and_test.yml

### DIFF
--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -25,10 +25,6 @@ on:
         type: string
         required: false
         default: "default"
-      build_cache_size:
-        type: string
-        required: false
-        default: 8G
       build_configure_extra_args:
         type: string
         required: false
@@ -108,10 +104,6 @@ on:
       #   type: choice
       #   options:
       #     - "default"
-      # build_cache_size:
-      #   type: choice
-      #   options:
-      #     - "8G"
       # build_configure_extra_args:
       #   type: choice
       #   options:
@@ -183,7 +175,7 @@ jobs:
       build_conclusion: ${{ steps.build.conclusion }}
     env:
       CCACHE_DIR: ${{ inputs.build_cache_root }}/build_cache_${{ inputs.build_cache_suffix }}
-      CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
+      CCACHE_MAXSIZE: 8G
     steps:
     - uses: actions/checkout@v3
       with:

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -53,14 +53,6 @@ on:
         type: string
         required: false
         default: "[]"
-      lts_cmake_extra_args:
-        type: string
-        required: false
-        default: ""
-      lts_ref:
-        type: string
-        required: false
-        default: 'intel'
       cts_matrix:
         type: string
         required: false
@@ -69,10 +61,6 @@ on:
         type: string
         required: false
         default: ""
-      cts_ref:
-        type: string
-        required: false
-        default: 'SYCL-2020'
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
@@ -154,14 +142,6 @@ on:
       #   type: choice
       #   options:
       #     - "[]"
-      # lts_cmake_extra_args:
-      #   type: choice
-      #   options:
-      #     - ""
-      # lts_ref:
-      #   type: choice
-      #   options:
-      #     - "intel"
 
       # cts_matrix:
       #   type: choice
@@ -171,10 +151,6 @@ on:
       #   type: choice
       #   options:
       #     - ""
-      # cts_ref:
-      #   type: choice
-      #   options:
-      #     - "SYCL-2020"
 
       # changes:
       #   description: 'Filter matches for the changed files in the PR'
@@ -339,7 +315,7 @@ jobs:
       runner: ${{ toJSON(matrix.runs-on) }}
       image: ${{ matrix.image }}
       image_options: ${{ matrix.container_options }}
-      extra_cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
+      extra_cmake_args: ${{ matrix.cmake_args }}
       target_devices: ${{ matrix.targets }}
       ref: ${{ inputs.build_ref || github.sha }}
       merge_ref: ${{ inputs.merge_ref }}
@@ -394,7 +370,6 @@ jobs:
     - uses: ./llvm/devops/actions/khronos_cts_test
       name: Run Khronos SYCL CTS
       with:
-        test_ref: ${{ inputs.cts_ref }}
         sycl_artifact: sycl_linux_${{ inputs.build_artifact_suffix }}
         sycl_archive: ${{ inputs.artifact_archive_name }}
         decompress_command: ${{ inputs.artifact_decompress_command }}

--- a/.github/workflows/sycl_precommit_linux.yml
+++ b/.github/workflows/sycl_precommit_linux.yml
@@ -87,7 +87,6 @@ jobs:
       build_ref: ${{ github.event.pull_request.head.sha }}
       merge_ref: ${{ github.event.pull_request.base.sha }}
       build_cache_root: "/__w/"
-      build_cache_size: "8G"
       build_artifact_suffix: "default"
       build_cache_suffix: "default"
       lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}

--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -14,10 +14,6 @@ on:
         type: string
         required: false
         default: "[]"
-      lts_cmake_extra_args:
-        type: string
-        required: false
-        default: ""
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
@@ -161,4 +157,4 @@ jobs:
       with:
         sycl_artifact: sycl_windows_default
         targets: ${{ matrix.targets }}
-        cmake_args: '${{ matrix.cmake_args }} ${{ inputs.lts_cmake_extra_args }}'
+        cmake_args: '${{ matrix.cmake_args }}'


### PR DESCRIPTION
Github has a limit of 10 inputs for manually triggered workflows, so
remove anything unused. We can see how can re-enable them back in future,
if it will become needed.