### PR TITLE
[SYCL][OpenCL] Return the right value when querying PI_EVENT_INFO_COMMAND_EXECUTION_STATUS

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -3941,6 +3941,17 @@ inline pi_result piEventGetInfo(pi_event Event, pi_event_info ParamName,
   HANDLE_ERRORS(urEventGetInfo(UREvent, PropName, ParamValueSize, ParamValue,
                                ParamValueSizeRet));
 
+  if (ParamName == PI_EVENT_INFO_COMMAND_EXECUTION_STATUS) {
+    /* If the PI_EVENT_INFO_COMMAND_EXECUTION_STATUS info value is
+     * PI_EVENT_QUEUED, change it to PI_EVENT_SUBMITTED. This change is needed
+     * since sycl::info::event::event_command_status has no equivalent to
+     * PI_EVENT_QUEUED. */
+    const auto param_value_int = static_cast<pi_int32 *>(ParamValue);
+    if (*param_value_int == PI_EVENT_QUEUED) {
+      *param_value_int = PI_EVENT_SUBMITTED;
+    }
+  }
+
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
If PI_EVENT_INFO_COMMAND_EXECUTION_STATUS info value is PI_EVENT_QUEUED, change it to PI_EVENT_SUBMITTED.

This change was originally in the OpenCL PI plugin: https://github.com/intel/llvm/commit/5a91df97973a5099d69b163140a6bb17b28ac59b

However, I decided to move it to pi2ur since I think its scope is wider than just OpenCL.