### PR TITLE
[Opaque Pointer] Fix bad code within INTEL_SYCL_OPAQUEPOINTER_READY 

### DIFF
--- a/clang/lib/CodeGen/ABIInfoImpl.cpp
+++ b/clang/lib/CodeGen/ABIInfoImpl.cpp
@@ -170,7 +170,11 @@ CodeGen::emitVoidPtrDirectVAArg(CodeGenFunction &CGF, Address VAListAddr,
   // Cast the element type to i8* if necessary.  Some platforms define
   // va_list as a struct containing an i8* instead of just an i8*.
   if (VAListAddr.getElementType() != CGF.Int8PtrTy)
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
     VAListAddr = CGF.Builder.CreateElementBitCast(VAListAddr, CGF.Int8PtrTy);
+#else
+    VAListAddr = VAListAddr.withElementType(CGF.Int8PtrTy);
+#endif
 
   llvm::Value *Ptr = CGF.Builder.CreateLoad(VAListAddr, "argp.cur");
 
@@ -196,7 +200,11 @@ CodeGen::emitVoidPtrDirectVAArg(CodeGenFunction &CGF, Address VAListAddr,
     Addr = CGF.Builder.CreateConstInBoundsByteGEP(Addr, SlotSize - DirectSize);
   }
 
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
   Addr = CGF.Builder.CreateElementBitCast(Addr, DirectTy);
+#else
+  return Addr.withElementType(DirectTy);
+#endif
   return Addr;
 }
 

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -13102,7 +13102,8 @@ static Value *EmitX86MaskedStore(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
   Value *Ptr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
       Ops[0], llvm::PointerType::getUnqual(Ops[1]->getType()));
 #else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Value *Ptr = Ops[0];
+  Value *Ptr = CGF.Builder.CreateAddrSpaceCast(
+      Ops[0], llvm::PointerType::getUnqual(Ops[1]->getType()));
 #endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Value *MaskVec = getMaskVecValue(
@@ -13119,7 +13120,8 @@ static Value *EmitX86MaskedLoad(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
   Value *Ptr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
       Ops[0], llvm::PointerType::getUnqual(Ty));
 #else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Value *Ptr = Ops[0];
