### PR TITLE
[SYCL-MLIR] Add flag to allow relax sycl-opt tweaks

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -5491,6 +5491,8 @@ def : Flag<["-"], "fno-sycl-explicit-simd">,
   HelpText<"Disable SYCL explicit SIMD extension. (deprecated)">;
 defm sycl_early_optimizations : OptOutCC1FFlag<"sycl-early-optimizations", "Enable", "Disable", " standard optimization pipeline for SYCL device compiler", [CoreOption]>,
   MarshallingInfoFlag<CodeGenOpts<"DisableSYCLEarlyOpts">>;
+def fsycl_relaxed_opt : Flag<["-"], "fsycl-relaxed-opt">, Flags<[NoXarchOption, CoreOption]>, Group<sycl_Group>,
+  HelpText<"Relax SYCL optimization tweaks (SPIR only)">;
 def fsycl_dead_args_optimization : Flag<["-"], "fsycl-dead-args-optimization">,
   Group<sycl_Group>, Flags<[CoreOption]>, HelpText<"Enables "
   "elimination of DPC++ dead kernel arguments">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5143,7 +5143,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     else if (RawTriple.isSPIR() || IsSYCLNativeCPU) {
       // Set `sycl-opt` option to configure LLVM passes for SPIR target
       CmdArgs.push_back("-mllvm");
-      CmdArgs.push_back("-sycl-opt");
+      if (Args.hasArg(options::OPT_fsycl_relaxed_opt))
+        CmdArgs.push_back("-sycl-relaxed-opt");
+      else
+        CmdArgs.push_back("-sycl-opt");
     }
     if (IsSYCLNativeCPU) {
       CmdArgs.push_back("-fsycl-is-native-cpu");

--- a/llvm/include/llvm/Passes/PassBuilder.h
+++ b/llvm/include/llvm/Passes/PassBuilder.h
@@ -183,6 +183,9 @@ public:
   FunctionPassManager
   buildFunctionSimplificationPipeline(OptimizationLevel Level,
                                       ThinOrFullLTOPhase Phase);
+  FunctionPassManager
+  buildFunctionSimplificationPipelineSYCLRelaxed(OptimizationLevel Level,
+                                                 ThinOrFullLTOPhase Phase);
 
   /// Construct the core LLVM module canonicalization and simplification
   /// pipeline.
@@ -596,6 +599,9 @@ private:
   FunctionPassManager
   buildO1FunctionSimplificationPipeline(OptimizationLevel Level,
                                         ThinOrFullLTOPhase Phase);
+  FunctionPassManager
+  buildO1FunctionSimplificationPipelineSYCLRelaxed(OptimizationLevel Level,
+                                                   ThinOrFullLTOPhase Phase);
 
   void addRequiredLTOPreLinkPasses(ModulePassManager &MPM);
 


### PR DESCRIPTION
`sycl-opt` llvm flag prevent a few loop optimizations.

The patch add `-fsycl-relaxed-opt` to clang and `sycl-relaxed-opt` in llvm which allows loop rotate, idom and simplify to run.