### PR TITLE
[UR][CUDA][HIP][L0] Cleanup licence header

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.cpp
+++ b/sycl/plugins/unified_runtime/pi2ur.cpp
@@ -1,10 +1,10 @@
-//===---------------- pi2ur.cpp - PI API to UR API  --------------------==//
+//===---------------- pi2ur.cpp - PI API to UR API  ------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 // This thin layer performs conversion from PI API to Unified Runtime API
 // TODO: remove when SYCL RT is changed to talk in UR directly

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -1,10 +1,10 @@
-//===---------------- pi2ur.hpp - PI API to UR API  --------------------==//
+//===---------------- pi2ur.hpp - PI API to UR API  ------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "ur_api.h"

--- a/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
+++ b/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
@@ -1,10 +1,10 @@
-//===--- pi_unified_runtime.cpp - Unified Runtime PI Plugin  -----------==//
+//===--- pi_unified_runtime.cpp - Unified Runtime PI Plugin  ---------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <cstring>
 

--- a/sycl/plugins/unified_runtime/pi_unified_runtime.hpp
+++ b/sycl/plugins/unified_runtime/pi_unified_runtime.hpp
@@ -1,10 +1,10 @@
-//===--- pi_unified_runtime.hpp - Unified Runtime PI Plugin  -----------==//
+//===--- pi_unified_runtime.hpp - Unified Runtime PI Plugin  ---------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 // This version should be incremented for any change made to this file or its

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/adapter.cpp
@@ -1,10 +1,10 @@
-//===--------- adapter.cpp - CUDA Adapter ----------------------------===//
+//===--------- adapter.cpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur_api.h>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/adapter.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/adapter.hpp
@@ -1,4 +1,4 @@
-//===--------- adapter.cpp - CUDA Adapter ----------------------------===//
+//===--------- adapter.hpp - CUDA Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/adapter.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/adapter.hpp
@@ -1,10 +1,10 @@
-//===--------- adapter.hpp - CUDA Adapter ----------------------------===//
+//===--------- adapter.hpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 struct ur_adapter_handle_t_;
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.cpp
@@ -1,10 +1,10 @@
-//===--------- command_buffer.cpp - CUDA Adapter ---------------------===//
+//===--------- command_buffer.cpp - CUDA Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "command_buffer.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/command_buffer.hpp
@@ -1,10 +1,10 @@
-//===--------- command_buffer.hpp - CUDA Adapter ---------------------===//
+//===--------- command_buffer.hpp - CUDA Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur/ur.hpp>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
@@ -1,10 +1,10 @@
-//===--------- common.cpp - CUDA Adapter -----------------------------===//
+//===--------- common.cpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
@@ -1,10 +1,10 @@
-//===--------- common.hpp - CUDA Adapter -----------------------------===//
+//===--------- common.hpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cuda.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/context.cpp
@@ -1,10 +1,10 @@
-//===--------- context.cpp - CUDA Adapter ----------------------------===//
+//===--------- context.cpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "context.hpp"
 #include "usm.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/context.hpp
@@ -1,10 +1,10 @@
-//===--------- context.hpp - CUDA Adapter ----------------------------===//
+//===--------- context.hpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cuda.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.cpp
@@ -1,10 +1,10 @@
-//===--------- device.cpp - CUDA Adapter -----------------------------===//
+//===--------- device.cpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <array>
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/device.hpp
@@ -1,10 +1,10 @@
-//===--------- device.hpp - CUDA Adapter -----------------------------===//
+//===--------- device.hpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur/ur.hpp>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -1,10 +1,10 @@
-//===--------- enqueue.cpp - CUDA Adapter ----------------------------===//
+//===--------- enqueue.cpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "enqueue.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.hpp
@@ -1,10 +1,10 @@
-//===--------- enqueue.hpp - CUDA Adapter ----------------------------===//
+//===--------- enqueue.hpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
@@ -1,10 +1,10 @@
-//===--------- event.cpp - CUDA Adapter ------------------------------===//
+//===--------- event.cpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "event.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.hpp
@@ -1,10 +1,10 @@
-//===--------- event.hpp - CUDA Adapter ------------------------------===//
+//===--------- event.hpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cuda.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/image.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/image.cpp
@@ -1,10 +1,10 @@
-//===--------- image.cpp - CUDA Adapter ------------------------------===//
+//===--------- image.cpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <cuda.h>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/image.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/image.hpp
@@ -1,10 +1,10 @@
-//===--------- image.hpp - CUDA Adapter ------------------------------===//
+//===--------- image.hpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
@@ -1,10 +1,10 @@
-//===--------- kernel.cpp - CUDA Adapter ---------------------------===//
+//===--------- kernel.cpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "kernel.hpp"
 #include "memory.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.hpp
