### PR TITLE
[clang] Fix test in pulldown

### DIFF
--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -1649,6 +1649,8 @@ llvm::Value *ItaniumCXXABI::EmitDynamicCastToVoid(CodeGenFunction &CGF,
                                                   QualType SrcRecordTy,
                                                   QualType DestTy) {
   llvm::Type *DestLTy = CGF.ConvertType(DestTy);
+  if (!DestLTy->isPointerTy())
+    DestLTy = DestLTy->getPointerTo();
 #endif //INTEL_SYCL_OPAQUEPOINTER_READY
   auto *ClassDecl =
       cast<CXXRecordDecl>(SrcRecordTy->castAs<RecordType>()->getDecl());


### PR DESCRIPTION
Clang::CodeGenCXX/dynamic-cast-exact.cpp was failing because we still preseve non-opaque pointers version of `EmitDynamicCastToVoid` function which expects DestTy parameter as a pointer type.
9d525bf added new usage of `EmitDynamicCastToVoid` but since upstream doesn't care about typed pointers it was broken because `DestTy` parameter which doesn't exist in upstream ended up being non-pointer type.