### PR TITLE
[SYCL] Fix missing climits include

### DIFF
--- a/sycl/source/stream.cpp
+++ b/sycl/source/stream.cpp
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <climits>
 #include <detail/queue_impl.hpp>
 #include <detail/stream_impl.hpp>
 #include <sycl/properties/all_properties.hpp>


### PR DESCRIPTION
This commit https://github.com/intel/llvm/pull/10648 broke the build with:

```
/home/hugh/llvm/sycl/source/stream.cpp:19:12: error: ‘CHAR_BIT’ was not declared in this scope
   19 |     (1 << (CHAR_BIT * detail::FLUSH_BUF_OFFSET_SIZE)) - 1;
      |            ^~~~~~~~
/home/hugh/llvm/sycl/source/stream.cpp:12:1: note: ‘CHAR_BIT’ is defined in header ‘<climits>’; did you forget to ‘#include <climits>’?
   11 | #include <sycl/properties/all_properties.hpp>
  +++ |+#include <climits>
   12 | #include <sycl/stream.hpp>
```

This fixes that