### PR TITLE
[CI] Use ubuntu2204_intel_drivers:latest image for ESIMD testing

### DIFF
--- a/.github/workflows/sycl_precommit_linux.yml
+++ b/.github/workflows/sycl_precommit_linux.yml
@@ -73,7 +73,7 @@ jobs:
         include:
           - name: ESIMD Emu
             runner: '["Linux", "x86-cpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2204_build:latest
+            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001
             target_devices: ext_intel_esimd_emulator:gpu
             install_drivers: ${{ contains(needs.detect_changes.outputs.filters, 'drivers') }}


### PR DESCRIPTION
1) That's what we used to have when using matrix, see https://github.com/intel/llvm/blob/632c2889e33bb3c43e0768b920a35da6e3267579/devops/test_configs.json#L70

2) That makes sense and I'm not sure how it worked before.

3)
https://github.com/intel/llvm/blob/632c2889e33bb3c43e0768b920a35da6e3267579/devops/containers/ubuntu2204_base.Dockerfile#L20 should enable proper pre-commit testing for drivers update for the ESIMD Emulator target (which is the main motiviation for this change).