### PR TITLE
[SYCL-MLIR][ReachingDefinition] Do not break on non-function symbols

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.cpp
@@ -260,6 +260,11 @@ void ReachingDefinitionAnalysis::visitOperation(
 
   // Retrieve the alias oracle for the function this operation belongs to.
   auto funcOp = op->getParentOfType<FunctionOpInterface>();
+  if (!funcOp) {
+    LLVM_DEBUG(llvm::dbgs()
+               << "Will not analyze operations not in a function\n");
+    return setToEntryState(after);
+  }
   AliasOracle &aliasOracle = *aliasOracles[funcOp];
 
   // Analyze the operation's memory effects.

--- a/polygeist/test/polygeist-opt/reachingDefinitions.mlir
+++ b/polygeist/test/polygeist-opt/reachingDefinitions.mlir
@@ -459,9 +459,16 @@ func.func @caller() {
 
 // COM: Test that the analysis does not break with non-functions
 
+// CHECK-LABEL: test_tag: last_insert:
+// CHECK-NEXT:   operand #0
+// CHECK-NEXT:   - mods: <unknown>
+// CHECK-NEXT:   - pMods: <unknown>
+// CHECK-NEXT:   operand #1
+// CHECK-NEXT:   - mods: <unknown>
+// CHECK-NEXT:   - pMods: <unknown>
 llvm.mlir.global internal @init_glboal() : !llvm.struct<"foo", (i8)> {
   %0 = llvm.mlir.constant(0 : i8) : i8
-  %1 = llvm.mlir.undef : !llvm.struct<"foo", (i8)>
-  %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<"foo", (i8)>
+  %1 = llvm.mlir.undef {tag_name = "undef"} : !llvm.struct<"foo", (i8)>
+  %2 = llvm.insertvalue %0, %1[0] {tag = "last_insert"} : !llvm.struct<"foo", (i8)>
   llvm.return %2 : !llvm.struct<"foo", (i8)>
 }

--- a/polygeist/test/polygeist-opt/reachingDefinitions.mlir
+++ b/polygeist/test/polygeist-opt/reachingDefinitions.mlir
@@ -454,3 +454,14 @@ func.func @caller() {
   %0 = func.call @callee(%ptr) : (memref<i32>) -> memref<i32>
   return
 }
+
+// -----
+
+// COM: Test that the analysis does not break with non-functions
+
+llvm.mlir.global internal @init_glboal() : !llvm.struct<"foo", (i8)> {
+  %0 = llvm.mlir.constant(0 : i8) : i8
+  %1 = llvm.mlir.undef : !llvm.struct<"foo", (i8)>
+  %2 = llvm.insertvalue %0, %1[0] : !llvm.struct<"foo", (i8)>
+  llvm.return %2 : !llvm.struct<"foo", (i8)>
+}


### PR DESCRIPTION
If the analysis runs into a non-function symbol, abort analysis to avoid breaking.