### PR TITLE
[SYCL][UR] Fix device partition queries (2)

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -469,6 +469,10 @@ inline pi_result ur2piDeviceInfoValue(ur_device_info_t ParamName,
           *pValuePI = pValueUR->value.affinity_domain;
           break;
         }
+        case UR_DEVICE_PARTITION_BY_CSLICE: {
+          *pValuePI = 0;
+          break;
+        }
         default:
           die("UR_DEVICE_INFO_PARTITION_TYPE query returned unsupported type");
         }
@@ -1283,6 +1287,14 @@ inline pi_result piDevicePartition(
   }
 
   std::vector<ur_device_partition_property_t> UrProperties{};
+
+  // UR_DEVICE_PARTITION_BY_CSLICE doesn't have a value, so
+  // handle it outside the while loop below.
+  if (UrType == UR_DEVICE_PARTITION_BY_CSLICE) {
+    ur_device_partition_property_t UrProperty{};
+    UrProperty.type = UrType;
+    UrProperties.push_back(UrProperty);
+  }
   while (*(++Properties)) {
     ur_device_partition_property_t UrProperty;
     UrProperty.type = UrType;
@@ -1299,9 +1311,6 @@ inline pi_result piDevicePartition(
       /* No need to convert affinity domain enums from pi to ur because they
        * are equivalent */
       UrProperty.value.affinity_domain = *Properties;
-      break;
-    }
-    case UR_DEVICE_PARTITION_BY_CSLICE: {
       break;
     }
     default: {

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
@@ -340,6 +340,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
       return UR_RESULT_SUCCESS;
     }
 
+    if (Device->isCCS()) {
+      ur_device_partition_property_t cslice = {
+          UR_DEVICE_PARTITION_BY_CSLICE,
+      };
+
+      return ReturnValue(cslice);
+    }
+
     return ReturnValue(Device->SubDeviceCreationProperty);
   }
   // Everything under here is not supported yet

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -8,12 +8,12 @@
 // RUN: env SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
 // RUN:   ZEX_NUMBER_OF_CCS=0:4 ZE_DEBUG=1 %{run} %t.out  2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
-// Same, but using immediate commandlists:
+// Same, but without using immediate commandlists:
 
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 ZEX_NUMBER_OF_CCS=0:4 \
+// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 ZEX_NUMBER_OF_CCS=0:4 \
 // RUN:   ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
+// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
 // RUN:   ZEX_NUMBER_OF_CCS=0:4 ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
Fix CSLICE partitioning for PVC.

Also, fix level_zero_ext_intel_cslice to correctly test with
and without immediate command list.

Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>
Signed-off-by: Piotr Balcer <piotr.balcer@intel.com>
Signed-off-by: Fábio Mestre <fabio.mestre@codeplay.com>