### PR TITLE
[SYCL][Doc] Fix dead links in extension docs

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_matrix/sycl_ext_oneapi_matrix.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_matrix/sycl_ext_oneapi_matrix.asciidoc
@@ -549,7 +549,7 @@ joint_matrix<sub_group, int, use::accumulator, msize, nsize> sub_c;
 ## Future-looking API
 
 ### Memory scope
-The current experimental API uses `joint_` semantics to define the memory scope of the matrix. The long term solution is to use the proposed link:../supported/sycl_ext_oneapi_local_memory.asciidoc[`group_local_memory` extension] to allocate the matrix in local memory associated with a SYCL group as shown in the example below.
+The current experimental API uses `joint_` semantics to define the memory scope of the matrix. The long term solution is to use the proposed link:../../supported/sycl_ext_oneapi_local_memory.asciidoc[`group_local_memory` extension] to allocate the matrix in local memory associated with a SYCL group as shown in the example below.
 
 
 ```c++

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_graph.asciidoc
@@ -1348,7 +1348,7 @@ Recorded commands are not counted as submitted for the purposes of its operation
 ==== sycl_ext_oneapi_device_global
 
 The new handler methods, and queue shortcuts, defined by
-link:../proposed/sycl_ext_oneapi_device_global.asciidoc[sycl_ext_oneapi_device_global].
+link:../experimental/sycl_ext_oneapi_device_global.asciidoc[sycl_ext_oneapi_device_global].
 cannot be used in graph nodes. A synchronous exception will be thrown with error
 code `invalid` if a user tries to add them to a graph.
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_named_sub_group_sizes.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_named_sub_group_sizes.asciidoc
@@ -45,7 +45,7 @@ This extension also depends on the following other SYCL extensions:
 * link:../experimental/sycl_ext_oneapi_properties.asciidoc[
   sycl_ext_oneapi_properties]
 
-* link:../proposed/sycl_ext_oneapi_kernel_properties.asciidoc[
+* link:../experimental/sycl_ext_oneapi_kernel_properties.asciidoc[
   sycl_ext_oneapi_kernel_properties]
 
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_root_group.asciidoc
@@ -501,8 +501,7 @@ synchronization are restricted to launching at most one work-group).
 Detecting that a developer has attempted to synchronize a `root_group` from
 an incompatible kernel launch could use a similar mechanism to that outlined in
 the
-https://github.com/intel/llvm/blob/sycl/sycl/doc/design/OptionalDeviceFeatures.md
-link:../../doc/design/OptionalDeviceFeatures.md[optional device features]
+link:../../../doc/design/OptionalDeviceFeatures.md[optional device features]
 design document. Specifically, the overload of `sycl::group_barrier` accepting
 a `root_group` could be marked with an attribute denoting that the function
 requires root-group synchronization, and the compiler could propagate that

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_usm_malloc_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_usm_malloc_properties.asciidoc
@@ -39,7 +39,7 @@ SYCL specification refer to that revision.
 This extension also depends on the following other SYCL extensions:
 
 - link:../experimental/sycl_ext_oneapi_properties.asciidoc[sycl_ext_oneapi_properties]
-- link:../proposed/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr]
+- link:../experimental/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr]
 
 == Status
 
@@ -146,7 +146,7 @@ auto APtr8 = malloc_annotated<int>(N, q, sycl::usm::alloc::host, P5);
 auto APtr9 = malloc_host_annotated<int>(N, q, P5);
 ----
 
-The following example uses the compile-time-constant property `alignment`, defined in the link:../proposed/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr] extension.
+The following example uses the compile-time-constant property `alignment`, defined in the link:../experimental/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr] extension.
 When the `alignment` property is passed to a USM memory allocation function with `properties` support, it will appear on the returned `annotated_ptr` since it is a compile-time constant property.
 It also informs the runtime to allocate the memory with this alignment.
  
@@ -1243,7 +1243,7 @@ sycl::ext::oneapi::experimental::alignment
 If this property is passed to a USM memory allocation function with `properties` support, it instructs the runtime to allocate memory with this alignment in bytes.
 The set of allowed alignments is implementation defined. Specifying an alignment that is not supported causes the allocation function to return an `annotated_ptr` containing a null raw pointer.
 |
-link:../proposed/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr]
+link:../experimental/sycl_ext_oneapi_annotated_ptr.asciidoc[sycl_ext_oneapi_annotated_ptr]
 |====
 
 Table <<table.usm.malloc.devhostsh>> lists the new properties introduced by this extension.

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_extended_atomics.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_extended_atomics.asciidoc
@@ -1,2 +1,0 @@
-This extension has been deprecated, but the specification is still available
-link:../deprecated/sycl_ext_oneapi_extended_atomics.asciidoc[here].

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_group_algorithms.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_group_algorithms.asciidoc
@@ -1,2 +1,0 @@
-This extension has been deprecated, but the specification is still available
-link:../deprecated/sycl_ext_oneapi_group_algorithms.asciidoc[here].


### PR DESCRIPTION
Also removed `supported/sycl_ext_oneapi_extended_atomics.asciidoc` and `supported/sycl_ext_oneapi_group_algorithms.asciidoc` because those extensions are fully removed instead of just deprecated.