### PR TITLE
[SYCL][NATIVECPU] native_cpu plugin enable fix

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -167,9 +167,9 @@ if ("opencl" IN_LIST SYCL_ENABLE_PLUGINS)
 endif()
 if ("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
   set(SYCL_BUILD_PI_LEVEL_ZERO ON)
+endif()
 if ("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
   set(SYCL_BUILD_NATIVE_CPU ON)
-endif()
 endif()
 
 # Configure SYCL version macro


### PR DESCRIPTION
Fixed the native_cpu plugin only being built if level_zero was enabled as well