### PR TITLE
[SYCL-MLIR][constant-propagation] Propagate `local_accessor` members

### DIFF
--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -802,8 +802,12 @@ void ConstantAccessorArg::propagate(OpBuilder &builder, Region &region) {
     recordHit();
   };
 
-  LLVM_DEBUG(llvm::dbgs().indent(2)
-             << "Propagating accessor at position #" << index << "\n");
+  LLVM_DEBUG({
+    llvm::dbgs().indent(2) << "Propagating ";
+    if (info.isLocalAccessor())
+      llvm::dbgs() << "local_";
+    llvm::dbgs() << "accessor at position #" << index << "\n";
+  });
 
   if (info.needsRange()) {
     if (info.hasConstantRange()) {
@@ -817,6 +821,18 @@ void ConstantAccessorArg::propagate(OpBuilder &builder, Region &region) {
       replace(accessRangeMemberOffset, [&](Type type) {
         return createIDRange<SYCLRangeConstructorOp>(builder, loc, type,
                                                      accessRange);
+      });
+      if (info.isLocalAccessor()) {
+        replace(memoryRangeMemberOffset, [&](Type type) {
+          return createIDRange<SYCLRangeConstructorOp>(builder, loc, type,
+                                                       accessRange);
+        });
+      }
+    } else if (info.isLocalAccessor()) {
+      LLVM_DEBUG(llvm::dbgs().indent(4)
+                 << "local_accessor can share access and memory range\n");
+      replace(accessRangeMemberOffset, [&](Type) {
+        return region.getArgument(index + memoryRangeMemberOffset);
       });
     }
   } else {
@@ -984,7 +1000,7 @@ getSYCLGridPropagator(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
 static std::unique_ptr<ConstantAccessorArg>
 getConstantAccessorArg(SYCLHostScheduleKernel op,
                        polygeist::SYCLAccessorAnalysis &accessorAnalysis,
-                       unsigned index, Value value, AccessorType type) {
+                       unsigned index, Value value) {
   LLVM_DEBUG(llvm::dbgs().indent(2)
              << "Handling accessor at operand #" << index << "\n");
 
@@ -1023,9 +1039,10 @@ static unsigned getTrueIndex(const RangeTy &typeAttrs, unsigned originalIndex) {
       begin, std::next(begin, originalIndex), 0,
       [](unsigned index, TypeAttr attr) {
         Type type = attr.getValue();
-        unsigned offset = TypeSwitch<Type, unsigned>(type)
-                              .Case<AccessorType>([](auto) { return 4; })
-                              .template Case<NoneType>([](auto) { return 1; });
+        unsigned offset =
+            TypeSwitch<Type, unsigned>(type)
+                .Case<AccessorType, LocalAccessorType>([](auto) { return 4; })
+                .template Case<NoneType>([](auto) { return 1; });
         return index + offset;
       });
 }
@@ -1117,11 +1134,13 @@ auto ConstantPropagationPass::getConstantArgs(
                                                           arrayDefinitionOp);
               }
             }
-            auto accType =
-                llvm::dyn_cast_or_null<AccessorType>(type.getValue());
-            return accType ? getConstantAccessorArg(op, accessorAnalysis,
-                                                    trueIndex, value, accType)
-                           : nullptr;
+            return TypeSwitch<Type, std::unique_ptr<ConstantExplicitArg>>(
+                       type.getValue())
+                .Case<AccessorType, LocalAccessorType>([&](auto) {
+                  return getConstantAccessorArg(op, accessorAnalysis, trueIndex,
+                                                value);
+                })
+                .template Case<NoneType>([](auto) { return nullptr; });
           }),
       llvm::identity<std::unique_ptr<ConstantExplicitArg>>());
 }

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -1737,7 +1737,7 @@ gpu.module @kernels0 {
                           %memRange: memref<?x!sycl_range_1_>,
                           %offset: memref<?x!sycl_id_1_>)
 