@@ -1,10 +1,10 @@
-//===--------- kernel.hpp - CUDA Adapter ---------------------------===//
+//===--------- kernel.hpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cuda.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
@@ -1,10 +1,10 @@
-//===--------- memory.cpp - CUDA Adapter ---------------------------===//
+//===--------- memory.cpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <cuda.h>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.hpp
@@ -1,10 +1,10 @@
-//===--------- memory.hpp - CUDA Adapter ---------------------------===//
+//===--------- memory.hpp - CUDA Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
@@ -1,10 +1,10 @@
-//===--------- platform.cpp - CUDA Adapter ---------------------------===//
+//===--------- platform.cpp - CUDA Adapter --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "platform.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.hpp
@@ -1,10 +1,10 @@
-//===--------- platform.hpp - CUDA Adapter ---------------------------===//
+//===--------- platform.hpp - CUDA Adapter --------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur/ur.hpp>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/program.cpp
@@ -1,10 +1,10 @@
-//===--------- program.cpp - CUDA Adapter ---------------------------===//
+//===--------- program.cpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "program.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/program.hpp
@@ -1,10 +1,10 @@
-//===--------- program.hpp - CUDA Adapter ---------------------------===//
+//===--------- program.hpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cuda.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
@@ -1,10 +1,10 @@
-//===--------- queue.cpp - CUDA Adapter ------------------------------===//
+//===--------- queue.cpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "queue.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.hpp
@@ -1,10 +1,10 @@
-//===--------- queue.hpp - CUDA Adapter ------------------------------===//
+//===--------- queue.hpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur/ur.hpp>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.cpp
@@ -1,10 +1,10 @@
-//===--------- sampler.cpp - CUDA Adapter ----------------------------===//
+//===--------- sampler.cpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "sampler.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/sampler.hpp
@@ -1,10 +1,10 @@
-//===--------- sampler.hpp - CUDA Adapter ----------------------------===//
+//===--------- sampler.hpp - CUDA Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur/ur.hpp>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/ur_interface_loader.cpp
@@ -1,10 +1,10 @@
-//===--------- ur_interface_loader.cpp - Unified Runtime  ------------===//
+//===--------- ur_interface_loader.cpp - Unified Runtime  -----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur_api.h>
 #include <ur_ddi.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
@@ -1,10 +1,10 @@
-//===--------- usm.cpp - CUDA Adapter ------------------------------===//
+//===--------- usm.cpp - CUDA Adapter -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <cassert>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.hpp
@@ -1,10 +1,10 @@
-//===--------- usm.hpp - CUDA Adapter --------------------------------===//
+//===--------- usm.hpp - CUDA Adapter -------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm_p2p.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm_p2p.cpp
@@ -1,10 +1,10 @@
-//===--------- usm_p2p.cpp - CUDA Adapter---------------------------===//
+//===--------- usm_p2p.cpp - CUDA Adapter----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===---------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 #include "context.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/adapter.cpp
@@ -1,10 +1,10 @@
-//===--------- adapter.cpp - HIP Adapter -----------------------------===//
+//===--------- adapter.cpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "adapter.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/adapter.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/adapter.hpp
@@ -1,10 +1,10 @@
-//===--------- adapter.hpp - HIP Adapter -----------------------------===//
+//===--------- adapter.hpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 struct ur_adapter_handle_t_;
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/command_buffer.cpp
@@ -1,10 +1,10 @@
-//===--------- command_buffer.cpp - HIP Adapter ---------------------===//
+//===--------- command_buffer.cpp - HIP Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "command_buffer.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/command_buffer.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/command_buffer.hpp
@@ -1,10 +1,10 @@
-//===--------- command_buffer.hpp - HIP Adapter ---------------------===//
+//===--------- command_buffer.hpp - HIP Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur/ur.hpp>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/common.cpp
@@ -1,10 +1,10 @@
-//===--------- common.cpp - HIP Adapter -----------------------------===//
+//===--------- common.cpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #include "common.hpp"
 
 #include <sstream>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/common.hpp
