### PR TITLE
[SYCL] Do not set CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON for plugins

### DIFF
--- a/sycl/plugins/CMakeLists.txt
+++ b/sycl/plugins/CMakeLists.txt
@@ -1,5 +1,3 @@
-set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)
-
 if ("${CMAKE_CXX_COMPILER_ID}" MATCHES "Clang|IntelLLVM" )
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-covered-switch-default")
 endif()

--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -8,8 +8,6 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)
-  # Prevent L0 loader from exporting extra symbols
-  set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS OFF)
 
   message(STATUS "Will fetch Level Zero Loader from ${LEVEL_ZERO_LOADER_REPO}")
   include(FetchContent)


### PR DESCRIPTION
We just don't need it:
1) PI interfaces are specifically marked with __SYCL_EXPORT, e.g. https://github.com/intel/llvm/blob/8e0cc4b7a845df9389a1313a3e680babc4d87782/sycl/include/sycl/detail/pi.h#L1148
2) We call to PI interfaces (except for `piPluginInit`) via a pointer from a table set up during `piPluginInit`:https://github.com/intel/llvm/blob/8e0cc4b7a845df9389a1313a3e680babc4d87782/sycl/include/sycl/detail/pi.hpp#L220
