### PR TITLE
[SYCL][UR][HIP] Check if module needs to be unloaded

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
@@ -211,7 +211,12 @@ urProgramRelease(ur_program_handle_t hProgram) {
     try {
       ScopedContext Active(hProgram->getContext()->getDevice());
       auto HIPModule = hProgram->get();
-      Result = UR_CHECK_ERROR(hipModuleUnload(HIPModule));
+      if (HIPModule) {
+        Result = UR_CHECK_ERROR(hipModuleUnload(HIPModule));
+      } else {
+        // no module to unload
+        Result = UR_RESULT_SUCCESS;
+      }
     } catch (...) {
       Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
     }


### PR DESCRIPTION
In the HIP adapter the HIP module is not set until the program is built with `urProgramBuild`, therefore we should check that the module actually needs to be unloaded in `urProgramRelease`.

The following will result in a failure, but should still be valid UR trace:

```cpp
uint8_t *source = "<some ptx>";
ur_program_handle_t prog;
urProgramCreate(context, device, sizeof(source), ptxSource, nullptr, &prog);
urProgramRelease(prog); // fails when it tries to unload the module.
```