### PR TITLE
[SYCL] Fix std::enable_if typo

### DIFF
--- a/sycl/include/sycl/marray.hpp
+++ b/sycl/include/sycl/marray.hpp
@@ -132,7 +132,7 @@ public:
 
   // Available only when: NumElements == 1
   template <std::size_t Size = NumElements,
-            typename = typename std::enable_if<Size == 1>>
+            typename = std::enable_if_t<Size == 1>>
   operator Type() const {
     return MData[0];
   }
@@ -210,7 +210,7 @@ public:
 
 #define __SYCL_BINOP_INTEGRAL(BINOP, OPASSIGN)                                 \
   template <typename T = DataT,                                                \
-            typename = std::enable_if<std::is_integral_v<T>, marray>>          \
+            typename = std::enable_if_t<std::is_integral_v<T>, marray>>        \
   friend marray operator BINOP(const marray &Lhs, const marray &Rhs) {         \
     marray Ret;                                                                \
     for (size_t I = 0; I < NumElements; ++I) {                                 \
@@ -235,7 +235,7 @@ public:
     return marray(static_cast<DataT>(Lhs)) BINOP Rhs;                          \
   }                                                                            \
   template <typename T = DataT,                                                \
-            typename = std::enable_if<std::is_integral_v<T>, marray>>          \
+            typename = std::enable_if_t<std::is_integral_v<T>, marray>>        \
   friend marray &operator OPASSIGN(marray &Lhs, const marray &Rhs) {           \
     Lhs = Lhs BINOP Rhs;                                                       \
     return Lhs;                                                                \

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -1437,7 +1437,7 @@ address_space_cast(ElementType *pointer) {
 template <
     typename ElementType, access::address_space Space,
     access::decorated DecorateAddress = access::decorated::legacy,
-    typename = std::enable_if<DecorateAddress == access::decorated::legacy>>
+    typename = std::enable_if_t<DecorateAddress == access::decorated::legacy>>
 __SYCL2020_DEPRECATED("make_ptr is deprecated since SYCL 2020. Please use "
                       "address_space_cast instead.")
 multi_ptr<ElementType, Space, DecorateAddress> make_ptr(
@@ -1449,7 +1449,7 @@ multi_ptr<ElementType, Space, DecorateAddress> make_ptr(
 template <
     typename ElementType, access::address_space Space,
     access::decorated DecorateAddress,
-    typename = std::enable_if<DecorateAddress != access::decorated::legacy>>
+    typename = std::enable_if_t<DecorateAddress != access::decorated::legacy>>
 __SYCL2020_DEPRECATED("make_ptr is deprecated since SYCL 2020. Please use "
                       "address_space_cast instead.")
 multi_ptr<ElementType, Space, DecorateAddress> make_ptr(

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -328,7 +328,7 @@ int main() {
           // expected-warning@+8{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
           // expected-warning@+8{{'get_pointer' is deprecated: accessor::get_pointer() is deprecated, please use get_multi_ptr()}}
           // expected-warning@+7{{'get_pointer<sycl::access::target::global_buffer, void>' is deprecated: accessor::get_pointer() is deprecated, please use get_multi_ptr()}}
-          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::global_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
+          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::global_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
           sycl::multi_ptr<int, sycl::access::address_space::global_space,
                           sycl::access::decorated::legacy>
               LegacyGlobalMptr =
@@ -338,7 +338,7 @@ int main() {
           // expected-warning@+5{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
           // expected-warning@+7{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
           // expected-warning@+7{{'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr()}}
-          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::local_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
+          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::local_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
           sycl::multi_ptr<int, sycl::access::address_space::local_space,
                           sycl::access::decorated::legacy>
               LegacyLocalMptr =
@@ -347,7 +347,7 @@ int main() {
                       LocalAcc.get_pointer());
 
           // expected-warning@+4{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
-          // expected-warning@+5{{'make_ptr<int, sycl::access::address_space::private_space, sycl::access::decorated::legacy, std::enable_if<true>>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
+          // expected-warning@+5{{'make_ptr<int, sycl::access::address_space::private_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
           // expected-warning@+6{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
           sycl::multi_ptr<int, sycl::access::address_space::private_space,
                           sycl::access::decorated::legacy>


### PR DESCRIPTION
This PR introduces a fix for the `marray.hpp` and `multi_ptr.hpp` where the trait `std::enable_if` had a typo and thus was not restraining the function depending on the inner condition.

```
std::enable_if<...> // does not restrain
std::enable_if_t<...> or std::enable_if<...>::type // does restrain
```

It also fixes the test of `multi_ptr`, where when the function is called with the correct arguments, the default template argument will be used, and the second template parameter will be deduced as void, not `std::enable_if<true>`