### PR TITLE
[CI] Use separate Linux build/test jobs and no matrix generator in nightly

### DIFF
--- a/.github/workflows/sycl_linux_build.yml
+++ b/.github/workflows/sycl_linux_build.yml
@@ -52,6 +52,8 @@ on:
         default: 3
 
     outputs:
+      build_conclusion:
+        value: ${{ jobs.build.outputs.build_conclusion }}
       artifact_archive_name:
         value: ${{ jobs.build.outputs.artifact_archive_name }}
       artifact_decompress_command:

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -68,7 +68,7 @@ jobs:
     uses: ./.github/workflows/sycl_linux_run_tests.yml
     with:
       name: ${{ matrix.name }}
-      runner: ${{ matrix. runner }}
+      runner: ${{ matrix.runner }}
       image: ${{ matrix.image }}
       image_options: ${{ matrix.image_options }}
       target_devices: ${{ matrix.target_devices }}

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -6,17 +6,9 @@ on:
     - cron: '0 3 * * *'
 
 jobs:
-  test_matrix:
+  ubuntu2204_build:
     if: github.repository == 'intel/llvm'
-    name: Generate Test Matrix
-    uses: ./.github/workflows/sycl_gen_test_matrix.yml
-    with:
-      lts_config: "hip_amdgpu;ocl_gen12;ocl_x64;l0_gen12;esimd_emu;cuda_aws;win_l0_gen12"
-
-  ubuntu2204_build_test:
-    if: github.repository == 'intel/llvm'
-    uses: ./.github/workflows/sycl_linux_build_and_test.yml
-    needs: test_matrix
+    uses: ./.github/workflows/sycl_linux_build.yml
     secrets: inherit
     with:
       build_cache_root: "/__w/"
@@ -24,12 +16,76 @@ jobs:
       build_configure_extra_args: '--hip --cuda --enable-esimd-emulator'
       merge_ref: ''
       retention-days: 90
-      lts_matrix: ${{ needs.test_matrix.outputs.lts_lx_matrix }}
-      lts_aws_matrix: ${{ needs.test_matrix.outputs.lts_aws_matrix }}
 
       # We upload the build for people to download/use, override its name and
       # prefer widespread gzip compression.
       artifact_archive_name: sycl_linux.tar.gz
+
+  ubuntu2204_test:
+    needs: [ubuntu2204_build]
+    if: ${{ always() && !cancelled() && needs.ubuntu2204_build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: AMD/HIP
+            runner: '["Linux", "amdgpu"]'
+            image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+            image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
+            target_devices: ext_oneapi_hip:gpu
+
+          - name: Intel L0 GPU
+            runner: '["Linux", "gen12"]'
+            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
+            image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+            target_devices: ext_oneapi_level_zero:gpu
+            reset_gpu: true
+
+          - name: Intel OCL GPU
+            runner: '["Linux", "gen12"]'
+            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
+            image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+            target_devices: opencl:gpu
+            reset_gpu: true
+
+          - name: OCL CPU
+            runner: '["Linux", "x86-cpu"]'
+            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
+            image_options: -u 1001
+            target_devices: opencl:cpu
+
+          - name: ESIMD Emu
+            runner: '["Linux", "x86-cpu"]'
+            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
+            image_options: -u 1001
+            target_devices: ext_intel_esimd_emulator:gpu
+
+          - name: Self-hosted CUDA
+            runner: '["Linux", "cuda"]'
+            image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+            target_devices: ext_oneapi_cuda:gpu
+    uses: ./.github/workflows/sycl_linux_run_tests.yml
+    with:
+      name: ${{ matrix.name }}
+      runner: ${{ matrix. runner }}
+      image: ${{ matrix.image }}
+      image_options: ${{ matrix.image_options }}
+      target_devices: ${{ matrix.target_devices }}
+      reset_gpu: ${{ matrix.reset_gpu }}
+      ref: ${{ github.sha }}
+      merge_ref: ''
+      sycl_toolchain_artifact: sycl_linux_default
+      sycl_toolchain_archive: ${{ needs.ubuntu2204_build.outputs.artifact_archive_name }}
+      sycl_toolchain_decompress_command: ${{ needs.ubuntu2204_build.outputs.artifact_decompress_command }}
+
+
+  test_matrix:
+    if: github.repository == 'intel/llvm'
+    name: Generate Test Matrix
+    uses: ./.github/workflows/sycl_gen_test_matrix.yml
+    with:
+      lts_config: "win_l0_gen12"
 
   windows_default:
     name: Windows
@@ -47,7 +103,7 @@ jobs:
   nightly_build_upload:
     name: Nightly Build Upload
     if: ${{ github.ref_name == 'sycl' }}
-    needs: [ubuntu2204_build_test, windows_default]
+    needs: [ubuntu2204_build, windows_default]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v3
@@ -80,7 +136,7 @@ jobs:
   ubuntu2204_docker_build_push:
     if: github.repository == 'intel/llvm'
     runs-on: [Linux, build]
-    needs: ubuntu2204_build_test
+    needs: ubuntu2204_build
     steps:
     - uses: actions/checkout@v3
     - uses: actions/download-artifact@v3


### PR DESCRIPTION
Also changes daily build upload (via github release) to only require successful build/LIT and not E2E tests.

In addition to that, I switched CUDA E2E from using AWS runner to using our self-hosted one. The load of this workflow is low so our single runner can handle that.