### PR TITLE
[SYCL] Fix arithmetic unary operators for non-native vec

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1281,26 +1281,34 @@ public:
 // Use __SYCL_DEVICE_ONLY__ macro because cast to OpenCL vector type is defined
 // by SYCL device compiler only.
 #ifdef __SYCL_DEVICE_ONLY__
-    return vec{+m_Data};
-#else
-    vec Ret{};
-    for (size_t I = 0; I < NumElements; ++I)
-      Ret.setValue(I, vec_data<DataT>::get(+vec_data<DataT>::get(getValue(I))));
-    return Ret;
+    if constexpr (NativeVec) {
+      return vec{+m_Data};
+    } else
 #endif
+    {
+      vec Ret{};
+      for (size_t I = 0; I < NumElements; ++I)
+        Ret.setValue(I,
+                     vec_data<DataT>::get(+vec_data<DataT>::get(getValue(I))));
+      return Ret;
+    }
   }
 
   vec operator-() const {
 // Use __SYCL_DEVICE_ONLY__ macro because cast to OpenCL vector type is defined
 // by SYCL device compiler only.
 #ifdef __SYCL_DEVICE_ONLY__
-    return vec{-m_Data};
-#else
-    vec Ret{};
-    for (size_t I = 0; I < NumElements; ++I)
-      Ret.setValue(I, vec_data<DataT>::get(-vec_data<DataT>::get(getValue(I))));
-    return Ret;
+    if constexpr (NativeVec) {
+      return vec{-m_Data};
+    } else
 #endif
+    {
+      vec Ret{};
+      for (size_t I = 0; I < NumElements; ++I)
+        Ret.setValue(I,
+                     vec_data<DataT>::get(-vec_data<DataT>::get(getValue(I))));
+      return Ret;
+    }
   }
 
   // OP is: &&, ||

--- a/sycl/test/regression/vec_arith_unary_ops.cpp
+++ b/sycl/test/regression/vec_arith_unary_ops.cpp
@@ -1,0 +1,16 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+
+// Tests that the arithmetic unary operators - and + on vectors that do not use
+// native OpenCL vector implementations compile.
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue Q;
+  Q.single_task([=]() {
+    sycl::vec<long, 16> V1{32};
+    auto V2 = -V1;
+    auto V3 = +V2;
+  });
+  return 0;
+}


### PR DESCRIPTION
This commit fixes an issue where the arithmetic unary operators + and - for sycl::vec assume that the native vector representation is always used on the device.