### PR TITLE
[SYCL][NATIVECPU] UR adapter updates

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/context.cpp
@@ -20,9 +20,6 @@ urContextCreate(uint32_t DeviceCount, const ur_device_handle_t *phDevices,
                 const ur_context_properties_t *pProperties,
                 ur_context_handle_t *phContext) {
   std::ignore = pProperties;
-  UR_ASSERT(phDevices, UR_RESULT_ERROR_INVALID_NULL_POINTER);
-  UR_ASSERT(phContext, UR_RESULT_ERROR_INVALID_NULL_POINTER);
-
   assert(DeviceCount == 1);
 
   // TODO: Proper error checking.
@@ -46,9 +43,6 @@ urContextRelease(ur_context_handle_t hContext) {
 UR_APIEXPORT ur_result_t UR_APICALL
 urContextGetInfo(ur_context_handle_t hContext, ur_context_info_t propName,
                  size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
-
-  UR_ASSERT(hContext, UR_RESULT_ERROR_INVALID_NULL_HANDLE);
-
   UrReturnHelper returnValue(propSize, pPropValue, pPropSizeRet);
 
   switch (propName) {

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/device.cpp
@@ -315,11 +315,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceCreateWithNativeHandle(
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetGlobalTimestamps(
     ur_device_handle_t hDevice, uint64_t *pDeviceTimestamp,
     uint64_t *pHostTimestamp) {
-  std::ignore = hDevice;
-  std::ignore = pDeviceTimestamp;
-  std::ignore = pHostTimestamp;
-
-  DIE_NO_IMPLEMENTATION;
+  std::ignore = hDevice; // todo
+  if (pHostTimestamp) {
+    using namespace std::chrono;
+    *pHostTimestamp =
+        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch())
+            .count();
+  }
+  if (pDeviceTimestamp) {
+    // todo: calculate elapsed time properly
+    using namespace std::chrono;
+    *pDeviceTimestamp =
+        duration_cast<nanoseconds>(steady_clock::now().time_since_epoch())
+            .count();
+  }
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urDeviceSelectBinary(


### PR DESCRIPTION
Removes some unneeded UR_ASSERTS
Added initial GlobalTimeStamp implementation for `sycl-ls`. 