### PR TITLE
[SYCL] mark failing image tests as unsupported at O0. 

### DIFF
--- a/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
@@ -1,5 +1,9 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // UNSUPPORTED: hip
+
+// spir-v gen for legacy images at O0 not working
+// UNSUPPORTED: O0
+
 // RUN: %{build} -o %t.out
 // Native images are created with host pointers only with host unified memory
 // support, enforce it for this test.

--- a/sycl/test-e2e/Plugin/interop-level-zero-image-get-native-mem.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image-get-native-mem.cpp
@@ -2,6 +2,9 @@
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 
+// spir-v gen for legacy images at O0 not working
+// UNSUPPORTED: O0
+
 // we use the interop to get the native image handle and then use that to make a
 // new image and enumerate the pixels.
 

--- a/sycl/test-e2e/Plugin/interop-level-zero-image-ownership.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image-ownership.cpp
@@ -4,6 +4,9 @@
 // makes an 'unbalanced' create/destroy situation for the test.
 // UNSUPPORTED: ze_debug
 
+// spir-v gen for legacy images at O0 not working
+// UNSUPPORTED: O0
+
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: env ZE_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
@@ -2,6 +2,9 @@
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
 
+// spir-v gen for legacy images at O0 not working
+// UNSUPPORTED: O0
+
 // This test verifies that make_image is working for 1D, 2D and 3D images.
 // We instantiate an image with L0, set its body, then use a host accessor to
 // verify that the pixels are set correctly.


### PR DESCRIPTION
The spir-v generation is not working correctly for legacy images at O0. There is no intention of fixing it at this time, given that the image thing is going to be completely overhauled in the future. Marking these tests as unsupported in O0.