### PR TITLE
[SYCL-MLIR][sycl-constant-propgation][test] Revamp tests

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Transforms/Passes.td
@@ -20,6 +20,9 @@ def ConstantPropagationPass
     passed as an argument to `sycl.host.schedule_kernel`, and replaces the
     corresponding `gpu.func` argument with the constant value.
 
+    This pass is also capable of propagating constant members of
+    `sycl::accessor` arguments, i.e., offset and range.
+
     No further change is needed to the `sycl.host.schedule_kernel` operation or
     the kernel, as the Dead Argument Elimination SYCL LLVM pass (`DAESYCL`) will
     remove the kernel arguments that become unused as the result of this pass.

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -274,7 +274,7 @@ public:
   NDRInfo(polygeist::NDRangeInformation &&info) : info(std::move(info)) {}
 
   template <typename... Args>
-  NDRInfo(Args &&... args)
+  NDRInfo(Args &&...args)
       : info(std::in_place, std::in_place_type<RangeAndOffsetInfo>,
              std::forward<Args>(args)...) {}
 
@@ -522,8 +522,8 @@ void ConstantSYCLGridArgs::RewriterBase::rewrite(Operation *op,
   TypeSwitch<const RewriterBase *>(this)
       .Case<NumWorkItemsRewriter, NumWorkGroupsRewriter, WorkGroupSizeRewriter,
             GlobalOffsetRewriter>([&](const auto *rewriter) {
-        return rewriter->rewrite(cast<typename std::remove_pointer_t<decltype(
-                                     rewriter)>::operation_type>(op),
+        return rewriter->rewrite(cast<typename std::remove_pointer_t<
+                                     decltype(rewriter)>::operation_type>(op),
                                  info, builder);
       });
 }

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -483,7 +483,7 @@ private:
 class ConstantAccessorArg : public ConstantExplicitArg {
 public:
   template <typename... Args>
-  ConstantAccessorArg(unsigned index, Args &&... args)
+  ConstantAccessorArg(unsigned index, Args &&...args)
       : ConstantExplicitArg(ConstantExplicitArg::Kind::ConstantAccessorArg,
                             index),
         info(std::forward<Args>(args)...) {}
@@ -499,7 +499,6 @@ private:
   RangeAndOffsetInfo info;
 };
 } // namespace
-
 
 //===----------------------------------------------------------------------===//
 // ConstantSYCLGridArgs::RewriterBase
@@ -1063,7 +1062,8 @@ void ConstantPropagationPass::runOnOperation() {
                     "point to be 'sycl.host.schedule_kernel'\n");
     }
 
-    propagateConstantArgs(getConstantArgs(launchPoint, accessorAnalysis), op, launchPoint);
+    propagateConstantArgs(getConstantArgs(launchPoint, accessorAnalysis), op,
+                          launchPoint);
     propagateImplicitConstantArgs(
         getConstantImplicitArgs(launchPoint, ndrAnalysis, idrAnalysis), op);
   });

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -9,6 +9,7 @@
 #include "mlir/Dialect/SYCL/Transforms/Passes.h"
 
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/SYCLNDRangeAnalysis.h"
@@ -82,8 +83,10 @@ class ConstantArg {
 public:
   enum class Kind {
     ConstantArithArg,
+    ConstantArrayArg,
     ConstantAccessorArg,
     ConstantSYCLGridArgs,
+    OpArgEnd = ConstantAccessorArg,
     ExplicitEnd = ConstantSYCLGridArgs,
     ImplicitBegin = ExplicitEnd
   };
@@ -122,13 +125,34 @@ private:
   unsigned index;
 };
 
+/// Class representing a constant argument backed by an operation in host code
+class ConstantOpArg : public ConstantExplicitArg {
+public:
+  static bool classof(const ConstantArg *c) {
+    return c->getKind() < ConstantArg::Kind::OpArgEnd;
+  }
+
+protected:
+  ConstantOpArg(ConstantArg::Kind kind, unsigned index, Operation *definingOp)
+      : ConstantExplicitArg(kind, index), definingOp(definingOp) {
+    assert(definingOp && "Expecting valid operation");
+  }
+
+  Operation *getDefiningOp() const { return definingOp; }
+
+  template <typename OpTy> OpTy getDefiningOp() const {
+    return cast<OpTy>(definingOp);
+  }
+
+private:
+  Operation *definingOp;
+};
+
 /// Class representing a constant arithmetic argument.
