### PR TITLE
[libdevice] Remove weak_odr attribute from ITT functions

### DIFF
--- a/libdevice/device_itt.h
+++ b/libdevice/device_itt.h
@@ -33,7 +33,7 @@ enum __itt_atomic_mem_order_t {
 };
 
 // FIXME: must be enabled via -fdeclare-spirv-builtins
-DEVICE_EXTERN_C char __spirv_SpecConstant(int, char);
+SYCL_EXTERNAL EXTERN_C char __spirv_SpecConstant(int, char);
 
 #define ITT_SPEC_CONSTANT 0xFF747469
 
@@ -56,48 +56,55 @@ static ITT_WRAPPER_ATTRIBUTES bool isITTEnabled() {
 //        for atomic_op_start/finish. Compiler calls user
 //        wrappers right now, and they may interfere with
 //        debugging user code in non-ITT mode.
-DEVICE_EXTERN_C ITT_WRAPPER_ATTRIBUTES void __itt_offload_wi_start_wrapper();
-DEVICE_EXTERN_C ITT_WRAPPER_ATTRIBUTES void __itt_offload_wi_finish_wrapper();
-DEVICE_EXTERN_C ITT_WRAPPER_ATTRIBUTES void __itt_offload_wg_barrier_wrapper();
-DEVICE_EXTERN_C ITT_WRAPPER_ATTRIBUTES void __itt_offload_wi_resume_wrapper();
+SYCL_EXTERNAL EXTERN_C ITT_WRAPPER_ATTRIBUTES void
+__itt_offload_wi_start_wrapper();
+SYCL_EXTERNAL EXTERN_C ITT_WRAPPER_ATTRIBUTES void
+__itt_offload_wi_finish_wrapper();
+SYCL_EXTERNAL EXTERN_C ITT_WRAPPER_ATTRIBUTES void
+__itt_offload_wg_barrier_wrapper();
+SYCL_EXTERNAL EXTERN_C ITT_WRAPPER_ATTRIBUTES void
+__itt_offload_wi_resume_wrapper();
 
 // Non-inlinable and non-optimizable APIs that are recognized
 // by profiling tools.
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wi_start_stub(size_t *group_id, size_t wi_id, uint32_t wg_size);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wi_finish_stub(size_t *group_id, size_t wi_id);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wg_barrier_stub(uintptr_t barrier_id);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wi_resume_stub(size_t *group_id, size_t wi_id);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_sync_acquired_stub(uintptr_t sync_id);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_sync_releasing_stub(uintptr_t sync_id);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wg_local_range_stub(void *ptr, size_t size);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_atomic_op_start_stub(void *object, __itt_atomic_mem_op_t op_type,
                                    __itt_atomic_mem_order_t mem_order);
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_atomic_op_finish_stub(void *object, __itt_atomic_mem_op_t op_type,
                                     __itt_atomic_mem_order_t mem_order);
 
 // User visible APIs. These may called both from user code and from
 // compiler generated code.
-DEVICE_EXTERN_C void __itt_offload_wi_start(size_t *group_id, size_t wi_id,
-                                            uint32_t wg_size);
-DEVICE_EXTERN_C void __itt_offload_wi_finish(size_t *group_id, size_t wi_id);
-DEVICE_EXTERN_C void __itt_offload_wg_barrier(uintptr_t barrier_id);
-DEVICE_EXTERN_C void __itt_offload_wi_resume(size_t *group_id, size_t wi_id);
-DEVICE_EXTERN_C void __itt_offload_sync_acquired(uintptr_t sync_id);
-DEVICE_EXTERN_C void __itt_offload_sync_releasing(uintptr_t sync_id);
-DEVICE_EXTERN_C void __itt_offload_wg_local_range(void *ptr, size_t size);
-DEVICE_EXTERN_C void
+SYCL_EXTERNAL EXTERN_C void
+__itt_offload_wi_start(size_t *group_id, size_t wi_id, uint32_t wg_size);
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_finish(size_t *group_id,
+                                                    size_t wi_id);
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wg_barrier(uintptr_t barrier_id);
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_resume(size_t *group_id,
+                                                    size_t wi_id);
+SYCL_EXTERNAL EXTERN_C void __itt_offload_sync_acquired(uintptr_t sync_id);
+SYCL_EXTERNAL EXTERN_C void __itt_offload_sync_releasing(uintptr_t sync_id);
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wg_local_range(void *ptr,
+                                                         size_t size);
+SYCL_EXTERNAL EXTERN_C void
 __itt_offload_atomic_op_start(void *object, __itt_atomic_mem_op_t op_type,
                               __itt_atomic_mem_order_t mem_order);
-DEVICE_EXTERN_C void
+SYCL_EXTERNAL EXTERN_C void
 __itt_offload_atomic_op_finish(void *object, __itt_atomic_mem_op_t op_type,
                                __itt_atomic_mem_order_t mem_order);
 

--- a/libdevice/itt_compiler_wrappers.cpp
+++ b/libdevice/itt_compiler_wrappers.cpp
@@ -10,8 +10,7 @@
 
 #ifdef __SPIR__
 
-DEVICE_EXTERN_C
-void __itt_offload_wi_start_wrapper() {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_start_wrapper() {
   if (!isITTEnabled())
     return;
 
@@ -25,8 +24,7 @@ void __itt_offload_wi_start_wrapper() {
   __itt_offload_wi_start_stub(GroupID, WIID, WGSize);
 }
 
-DEVICE_EXTERN_C
-void __itt_offload_wi_finish_wrapper() {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_finish_wrapper() {
   if (!isITTEnabled())
     return;
 
@@ -37,16 +35,14 @@ void __itt_offload_wi_finish_wrapper() {
   __itt_offload_wi_finish_stub(GroupID, WIID);
 }
 
-DEVICE_EXTERN_C
-void __itt_offload_wg_barrier_wrapper() {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wg_barrier_wrapper() {
   if (!isITTEnabled())
     return;
 
   __itt_offload_wg_barrier_stub(0);
 }
 
-DEVICE_EXTERN_C
-void __itt_offload_wi_resume_wrapper() {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_resume_wrapper() {
   if (!isITTEnabled())
     return;
 

--- a/libdevice/itt_stubs.cpp
+++ b/libdevice/itt_stubs.cpp
@@ -10,28 +10,28 @@
 
 #ifdef __SPIR__
 
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wi_start_stub(size_t *group_id, size_t wi_id, uint32_t wg_size) {}
 
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wi_finish_stub(size_t *group_id, size_t wi_id) {}
 
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wg_barrier_stub(uintptr_t barrier_id) {}
 
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wi_resume_stub(size_t *group_id, size_t wi_id) {}
 
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_sync_acquired_stub(uintptr_t sync_id) {}
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_sync_releasing_stub(uintptr_t sync_id) {}
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_wg_local_range_stub(void *ptr, size_t size) {}
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_atomic_op_start_stub(void *object, __itt_atomic_mem_op_t op_type,
                                    __itt_atomic_mem_order_t mem_order) {}
-DEVICE_EXTERN_C ITT_STUB_ATTRIBUTES void
+SYCL_EXTERNAL EXTERN_C ITT_STUB_ATTRIBUTES void
 __itt_offload_atomic_op_finish_stub(void *object, __itt_atomic_mem_op_t op_type,
                                     __itt_atomic_mem_order_t mem_order) {}
 

--- a/libdevice/itt_user_wrappers.cpp
+++ b/libdevice/itt_user_wrappers.cpp
@@ -10,50 +10,53 @@
 
 #ifdef __SPIR__
 
-DEVICE_EXTERN_C void __itt_offload_wi_start(size_t *group_id, size_t wi_id,
-                                            uint32_t wg_size) {
+SYCL_EXTERNAL EXTERN_C void
+__itt_offload_wi_start(size_t *group_id, size_t wi_id, uint32_t wg_size) {
   if (isITTEnabled())
     __itt_offload_wi_start_stub(group_id, wi_id, wg_size);
 }
 
-DEVICE_EXTERN_C void __itt_offload_wi_finish(size_t *group_id, size_t wi_id) {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_finish(size_t *group_id,
+                                                    size_t wi_id) {
   if (isITTEnabled())
     __itt_offload_wi_finish_stub(group_id, wi_id);
 }
 
-DEVICE_EXTERN_C void __itt_offload_wg_barrier(uintptr_t barrier_id) {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wg_barrier(uintptr_t barrier_id) {
   if (isITTEnabled())
     __itt_offload_wg_barrier_stub(barrier_id);
 }
 
-DEVICE_EXTERN_C void __itt_offload_wi_resume(size_t *group_id, size_t wi_id) {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wi_resume(size_t *group_id,
+                                                    size_t wi_id) {
   if (isITTEnabled())
     __itt_offload_wi_resume_stub(group_id, wi_id);
 }
 
-DEVICE_EXTERN_C void __itt_offload_sync_acquired(uintptr_t sync_id) {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_sync_acquired(uintptr_t sync_id) {
   if (isITTEnabled())
     __itt_offload_sync_acquired_stub(sync_id);
 }
 
-DEVICE_EXTERN_C void __itt_offload_sync_releasing(uintptr_t sync_id) {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_sync_releasing(uintptr_t sync_id) {
   if (isITTEnabled())
     __itt_offload_sync_releasing_stub(sync_id);
 }
 
-DEVICE_EXTERN_C void __itt_offload_wg_local_range(void *ptr, size_t size) {
+SYCL_EXTERNAL EXTERN_C void __itt_offload_wg_local_range(void *ptr,
+                                                         size_t size) {
   if (isITTEnabled())
     __itt_offload_wg_local_range_stub(ptr, size);
 }
 
-DEVICE_EXTERN_C void
+SYCL_EXTERNAL EXTERN_C void
 __itt_offload_atomic_op_start(void *object, __itt_atomic_mem_op_t op_type,
                               __itt_atomic_mem_order_t mem_order) {
   if (isITTEnabled())
     __itt_offload_atomic_op_start_stub(object, op_type, mem_order);
 }
 
-DEVICE_EXTERN_C void
+SYCL_EXTERNAL EXTERN_C void
 __itt_offload_atomic_op_finish(void *object, __itt_atomic_mem_op_t op_type,
                                __itt_atomic_mem_order_t mem_order) {
   if (isITTEnabled())


### PR DESCRIPTION
weak_odr attribute prohibits removing unused functions and ITT functions
are supposed to be optimized out the compiler if they are not used. The
attribute seems to be added by mistake with the common refactoring
accross the whole libdevice library.
