### PR TITLE
[XPTI][SYCL] remove filtered XPTI enabling check from XPTIScope

### DIFF
--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -222,9 +222,8 @@ public:
   /// @brief Method that emits begin/end trace notifications
   /// @return Current class
   XPTIScope &scopedNotify(uint16_t TraceType) {
-    TraceType &= 0xfffe;
-    if (xptiCheckTraceEnabled(MStreamID, TraceType) && MTP) {
-      MTraceType = TraceType;
+    if (xptiTraceEnabled() && MTP) {
+      MTraceType = TraceType & 0xfffe;
       MScopedNotify = true;
       xptiNotifySubscribers(MStreamID, MTraceType, nullptr, MTraceEvent,
                             MInstanceID, static_cast<const void *>(MUserData));
@@ -232,7 +231,7 @@ public:
     return *this;
   }
   ~XPTIScope() {
-    if (xptiCheckTraceEnabled(MStreamID, MTraceType) && MTP && MScopedNotify) {
+    if (xptiTraceEnabled() && MTP && MScopedNotify) {
       if (MTraceType == (uint16_t)xpti::trace_point_type_t::signal ||
           MTraceType == (uint16_t)xpti::trace_point_type_t::graph_create ||
           MTraceType == (uint16_t)xpti::trace_point_type_t::node_create ||

--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -222,8 +222,8 @@ public:
   /// @brief Method that emits begin/end trace notifications
   /// @return Current class
   XPTIScope &scopedNotify(uint16_t TraceType) {
-    // Keep this data even if no subscribers for this TraceType (begin). Someone
-    // could still use (end) emitted from destructor.
+    // Keep this data even if no subscribers are for this TraceType (begin).
+    // Someone could still use (end) emitted from destructor.
     MTraceType = TraceType & 0xfffe;
     MScopedNotify = true;
     if (xptiCheckTraceEnabled(MStreamID, TraceType) && MTP) {


### PR DESCRIPTION
collectors could be subscribed for only one trace type from begin-end pair. In this case the logic with filtered check causes wrong logic.