### PR TITLE
[SYCL][InvokeSimd][E2E] Fixed simd8_platform_error.cpp self-check

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8_platform_error.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8_platform_error.cpp
@@ -21,7 +21,7 @@ int main(void) {
 
   // VL = 8
   passed &= test<8, 8>(q);
-  // CHECK: {{.*}}error: Kernel compiled with required subgroup size 8, which is unsupported on this platform{{.*}}
+  // CHECK: {{.*}}SYCL exception caught: Sub-group size 8 is not supported on the device{{.*}}
 
   std::cout << (passed ? "Passed\n" : "FAILED\n");
   return passed ? 0 : 1;


### PR DESCRIPTION
The self-check of the test changed according to the previously changed error message.