### PR TITLE
[SYCL-MLIR] Enable raising host by default

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -371,6 +371,8 @@ def warn_drv_opt_requires_opt
   : Warning<"'%0' should be used only in conjunction with '%1'">, InGroup<UnusedCommandLineArgument>;
 def err_drv_sycl_missing_amdgpu_arch : Error<
   "missing AMDGPU architecture for SYCL offloading; specify it with '-Xsycl-target-backend --offload-arch'">;
+def warn_drv_sycl_ignoring_no_opaque_pointer : Warning<
+  "-fsycl-raise-host is active, forcing -opaque-pointer">, InGroup<SyclTarget>;
 def warn_drv_sycl_offload_target_duplicate : Warning<
   "SYCL offloading target '%0' is similar to target '%1' already specified; "
   "will be ignored">, InGroup<SyclTarget>;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3097,8 +3097,10 @@ def fsycl_device_only : Flag<["-"], "fsycl-device-only">, Flags<[CoreOption]>,
   HelpText<"Compile SYCL kernels for device">;
 def fsycl_embed_ir : Flag<["-"], "fsycl-embed-ir">, Flags<[CoreOption]>,
   HelpText<"Embed LLVM IR for runtime kernel fusion">;
-def fsycl_raise_host : Flag<["-"], "fsycl-raise-host">, Flags<[CoreOption]>,
-  HelpText<"Raise SYCL host code to MLIR after compiling to LLVM IR">;
+defm sycl_raise_host : BoolOptionWithoutMarshalling<"f", "sycl-raise-host",
+    PosFlag<SetTrue, [], "Raise SYCL host code to MLIR after compiling to LLVM IR">,
+    NegFlag<SetFalse, [], "Do not Raise SYCL host code to MLIR after compiling to LLVM IR">,
+    BothFlags<[CoreOption], "">>;
 defm sycl_esimd_force_stateless_mem : BoolFOption<"sycl-esimd-force-stateless-mem",
     LangOpts<"SYCLESIMDForceStatelessMem">, DefaultFalse,
     PosFlag<SetTrue, [], "Enforce using stateless memory accesses. "

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5334,7 +5334,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // are currently not understood by mlir-translate. Therefore deactive the
       // debug assignment tracking when we want to raise this host module later
       // on to MLIR.
