### PR TITLE
[SYCL] Add missing include for uint16_t type

### DIFF
--- a/sycl/include/sycl/half_type.hpp
+++ b/sycl/include/sycl/half_type.hpp
@@ -15,6 +15,7 @@
 #include <sycl/detail/iostream_proxy.hpp>
 #include <sycl/detail/vector_traits.hpp>
 
+#include <cstdint> // for uint16_t
 #include <functional>
 #include <limits>
 


### PR DESCRIPTION
half_type.hpp uses uint16_t type without including proper standard
library header.
