### PR TITLE
[SYCL] Ignore vec_type_hint attribute in SYCL 2020

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -4031,6 +4031,7 @@ def VecTypeHint : InheritableAttr {
   let Spellings = [GNU<"vec_type_hint">, CXX11<"sycl", "vec_type_hint">];
   let Args = [TypeArgument<"TypeHint">];
   let Subjects = SubjectList<[Function], ErrorDiag>;
+  let SupportsNonconformingLambdaSyntax = 1;
   let Documentation = [Undocumented];
 }
 

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -11979,6 +11979,9 @@ def warn_ivdep_attribute_argument : Warning<
 def warn_attribute_spelling_deprecated : Warning<
   "attribute %0 is deprecated">,
   InGroup<DeprecatedAttributes>;
+def warn_attribute_deprecated_ignored : Warning<
+  "attribute %0 is deprecated; attribute ignored">,
+  InGroup<DeprecatedAttributes>;
 def note_spelling_suggestion : Note<
   "did you mean to use %0 instead?">;
 def warn_attribute_requires_non_negative_integer_argument :

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -4550,8 +4550,11 @@ static void handleSYCLIntelLoopFuseAttr(Sema &S, Decl *D, const ParsedAttr &A) {
 
 static void handleVecTypeHint(Sema &S, Decl *D, const ParsedAttr &AL) {
   // This attribute is deprecated without replacement in SYCL 2020 mode.
-  if (S.LangOpts.getSYCLVersion() > LangOptions::SYCL_2017)
-    S.Diag(AL.getLoc(), diag::warn_attribute_spelling_deprecated) << AL;
+  // Ignore the attribute in SYCL 2020.
+  if (S.LangOpts.getSYCLVersion() > LangOptions::SYCL_2017) {
+    S.Diag(AL.getLoc(), diag::warn_attribute_deprecated_ignored) << AL;
+    return;
+  }
 
   // If the attribute is used with the [[sycl::vec_type_hint]] spelling in SYCL
   // 2017 mode, we want to warn about using the newer name in the older

--- a/clang/test/SemaSYCL/vec-type-hint-2.cpp
+++ b/clang/test/SemaSYCL/vec-type-hint-2.cpp
@@ -1,0 +1,26 @@
+// RUN: %clang_cc1 -fsycl-is-device -sycl-std=2020 -internal-isystem %S/Inputs -fsyntax-only -verify %s
+
+// Test which verifies [[sycl::vec_type_hint()]] is accepted
+// with non-conforming lambda syntax.
+
+// NOTE: This attribute is not supported in the SYCL backends.
+// To be minimally conformant with SYCL2020, attribute is
+// accepted by the Clang FE with a warning. No additional
+// semanatic handling or IR generation is done for this
+// attribute.
+
+#include "sycl.hpp"
+
+struct test {};
+
+using namespace sycl;
+queue q;
+
+void bar() {
+  q.submit([&](handler &h) {
+    h.single_task<class kernelname>(
+        // expected-warning@+1 {{attribute 'vec_type_hint' is deprecated; attribute ignored}}
+        []() [[sycl::vec_type_hint(test)]] {});
+  });
+}
+

--- a/clang/test/SemaSYCL/vec-type-hint-2.cpp
+++ b/clang/test/SemaSYCL/vec-type-hint-2.cpp
@@ -6,7 +6,7 @@
 // NOTE: This attribute is not supported in the SYCL backends.
 // To be minimally conformant with SYCL2020, attribute is
 // accepted by the Clang FE with a warning. No additional
-// semanatic handling or IR generation is done for this
+// semantic handling or IR generation is done for this
 // attribute.
 
 #include "sycl.hpp"

--- a/clang/test/SemaSYCL/vec-type-hint.cpp
+++ b/clang/test/SemaSYCL/vec-type-hint.cpp
@@ -4,6 +4,7 @@
 
 // opencl-no-diagnostics
 // sycl-2017-no-diagnostics
+
 // __attribute__((vec_type_hint)) is deprecated without replacement in SYCL
 // 2020 mode, but is allowed in SYCL 2017 and OpenCL modes.
 KERNEL __attribute__((vec_type_hint(int))) void foo() {} // sycl-2020-warning {{attribute 'vec_type_hint' is deprecated; attribute ignored}}

--- a/clang/test/SemaSYCL/vec-type-hint.cpp
+++ b/clang/test/SemaSYCL/vec-type-hint.cpp
@@ -4,7 +4,6 @@
 
 // opencl-no-diagnostics
 // sycl-2017-no-diagnostics
-
 // __attribute__((vec_type_hint)) is deprecated without replacement in SYCL
 // 2020 mode, but is allowed in SYCL 2017 and OpenCL modes.
-KERNEL __attribute__((vec_type_hint(int))) void foo() {} // sycl-2020-warning {{attribute 'vec_type_hint' is deprecated}}
+KERNEL __attribute__((vec_type_hint(int))) void foo() {} // sycl-2020-warning {{attribute 'vec_type_hint' is deprecated; attribute ignored}}


### PR DESCRIPTION
According to the SYCL 2020 spec, [[sycl::vec_type_hint()]] attribute should accept arguments of the type sycl::vec type. The attribute should also be accepted with non conforming lambda syntax.

The current implementation in SYCL corresponds to the openCL version of this argument (with an additional spelling for SYCL), i.e. the attribute accepts extended vector type, floating point types and integral type. An error diagnostic is thrown for sycl:vec type. 

Since the attribute is deprecated and is not handled by any SYCL backend, and will be removed in a future version of the spec, to be minimally conformant with SYCL 2020 spec, this PR just ignores the attribute instead of adding support for sycl::vec type. Support was also added for non conforming lambda syntax