### PR TITLE
SYCL: Implement sub_group_mask copy assignment operator

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -255,7 +255,11 @@ struct sub_group_mask {
   sub_group_mask(const sub_group_mask &rhs)
       : Bits(rhs.Bits), bits_num(rhs.bits_num) {}
 
-  sub_group_mask &operator=(const sub_group_mask &rhs) = delete;
+  sub_group_mask &operator=(const sub_group_mask &rhs) {
+    Bits = rhs.Bits;
+    bits_num = rhs.bits_num;
+    return *this;
+  }
 
   template <typename Group>
   friend std::enable_if_t<std::is_same_v<std::decay_t<Group>, sub_group>,


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/pull/10564#discussion_r1274422783. It's not clear why the copy assignment operator was deleted instead of providing a proper implementation and this causes issues downstream, e.g., in https://github.com/desul/desul/blob/d2a78e176e0a30f5893c596012d1115df5289be7/atomics/include/desul/atomics/Compare_Exchange_SYCL.hpp#L106.
This pull request rather implements the copy assignment operator for `sub_group_mask` than deleting it. It looks like the copy constructor and the copy assignment operator could be defaulted instead but maybe (implicitly) deleting the move constructor and move copy assignment operator is intentional.