### PR TITLE
Coverity fixes

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -352,7 +352,18 @@ exec_graph_impl::~exec_graph_impl() {
   // We need to wait on all command buffer executions before we can release
   // them.
   for (auto &Event : MExecutionEvents) {
-    Event->wait(Event);
+   try {
+	   Event->wait(Event);
+   }
+   catch(std::runtime_error &e)
+   {
+      std::cout << "Runtime exception caught: " << e.what() << std::endl;
+   }
+   catch(sycl::exception &e)
+   {
+      std::cout << "SYCL exception caught: " << e.what() << std::endl;
+   }
+
   }
 
   for (auto Iter : MPiCommandBuffers) {
@@ -572,7 +583,7 @@ bool modifiable_command_graph::end_recording(
 
 executable_command_graph::executable_command_graph(
     const std::shared_ptr<detail::graph_impl> &Graph, const sycl::context &Ctx)
-    : MTag(rand()),
+    : MTag(random()),
       impl(std::make_shared<detail::exec_graph_impl>(Ctx, Graph)) {
   finalizeImpl(); // Create backend representation for executable graph
 }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -352,18 +352,13 @@ exec_graph_impl::~exec_graph_impl() {
   // We need to wait on all command buffer executions before we can release
   // them.
   for (auto &Event : MExecutionEvents) {
-   try {
-	   Event->wait(Event);
-   }
-   catch(std::runtime_error &e)
-   {
+    try {
+      Event->wait(Event);
+    } catch (std::runtime_error &e) {
       std::cout << "Runtime exception caught: " << e.what() << std::endl;
-   }
-   catch(sycl::exception &e)
-   {
+    } catch (sycl::exception &e) {
       std::cout << "SYCL exception caught: " << e.what() << std::endl;
-   }
-
+    }
   }
 
   for (auto Iter : MPiCommandBuffers) {

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -12,7 +12,6 @@
 #include <detail/program_manager/program_manager.hpp>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
-#include <random>
 #include <sycl/feature_test.hpp>
 #include <sycl/queue.hpp>
 
@@ -579,7 +578,7 @@ bool modifiable_command_graph::end_recording(
 
 executable_command_graph::executable_command_graph(
     const std::shared_ptr<detail::graph_impl> &Graph, const sycl::context &Ctx)
-    : MTag(random()),
+    : MTag(rand()),
       impl(std::make_shared<detail::exec_graph_impl>(Ctx, Graph)) {
   finalizeImpl(); // Create backend representation for executable graph
 }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -12,9 +12,9 @@
 #include <detail/program_manager/program_manager.hpp>
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
+#include <random>
 #include <sycl/feature_test.hpp>
 #include <sycl/queue.hpp>
-#include <random>
 
 // Developer switch to use emulation mode on all backends, even those that
 // report native support, this is useful for debugging.

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -14,6 +14,7 @@
 #include <detail/scheduler/commands.hpp>
 #include <sycl/feature_test.hpp>
 #include <sycl/queue.hpp>
+#include <random>
 
 // Developer switch to use emulation mode on all backends, even those that
 // report native support, this is useful for debugging.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -424,7 +424,7 @@ event handler::finalize() {
     // Empty nodes are handled by Graph like standard nodes
     // For Standard mode (non-graph),
     // empty nodes are not sent to the scheduler to save time
-    if (MGraph || MQueue->getCommandGraph()) {
+    if (MGraph ||( MQueue && MQueue->getCommandGraph())) {
       CommandGroup.reset(
           new detail::CG(detail::CG::None, std::move(CGData), MCodeLoc));
     } else {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -424,7 +424,7 @@ event handler::finalize() {
     // Empty nodes are handled by Graph like standard nodes
     // For Standard mode (non-graph),
     // empty nodes are not sent to the scheduler to save time
-    if (MGraph || (MQueue && MQueue->getCommandGraph())) {
+    if (MGraph || MQueue->getCommandGraph()) {
       CommandGroup.reset(
           new detail::CG(detail::CG::None, std::move(CGData), MCodeLoc));
     } else {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -424,7 +424,7 @@ event handler::finalize() {
     // Empty nodes are handled by Graph like standard nodes
     // For Standard mode (non-graph),
     // empty nodes are not sent to the scheduler to save time
-    if (MGraph ||( MQueue && MQueue->getCommandGraph())) {
+    if (MGraph || (MQueue && MQueue->getCommandGraph())) {
       CommandGroup.reset(
           new detail::CG(detail::CG::None, std::move(CGData), MCodeLoc));
     } else {


### PR DESCRIPTION
Coverity reports two Uncaught exceptions from:~exec_graph_impl()- A runtime error thrown from checkPiResult() and a runtime exception thrown from event_impl::wait(). Modified the cod to catch both from the destructor. 