@@ -1,10 +1,10 @@
-//===--------- common.hpp - HIP Adapter -----------------------------===//
+//===--------- common.hpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <hip/hip_runtime.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/context.cpp
@@ -1,10 +1,10 @@
-//===--------- context.cpp - HIP Adapter ----------------------------===//
+//===--------- context.cpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "context.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/context.hpp
@@ -1,10 +1,10 @@
-//===--------- context.hpp - HIP Adapter ----------------------------===//
+//===--------- context.hpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <unordered_map>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/device.cpp
@@ -1,10 +1,10 @@
-//===--------- device.cpp - HIP Adapter -----------------------------===//
+//===--------- device.cpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "device.hpp"
 #include "context.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/device.hpp
@@ -1,10 +1,10 @@
-//===--------- device.hpp - HIP Adapter -----------------------------===//
+//===--------- device.hpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/enqueue.cpp
@@ -1,10 +1,10 @@
-//===--------- enqueue.cpp - HIP Adapter -----------------------------===//
+//===--------- enqueue.cpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 #include "context.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/event.cpp
@@ -1,10 +1,10 @@
-//===--------- event.cpp - HIP Adapter ------------------------------===//
+//===--------- event.cpp - HIP Adapter ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "event.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/event.hpp
@@ -1,10 +1,10 @@
-//===--------- event.hpp - HIP Adapter -------------------------------===//
+//===--------- event.hpp - HIP Adapter ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/image.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/image.cpp
@@ -1,10 +1,10 @@
-//===--------- image.cpp - CUDA Adapter ------------------------------===//
+//===--------- image.cpp - CUDA Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "ur/ur.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.cpp
@@ -1,10 +1,10 @@
-//===--------- kernel.cpp - HIP Adapter ---------------------------===//
+//===--------- kernel.cpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "kernel.hpp"
 #include "memory.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.hpp
@@ -1,10 +1,10 @@
-//===--------- kernel.hpp - HIP Adapter ---------------------------===//
+//===--------- kernel.hpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur_api.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
@@ -1,3 +1,11 @@
+//===--------- memory.cpp - HIP Adapter -----------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-----------------------------------------------------------------===//
+
 #include "memory.hpp"
 #include "context.hpp"
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
@@ -4,7 +4,7 @@
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "memory.hpp"
 #include "context.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
@@ -1,4 +1,4 @@
-//===--------- context.cpp - HIP Adapter ----------------------------===//
+//===--------- memory.hpp - HIP Adapter ------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
@@ -1,10 +1,10 @@
-//===--------- memory.hpp - HIP Adapter ------------------------------===//
+//===--------- memory.hpp - HIP Adapter -----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/platform.cpp
@@ -1,10 +1,10 @@
-//===--------- platform.cpp - HIP Adapter ---------------------------===//
+//===--------- platform.cpp - HIP Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "platform.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/platform.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/platform.hpp
@@ -1,10 +1,10 @@
-//===--------- platform.hpp - HIP Adapter ---------------------------===//
+//===--------- platform.hpp - HIP Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
@@ -1,10 +1,10 @@
-//===--------- program.cpp - HIP Adapter ---------------------------===//
+//===--------- program.cpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "program.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/program.hpp
@@ -1,10 +1,10 @@
-//===--------- program.hpp - HIP Adapter ---------------------------===//
+//===--------- program.hpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur_api.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/queue.cpp
@@ -1,10 +1,10 @@
-//===--------- queue.cpp - HIP Adapter ------------------------------===//
+//===--------- queue.cpp - HIP Adapter ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "queue.hpp"
 #include "context.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/queue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/queue.hpp
