### PR TITLE
Fix missing types in Ubuntu 22

### DIFF
--- a/sycl/include/sycl/detail/stl_type_traits.hpp
+++ b/sycl/include/sycl/detail/stl_type_traits.hpp
@@ -11,6 +11,7 @@
 #include <sycl/detail/defines_elementary.hpp>
 
 #include <iterator>
+#include <memory>
 #include <type_traits>
 
 namespace sycl {


### PR DESCRIPTION
We met build failure in building sycl cts on Ubuntu 22 after #10458.
quite some types are not defined 
 unknown type name 'uint16_t'


This is to restore include of <memory> to fix the failures.
