### PR TITLE
[SYCL-MLIR] Hack to allow polygeist to reuse the clang backend utils

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9040,7 +9040,13 @@ void OffloadBundler::ConstructJob(Compilation &C, const JobAction &JA,
                    ? Action::GetOffloadKindName(Action::OFK_SYCL)
                    : Action::GetOffloadKindName(CurKind);
     Triples += '-';
-    Triples += CurTC->getTriple().normalize();
+    if (CurTC->getTriple().getEnvironment() == llvm::Triple::SYCLMLIR) {
+      llvm::Triple Tmp{CurTC->getTriple().getArchName(),
+                       CurTC->getTriple().getVendorName(),
+                       CurTC->getTriple().getOSName()};
+      Triples += Tmp.normalize();
+    } else
+      Triples += CurTC->getTriple().normalize();
     if ((CurKind == Action::OFK_HIP || CurKind == Action::OFK_OpenMP ||
          CurKind == Action::OFK_Cuda || CurKind == Action::OFK_SYCL) &&
         !StringRef(CurDep->getOffloadingArch()).empty() &&
@@ -9249,8 +9255,16 @@ void OffloadBundler::ConstructJobMultipleOutputs(
           TCArgs.getLastArg(options::OPT_fsycl_force_target_EQ)->getValue());
       llvm::Triple TT(C.getDriver().MakeSYCLDeviceTriple(Val));
       Triples += TT.normalize();
-    } else
-      Triples += Dep.DependentToolChain->getTriple().normalize();
+    } else {
+      if (Dep.DependentToolChain->getTriple().getEnvironment() ==
+          llvm::Triple::SYCLMLIR) {
+        llvm::Triple Tmp{Dep.DependentToolChain->getTriple().getArchName(),
+                         Dep.DependentToolChain->getTriple().getVendorName(),
+                         Dep.DependentToolChain->getTriple().getOSName()};
+        Triples += Tmp.normalize();
+      } else
+        Triples += Dep.DependentToolChain->getTriple().normalize();
+    }
     if ((Dep.DependentOffloadKind == Action::OFK_HIP ||
          Dep.DependentOffloadKind == Action::OFK_OpenMP ||
          Dep.DependentOffloadKind == Action::OFK_Cuda ||

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9255,16 +9255,14 @@ void OffloadBundler::ConstructJobMultipleOutputs(
           TCArgs.getLastArg(options::OPT_fsycl_force_target_EQ)->getValue());
       llvm::Triple TT(C.getDriver().MakeSYCLDeviceTriple(Val));
       Triples += TT.normalize();
-    } else {
-      if (Dep.DependentToolChain->getTriple().getEnvironment() ==
-          llvm::Triple::SYCLMLIR) {
-        llvm::Triple Tmp{Dep.DependentToolChain->getTriple().getArchName(),
-                         Dep.DependentToolChain->getTriple().getVendorName(),
-                         Dep.DependentToolChain->getTriple().getOSName()};
-        Triples += Tmp.normalize();
-      } else
-        Triples += Dep.DependentToolChain->getTriple().normalize();
-    }
+    } else if (Dep.DependentToolChain->getTriple().getEnvironment() ==
+               llvm::Triple::SYCLMLIR) {
+      llvm::Triple Tmp{Dep.DependentToolChain->getTriple().getArchName(),
+                       Dep.DependentToolChain->getTriple().getVendorName(),
+                       Dep.DependentToolChain->getTriple().getOSName()};
+      Triples += Tmp.normalize();
+    } else
+      Triples += Dep.DependentToolChain->getTriple().normalize();
     if ((Dep.DependentOffloadKind == Action::OFK_HIP ||
          Dep.DependentOffloadKind == Action::OFK_OpenMP ||
          Dep.DependentOffloadKind == Action::OFK_Cuda ||

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -258,7 +258,7 @@
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %t.o %s 2>&1     \
 // RUN: | FileCheck -check-prefix=CHK-UNBUNDLER-RAISE %s
 
-// CHK-UNBUNDLER-RAISE: "{{.*}}clang-offload-bundler" "-type=o" "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64-unknown-unknown-syclmlir"
+// CHK-UNBUNDLER-RAISE: "{{.*}}clang-offload-bundler" "-type=o" "-targets=host-x86_64-unknown-linux-gnu,sycl-spir64-unknown-unknown"
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \

--- a/llvm/lib/SYCLLowerIR/MutatePrintfAddrspace.cpp
+++ b/llvm/lib/SYCLLowerIR/MutatePrintfAddrspace.cpp
@@ -89,6 +89,9 @@ SYCLMutatePrintfAddrspacePass::run(Module &M, ModuleAnalysisManager &MAM) {
   for (Function *F : FunctionsToDrop)
     F->eraseFromParent();
 
+  if (CASPrintfFunc->use_empty())
+    CASPrintfFunc->eraseFromParent();
+
   return ModuleChanged ? PreservedAnalyses::all() : PreservedAnalyses::none();
 }
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2712,8 +2712,9 @@ MLIRScanner::getMangledFuncName(const clang::FunctionDecl &FD,
 static bool parseMLIR(const char *Argv0, std::vector<std::string> Filenames,
                       std::string Fn, std::vector<std::string> IncludeDirs,
                       std::vector<std::string> Defines,
-                      OwningOpRef<ModuleOp> &Module, llvm::Triple &Triple,
-                      llvm::DataLayout &DL,
+                      OwningOpRef<ModuleOp> &Module,
+                      std::unique_ptr<clang::CompilerInstance> &Clang,
+                      llvm::Triple &Triple, llvm::DataLayout &DL,
                       std::vector<std::string> InputCommandArgs) {
   clang::IntrusiveRefCntPtr<clang::DiagnosticIDs> DiagID(
       new clang::DiagnosticIDs());
@@ -2804,8 +2805,7 @@ static bool parseMLIR(const char *Argv0, std::vector<std::string> Filenames,
                  Filenames.size() == 1 ? Filenames[0] : "LLVMDialectModule");
 
   for (const llvm::opt::ArgStringList *Args : CommandList) {
-    std::unique_ptr<clang::CompilerInstance> Clang(
-        new clang::CompilerInstance());
+    Clang.reset(new clang::CompilerInstance());
 
     Success = clang::CompilerInvocation::CreateFromArgs(Clang->getInvocation(),
                                                         *Args, Diags);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -282,4 +282,4 @@ extern "C" SYCL_EXTERNAL void cons_11() {
 }
 
 // Keep at the end.
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/Test/Verification/sycl/constructors.cpp" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/Test/Verification/sycl/constructors.cpp" "sycl-optlevel"="0" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -29,6 +29,7 @@
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE(
 // CHECK-LLVM-SAME:        ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
 // CHECK-LLVM-SAME:        ptr noundef byval({ ptr addrspace(1) }) align 8 %1)
+// CHECK-LLVM-NEXT:    call void @__itt_offload_wi_start_wrapper()
 // CHECK-LLVM-NEXT:    %3 = alloca %"class.sycl::_V1::item.1.true", align 8
 // CHECK-LLVM-NEXT:    %4 = alloca { ptr addrspace(4) }, i64 1, align 8
 // CHECK-LLVM-NEXT:    %5 = alloca %"class.sycl::_V1::range.1", align 8
@@ -50,6 +51,7 @@
 // CHECK-LLVM-NEXT:    %17 = addrspacecast ptr %6 to ptr addrspace(4)
 // CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %16, ptr %3, align 8
 // CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %17, ptr %3)
+// CHECK-LLVM-NEXT:    call void @__itt_offload_wi_finish_wrapper()
 // CHECK-LLVM-NEXT:    ret void
 
 int test(sycl::queue &q) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp
@@ -82,4 +82,4 @@ SYCL_EXTERNAL void function_1(sycl::item<2, true> item) {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" "uniform-work-group-size"="true" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels.cpp" "sycl-optlevel"="0" "uniform-work-group-size"="true" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp
@@ -20,7 +20,7 @@
 // CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTS8kernel_1({{.*}}) #[[FUNCATTRS1:[0-9]+]]
 // CHECK-LLVM-DAG:      define weak_odr spir_kernel void @_ZTSZZ6host_2vENKUlRN4sycl3_V17handlerEE_clES2_E8kernel_2({{.*}}) #[[FUNCATTRS1]]
 
-// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" "uniform-work-group-size"="true" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/kernels_funcs.cpp" "sycl-optlevel"="0" "uniform-work-group-size"="true" }
 
 template <typename DataT,
           int Dimensions = 1,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/single_task.cpp
@@ -4,7 +4,7 @@
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 -w %s -o %t.O3.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 // RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -Ofast -w %s -o %t.Ofast.out 2>&1 | FileCheck %s --allow-empty --implicit-check-not="{{error|Error}}:"
 
-// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
+// RUN: clang++ -Xcgeist --use-opaque-pointers=1 -fno-sycl-instrument-device-code -fsycl -fsycl-device-only -O0 -w -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o %t.bc
 
 // Test that the LLVMIR generated is verifiable.
 // RUN: opt -passes=verify -disable-output < %t.bc

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -43,5 +43,5 @@ void host_single_task() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS0]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" }
-// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" "uniform-work-group-size"="true" }
+// CHECK-LLVM: attributes #[[FUNCATTRS0]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" "sycl-optlevel"="0" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp" "sycl-optlevel"="0" "uniform-work-group-size"="true" }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp
@@ -95,5 +95,5 @@ int main() {
 }
 
 // Keep at the end of the file.
-// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" }
-// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" "uniform-work-group-size"="true" }
+// CHECK-LLVM: attributes #[[FUNCATTRS]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" "sycl-optlevel"="0" }
+// CHECK-LLVM: attributes #[[FUNCATTRS1]] = { convergent mustprogress noinline norecurse nounwind optnone "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="{{.*}}/polygeist/tools/cgeist/Test/Verification/sycl/vec_add.cpp" "sycl-optlevel"="0" "uniform-work-group-size"="true" }

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -1,10 +1,4 @@
-Assert/assert_in_kernels.cpp
-Assert/assert_in_multiple_tus.cpp
-Assert/assert_in_multiple_tus_one_ndebug.cpp
-Assert/assert_in_one_kernel.cpp
-Assert/assert_in_simultaneous_kernels.cpp
 Assert/assert_in_simultaneously_multiple_tus.cpp
-Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
 AtomicRef/accessor.cpp
 AtomicRef/add.cpp
 AtomicRef/add_generic.cpp
@@ -159,7 +153,6 @@ DeviceLib/std_complex_math_fp64_test.cpp
 DeviceLib/std_complex_math_test.cpp
 DeviceLib/string_test.cpp
 DiscardEvents/discard_events_check_images.cpp
-DiscardEvents/discard_events_using_assert.cpp
 DotProduct/dot_product_int_test.cpp
 ESIMD/BitonicSortK.cpp
 ESIMD/BitonicSortKv2.cpp
@@ -369,7 +362,6 @@ GroupAlgorithm/exclusive_scan_sycl2020.cpp
 GroupAlgorithm/inclusive_scan_sycl2020.cpp
 GroupAlgorithm/reduce_sycl2020.cpp
 GroupLocalMemory/group_local_memory.cpp
-GroupLocalMemory/no_early_opt.cpp
 HierPar/hier_par_basic.cpp
 HierPar/hier_par_wgscope.cpp
 HierPar/hier_par_wgscope_O0.cpp
@@ -468,7 +460,6 @@ Printf/int.cpp
 Printf/long.cpp
 Printf/mixed-address-space.cpp
 Printf/percent-symbol.cpp
-PropagateOptionsToBackend/sycl-opt-level-level-zero.cpp
 Properties/cache_config.cpp
 Reduction/reduction_big_data.cpp
 Reduction/reduction_complex_nums.cpp
@@ -584,5 +575,4 @@ USM/memops2d/memcpy2d_shared_to_host.cpp
 USM/memops2d/memcpy2d_shared_to_shared.cpp
 UserDefinedReductions/user_defined_reductions.cpp
 UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
-XPTI/kernel/basic.cpp
 XPTI/kernel/content.cpp


### PR DESCRIPTION
Hack to allow cgiest to use the clang routine to setup the llvm pipeline rather than its own. This allows to capture the SYCL specific pass setup and allows cgeist to honor clang's codegen options.

The patch also fixes a small issue in handling the libsycl unbundling.