@@ -1,10 +1,10 @@
-//===--------- queue.hpp - HIP Adapter -------------------------------===//
+//===--------- queue.hpp - HIP Adapter ------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/sampler.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/sampler.cpp
@@ -1,10 +1,10 @@
-//===--------- sampler.cpp - HIP Adapter ----------------------------===//
+//===--------- sampler.cpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "sampler.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/sampler.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/sampler.hpp
@@ -1,10 +1,10 @@
-//===--------- sampler.hpp - HIP Adapter ----------------------------===//
+//===--------- sampler.hpp - HIP Adapter ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur/ur.hpp>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/ur_interface_loader.cpp
@@ -1,10 +1,10 @@
-//===--------- ur_interface_loader.cpp - Unified Runtime  ------------===//
+//===--------- ur_interface_loader.cpp - Unified Runtime  -----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur_api.h>
 #include <ur_ddi.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
@@ -1,10 +1,10 @@
-//===--------- usm.cpp - HIP Adapter ------------------------------===//
+//===--------- usm.cpp - HIP Adapter --------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <cassert>
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/usm_p2p.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/usm_p2p.cpp
@@ -1,10 +1,10 @@
-//===--------- usm_p2p.cpp - HIP Adapter---------------------------===//
+//===--------- usm_p2p.cpp - HIP Adapter-----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===---------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
@@ -1,10 +1,10 @@
-//===--------- adapter.cpp - Level Zero Adapter ----------------------===//
+//===--------- adapter.cpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "adapter.hpp"
 #include "ur_level_zero.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.hpp
@@ -1,10 +1,10 @@
-//===--------- adapters.hpp - Level Zero Adapter ---------------------===//
+//===--------- adapters.hpp - Level Zero Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <atomic>
 #include <mutex>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.cpp
@@ -1,10 +1,10 @@
-//===--------- command_buffer.cpp - Level Zero Adapter ---------------===//
+//===--------- command_buffer.cpp - Level Zero Adapter --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #include "command_buffer.hpp"
 #include "ur_level_zero.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/command_buffer.hpp
@@ -1,10 +1,10 @@
-//===--------- command_buffer.hpp - Level Zero Adapter ---------------===//
+//===--------- command_buffer.hpp - Level Zero Adapter --------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur/ur.hpp>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/common.cpp
@@ -1,10 +1,10 @@
-//===--------- common.cpp - Level Zero Adapter -----------------------===//
+//===--------- common.cpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 #include "usm.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/common.hpp
@@ -1,10 +1,10 @@
-//===--------- common.hpp - Level Zero Adapter -----------------------===//
+//===--------- common.hpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
@@ -1,10 +1,10 @@
-//===--------- context.cpp - Level Zero Adapter ----------------------===//
+//===--------- context.cpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <algorithm>
 #include <climits>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.hpp
@@ -1,10 +1,10 @@
-//===--------- context.hpp - Level Zero Adapter ----------------------===//
+//===--------- context.hpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <list>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
@@ -1,10 +1,10 @@
-//===--------- device.cpp - Level Zero Adapter -----------------------===//
+//===--------- device.cpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "device.hpp"
 #include "ur_level_zero.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.hpp
@@ -1,10 +1,10 @@
-//===--------- device.hpp - Level Zero Adapter -----------------------===//
+//===--------- device.hpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.cpp
@@ -1,10 +1,10 @@
-//===--------- event.cpp - Level Zero Adapter ------------------------===//
+//===--------- event.cpp - Level Zero Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <algorithm>
 #include <climits>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/event.hpp
