### PR TITLE
[SYCL-MLIR][raise-scf-to-affine] Use ceil division to calculate ub

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/RaiseToAffine.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/RaiseToAffine.cpp
@@ -113,7 +113,7 @@ struct ForOpRaising : public OpRewritePattern<scf::ForOp> {
                    << "Failed: more than one lower/upper bounds\n");
         return failure();
       }
-      ubs[0] = rewriter.create<DivUIOp>(
+      ubs[0] = rewriter.create<CeilDivUIOp>(
           loop.getLoc(),
           rewriter.create<SubIOp>(loop.getLoc(), loop.getUpperBound(),
                                   loop.getLowerBound()),

--- a/polygeist/test/polygeist-opt/affraise.mlir
+++ b/polygeist/test/polygeist-opt/affraise.mlir
@@ -25,6 +25,13 @@ module {
     }
     return 
   }
+  func.func @complete(%lb: index, %ub: index, %step: index) {
+    scf.for %i = %lb to %ub step %step {
+      "foo"(%i) : (index) -> ()
+      scf.yield
+    }
+    return
+  }
 }
 
 // CHECK:   func.func @withinif(%arg0: memref<?xf64>, %arg1: i32, %arg2: memref<?xf64>, %arg3: i1) {
@@ -47,3 +54,15 @@ module {
 // CHECK-NEXT:     }
 // CHECK-NEXT:     return
 // CHECK-NEXT:   }
+
+// CHECK-LABEL:   func.func @complete(
+// CHECK-SAME:                        %[[VAL_0:.*]]: index, %[[VAL_1:.*]]: index, %[[VAL_2:.*]]: index) {
+// CHECK-NEXT:      %[[VAL_3:.*]] = arith.subi %[[VAL_1]], %[[VAL_0]] : index
+// CHECK-NEXT:      %[[VAL_4:.*]] = arith.ceildivui %[[VAL_3]], %[[VAL_2]] : index
+// CHECK-NEXT:      affine.for %[[VAL_5:.*]] = 0 to %[[VAL_4]] {
+// CHECK-NEXT:        %[[VAL_6:.*]] = arith.muli %[[VAL_5]], %[[VAL_2]] : index
+// CHECK-NEXT:        %[[VAL_7:.*]] = arith.addi %[[VAL_0]], %[[VAL_6]] : index
+// CHECK-NEXT:        "foo"(%[[VAL_7]]) : (index) -> ()
+// CHECK-NEXT:      }
+// CHECK-NEXT:      return
+// CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/CMakeLists.txt
+++ b/polygeist/tools/cgeist/CMakeLists.txt
@@ -65,6 +65,7 @@ target_link_libraries(cgeist PRIVATE
   MLIRSCFToControlFlow
   MLIRFuncToLLVM
   MLIRAffineTransforms
+  MLIRArithTransforms
   MLIRAffineToStandard
   MLIRMathToLLVM
   MLIRTargetLLVMIRImport

--- a/polygeist/tools/cgeist/Test/Verification/affineraise.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/affineraise.cpp
@@ -1,0 +1,26 @@
+// RUN: cgeist --use-opaque-pointers %s -O3 --function=* -S | FileCheck %s
+// COM: Simply check we can lower
+// RUN: cgeist --use-opaque-pointers %s -O3 --function=* -S -emit-llvm
+
+void foo(int);
+
+// CHECK-LABEL:   func.func @_Z4loopiii(
+// CHECK-SAME:                          %[[VAL_0:.*]]: i32, %[[VAL_1:.*]]: i32, %[[VAL_2:.*]]: i32)
+// CHECK:           %[[VAL_3:.*]] = arith.index_cast %[[VAL_1]] : i32 to index
+// CHECK:           %[[VAL_4:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK:           %[[VAL_5:.*]] = arith.index_cast %[[VAL_2]] : i32 to index
+// CHECK:           %[[VAL_6:.*]] = arith.subi %[[VAL_3]], %[[VAL_4]] : index
+// CHECK:           %[[VAL_7:.*]] = arith.ceildivui %[[VAL_6]], %[[VAL_5]] : index
+// CHECK:           affine.for %[[VAL_8:.*]] = 0 to %[[VAL_7]] {
+// CHECK:             %[[VAL_9:.*]] = arith.muli %[[VAL_8]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_10:.*]] = arith.divui %[[VAL_9]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_11:.*]] = arith.muli %[[VAL_10]], %[[VAL_5]] : index
+// CHECK:             %[[VAL_12:.*]] = arith.addi %[[VAL_4]], %[[VAL_11]] : index
+// CHECK:             %[[VAL_13:.*]] = arith.index_cast %[[VAL_12]] : index to i32
+// CHECK:             func.call @_Z3fooi(%[[VAL_13]]) : (i32) -> ()
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
+void loop(int lb, int ub, int step) {
+  for (int x = lb; x < ub; x += step) foo(x);
+}

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -29,6 +29,7 @@
 #include "mlir/Conversion/SCFToControlFlow/SCFToControlFlow.h"
 #include "mlir/Conversion/SCFToOpenMP/SCFToOpenMP.h"
 #include "mlir/Dialect/Affine/Passes.h"
+#include "mlir/Dialect/Arith/Transforms/Passes.h"
 #include "mlir/Dialect/Async/IR/Async.h"
 #include "mlir/Dialect/DLTI/DLTI.h"
 #include "mlir/Dialect/Func/Extensions/InlinerExtension.h"
@@ -817,6 +818,7 @@ static LogicalResult finalize(mlir::MLIRContext &Ctx,
         ConvertOptions.syclImplementation = SYCLImplementation;
         ConvertOptions.syclTarget = ExitOnErr(getSYCLTargetFromTriple(Triple));
       }
+      PM3.addPass(arith::createArithExpandOpsPass());
       PM3.addPass(createConvertPolygeistToLLVM(ConvertOptions));
       PM3.addPass(createReconcileUnrealizedCastsPass());
       // PM3.addPass(mlir::createLowerFuncToLLVMPass(options));

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -818,6 +818,8 @@ static LogicalResult finalize(mlir::MLIRContext &Ctx,
         ConvertOptions.syclImplementation = SYCLImplementation;
         ConvertOptions.syclTarget = ExitOnErr(getSYCLTargetFromTriple(Triple));
       }
+      // Needed to expand `arith.ceildivui` operations introduced by
+      // `-raise-scf-to-affine`
       PM3.addPass(arith::createArithExpandOpsPass());
       PM3.addPass(createConvertPolygeistToLLVM(ConvertOptions));
       PM3.addPass(createReconcileUnrealizedCastsPass());


### PR DESCRIPTION
Use `arith.ceildivui` to calculate new upper bounds for a raised loop, as using regular division leads to one less iteration of the loop when the division is not exact.

This way, the loop:

```mlir
scf.for %i = %lb to %ub step %step {
  "foo"(%i) : (index) -> ()
  scf.yield
}
```

will be transformed into:

```mlir
%0 = arith.subi %ub, %lb : index
%1 = arith.ceildivui %0, %step : index
affine.for %i = 0 to %1 {
  %2 = arith.muli %i, %step : index
  %3 = arith.addi %lb, %2 : index
  "foo"(%3) : (index) -> ()
}
```