### PR TITLE
[SYCL-MLIR] Enable -sycl-constant-propagation by default

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -127,6 +127,10 @@ static llvm::cl::opt<bool> OpenMPOpt("openmp-opt", llvm::cl::init(true),
 static llvm::cl::opt<bool> EnableLICM("licm", llvm::cl::init(true),
                                       llvm::cl::desc("Turn on LICM"));
 
+static llvm::cl::opt<bool> EnableSYCLConstantPropagation(
+    "sycl-constant-propagation", llvm::cl::init(true),
+    llvm::cl::desc("Turn on SYCL host-device constant propagation"));
+
 static llvm::cl::opt<bool>
     EnableLoopInternalization("loop-internalization", llvm::cl::init(false),
                               llvm::cl::desc("Enable loop internalization"));

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_pipeline.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_pipeline.cpp
@@ -7,9 +7,10 @@
 // CHECK-SAME:    gpu.module(any({{.*}})))
 
 // CHECK-LABEL: Optimization pipeline:
-// CHECK:       Pass Manager with 5 passes:
+// CHECK:       Pass Manager with 6 passes:
 // CHECK:       any(
 // CHECK-SAME:    sycl-raise-host{ }
+// CHECK-SAME:    sycl-constant-propagation{relaxed-aliasing=false}
 // CHECK-SAME:    arg-promotion
 // CHECK-SAME:    kernel-disjoint-specialization{relaxed-aliasing=false use-opaque-pointers=false}
 // CHECK-SAME:    gpu.module(any({{.*}}))

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -413,8 +413,12 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
   CanonicalizerConfig.maxIterations = CanonicalizeIterations;
 
   if (OptLevel != llvm::OptimizationLevel::O0) {
-    if (SYCLRaiseHost)
+    if (SYCLRaiseHost) {
       PM.addPass(polygeist::createSYCLHostRaisingPass());
+      if (EnableSYCLConstantPropagation)
+        PM.addPass(sycl::createConstantPropagationPass(
+            {options.getCgeistOpts().getRelaxedAliasing()}));
+    }
     PM.addPass(polygeist::createArgumentPromotionPass());
     PM.addPass(polygeist::createKernelDisjointSpecializationPass(
         {options.getCgeistOpts().getRelaxedAliasing(), UseOpaquePointers}));


### PR DESCRIPTION
Run `-sycl-constant-propagation` after `-sycl-raise-host`.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>
