### PR TITLE
[Clang] Update test checks after 98322d3eb431.

### DIFF
--- a/clang/test/SemaSYCL/fpga_pipes.cpp
+++ b/clang/test/SemaSYCL/fpga_pipes.cpp
@@ -11,7 +11,7 @@ using type2 = __attribute__((pipe("write_only"))) const int;
 // expected-error@+1 {{'42' mode for pipe attribute is not supported; allowed modes are 'read_only' and 'write_only'}}
 using type3 = __attribute__((pipe("42"))) const int;
 
-// expected-error@+1{{'pipe' attribute requires a string}}
+// expected-error@+1{{expected string literal as argument of 'pipe' attribute}}
 using type4 = __attribute__((pipe(0))) const int;
 
 // expected-error@+1{{'pipe' attribute takes one argument}}

--- a/clang/test/SemaSYCL/fpga_pipes_ast.cpp
+++ b/clang/test/SemaSYCL/fpga_pipes_ast.cpp
@@ -17,15 +17,6 @@ const pipe_storage Storage1 __attribute__((io_pipe_id(5)));
 // CHECK-NEXT: CXXConstructExpr {{.*}}'pipe_storage' 'void () noexcept'
 // CHECK-NEXT: SYCLIntelPipeIOAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
-// CHECK: VarTemplateSpecializationDecl {{.*}} used Storage2 {{.*}}'pipe_storage' callinit
-// CHECK-NEXT: TemplateArgument integral 2
-// CHECK-NEXT: CXXConstructExpr {{.*}}'pipe_storage' 'void () noexcept'
-// CHECK-NEXT: SYCLIntelPipeIOAttr
-// CHECK-NEXT: ConstantExpr{{.*}}'int'
-// CHECK-NEXT: value: Int 2
-// CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}} 'int'
-// CHECK-NEXT: NonTypeTemplateParmDecl {{.*}} referenced 'int' depth 0 index 0 N
-// CHECK-NEXT: IntegerLiteral {{.*}} 'int' 2
 template <int N>
 pipe_storage Storage2 __attribute__((io_pipe_id(N)));
 

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -285,7 +285,7 @@ void diagnostics()
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int mrg_reg[4];
 
-  //expected-error@+1{{attribute requires a string}}
+  //expected-error@+1{{expected string literal as argument of 'merge' attribute}}
   [[intel::merge(3, 9.0f)]] unsigned int mrg_float[4];
 
   //expected-error@+1{{attribute requires exactly 2 arguments}}


### PR DESCRIPTION
The referenced commit changes the wording of some diagnostics from

    "'foo' attribute requires a string'

to

    "expected string literal as argument of 'foo' attribute"

This patch updates those checks accordingly. Additionally, some AST
changes were necessary (in a similar way to other AST changes in the
referenced commit).
