### PR TITLE
[DOC] Update section on new contributing and new CI flow process and other small edits

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,14 +28,14 @@ To contribute:
 
 - Create a personal fork of the project on GitHub
 - Prepare your patch
-  - follow [LLVM coding standards](https://llvm.org/docs/CodingStandards.html)
-  - [clang-format](https://clang.llvm.org/docs/ClangFormat.html) and
+  - Follow [LLVM coding standards](https://llvm.org/docs/CodingStandards.html)
+  - [Clang-format](https://clang.llvm.org/docs/ClangFormat.html) and
     [clang-tidy](https://clang.llvm.org/extra/clang-tidy/) tools can be
     integrated into your workflow to ensure formatting and stylistic
     compliance of your changes. To avoid code formatting misalignment with
     GitHub Actions check we recommend using 10 version of clang-format tool
     (default version on Ubuntu 22.04).
-  - use
+  - Use
 
     ```bash
     ./clang/tools/clang-format/git-clang-format `git merge-base origin/sycl HEAD`
@@ -84,13 +84,13 @@ ready for merge.
 - Sometimes unrelated fails can be observed in the PR. It's author
 responsibility to find/guess the reason of these fails and post a comment in
 the PR with:
-  - possible reason of fails, ideally with a link to the PR, which caused fails
-  - link to other PR(s), which expected to fix fails
-  - person who is currently looking into fails
-  - link to existing open issue
-  - if author cannot identify any of these, the minimal action expected is to
+  - Possible reason of fails, ideally with a link to the PR, which caused fails
+  - Link to other PR(s), which expected to fix fails
+  - Person who is currently looking into fails
+  - Link to existing open issue
+  - If author cannot identify any of these, the minimal action expected is to
     open a new [issue](/../../issues)
-  - list of unrelated tests failing in pre-commit CI. This would enable easy
+  - List of unrelated tests failing in pre-commit CI. This would enable easy
     access to them via github search functionality.
 
 ### Merge

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -78,6 +78,12 @@ To contribute:
 
 - CI will run several build and functional testing checks as soon as the PR is
 approved by an Intel representative.
+  - By default, pre-commit activies (build/test) will not auto start when PR
+    is submitted for new contributors and non members of the project. If your
+    PR shows "workflow awaiting approval" then your assigned code reviewer or 
+    another member of the project will need to approve the test run and start
+    it for you. If you are unable to reach someone to approve your run, please
+    contact the project gatekeepers (@intel/llvm-gatekeepers).  
   - A new approval is needed if the PR was updated (e.g. during code review).
 - Once the PR is approved and all checks have passed, the pull request is
 ready for merge.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,10 @@ Submit an [issue](https://github.com/intel/llvm/issues) or initiate a
 
 ### How to contribute to DPC++
 
-See [ContributeToDPCPP](./sycl/doc/developer/ContributeToDPCPP.md).
+This project welcomes contributions from the community. Please refer to [CONTRIBUTING](/CONTRIBUTING.md) 
+for general guidelines around contributing to this project. You can then see 
+[ContributeToDPCPP](./sycl/doc/developer/ContributeToDPCPP.md) for DPC++ specific 
+guidelines.
 
 ## Late-outline OpenMP\* and OpenMP\* Offload
 

--- a/README.md
+++ b/README.md
@@ -79,10 +79,6 @@ for general guidelines around contributing to this project. You can then see
 [ContributeToDPCPP](./sycl/doc/developer/ContributeToDPCPP.md) for DPC++ specific 
 guidelines.
 
-## Late-outline OpenMP\* and OpenMP\* Offload
-
-See [openmp](/tree/openmp) branch.
-
 # License
 
 See [LICENSE](./sycl/LICENSE.TXT) for details.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ for general guidelines around contributing to this project. You can then see
 [ContributeToDPCPP](./sycl/doc/developer/ContributeToDPCPP.md) for DPC++ specific 
 guidelines.
 
+## Late-outline OpenMP\* and OpenMP\* Offload
+
+See [openmp](/tree/openmp) branch.
+
 # License
 
 See [LICENSE](./sycl/LICENSE.TXT) for details.


### PR DESCRIPTION
The CI system no longer auto runs pre-commit activities for new contributors by default. Update the documentation to reflect the new process of needing someone to approve workload run.  Also, since i'm here, make some small constancy edits in some files I was touching. 