### PR TITLE
[SYCL] overlooked inclusion, VS2017

### DIFF
--- a/sycl/include/sycl/detail/vector_traits.hpp
+++ b/sycl/include/sycl/detail/vector_traits.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>   // for std::min and vs2017 win
 #include <type_traits> // for integral_constant, conditional_t, remove_cv_t
 
 namespace sycl {


### PR DESCRIPTION
VS2017 will require direct inclusion of `<algorhythm>` for the std::min usage in vector_traits.hpp