### PR TITLE
[SYCL][UR][L0] Replace memory type look-up with UMF tracking

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -6,6 +6,7 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
   set(UNIFIED_RUNTIME_TAG v0.7.1)
 
+  set(UMF_ENABLE_POOL_TRACKING ON)
   message(STATUS "Will fetch Unified Runtime from ${UNIFIED_RUNTIME_REPO}")
   FetchContent_Declare(unified-runtime
     GIT_REPOSITORY    ${UNIFIED_RUNTIME_REPO}
@@ -40,13 +41,11 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
   add_library(UnifiedRuntimeLoader ALIAS ur_loader)
   add_library(UnifiedRuntimeCommon ALIAS ur_common)
   add_library(UnifiedMallocFramework ALIAS unified_malloc_framework)
-  set(UMF_ENABLE_POOL_TRACKING ON)
 
   set(UNIFIED_RUNTIME_SOURCE_DIR
     ${unified-runtime_SOURCE_DIR} CACHE PATH "Path to Unified Runtime Headers")
   set(UNIFIED_RUNTIME_INCLUDE_DIR "${UNIFIED_RUNTIME_SOURCE_DIR}/include")
 endif()
-
 
 add_library(UnifiedRuntime-Headers INTERFACE)
 

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -40,6 +40,7 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
   add_library(UnifiedRuntimeLoader ALIAS ur_loader)
   add_library(UnifiedRuntimeCommon ALIAS ur_common)
   add_library(UnifiedMallocFramework ALIAS unified_malloc_framework)
+  set(UMF_ENABLE_POOL_TRACKING ON)
 
   set(UNIFIED_RUNTIME_SOURCE_DIR
     ${unified-runtime_SOURCE_DIR} CACHE PATH "Path to Unified Runtime Headers")

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
@@ -182,7 +182,7 @@ ur_result_t ur_context_handle_t_::initialize() {
   // Note that the CCS devices and their respective subdevices share a
   // common ze_device_handle and therefore, also share USM allocators.
   auto createUSMAllocators = [this](ur_device_handle_t Device) {
-    auto MemProvider = umf::memoryProviderMakeUnique<USMDeviceMemoryProvider>(
+    auto MemProvider = umf::memoryProviderMakeUnique<L0DeviceMemoryProvider>(
                            reinterpret_cast<ur_context_handle_t>(this), Device)
                            .second;
     DeviceMemPools.emplace(
@@ -193,7 +193,7 @@ ur_result_t ur_context_handle_t_::initialize() {
                                 .Configs[usm::DisjointPoolMemType::Device])
                             .second));
 
-    MemProvider = umf::memoryProviderMakeUnique<USMSharedMemoryProvider>(
+    MemProvider = umf::memoryProviderMakeUnique<L0SharedMemoryProvider>(
                       reinterpret_cast<ur_context_handle_t>(this), Device)
                       .second;
     SharedMemPools.emplace(
@@ -204,10 +204,9 @@ ur_result_t ur_context_handle_t_::initialize() {
                                 .Configs[usm::DisjointPoolMemType::Shared])
                             .second));
 
-    MemProvider =
-        umf::memoryProviderMakeUnique<USMSharedReadOnlyMemoryProvider>(
-            reinterpret_cast<ur_context_handle_t>(this), Device)
-            .second;
+    MemProvider = umf::memoryProviderMakeUnique<L0SharedReadOnlyMemoryProvider>(
+                      reinterpret_cast<ur_context_handle_t>(this), Device)
+                      .second;
     SharedReadOnlyMemPools.emplace(
         std::piecewise_construct, std::make_tuple(Device->ZeDevice),
         std::make_tuple(
@@ -217,7 +216,7 @@ ur_result_t ur_context_handle_t_::initialize() {
                     .Configs[usm::DisjointPoolMemType::SharedReadOnly])
                 .second));
 
-    MemProvider = umf::memoryProviderMakeUnique<USMDeviceMemoryProvider>(
+    MemProvider = umf::memoryProviderMakeUnique<L0DeviceMemoryProvider>(
                       reinterpret_cast<ur_context_handle_t>(this), Device)
                       .second;
     DeviceMemProxyPools.emplace(
@@ -226,7 +225,7 @@ ur_result_t ur_context_handle_t_::initialize() {
             umf::poolMakeUnique<USMProxyPool, 1>({std::move(MemProvider)})
                 .second));
 
-    MemProvider = umf::memoryProviderMakeUnique<USMSharedMemoryProvider>(
+    MemProvider = umf::memoryProviderMakeUnique<L0SharedMemoryProvider>(
                       reinterpret_cast<ur_context_handle_t>(this), Device)
                       .second;
     SharedMemProxyPools.emplace(
@@ -235,10 +234,9 @@ ur_result_t ur_context_handle_t_::initialize() {
             umf::poolMakeUnique<USMProxyPool, 1>({std::move(MemProvider)})
                 .second));
 
-    MemProvider =
-        umf::memoryProviderMakeUnique<USMSharedReadOnlyMemoryProvider>(
-            reinterpret_cast<ur_context_handle_t>(this), Device)
-            .second;
+    MemProvider = umf::memoryProviderMakeUnique<L0SharedReadOnlyMemoryProvider>(
+                      reinterpret_cast<ur_context_handle_t>(this), Device)
+                      .second;
     SharedReadOnlyMemProxyPools.emplace(
         std::piecewise_construct, std::make_tuple(Device->ZeDevice),
         std::make_tuple(
@@ -264,7 +262,7 @@ ur_result_t ur_context_handle_t_::initialize() {
   // Create USM pool for host. Device and Shared USM allocations
   // are device-specific. Host allocations are not device-dependent therefore
   // we don't need a map with device as key.
-  auto MemProvider = umf::memoryProviderMakeUnique<USMHostMemoryProvider>(
+  auto MemProvider = umf::memoryProviderMakeUnique<L0HostMemoryProvider>(
                          reinterpret_cast<ur_context_handle_t>(this), nullptr)
                          .second;
   HostMemPool =
@@ -273,7 +271,7 @@ ur_result_t ur_context_handle_t_::initialize() {
           DisjointPoolConfigInstance.Configs[usm::DisjointPoolMemType::Host])
           .second;
 
-  MemProvider = umf::memoryProviderMakeUnique<USMHostMemoryProvider>(
+  MemProvider = umf::memoryProviderMakeUnique<L0HostMemoryProvider>(
                     reinterpret_cast<ur_context_handle_t>(this), nullptr)
                     .second;
   HostMemProxyPool =

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.hpp
@@ -104,6 +104,15 @@ struct ur_context_handle_t_ : _ur_object {
   // Store the host memory pool. It does not depend on any device.
   umf::pool_unique_handle_t HostMemPool;
 
+  // Allocation-tracking proxy pools for direct allocations. No pooling used.
+  std::unordered_map<ze_device_handle_t, umf::pool_unique_handle_t>
+      DeviceMemProxyPools;
+  std::unordered_map<ze_device_handle_t, umf::pool_unique_handle_t>
+      SharedMemProxyPools;
+  std::unordered_map<ze_device_handle_t, umf::pool_unique_handle_t>
+      SharedReadOnlyMemProxyPools;
+  umf::pool_unique_handle_t HostMemProxyPool;
+
   // We need to store all memory allocations in the context because there could
   // be kernels with indirect access. Kernels with indirect access start to
   // reference all existing memory allocations at the time when they are

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.hpp
@@ -101,11 +101,6 @@ struct ur_context_handle_t_ : _ur_object {
   std::unordered_map<ze_device_handle_t, umf::pool_unique_handle_t>
       SharedReadOnlyMemPools;
 
-  // Since L0 native runtime does not distinguisg "shared device_read_only"
-  // vs regular "shared" allocations, we have keep track of it to use
-  // proper memory pool when freeing allocations.
-  std::unordered_set<void *> SharedReadOnlyAllocs;
-
   // Store the host memory pool. It does not depend on any device.
   umf::pool_unique_handle_t HostMemPool;
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.cpp
@@ -433,6 +433,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMSharedAlloc(
       const ur_usm_host_desc_t *UsmHostDesc =
           reinterpret_cast<const ur_usm_host_desc_t *>(pNext);
       UsmHostFlags = UsmHostDesc->flags;
+      std::ignore = UsmHostFlags;
     }
     pNext = const_cast<void *>(BaseDesc->pNext);
   }

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.hpp
@@ -40,73 +40,98 @@ public:
   ur_result_t getError() const { return Error; }
 };
 
-// Implements memory allocation via L0 RT for USM allocator interface.
-class USMMemoryProvider {
-private:
+// UMF memory provider interface for USM.
+class USMMemoryProviderBase {
+protected:
+  ur_context_handle_t Context;
+  ur_device_handle_t Device;
+
   ur_result_t &getLastStatusRef() {
     static thread_local ur_result_t LastStatus = UR_RESULT_SUCCESS;
     return LastStatus;
   }
 
-protected:
-  ur_context_handle_t Context;
-  ur_device_handle_t Device;
-  size_t MinPageSize;
-
   // Internal allocation routine which must be implemented for each allocation
   // type
-  virtual ur_result_t allocateImpl(void **ResultPtr, size_t Size,
-                                   uint32_t Alignment) = 0;
+  virtual ur_result_t allocateImpl(void **, size_t, uint32_t) = 0;
 
 public:
-  umf_result_t initialize(ur_context_handle_t Ctx, ur_device_handle_t Dev);
-  umf_result_t alloc(size_t Size, size_t Align, void **Ptr);
-  umf_result_t free(void *Ptr, size_t Size);
-  void get_last_native_error(const char **ErrMsg, int32_t *ErrCode);
-  umf_result_t get_min_page_size(void *, size_t *);
-  umf_result_t get_recommended_page_size(size_t, size_t *) {
+  virtual void get_last_native_error(const char **ErrMsg, int32_t *ErrCode) {
+    std::ignore = ErrMsg;
+    *ErrCode = static_cast<int32_t>(getLastStatusRef());
+  };
+  virtual umf_result_t initialize(ur_context_handle_t, ur_device_handle_t) {
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
   };
-  umf_result_t purge_lazy(void *, size_t) {
+  virtual umf_result_t alloc(size_t, size_t, void **) {
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
   };
-  umf_result_t purge_force(void *, size_t) {
+  virtual umf_result_t free(void *, size_t) {
     return UMF_RESULT_ERROR_NOT_SUPPORTED;
   };
+  virtual umf_result_t get_min_page_size(void *, size_t *) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  };
+  virtual umf_result_t get_recommended_page_size(size_t, size_t *) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  };
+  virtual umf_result_t purge_lazy(void *, size_t) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  };
+  virtual umf_result_t purge_force(void *, size_t) {
+    return UMF_RESULT_ERROR_NOT_SUPPORTED;
+  };
+  virtual const char *get_name() { return ""; };
+  virtual ~USMMemoryProviderBase() = default;
+};
+
+// Implements USM memory provider interface for L0 RT USM memory allocations.
+class L0MemoryProvider : public USMMemoryProviderBase {
+private:
+  // Min page size query function for L0MemoryProvider.
+  umf_result_t GetL0MinPageSize(void *Mem, size_t *PageSize);
+  size_t MinPageSize = 0;
+  bool MinPageSizeCached = false;
+
+public:
+  umf_result_t initialize(ur_context_handle_t Ctx,
+                          ur_device_handle_t Dev) override;
+  umf_result_t alloc(size_t Size, size_t Align, void **Ptr) override;
+  umf_result_t free(void *Ptr, size_t Size) override;
+  umf_result_t get_min_page_size(void *, size_t *) override;
   // TODO: Different name for each provider (Host/Shared/SharedRO/Device)
-  const char *get_name() { return "USM"; };
-  virtual ~USMMemoryProvider() = default;
+  const char *get_name() override { return "L0"; };
 };
 
 // Allocation routines for shared memory type
-class USMSharedMemoryProvider final : public USMMemoryProvider {
+class L0SharedMemoryProvider final : public L0MemoryProvider {
 protected:
   ur_result_t allocateImpl(void **ResultPtr, size_t Size,
                            uint32_t Alignment) override;
 };
 
 // Allocation routines for shared memory type that is only modified from host.
-class USMSharedReadOnlyMemoryProvider final : public USMMemoryProvider {
+class L0SharedReadOnlyMemoryProvider final : public L0MemoryProvider {
 protected:
   ur_result_t allocateImpl(void **ResultPtr, size_t Size,
                            uint32_t Alignment) override;
 };
 
 // Allocation routines for device memory type
-class USMDeviceMemoryProvider final : public USMMemoryProvider {
+class L0DeviceMemoryProvider final : public L0MemoryProvider {
 protected:
   ur_result_t allocateImpl(void **ResultPtr, size_t Size,
                            uint32_t Alignment) override;
 };
 
 // Allocation routines for host memory type
-class USMHostMemoryProvider final : public USMMemoryProvider {
+class L0HostMemoryProvider final : public L0MemoryProvider {
 protected:
   ur_result_t allocateImpl(void **ResultPtr, size_t Size,
                            uint32_t Alignment) override;
 };
 
-// Simple proxy for UMF allocations. It is used for the UMF tracking
+// Simple proxy for memory allocations. It is used for the UMF tracking
 // capabilities.
 class USMProxyPool {
 public:

--- a/sycl/test-e2e/USM/usm_pooling.cpp
+++ b/sycl/test-e2e/USM/usm_pooling.cpp
@@ -113,9 +113,7 @@ int main(int argc, char *argv[]) {
 // CHECK-12345: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
 // CHECK-12345-NEXT:  ZE ---> [[API]](
 // CHECK-12345-NEXT:  ZE ---> [[API]](
-// CHECK-12345-NEXT:  ZE ---> zeMemGetAllocProperties
 // CHECK-12345-NEXT:  ZE ---> zeMemFree
-// CHECK-12345-NEXT:  ZE ---> zeMemGetAllocProperties
 // CHECK-12345-NEXT:  ZE ---> zeMemFree
 // CHECK-12345-NEXT:  ZE ---> [[API]](
 // CHECK-12345-NEXT:  ZE ---> [[API]](
@@ -124,18 +122,11 @@ int main(int argc, char *argv[]) {
 // CHECK-1245: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
 // CHECK-1245-NEXT:  ZE ---> [[API]](
 // CHECK-1245-NEXT:  ZE ---> [[API]](
-// CHECK-1245-NEXT:  ZE ---> zeMemGetAllocProperties
-// CHECK-1245-NEXT:  ZE ---> zeMemGetAllocProperties
 // CHECK-1245-NEXT:  ZE ---> zeMemFree
 // CHECK-1245-NEXT:  ZE ---> [[API]](
 // CHECK-1245-NEXT:  ZE ---> [[API]](
 
 // CHECK-15: Test [[API:zeMemAllocHost|zeMemAllocDevice|zeMemAllocShared]]
 // CHECK-15-NEXT:  ZE ---> [[API]](
-// CHECK-15-NEXT:  ZE ---> zeMemGetAllocProperties
-// CHECK-15-NEXT:  ZE ---> zeMemGetAllocProperties
 // CHECK-15-NEXT:  ZE ---> [[API]](
-// CHECK-15-NEXT:  ZE ---> zeMemGetAllocProperties
-// CHECK-15-NEXT:  ZE ---> zeMemGetAllocProperties
-// CHECK-15-NEXT:  ZE ---> zeMemGetAllocProperties
 // CHECK-15-NEXT:  ZE ---> zeMemFree


### PR DESCRIPTION
This also makes SharedReadOnly allocations tracking obsolete.