+  Value *Ptr = CGF.Builder.CreateAddrSpaceCast(
+      Ops[0], llvm::PointerType::getUnqual(Ops[1]->getType()));
 #endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Value *MaskVec = getMaskVecValue(

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -16545,7 +16545,9 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
       // Storing the whole vector, simply store it on BE and reverse bytes and
       // store on LE.
       if (Width == 16) {
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
         Value *BC = Builder.CreateBitCast(Op0, Op2->getType()->getPointerTo());
+#endif
         Value *StVec = Op2;
         if (IsLE) {
           SmallVector<int, 16> RevMask;
@@ -22628,7 +22630,7 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
   case Hexagon::BI__builtin_HEXAGON_V6_vsubcarryo_128B: {
     // Get the type from the 0-th argument.
     llvm::Type *VecType = ConvertType(E->getArg(0)->getType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
     Address PredAddr = Builder.CreateElementBitCast(
         EmitPointerWithAlignment(E->getArg(2)), VecType);
 #else // INTEL_SYCL_OPAQUEPOINTER_READY

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -2633,9 +2633,10 @@ void CodeGenFunction::InitializeVTablePointer(const VPtr &Vptr) {
       llvm::FunctionType::get(CGM.Int32Ty, /*isVarArg=*/true)
           ->getPointerTo(ProgAS)
           ->getPointerTo(GlobalsAS);
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+  llvm::Type *PtrTy = llvm::PointerType::get(CGM.getLLVMContext(), GlobalsAS);
   // vtable field is derived from `this` pointer, therefore they should be in
   // the same addr space. Note that this might not be LLVM address space 0.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   VTableField = VTableField.withElementType(PtrTy);
 #else
   VTableField = Builder.CreateElementBitCast(VTableField, VTablePtrTy);

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -777,7 +777,9 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
             CGM.getIntrinsic(llvm::Intrinsic::load_relative,
                              {VTableOffset->getType()}),
             {VTable, VTableOffset});
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
         VirtualFn = CGF.Builder.CreateBitCast(VirtualFn, FTy->getPointerTo());
+#endif
       } else {
         llvm::Value *VFPAddr =
             CGF.Builder.CreateGEP(CGF.Int8Ty, VTable, VTableOffset);
@@ -2141,7 +2143,9 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
       llvm::Value *Load = CGF.Builder.CreateCall(
           CGM.getIntrinsic(llvm::Intrinsic::load_relative, {CGM.Int32Ty}),
           {VTable, llvm::ConstantInt::get(CGM.Int32Ty, 4 * VTableIndex)});
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
       VFuncLoad = CGF.Builder.CreateBitCast(Load, TyPtr);
+#endif
     } else {
       VTable =
           CGF.Builder.CreateBitCast(VTable, TyPtr->getPointerTo());

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -2118,19 +2118,27 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
                                                   llvm::Type *Ty,
                                                   SourceLocation Loc) {
 #ifdef INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *TyPtr = CGM.GlobalsInt8PtrTy;
+  llvm::Type *PtrTy = CGM.GlobalsInt8PtrTy;
 #else  // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *TyPtr = Ty->getPointerTo();
 #endif // INTEL_SYCL_OPAQUEPOINTER_READY
   auto *MethodDecl = cast<CXXMethodDecl>(GD.getDecl());
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+  llvm::Value *VTable = CGF.GetVTablePtr(This, PtrTy, MethodDecl->getParent());
+#else
   llvm::Value *VTable = CGF.GetVTablePtr(
       This, TyPtr->getPointerTo(), MethodDecl->getParent());
+#endif
 
   uint64_t VTableIndex = CGM.getItaniumVTableContext().getMethodVTableIndex(GD);
   llvm::Value *VFunc;
   if (CGF.ShouldEmitVTableTypeCheckedLoad(MethodDecl->getParent())) {
     VFunc = CGF.EmitVTableTypeCheckedLoad(
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+        MethodDecl->getParent(), VTable, PtrTy,
+#else
         MethodDecl->getParent(), VTable, TyPtr,
+#endif
         VTableIndex *
             CGM.getContext().getTargetInfo().getPointerWidth(LangAS::Default) /
             8);
@@ -2139,14 +2147,25 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
 
     llvm::Value *VFuncLoad;
     if (CGM.getItaniumVTableContext().isRelativeLayout()) {
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+      VFuncLoad = CGF.Builder.CreateCall(
+          CGM.getIntrinsic(llvm::Intrinsic::load_relative, {CGM.Int32Ty}),
+          {VTable, llvm::ConstantInt::get(CGM.Int32Ty, 4 * VTableIndex)});
+#else
       VTable = CGF.Builder.CreateBitCast(VTable, CGM.Int8PtrTy);
       llvm::Value *Load = CGF.Builder.CreateCall(
           CGM.getIntrinsic(llvm::Intrinsic::load_relative, {CGM.Int32Ty}),
           {VTable, llvm::ConstantInt::get(CGM.Int32Ty, 4 * VTableIndex)});
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
+
       VFuncLoad = CGF.Builder.CreateBitCast(Load, TyPtr);
 #endif
     } else {
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+      llvm::Value *VTableSlotPtr = CGF.Builder.CreateConstInBoundsGEP1_64(
+          PtrTy, VTable, VTableIndex, "vfn");
+      VFuncLoad = CGF.Builder.CreateAlignedLoad(PtrTy, VTableSlotPtr,
+                                                CGF.getPointerAlign());
+#else
       VTable =
           CGF.Builder.CreateBitCast(VTable, TyPtr->getPointerTo());
       llvm::Value *VTableSlotPtr = CGF.Builder.CreateConstInBoundsGEP1_64(
@@ -2154,6 +2173,7 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
       VFuncLoad =
           CGF.Builder.CreateAlignedLoad(TyPtr, VTableSlotPtr,
                                         CGF.getPointerAlign());
+#endif
     }
 
     // Add !invariant.load md to virtual function load to indicate that

--- a/llvm/include/llvm/IR/DerivedTypes.h
+++ b/llvm/include/llvm/IR/DerivedTypes.h
@@ -645,9 +645,8 @@ class PointerType : public Type {
 
 #ifndef INTEL_SYCL_OPAQUEPOINTER_READY
   explicit PointerType(Type *ElType, unsigned AddrSpace);
-
-  Type *PointeeTy;
 #endif // INTEL_SYCL_OPAQUEPOINTER_READY
+  Type *PointeeTy;
 
 public:
   PointerType(const PointerType &) = delete;

--- a/llvm/include/llvm/IR/Intrinsics.h
+++ b/llvm/include/llvm/IR/Intrinsics.h
@@ -165,8 +165,7 @@ namespace Intrinsic {
 #ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       assert(Kind == Argument || Kind == ExtendArgument ||
              Kind == TruncArgument || Kind == HalfVecArgument ||
-             Kind == SameVecWidthArgument ||
-             Kind == PtrToElt || Kind == VecElementArgument ||
+             Kind == SameVecWidthArgument || Kind == VecElementArgument ||
              Kind == Subdivide2Argument || Kind == Subdivide4Argument ||
              Kind == VecOfBitcastsToInt);
 #else

--- a/llvm/include/llvm/IR/Intrinsics.td
+++ b/llvm/include/llvm/IR/Intrinsics.td
@@ -1909,14 +1909,22 @@ def int_vp_scatter: DefaultAttrsIntrinsic<[],
 // Experimental strided memory accesses
 def int_experimental_vp_strided_store : DefaultAttrsIntrinsic<[],
                              [ llvm_anyvector_ty,
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+                               llvm_anyptr_ty,
+#else
                                LLVMAnyPointerToElt<0>,
+#endif
                                llvm_anyint_ty, // Stride in bytes
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],
                              [ NoCapture<ArgIndex<1>>, IntrNoSync, IntrWriteMem, IntrArgMemOnly, IntrWillReturn ]>;
 
 def int_experimental_vp_strided_load  : DefaultAttrsIntrinsic<[llvm_anyvector_ty],
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
+                             [ llvm_anyptr_ty,
+#else
                              [ LLVMAnyPointerToElt<0>,
+#endif
                                llvm_anyint_ty, // Stride in bytes
                                LLVMScalarOrSameVectorWidth<0, llvm_i1_ty>,
                                llvm_i32_ty],

--- a/llvm/lib/AsmParser/LLParser.cpp
+++ b/llvm/lib/AsmParser/LLParser.cpp
@@ -61,6 +61,7 @@ static std::string getTypeString(Type *T) {
   return Tmp.str();
 }
 
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
 static void setContextOpaquePointers(LLLexer &L, LLVMContext &C) {
   while (true) {
     lltok::Kind K = L.Lex();
@@ -74,10 +75,11 @@ static void setContextOpaquePointers(LLLexer &L, LLVMContext &C) {
     }
   }
 }
-
+#endif
 /// Run: module ::= toplevelentity*
 bool LLParser::Run(bool UpgradeDebugInfo,
                    DataLayoutCallbackTy DataLayoutCallback) {
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
   // If we haven't decided on whether or not we're using opaque pointers, do a
   // quick lex over the tokens to see if we explicitly construct any typed or
   // opaque pointer types.
@@ -85,7 +87,7 @@ bool LLParser::Run(bool UpgradeDebugInfo,
   // regardless of if --opaque-pointers is set.
   if (!Context.hasSetOpaquePointersValue())
     setContextOpaquePointers(OPLex, Context);
-
+#endif
   // Prime the lexer.
   Lex.Lex();
 

--- a/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
+++ b/llvm/lib/Bitcode/Reader/BitcodeReader.cpp
@@ -2364,8 +2364,10 @@ Error BitcodeReader::parseTypeTableBody() {
                                     //          [pointee type, address space]
       if (Record.empty())
         return error("Invalid pointer record");
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
       if (LLVM_UNLIKELY(!Context.hasSetOpaquePointersValue()))
         Context.setOpaquePointers(false);
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       unsigned AddressSpace = 0;
       if (Record.size() == 2)
         AddressSpace = Record[1];

--- a/llvm/lib/IR/LLVMContext.cpp
+++ b/llvm/lib/IR/LLVMContext.cpp
@@ -373,10 +373,11 @@ std::unique_ptr<DiagnosticHandler> LLVMContext::getDiagnosticHandler() {
   return std::move(pImpl->DiagHandler);
 }
 
+#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
 bool LLVMContext::hasSetOpaquePointersValue() const {
   return pImpl->hasOpaquePointersValue();
 }
-
+#endif
 void LLVMContext::setOpaquePointers(bool Enable) const {
 #ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   assert(Enable && "Cannot disable opaque pointers");

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -2018,6 +2018,8 @@ void Verifier::verifyParameterAttrs(AttributeSet Attrs, Type *Ty,
       }
     }
   }
+#else
+  }
 #endif // INTEL_SYCL_OPAQUEPOINTER_READY
   if (Attrs.hasAttribute(Attribute::NoFPClass)) {
     uint64_t Val = Attrs.getAttribute(Attribute::NoFPClass).getValueAsInt();


### PR DESCRIPTION
This is in preparation for setting -DINTEL_SYCL_OPAQUEPOINTER_READY=1

- Fix bad guard for INTEL_SYCL_OPAQUEPOINTER_READY
- Keep the addressspace cast for opaque pointer
- Fix opaque pointer guard for getVirtualFunctionPointer
