### PR TITLE
[SYCL-MLIR] Drop `-lower-affine` pass

### DIFF
--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -460,8 +460,6 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
 
     OptPM.addPass(mlir::createCanonicalizerPass(CanonicalizerConfig, {}, {}));
     OptPM.addPass(mlir::createCSEPass());
-    // Note: affine dialects must be lowered to allow callees containing affine
-    // operations to be inlined.
     if (RaiseToAffine)
       OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
     OptPM.addPass(polygeist::createReplaceAffineCFGPass());

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -463,14 +463,11 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
     // Note: affine dialects must be lowered to allow callees containing affine
     // operations to be inlined.
     if (RaiseToAffine)
-      OptPM.addPass(mlir::createLowerAffinePass());
+      OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
+    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
 
     PM.addPass(sycl::createInlinePass({sycl::InlineMode::Simple,
                                        /* RemoveDeadCallees */ true}));
-
-    if (RaiseToAffine)
-      OptPM.addPass(polygeist::createRaiseSCFToAffinePass());
-    OptPM.addPass(polygeist::createReplaceAffineCFGPass());
   }
 
   if (PrintPipeline) {


### PR DESCRIPTION
Drop `-lower-affine` pass and make code more readable by moving `-raise-scf-to-affine` and `-affine-cfg` passes creation point.

Note not dropping the pass would lead to the redundant pipeline:

```
...,lower-affine,raise-scf-to-affine,affine-cfg)
```