### PR TITLE
Add missing clangSerialization dependency for include-cleaner unittests

### DIFF
--- a/clang-tools-extra/include-cleaner/unittests/CMakeLists.txt
+++ b/clang-tools-extra/include-cleaner/unittests/CMakeLists.txt
@@ -25,6 +25,7 @@ clang_target_link_libraries(ClangIncludeCleanerTests
   clangFrontend
   clangFormat
   clangLex
+  clangSerialization
   clangToolingInclusionsStdlib
   )
 


### PR DESCRIPTION
Cherry pick to fix link error.