### PR TITLE
[SYCL] Fix sycl::vec unary ops

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1245,7 +1245,7 @@ public:
   // operator~() available only when: dataT != float && dataT != double
   // && dataT != half
   template <typename T = DataT>
-  typename std::enable_if_t<std::is_integral_v<vec_data_t<T>> &&
+  typename std::enable_if_t<!std::is_floating_point_v<vec_data_t<T>> &&
                                 (!IsUsingArrayOnDevice && !IsUsingArrayOnHost),
                             vec>
   operator~() const {
@@ -1256,7 +1256,7 @@ public:
     return Ret;
   }
   template <typename T = DataT>
-  typename std::enable_if_t<std::is_integral_v<vec_data_t<T>> &&
+  typename std::enable_if_t<!std::is_floating_point_v<vec_data_t<T>> &&
                                 (IsUsingArrayOnDevice || IsUsingArrayOnHost),
                             vec>
   operator~() const {

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1274,7 +1274,8 @@ public:
   }
 
   // std::byte neither supports ! unary op or casting, so special handling is
-  // needed.
+  // needed. And, worse, Windows has a conflict with 'byte'.
+#if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
   template <typename T = DataT, int N = NumElements>
   typename std::enable_if_t<std::is_same<std::byte, T>::value &&
                                 (IsUsingArrayOnDevice || IsUsingArrayOnHost),
@@ -1297,6 +1298,15 @@ public:
       Ret.setValue(I, !vec_data<DataT>::get(getValue(I)));
     return Ret;
   }
+#else
+  template <typename T = DataT, int N = NumElements>
+  EnableIfUsingArray<vec<T, N>> operator!() const {
+    vec Ret{};
+    for (size_t I = 0; I < NumElements; ++I)
+      Ret.setValue(I, !vec_data<DataT>::get(getValue(I)));
+    return Ret;
+  }
+#endif
 
   // operator +
   template <typename T = vec> EnableIfNotUsingArray<T> operator+() const {

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -101,6 +101,67 @@ template <> inline void checkSizeForFloatingPoint<s::half, sizeof(int16_t)>() {
   static_assert(sizeof(s::half) == sizeof(int16_t), "");
 }
 
+template <typename vecType, int numOfElems>
+std::string vec2string(const sycl::vec<vecType, numOfElems> &vec) {
+  std::string str = "";
+  for (size_t i = 0; i < numOfElems - 1; ++i) {
+    str += std::to_string(vec[i]) + ",";
+  }
+  str = "{" + str + std::to_string(vec[numOfElems - 1]) + "}";
+  return str;
+}
+
+// the math built-in testing ensures that the vec binary ops get tested,
+// but the unary ops are only tested by the CTS tests. Here we do some
+// basic testing of the unary ops, ensuring they compile correctly.
+template <typename T> void checkVecUnaryOps(T &v) {
+
+  std::cout << vec2string(v) << std::endl;
+
+  T d = +v;
+  std::cout << vec2string(d) << std::endl;
+
+  T e = -v;
+  std::cout << vec2string(e) << std::endl;
+
+  // ~ only supported by integral types.
+  if constexpr (std::is_integral_v<T>) {
+    T g = ~v;
+    std::cout << vec2string(g) << std::endl;
+  }
+
+  T f = !v;
+  std::cout << vec2string(f) << std::endl;
+}
+
+void checkVariousVecUnaryOps() {
+  sycl::vec<int, 1> vi1{1};
+  checkVecUnaryOps(vi1);
+  sycl::vec<int, 16> vi{1, 2, 0, -4, 1, 2, 0, -4, 1, 2, 0, -4, 1, 2, 0, -4};
+  checkVecUnaryOps(vi);
+
+  sycl::vec<long, 1> vl1{1};
+  checkVecUnaryOps(vl1);
+  sycl::vec<long, 16> vl{2, 3, 0, -5, 2, 3, 0, -5, 2, 3, 0, -5, 2, 3, 0, -5};
+  checkVecUnaryOps(vl);
+
+  sycl::vec<long long, 1> vll1{1};
+  checkVecUnaryOps(vll1);
+  sycl::vec<long long, 16> vll{0, 3, 4, -6, 0, 3, 4, -6,
+                               0, 3, 4, -6, 0, 3, 4, -6};
+  checkVecUnaryOps(vll);
+
+  sycl::vec<float, 1> vf1{1};
+  checkVecUnaryOps(vf1);
+  sycl::vec<float, 16> vf{0, 4, 5, -9, 0, 4, 5, -9, 0, 4, 5, -9, 0, 4, 5, -9};
+  checkVecUnaryOps(vf);
+
+  sycl::vec<double, 1> vd1{1};
+  checkVecUnaryOps(vd1);
+  sycl::vec<double, 16> vd{0, 4, 5, -9, 0, 4, 5, -9, 0, 4, 5, -9, 0, 4, 5, -9};
+  checkVecUnaryOps(vd);
+}
+
 int main() {
   // Test for creating constexpr expressions
   constexpr sycl::specialization_id<sycl::vec<sycl::half, 2>> id(1.0);
@@ -125,6 +186,8 @@ int main() {
   checkSizeForFloatingPoint<s::opencl::cl_half, sizeof(int16_t)>();
   checkSizeForFloatingPoint<s::opencl::cl_float, sizeof(int32_t)>();
   checkSizeForFloatingPoint<s::opencl::cl_double, sizeof(int64_t)>();
+
+  checkVariousVecUnaryOps();
 
   return 0;
 }


### PR DESCRIPTION
The recent sycl::vec changes (https://github.com/intel/llvm/pull/9492)  broke they unary operations. This PR fixes them and adds some testing to avoid that in the future.