### PR TITLE
[SYCL][CODEOWNERS] Update files owned by Graphs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -123,6 +123,7 @@ sycl/source/detail/graph_impl.hpp @intel/sycl-graphs-reviewers
 sycl/unittests/Extensions/CommandGraph.cpp @intel/sycl-graphs-reviewers
 sycl/doc/design/CommandGraph.md @intel/sycl-graphs-reviewers
 sycl/test-e2e/Graph @intel/sycl-graphs-reviewers
+sycl/doc/extensions/**/sycl_ext_oneapi_graph.asciidoc @intel/sycl-graphs-reviewers
 
 # syclcompat library
 sycl/**/syclcompat/ @intel/syclcompat-lib-reviewers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -121,6 +121,8 @@ sycl/include/sycl/ext/oneapi/experimental/graph.hpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.cpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.hpp @intel/sycl-graphs-reviewers
 sycl/unittests/Extensions/CommandGraph.cpp @intel/sycl-graphs-reviewers
+sycl/doc/design/CommandGraph.md @intel/sycl-graphs-reviewers
+sycl/test-e2e/Graph @intel/sycl-graphs-reviewers
 
 # syclcompat library
 sycl/**/syclcompat/ @intel/syclcompat-lib-reviewers


### PR DESCRIPTION
It would be nice if the [design doc](https://github.com/intel/llvm/blob/sycl/sycl/doc/design/CommandGraph.md) and [specific E2E tests](https://github.com/intel/llvm/tree/sycl/sycl/test-e2e/Graph) for SYCL-Graphs had automatic reviewers from
[@sycl-graphs-reviewers](https://github.com/orgs/intel/teams/sycl-graphs-reviewers)