### PR TITLE
[SYCL][Driver] Add hidden option to specify spirv-to-ir-wrapper flags

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -894,6 +894,11 @@ def Xspirv_translator : Separate<["-"], "Xspirv-translator">,
 def Xspirv_translator_EQ : JoinedAndSeparate<["-"], "Xspirv-translator=">,
   HelpText<"Pass <arg> to the LLVM IR to SPIR-V translation backend identified by <triple>.">,
   MetaVarName<"<triple> <arg>">, Flags<[CoreOption, HelpHidden]>;
+def Xspirv_to_ir_wrapper : Separate<["-"], "Xspirv-to-ir-wrapper">,
+  HelpText<"Pass <arg> to the SPIR-V to LLVM IR translation backend.">, MetaVarName<"<arg>">, Flags<[CoreOption, HelpHidden]>;
+def Xspirv_to_ir_wrapper_EQ : JoinedAndSeparate<["-"], "Xspirv-to-ir-wrapper=">,
+  HelpText<"Pass <arg> to the SPIR-V to LLVM IR translation backend identified by <triple>.">,
+  MetaVarName<"<triple> <arg>">, Flags<[CoreOption, HelpHidden]>;
 def Xsycl_backend : Separate<["-"], "Xsycl-target-backend">,
   HelpText<"Pass <arg> to the SYCL based target backend.">, MetaVarName<"<arg>">, Flags<[CoreOption]>;
 def Xsycl_backend_EQ : JoinedAndSeparate<["-"], "Xsycl-target-backend=">,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10107,6 +10107,14 @@ void SpirvToIrWrapper::ConstructJob(Compilation &C, const JobAction &JA,
            "--spirv-preserve-auxdata --spirv-target-env=SPV-IR "
            "--spirv-builtin-format=global"});
 
+  const toolchains::SYCLToolChain &TC =
+      static_cast<const toolchains::SYCLToolChain &>(getToolChain());
+
+  // Handle -Xspirv-to-ir-wrapper
+  TC.TranslateTargetOpt(TCArgs, CmdArgs, options::OPT_Xspirv_to_ir_wrapper,
+                        options::OPT_Xspirv_to_ir_wrapper_EQ,
+                        JA.getOffloadingArch());
+
   auto Cmd = std::make_unique<Command>(
       JA, *this, ResponseFileSupport::None(),
       TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),

--- a/clang/test/Driver/sycl-spirv-to-ir-opt.cpp
+++ b/clang/test/Driver/sycl-spirv-to-ir-opt.cpp
@@ -1,0 +1,22 @@
+///
+/// Tests for -Xspirv-to-ir-wrapper
+///
+
+// RUN: touch %tfoo.o
+// RUN: %clangxx -fsycl -Xspirv-to-ir-wrapper "foo" -### %tfoo.o 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET
+
+// RUN: %clangxx -fsycl -Xspirv-to-ir-wrapper=spir64_gen "foo" -### %tfoo.o 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-SINGLE-TARGET-UNUSED --implicit-check-not 'spirv-to-ir-wrapper{{.*}} "foo"'
+
+// RUN: %clangxx -fsycl -fsycl-targets=spir64,spir64_gen -Xspirv-to-ir-wrapper=spir64_gen "foo" -Xspirv-to-ir-wrapper=spir64 "bar" -### %tfoo.o 2>&1 | \
+// RUN:  FileCheck %s -check-prefix CHECK-MULTIPLE-TARGET --implicit-check-not 'spirv-to-ir-wrapper{{.*}} "foo" "bar"'
+
+// CHECK-SINGLE-TARGET: spirv-to-ir-wrapper{{.*}} "foo"
+
+// CHECK-SINGLE-TARGET-UNUSED: argument unused during compilation: '-Xspirv-to-ir-wrapper=spir64_gen foo'
+
+// CHECK-MULTIPLE-TARGET: spirv-to-ir-wrapper{{.*}} "bar"
+// CHECK-MULTIPLE-TARGET: clang-offload-wrapper{{.*}} "-target=spir64" "-kind=sycl"
+// CHECK-MULTIPLE-TARGET: spirv-to-ir-wrapper{{.*}} "foo"
+// CHECK-MULTIPLE-TARGET: clang-offload-wrapper{{.*}} "-target=spir64_gen" "-kind=sycl"


### PR DESCRIPTION
This is a hidden option and is not intended for use by end users. It has value for local testing and validation of the generated SPIR-V.

This addresses a missed usecase from https://github.com/intel/llvm/pull/9569