### PR TITLE
[SYCL][UR][L0] Don't overwrite context's devices

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
@@ -279,8 +279,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
     ur_queue_handle_t
         *Queue ///< [out] pointer to handle of queue object created
 ) {
-  Context->Devices[0] = Device;
-
   ur_queue_flags_t Flags{};
   if (Props) {
     Flags = Props->flags;


### PR DESCRIPTION
They are only set at contextCreate time.