### PR TITLE
[ITT][SYCL][NFC] Update ITT instrumentation tests

### DIFF
--- a/clang/test/CodeGenSYCL/kernel-simple-instrumentation.cpp
+++ b/clang/test/CodeGenSYCL/kernel-simple-instrumentation.cpp
@@ -1,7 +1,6 @@
-/// Check if start/finish ITT annotations are being added during compilation of
-/// SYCL device code
+// Check if start/finish ITT annotations are being added during compilation of
+// SYCL device code
 
-// RUN: %clang_cc1 -fsycl-is-device -fsycl-instrument-device-code -triple spir64-unknown-unknown -emit-llvm %s -o - | FileCheck %s
 // RUN: %clang_cc1 -fsycl-is-device -fsycl-instrument-device-code -triple spir64-unknown-unknown -emit-llvm %s -o - | FileCheck %s
 
 // CHECK: kernel_function

--- a/clang/test/Driver/sycl-instrumentation.c
+++ b/clang/test/Driver/sycl-instrumentation.c
@@ -1,14 +1,15 @@
-/// Check if -fsycl-instrument-device-code is passed to device-side -cc1
-/// and if ITT device libraries are pulled in.
-/// The following conditions must be fulfilled:
-/// 1. A SPIR-V-based environment must be targetted
-/// 2. The option must not be explicitly disabled in the Driver call
+// Check if -fsycl-instrument-device-code is passed to device-side -cc1
+// and if ITT device libraries are pulled in.
+// The following conditions must be fulfilled:
+// 1. A SPIR-V-based environment must be targetted
+// 2. The option must not be explicitly disabled in the Driver call
 
-/// FIXME: Force linux targets to allow for the libraries to be found.  Dummy
-/// inputs for --sysroot should be updated to work better for Windows.
+// FIXME: Force linux targets to allow for the libraries to be found.  Dummy
+// inputs for --sysroot should be updated to work better for Windows.
+
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --sysroot=%S/Inputs/SYCL -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV,CHECK-HOST %s
-/// -fno-sycl-device-lib mustn't affect the linkage of ITT libraries
+// -fno-sycl-device-lib mustn't affect the linkage of ITT libraries
 // RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl --sysroot=%S/Inputs/SYCL -fno-sycl-device-lib=all -fsycl-targets=spir64 -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV %s
 
@@ -23,5 +24,6 @@
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 // RUN: %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda -fno-sycl-instrument-device-code -nocudalib -### %s 2>&1 \
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
+
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"
 // CHECK-NONPASSED-NOT: "-input={{.*}}libsycl-itt-{{.*}}.{{o|obj}}"

--- a/sycl/test-e2e/DeviceLib/ITTAnnotations/barrier.cpp
+++ b/sycl/test-e2e/DeviceLib/ITTAnnotations/barrier.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -fsycl-instrument-device-code -o %t.out
 // RUN: %{run} %t.out
 
-#include "CL/sycl.hpp"
+#include "sycl/sycl.hpp"
 #include <vector>
 
 using namespace sycl;


### PR DESCRIPTION
Minor fixes in -fsycl-instrument-device-code option tests:

1. Remove Doxygen style comments from the tests
2. Remove run command duplicate from clang/test/Driver/sycl-instrumentation.c
3. Update SYCL include header to SYCL 2020 in barrer.cpp test.