-      if (Args.hasArg(options::OPT_fsycl_raise_host))
+      if (Args.hasFlag(options::OPT_fsycl_raise_host,
+                       options::OPT_fno_sycl_raise_host, true))
         CmdArgs.push_back("-fexperimental-assignment-tracking=disabled");
 
       if (!D.IsCLMode()) {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5335,8 +5335,10 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       // debug assignment tracking when we want to raise this host module later
       // on to MLIR.
       if (Args.hasFlag(options::OPT_fsycl_raise_host,
-                       options::OPT_fno_sycl_raise_host, true))
+                       options::OPT_fno_sycl_raise_host, true)) {
         CmdArgs.push_back("-fexperimental-assignment-tracking=disabled");
+        CmdArgs.push_back("-opaque-pointer");
+      }
 
       if (!D.IsCLMode()) {
         // SYCL library is guaranteed to work correctly only with dynamic

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -12,7 +12,7 @@
 // CHK-PHASES-LLVM: 3: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {2}, ir
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
-// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
 // RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-LLVM-RAISE %s
@@ -43,7 +43,7 @@
 // CHK-PHASES-MLIR: 3: offload, "device-sycl (spir64-unknown-unknown-syclmlir)" {2}, mlir
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
-// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
 // RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-RAISE %s
@@ -74,7 +74,7 @@
 // CHK-PHASES-MLIR-NO-TRIPLE: 3: offload, "device-sycl (spir64-unknown-unknown)" {2}, mlir
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \
-// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
 // RUN: -fsycl-raise-host -Xclang -opaque-pointers                      \
 // RUN: -fsycl-targets=spir64-unknown-unknown -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-PHASES-MLIR-NO-TRIPLE-RAISE %s
@@ -96,6 +96,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fno-sycl-raise-host                                            \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-LLVM %s
 //
@@ -115,6 +116,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -fsycl-device-only   \
+// RUN: -fno-sycl-raise-host                                            \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-MLIR %s
 //
@@ -134,6 +136,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                 \
+// RUN: -fno-sycl-raise-host                                       \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1     \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-LLVM %s
 //
@@ -158,6 +161,7 @@
 
 // RUN: %clangxx -ccc-print-bindings --sysroot=%S/Inputs/SYCL           \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fno-sycl-raise-host                                            \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-BINDINGS-FULL-MLIR %s
 
@@ -180,6 +184,7 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c                      \
+// RUN: -fno-sycl-raise-host                                            \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM-BC %s
 //
@@ -198,6 +203,7 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c  -S -emit-llvm       \
+// RUN: -fno-sycl-raise-host                                            \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-LLVM %s
 //
@@ -216,6 +222,7 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only      \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -emit-mlir          \
+// RUN: -fno-sycl-raise-host                                           \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1         \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-MLIR %s
 //
@@ -235,6 +242,7 @@
 
 // RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
 // RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
+// RUN: -fno-sycl-raise-host                                            \
 // RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
 // RUN: | FileCheck -check-prefix=CHK-INVOKE-ARG-PASS %s
 //

--- a/clang/test/Driver/sycl-mlir.cpp
+++ b/clang/test/Driver/sycl-mlir.cpp
@@ -285,6 +285,14 @@
 
 // CHK-RAISE-HOST-CCMP: error: the combination of '-fsycl-raise-host' and '-fsycl-host-compiler=' is incompatible
 
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl-device-only       \
+// RUN: -target x86_64-unknown-linux-gnu -fsycl -c -Xcgeist -S          \
+// RUN: -fsycl-raise-host -fsycl-host-compiler=g++                      \
+// RUN: -fsycl-targets=spir64-unknown-unknown-syclmlir %s 2>&1          \
+// RUN: | FileCheck -check-prefix=CHK-RAISE-HOST-CCMP-IMPLICIT-OPAQUE %s
+
+// CHK-RAISE-HOST-CCMP-IMPLICIT-OPAQUE: -opaque-pointers
+
 // Make sure -fsycl-raise-host is ignored with -fsycl-link and -fsycl-link-targets
 
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL             \

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -30,6 +30,7 @@ set(compile_opts
   # we declare all functions as 'static'.
   -Wno-undefined-internal
   -sycl-std=2020
+  -fno-sycl-raise-host
   )
 
 if(NOT SPIRV_ENABLE_OPAQUE_POINTERS)

--- a/sycl/test/check_device_code/cuda/ldg.cpp
+++ b/sycl/test/check_device_code/cuda/ldg.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xclang -fnative-half-type -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// RUN: %clangxx -Xclang -fno-sycl-raise-host -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xclang -fnative-half-type -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xclang -fnative-half-type -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/ext/oneapi/experimental/cuda/builtins.hpp>

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-bfloat16-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-bfloat16-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-double-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-double-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-float-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-float-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-half-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-half-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_70 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-int8-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-int8-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-tf32-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-tf32-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_80 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 // IMPORTANT: before updating sm version support beyond sm_90 read the following

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-uint8-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-uint8-test.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
-// RUN: %clangxx -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -Xclang -no-opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s
 // RUN: %clangxx -Xclang -opaque-pointers -fsycl-device-only -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_72 -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 -S -Xclang -emit-llvm %s -o -| FileCheck %s --check-prefixes=CHECK-OPAQUE
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_device_has_warning.cpp
@@ -1,4 +1,5 @@
-// RUN: %clangxx -fsycl-device-only -Xclang -no-opaque-pointers -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -fsycl-device-only -Xclang -no-opaque-pointers -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 // RUN: %clangxx -fsycl-device-only -Xclang -opaque-pointers -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
 // Tests for warnings when propagated aspects do not match the aspects available

--- a/sycl/test/warnings/aspect_perserve_srcloc.cpp
+++ b/sycl/test/warnings/aspect_perserve_srcloc.cpp
@@ -1,4 +1,5 @@
-// RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -no-opaque-pointers -Xclang -verify %s
+// Disable no opaque pointers
+// RUN: %clangxx -fno-sycl-raise-host -fsycl-device-only -fsycl-early-optimizations -Xclang -no-opaque-pointers -Xclang -verify %s
 // RUN: %clangxx -fsycl-device-only -fsycl-early-optimizations -Xclang -opaque-pointers -Xclang -verify %s
 
 // Tests for the preservation of source location information when warning


### PR DESCRIPTION
Make the host raising default when building for MLIR. The patch adds -fno-sycl-raise-host in order to opt out of raising.