### PR TITLE
[SYCL][E2] Add "UNSUPPORTED: ze_debug" for some tests

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: level_zero
+// UNSUPPORTED: ze_debug
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Plugin/level_zero_batch_test_copy_with_compute.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_batch_test_copy_with_compute.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: ze_debug
 
 // RUN: %{build} -o %t.out
 

--- a/sycl/test-e2e/Plugin/level_zero_dynamic_batch_test.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_dynamic_batch_test.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: ze_debug
 
 // RUN: %{build} -o %t.ooo.out
 // RUN: %{build} -DUSING_INORDER -o %t.ino.out

--- a/sycl/test-e2e/Plugin/level_zero_queue_profiling.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_queue_profiling.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: ze_debug
 
 // RUN: %{build} -o %t.out
 // RUN: env ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=WITHOUT %s

--- a/sycl/test-e2e/Plugin/level_zero_usm_device_read_only.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_usm_device_read_only.cpp
@@ -1,4 +1,5 @@
 // REQUIRES: gpu, level_zero
+// UNSUPPORTED: ze_debug
 
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_PI_TRACE=2 ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s


### PR DESCRIPTION
We use that to run the tests with ZE_DEBUG=6 to avoid unintended interaction with CHECKs in the majority of tests but that also means that tests explicitly requesting ZE_DEBUG=1 can't be executed under such scenario.