### PR TITLE
[SYCL] add deep copy for annotated_ref assignment operator

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -566,7 +566,7 @@ class annotated_ref {
     annotated_ref(const annotated_ref&) = default;
     operator T() const;
     annotated_ref& operator=(const T &);
-    annotated_ref& operator=(const annotated_ref&) = default;
+    annotated_ref& operator=(const annotated_ref&);
   };
 } // namespace sycl::ext::oneapi::experimental
 ```
@@ -610,10 +610,11 @@ applying the annotations when the object is stored to memory.
 a|
 [source,c++]
 ----
-annotated_ref& operator=(const annotated_ref&) = default;
+annotated_ref& operator=(const annotated_ref&);
 ----
 |
-Assign from another `annotated_ref` object.
+Copy an object of type `T` from another `annotated_ref<T, ...>` object.
+applying the annotations when the object is loaded from and stored to memory.
 
 |===
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -614,7 +614,7 @@ annotated_ref& operator=(const annotated_ref&);
 ----
 |
 Copy an object of type `T` from another `annotated_ref<T, ...>` object.
-applying the annotations when the object is loaded from and stored to memory.
+Applying the annotations when the object is loaded from and stored to memory.
 
 |===
 

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -102,6 +102,7 @@ class annotated_ref {
 template <typename T, typename... Props>
 class annotated_ref<T, detail::properties_t<Props...>> {
   using property_list_t = detail::properties_t<Props...>;
+  using this_t = annotated_ref<T, detail::properties_t<Props...>>;
 
 private:
   T *m_Ptr;
@@ -120,7 +121,7 @@ public:
 #endif
   }
 
-  annotated_ref &operator=(const T &Obj) {
+  this_t &operator=(const T &Obj) {
 #ifdef __SYCL_DEVICE_ONLY__
     *__builtin_intel_sycl_ptr_annotation(
         m_Ptr, detail::PropertyMetaInfo<Props>::name...,
@@ -131,7 +132,19 @@ public:
     return *this;
   }
 
-  annotated_ref &operator=(const annotated_ref &) = default;
+  this_t &operator=(const this_t &Obj) {
+    const T &t = Obj;
+    this->operator=(t);
+    return *this;
+  }
+
+  template <typename... OtherProperties>
+  this_t &operator=(
+      const annotated_ref<T, detail::properties_t<OtherProperties...>> &Obj) {
+    const T &t = Obj;
+    this->operator=(t);
+    return *this;
+  }
 
   PROPAGATE_OP(+=)
   PROPAGATE_OP(-=)


### PR DESCRIPTION
annotated_ref assignment should copy the underneath pointer