-// COM: Check we omit offset and use same access and memory range for local_accessor
+// COM: Check we use zero-initialized range/id as memory range/offset
 
 // CHECK-LABEL:     gpu.func @k(
 // CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi64, 1>, %[[VAL_1:.*]]: memref<?x!sycl_range_1_>, %[[VAL_2:.*]]: memref<?x!sycl_range_1_>, %[[VAL_3:.*]]: memref<?x!sycl_id_1_>) kernel {
@@ -1784,7 +1784,7 @@ gpu.module @kernels1 {
                           %memRange: memref<?x!sycl_range_1_>,
                           %offset: memref<?x!sycl_id_1_>)
 
-// COM: Check we omit offset and use constant access and memory range for local_accessor
+// COM: Check we use 0-initialized range/id as memory range/offset and constant access range
 
 // CHECK-LABEL:     gpu.func @k(
 // CHECK-SAME:        %[[VAL_0:.*]]: memref<?xi64, 1>, %[[VAL_1:.*]]: memref<?x!sycl_range_1_>, %[[VAL_2:.*]]: memref<?x!sycl_range_1_>, %[[VAL_3:.*]]: memref<?x!sycl_id_1_>) kernel {

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -1721,3 +1721,111 @@ llvm.func internal @constant_acc(
       : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return
 }