-class ConstantArithArg : public ConstantExplicitArg {
+class ConstantArithArg : public ConstantOpArg {
 public:
   ConstantArithArg(unsigned index, Operation *definingOp)
-      : ConstantExplicitArg(ConstantArg::Kind::ConstantArithArg, index),
-        definingOp(definingOp) {
-    assert(definingOp && "Expecting valid operation");
+      : ConstantOpArg(ConstantArg::Kind::ConstantArithArg, index, definingOp) {
     assert(definingOp->hasTrait<OpTrait::ConstantLike>() &&
            "Expecting constant");
   }
@@ -136,16 +160,27 @@ public:
   /// Propagate the constant this argument represents.
   void propagate(OpBuilder &builder, Region &region) {
     Value toReplace = region.getArgument(getIndex());
-    toReplace.replaceAllUsesWith(builder.clone(*definingOp)->getResult(0));
+    toReplace.replaceAllUsesWith(builder.clone(*getDefiningOp())->getResult(0));
     recordHit();
   }
 
   static bool classof(const ConstantArg *c) {
     return c->getKind() == ConstantExplicitArg::Kind::ConstantArithArg;
   }
+};
 
-private:
-  Operation *definingOp;
+/// Class representing a constant arithmetic argument.
+class ConstantArrayArg : public ConstantOpArg {
+public:
+  ConstantArrayArg(unsigned index, LLVM::GlobalOp definingOp)
+      : ConstantOpArg(ConstantArg::Kind::ConstantArrayArg, index, definingOp) {}
+
+  /// Propagate the constant this argument represents.
+  void propagate(OpBuilder &builder, Region &region);
+
+  static bool classof(const ConstantArg *c) {
+    return c->getKind() == ConstantExplicitArg::Kind::ConstantArrayArg;
+  }
 };
 
 /// Class representing a constant implicit argument.
@@ -832,6 +867,33 @@ void ConstantAccessorArg::propagate(OpBuilder &builder, Region &region) {
 }
 
 //===----------------------------------------------------------------------===//
+// ConstantArrayArg
+//===----------------------------------------------------------------------===//
+
+void ConstantArrayArg::propagate(OpBuilder &builder, Region &region) {
+  unsigned index = getIndex();
+  Value toReplace = region.getArgument(index);
+  OpBuilder globalCloner(region.getParentOfType<gpu::GPUFuncOp>());
+  auto newGlobal =
+      globalCloner.cloneWithoutRegions(getDefiningOp<LLVM::GlobalOp>());
+  LLVM_DEBUG({
+    llvm::dbgs().indent(2) << "Handling constant array at pos #" << index
+                           << "\n";
+    llvm::dbgs().indent(4) << "Replacing using new global " << newGlobal
+                           << "\n";
+  });
+  Location loc = toReplace.getLoc();
+  Value addressof = builder.create<LLVM::AddressOfOp>(loc, newGlobal);
+  auto pt = cast<LLVM::LLVMPointerType>(toReplace.getType());
+  if (pt != addressof.getType()) {
+    LLVM_DEBUG(llvm::dbgs().indent(4) << "Performing cast to " << pt << "\n");
+    addressof = builder.create<LLVM::BitcastOp>(loc, pt, addressof);
+  }
+  toReplace.replaceAllUsesWith(addressof);
+  recordHit();
+}
+
+//===----------------------------------------------------------------------===//
 // ConstantPropagationPass
 //===----------------------------------------------------------------------===//
 
@@ -941,6 +1003,18 @@ static unsigned getTrueIndex(const RangeTy &typeAttrs, unsigned originalIndex) {
       });
 }
 
