### PR TITLE
[SYCL][EXT][COMPLEX] Enable std::enable_if via Return type instead of type template parameter

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
@@ -137,13 +137,13 @@ public:
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
       : __re_(__c.real()), __im_(__c.imag()) {}
 
-  template <class _Xp, class = std::enable_if_t<is_genfloat<_Xp>::value>>
+  template <class _Xp, typename = std::enable_if_t<is_genfloat<_Xp>::value>>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
       const std::complex<_Xp> &__c)
       : __re_(static_cast<value_type>(__c.real())),
         __im_(static_cast<value_type>(__c.imag())) {}
 
-  template <class _Xp, class = std::enable_if_t<is_genfloat<_Xp>::value>>
+  template <class _Xp, typename = std::enable_if_t<is_genfloat<_Xp>::value>>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
   operator std::complex<_Xp>() const {
     return std::complex<_Xp>(static_cast<_Xp>(__re_), static_cast<_Xp>(__im_));
@@ -499,9 +499,8 @@ template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
 // real
 
 template <class _Tp>
-__DPCPP_SYCL_EXTERNAL
-    _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr std::enable_if_t<
-        is_genfloat<_Tp>::value, _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
     real(const complex<_Tp> &__c) {
   return __c.real();
 }
@@ -516,9 +515,8 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 // imag
 
 template <class _Tp>
-__DPCPP_SYCL_EXTERNAL
-    _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr std::enable_if_t<
-        is_genfloat<_Tp>::value, _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
     imag(const complex<_Tp> &__c) {
   return __c.imag();
 }
@@ -534,7 +532,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
     abs(const complex<_Tp> &__c) {
   return sycl::hypot(__c.real(), __c.imag());
 }
@@ -543,7 +541,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
     arg(const complex<_Tp> &__c) {
   return sycl::atan2(__c.imag(), __c.real());
 }
@@ -562,7 +560,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
     norm(const complex<_Tp> &__c) {
   if (sycl::isinf(__c.real()))
     return sycl::fabs(__c.real());
@@ -585,7 +583,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     conj(const complex<_Tp> &__c) {
   return complex<_Tp>(__c.real(), -__c.imag());
 }
@@ -604,7 +602,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     proj(const complex<_Tp> &__c) {
   complex<_Tp> __r = __c;
   if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
@@ -632,7 +630,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
   if (sycl::isnan(__rho) || sycl::signbit(__rho))
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
@@ -659,7 +657,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     log(const complex<_Tp> &__x) {
   return complex<_Tp>(sycl::log(abs(__x)), arg(__x));
 }
@@ -668,7 +666,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     log10(const complex<_Tp> &__x) {
   return log(__x) / sycl::log(_Tp(10));
 }
@@ -677,7 +675,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     sqrt(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(_Tp(INFINITY), __x.imag());
@@ -696,7 +694,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     exp(const complex<_Tp> &__x) {
   _Tp __i = __x.imag();
   if (__i == 0) {
@@ -721,15 +719,16 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     pow(const complex<_Tp> &__x, const complex<_Tp> &__y) {
   return exp(__y * log(__x));
 }
 
 template <class _Tp, class _Up>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value,
-                     complex<typename cplx::detail::__promote<_Tp, _Up>::type>>
+    typename std::enable_if_t<
+        is_genfloat<_Tp>::value,
+        complex<typename cplx::detail::__promote<_Tp, _Up>::type>>
     pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
   using result_type = complex<typename cplx::detail::__promote<_Tp, _Up>::type>;
   return pow(result_type(__x), result_type(__y));
@@ -760,7 +759,7 @@ namespace cplx::detail {
 
 template <class _Tp>
 _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     __sqr(const complex<_Tp> &__x) {
   return complex<_Tp>((__x.real() - __x.imag()) * (__x.real() + __x.imag()),
                       _Tp(2) * __x.real() * __x.imag());
@@ -771,7 +770,7 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     asinh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
@@ -801,7 +800,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     acosh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
@@ -836,7 +835,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     atanh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.imag())) {
@@ -868,7 +867,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     sinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(__x.real(), _Tp(NAN));
@@ -884,7 +883,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     cosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
@@ -902,7 +901,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     tanh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real())) {
     if (!sycl::isfinite(__x.imag()))
@@ -926,7 +925,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     asin(const complex<_Tp> &__x) {
   complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
@@ -936,7 +935,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     acos(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
@@ -972,7 +971,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     atan(const complex<_Tp> &__x) {
   complex<_Tp> __z = atanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
@@ -982,7 +981,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     sin(const complex<_Tp> &__x) {
   complex<_Tp> __z = sinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
@@ -992,7 +991,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     cos(const complex<_Tp> &__x) {
   return cosh(complex<_Tp>(-__x.imag(), __x.real()));
 }
@@ -1001,7 +1000,7 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 template <class _Tp>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    typename std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
     tan(const complex<_Tp> &__x) {
   complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());

--- a/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/sycl_complex.hpp
@@ -120,7 +120,7 @@ struct is_genfloat
                                        std::is_same_v<_Tp, sycl::half>> {};
 
 template <class _Tp>
-class complex<_Tp, typename std::enable_if<is_genfloat<_Tp>::value>::type> {
+class complex<_Tp, typename std::enable_if_t<is_genfloat<_Tp>::value>> {
 public:
   typedef _Tp value_type;
 
@@ -137,13 +137,13 @@ public:
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
       : __re_(__c.real()), __im_(__c.imag()) {}
 
-  template <class _Xp, class = std::enable_if<is_genfloat<_Xp>::value>>
+  template <class _Xp, class = std::enable_if_t<is_genfloat<_Xp>::value>>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
       const std::complex<_Xp> &__c)
       : __re_(static_cast<value_type>(__c.real())),
         __im_(static_cast<value_type>(__c.imag())) {}
 
-  template <class _Xp, class = std::enable_if<is_genfloat<_Xp>::value>>
+  template <class _Xp, class = std::enable_if_t<is_genfloat<_Xp>::value>>
   _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
   operator std::complex<_Xp>() const {
     return std::complex<_Xp>(static_cast<_Xp>(__re_), static_cast<_Xp>(__im_));
@@ -498,9 +498,11 @@ template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
 
 // real
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
-real(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL
+    _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr std::enable_if_t<
+        is_genfloat<_Tp>::value, _Tp>
+    real(const complex<_Tp> &__c) {
   return __c.real();
 }
 
@@ -513,9 +515,11 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 
 // imag
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr _Tp
-imag(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL
+    _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr std::enable_if_t<
+        is_genfloat<_Tp>::value, _Tp>
+    imag(const complex<_Tp> &__c) {
   return __c.imag();
 }
 
@@ -528,17 +532,19 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
 
 // abs
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-abs(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    abs(const complex<_Tp> &__c) {
   return sycl::hypot(__c.real(), __c.imag());
 }
 
 // arg
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-arg(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    arg(const complex<_Tp> &__c) {
   return sycl::atan2(__c.imag(), __c.real());
 }
 
@@ -554,9 +560,10 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 // norm
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY _Tp
-norm(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    norm(const complex<_Tp> &__c) {
   if (sycl::isinf(__c.real()))
     return sycl::fabs(__c.real());
   if (sycl::isinf(__c.imag()))
@@ -576,9 +583,10 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 // conj
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-conj(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    conj(const complex<_Tp> &__c) {
   return complex<_Tp>(__c.real(), -__c.imag());
 }
 
@@ -594,9 +602,10 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 // proj
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-proj(const complex<_Tp> &__c) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    proj(const complex<_Tp> &__c) {
   complex<_Tp> __r = __c;
   if (sycl::isinf(__c.real()) || sycl::isinf(__c.imag()))
     __r = complex<_Tp>(INFINITY, sycl::copysign(_Tp(0), __c.imag()));
@@ -621,9 +630,10 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
 
 // polar
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
   if (sycl::isnan(__rho) || sycl::signbit(__rho))
     return complex<_Tp>(_Tp(NAN), _Tp(NAN));
   if (sycl::isnan(__theta)) {
@@ -647,25 +657,28 @@ polar(const _Tp &__rho, const _Tp &__theta = _Tp()) {
 
 // log
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-log(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    log(const complex<_Tp> &__x) {
   return complex<_Tp>(sycl::log(abs(__x)), arg(__x));
 }
 
 // log10
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-log10(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    log10(const complex<_Tp> &__x) {
   return log(__x) / sycl::log(_Tp(10));
 }
 
 // sqrt
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-sqrt(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    sqrt(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.imag()))
     return complex<_Tp>(_Tp(INFINITY), __x.imag());
   if (sycl::isinf(__x.real())) {
@@ -681,9 +694,10 @@ sqrt(const complex<_Tp> &__x) {
 
 // exp
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-exp(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    exp(const complex<_Tp> &__x) {
   _Tp __i = __x.imag();
   if (__i == 0) {
     return complex<_Tp>(sycl::exp(__x.real()),
@@ -705,46 +719,49 @@ exp(const complex<_Tp> &__x) {
 
 // pow
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-pow(const complex<_Tp> &__x, const complex<_Tp> &__y) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    pow(const complex<_Tp> &__x, const complex<_Tp> &__y) {
   return exp(__y * log(__x));
 }
 
-template <class _Tp, class _Up,
-          class = std::enable_if<is_gencomplex<_Tp>::value>>
+template <class _Tp, class _Up>
 __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
-    complex<typename cplx::detail::__promote<_Tp, _Up>::type>
+    std::enable_if_t<is_genfloat<_Tp>::value,
+                     complex<typename cplx::detail::__promote<_Tp, _Up>::type>>
     pow(const complex<_Tp> &__x, const complex<_Up> &__y) {
-  typedef complex<typename cplx::detail::__promote<_Tp, _Up>::type> result_type;
+  using result_type = complex<typename cplx::detail::__promote<_Tp, _Up>::type>;
   return pow(result_type(__x), result_type(__y));
 }
 
-template <class _Tp, class _Up,
-          class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
-    is_genfloat<_Up>::value,
-    complex<typename cplx::detail::__promote<_Tp, _Up>::type>>::type
-pow(const complex<_Tp> &__x, const _Up &__y) {
-  typedef complex<typename cplx::detail::__promote<_Tp, _Up>::type> result_type;
+template <class _Tp, class _Up>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename std::enable_if_t<
+        is_genfloat<_Tp>::value && is_genfloat<_Up>::value,
+        complex<typename cplx::detail::__promote<_Tp, _Up>::type>>
+    pow(const complex<_Tp> &__x, const _Up &__y) {
+  using result_type = complex<typename cplx::detail::__promote<_Tp, _Up>::type>;
   return pow(result_type(__x), result_type(__y));
 }
 
-template <class _Tp, class _Up,
-          class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY typename std::enable_if<
-    is_genfloat<_Up>::value,
-    complex<typename cplx::detail::__promote<_Tp, _Up>::type>>::type
-pow(const _Tp &__x, const complex<_Up> &__y) {
-  typedef complex<typename cplx::detail::__promote<_Tp, _Up>::type> result_type;
+template <class _Tp, class _Up>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    typename std::enable_if_t<
+        is_genfloat<_Tp>::value && is_genfloat<_Up>::value,
+        complex<typename cplx::detail::__promote<_Tp, _Up>::type>>
+    pow(const _Tp &__x, const complex<_Up> &__y) {
+  using result_type = complex<typename cplx::detail::__promote<_Tp, _Up>::type>;
   return pow(result_type(__x), result_type(__y));
 }
 
 namespace cplx::detail {
 // __sqr, computes pow(x, 2)
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-_SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
+template <class _Tp>
+_SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    __sqr(const complex<_Tp> &__x) {
   return complex<_Tp>((__x.real() - __x.imag()) * (__x.real() + __x.imag()),
                       _Tp(2) * __x.real() * __x.imag());
 }
@@ -752,9 +769,10 @@ _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp> __sqr(const complex<_Tp> &__x) {
 
 // asinh
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-asinh(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    asinh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -781,9 +799,10 @@ asinh(const complex<_Tp> &__x) {
 
 // acosh
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-acosh(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    acosh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -815,9 +834,10 @@ acosh(const complex<_Tp> &__x) {
 
 // atanh
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-atanh(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    atanh(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.imag())) {
     return complex<_Tp>(sycl::copysign(_Tp(0), __x.real()),
@@ -846,9 +866,10 @@ atanh(const complex<_Tp> &__x) {
 
 // sinh
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-sinh(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    sinh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(__x.real(), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -861,9 +882,10 @@ sinh(const complex<_Tp> &__x) {
 
 // cosh
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-cosh(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    cosh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real()) && !sycl::isfinite(__x.imag()))
     return complex<_Tp>(sycl::fabs(__x.real()), _Tp(NAN));
   if (__x.real() == 0 && !sycl::isfinite(__x.imag()))
@@ -878,9 +900,10 @@ cosh(const complex<_Tp> &__x) {
 
 // tanh
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-tanh(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    tanh(const complex<_Tp> &__x) {
   if (sycl::isinf(__x.real())) {
     if (!sycl::isfinite(__x.imag()))
       return complex<_Tp>(sycl::copysign(_Tp(1), __x.real()), _Tp(0));
@@ -901,18 +924,20 @@ tanh(const complex<_Tp> &__x) {
 
 // asin
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-asin(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    asin(const complex<_Tp> &__x) {
   complex<_Tp> __z = asinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
 
 // acos
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-acos(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    acos(const complex<_Tp> &__x) {
   const _Tp __pi(sycl::atan2(_Tp(+0.), _Tp(-0.)));
   if (sycl::isinf(__x.real())) {
     if (sycl::isnan(__x.imag()))
@@ -945,35 +970,39 @@ acos(const complex<_Tp> &__x) {
 
 // atan
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-atan(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    atan(const complex<_Tp> &__x) {
   complex<_Tp> __z = atanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
 
 // sin
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-sin(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    sin(const complex<_Tp> &__x) {
   complex<_Tp> __z = sinh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }
 
 // cos
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-cos(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    cos(const complex<_Tp> &__x) {
   return cosh(complex<_Tp>(-__x.imag(), __x.real()));
 }
 
 // tan
 
-template <class _Tp, class = std::enable_if<is_gencomplex<_Tp>::value>>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY complex<_Tp>
-tan(const complex<_Tp> &__x) {
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
+    std::enable_if_t<is_genfloat<_Tp>::value, complex<_Tp>>
+    tan(const complex<_Tp> &__x) {
   complex<_Tp> __z = tanh(complex<_Tp>(-__x.imag(), __x.real()));
   return complex<_Tp>(__z.imag(), -__z.real());
 }


### PR DESCRIPTION
Following a review of the marray complex specialization PR (https://github.com/intel/llvm/pull/8647), where the `std::enable_if` are enabled via template type parameter. It has been asked to be switched to return type instead; this PR follows the same approach to have a coherent codebase.

Furthermore, all `std::enable_if<...>::type` has been switched to `std::enable_if_t` for coherence.

And finally, this PR also fixes a bug where the `std::enable_if` depends on the trait `is_gencomplex`, but should depend on `is_genfloat`  since the functions are specialized for `complex<T>`, `T` is the one that should be tested.