### PR TITLE
[SYCL][InvokeSimd] Allow callables to return uniform

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDVerifier.cpp
@@ -63,6 +63,7 @@ static const char *LegalSYCLFunctions[] = {
     "^sycl::_V1::ext::oneapi::sub_group::.+",
     "^sycl::_V1::ext::oneapi::experimental::spec_constant<.+>::.+",
     "^sycl::_V1::ext::oneapi::experimental::this_sub_group",
+    "^sycl::_V1::ext::oneapi::experimental::uniform<.+>::.+",
     "^sycl::_V1::ext::oneapi::bfloat16::.+",
     "^sycl::_V1::ext::oneapi::experimental::if_architecture_is"};
 

--- a/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp
@@ -371,7 +371,8 @@ constexpr bool has_struct_arg(Ret (*)(Args...)) {
 
 template <typename Ret, typename... Args>
 constexpr bool has_struct_ret(Ret (*)(Args...)) {
-  return std::is_class_v<Ret> && !is_simd_or_mask_type<Ret>::value;
+  return std::is_class_v<Ret> && !is_simd_or_mask_type<Ret>::value &&
+         !is_uniform_type<Ret>::value;
 }
 
 template <typename Ret, typename... Args>

--- a/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
@@ -7,6 +7,12 @@
 //
 // VISALTO enable run
 // RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
+//
+// RUN: %{build} -DUNIFORM_RET_TYPE -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t2.out
+// RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t2.out
+//
+// VISALTO enable run
+// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t2.out
 
 /*
  * Test case #1
@@ -98,17 +104,35 @@ template <class T>
  * returning the scalar as a SIMD type seems to work fine.
  */
 template <class T>
-__attribute__((always_inline)) T
+__attribute__((always_inline))
+#ifdef UNIFORM_RET_TYPE
+uniform<T>
+#else
+T
+#endif
 ESIMD_CALLEE_return_uniform_scalar(esimd::simd<T, VL> x,
                                    T n) SYCL_ESIMD_FUNCTION {
+#ifdef UNIFORM_RET_TYPE
+  return uniform<T>{n};
+#else
   return n;
+#endif
 }
 
 template <class T>
 [[intel::device_indirectly_callable]] SYCL_EXTERNAL
-    T __regcall SIMD_CALLEE_return_uniform_scalar(simd<T, VL> x,
-                                                  T n) SYCL_ESIMD_FUNCTION {
+#ifdef UNIFORM_RET_TYPE
+    uniform<T>
+#else
+    T
+#endif
+    __regcall SIMD_CALLEE_return_uniform_scalar(simd<T, VL> x,
+                                                T n) SYCL_ESIMD_FUNCTION {
+#ifdef UNIFORM_RET_TYPE
+  uniform<T> r = ESIMD_CALLEE_return_uniform_scalar<T>(x, n);
+#else
   T r = ESIMD_CALLEE_return_uniform_scalar<T>(x, n);
+#endif
   return r;
 }
 

--- a/sycl/test/invoke_simd/return-type-uniform.cpp
+++ b/sycl/test/invoke_simd/return-type-uniform.cpp
@@ -1,0 +1,29 @@
+// RUN: %clangxx -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %s -o /dev/null
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl;
+namespace esimd = sycl::ext::intel::esimd;
+
+[[intel::device_indirectly_callable]] uniform<int>
+callee(simd<int, 8>) SYCL_ESIMD_FUNCTION {
+  return uniform<int>(5);
+}
+
+void foo() {
+  constexpr unsigned Size = 1024;
+  constexpr unsigned GroupSize = 64;
+  sycl::range<1> GlobalRange{Size};
+  sycl::range<1> LocalRange{GroupSize};
+  sycl::nd_range<1> Range(GlobalRange, LocalRange);
+  queue q;
+  auto e = q.submit([&](handler &cgh) {
+    cgh.parallel_for(Range, [=](nd_item<1> ndi) {
+      uniform<int> x = invoke_simd(ndi.get_sub_group(), callee, 0);
+    });
+  });
+}
+
+int main() { foo(); }


### PR DESCRIPTION
The spec states that returning a `uniform` object is allowed:

"Return values of type sycl::ext::oneapi::experimental::uniform<T> are not anyhow converted, and broadcast to each work-item; every work-item in the sub-group receives the same value. NOTE: sycl::ext::oneapi::experimental::uniform<T> return type is the way to return a uniform value of simd or simd_mask type."

Update the compile-time error checking and ESIMD verifier to allow this.