### PR TITLE
Guard a change from e53b28c83301 with INTEL_SYCL_OPAQUEPOINTER_READY.

### DIFF
--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -936,7 +936,11 @@ static TargetTypeInfo getTargetTypeInfo(const TargetExtType *Ty) {
   LLVMContext &C = Ty->getContext();
   StringRef Name = Ty->getName();
   if (Name.startswith("spirv."))
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return TargetTypeInfo(PointerType::get(C, 0), TargetExtType::HasZeroInit,
+#else //INTEL_SYCL_OPAQUEPOINTER_READY
+    return TargetTypeInfo(Type::getInt8PtrTy(C, 0), TargetExtType::HasZeroInit,
+#endif //INTEL_SYCL_OPAQUEPOINTER_READY
                           TargetExtType::CanBeGlobal);
 
   // Opaque types in the AArch64 name space.


### PR DESCRIPTION
Fix some LIT failures related to target type info.
