### PR TITLE
[SYCL][L0] Optimize mutex acquisition.

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.cpp
@@ -816,13 +816,16 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle) {
 // the event, updates the last command event in the queue and cleans up all dep
 // events of the event.
 // If the caller locks queue mutex then it must pass 'true' to QueueLocked.
-ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked) {
+ur_result_t CleanupCompletedEvent(ur_event_handle_t Event, bool QueueLocked,
+                                  bool SetEventCompleted) {
   ur_kernel_handle_t AssociatedKernel = nullptr;
   // List of dependent events.
   std::list<ur_event_handle_t> EventsToBeReleased;
   ur_queue_handle_t AssociatedQueue = nullptr;
   {
     std::scoped_lock<ur_shared_mutex> EventLock(Event->Mutex);
+    if (SetEventCompleted)
+      Event->Completed = true;
     // Exit early of event was already cleanedup.
     if (Event->CleanedUp)
       return UR_RESULT_SUCCESS;

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
@@ -237,7 +237,8 @@ template <> ze_result_t zeHostSynchronize(ze_command_queue_handle_t Handle);
 // events of the event.
 // If the caller locks queue mutex then it must pass 'true' to QueueLocked.
 ur_result_t CleanupCompletedEvent(ur_event_handle_t Event,
-                                  bool QueueLocked = false);
+                                  bool QueueLocked = false,
+                                  bool SetEventCompleted = false);
 
 // Get value of device scope events env var setting or default setting
 static const EventsScope DeviceEventsSetting = [] {

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
@@ -1349,11 +1349,7 @@ ur_result_t CleanupEventListFromResetCmdList(
   for (auto &Event : EventListToCleanup) {
     // We don't need to synchronize the events since the fence associated with
     // the command list was synchronized.
-    {
-      std::scoped_lock<ur_shared_mutex> EventLock(Event->Mutex);
-      Event->Completed = true;
-    }
-    UR_CALL(CleanupCompletedEvent(Event, QueueLocked));
+    UR_CALL(CleanupCompletedEvent(Event, QueueLocked, true));
     // This event was removed from the command list, so decrement ref count
     // (it was incremented when they were added to the command list).
     UR_CALL(urEventReleaseInternal(Event));


### PR DESCRIPTION
CleanupEventListFromResetCmdList sets the event as completed under mutex.
Then releases the mutex and calls CleanupCompletedEvent.
In this method the same mutex is taken again.
This causes that we take the same mutex twice for every event in
CleanupEventListFromResetCmdList.
This change adds paramter to CleanupCompletedEvent and moves the code
from CleanupEventListFromResetCmdList to CleanupCompletedEvent, which
avoids taking the same mutex twice.

Signed-off-by: mmrozek <michal.mrozek@intel.com>