### PR TITLE
[SYCL] Disable PI unit tests by default

### DIFF
--- a/sycl/unittests/CMakeLists.txt
+++ b/sycl/unittests/CMakeLists.txt
@@ -27,7 +27,7 @@ include(AddSYCLUnitTest)
 add_custom_target(check-sycl-unittests)
 
 # TODO PI tests require real hardware and must be moved to sycl/test-e2e.
-option(SYCL_PI_TESTS "Enable PI-specific unit tests" ON)
+option(SYCL_PI_TESTS "Enable PI-specific unit tests" OFF)
 
 if (SYCL_PI_TESTS)
   add_subdirectory(pi)


### PR DESCRIPTION
These tests are currently disabled in the CI and ended up broken.

Since we're also currently moving to the Unified Runtime we might be able to replace most of them with the Unified Runtime CTS, or they will also need to be ported to the Unified Runtime.

So disable them by default until we figure out a proper course of action of these.

Related ticket: https://github.com/intel/llvm/issues/10688