### PR TITLE
[SYCL-MLIR][LoopInternalization] Enable by default

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -128,7 +128,7 @@ static llvm::cl::opt<bool> EnableLICM("licm", llvm::cl::init(true),
                                       llvm::cl::desc("Turn on LICM"));
 
 static llvm::cl::opt<bool>
-    EnableLoopInternalization("loop-internalization", llvm::cl::init(false),
+    EnableLoopInternalization("loop-internalization", llvm::cl::init(true),
                               llvm::cl::desc("Enable loop internalization"));
 
 static llvm::cl::opt<bool>


### PR DESCRIPTION
We are aware of degradation with `Gesummv` on PVC when `DetectReduction` is enabled. 