### PR TITLE
[CI] Ignore E2E on AWS CUDA job when targeting sycl-mlir branch

### DIFF
--- a/.github/workflows/sycl_precommit_aws.yml
+++ b/.github/workflows/sycl_precommit_aws.yml
@@ -13,12 +13,25 @@ on:
     workflows: [SYCL Pre Commit on Linux]
     types:
       - completed
-    branches-ignore:
-      - sycl-mlir
 
 jobs:
+  setup:
+    runs-on: [Lunx, build]
+    outputs:
+      condition: ${{ steps.condition.outputs.condition }}
+    steps:
+      - id: condition
+        run: |
+          if [[ ${{ github.head_ref }} == "sycl-mlir" ]]; then
+            echo "condition=false" >> $GITHUB_OUTPUT
+          else
+            echo "condition=true" >> $GITHUB_OUTPUT
+          fi
+
   create-check:
+    needs: [setup]
     runs-on: [Linux, build]
+    if: ${{ needs.setup.outputs.condition }} == 'true'
     steps:
       - uses: actions/github-script@v6
         with:
@@ -39,8 +52,10 @@ jobs:
             })
 
   aws-start:
+    needs: [setup]
     runs-on: ubuntu-20.04
     environment: aws
+    if: ${{ needs.setup.outputs.condition }} == 'true'
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/sycl_precommit_aws.yml
+++ b/.github/workflows/sycl_precommit_aws.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - id: condition
         run: |
-          if [[ ${{ github.head_ref }} == "sycl-mlir" ]]; then
+          if [[ ${{ github.base_ref }} == "sycl-mlir" ]]; then
             echo "condition=false" >> $GITHUB_OUTPUT
           else
             echo "condition=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/sycl_precommit_aws.yml
+++ b/.github/workflows/sycl_precommit_aws.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   setup:
-    runs-on: [Lunx, build]
+    runs-on: [Linux, build]
     outputs:
       condition: ${{ steps.condition.outputs.condition }}
     steps:


### PR DESCRIPTION
4e737e2 ignores this job when the branch name is `sycl-mlir` when the intention was to ignore it for pull requests targeting `sycl-mlir`.

This commit implements the intended behavior using a new job which simply checks the target branch is not `sycl-mlir`.