### PR TITLE
[SYCL-MLIR] Raise more `set_capture` ops.

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/Transforms/Passes.td
@@ -194,7 +194,7 @@ def LICM : Pass<"licm"> {
 def SYCLRaiseHostConstructs : Pass<"sycl-raise-host"> {
   let summary = "Raise relevant sequences of host code to SYCL dialect operations";
   // TODO: Description
-  let dependentDialects = ["arith::ArithDialect", "sycl::SYCLDialect"];
+  let dependentDialects = ["arith::ArithDialect", "sycl::SYCLDialect", "vector::VectorDialect"];
   let constructor = "mlir::polygeist::createSYCLHostRaisingPass()";
   let options = RewritePassUtils.options;
   // TODO: Statistics

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -53,4 +53,5 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRSideEffectInterfaces
   MLIRSCFToControlFlow
   MLIRTransformUtils
+  MLIRVectorDialect
 )

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -23,6 +23,8 @@
 #include "mlir/Dialect/Polygeist/Utils/TransformUtils.h"
 #include "mlir/Dialect/Polygeist/Utils/Utils.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/Vector/IR/VectorOps.h"
+#include "mlir/IR/ImplicitLocOpBuilder.h"
 #include "mlir/Transforms/GreedyPatternRewriteDriver.h"
 #include "llvm/ADT/TypeSwitch.h"
 #include "llvm/Demangle/Demangle.h"
@@ -1605,6 +1607,21 @@ public:
 
     auto captureTypes = lambdaClassTy.getBody();
 
+    auto createOps = [&, &lo = lambdaObj](Operation *captureOp,
+                                          Value capturedVal, unsigned index) {
+      ImplicitLocOpBuilder builder(captureOp->getLoc(), rewriter);
+      builder.setInsertionPointAfter(captureOp);
+
+      auto adaptedValuesAndTypes =
+          tryToAdapt(capturedVal, captureTypes[index], builder);
+      for (auto it : llvm::enumerate(adaptedValuesAndTypes)) {
+        auto [adaptedVal, typeAttr] = it.value();
+        builder.create<sycl::SYCLHostSetCaptured>(
+            lo, rewriter.getI64IntegerAttr(index + it.index()), adaptedVal,
+            typeAttr);
+      }
+    };
+
     // Look for unique assignments that represent the capturing of kernel args.
     // Assuming the no-op `getelementptr %lambdaObj[0, 0]` was folded, the
     // first capture is actually a store to the pointer.
@@ -1613,12 +1630,7 @@ public:
     if (auto [captureOp, capturedVal] =
             getUniqueAssignment(lambdaObj, annotatedPtr);
         captureOp) {
-      auto [broadenedVal, typeAttr] =
-          tryToBroaden(capturedVal, captureTypes[0]);
-      rewriter.setInsertionPointAfter(captureOp);
-      rewriter.create<sycl::SYCLHostSetCaptured>(captureOp->getLoc(), lambdaObj,
-                                                 rewriter.getI64IntegerAttr(0),
-                                                 broadenedVal, typeAttr);
+      createOps(captureOp, capturedVal, 0);
     }
 
     // All other captures are unique assignments to GEPs with two constant
@@ -1639,12 +1651,7 @@ public:
       if (!captureOp)
         continue;
 
-      auto [broadenedVal, typeAttr] =
-          tryToBroaden(capturedVal, captureTypes[captureIdx]);
-      rewriter.setInsertionPointAfter(captureOp);
-      rewriter.create<sycl::SYCLHostSetCaptured>(
-          captureOp->getLoc(), lambdaObj,
-          rewriter.getI64IntegerAttr(captureIdx), broadenedVal, typeAttr);
+      createOps(captureOp, capturedVal, captureIdx);
     }
 
     // Finally erase the annotation op.
@@ -1683,14 +1690,19 @@ private:
                 LLVM::LoadOp, LLVM::MemcpyOp>(user))
           continue;
 
