### PR TITLE
Fix of 66c18fee337f, which guard opaque ptr changes

### DIFF
--- a/clang/lib/CodeGen/CGVTT.cpp
+++ b/clang/lib/CodeGen/CGVTT.cpp
@@ -83,7 +83,7 @@ CodeGenVTables::EmitVTTDefinition(llvm::GlobalVariable *VTT,
 
 #ifndef INTEL_SYCL_OPAQUEPOINTER_READY
      Init = llvm::ConstantExpr::getPointerBitCastOrAddrSpaceCast(
-         Init, CGM.GlobalsInt8PtrTy);
+         Init, CGM.Int8PtrTy);
 #endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
      VTTComponents.push_back(Init);


### PR DESCRIPTION
This is a fix of 66c18fee337fdf04f04f48e0fefb68157915b8a8