### PR TITLE
[SYCL][UR][L0] Deprecate SYCL_ENABLE_PCI

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -152,7 +152,7 @@ Note that conflicting configuration tuples in the same list will favor the last 
 
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
-| `SYCL_ENABLE_PCI` (Deprecated) | Integer | When set to 1, enables obtaining the GPU PCI address when using the Level Zero backend. The default is 0. This option is kept for compatibility reasons and is immediately deprecated. New code does not need this setting. |
+| `SYCL_ENABLE_PCI` (Deprecated) | Integer | When set to 1, enables obtaining the GPU PCI address when using the Level Zero backend. The default is 1. This option is kept for compatibility reasons and is immediately deprecated. |
 | `SYCL_PI_LEVEL_ZERO_DISABLE_USM_ALLOCATOR` | Any(\*) | Disable USM allocator in Level Zero plugin (each memory request will go directly to Level Zero runtime) |
 | `SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY` | Any(\*) | Enable support of the kernels with indirect access and corresponding deferred release of memory allocations in the Level Zero plugin. |
 

--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -152,6 +152,7 @@ Note that conflicting configuration tuples in the same list will favor the last 
 
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
+| `SYCL_ENABLE_PCI` (Deprecated) | Integer | When set to 1, enables obtaining the GPU PCI address when using the Level Zero backend. The default is 0. This option is kept for compatibility reasons and is immediately deprecated. New code does not need this setting. |
 | `SYCL_PI_LEVEL_ZERO_DISABLE_USM_ALLOCATOR` | Any(\*) | Disable USM allocator in Level Zero plugin (each memory request will go directly to Level Zero runtime) |
 | `SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY` | Any(\*) | Enable support of the kernels with indirect access and corresponding deferred release of memory allocations in the Level Zero plugin. |
 

--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -152,7 +152,6 @@ Note that conflicting configuration tuples in the same list will favor the last 
 
 | Environment variable | Values | Description |
 | -------------------- | ------ | ----------- |
-| `SYCL_ENABLE_PCI` | Integer | When set to 1, enables obtaining the GPU PCI address when using the Level Zero backend. The default is 0. |
 | `SYCL_PI_LEVEL_ZERO_DISABLE_USM_ALLOCATOR` | Any(\*) | Disable USM allocator in Level Zero plugin (each memory request will go directly to Level Zero runtime) |
 | `SYCL_PI_LEVEL_ZERO_TRACK_INDIRECT_ACCESS_MEMORY` | Any(\*) | Enable support of the kernels with indirect access and corresponding deferred release of memory allocations in the Level Zero plugin. |
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/common.cpp
@@ -259,7 +259,11 @@ ze_structure_type_t getZeStructureType<ze_memory_allocation_properties_t>() {
   return ZE_STRUCTURE_TYPE_MEMORY_ALLOCATION_PROPERTIES;
 }
 
-template <> zes_structure_type_t getZesStructureType<zes_pci_properties_t>() {
+template <> ze_structure_type_t getZeStructureType<ze_pci_ext_properties_t>() {
+  return ZE_STRUCTURE_TYPE_PCI_EXT_PROPERTIES;
+}
+
+template <> zes_structure_type_t getZesStructureType<ze_pci_address_ext_t>() {
   return ZES_STRUCTURE_TYPE_PCI_PROPERTIES;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
@@ -612,12 +612,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(
   case UR_DEVICE_INFO_DEVICE_ID:
     return ReturnValue(uint32_t{Device->ZeDeviceProperties->deviceId});
   case UR_DEVICE_INFO_PCI_ADDRESS: {
-    if (getenv("ZES_ENABLE_SYSMAN") == nullptr) {
-      urPrint("Set SYCL_ENABLE_PCI=1 to obtain PCI data.\n");
-      return UR_RESULT_ERROR_INVALID_VALUE;
-    }
-    ZesStruct<zes_pci_properties_t> ZeDevicePciProperties;
-    ZE2UR_CALL(zesDevicePciGetProperties, (ZeDevice, &ZeDevicePciProperties));
+    ze_pci_address_ext_t PciAddr{};
+    ZeStruct<ze_pci_ext_properties_t> ZeDevicePciProperties;
+    ZeDevicePciProperties.address = PciAddr;
+    ZE2UR_CALL(zeDevicePciGetPropertiesExt, (ZeDevice, &ZeDevicePciProperties));
     constexpr size_t AddressBufferSize = 13;
     char AddressBuffer[AddressBufferSize];
     std::snprintf(AddressBuffer, AddressBufferSize, "%04x:%02x:%02x.%01x",

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.cpp
@@ -45,6 +45,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
     setEnvVar("ZE_ENABLE_PARAMETER_VALIDATION", "1");
   }
 
+  if (getenv("SYCL_ENABLE_PCI") != nullptr) {
+    urPrint("WARNING: SYCL_ENABLE_PCI is deprecated and no longer needed.\n");
+  }
+
   // TODO: We can still safely recover if something goes wrong during the init.
   // Implement handling segfault using sigaction.
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.cpp
@@ -45,12 +45,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urPlatformGet(
     setEnvVar("ZE_ENABLE_PARAMETER_VALIDATION", "1");
   }
 
-  // Enable SYSMAN support for obtaining the PCI address
-  // and maximum memory bandwidth.
-  if (getenv("SYCL_ENABLE_PCI") != nullptr) {
-    setEnvVar("ZES_ENABLE_SYSMAN", "1");
-  }
-
   // TODO: We can still safely recover if something goes wrong during the init.
   // Implement handling segfault using sigaction.
 

--- a/sycl/test-e2e/Basic/intel-ext-device.cpp
+++ b/sycl/test-e2e/Basic/intel-ext-device.cpp
@@ -26,9 +26,6 @@ using namespace sycl;
 #endif
 
 int main(int argc, char **argv) {
-  // Must be enabled at the beginning of the application
-  // to obtain the PCI address
-  setenv("SYCL_ENABLE_PCI", "1", 0);
 
   int pltCount = 1;
   for (const auto &plt : platform::get_platforms()) {

--- a/sycl/test-e2e/DeprecatedFeatures/deprecated_intel_ext_device.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/deprecated_intel_ext_device.cpp
@@ -29,10 +29,6 @@ using namespace sycl;
 #endif
 
 int main(int argc, char **argv) {
-  // Must be enabled at the beginning of the application
-  // to obtain the PCI address
-  setenv("SYCL_ENABLE_PCI", "1", 0);
-
   int pltCount = 1;
   for (const auto &plt : platform::get_platforms()) {
     int devCount = 1;

--- a/sycl/test-e2e/Regression/device_pci_address_bdf_format.cpp
+++ b/sycl/test-e2e/Regression/device_pci_address_bdf_format.cpp
@@ -26,10 +26,6 @@ using namespace sycl;
 #endif
 
 int main(int argc, char **argv) {
-  // Must be enabled at the beginning of the application
-  // to obtain the PCI address
-  setenv("SYCL_ENABLE_PCI", "1", 0);
-
   // Expected format is "{domain}:{bus}:{device}.{function} where:
   // * {domain} is a 4 character hexadecimal value.
   // * {bus} is a 2 character hexadecimal value.


### PR DESCRIPTION
L0 already provides an interface to access PCI information without needing to set an environment variable to access SYSMAN interfaces.