### PR TITLE
Re-add bitcasts behind !INTEL_SYCL_OPAQUEPOINTERS_READY.

### DIFF
--- a/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
+++ b/llvm/lib/Transforms/Coroutines/CoroSplit.cpp
@@ -811,6 +811,9 @@ Value *CoroCloner::deriveNewFramePointer() {
     auto *ActiveAsyncSuspend = cast<CoroSuspendAsyncInst>(ActiveSuspend);
     auto ContextIdx = ActiveAsyncSuspend->getStorageArgumentIndex() & 0xff;
     auto *CalleeContext = NewF->getArg(ContextIdx);
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+    auto *FramePtrTy = Shape.FrameTy->getPointerTo();
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     auto *ProjectionFunc =
         ActiveAsyncSuspend->getAsyncContextProjectionFunction();
     auto DbgLoc =
@@ -830,7 +833,11 @@ Value *CoroCloner::deriveNewFramePointer() {
     auto InlineRes = InlineFunction(*CallerContext, InlineInfo);
     assert(InlineRes.isSuccess());
     (void)InlineRes;
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return FramePtrAddr;
+#else // INTEL_SYCL_OPAQUEPOINTER_READY
+    return Builder.CreateBitCast(FramePtrAddr, FramePtrTy);
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   // In continuation-lowering, the argument is the opaque storage.
   case coro::ABI::Retcon:
@@ -840,10 +847,20 @@ Value *CoroCloner::deriveNewFramePointer() {
 
     // If the storage is inline, just bitcast to the storage to the frame type.
     if (Shape.RetconLowering.IsFrameInlineInStorage)
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       return NewStorage;
+#else // INTEL_SYCL_OPAQUEPOINTER_READY
+      return Builder.CreateBitCast(NewStorage, FramePtrTy);
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Otherwise, load the real frame from the opaque storage.
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateLoad(FramePtrTy, NewStorage);
+#else // INTEL_SYCL_OPAQUEPOINTER_READY
+    auto FramePtrPtr =
+      Builder.CreateBitCast(NewStorage, FramePtrTy->getPointerTo());
+    return Builder.CreateLoad(FramePtrTy, FramePtrPtr);
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   }
   llvm_unreachable("bad ABI");
@@ -1826,7 +1843,13 @@ static void splitRetconCoroutine(Function &F, coro::Shape &Shape,
       Builder.CreateBitCast(RawFramePtr, Shape.CoroBegin->getType());
 
     // Stash the allocated frame pointer in the continuation storage.
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateStore(RawFramePtr, Id->getStorage());
+#else // INTEL_SYCL_OPAQUEPOINTER_READY
+    auto Dest = Builder.CreateBitCast(Id->getStorage(),
+                                      RawFramePtr->getType()->getPointerTo());
+    Builder.CreateStore(RawFramePtr, Dest);
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   // Map all uses of llvm.coro.begin to the allocated frame pointer.


### PR DESCRIPTION
Fixes
```
LLVM::Transforms/Coroutines/coro-async-remat.ll
LLVM::Transforms/Coroutines/coro-retcon-remat.ll
```

JR: CMPLRLLVM-50207.
