### PR TITLE
[ESIMD] Fix LSC APIs that use raw_send

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2875,7 +2875,7 @@ ESIMD_INLINE SYCL_ESIMD_FUNCTION __ESIMD_NS::simd<T, N> lsc_load_2d(
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numDst = (N * sizeof(T)) / 64;
-  __ESIMD_NS::simd<T, ActualN> Raw = raw_send<execSize, numSrc0, numDst, sfid>(
+  __ESIMD_NS::simd<T, ActualN> Raw = raw_send<execSize, sfid, numSrc0, numDst>(
       oldDst, payload.get_raw_data(), exDesc, desc);
 
   if constexpr (ActualN == N) {
@@ -2939,7 +2939,7 @@ ESIMD_INLINE SYCL_ESIMD_FUNCTION void lsc_prefetch_2d(
   constexpr uint8_t execSize = 0x0;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numDst = (N * sizeof(T)) / 64;
-  raw_send<execSize, numDst, sfid>(payload.get_raw_data(), exDesc, desc);
+  raw_send<execSize, sfid, numDst>(payload.get_raw_data(), exDesc, desc);
 }
 
 /// A variation of \c 2D stateless block store \c with parameters passed as
@@ -2979,7 +2979,7 @@ lsc_store_2d(config_2d_mem_access<T, BlockWidth, BlockHeight, NBlocks> &payload,
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numSrc1 = (N * sizeof(T)) / 64;
 
-  raw_sends<execSize, numSrc0, numSrc1, sfid>(payload.get_raw_data(), Data,
+  raw_sends<execSize, sfid, numSrc0, numSrc1>(payload.get_raw_data(), Data,
                                               exDesc, desc);
 }
 


### PR DESCRIPTION
This fixes fallout from https://github.com/intel/llvm/commit/1a5e53216b009177c73dfd6d644a5c016b71b552.

I reordered the template arguments in the review process but missed updating the LSC callsites.

We have tests for this but they don't run in CI. I manually verified the tests pass.