### PR TITLE
[NFC][OpaquePtrs] Remove -opaque-pointers option

### DIFF
--- a/llvm/test/SYCLLowerIR/ESIMD/global_opaque_ptrs.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/global_opaque_ptrs.ll
@@ -1,7 +1,7 @@
 ; This test checks whether globals are converted
 ; correctly to llvm's native vector type with opaque pointers.
 ;
-; RUN: opt -opaque-pointers < %s -passes=LowerESIMD -S | FileCheck %s
+; RUN: opt < %s -passes=LowerESIMD -S | FileCheck %s
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"


### PR DESCRIPTION
Update test to remove -opaque-pointers option since it is enabled be default now. 