### PR TITLE
[SYCL][E2E] Use float instead of double in InlineAsm/asm_float_imm_arg.cpp

### DIFF
--- a/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
@@ -1,6 +1,3 @@
-// https://github.com/intel/llvm/issues/10369
-// UNSUPPORTED: gpu
-//
 // UNSUPPORTED: cuda, hip
 // REQUIRES: gpu,linux
 // RUN: %{build} -o %t.out
@@ -12,8 +9,8 @@
 #include <sycl/sycl.hpp>
 #include <vector>
 
-constexpr double IMM_ARGUMENT = 0.5;
-using dataType = sycl::opencl::cl_double;
+constexpr float IMM_ARGUMENT = 0.5;
+using dataType = sycl::opencl::cl_float;
 
 template <typename T = dataType>
 struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
@@ -45,7 +42,7 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 int main() {
   std::vector<dataType> input(DEFAULT_PROBLEM_SIZE);
   for (int i = 0; i < DEFAULT_PROBLEM_SIZE; i++)
-    input[i] = (double)1 / std::pow(2, i);
+    input[i] = (float)1 / std::pow(2, i);
 
   KernelFunctor<> f(input);
   if (!launchInlineASMTest(f))


### PR DESCRIPTION
And re-enable it after the temporary disablement during GEN12 transition.