### PR TITLE
[SYCL] Fix check-all after #10635

### DIFF
--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -83,6 +83,7 @@ add_lit_testsuite(check-sycl-spirv "Running device-agnostic SYCL regression test
   PARAMS "SYCL_TRIPLE=spir64-unknown-unknown"
   DEPENDS ${SYCL_TEST_DEPS}
   ${SYCL_TEST_EXCLUDE}
+  EXCLUDE_FROM_CHECK_ALL
   )
 
 add_lit_testsuite(check-sycl-dumps "Running ABI dump tests only"
@@ -100,6 +101,7 @@ if(SYCL_BUILD_PI_CUDA)
     PARAMS "SYCL_TRIPLE=nvptx64-nvidia-cuda"
     DEPENDS ${SYCL_TEST_DEPS}
     ${SYCL_TEST_EXCLUDE}
+    EXCLUDE_FROM_CHECK_ALL
   )
 
   add_custom_target(check-sycl-cuda)
@@ -115,6 +117,7 @@ if(SYCL_BUILD_PI_HIP)
       PARAMS "SYCL_TRIPLE=nvptx64-nvidia-cuda"
       DEPENDS ${SYCL_TEST_DEPS}
       ${SYCL_TEST_EXCLUDE}
+      EXCLUDE_FROM_CHECK_ALL
     )
 
     add_dependencies(check-sycl-hip check-sycl-hip-ptx)
@@ -125,6 +128,7 @@ if(SYCL_BUILD_PI_HIP)
       PARAMS "SYCL_TRIPLE=amdgcn-amd-amdhsa"
       DEPENDS ${SYCL_TEST_DEPS}
       ${SYCL_TEST_EXCLUDE}
+      EXCLUDE_FROM_CHECK_ALL
     )
 
     add_dependencies(check-sycl-hip check-sycl-hip-gcn)


### PR DESCRIPTION
Single triple targets are only meant for manual run and should not be included into check-all, only check-sycl-combined-triples should be. Otherwise we are running the same tests from multiple processes resulting in race conditions (beside unnecessary work).