@@ -1,10 +1,10 @@
-//===--------- event.hpp - Level Zero Adapter ------------------------===//
+//===--------- event.hpp - Level Zero Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/image.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/image.cpp
@@ -1,10 +1,10 @@
-//===--------- image.cpp - Level Zero Adapter ------------------------===//
+//===--------- image.cpp - Level Zero Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "image.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/image.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/image.hpp
@@ -1,10 +1,10 @@
-//===--------- image.hpp - Level Zero Adapter ------------------------===//
+//===--------- image.hpp - Level Zero Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur/ur.hpp>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
@@ -1,10 +1,10 @@
-//===--------- kernel.cpp - Level Zero Adapter -----------------------===//
+//===--------- kernel.cpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "kernel.hpp"
 #include "ur_level_zero.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
@@ -1,10 +1,10 @@
-//===--------- kernel.hpp - Level Zero Adapter -----------------------===//
+//===--------- kernel.hpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/memory.cpp
@@ -1,10 +1,10 @@
-//===--------- memory.cpp - Level Zero Adapter -----------------------===//
+//===--------- memory.cpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <algorithm>
 #include <climits>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/memory.hpp
@@ -1,10 +1,10 @@
-//===--------- memory.hpp - Level Zero Adapter -----------------------===//
+//===--------- memory.hpp - Level Zero Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.cpp
@@ -1,10 +1,10 @@
-//===--------- platform.cpp - Level Zero Adapter ---------------------===//
+//===--------- platform.cpp - Level Zero Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "platform.hpp"
 #include "adapter.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/platform.hpp
@@ -1,10 +1,10 @@
-//===--------- platform.hpp - Level Zero Adapter ---------------------===//
+//===--------- platform.hpp - Level Zero Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.cpp
@@ -1,10 +1,10 @@
-//===--------- program.cpp - Level Zero Adapter ----------------------===//
+//===--------- program.cpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "program.hpp"
 #include "ur_level_zero.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.hpp
@@ -1,10 +1,10 @@
-//===--------- program.hpp - Level Zero Adapter ----------------------===//
+//===--------- program.hpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
@@ -1,10 +1,10 @@
-//===--------- queue.cpp - Level Zero Adapter ------------------------===//
+//===--------- queue.cpp - Level Zero Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <algorithm>
 #include <climits>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.hpp
@@ -1,4 +1,4 @@
-//===--------- ur_level_zero.hpp - Level Zero Adapter -----------------===//
+//===--------- queue.hpp - Level Zero Adapter ------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.hpp
@@ -1,10 +1,10 @@
-//===--------- queue.hpp - Level Zero Adapter ------------------------===//
+//===--------- queue.hpp - Level Zero Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/sampler.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/sampler.cpp
@@ -1,10 +1,10 @@
-//===--------- sampler.cpp - Level Zero Adapter ----------------------===//
+//===--------- sampler.cpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "sampler.hpp"
 #include "ur_level_zero.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/sampler.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/sampler.hpp
@@ -1,10 +1,10 @@
-//===--------- sampler.hpp - Level Zero Adapter ----------------------===//
+//===--------- sampler.hpp - Level Zero Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_interface_loader.cpp
@@ -1,10 +1,10 @@
-//===--------- ur_interface_loader.cpp - Level Zero Adapter-----------===//
+//===--------- ur_interface_loader.cpp - Level Zero Adapter----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <ur_api.h>
 #include <ur_ddi.h>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
@@ -1,4 +1,4 @@
-//===--------- ur_level_zero.hpp - Level Zero Adapter -----------------===//
+//===--------- ur_level_zero.cpp - Level Zero Adapter -----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.cpp
@@ -1,10 +1,10 @@
-//===--------- ur_level_zero.cpp - Level Zero Adapter -----------------===//
+//===--------- ur_level_zero.cpp - Level Zero Adapter ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <algorithm>
 #include <climits>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/ur_level_zero.hpp
