### PR TITLE
[SYCL] Fix require alignment in buffers

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -198,8 +198,7 @@ public:
   buffer(const range<dimensions> &bufferRange,
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
-      : buffer_plain(bufferRange.size() * sizeof(T),
-                     detail::getNextPowerOfTwo(sizeof(T)), propList,
+      : buffer_plain(bufferRange.size() * sizeof(T), alignof(T), propList,
                      make_unique_ptr<
                          detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>()),
         Range(bufferRange) {
@@ -212,8 +211,7 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator)),
         Range(bufferRange) {
@@ -225,8 +223,8 @@ public:
   buffer(T *hostData, const range<dimensions> &bufferRange,
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
-      : buffer_plain(hostData, bufferRange.size() * sizeof(T),
-                     detail::getNextPowerOfTwo(sizeof(T)), propList,
+      : buffer_plain(hostData, bufferRange.size() * sizeof(T), alignof(T),
+                     propList,
                      make_unique_ptr<
                          detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>()),
         Range(bufferRange) {
@@ -239,8 +237,7 @@ public:
          AllocatorT allocator, const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            hostData, bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            hostData, bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator)),
         Range(bufferRange) {
@@ -254,8 +251,8 @@ public:
          const range<dimensions> &bufferRange,
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
-      : buffer_plain(hostData, bufferRange.size() * sizeof(T),
-                     detail::getNextPowerOfTwo(sizeof(T)), propList,
+      : buffer_plain(hostData, bufferRange.size() * sizeof(T), alignof(T),
+                     propList,
                      make_unique_ptr<
                          detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>()),
         Range(bufferRange) {
@@ -270,8 +267,7 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            hostData, bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            hostData, bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator)),
         Range(bufferRange) {
@@ -285,8 +281,7 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            hostData, bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            hostData, bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator),
             std::is_const<T>::value),
@@ -302,8 +297,7 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            hostData, bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            hostData, bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator),
             std::is_const<T>::value),
@@ -319,8 +313,7 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            hostData, bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            hostData, bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(),
             std::is_const<T>::value),
         Range(bufferRange) {
@@ -335,8 +328,7 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            hostData, bufferRange.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            hostData, bufferRange.size() * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(),
             std::is_const<T>::value),
         Range(bufferRange) {
@@ -367,8 +359,7 @@ public:
               std::copy(first, last,
                         static_cast<IteratorPointerToNonConstValueType>(ToPtr));
             },
-            std::distance(first, last) * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            std::distance(first, last) * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator),
             detail::iterator_to_const_type_t<InputIterator>::value),
@@ -400,8 +391,7 @@ public:
               std::copy(first, last,
                         static_cast<IteratorPointerToNonConstValueType>(ToPtr));
             },
-            std::distance(first, last) * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            std::distance(first, last) * sizeof(T), alignof(T), propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(),
             detail::iterator_to_const_type_t<InputIterator>::value),
         Range(range<1>(std::distance(first, last))) {
@@ -419,8 +409,8 @@ public:
          const property_list &propList = {},
          const detail::code_location CodeLoc = detail::code_location::current())
       : buffer_plain(
-            container.data(), container.size() * sizeof(T),
-            detail::getNextPowerOfTwo(sizeof(T)), propList,
+            container.data(), container.size() * sizeof(T), alignof(T),
+            propList,
             make_unique_ptr<detail::SYCLMemObjAllocatorHolder<AllocatorT, T>>(
                 allocator)),
         Range(range<1>(container.size())) {

--- a/sycl/test-e2e/Regression/subalign_no_alloc.cpp
+++ b/sycl/test-e2e/Regression/subalign_no_alloc.cpp
@@ -1,0 +1,51 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests that a type with a different alignment from its size does not cause
+// the runtime to reallocate memory.
+
+#include <sycl/sycl.hpp>
+
+#include <vector>
+
+using namespace sycl;
+
+constexpr size_t N = 100;
+
+struct alignas(long) SubalignedStruct {
+  long x, y, z;
+};
+
+struct PanicAllocator {
+  using value_type = SubalignedStruct;
+  using size_type = std::size_t;
+
+  PanicAllocator() = default;
+  PanicAllocator(const PanicAllocator &) {}
+
+  SubalignedStruct *allocate(size_type) {
+    assert(false && "Allocation should not have happened! Panic!");
+    return nullptr;
+  }
+  void deallocate(SubalignedStruct *, size_type) {}
+  bool operator==(const PanicAllocator &) const { return true; }
+  bool operator!=(const PanicAllocator &) const { return false; }
+};
+
+int main() {
+  queue Q;
+
+  std::vector<SubalignedStruct> Data{N};
+  buffer<SubalignedStruct, 1, PanicAllocator> Buf{Data.data(), N};
+
+  Q.submit([&](handler &CGH) {
+    accessor Acc{Buf, CGH, write_only};
+    CGH.parallel_for(N, [=](item<1> I) {
+      Acc[I].x = I.get_linear_id() + 1;
+      Acc[I].y = I.get_linear_id() + 2;
+      Acc[I].z = I.get_linear_id() + 3;
+    });
+  });
+
+  return 0;
+}


### PR DESCRIPTION
This commit changes the required alignment determined by buffers to use alignof rather than some power-of-two higher than the size of the element type. This avoids the need for reallocation when the element type has a different alignment than its size.