### PR TITLE
Guard e53b28c833010, d03f4177dfbb changes with INTEL_SYCL_OPAQUEPOINTER_READY.

### DIFF
--- a/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
+++ b/llvm/lib/ExecutionEngine/ExecutionEngine.cpp
@@ -430,7 +430,11 @@ int ExecutionEngine::runFunctionAsMain(Function *Fn,
   // Check main() type
   unsigned NumArgs = Fn->getFunctionType()->getNumParams();
   FunctionType *FTy = Fn->getFunctionType();
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Type *PPInt8Ty = PointerType::get(Fn->getContext(), 0);
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+  Type *PPInt8Ty = Type::getInt8PtrTy(Fn->getContext())->getPointerTo();
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Check the argument types.
   if (NumArgs > 3)

--- a/llvm/lib/IR/AutoUpgrade.cpp
+++ b/llvm/lib/IR/AutoUpgrade.cpp
@@ -1227,15 +1227,25 @@ GlobalVariable *llvm::UpgradeGlobalVariable(GlobalVariable *GV) {
   LLVMContext &C = GV->getContext();
   IRBuilder<> IRB(C);
   auto EltTy = StructType::get(STy->getElementType(0), STy->getElementType(1),
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                                IRB.getPtrTy());
+#else //INTEL_SYCL_OPAQUEPOINTER_READY
+                               IRB.getInt8PtrTy());
+#endif //INTEL_SYCL_OPAQUEPOINTER_READY
   Constant *Init = GV->getInitializer();
   unsigned N = Init->getNumOperands();
   std::vector<Constant *> NewCtors(N);
   for (unsigned i = 0; i != N; ++i) {
     auto Ctor = cast<Constant>(Init->getOperand(i));
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     NewCtors[i] = ConstantStruct::get(EltTy, Ctor->getAggregateElement(0u),
                                       Ctor->getAggregateElement(1),
                                       Constant::getNullValue(IRB.getPtrTy()));
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+    NewCtors[i] = ConstantStruct::get(
+        EltTy, Ctor->getAggregateElement(0u), Ctor->getAggregateElement(1),
+        Constant::getNullValue(IRB.getInt8PtrTy()));
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   Constant *NewInit = ConstantArray::get(ArrayType::get(EltTy, N), NewCtors);
 
@@ -4232,7 +4242,11 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     NewCall =
         Builder.CreateCall(NewFn, {CI->getArgOperand(0), CI->getArgOperand(1),
                                    CI->getArgOperand(2), CI->getArgOperand(3),
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                                    Constant::getNullValue(Builder.getPtrTy())});
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+                                   Constant::getNullValue(Builder.getInt8PtrTy())});
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     NewCall->takeName(CI);
     CI->replaceAllUsesWith(NewCall);
     CI->eraseFromParent();
@@ -4248,7 +4262,11 @@ void llvm::UpgradeIntrinsicCall(CallBase *CI, Function *NewFn) {
     NewCall =
         Builder.CreateCall(NewFn, {CI->getArgOperand(0), CI->getArgOperand(1),
                                    CI->getArgOperand(2), CI->getArgOperand(3),
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                                    Constant::getNullValue(Builder.getPtrTy())});
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+                                   Constant::getNullValue(Builder.getInt8PtrTy())});
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     NewCall->takeName(CI);
     CI->replaceAllUsesWith(NewCall);
     CI->eraseFromParent();

--- a/llvm/lib/IR/Type.cpp
+++ b/llvm/lib/IR/Type.cpp
@@ -938,9 +938,9 @@ static TargetTypeInfo getTargetTypeInfo(const TargetExtType *Ty) {
   if (Name.startswith("spirv."))
 #ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return TargetTypeInfo(PointerType::get(C, 0), TargetExtType::HasZeroInit,
-#else //INTEL_SYCL_OPAQUEPOINTER_READY
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
     return TargetTypeInfo(Type::getInt8PtrTy(C, 0), TargetExtType::HasZeroInit,
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
                           TargetExtType::CanBeGlobal);
 
   // Opaque types in the AArch64 name space.

--- a/llvm/lib/IR/Verifier.cpp
+++ b/llvm/lib/IR/Verifier.cpp
@@ -796,7 +796,12 @@ void Verifier::visitGlobalVariable(const GlobalVariable &GV) {
     if (ArrayType *ATy = dyn_cast<ArrayType>(GV.getValueType())) {
       StructType *STy = dyn_cast<StructType>(ATy->getElementType());
       PointerType *FuncPtrTy =
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           PointerType::get(Context, DL.getProgramAddressSpace());
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+          FunctionType::get(Type::getVoidTy(Context), false)
+              ->getPointerTo(DL.getProgramAddressSpace());
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       Check(STy && (STy->getNumElements() == 2 || STy->getNumElements() == 3) &&
                 STy->getTypeAtIndex(0u)->isIntegerTy(32) &&
                 STy->getTypeAtIndex(1) == FuncPtrTy,

--- a/llvm/lib/Transforms/Coroutines/Coroutines.cpp
+++ b/llvm/lib/Transforms/Coroutines/Coroutines.cpp
@@ -37,7 +37,11 @@ using namespace llvm;
 // Construct the lowerer base class and initialize its members.
 coro::LowererBase::LowererBase(Module &M)
     : TheModule(M), Context(M.getContext()),
+#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Int8Ptr(PointerType::get(Context, 0)),
+#else  // INTEL_SYCL_OPAQUEPOINTER_READY
+      Int8Ptr(Type::getInt8PtrTy(Context, 0)),
+#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       ResumeFnType(FunctionType::get(Type::getVoidTy(Context), Int8Ptr,
                                      /*isVarArg=*/false)),
       NullPtr(ConstantPointerNull::get(Int8Ptr)) {}


### PR DESCRIPTION
- Revert "[clang] Drop some references to typed pointers (getInt8PtrTy).
NFC"
- Guard d03f4177dfbb6a910edde31acd0f14786b549bad within
INTEL_SYCL_OPAQUEPOINTER_READY
- Revert "[llvm] Drop some bitcasts and references related to typed
pointers"
- Guard e53b28c8330102bf21ac717ade2bfac9b1f09517 within
INTEL_SYCL_OPAQUEPOINTER_READY
