### PR TITLE
[SYCL-MLIR][sycl-raise-host] Handle `parallel_for` "lambda" arguments allocated in a calling function

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -1708,7 +1708,7 @@ private:
     if (blockArg == block->args_end())
       return nullptr;
 
-    // Recurisvely search for alloca defining operation.
+    // Recursively search for alloca defining operation.
     Value callChainAncestor =
         getCallChainAncestor(parentFunction, blockArg->getArgNumber());
     return getAlloca(callChainAncestor);

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -1691,7 +1691,7 @@ private:
             return alloca.getElemType().has_value() ? alloca : nullptr;
           })
           // Safely bail out
-          .Default(LLVM::AllocaOp());
+          .Default(LLVM::AllocaOp(nullptr));
     }
     // Check lambdaObj is a function argument
     Block *block = lambdaObj.getParentBlock();


### PR DESCRIPTION
Handle "lambda" arguments of `parallel_for` allocated in calling function, i.e., the case in which `parallel_for` is not inlined.