### PR TITLE
[SYCL] Update kernel function metadata after local accessor pass

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/TargetHelpers.h
+++ b/llvm/include/llvm/SYCLLowerIR/TargetHelpers.h
@@ -28,6 +28,7 @@ struct KernelPayload {
   KernelPayload(Function *Kernel, MDNode *MD = nullptr);
   Function *Kernel;
   MDNode *MD;
+  SmallVector<MDNode *> DependentMDs;
 };
 
 ArchType getArchType(const Module &M);

--- a/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
@@ -213,7 +213,7 @@ void LocalAccessorToSharedMemoryPass::postProcessKernels(
     KP.MD->replaceOperandWith(0, llvm::ConstantAsMetadata::get(F));
     // The MD node of the kernel has been altered, make sure that all the
     // dependent nodes are kept up to date.
-    for (auto *D : KP.DependentMDs)
+    for (MDNode *D : KP.DependentMDs)
       D->replaceOperandWith(0, llvm::ConstantAsMetadata::get(F));
   }
 }

--- a/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
+++ b/llvm/lib/SYCLLowerIR/LocalAccessorToSharedMemory.cpp
@@ -208,7 +208,12 @@ Function *LocalAccessorToSharedMemoryPass::processKernel(Module &M,
 void LocalAccessorToSharedMemoryPass::postProcessKernels(
     SmallVectorImpl<std::pair<Function *, KernelPayload>> &NewToOldKernels) {
   for (auto &Pair : NewToOldKernels) {
-    std::get<1>(Pair).MD->replaceOperandWith(
-        0, llvm::ConstantAsMetadata::get(std::get<0>(Pair)));
+    auto KP = std::get<1>(Pair);
+    auto *F = std::get<0>(Pair);
+    KP.MD->replaceOperandWith(0, llvm::ConstantAsMetadata::get(F));
+    // The MD node of the kernel has been altered, make sure that all the
+    // dependent nodes are kept up to date.
+    for (auto *D : KP.DependentMDs)
+      D->replaceOperandWith(0, llvm::ConstantAsMetadata::get(F));
   }
 }

--- a/llvm/lib/SYCLLowerIR/TargetHelpers.cpp
+++ b/llvm/lib/SYCLLowerIR/TargetHelpers.cpp
@@ -56,7 +56,7 @@ void populateKernels(Module &M, SmallVectorImpl<KernelPayload> &Kernels,
   if (!AnnotationMetadata)
     return;
 
-  std::vector<MDNode *> PossibleDependencies;
+  SmallVector<MDNode *, 4> PossibleDependencies;
   // It is possible that the annotations node contains multiple pointers to the
   // same metadata, recognise visited ones.
   SmallSet<MDNode *, 4> Visited;

--- a/llvm/lib/SYCLLowerIR/TargetHelpers.cpp
+++ b/llvm/lib/SYCLLowerIR/TargetHelpers.cpp
@@ -92,7 +92,7 @@ void populateKernels(Module &M, SmallVectorImpl<KernelPayload> &Kernels,
   for (auto &KP : Kernels) {
     auto *KernelConstant = cast<ConstantAsMetadata>(KP.MD->getOperand(0));
     auto KernelName =
-        dyn_cast<Function>(KernelConstant->getValue())->getFunction().getName();
+        cast<Function>(KernelConstant->getValue())->getFunction().getName();
     // Keep track of matched nodes, to decrease the search space with each
     // iteration.
     SmallVector<unsigned> ToDelete;

--- a/llvm/lib/SYCLLowerIR/TargetHelpers.cpp
+++ b/llvm/lib/SYCLLowerIR/TargetHelpers.cpp
@@ -90,8 +90,7 @@ void populateKernels(Module &M, SmallVectorImpl<KernelPayload> &Kernels,
   // We need to match non-kernel metadata nodes using the kernel name to the
   // kernel nodes.
   for (auto &KP : Kernels) {
-    auto *KernelConstant = dyn_cast<ConstantAsMetadata>(KP.MD->getOperand(0));
-    assert(KernelConstant);
+    auto *KernelConstant = cast<ConstantAsMetadata>(KP.MD->getOperand(0));
     auto KernelName =
         dyn_cast<Function>(KernelConstant->getValue())->getFunction().getName();
     // Keep track of matched nodes, to decrease the search space with each

--- a/llvm/test/CodeGen/NVPTX/local-accessor-to-shared-memory-basic-transformation.ll
+++ b/llvm/test/CodeGen/NVPTX/local-accessor-to-shared-memory-basic-transformation.ll
@@ -4,7 +4,9 @@ source_filename = "basic-transformation.ll"
 target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
 
-; This test checks that the transformation is applied in the basic case.
+; This test checks that the transformation is applied in the basic case. It
+; aslo makes sure that a non-kernel node using the function's signature gets
+; correcly updated (`maxntid`).
 
 ; CHECK: @_ZTS14example_kernel_shared_mem = external addrspace(3) global [0 x i8], align 4
 
@@ -23,8 +25,8 @@ entry:
   ret void
 }
 
-!nvvm.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3}
-!nvvmir.version = !{!5}
+!nvvm.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5}
+!nvvmir.version = !{!6}
 
 !0 = distinct !{void (i32 addrspace(3)*, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"kernel", i32 1}
 ; CHECK: !0 = distinct !{void (i32, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"kernel", i32 1}
@@ -32,4 +34,6 @@ entry:
 !2 = !{null, !"align", i32 8, !"align", i32 65544, !"align", i32 131080}
 !3 = !{null, !"align", i32 16}
 !4 = !{null, !"align", i32 16, !"align", i32 65552, !"align", i32 131088}
-!5 = !{i32 1, i32 4}
+; CHECK: !5 = distinct !{void (i32, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"maxntid", i32 256}
+!5 = !{void (i32 addrspace(3)*, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"maxntidx", i32 256}
+!6 = !{i32 1, i32 4}

--- a/llvm/test/CodeGen/NVPTX/local-accessor-to-shared-memory-basic-transformation.ll
+++ b/llvm/test/CodeGen/NVPTX/local-accessor-to-shared-memory-basic-transformation.ll
@@ -5,7 +5,7 @@ target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
 
 ; This test checks that the transformation is applied in the basic case. It
-; aslo makes sure that a non-kernel node using the function's signature gets
+; also makes sure that a non-kernel node using the function's signature gets
 ; correcly updated (`maxntid`).
 
 ; CHECK: @_ZTS14example_kernel_shared_mem = external addrspace(3) global [0 x i8], align 4

--- a/llvm/test/CodeGen/NVPTX/local-accessor-to-shared-memory-basic-transformation.ll
+++ b/llvm/test/CodeGen/NVPTX/local-accessor-to-shared-memory-basic-transformation.ll
@@ -34,6 +34,6 @@ entry:
 !2 = !{null, !"align", i32 8, !"align", i32 65544, !"align", i32 131080}
 !3 = !{null, !"align", i32 16}
 !4 = !{null, !"align", i32 16, !"align", i32 65552, !"align", i32 131088}
-; CHECK: !5 = distinct !{void (i32, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"maxntid", i32 256}
+; CHECK: !5 = distinct !{void (i32, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"maxntidx", i32 256}
 !5 = !{void (i32 addrspace(3)*, i32 addrspace(1)*, i32)* @_ZTS14example_kernel, !"maxntidx", i32 256}
 !6 = !{i32 1, i32 4}


### PR DESCRIPTION
Make sure that metadata containing the kernel function is correctly updated after local accessor to shared memory pass is run.