### PR TITLE
[SYCL][UR][L0] Fix command buffer memory leaks and minor formatting issues

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -114,18 +114,18 @@ ur_exp_command_buffer_handle_t_::~ur_exp_command_buffer_handle_t_() {
   // Release additional signal and wait events used by command_buffer
   if (SignalEvent) {
     CleanupCompletedEvent(SignalEvent, false);
-    UR_CALL(urEventReleaseInternal(SignalEvent));
+    urEventReleaseInternal(SignalEvent);
   }
   if (WaitEvent) {
     CleanupCompletedEvent(WaitEvent, false);
-    UR_CALL(urEventReleaseInternal(WaitEvent));
+    urEventReleaseInternal(WaitEvent);
   }
 
   // Release events added to the command_buffer
   for (auto &Sync : SyncPoints) {
     auto &Event = Sync.second;
     CleanupCompletedEvent(Event, false);
-    UR_CALL(urEventReleaseInternal(Event));
+    urEventReleaseInternal(Event);
   }
 
   // Release Fences allocated to command_buffer

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -5,8 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===-----------------------------------------------------------------===//
-#include <cinttypes>
-
 #include "command_buffer.hpp"
 #include "ur_level_zero.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -295,7 +295,7 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
   UR_CALL(EventCreate(CommandBuffer->Context, nullptr, true, &LaunchEvent));
   LaunchEvent->CommandType = CommandType;
 
-    // Get sync point and register the event with it.
+  // Get sync point and register the event with it.
   *SyncPoint = CommandBuffer->GetNextSyncPoint();
   CommandBuffer->RegisterSyncPoint(*SyncPoint, LaunchEvent);
 
@@ -360,7 +360,7 @@ static ur_result_t enqueueCommandBufferMemCopyRectHelper(
   UR_CALL(EventCreate(CommandBuffer->Context, nullptr, true, &LaunchEvent));
   LaunchEvent->CommandType = CommandType;
 
-    // Get sync point and register the event with it.
+  // Get sync point and register the event with it.
   *SyncPoint = CommandBuffer->GetNextSyncPoint();
   CommandBuffer->RegisterSyncPoint(*SyncPoint, LaunchEvent);
 
@@ -502,7 +502,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
   // Get sync point and register the event with it.
   *SyncPoint = CommandBuffer->GetNextSyncPoint();
   CommandBuffer->RegisterSyncPoint(*SyncPoint, LaunchEvent);
-  
+
   LaunchEvent->CommandData = (void *)Kernel;
   // Increment the reference count of the Kernel and indicate that the Kernel
   // is in use. Once the event has been signalled, the code in

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===-----------------------------------------------------------------===//
+#include <cinttypes>
 
 #include "command_buffer.hpp"
 #include "ur_level_zero.hpp"
@@ -304,7 +305,7 @@ static ur_result_t enqueueCommandBufferMemCopyHelper(
               LaunchEvent->ZeEvent, ZeEventList.size(), ZeEventList.data()));
 
   urPrint("calling zeCommandListAppendMemoryCopy() with"
-          "  ZeEvent %#llx\n",
+          "  ZeEvent %#" PRIxPTR "\n",
           ur_cast<std::uintptr_t>(LaunchEvent->ZeEvent));
 
   return UR_RESULT_SUCCESS;
@@ -516,7 +517,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urCommandBufferAppendKernelLaunchExp(
               ZeEventList.size(), ZeEventList.data()));
 
   urPrint("calling zeCommandListAppendLaunchKernel() with"
-          "  ZeEvent %#llx\n",
+          "  ZeEvent %#" PRIxPTR "\n",
           ur_cast<std::uintptr_t>(LaunchEvent->ZeEvent));
 
   return UR_RESULT_SUCCESS;

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
@@ -240,7 +240,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
   }
 
   urPrint("calling zeCommandListAppendLaunchKernel() with"
-          "  ZeEvent %#llx\n",
+          "  ZeEvent %#" PRIxPTR "\n",
           ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList((*Event)->WaitList);
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/memory.cpp
@@ -73,7 +73,7 @@ ur_result_t enqueueMemCopyHelper(ur_command_t CommandType,
   const auto &WaitList = (*Event)->WaitList;
 
   urPrint("calling zeCommandListAppendMemoryCopy() with\n"
-          "  ZeEvent %#llx\n",
+          "  ZeEvent %#" PRIxPTR "\n",
           ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList(WaitList);
 
@@ -124,7 +124,7 @@ ur_result_t enqueueMemCopyRectHelper(
   const auto &WaitList = (*Event)->WaitList;
 
   urPrint("calling zeCommandListAppendMemoryCopy() with\n"
-          "  ZeEvent %#llx\n",
+          "  ZeEvent %#" PRIxPTR "\n",
           ur_cast<std::uintptr_t>(ZeEvent));
   printZeEventList(WaitList);
 
@@ -238,7 +238,7 @@ static ur_result_t enqueueMemFillHelper(ur_command_t CommandType,
               WaitList.Length, WaitList.ZeEventList));
 
   urPrint("calling zeCommandListAppendMemoryFill() with\n"
-          "  ZeEvent %#llx\n",
+          "  ZeEvent %#" PRIxPTR "\n",
           ur_cast<uint64_t>(ZeEvent));
   printZeEventList(WaitList);
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
@@ -8,6 +8,7 @@
 #pragma once
 
 #include <cassert>
+#include <cinttypes>
 #include <list>
 #include <map>
 #include <stdarg.h>


### PR DESCRIPTION
This patch should fix issues that have been reported by static code analysis.
UR calls in between event allocation and register with the command buffer need to be avoided because they could potentially fail. Leading to a memory leak, because the event isn't registered properly. Deallocation in command buffer destructor.

## Authors

Co-authored-by: Piotr Balcer <piotr.balcer@intel.com>
