### PR TITLE
[SYCL] Skip alloca commands when checking for leaves completion

### DIFF
--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -27,11 +27,15 @@ namespace detail {
 
 bool Scheduler::checkLeavesCompletion(MemObjRecord *Record) {
   for (Command *Cmd : Record->MReadLeaves) {
-    if (!Cmd->getEvent()->isCompleted())
+    if (!(Cmd->getType() == detail::Command::ALLOCA ||
+          Cmd->getType() == detail::Command::ALLOCA_SUB_BUF) &&
+        !Cmd->getEvent()->isCompleted())
       return false;
   }
   for (Command *Cmd : Record->MWriteLeaves) {
-    if (!Cmd->getEvent()->isCompleted())
+    if (!(Cmd->getType() == detail::Command::ALLOCA ||
+          Cmd->getType() == detail::Command::ALLOCA_SUB_BUF) &&
+        !Cmd->getEvent()->isCompleted())
       return false;
   }
   return true;


### PR DESCRIPTION
Scheduler::checkLeavesCompletion checks status of all leaves of the buffer to see whether we can destroy that sycl::buffer. There are many scenarios when alloca commands are leaves, these commands don't have associated event and currently they are always incorrectly considered "in progress" because of that preventing buffers to be destroyed timely and deferring their destruction till the point of program termination. Skip alloca commands to fix that.