### PR TITLE
[SYCL] Change sub_group_mask copy-assignment operator to default

### DIFF
--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -255,7 +255,7 @@ struct sub_group_mask {
   sub_group_mask(const sub_group_mask &rhs)
       : Bits(rhs.Bits), bits_num(rhs.bits_num) {}
 
-  sub_group_mask &operator=(const sub_group_mask &rhs) = delete;
+  sub_group_mask &operator=(const sub_group_mask &rhs) = default;
 
   template <typename Group>
   friend std::enable_if_t<std::is_same_v<std::decay_t<Group>, sub_group>,

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -252,8 +252,7 @@ struct sub_group_mask {
     return Tmp;
   }
 
-  sub_group_mask(const sub_group_mask &rhs)
-      : Bits(rhs.Bits), bits_num(rhs.bits_num) {}
+  sub_group_mask(const sub_group_mask &rhs) = default;
 
   sub_group_mask &operator=(const sub_group_mask &rhs) = default;
 


### PR DESCRIPTION
As part of version two of [sycl_ext_oneapi_sub_group_mask](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group_mask.asciidoc) the copy-asssignment operator is defined as default but were deleted as part of https://github.com/intel/llvm/pull/10564. This changes them to `default` ahead of version 2 of the extension to avoid regressions.