+
+// -----
+
+!sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
+!sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
+!sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
+!sycl_local_accessor_1_i64 = !sycl.local_accessor<[1, i64], (memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>)>
+!sycl_local_accessor_host = !sycl.local_accessor<[1, !llvm.void], (!sycl_range_1_)>
+
+gpu.module @kernels0 {
+  func.func private @init(%acc: memref<1x!sycl_local_accessor_1_i64>,
+                          %ptr: memref<?xi64, 1>,
+                          %accRange: memref<?x!sycl_range_1_>,
+                          %memRange: memref<?x!sycl_range_1_>,
+                          %offset: memref<?x!sycl_id_1_>)
+
+// COM: Check we omit offset and use same access and memory range for local_accessor
+
+// CHECK-LABEL:     gpu.func @k(
+// CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi64, 1>, %[[VAL_1:.*]]: memref<?x!sycl_range_1_>, %[[VAL_2:.*]]: memref<?x!sycl_range_1_>, %[[VAL_3:.*]]: memref<?x!sycl_id_1_>) kernel {
+// CHECK-NEXT:             %[[VAL_4:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
+// CHECK-NEXT:             %[[VAL_5:.*]] = memref.cast %[[VAL_4]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
+// CHECK-NEXT:             %[[VAL_6:.*]] = memref.alloca() : memref<1x!sycl_local_accessor_1_i64_>
+// CHECK-NEXT:             func.call @init(%[[VAL_6]], %[[VAL_0]], %[[VAL_2]], %[[VAL_2]], %[[VAL_5]]) : (memref<1x!sycl_local_accessor_1_i64_>, memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:             gpu.return
+// CHECK-NEXT:           }
+  gpu.func @k(%ptr: memref<?xi64, 1>,
+              %accRange: memref<?x!sycl_range_1_>,
+              %memRange: memref<?x!sycl_range_1_>,
+              %offset: memref<?x!sycl_id_1_>) kernel {
+    %acc = memref.alloca() : memref<1x!sycl_local_accessor_1_i64>
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
+        : (memref<1x!sycl_local_accessor_1_i64>, memref<?xi64, 1>,
+           memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
+           memref<?x!sycl_id_1_>) -> ()
+    gpu.return
+  }
+}
+
+llvm.func internal @unknown_range(
+  %lambda: !llvm.ptr, %handler: !llvm.ptr, %range: !llvm.ptr) {
+  %c1_i32 = llvm.mlir.constant(1 : i32) : i32
+  %acc = llvm.alloca %c1_i32 x !llvm.struct<"sycl::_V1::local_accessor", opaque>
+      : (i32) -> !llvm.ptr
+  sycl.host.constructor(%acc, %range, %handler)
+      {type=!sycl_local_accessor_host}
+      : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.set_captured %lambda[0] = %acc : !llvm.ptr, !llvm.ptr (!sycl_local_accessor_host)
+  sycl.host.schedule_kernel %handler -> @kernels0::@k(%acc: !sycl_local_accessor_host)
+      : (!llvm.ptr, !llvm.ptr) -> ()
+  llvm.return
+}
+
+gpu.module @kernels1 {
+  func.func private @init(%acc: memref<1x!sycl_local_accessor_1_i64>,
+                          %ptr: memref<?xi64, 1>,
+                          %accRange: memref<?x!sycl_range_1_>,
+                          %memRange: memref<?x!sycl_range_1_>,
+                          %offset: memref<?x!sycl_id_1_>)
+
+// COM: Check we omit offset and use constant access and memory range for local_accessor
+
+// CHECK-LABEL:     gpu.func @k(
+// CHECK-SAME:        %[[VAL_0:.*]]: memref<?xi64, 1>, %[[VAL_1:.*]]: memref<?x!sycl_range_1_>, %[[VAL_2:.*]]: memref<?x!sycl_range_1_>, %[[VAL_3:.*]]: memref<?x!sycl_id_1_>) kernel {
+// CHECK-NEXT:             %[[VAL_4:.*]] = arith.constant 512 : index
+// CHECK-NEXT:             %[[VAL_5:.*]] = sycl.range.constructor(%[[VAL_4]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK-NEXT:             %[[VAL_6:.*]] = memref.cast %[[VAL_5]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
+// CHECK-NEXT:             %[[VAL_7:.*]] = arith.constant 512 : index
+// CHECK-NEXT:             %[[VAL_8:.*]] = sycl.range.constructor(%[[VAL_7]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK-NEXT:             %[[VAL_9:.*]] = memref.cast %[[VAL_8]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
+// CHECK-NEXT:             %[[VAL_10:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
+// CHECK-NEXT:             %[[VAL_11:.*]] = memref.cast %[[VAL_10]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
+// CHECK-NEXT:             %[[VAL_12:.*]] = memref.alloca() : memref<1x!sycl_local_accessor_1_i64_>
+// CHECK-NEXT:             func.call @init(%[[VAL_12]], %[[VAL_0]], %[[VAL_6]], %[[VAL_9]], %[[VAL_11]]) : (memref<1x!sycl_local_accessor_1_i64_>, memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:             gpu.return
+// CHECK-NEXT:           }
+  gpu.func @k(%ptr: memref<?xi64, 1>,
+              %accRange: memref<?x!sycl_range_1_>,
+              %memRange: memref<?x!sycl_range_1_>,
+              %offset: memref<?x!sycl_id_1_>) kernel {
+    %acc = memref.alloca() : memref<1x!sycl_local_accessor_1_i64>
+    func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
+        : (memref<1x!sycl_local_accessor_1_i64>, memref<?xi64, 1>,
+           memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
+           memref<?x!sycl_id_1_>) -> ()
+    gpu.return
+  }
+}
+
+llvm.func internal @known_range(
+  %lambda: !llvm.ptr, %handler: !llvm.ptr) {
+  %c1_i32 = llvm.mlir.constant(1 : i32) : i32
+  %n = llvm.mlir.constant(512 : i64) : i64
+  %range = llvm.alloca %c1_i32 x !llvm.struct<"sycl::_V1::range.1", opaque>
+      : (i32) -> !llvm.ptr
+  %acc = llvm.alloca %c1_i32 x !llvm.struct<"sycl::_V1::local_accessor", opaque>
+      : (i32) -> !llvm.ptr
+  sycl.host.constructor(%range, %n)
+      {type=!sycl_range_1_}
+      : (!llvm.ptr, i64) -> ()
+  sycl.host.constructor(%acc, %range, %handler)
+      {type=!sycl_local_accessor_host}
+      : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.set_captured %lambda[0] = %acc : !llvm.ptr, !llvm.ptr (!sycl_local_accessor_host)
+  sycl.host.schedule_kernel %handler -> @kernels1::@k(%acc: !sycl_local_accessor_host)
+      : (!llvm.ptr, !llvm.ptr) -> ()
+  llvm.return
+}

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -1741,10 +1741,13 @@ gpu.module @kernels0 {
 
 // CHECK-LABEL:     gpu.func @k(
 // CHECK-SAME:                  %[[VAL_0:.*]]: memref<?xi64, 1>, %[[VAL_1:.*]]: memref<?x!sycl_range_1_>, %[[VAL_2:.*]]: memref<?x!sycl_range_1_>, %[[VAL_3:.*]]: memref<?x!sycl_id_1_>) kernel {
-// CHECK-NEXT:             %[[VAL_4:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
-// CHECK-NEXT:             %[[VAL_5:.*]] = memref.cast %[[VAL_4]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
-// CHECK-NEXT:             %[[VAL_6:.*]] = memref.alloca() : memref<1x!sycl_local_accessor_1_i64_>
-// CHECK-NEXT:             func.call @init(%[[VAL_6]], %[[VAL_0]], %[[VAL_2]], %[[VAL_2]], %[[VAL_5]]) : (memref<1x!sycl_local_accessor_1_i64_>, memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:             %[[C0:.*]] = arith.constant 0 : index
+// CHECK-NEXT:             %[[VAL_4:.*]] = sycl.range.constructor(%[[C0]]) : (index) -> memref<1x!sycl_range_1_>
+// CHECK-NEXT:             %[[VAL_5:.*]] = memref.cast %[[VAL_4]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
+// CHECK-NEXT:             %[[VAL_6:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
+// CHECK-NEXT:             %[[VAL_7:.*]] = memref.cast %[[VAL_6]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
+// CHECK-NEXT:             %[[VAL_8:.*]] = memref.alloca() : memref<1x!sycl_local_accessor_1_i64_>
+// CHECK-NEXT:             func.call @init(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]], %[[VAL_5]], %[[VAL_7]]) : (memref<1x!sycl_local_accessor_1_i64_>, memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:             gpu.return
 // CHECK-NEXT:           }
   gpu.func @k(%ptr: memref<?xi64, 1>,
@@ -1788,7 +1791,7 @@ gpu.module @kernels1 {
 // CHECK-NEXT:             %[[VAL_4:.*]] = arith.constant 512 : index
 // CHECK-NEXT:             %[[VAL_5:.*]] = sycl.range.constructor(%[[VAL_4]]) : (index) -> memref<1x!sycl_range_1_>
 // CHECK-NEXT:             %[[VAL_6:.*]] = memref.cast %[[VAL_5]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
-// CHECK-NEXT:             %[[VAL_7:.*]] = arith.constant 512 : index
+// CHECK-NEXT:             %[[VAL_7:.*]] = arith.constant 0 : index
 // CHECK-NEXT:             %[[VAL_8:.*]] = sycl.range.constructor(%[[VAL_7]]) : (index) -> memref<1x!sycl_range_1_>
 // CHECK-NEXT:             %[[VAL_9:.*]] = memref.cast %[[VAL_8]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
 // CHECK-NEXT:             %[[VAL_10:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>

--- a/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h
@@ -39,7 +39,8 @@ public:
         constantOffset{constOffset} {}
 
   AccessorInformation(bool hasRange, llvm::ArrayRef<size_t> constRange)
-      : isLocal{true}, needRange{hasRange}, constantRange{constRange} {}
+      : isLocal{true}, needRange{hasRange}, constantRange{constRange},
+        needOffset{false} {}
 
   /// Return whether the accessor is local.
   bool isLocalAccessor() const { return isLocal; }

--- a/polygeist/lib/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.cpp
@@ -394,7 +394,9 @@ SYCLAccessorAnalysis::getInformation(const Definition &def) {
                                    needsOffset, constOffset);
       })
       .Case<sycl::LocalAccessorType>([=](auto accessorTy) {
-        bool needsRange = constructor->getNumOperands() > 3;
+        bool needsRange = llvm::any_of(accessorTy.getBody(), [](Type ty) {
+          return isa<sycl::RangeType>(ty);
+        });
         ArrayRef<size_t> constRange = std::nullopt;
         if (needsRange) {
           // In the SYCL API, the range must be the first parameter to the


### PR DESCRIPTION
Use following rules for `local_accessor`:

- Use same memory and access range
- Propagate known range
- Always use zero-initialized `id` as an offset