### PR TITLE
[SYCL][NATIVECPU] Fixed missing changes from latest UR version

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/adapter.cpp
@@ -1,4 +1,4 @@
-//===---------------- runtime.cpp - Native CPU Adapter --------------------===//
+//===---------------- adapter.cpp - Native CPU Adapter --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -41,6 +41,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRelease(ur_adapter_handle_t) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
   Adapter.RefCount++;
+  return UR_RESULT_SUCCESS;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
+    ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
+  *ppMessage = ErrorMessage;
+  *pError = ErrorMessageCode;
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -15,8 +15,8 @@
 #include <iostream>
 
 UR_APIEXPORT ur_result_t UR_APICALL
-urPlatformGet(uint32_t NumEntries, ur_platform_handle_t *phPlatforms,
-              uint32_t *pNumPlatforms) {
+urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
+              ur_platform_handle_t *phPlatforms, uint32_t *pNumPlatforms) {
 
   UR_ASSERT(pNumPlatforms || phPlatforms, UR_RESULT_ERROR_INVALID_VALUE);
 


### PR DESCRIPTION
This PR fixes some errors while building the Native CPU plugin:

Updated urPlatformGet signature
Added missing function urAdapterGetLastError