### PR TITLE
[SYCL] Accept integral type in parallel_for with offsets

### DIFF
--- a/sycl/test-e2e/Basic/parallel_for_offset_integral_t.cpp
+++ b/sycl/test-e2e/Basic/parallel_for_offset_integral_t.cpp
@@ -3,7 +3,6 @@
 // RUN: %{build} -DLAMBDA_KERNEL=0 -o %t2.out
 // RUN: %{run} %t2.out
 
-#include <iostream>
 #include <sycl/sycl.hpp>
 
 template <typename AccT> class func {
@@ -15,11 +14,11 @@ public:
 };
 
 int main() {
-  sycl::queue q{};
   constexpr int arr_size = 16;
   int arr[arr_size];
 
   {
+    sycl::queue q;
     sycl::buffer<int, 1> buf(arr, arr_size);
     q.submit([&](sycl::handler &cgh) {
       auto acc = buf.get_access<sycl::access_mode::write>(cgh);

--- a/sycl/test-e2e/Basic/parallel_for_offset_integral_t.cpp
+++ b/sycl/test-e2e/Basic/parallel_for_offset_integral_t.cpp
@@ -1,0 +1,42 @@
+// RUN: %{build} -DLAMBDA_KERNEL=1 -o %t1.out
+// RUN: %{run} %t1.out
+// RUN: %{build} -DLAMBDA_KERNEL=0 -o %t2.out
+// RUN: %{run} %t2.out
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+template <typename AccT> class func {
+  AccT acc;
+
+public:
+  func(AccT acc) { this->acc = acc; }
+  void operator()(size_t ind) const { acc[ind - 1] = ind; }
+};
+
+int main() {
+  sycl::queue q{};
+  constexpr int arr_size = 16;
+  int arr[arr_size];
+
+  {
+    sycl::buffer<int, 1> buf(arr, arr_size);
+    q.submit([&](sycl::handler &cgh) {
+      auto acc = buf.get_access<sycl::access_mode::write>(cgh);
+#if LAMBDA_KERNEL
+      cgh.parallel_for(sycl::range<1>(arr_size), sycl::id<1>(1),
+                       [=](size_t ind) {
+                         func f(acc);
+                         f(ind);
+                       });
+#else
+      cgh.parallel_for(sycl::range<1>(arr_size), sycl::id<1>(1), func(acc));
+#endif
+    });
+  }
+
+  for (int i = 0; i < arr_size; i++)
+    assert(arr[i] == i + 1);
+
+  return 0;
+}


### PR DESCRIPTION
According to SYCL 2020, using kernel function which accept an integral type is supported because of implicit conversion of item<1> to integral type. This patch fixes compilation failure for such case.

Fixes: https://github.com/intel/llvm/issues/9839