-        // Special case for the first capture: if `ptr` is an alloca, there may
-        // be a destructor call for it.
+        // Special case for the first capture: if `ptr` is an alloca (= the
+        // lambda object), there may be calls to a destructor or certain API
+        // methods with it.
         if (auto call = dyn_cast<CallOpInterface>(user); ptrIsAlloca && call) {
           llvm::ItaniumPartialDemangler demangler;
           auto res = partialDemangle(demangler, call);
-          if (succeeded(res) && demangler.isCtorOrDtor() &&
-              !isConstructor(demangler))
-            continue;
+          if (succeeded(res)) {
+            if (demangler.isCtorOrDtor() && !isConstructor(demangler))
+              continue;
+            if (isMemberFunction(demangler, syclNamespace, "handler") &&
+                functionNameMatches(demangler, "unpack"))
+              continue;
+          }
         }
 
         // GEPs with only constant indices have a non-zero offset to `ptr`
@@ -1709,6 +1721,9 @@ private:
           continue;
 
         // Unexpected user; conservatively assume that assignment is not unique.
+        LLVM_DEBUG(llvm::dbgs() << "getUniqueAssignment: unexpected user\n";
+                   llvm::dbgs().indent(2) << "- " << ptr << '\n';
+                   llvm::dbgs().indent(2) << "- " << *user << '\n';);
         return {nullptr, Value()};
       }
     }
@@ -1716,10 +1731,11 @@ private:
     return {op, value};
   }
 
-  // Use the \p expected type as domain knowledge to try to broaden an
-  // \p assigned value to an entity of interest (e.g. an accessor).
-  std::tuple<Value, TypeAttr> tryToBroaden(Value assigned,
-                                           Type expected) const {
+  // Use domain knowledge to try to adapt an \p assigned value to match the
+  // \p expected type.
+  SmallVector<std::tuple<Value, TypeAttr>>
+  tryToAdapt(Value assigned, Type expected,
+             ImplicitLocOpBuilder &builder) const {
     if (isClassType(expected, accessorTypeTag.getTypeName())) {
       // The getelementpointer[0, <capture #>] we have matched earlier might not
       // address the entire accessor, but rather the first member in the
@@ -1739,15 +1755,27 @@ private:
                         dyn_cast<sycl::SYCLHostConstructorOp>(user)) {
                   assert(
                       isa<sycl::AccessorType>(hostCons.getType().getValue()));
-                  return {accessorAlloca, hostCons.getType()};
+                  return {{accessorAlloca, hostCons.getType()}};
                 }
 
       LLVM_DEBUG(llvm::dbgs()
-                 << "tryToBroaden: Could not infer captured accessor\n");
+                 << "tryToAdapt: Could not infer captured accessor\n");
+    }
+
+    // The frontend sometimes groups multiple scalars in vectors - reverse that.
+    if (auto vecTy = dyn_cast<VectorType>(assigned.getType());
+        vecTy && vecTy.getElementType() == expected) {
+      SmallVector<std::tuple<Value, TypeAttr>> scalars;
+      for (unsigned i = 0; i < vecTy.getNumElements(); ++i)
+        scalars.emplace_back(
+            builder.create<vector::ExtractElementOp>(
+                expected, assigned, builder.create<arith::ConstantIndexOp>(i)),
+            TypeAttr());
+      return scalars;
     }
 
     // No special handling, just return the argument as-is.
