### PR TITLE
[SYCL][UR][L0] Use atoi instead of stoi when reading env vars

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
@@ -78,7 +78,7 @@ static const bool UseMemcpy2DOperations = [] {
       UrRet ? UrRet : (PiRet ? PiRet : nullptr);
   if (!UseMemcpy2DOperationsFlag)
     return false;
-  return std::stoi(UseMemcpy2DOperationsFlag) > 0;
+  return std::atoi(UseMemcpy2DOperationsFlag) > 0;
 }();
 
 UR_APIEXPORT ur_result_t UR_APICALL urContextGetInfo(

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
@@ -861,7 +861,7 @@ ur_device_handle_t_::useImmediateCommandLists() {
         UrRet ? UrRet : (PiRet ? PiRet : nullptr);
     if (!ImmediateCommandlistsSettingStr)
       return -1;
-    return std::stoi(ImmediateCommandlistsSettingStr);
+    return std::atoi(ImmediateCommandlistsSettingStr);
   }();
 
   if (ImmediateCommandlistsSetting == -1)

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.cpp
@@ -37,7 +37,7 @@ static const bool UseMultipleCmdlistBarriers = [] {
       UrRet ? UrRet : (PiRet ? PiRet : nullptr);
   if (!UseMultipleCmdlistBarriersFlag)
     return true;
-  return std::stoi(UseMultipleCmdlistBarriersFlag) > 0;
+  return std::atoi(UseMultipleCmdlistBarriersFlag) > 0;
 }();
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWait(

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
@@ -40,7 +40,7 @@ const bool DisableEventsCaching = [] {
       UrRet ? UrRet : (PiRet ? PiRet : nullptr);
   if (!DisableEventsCachingFlag)
     return false;
-  return std::stoi(DisableEventsCachingFlag) != 0;
+  return std::atoi(DisableEventsCachingFlag) != 0;
 }();
 
 // This is an experimental option that allows reset and reuse of uncompleted
@@ -52,7 +52,7 @@ const bool ReuseDiscardedEvents = [] {
       UrRet ? UrRet : (PiRet ? PiRet : nullptr);
   if (!ReuseDiscardedEventsFlag)
     return true;
-  return std::stoi(ReuseDiscardedEventsFlag) > 0;
+  return std::atoi(ReuseDiscardedEventsFlag) > 0;
 }();
 
 const bool FilterEventWaitList = [] {


### PR DESCRIPTION
This to handle scenarios where incorrect values or strings are passed to the variables.