### PR TITLE
[SYCL-MLIR][sycl-raise-host] nd_range constructor: Ensure domination

### DIFF
--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -635,10 +635,10 @@ llvm.func @raise_nd_range_memcpy_offset(%globalSize: !llvm.ptr, %localSize: !llv
 // CHECK-DAG:       %[[VAL_6:.*]] = llvm.mlir.constant(24 : i64) : i64
 // CHECK-DAG:       %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_11]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
 // CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_12]], %[[VAL_4]], %[[VAL_6]]) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
@@ -670,12 +670,12 @@ llvm.func @raise_nd_range_store(%g0: i64, %g1: i64, %l0: i64, %l1: i64) {
 // CHECK-SAME:                                           %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64, %[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64) {
 // CHECK-DAG:       %[[VAL_6:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_11]], %[[VAL_8]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.return
 // CHECK-NEXT:    }
@@ -705,12 +705,12 @@ llvm.func @raise_nd_range_store_offset(%g0: i64, %g1: i64, %l0: i64, %l1: i64, %
 // CHECK-SAME:                                     %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64, %[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64) {
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_7]], %[[VAL_8]], %[[VAL_9]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.return
 // CHECK-NEXT:    }
@@ -890,5 +890,57 @@ llvm.func @raise_set_globalsize_offset(%handler: !llvm.ptr, %condition: i1) {
   "llvm.intr.var.annotation"(%offset, %offsetStr, %offsetStr, %c0, %nullptr) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
   llvm.br ^exit
 ^exit:
+  llvm.return
+}
+
+// -----
+
+// COM: Check we do not violate dominance when raising nd_range constructor using stores
+
+// CHECK-LABEL:   llvm.func @raise_nd_range_load_store_offset(
+// CHECK-SAME:                                                %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr, %[[VAL_2:.*]]: !llvm.ptr, %[[VAL_3:.*]]: !llvm.ptr, %[[VAL_4:.*]]: !llvm.ptr, %[[VAL_5:.*]]: !llvm.ptr) {
+// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> i64
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_8]], %[[VAL_9]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_13]], %[[VAL_11]], %[[VAL_12]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> i64
+// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_16]], %[[VAL_14]], %[[VAL_15]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_10]], %[[VAL_13]], %[[VAL_16]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      llvm.return
+// CHECK-NEXT:    }
+
+llvm.func @raise_nd_range_load_store_offset(%g0: !llvm.ptr,
+                                            %g1: !llvm.ptr,
+                                            %l0: !llvm.ptr,
+                                            %l1: !llvm.ptr,
+                                            %off0: !llvm.ptr,
+                                            %off1: !llvm.ptr) {
+  %c1 = llvm.mlir.constant (1 : i32) : i32
+  %nd = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)> : (i32) -> !llvm.ptr
+  %g0_val = llvm.load %g0 : !llvm.ptr -> i64
+  llvm.store %g0_val, %nd : i64, !llvm.ptr
+  %g1_ref = llvm.getelementptr inbounds %nd[0, 0, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  %g1_val = llvm.load %g1 : !llvm.ptr -> i64
+  llvm.store %g1_val, %g1_ref : i64, !llvm.ptr
+  %l0_ref = llvm.getelementptr inbounds %nd[0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  %l0_val = llvm.load %l0 : !llvm.ptr -> i64
+  llvm.store %l0_val, %l0_ref : i64, !llvm.ptr
+  %l1_ref = llvm.getelementptr inbounds %nd[0, 1, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  %l1_val = llvm.load %l1 : !llvm.ptr -> i64
+  llvm.store %l1_val, %l1_ref : i64, !llvm.ptr
+  %off0_ref = llvm.getelementptr inbounds %nd[0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  %off0_val = llvm.load %off0 : !llvm.ptr -> i64
+  llvm.store %off0_val, %off0_ref : i64, !llvm.ptr
+  %off1_ref = llvm.getelementptr inbounds %nd[0, 2, 0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::nd_range", (struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::range", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>, struct<"class.sycl::_V1::id", (struct<"class.sycl::_V1::detail::array", (array<2 x i64>)>)>)>
+  %off1_val = llvm.load %off1 : !llvm.ptr -> i64
+  llvm.store %off1_val, %off1_ref : i64, !llvm.ptr
   llvm.return
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
@@ -1,6 +1,6 @@
 // RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s --check-prefixes CHECK,NO-O1
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s --check-prefixes CHECK,NO-O1
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xclang -opaque-pointers | FileCheck %s
 
 #include <sycl/sycl.hpp>
 
@@ -27,19 +27,15 @@ class KernelName;
 // CHECK-DAG:      %[[ZERO:.*]] = llvm.mlir.constant(0 : i64) : i64
 
 // COM: These three lines are needed to match the right GS, LS and OFF.
-// NO-O1:          sycl.host.constructor(%{{.*}}, %[[N]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-// NO-O1:          sycl.host.constructor(%{{.*}}, %[[L]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-// NO-O1:          sycl.host.constructor(%{{.*}}, %[[ZERO]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
-
-// CHECK:          sycl.host.constructor(%[[GS:.*]], %[[N]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-// CHECK:          sycl.host.constructor(%[[LS:.*]], %[[L]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-// CHECK:          sycl.host.constructor(%[[OFF:.*]], %[[ZERO]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect nd-range assignment with an nd_range argument
 
+// CHECK:         sycl.host.constructor(%[[GS:.*]], %[[N]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK:         sycl.host.constructor(%[[LS:.*]], %[[L]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK:         sycl.host.constructor(%[[OFF:.*]], %[[ZERO]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
 // CHECK:         sycl.host.constructor(%[[ND_RANGE:.*]], %[[GS]], %[[LS]], %[[OFF]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:         sycl.host.handler.set_nd_range %[[HANDLER:.*]] -> nd_range %[[ND_RANGE]] : !llvm.ptr, !llvm.ptr
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range_constructors.cpp
@@ -40,13 +40,13 @@ void nd_range_move(sycl::nd_range<Dimensions> &&other) {
 // CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[RANGE1:.*]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_5]], %[[VAL_0]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[RANGE1]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_1]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[ID1:.*]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_3]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<[[ND1:.*]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT:      llvm.intr.lifetime.start 24, %[[VAL_8]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_5]], %[[VAL_0]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_1]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_3]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_5]], %[[VAL_6]], %[[VAL_7]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi1EEEEEvDpOT_(%[[VAL_8]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.intr.lifetime.end 24, %[[VAL_8]] : !llvm.ptr
@@ -60,11 +60,11 @@ template void nd_range(sycl::range<1>, sycl::range<1>);
 // CHECK-DAG:       %[[VAL_5:.*]] = llvm.mlir.constant(0 : i8) : i8
 // CHECK-DAG:       %[[VAL_6:.*]] = llvm.mlir.constant(16 : i64) : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<[[RANGE2:.*]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<[[RANGE2]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<[[ND2:.*]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT:      llvm.intr.lifetime.start 48, %[[VAL_10]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_8]], %[[VAL_9]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<[[ND2]]>
 // CHECK-NEXT:      "llvm.intr.memset"(%[[VAL_11]], %[[VAL_5]], %[[VAL_6]]) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
@@ -95,13 +95,13 @@ template void nd_range(sycl::range<3>, sycl::range<3>);
 // CHECK-SAME:                                                                                           %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64)
 // CHECK-DAG:       %[[VAL_3:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[RANGE1]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_5]], %[[VAL_0]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[RANGE1]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_1]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[ID1]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_2]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<[[ND1]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT:      llvm.intr.lifetime.start 24, %[[VAL_8]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_5]], %[[VAL_0]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_6]], %[[VAL_1]]) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_2]]) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_5]], %[[VAL_6]], %[[VAL_7]]) {type = !sycl_nd_range_1_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi1EEEEEvDpOT_(%[[VAL_8]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.intr.lifetime.end 24, %[[VAL_8]] : !llvm.ptr
@@ -113,13 +113,13 @@ template void nd_range_offset(sycl::range<1>, sycl::range<1>, sycl::id<1>);
 // CHECK-SAME:                                                                                           %[[VAL_0:.*]]: i64, %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64, %[[VAL_4:.*]]: i64, %[[VAL_5:.*]]: i64)
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<[[RANGE2]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<[[RANGE2]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<[[ID2:.*]]> : (i32) -> !llvm.ptr
-// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<[[ND2]]> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK-NEXT:      llvm.intr.lifetime.start 48, %[[VAL_10]] : !llvm.ptr
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_7]], %[[VAL_0]], %[[VAL_1]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_8]], %[[VAL_2]], %[[VAL_3]]) {type = !sycl_range_2_} : (!llvm.ptr, i64, i64) -> ()
+// CHECK-NEXT:      sycl.host.constructor(%[[VAL_9]], %[[VAL_4]], %[[VAL_5]]) {type = !sycl_id_2_} : (!llvm.ptr, i64, i64) -> ()
 // CHECK-NEXT:      sycl.host.constructor(%[[VAL_10]], %[[VAL_7]], %[[VAL_8]], %[[VAL_9]]) {type = !sycl_nd_range_2_} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.call @_Z4keepIJRN4sycl3_V18nd_rangeILi2EEEEEvDpOT_(%[[VAL_10]]) : (!llvm.ptr) -> ()
 // CHECK-NEXT:      llvm.intr.lifetime.end 48, %[[VAL_10]] : !llvm.ptr


### PR DESCRIPTION
When handling an `nd_range` constructor not `memcpy`-ing its components, i.e., storing each index, insert all of the member allocas before the `nd_range` alloca and all of the constructors after its correspondent store.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>