### PR TITLE
Guard some changes from a7ee80fab213 w/INTEL_SYCL_OPAQUEPOINTER_READY

### DIFF
--- a/llvm/lib/IR/Constants.cpp
+++ b/llvm/lib/IR/Constants.cpp
@@ -1770,7 +1770,11 @@ BlockAddress *BlockAddress::get(Function *F, BasicBlock *BB) {
 }
 
 BlockAddress::BlockAddress(Function *F, BasicBlock *BB)
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     : Constant(PointerType::get(F->getContext(), F->getAddressSpace()),
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+    : Constant(Type::getInt8PtrTy(F->getContext(), F->getAddressSpace()),
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
                Value::BlockAddressVal, &Op<0>(), 2) {
   setOperand(0, F);
   setOperand(1, BB);


### PR DESCRIPTION
Causes LIT failures when parsing `blockaddr` constants.
