### PR TITLE
[SYCL][Devicelib] Add missing round in devicelib

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -29,6 +29,9 @@ DEVICE_EXTERN_C_INLINE
 lldiv_t lldiv(long long x, long long y) { return __devicelib_lldiv(x, y); }
 
 DEVICE_EXTERN_C_INLINE
+float roundf(float x) { return __devicelib_roundf(x); }
+
+DEVICE_EXTERN_C_INLINE
 float scalbnf(float x, int n) { return __devicelib_scalbnf(x, n); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -19,6 +19,9 @@ DEVICE_EXTERN_C_INLINE
 double log(double x) { return __devicelib_log(x); }
 
 DEVICE_EXTERN_C_INLINE
+double round(double x) { return __devicelib_round(x); }
+
+DEVICE_EXTERN_C_INLINE
 double exp(double x) { return __devicelib_exp(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/device_math.h
+++ b/libdevice/device_math.h
@@ -50,6 +50,12 @@ DEVICE_EXTERN_C
 lldiv_t __devicelib_lldiv(long long int x, long long int y);
 
 DEVICE_EXTERN_C
+double __devicelib_round(double x);
+
+DEVICE_EXTERN_C
+float __devicelib_roundf(float x);
+
+DEVICE_EXTERN_C
 double __devicelib_log(double x);
 
 DEVICE_EXTERN_C

--- a/libdevice/fallback-cmath-fp64.cpp
+++ b/libdevice/fallback-cmath-fp64.cpp
@@ -39,6 +39,9 @@ double __devicelib_modf(double x, double *intpart) {
 }
 
 DEVICE_EXTERN_C_INLINE
+double __devicelib_round(double x) { return __spirv_ocl_round(x); }
+
+DEVICE_EXTERN_C_INLINE
 double __devicelib_exp2(double x) { return __spirv_ocl_exp2(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -38,6 +38,9 @@ DEVICE_EXTERN_C_INLINE
 float __devicelib_scalbnf(float x, int n) { return __spirv_ocl_ldexp(x, n); }
 
 DEVICE_EXTERN_C_INLINE
+float __devicelib_roundf(float x) { return __spirv_ocl_round(x); }
+
+DEVICE_EXTERN_C_INLINE
 float __devicelib_logf(float x) { return __spirv_ocl_log(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -19,12 +19,12 @@ namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;
 constexpr s::access::mode sycl_write = s::access::mode::write;
 
-#define TEST_NUM 61
+#define TEST_NUM 62
 
 double ref[TEST_NUM] = {
-    1, 0, 0, 0, 0, 0, 0, 1, 1, 0.5, 0, 2, 0, 0,   1,   0,   2,   0, 0, 0, 0,
-    0, 1, 0, 1, 2, 0, 1, 2, 5, 0,   0, 0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   0, 0, 0, 0,   0,   0,   0,   0, 0};
+    1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0.5, 0, 2, 0, 0,   1,   0,   2,   0, 0, 0,
+    0, 0, 1, 0, 1, 2, 0, 1, 2, 5, 0,   0, 0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   0, 0, 0, 0,   0,   0,   0,   0, 0};
 
 double refIptr = 1;
 
@@ -61,6 +61,7 @@ template <class T> void device_cmath_test(s::queue &deviceQueue) {
         *((uint64_t *)&subnormal) = 0xFFFFFFFFFFFFFULL;
         res_access[i++] = std::cos(0.0);
         res_access[i++] = std::sin(0.0);
+        res_access[i++] = std::round(1.0);
         res_access[i++] = std::log(1.0);
         res_access[i++] = std::acos(1.0);
         res_access[i++] = std::asin(0.0);

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -21,12 +21,12 @@ namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;
 constexpr s::access::mode sycl_write = s::access::mode::write;
 
-#define TEST_NUM 59
+#define TEST_NUM 60
 
-float ref[TEST_NUM] = {1, 0, 0,   0,   0,   0,   0, 1, 1, 0.5, 0, 0, 1, 0, 2,
-                       0, 0, 0,   0,   0,   1,   0, 1, 2, 0,   1, 2, 5, 0, 0,
-                       0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0, 0,   0, 0, 0, 0, 0,
-                       0, 0, 0,   0,   0,   0,   0, 0, 0, 0,   0, 0, 0, 0};
+float ref[TEST_NUM] = {1, 0, 1, 0,   0,   0,   0,   0, 1, 1, 0.5, 0, 0, 1, 0,
+                       2, 0, 0, 0,   0,   0,   1,   0, 1, 2, 0,   1, 2, 5, 0,
+                       0, 0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0, 0,   0, 0, 0, 0,
+                       0, 0, 0, 0,   0,   0,   0,   0, 0, 0, 0,   0, 0, 0, 0};
 
 float refIptr = 1;
 
@@ -58,6 +58,7 @@ template <class T> void device_cmath_test_1(s::queue &deviceQueue) {
 
         res_access[i++] = std::cos(0.0f);
         res_access[i++] = std::sin(0.0f);
+        res_access[i++] = std::round(1.0f);
         res_access[i++] = std::log(1.0f);
         res_access[i++] = std::acos(1.0f);
         res_access[i++] = std::asin(0.0f);


### PR DESCRIPTION
Since https://github.com/intel/llvm/pull/9768 `ffast-math` no longer chooses llvm intrinsics. This highlighted that `std::round` was missing in libdevice. This fixes that.