### PR TITLE
[SYCL] only remap linked host memory

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -533,7 +533,8 @@ Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
 
   if (sameCtx(HostAllocaCmd->getQueue()->getContextImplPtr(),
               Record->MCurContext)) {
-    if (!isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess))
+    if (!isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess) &&
+        HostAllocaCmd->MLinkedAllocaCmd)
       remapMemoryObject(Record, Req, HostAllocaCmd, ToEnqueue);
   } else
     insertMemoryMove(Record, Req, HostQueue, ToEnqueue);
@@ -1047,7 +1048,8 @@ void Scheduler::GraphBuilder::createGraphForCommand(
       // If the memory is already in the required host context, check if the
       // required access mode is valid, remap if not.
       if (Record->MCurContext->is_host() &&
-          !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess))
+          !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess) &&
+          AllocaCmd->MLinkedAllocaCmd)
         remapMemoryObject(Record, Req, AllocaCmd, ToEnqueue);
     } else {
       // Cannot directly copy memory from OpenCL device to OpenCL device -

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -534,7 +534,7 @@ Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
   if (sameCtx(HostAllocaCmd->getQueue()->getContextImplPtr(),
               Record->MCurContext)) {
     if (!isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess) &&
-        HostAllocaCmd->MLinkedAllocaCmd)
+        !Req->MIsSubBuffer)
       remapMemoryObject(Record, Req, HostAllocaCmd, ToEnqueue);
   } else
     insertMemoryMove(Record, Req, HostQueue, ToEnqueue);
@@ -1049,7 +1049,7 @@ void Scheduler::GraphBuilder::createGraphForCommand(
       // required access mode is valid, remap if not.
       if (Record->MCurContext->is_host() &&
           !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess) &&
-          AllocaCmd->MLinkedAllocaCmd)
+          !Req->MIsSubBuffer)
         remapMemoryObject(Record, Req, AllocaCmd, ToEnqueue);
     } else {
       // Cannot directly copy memory from OpenCL device to OpenCL device -

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -534,12 +534,12 @@ Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
   if (sameCtx(HostAllocaCmd->getQueue()->getContextImplPtr(),
               Record->MCurContext)) {
     if (!isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess)) {
-      remapMemoryObject(
-          Record, Req,
-          Req->MIsSubBuffer
-              ? ((AllocaSubBufCommand *)HostAllocaCmd)->getParentAlloca()
-              : HostAllocaCmd,
-          ToEnqueue);
+      remapMemoryObject(Record, Req,
+                        Req->MIsSubBuffer ? (static_cast<AllocaSubBufCommand *>(
+                                                 HostAllocaCmd))
+                                                ->getParentAlloca()
+                                          : HostAllocaCmd,
+                        ToEnqueue);
     }
   } else
     insertMemoryMove(Record, Req, HostQueue, ToEnqueue);
@@ -1054,12 +1054,12 @@ void Scheduler::GraphBuilder::createGraphForCommand(
       // required access mode is valid, remap if not.
       if (Record->MCurContext->is_host() &&
           !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess)) {
-        remapMemoryObject(
-            Record, Req,
-            Req->MIsSubBuffer
-                ? ((AllocaSubBufCommand *)AllocaCmd)->getParentAlloca()
-                : AllocaCmd,
-            ToEnqueue);
+        remapMemoryObject(Record, Req,
+                          Req->MIsSubBuffer
+                              ? (static_cast<AllocaSubBufCommand *>(AllocaCmd))
+                                    ->getParentAlloca()
+                              : AllocaCmd,
+                          ToEnqueue);
       }
     } else {
       // Cannot directly copy memory from OpenCL device to OpenCL device -

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -533,9 +533,14 @@ Scheduler::GraphBuilder::addHostAccessor(Requirement *Req,
 
   if (sameCtx(HostAllocaCmd->getQueue()->getContextImplPtr(),
               Record->MCurContext)) {
-    if (!isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess) &&
-        !Req->MIsSubBuffer)
-      remapMemoryObject(Record, Req, HostAllocaCmd, ToEnqueue);
+    if (!isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess)) {
+      remapMemoryObject(
+          Record, Req,
+          Req->MIsSubBuffer
+              ? ((AllocaSubBufCommand *)HostAllocaCmd)->getParentAlloca()
+              : HostAllocaCmd,
+          ToEnqueue);
+    }
   } else
     insertMemoryMove(Record, Req, HostQueue, ToEnqueue);
 
@@ -1048,9 +1053,14 @@ void Scheduler::GraphBuilder::createGraphForCommand(
       // If the memory is already in the required host context, check if the
       // required access mode is valid, remap if not.
       if (Record->MCurContext->is_host() &&
-          !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess) &&
-          !Req->MIsSubBuffer)
-        remapMemoryObject(Record, Req, AllocaCmd, ToEnqueue);
+          !isAccessModeAllowed(Req->MAccessMode, Record->MHostAccess)) {
+        remapMemoryObject(
+            Record, Req,
+            Req->MIsSubBuffer
+                ? ((AllocaSubBufCommand *)AllocaCmd)->getParentAlloca()
+                : AllocaCmd,
+            ToEnqueue);
+      }
     } else {
       // Cannot directly copy memory from OpenCL device to OpenCL device -
       // create two copies: device->host and host->device.

--- a/sycl/test-e2e/Scheduler/HostTaskSubBuffer.cpp
+++ b/sycl/test-e2e/Scheduler/HostTaskSubBuffer.cpp
@@ -1,5 +1,10 @@
 // RUN: %{build} -o %t.out
-// RUN: env SYCL_HOST_UNIFIED_MEMORY=1  %{run} %t.out
+// RUN: env SYCL_HOST_UNIFIED_MEMORY=1 env SYCL_PI_TRACE=2  %{run} %t.out | FileCheck %s
+
+// CHECK: piEnqueueMemBufferMap
+// CHECK: piEnqueueMemBufferMap
+// CHECK: piEnqueueMemUnmap
+// CHECK: piEnqueueMemUnmap
 
 /*
 

--- a/sycl/test-e2e/Scheduler/SubBufferRemapping.cpp
+++ b/sycl/test-e2e/Scheduler/SubBufferRemapping.cpp
@@ -1,6 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_HOST_UNIFIED_MEMORY=1 env SYCL_PI_TRACE=2  %{run} %t.out | FileCheck %s
 
+// sub-buffer host alloca are not mated with device alloca. That linkage occurs
+// in the parent alloca. this test ensures that any map operations are using the
+// correct alloca, even in the case of sub-buffer accessors in host tasks.
+
 // CHECK: == fills completed
 // CHECK: piEnqueueMemBufferMap
 // CHECK: piEnqueueMemBufferMap


### PR DESCRIPTION
sub-buffer req does not have to be remapped when setting up a host task ( the main Alloca has that covered)