### PR TITLE
[SYCL][E2E] Enable USM/memops2d on PVC

### DIFF
--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_device.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
@@ -12,7 +12,7 @@
 
 // Temporarily disabled until the failure is addressed.
 // For HIP see https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_device.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_dhost.cpp
@@ -10,7 +10,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_host.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_device.cpp
@@ -12,7 +12,7 @@
 
 // Temporarily disabled until the failure is addressed.
 // For HIP see https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_host.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_device.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_device.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
@@ -12,7 +12,7 @@
 
 // Temporarily disabled until the failure is addressed.
 // For HIP see https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_device.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_dhost.cpp
@@ -10,7 +10,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_host.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_device.cpp
@@ -12,7 +12,7 @@
 
 // Temporarily disabled until the failure is addressed.
 // For HIP see https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows) || hip
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_host.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_device.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_shared.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // Temporarily disabled until the failure is addressed.
-// UNSUPPORTED: gpu-intel-pvc || (level_zero && windows)
+// UNSUPPORTED: (level_zero && windows)
 
 #include "memcpy2d_common.hpp"
 


### PR DESCRIPTION
The underlying issue in the GPU RT seems to have been fixed, verified locally.

Closes https://github.com/intel/llvm/issues/8103.