### PR TITLE
[SYCL][E2E] Use float instead of double in Regression/commandlist/gpu.cpp

### DIFF
--- a/sycl/test-e2e/Regression/commandlist/Inputs/FindPrimesSYCL.cpp
+++ b/sycl/test-e2e/Regression/commandlist/Inputs/FindPrimesSYCL.cpp
@@ -51,7 +51,7 @@ float find_prime_s(work *w) {
         if (number < N) {
           for (size_t i = 0; i < niter; ++i) {
             bool is_prime = !(number % 2 == 0);
-            const int upper_bound = sycl::sqrt(1.0 * number) + 1;
+            const int upper_bound = sycl::sqrt(1.0f * number) + 1;
             int k = 3;
             while (k < upper_bound && is_prime) {
               is_prime = !(number % k == 0);

--- a/sycl/test-e2e/Regression/commandlist/gpu.cpp
+++ b/sycl/test-e2e/Regression/commandlist/gpu.cpp
@@ -1,6 +1,3 @@
-// https://github.com/intel/llvm/issues/10369
-// UNSUPPORTED: gpu
-//
 // REQUIRES: gpu, linux
 
 // UNSUPPORTED: ze_debug


### PR DESCRIPTION
And re-enable it (was disabled during transition to GEN12 runners).