### PR TITLE
[SYCL][UR] bump UR version

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  set(UNIFIED_RUNTIME_TAG 974a7d64dd1a26ede1ff27919b3b8713b848c376)
+  set(UNIFIED_RUNTIME_TAG 5513ee2f96c4a56b0ae1c1de307505b2f83984ca)
 
   message(STATUS "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO}")
   FetchContent_Declare(unified-runtime


### PR DESCRIPTION
to fix: "'scoped_lock' may not intend to support class template argument deduction [-Werror,-Wctad-maybe-unsupported]"

Ref: https://github.com/oneapi-src/unified-runtime/pull/757

This error showed up after merging: https://github.com/intel/llvm/pull/10269.