+static LLVM::GlobalOp
+getConstantArrayDefinition(Value value, SymbolTableCollection &symbolTable) {
+  auto addressOf = value.getDefiningOp<LLVM::AddressOfOp>();
+  if (!addressOf)
+    return nullptr;
+  LLVM::GlobalOp global = addressOf.getGlobal(symbolTable);
+  return global.getConstant() &&
+                 isa<LLVM::LLVMArrayType>(global.getGlobalType())
+             ? global
+             : nullptr;
+}
+
 auto ConstantPropagationPass::getConstantArgs(
     SYCLHostScheduleKernel op,
     polygeist::SYCLAccessorAnalysis &accessorAnalysis) {
@@ -949,6 +1023,8 @@ auto ConstantPropagationPass::getConstantArgs(
   // Map each argument to a ConstantExplicitArg and filter-out nullptr
   // (non-const) ones.
   auto types = op.getSyclTypes().getAsRange<TypeAttr>();
+
+  SymbolTableCollection symbolTable;
 
   // NOTE: We cannot filter here as `llvm::make_filter_range` does not work as
   // expected. (See comment at `llvm/ADT/STLExtras.h`).
@@ -965,6 +1041,15 @@ auto ConstantPropagationPass::getConstantArgs(
                      << "Arith constant: " << value << " at pos #" << trueIndex
                      << "\n");
           return res;
+        }
+        if (LLVM::GlobalOp arrayDefinitionOp =
+                getConstantArrayDefinition(value, symbolTable)) {
+          unsigned trueIndex = getTrueIndex(types, index);
+          LLVM_DEBUG(llvm::dbgs().indent(2)
+                     << "Array constant: " << arrayDefinitionOp << " at pos #"
+                     << trueIndex << "\n");
+          return std::make_unique<ConstantArrayArg>(trueIndex,
+                                                    arrayDefinitionOp);
         }
         auto accType = llvm::dyn_cast_or_null<AccessorType>(type.getValue());
         return accType ? getConstantAccessorArg(op, accessorAnalysis,
@@ -1003,7 +1088,7 @@ void ConstantPropagationPass::propagateConstantArgs(
     if (!arg)
       continue;
     TypeSwitch<ConstantExplicitArg *>(arg.get())
-        .Case<ConstantAccessorArg, ConstantArithArg>(
+        .Case<ConstantAccessorArg, ConstantArithArg, ConstantArrayArg>(
             [&](auto *arg) { arg->propagate(builder, *region); });
     size_t hits = arg->getNumHits();
     NumReplacedExplicitArguments += hits;

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -161,7 +161,9 @@ public:
 
 protected:
   explicit ConstantImplicitArgBase(ConstantArg::Kind kind)
-      : ConstantArg(kind) {}
+      : ConstantArg(kind) {
+    assert(kind >= ConstantArg::Kind::ImplicitBegin && "Invalid kind");
+  }
 
 private:
   static FunctionOpInterface cloneFunction(FunctionOpInterface original,

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -160,8 +160,7 @@ public:
   }
 
 protected:
-  explicit ConstantImplicitArgBase(ConstantArg::Kind kind)
-      : ConstantArg(kind) {
+  explicit ConstantImplicitArgBase(ConstantArg::Kind kind) : ConstantArg(kind) {
     assert(kind >= ConstantArg::Kind::ImplicitBegin && "Invalid kind");
   }
 
@@ -248,11 +247,7 @@ public:
   RangeAndOffsetInfo(OffsetInfo &&offsetInfo)
       : offsetInfo(std::move(offsetInfo)) {}
 
-  bool hasRangeInfo() const { return static_cast<bool>(rangeInfo); }
-
-  bool hasConstantRange() const {
-    return hasRangeInfo() && rangeInfo->isConstant();
-  }
+  bool hasConstantRange() const { return rangeInfo && rangeInfo->isConstant(); }
 
   Value getRangeValue(OpBuilder &builder, Location loc, Type type) const {
     assert(hasConstantRange() && "Expecting constant range");

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -1197,8 +1197,8 @@ llvm.func internal @foo_constant_constant_global_local_size(
 // COM: Third split
 
 // CHECK-LABEL: ConstantPropagationPass
-// CHECK-NEXT:   (S) 6 num-propagated-constants   - Number of propagated constants
-// CHECK-NEXT:   (S) 6 num-replaced-explicit-args - Number of replaced explicit arguments
+// CHECK-NEXT:   (S) 7 num-propagated-constants   - Number of propagated constants
+// CHECK-NEXT:   (S) 7 num-replaced-explicit-args - Number of replaced explicit arguments
 // CHECK-NEXT:   (S) 0 num-replaced-implicit-args - Number of replaced implicit arguments
 
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
@@ -1215,6 +1215,8 @@ gpu.module @kernels {
                           %accRange: memref<?x!sycl_range_1_>,
                           %memRange: memref<?x!sycl_range_1_>,
                           %offset: memref<?x!sycl_id_1_>)
+
+// COM: Constant access range and offset
 
 // CHECK-LABEL:     gpu.func @k0(
 // CHECK-SAME:                   %[[VAL_0:.*]]: memref<?xi32, 1>, %[[VAL_1:.*]]: memref<?x!sycl_range_1_>, %[[VAL_2:.*]]: memref<?x!sycl_range_1_>, %[[VAL_3:.*]]: memref<?x!sycl_id_1_>) kernel {
@@ -1240,6 +1242,8 @@ gpu.module @kernels {
     gpu.return
   }
 
+// COM: No access range needed, unknown memory range and default offset.
+
 // CHECK-LABEL:     gpu.func @k1(
 // CHECK-SAME:                   %[[VAL_11:.*]]: memref<?xi32, 1>, %[[VAL_12:.*]]: memref<?x!sycl_range_1_>, %[[VAL_13:.*]]: memref<?x!sycl_range_1_>, %[[VAL_14:.*]]: memref<?x!sycl_id_1_>) kernel {
 // CHECK-NEXT:        %[[VAL_15:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
@@ -1260,6 +1264,8 @@ gpu.module @kernels {
     gpu.return
   }
 
+// COM: No access range needed, constant memory range and default offset.
+
 // CHECK-LABEL:     gpu.func @k2(
 // CHECK-SAME:                   %[[VAL_18:.*]]: memref<?xi32, 1>, %[[VAL_19:.*]]: memref<?x!sycl_range_1_>, %[[VAL_20:.*]]: memref<?x!sycl_range_1_>, %[[VAL_21:.*]]: memref<?x!sycl_id_1_>) kernel {
 // CHECK-NEXT:        %[[VAL_22:.*]] = arith.constant 512 : index
@@ -1268,7 +1274,7 @@ gpu.module @kernels {
 // CHECK-NEXT:        %[[VAL_25:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_26:.*]] = memref.cast %[[VAL_25]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_27:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb2>
-// CHECK-NEXT:        func.call @init(%[[VAL_27]], %[[VAL_18]], %[[VAL_24]], %[[VAL_20]], %[[VAL_26]]) : (memref<1x!sycl_accessor_1_i32_w_gb2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        func.call @init(%[[VAL_27]], %[[VAL_18]], %[[VAL_24]], %[[VAL_24]], %[[VAL_26]]) : (memref<1x!sycl_accessor_1_i32_w_gb2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k2(%ptr: memref<?xi32, 1>,
@@ -1282,6 +1288,8 @@ gpu.module @kernels {
            memref<?x!sycl_id_1_>) -> ()
     gpu.return
   }
+
+// COM: Not enough info
 
 // CHECK-LABEL:     gpu.func @k3(
 // CHECK-SAME:                   %[[VAL_28:.*]]: memref<?xi32, 1>, %[[VAL_29:.*]]: memref<?x!sycl_range_1_>, %[[VAL_30:.*]]: memref<?x!sycl_range_1_>, %[[VAL_31:.*]]: memref<?x!sycl_id_1_>) kernel {

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -41,14 +41,14 @@ gpu.module @kernels {
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k0(%ptr: memref<?xi64, 1>,
-               %memRange: memref<?x!sycl_range_1_>,
                %accRange: memref<?x!sycl_range_1_>,
+               %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>,
                %c: i64) kernel {
     %c0 = arith.constant 0 : index
     %c0_i64 = arith.constant 0 : i64
     %acc = memref.alloca() : memref<1x!sycl_accessor_1_i64_w_gb>
-    func.call @init(%acc, %ptr, %memRange, %accRange, %offset)
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
         : (memref<1x!sycl_accessor_1_i64_w_gb>, memref<?xi64, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
@@ -1231,11 +1231,11 @@ gpu.module @kernels {
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k0(%ptr: memref<?xi32, 1>,
-               %memRange: memref<?x!sycl_range_1_>,
                %accRange: memref<?x!sycl_range_1_>,
+               %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
     %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
-    func.call @init(%acc, %ptr, %memRange, %accRange, %offset)
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
         : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
@@ -1253,11 +1253,11 @@ gpu.module @kernels {
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k1(%ptr: memref<?xi32, 1>,
-               %memRange: memref<?x!sycl_range_1_>,
                %accRange: memref<?x!sycl_range_1_>,
+               %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
     %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
-    func.call @init(%acc, %ptr, %memRange, %accRange, %offset)
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
         : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
@@ -1278,11 +1278,11 @@ gpu.module @kernels {
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k2(%ptr: memref<?xi32, 1>,
-               %memRange: memref<?x!sycl_range_1_>,
                %accRange: memref<?x!sycl_range_1_>,
+               %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
     %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
-    func.call @init(%acc, %ptr, %memRange, %accRange, %offset)
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
         : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
@@ -1298,11 +1298,11 @@ gpu.module @kernels {
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k3(%ptr: memref<?xi32, 1>,
-               %memRange: memref<?x!sycl_range_1_>,
                %accRange: memref<?x!sycl_range_1_>,
+               %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
     %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
-    func.call @init(%acc, %ptr, %memRange, %accRange, %offset)
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
         : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()


### PR DESCRIPTION
- Drop `-mlir-pass-statistics` tests, as no upstream MLIR pass does this and it makes testing harder (`stdout`/`stderr` order is not preserved).
- Add constant `f32` propagation test.