### PR TITLE
[SYCL][InvokeSimd][E2E] Remove VISALTO flag

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/invoke_simd_struct.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/invoke_simd_struct.cpp
@@ -4,9 +4,6 @@
 //
 // RUN: %{build} -DIMPL_SUBGROUP -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/feature/invoke_simd_struct.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/invoke_simd_struct_by_pointer.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/invoke_simd_struct_by_pointer.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -DIMPL_SUBGROUP -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as

--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/popcnt.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/popcnt.cpp
@@ -5,9 +5,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../popcnt.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/feature/popcnt.cpp, but compiles without

--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/popcnt_emu.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/popcnt_emu.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../popcnt_emu.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/feature/popcnt_emu.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/scale.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/scale.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../scale.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/feature/scale.cpp, but compiles without

--- a/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/void_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/ImplicitSubgroup/void_retval.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../void_retval.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/feature/void_retval.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Feature/invoke_simd_struct.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/invoke_simd_struct.cpp
@@ -4,9 +4,6 @@
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /* Test case specification:
  * -----------------------

--- a/sycl/test-e2e/InvokeSimd/Feature/invoke_simd_struct_by_pointer.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/invoke_simd_struct_by_pointer.cpp
@@ -1,8 +1,5 @@
 // RUN: %clangxx -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %s -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Feature/popcnt.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/popcnt.cpp
@@ -5,9 +5,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Feature/popcnt_emu.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/popcnt_emu.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * Tests invoke_simd support in the compiler/headers

--- a/sycl/test-e2e/InvokeSimd/Feature/split_module/SPMD_module.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/split_module/SPMD_module.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/Inputs/ESIMD_module.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support of modular code structure.
 // ESIMD part is located in split_module/Inputs/ESIMD_module.cpp

--- a/sycl/test-e2e/InvokeSimd/Feature/split_module/SPMD_module_ImplicitSubgroup.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/split_module/SPMD_module_ImplicitSubgroup.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/SPMD_module.cpp %S/Inputs/ESIMD_module.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/feature/split_module/SPMD_module.cpp,

--- a/sycl/test-e2e/InvokeSimd/Feature/void_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/void_retval.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /*

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../call_vadd_1d_loop.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/call_vadd_1d_loop.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_loop_naive.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../call_vadd_1d_loop_naive.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/call_vadd_1d_loop_naive.cpp,

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_spill.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/call_vadd_1d_spill.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../call_vadd_1d_spill.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/call_vadd_1d_spill.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/debug_symbols.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g %S/../debug_symbols.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/debug_symbols.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/dp4a.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/dp4a.cpp
@@ -3,9 +3,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../dp4a.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/dp4a.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/matrix_add.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/matrix_add.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../matrix_add.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/matrix_add.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/matrix_multiply_USM.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/matrix_multiply_USM.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../matrix_multiply_USM.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/regression/matrix_multiply_USM.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/matrix_multiply_accessor_get_pointer.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/matrix_multiply_accessor_get_pointer.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../matrix_multiply_accessor_get_pointer.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/nbarrier_basic.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/nbarrier_basic.cpp
@@ -3,9 +3,6 @@
 //
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../nbarrier_basic.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/Regression/slm_load_store.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp
@@ -1,8 +1,5 @@
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../slm_load_store.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/Regression/slm_load_store.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/tiled_matrix_multiplication.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/tiled_matrix_multiplication.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../tiled_matrix_multiplication.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as

--- a/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_loop.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_loop.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_loop_naive.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_loop_naive.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_spill.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_spill.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /* This program is basically an extension of the standard vector addition

--- a/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -g -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /* Tests invoke_simd support in the compiler/headers
  * Test checks support for passing a debug symbols option (-g) to the compiler.

--- a/sycl/test-e2e/InvokeSimd/Regression/dp4a.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/dp4a.cpp
@@ -3,9 +3,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /* The test checks that invoke_simd implementation performs proper call of
  * ESIMD math function dp4a.

--- a/sycl/test-e2e/InvokeSimd/Regression/matrix_add.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/matrix_add.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Regression/matrix_multiply_USM.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/matrix_multiply_USM.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Regression/matrix_multiply_accessor_get_pointer.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/matrix_multiply_accessor_get_pointer.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_basic.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_basic.cpp
@@ -3,9 +3,6 @@
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// vISA LTO run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * Test checks basic support for named barriers in invoke_simd context.

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_exec_in_order.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_exec_in_order.cpp
@@ -3,9 +3,6 @@
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// vISA LTO run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * Test checks basic support for named barriers in invoke_simd context.

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
@@ -3,9 +3,6 @@
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// vISA LTO run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * Test checks support of named barrier in a loop in invoke_simd context.

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
@@ -3,9 +3,6 @@
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// vISA LTO run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * Test checks support of named barrier in invoke_simd context with multiple

--- a/sycl/test-e2e/InvokeSimd/Regression/slm_load_store.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/slm_load_store.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * Test check basic support of local memory access in invoke_simd.

--- a/sycl/test-e2e/InvokeSimd/Regression/tiled_matrix_multiplication.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/tiled_matrix_multiplication.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Spec/ESIMD_to_unmarked_function.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ESIMD_to_unmarked_function.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/ESIMD_to_unmarked_function.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/ESIMD_to_unmarked_function.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../ESIMD_to_unmarked_function.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/ESIMD_to_unmarked_function.cpp,

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/function_overloads.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/function_overloads.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../function_overloads.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/function_overloads.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/multiple_SPMD_to_multiple_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/multiple_SPMD_to_multiple_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../multiple_SPMD_to_multiple_ESIMD.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/multiple_SPMD_to_single_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/multiple_SPMD_to_single_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../multiple_SPMD_to_single_ESIMD.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/multiple_SPMD_to_single_ESIMD.cpp,

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/nested_ESIMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/nested_ESIMD_to_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../nested_ESIMD_to_ESIMD.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/nested_ESIMD_to_ESIMD.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/nested_SPMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/nested_SPMD_to_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../nested_SPMD_to_ESIMD.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/nested_SPMD_to_ESIMD.cpp, but

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/simd_mask.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/simd_mask.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../simd_mask.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/simd_mask.cpp, but compiles without

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/tuple.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/tuple.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../tuple.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/tuple.cpp, but compiles without

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/tuple_return.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/tuple_return.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../tuple_return.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/tuple_return.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/tuple_vadd.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/tuple_vadd.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../tuple_vadd.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/tuple_vadd.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/uniform_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ImplicitSubgroup/uniform_retval.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../uniform_retval.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /*
  * This tests is the same as InvokeSimd/spec/uniform_retval.cpp, but compiles

--- a/sycl/test-e2e/InvokeSimd/Spec/function_overloads.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/function_overloads.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /*

--- a/sycl/test-e2e/InvokeSimd/Spec/multiple_SPMD_to_multiple_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/multiple_SPMD_to_multiple_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Spec/multiple_SPMD_to_single_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/multiple_SPMD_to_single_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Spec/nested_ESIMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/nested_ESIMD_to_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Spec/nested_SPMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/nested_SPMD_to_ESIMD.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_mask.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_mask.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /* Test case description:

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd16.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd16.cpp
@@ -1,9 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /* Tests invoke_simd support in the compiler/headers
  * Test checks support for different subgroup sizes in combination with

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd32.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd32.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /* Tests invoke_simd support in the compiler/headers
  * Test checks support for different subgroup sizes in combination with

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8.cpp
@@ -7,9 +7,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 /* Tests invoke_simd support in the compiler/headers
  * Test checks support for different subgroup sizes in combination with

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8_platform_error.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8_platform_error.cpp
@@ -21,7 +21,7 @@ int main(void) {
 
   // VL = 8
   passed &= test<8, 8>(q);
-  // CHECK: {{.*}}error: Kernel compiled with required subgroup size 8, which is unsupported on this platform{{.*}}
+  // CHECK: {{.*}}SYCL exception caught: Sub-group size 8 is not supported on the device{{.*}}
 
   std::cout << (passed ? "Passed\n" : "FAILED\n");
   return passed ? 0 : 1;

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8_platform_error.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8_platform_error.cpp
@@ -21,7 +21,7 @@ int main(void) {
 
   // VL = 8
   passed &= test<8, 8>(q);
-  // CHECK: {{.*}}SYCL exception caught: Sub-group size 8 is not supported on the device{{.*}}
+  // CHECK: {{.*}}error: Kernel compiled with required subgroup size 8, which is unsupported on this platform{{.*}}
 
   std::cout << (passed ? "Passed\n" : "FAILED\n");
   return passed ? 0 : 1;

--- a/sycl/test-e2e/InvokeSimd/Spec/tuple.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/tuple.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /* Test case description:

--- a/sycl/test-e2e/InvokeSimd/Spec/tuple_return.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/tuple_return.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /* Test case purpose:

--- a/sycl/test-e2e/InvokeSimd/Spec/tuple_vadd.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/tuple_vadd.cpp
@@ -4,9 +4,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 
 // Tests invoke_simd support in the compiler/headers
 /* Test case purpose:

--- a/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
@@ -5,14 +5,8 @@
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-//
 // RUN: %{build} -DUNIFORM_RET_TYPE -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t2.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t2.out
-//
-// VISALTO enable run
-// RUN: env IGC_VISALTO=63 IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t2.out
 
 /*
  * Test case #1


### PR DESCRIPTION
Removed runs with IGC_VISALTO flags, as LTO now enabled by default