-    return {assigned, TypeAttr()};
+    return {{assigned, TypeAttr()}};
   }
 
   AccessorTypeTag accessorTypeTag;

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -741,40 +741,49 @@ gpu.module @device_functions {
 
 llvm.mlir.global private unnamed_addr constant @kernel_str("kernel\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
 
-!lambda_class = !llvm.struct<"class.lambda", (i16, i32, !llvm.struct<"class.sycl::_V1::accessor", (ptr)>, !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)>)>
+!lambda_class = !llvm.struct<"class.lambda", (i16, i32, !llvm.struct<"class.sycl::_V1::accessor", (ptr)>, !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32)>
 !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
 
 llvm.func @_ZN5DummyD2Ev(%arg0: !llvm.ptr)
+llvm.func @_ZN4sycl3_V17handler6unpackEv(%arg0: !llvm.ptr)
 
 // COM: check that we correctly identify captured accessors, scalars and structs
 
 // CHECK-LABEL:   llvm.func @raise_set_captured(
 // CHECK-SAME:                                  %[[VAL_0:.*]]: !llvm.ptr) {
-// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(123 : i32) : i32
-// CHECK:           %[[VAL_2:.*]] = llvm.mlir.constant(123 : i16) : i16
-// CHECK:           %[[VAL_3:.*]] = llvm.mlir.constant(32 : i32) : i32
-// CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(1 : i32) : i32
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1.000000e+01 : f32
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1.100000e+01 : f32
+// CHECK:           %[[VAL_3:.*]] = arith.constant dense<[1.000000e+01, 1.100000e+01]> : vector<2xf32>
+// CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(123 : i32) : i32
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(123 : i16) : i16
+// CHECK:           %[[VAL_6:.*]] = llvm.mlir.constant(32 : i32) : i32
+// CHECK:           %[[VAL_7:.*]] = llvm.mlir.constant(1 : i32) : i32
 // CHECK:           sycl.host.handler.set_kernel %[[VAL_0]] -> @device_functions::@foo : !llvm.ptr
-// CHECK:           %[[VAL_5:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK:           %[[VAL_6:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<"class.sycl::_V1::accessor", (ptr)> : (i32) -> !llvm.ptr
-// CHECK:           %[[VAL_7:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)> : (i32) -> !llvm.ptr
-// CHECK:           sycl.host.constructor(%[[VAL_6]], %[[VAL_5]], %[[VAL_5]], %[[VAL_5]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>)> : (i32) -> !llvm.ptr
-// CHECK:           llvm.store %[[VAL_2]], %[[VAL_8]] : i16, !llvm.ptr
-// CHECK:           sycl.host.set_captured %[[VAL_8]][0] = %[[VAL_2]] : !llvm.ptr, i16
-// CHECK:           %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_8]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>)>
-// CHECK:           llvm.store %[[VAL_1]], %[[VAL_9]] : i32, !llvm.ptr
-// CHECK:           sycl.host.set_captured %[[VAL_8]][1] = %[[VAL_1]] : !llvm.ptr, i32
-// CHECK:           %[[VAL_10:.*]] = llvm.getelementptr %[[VAL_8]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>)>
-// CHECK:           %[[VAL_11:.*]] = llvm.load %[[VAL_6]] : !llvm.ptr -> !llvm.ptr
-// CHECK:           llvm.store %[[VAL_11]], %[[VAL_10]] : !llvm.ptr, !llvm.ptr
-// CHECK:           sycl.host.set_captured %[[VAL_8]][2] = %[[VAL_6]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
-// CHECK:           %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_8]][0, 3] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>)>
-// CHECK:           "llvm.intr.memcpy"(%[[VAL_12]], %[[VAL_7]], %[[VAL_3]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
-// CHECK:           sycl.host.set_captured %[[VAL_8]][3] = %[[VAL_7]] : !llvm.ptr, !llvm.ptr
-// CHECK:           %[[VAL_13:.*]] = llvm.alloca %[[VAL_4]] x !llvm.ptr : (i32) -> !llvm.ptr
-// CHECK:           llvm.store %[[VAL_8]], %[[VAL_13]] : !llvm.ptr, !llvm.ptr
-// CHECK:           llvm.call @_ZN5DummyD2Ev(%[[VAL_8]]) : (!llvm.ptr) -> ()
+// CHECK:           %[[VAL_8:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK:           %[[VAL_9:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::accessor", (ptr)> : (i32) -> !llvm.ptr
+// CHECK:           %[[VAL_10:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)> : (i32) -> !llvm.ptr
+// CHECK:           sycl.host.constructor(%[[VAL_9]], %[[VAL_8]], %[[VAL_8]], %[[VAL_8]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           %[[VAL_11:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32)> : (i32) -> !llvm.ptr
+// CHECK:           llvm.store %[[VAL_5]], %[[VAL_11]] : i16, !llvm.ptr
+// CHECK:           sycl.host.set_captured %[[VAL_11]][0] = %[[VAL_5]] : !llvm.ptr, i16
+// CHECK:           %[[VAL_12:.*]] = llvm.getelementptr %[[VAL_11]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32)>
+// CHECK:           llvm.store %[[VAL_4]], %[[VAL_12]] : i32, !llvm.ptr
+// CHECK:           sycl.host.set_captured %[[VAL_11]][1] = %[[VAL_4]] : !llvm.ptr, i32
+// CHECK:           %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_11]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32)>
+// CHECK:           %[[VAL_14:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.ptr
+// CHECK:           llvm.store %[[VAL_14]], %[[VAL_13]] : !llvm.ptr, !llvm.ptr
+// CHECK:           sycl.host.set_captured %[[VAL_11]][2] = %[[VAL_9]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
+// CHECK:           %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_11]][0, 3] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32)>
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_15]], %[[VAL_10]], %[[VAL_6]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
+// CHECK:           sycl.host.set_captured %[[VAL_11]][3] = %[[VAL_10]] : !llvm.ptr, !llvm.ptr
+// CHECK:           %[[VAL_16:.*]] = llvm.getelementptr %[[VAL_11]][0, 4] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32)>
+// CHECK:           llvm.store %[[VAL_3]], %[[VAL_16]] : vector<2xf32>, !llvm.ptr
+// CHECK:           sycl.host.set_captured %[[VAL_11]][4] = %[[VAL_1]] : !llvm.ptr, f32
+// CHECK:           sycl.host.set_captured %[[VAL_11]][5] = %[[VAL_2]] : !llvm.ptr, f32
+// CHECK:           %[[VAL_17:.*]] = llvm.alloca %[[VAL_7]] x !llvm.ptr : (i32) -> !llvm.ptr
+// CHECK:           llvm.store %[[VAL_11]], %[[VAL_17]] : !llvm.ptr, !llvm.ptr
+// CHECK:           llvm.call @_ZN5DummyD2Ev(%[[VAL_11]]) : (!llvm.ptr) -> ()
+// CHECK:           llvm.call @_ZN4sycl3_V17handler6unpackEv(%[[VAL_11]]) : (!llvm.ptr) -> ()
 // CHECK:           llvm.return
 // CHECK:         }
 
@@ -787,6 +796,7 @@ llvm.func @raise_set_captured(%handler: !llvm.ptr) {
   %c32 = llvm.mlir.constant (32 : i32) : i32
   %c123_16 = llvm.mlir.constant (123 : i16) : i16
   %c123_32 = llvm.mlir.constant (123 : i32) : i32
+  %vec_lit = arith.constant dense<[10.0, 11.0]> : vector<2xf32>
   %nullptr = llvm.mlir.null : !llvm.ptr
   %accessor = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::accessor", (ptr)> : (i32) -> !llvm.ptr
   %vector = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)> : (i32) -> !llvm.ptr
@@ -813,6 +823,10 @@ llvm.func @raise_set_captured(%handler: !llvm.ptr) {
   %gep3 = llvm.getelementptr %lambda_obj[0, 3] : (!llvm.ptr) -> !llvm.ptr, !lambda_class
   "llvm.intr.memcpy"(%gep3, %vector, %c32) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
 
+  // COM: Frontend sometimes groups scalars into vectors
+  %gep4 = llvm.getelementptr %lambda_obj[0, 4] : (!llvm.ptr) -> !llvm.ptr, !lambda_class
+  llvm.store %vec_lit, %gep4 : vector<2xf32>, !llvm.ptr
+
   // COM: the annotation (indirectly) marks the struct as the lambda object
   %annotated_ptr = llvm.alloca %c1 x !llvm.ptr : (i32) -> !llvm.ptr
   llvm.store %lambda_obj, %annotated_ptr : !llvm.ptr, !llvm.ptr
@@ -821,6 +835,9 @@ llvm.func @raise_set_captured(%handler: !llvm.ptr) {
   
   // COM: mockup destruction of lambda object, should not interfere with the raising
   llvm.call @_ZN5DummyD2Ev(%lambda_obj) : (!llvm.ptr) -> ()
+
+  // COM: mockup call to `sycl::handler::unpack`, should not interfere with the raising
+  llvm.call @_ZN4sycl3_V17handler6unpackEv(%lambda_obj) : (!llvm.ptr) -> ()
 
   llvm.return
 }


### PR DESCRIPTION
This PR adds two special cases to the `set_capture` op raising, for situations we observed in SYCLbench:
1. Ignore calls/invokes to `sycl::handler::unpack`.
2. The frontend sometimes groups scalar arguments into vectors, to capture them in a single store. The pattern was extended to create `set_captured` ops *per scalar value*, to later match the expected number and kinds of arguments in the integration header.