### PR TITLE
[SYCL-MLIR] Add `handler` operand with write effect to `schedule_kernel` op

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -181,8 +181,8 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
   let summary = "Schedules a SYCL kernel launch.";
   let description = [{
     This operation represents the scheduling of a launch of the given kernel
-    function with the specified range and kernel arguments. Its purpose is to
-    collect the information surfaced by the host-raising process about a 
+    function with the specified handler, range and kernel arguments. Its purpose
+    is to collect the information surfaced by the host-raising process about a 
     particular launch, thereby providing an entry-point for host-device analyses
     and optimizations.
 
@@ -205,12 +205,14 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
 
     Example:
     ```
-    sycl.host.schedule_kernel @kernels::@k0[range %1]
-      (%2: !sycl_accessor_1_f32_rw_gb, %3) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+    sycl.host.schedule_kernel %handler -> @kernels::@k0[range %1]
+      (%2: !sycl_accessor_1_f32_rw_gb, %3)
+      : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32) -> ()
     ```
   }];
 
   let arguments = (ins
+    LLVM_AnyPointer:$handler,
     SymbolRefAttr:$kernel_name,
     Optional<LLVM_AnyPointer>:$range,
     Optional<LLVM_AnyPointer>:$offset,
@@ -218,32 +220,36 @@ def SYCLHostScheduleKernel : SYCL_HostOp<"schedule_kernel",
     TypeArrayAttr:$sycl_types,
     UnitAttr:$nd_range);
   let builders = [
-    OpBuilder<(ins "::mlir::SymbolRefAttr":$kernel_name,
+    OpBuilder<(ins "::mlir::Value":$handler,
+                   "::mlir::SymbolRefAttr":$kernel_name,
                    "::mlir::ValueRange":$args), [{
-      build($_builder, $_state, kernel_name, /*range=*/Value(),
+      build($_builder, $_state, handler, kernel_name, /*range=*/Value(),
             /*offset=*/Value(), args);
     }]>,
-    OpBuilder<(ins "::mlir::SymbolRefAttr":$kernel_name,
+    OpBuilder<(ins "::mlir::Value":$handler,
+                   "::mlir::SymbolRefAttr":$kernel_name,
                    "::mlir::Value":$range,
                    "::mlir::ValueRange":$args,
                    "bool":$nd_range), [{
       ::llvm::SmallVector<::mlir::Type> noneTypes(args.size(), $_builder.getNoneType());
       auto syclTypes = $_builder.getTypeArrayAttr(noneTypes);
       auto ndRangeAttr = nd_range ? $_builder.getUnitAttr() : UnitAttr();
-      build($_builder, $_state, kernel_name, range,
+      build($_builder, $_state, handler, kernel_name, range,
             /*offset=*/Value(), args, syclTypes, ndRangeAttr);
     }]>,
-    OpBuilder<(ins "::mlir::SymbolRefAttr":$kernel_name,
+    OpBuilder<(ins "::mlir::Value":$handler,
+                    "::mlir::SymbolRefAttr":$kernel_name,
                    "::mlir::Value":$range,
                    "::mlir::Value":$offset,
                    "::mlir::ValueRange":$args), [{
       ::llvm::SmallVector<::mlir::Type> noneTypes(args.size(), $_builder.getNoneType());
       auto syclTypes = $_builder.getTypeArrayAttr(noneTypes);
-      build($_builder, $_state, kernel_name, range, offset, args, syclTypes);
+      build($_builder, $_state, handler, kernel_name, range, offset, args, syclTypes);
     }]>
   ];
   let assemblyFormat = [{
-    $kernel_name (`[` (`nd_range` $nd_range^):(```range`)? $range^ (`,` `offset` $offset^)? `]`)? ``
+    $handler `->` $kernel_name
+    (`[` (`nd_range` $nd_range^):(```range`)? $range^ (`,` `offset` $offset^)? `]`)? ``
     custom<ArgsWithSYCLTypes>($args, $sycl_types)
     attr-dict `:` functional-type(operands, results)
   }];

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -695,6 +695,10 @@ void SYCLHostScheduleKernel::getEffects(
     SmallVectorImpl<SideEffects::EffectInstance<MemoryEffects::Effect>>
         &effects) {
   auto *defaultResource = SideEffects::DefaultResource::get();
+  // Unconditionally add a write effect on the handler to prevent the op from
+  // being trivially dead when all other operands are read-only.
+  effects.emplace_back(MemoryEffects::Write::get(), getHandler(),
+                       defaultResource);
   // The nd-range arguments will be read from
   if (Value range = getRange())
     effects.emplace_back(MemoryEffects::Read::get(), range, defaultResource);

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -91,66 +91,66 @@ func.func @set_captured(%lambda: !llvm.ptr, %scalar_arg: i16, %struct_arg: !llvm
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_single_task(
-// CHECK-SAME:                                           %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: !llvm.ptr) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0 : () -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]]) : (i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]]) : (i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0(%[[VAL_0]], %[[VAL_1]], %[[VAL_2]]: !sycl_accessor_2_i32_r_gb) : (i32, i32, !llvm.ptr) -> ()
+// CHECK-SAME:                                           %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0 : (!llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_single_task(%arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
-  sycl.host.schedule_kernel @kernels::@k0 : () -> ()
-  sycl.host.schedule_kernel @kernels::@k0(%arg0) : (i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1) : (i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0(%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (i32, i32, !llvm.ptr) -> ()
+func.func @schedule_kernel_single_task(%handler: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
+  sycl.host.schedule_kernel %handler -> @kernels::@k0 : (!llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0) : (!llvm.ptr, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_nd_range(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: !llvm.ptr) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]] : (!llvm.ptr) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[nd_range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_nd_range(%nd_range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
-  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range] : (!llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0) : (!llvm.ptr, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+func.func @schedule_kernel_nd_range(%handler: !llvm.ptr, %nd_range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range] : (!llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_range(
-// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: !llvm.ptr) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]] : (!llvm.ptr) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]]](%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK-SAME:                                     %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_range(%range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
-  sycl.host.schedule_kernel @kernels::@k0[range %range] : (!llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0) : (!llvm.ptr, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+func.func @schedule_kernel_range(%handler: !llvm.ptr, %range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range] : (!llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
 // CHECK-LABEL:   func.func @schedule_kernel_range_with_offset(
-// CHECK-SAME:                                                 %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: i32, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: !llvm.ptr) {
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel @kernels::@k0[range %[[VAL_0]], offset %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr, %[[VAL_3:.*]]: i32, %[[VAL_4:.*]]: i32, %[[VAL_5:.*]]: !llvm.ptr) {
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]] : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]], %[[VAL_4]], %[[VAL_5]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
-func.func @schedule_kernel_range_with_offset(%range: !llvm.ptr, %offset: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
-  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset] : (!llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+func.func @schedule_kernel_range_with_offset(%handler: !llvm.ptr, %range: !llvm.ptr, %offset: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset] : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -590,7 +590,7 @@ func.func @set_captured_non_sycl_type_attribute(%lambda: !llvm.ptr, %value: !llv
 
 func.func @f(%handler: !llvm.ptr) {
   // expected-error @below {{'sycl.host.schedule_kernel' op '@kernels::@k0' does not reference a valid kernel}}
-  sycl.host.schedule_kernel @kernels::@k0 : () -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0 : (!llvm.ptr) -> ()
   func.return
 }
 
@@ -602,9 +602,9 @@ gpu.module @kernels {
 
 // -----
 
-func.func @schedule_kernel_nd_range_unexpected_attr() {
+func.func @schedule_kernel_nd_range_unexpected_attr(%handler: !llvm.ptr) {
   // expected-error @below {{'sycl.host.schedule_kernel' op expects nd_range to be unset when a range is not present}}
-  sycl.host.schedule_kernel @ekernels::@k0 {nd_range} : () -> ()
+  sycl.host.schedule_kernel %handler -> @ekernels::@k0 {nd_range} : (!llvm.ptr) -> ()
   func.return
 }
 
@@ -616,9 +616,9 @@ gpu.module @kernels {
 
 // -----
 
-func.func @schedule_kernel_nd_range_unexpected_offset(%nd_range: !llvm.ptr, %offset: !llvm.ptr) {
+func.func @schedule_kernel_nd_range_unexpected_offset(%handler: !llvm.ptr, %nd_range: !llvm.ptr, %offset: !llvm.ptr) {
   // expected-error @below {{'sycl.host.schedule_kernel' op expects no offset argument if the nd_range attribute is set}}
-  sycl.host.schedule_kernel @ekernels::@k0[nd_range %nd_range, offset %offset] : (!llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @ekernels::@k0[nd_range %nd_range, offset %offset] : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   func.return
 }
 
@@ -630,9 +630,9 @@ gpu.module @kernels {
 
 // -----
 
-func.func @schedule_kernel_inconsistent_type_attributes(%arg0: i32) {
+func.func @schedule_kernel_inconsistent_type_attributes(%handler: !llvm.ptr, %arg0: i32) {
   // expected-error @below {{'sycl.host.schedule_kernel' op has inconsistent SYCL type attributes}}
-  "sycl.host.schedule_kernel"(%arg0) {kernel_name = @kernels::@k0, operand_segment_sizes = array<i32: 0, 0, 1>, sycl_types = [none, none]} : (i32) -> ()
+  "sycl.host.schedule_kernel"(%handler, %arg0) {kernel_name = @kernels::@k0, operand_segment_sizes = array<i32: 1, 0, 0, 1>, sycl_types = [none, none]} : (!llvm.ptr, i32) -> ()
   func.return
 }
 
@@ -644,9 +644,9 @@ gpu.module @kernels {
 
 // -----
 
-func.func @schedule_kernel_scalar_type_attribute(%arg0: i32) {
+func.func @schedule_kernel_scalar_type_attribute(%handler: !llvm.ptr, %arg0: i32) {
   // expected-error @below {{'sycl.host.schedule_kernel' op does not expect a type attribute for a non-pointer value}}
-  sycl.host.schedule_kernel @kernels::@k0(%arg0: i32) : (i32) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0: i32) : (!llvm.ptr, i32) -> ()
   func.return
 }
 
@@ -658,9 +658,9 @@ gpu.module @kernels {
 
 // -----
 
-func.func @schedule_kernel_non_sycl_type_attribute(%arg0: !llvm.ptr) {
+func.func @schedule_kernel_non_sycl_type_attribute(%handler: !llvm.ptr, %arg0: !llvm.ptr) {
   // expected-error @below {{'sycl.host.schedule_kernel' op expects the type attribute to reference a SYCL type}}
-  sycl.host.schedule_kernel @kernels::@k0(%arg0: i32) : (!llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0: i32) : (!llvm.ptr, !llvm.ptr) -> ()
   func.return
 }
 

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -31,9 +31,9 @@ gpu.module @kernels {
   }
 }
 
-llvm.func internal @foo(%res: !llvm.ptr) {
+llvm.func internal @foo(%handler: !llvm.ptr, %res: !llvm.ptr) {
   %c = llvm.mlir.constant(0 : i64) : i64
-  sycl.host.schedule_kernel @kernels::@k0(%res, %c) : (!llvm.ptr, i64) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%res, %c) : (!llvm.ptr, !llvm.ptr, i64) -> ()
   llvm.return
 }
 
@@ -900,6 +900,7 @@ gpu.module @kernels {
 // COM: Check we can detect the offset is constant (all-zeroes)
 
 llvm.func internal @foo_default_offset(
+    %handler: !llvm.ptr,
     %range.0: i64,
     %res.offset: !llvm.ptr, %res.gs: !llvm.ptr,
     %res.ls: !llvm.ptr, %res.nws: !llvm.ptr) {
@@ -908,15 +909,16 @@ llvm.func internal @foo_default_offset(
       : (i32) -> !llvm.ptr
   sycl.host.constructor(%range, %range.0) {type=!sycl_range_1_}
       : (!llvm.ptr, i64) -> ()
-  sycl.host.schedule_kernel @kernels::@k0[range %range](
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](
       %res.offset, %res.gs, %res.ls, %res.nws)
-      : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+      : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }
 
 // COM: Check we can detect the range is constant
 
 llvm.func internal @foo_constant_range(
+    %handler: !llvm.ptr,
     %offset.0: i64,
     %res.offset: !llvm.ptr, %res.gs: !llvm.ptr,
     %res.ls: !llvm.ptr, %res.nws: !llvm.ptr) {
@@ -930,15 +932,16 @@ llvm.func internal @foo_constant_range(
       : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%offset, %offset.0) {type=!sycl_id_1_}
       : (!llvm.ptr, i64) -> ()
-  sycl.host.schedule_kernel @kernels::@k1[range %range, offset %offset](
+  sycl.host.schedule_kernel %handler -> @kernels::@k1[range %range, offset %offset](
       %res.offset, %res.gs, %res.ls, %res.nws)
-      : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+      : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }
 
 // COM: Check we can detect both range and offset are constant
 
 llvm.func internal @foo_constant_range_offset(
+    %handler: !llvm.ptr,
     %res.offset.0: !llvm.ptr, %res.offset.1: !llvm.ptr,
     %res.gs.0: !llvm.ptr, %res.gs.1: !llvm.ptr,
     %res.ls.0: !llvm.ptr, %res.ls.1: !llvm.ptr,
@@ -956,17 +959,18 @@ llvm.func internal @foo_constant_range_offset(
       : (!llvm.ptr, i64, i64) -> ()
   sycl.host.constructor(%offset, %c1_i64, %c2) {type=!sycl_id_2_}
       : (!llvm.ptr, i64, i64) -> ()
-  sycl.host.schedule_kernel @kernels::@k2[range %range, offset %offset](
+  sycl.host.schedule_kernel %handler -> @kernels::@k2[range %range, offset %offset](
       %res.offset.0, %res.offset.1, %res.gs.0, %res.gs.1,
       %res.ls.0, %res.ls.1, %res.nws.0, %res.nws.1)
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }
 
 // COM: Check we can detect default offset (nd-range)
 
 llvm.func internal @foo_default_offset_ndr(
+    %handler: !llvm.ptr,
     %i: i64,
     %res.offset.0: !llvm.ptr, %res.offset.1: !llvm.ptr, %res.offset.2: !llvm.ptr,
     %res.gs.0: !llvm.ptr, %res.gs.1: !llvm.ptr,  %res.gs.2: !llvm.ptr,
@@ -990,12 +994,12 @@ llvm.func internal @foo_default_offset_ndr(
   sycl.host.constructor(%nd_range, %global_size, %local_size)
       {type=!sycl_nd_range_3_}
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k3[nd_range %nd_range](
+  sycl.host.schedule_kernel %handler -> @kernels::@k3[nd_range %nd_range](
       %res.offset.0, %res.offset.1, %res.offset.2, %res.gs.0,
       %res.gs.1, %res.gs.2, %res.ls.0, %res.ls.1,
       %res.ls.2, %res.nws.0, %res.nws.1, %res.nws.2)
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }
@@ -1003,6 +1007,7 @@ llvm.func internal @foo_default_offset_ndr(
 // COM: Check we can detect constant offset (nd-range)
 
 llvm.func internal @foo_constant_constant_offset_ndr(
+    %handler: !llvm.ptr,
     %i: i64,
     %res.offset.0: !llvm.ptr, %res.offset.1: !llvm.ptr, %res.offset.2: !llvm.ptr,
     %res.gs.0: !llvm.ptr, %res.gs.1: !llvm.ptr,  %res.gs.2: !llvm.ptr,
@@ -1030,12 +1035,12 @@ llvm.func internal @foo_constant_constant_offset_ndr(
   sycl.host.constructor(%nd_range, %global_size, %local_size, %offset)
       {type=!sycl_nd_range_3_}
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k4[nd_range %nd_range](
+  sycl.host.schedule_kernel %handler -> @kernels::@k4[nd_range %nd_range](
       %res.offset.0, %res.offset.1, %res.offset.2, %res.gs.0,
       %res.gs.1, %res.gs.2, %res.ls.0, %res.ls.1,
       %res.ls.2, %res.nws.0, %res.nws.1, %res.nws.2)
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-         !llvm.ptr, !llvm.ptr, !llvm.ptr,
+         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
@@ -1044,6 +1049,7 @@ llvm.func internal @foo_constant_constant_offset_ndr(
 // COM: Check we can detect constant global size (nd-range)
 
 llvm.func internal @foo_constant_constant_global_size(
+    %handler: !llvm.ptr,
     %i: i64,
     %res.offset.0: !llvm.ptr, %res.offset.1: !llvm.ptr, %res.offset.2: !llvm.ptr,
     %res.gs.0: !llvm.ptr, %res.gs.1: !llvm.ptr,  %res.gs.2: !llvm.ptr,
@@ -1071,12 +1077,12 @@ llvm.func internal @foo_constant_constant_global_size(
   sycl.host.constructor(%nd_range, %global_size, %local_size, %offset)
       {type=!sycl_nd_range_3_}
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k5[nd_range %nd_range](
+  sycl.host.schedule_kernel %handler -> @kernels::@k5[nd_range %nd_range](
       %res.offset.0, %res.offset.1, %res.offset.2, %res.gs.0,
       %res.gs.1, %res.gs.2, %res.ls.0, %res.ls.1,
       %res.ls.2, %res.nws.0, %res.nws.1, %res.nws.2)
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-         !llvm.ptr, !llvm.ptr, !llvm.ptr,
+         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
@@ -1085,6 +1091,7 @@ llvm.func internal @foo_constant_constant_global_size(
 // COM: Check we can detect constant local size (nd-range)
 
 llvm.func internal @foo_constant_constant_local_size(
+    %handler: !llvm.ptr,
     %i: i64,
     %res.offset.0: !llvm.ptr, %res.offset.1: !llvm.ptr, %res.offset.2: !llvm.ptr,
     %res.gs.0: !llvm.ptr, %res.gs.1: !llvm.ptr,  %res.gs.2: !llvm.ptr,
@@ -1112,12 +1119,12 @@ llvm.func internal @foo_constant_constant_local_size(
   sycl.host.constructor(%nd_range, %global_size, %local_size, %offset)
       {type=!sycl_nd_range_3_}
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k6[nd_range %nd_range](
+  sycl.host.schedule_kernel %handler -> @kernels::@k6[nd_range %nd_range](
       %res.offset.0, %res.offset.1, %res.offset.2, %res.gs.0,
       %res.gs.1, %res.gs.2, %res.ls.0, %res.ls.1,
       %res.ls.2, %res.nws.0, %res.nws.1, %res.nws.2)
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-         !llvm.ptr, !llvm.ptr, !llvm.ptr,
+         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
@@ -1126,6 +1133,7 @@ llvm.func internal @foo_constant_constant_local_size(
 // COM: Check we can detect constant global and local size (nd-range)
 
 llvm.func internal @foo_constant_constant_global_local_size(
+    %handler: !llvm.ptr,
     %i: i64,
     %res.offset.0: !llvm.ptr, %res.offset.1: !llvm.ptr, %res.offset.2: !llvm.ptr,
     %res.gs.0: !llvm.ptr, %res.gs.1: !llvm.ptr,  %res.gs.2: !llvm.ptr,
@@ -1153,12 +1161,12 @@ llvm.func internal @foo_constant_constant_global_local_size(
   sycl.host.constructor(%nd_range, %global_size, %local_size, %offset)
       {type=!sycl_nd_range_3_}
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.schedule_kernel @kernels::@k7[nd_range %nd_range](
+  sycl.host.schedule_kernel %handler -> @kernels::@k7[nd_range %nd_range](
       %res.offset.0, %res.offset.1, %res.offset.2, %res.gs.0,
       %res.gs.1, %res.gs.2, %res.ls.0, %res.ls.1,
       %res.ls.2, %res.nws.0, %res.nws.1, %res.nws.2)
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
-         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
+         !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr,
          !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }


### PR DESCRIPTION
Intent: Prevent the `schedule_kernel` op from being trivially dead when all arguments are read-only, without breaking our reaching definitions analyses.