### PR TITLE
[SYCL] Fix error ‘CHAR_BIT’ was not declared in this scope in sycl/source/stream.cpp

### DIFF
--- a/sycl/source/stream.cpp
+++ b/sycl/source/stream.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <climits>
 #include <detail/queue_impl.hpp>
 #include <detail/stream_impl.hpp>
 #include <sycl/properties/all_properties.hpp>

--- a/sycl/source/stream.cpp
+++ b/sycl/source/stream.cpp
@@ -6,11 +6,12 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <climits>
 #include <detail/queue_impl.hpp>
 #include <detail/stream_impl.hpp>
 #include <sycl/properties/all_properties.hpp>
 #include <sycl/stream.hpp>
+
+#include <climits>
 
 namespace sycl {
 inline namespace _V1 {


### PR DESCRIPTION
Fix:
error: ‘CHAR_BIT’ was not declared in this scope