@@ -1,10 +1,10 @@
-//===--------- ur_level_zero.hpp - Level Zero Adapter -----------------===//
+//===--------- ur_level_zero.hpp - Level Zero Adapter ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.cpp
@@ -1,10 +1,10 @@
-//===--------- usm.cpp - Level Zero Adapter --------------------------===//
+//===--------- usm.cpp - Level Zero Adapter -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include <algorithm>
 #include <climits>

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm.hpp
@@ -1,10 +1,10 @@
-//===--------- usm.hpp - Level Zero Adapter --------------------------===//
+//===--------- usm.hpp - Level Zero Adapter -------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm_p2p.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/usm_p2p.cpp
@@ -1,10 +1,10 @@
-//===----------- usm_p2p.cpp - L0 Adapter ----------------------------===//
+//===----------- usm_p2p.cpp - L0 Adapter ---------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "ur_level_zero.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/common.hpp
@@ -1,4 +1,4 @@
-//===----------- common.cpp - Native CPU Adapter ---------------------===//
+//===----------- common.hpp - Native CPU Adapter ---------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.hpp
@@ -1,10 +1,10 @@
-//===--------- context.hpp - Native CPU Adapter ----------------------===//
+//===--------- context.hpp - Native CPU Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.hpp
@@ -1,10 +1,10 @@
-//===--------- device.hpp - Native CPU Adapter 0----------------------===//
+//===--------- device.hpp - Native CPU Adapter ----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/event.cpp
@@ -1,4 +1,4 @@
-//===--------- event.cpp - NATIVE CPU Adapter ----------------------------===//
+//===--------- event.cpp - NATIVE CPU Adapter -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.cpp
@@ -1,10 +1,10 @@
-//===--------- platform.cpp - Native CPU Adapter ---------------------===//
+//===--------- platform.cpp - Native CPU Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "platform.hpp"
 #include "common.hpp"

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/platform.hpp
@@ -1,10 +1,10 @@
-//===--------- platform.hpp - Native CPU Adapter ---------------------===//
+//===--------- platform.hpp - Native CPU Adapter --------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.cpp
@@ -1,10 +1,10 @@
-//===--------- program.cpp - Native CPU Adapter ----------------------===//
+//===--------- program.cpp - Native CPU Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "ur_api.h"
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/program.hpp
@@ -1,10 +1,10 @@
-//===--------- program.hpp - Native CPU Adapter ----------------------===//
+//===--------- program.hpp - Native CPU Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #pragma once
 

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/usm_p2p.cpp
@@ -1,10 +1,10 @@
-//===--------- usm_p2p.cpp - Native CPU Adapter ------------------------===//
+//===--------- usm_p2p.cpp - Native CPU Adapter ---------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "common.hpp"
 

--- a/sycl/plugins/unified_runtime/ur/ur.cpp
+++ b/sycl/plugins/unified_runtime/ur/ur.cpp
@@ -1,5 +1,5 @@
 
-//===--------- ur.hpp - Unified Runtime  -----------------------------===//
+//===--------- ur.cpp - Unified Runtime  -----------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/plugins/unified_runtime/ur/ur.cpp
+++ b/sycl/plugins/unified_runtime/ur/ur.cpp
@@ -1,11 +1,11 @@
 
-//===--------- ur.cpp - Unified Runtime  -----------------------------===//
+//===--------- ur.cpp - Unified Runtime  ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 
 #include "ur.hpp"
 #include <cassert>

--- a/sycl/plugins/unified_runtime/ur/ur.hpp
+++ b/sycl/plugins/unified_runtime/ur/ur.hpp
@@ -1,10 +1,10 @@
-//===--------- ur.hpp - Unified Runtime  -----------------------------===//
+//===--------- ur.hpp - Unified Runtime  ----------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===-----------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <atomic>

--- a/sycl/plugins/unified_runtime/ur_bindings.hpp
+++ b/sycl/plugins/unified_runtime/ur_bindings.hpp
@@ -1,10 +1,10 @@
-//===------ ur_bindings.hpp - Complete definitions of UR handles -------==//
+//===------ ur_bindings.hpp - Complete definitions of UR handles -----------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
-//===------------------------------------------------------------------===//
+//===----------------------------------------------------------------------===//
 #pragma once
 
 #include <ur/adapters/level_zero/ur_level_zero.hpp>


### PR DESCRIPTION
Fix the license headers at the top of each source file in the unified runtime directory.