### PR TITLE
[SYCL] Change alignment to common property

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -613,44 +613,6 @@ increment and decrement operator of annotated_ref. The annotations are applied
 when the object `T` is loaded and stored to the memory.
 |===
 
-=== Properties
-
-Below is a list of compile-time constant properties supported with
-`annotated_ptr`. Other extensions can define additional compile-time constant
-properties that can be supported with `annotated_ptr`. Runtime properties
-are not supported.
-
-```c++
-namespace sycl::ext::oneapi::experimental {
-struct alignment_key {
-  template<int K>
-  using value_t = property_value<alignment_key, std::integral_constant<int, K>>;
-};
-
-template<int K>
-inline constexpr alignment_key::value_t<K> alignment;
-
-template<>
-struct is_property_key<alignment_key> : std::true_type {};
-
-template<typename T, typename PropertyListT>
-struct is_property_key_of<
-  alignment_key, annotated_ptr<T, PropertyListT>> : std::true_type {};
-template<typename T, typename PropertyListT>
-} // namespace sycl::ext::oneapi::experimental
-```
---
-[options="header"]
-|====
-| Property | Description
-|`alignment`
-|
-This property is an assertion by the application that the `annotated_ptr` has
-the given alignment, specified in bytes. The behavior is undefined if the
-pointer value does not have the indicated alignment.
-|====
---
-
 == Issues related to `annotated_ptr`
 
 1) [RESOLVED] Should we allow implicit conversion to base class by default?

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
@@ -116,8 +116,6 @@ struct is_property_key_of<
   restrict_key, annotated_arg<T, PropertyListT>> : std::true_type {};
 } // namespace sycl::ext::oneapi::experimental
 ```
---
-
 === `alignment` property
 
 The `alignment` property defined here is only meaningful on the kernel arguments
@@ -139,7 +137,11 @@ template<> struct is_property_key<
 
 template<typename T, typename PropertyListT>
 struct is_property_key_of<
-  restrict_key, annotated_ptr<T, PropertyListT>> : std::true_type {};
+  alignment_key, annotated_ptr<T, PropertyListT>> : std::true_type {};
+
+template<typename T, typename PropertyListT>
+struct is_property_key_of<
+  alignment_key, annotated_arg<T, PropertyListT>> : std::true_type {};
 
 template<typename T, typename PropertyListT>
 struct is_property_key_of<

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
@@ -118,6 +118,37 @@ struct is_property_key_of<
 ```
 --
 
+=== `alignment` property
+
+The `alignment` property defined here is only meaningful on the kernel arguments
+when the kernel argument is a pointer type. It is ignored for other types.
+
+
+```c++
+namespace sycl::ext::oneapi::experimental {
+struct alignment_key {
+  template <int K>
+  using value_t = property_value<alignment_key, std::integral_constant<int, K>>;
+};
+
+template<int K>
+inline constexpr alignment_key::value_t<K> alignment;
+
+template<> struct is_property_key<
+  sycl::ext::intel::experimental::alignment_key> : std::true_type {};
+
+template<typename T, typename PropertyListT>
+struct is_property_key_of<
+  restrict_key, annotated_ptr<T, PropertyListT>> : std::true_type {};
+
+template<typename T, typename PropertyListT>
+struct is_property_key_of<
+  sycl::ext::intel::experimental::alignment_key,
+  annotated_arg<T, PropertyListT>> : std::true_type {};
+} // namespace sycl::ext::oneapi::experimental
+```
+--
+
 [frame="topbot",options="header"]
 |===
 |Property |Description
@@ -133,8 +164,19 @@ with this property do not alias with one another with the same semantics as the
 C99 `restrict` keyword. The behavior is undefined if these pointer values do
 alias.
 
+a|
+[source,c++]
+----
+alignment
+----
+a|
+This property is an assertion by the application that the associated pointer has
+the given alignment, specified in bytes. The behavior is undefined if the
+pointer value does not have the indicated alignment.
+
 |===
 --
+
 
 === Usage Examples
 
@@ -153,7 +195,7 @@ using sycl::ext::oneapi::experimental;
   int* ptr_b = ...;
 
   // Add properties
-  auto arg_a = annotated_ptr(ptr_a, properties{restrict});
+  auto arg_a = annotated_ptr(ptr_a, properties{restrict, alignment<32>});
   auto arg_n = annotated_arg(ptr_b, properties{restrict});
   ...
 
@@ -177,6 +219,7 @@ None
 [options="header"]
 |========================================
 |Rev|Date       |Author           |Changes
+|2  |2023-08-28 |Brox Chen        |*add alignment property*
 |1  |2022-07-1  |Abhishek Tiwari  |*Initial draft*
 |========================================
 

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -28,41 +28,6 @@ namespace ext {
 namespace oneapi {
 namespace experimental {
 
-//===----------------------------------------------------------------------===//
-//        Specific properties of annotated_ptr
-//===----------------------------------------------------------------------===//
-struct alignment_key {
-  template <int K>
-  using value_t = property_value<alignment_key, std::integral_constant<int, K>>;
-};
-
-template <int K> inline constexpr alignment_key::value_t<K> alignment;
-
-template <> struct is_property_key<alignment_key> : std::true_type {};
-
-template <typename T, int W>
-struct is_valid_property<T, alignment_key::value_t<W>>
-    : std::bool_constant<std::is_pointer<T>::value> {};
-
-template <typename T, typename PropertyListT>
-struct is_property_key_of<alignment_key, annotated_ptr<T, PropertyListT>>
-    : std::true_type {};
-
-namespace detail {
-
-template <> struct PropertyToKind<alignment_key> {
-  static constexpr PropKind Kind = PropKind::Alignment;
-};
-
-template <> struct IsCompileTimeProperty<alignment_key> : std::true_type {};
-
-template <int N> struct PropertyMetaInfo<alignment_key::value_t<N>> {
-  static constexpr const char *name = "sycl-alignment";
-  static constexpr int value = N;
-};
-
-} // namespace detail
-
 namespace {
 #define PROPAGATE_OP(op)                                                       \
   T operator op##=(const T &rhs) const { return *this = *this op rhs; }

--- a/sycl/include/sycl/ext/oneapi/experimental/common_annotated_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/common_annotated_properties/properties.hpp
@@ -93,7 +93,6 @@ template <int N> struct PropertyMetaInfo<alignment_key::value_t<N>> {
 
 } // namespace detail
 
-
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext

--- a/sycl/include/sycl/ext/oneapi/experimental/common_annotated_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/common_annotated_properties/properties.hpp
@@ -24,10 +24,6 @@ template <typename T, typename PropertyListT> class annotated_arg;
 template <typename T, typename PropertyListT> class annotated_ptr;
 
 //===----------------------------------------------------------------------===//
-//        Common properties of annotated_arg/annotated_ptr
-//===----------------------------------------------------------------------===//
-
-//===----------------------------------------------------------------------===//
 //   Utility type trait for annotated_arg/annotated_ptr deduction guide
 //===----------------------------------------------------------------------===//
 template <typename T, typename PropertyValueT>
@@ -57,6 +53,46 @@ struct check_property_list<T, Prop, Props...>
   static_assert(is_valid_property<T, Prop>::value,
                 "Property is invalid for the given type.");
 };
+
+//===----------------------------------------------------------------------===//
+//        Common properties of annotated_arg/annotated_ptr
+//===----------------------------------------------------------------------===//
+struct alignment_key {
+  template <int K>
+  using value_t = property_value<alignment_key, std::integral_constant<int, K>>;
+};
+
+template <int K> inline constexpr alignment_key::value_t<K> alignment;
+
+template <> struct is_property_key<alignment_key> : std::true_type {};
+
+template <typename T, int W>
+struct is_valid_property<T, alignment_key::value_t<W>>
+    : std::bool_constant<std::is_pointer<T>::value> {};
+
+template <typename T, typename PropertyListT>
+struct is_property_key_of<alignment_key, annotated_ptr<T, PropertyListT>>
+    : std::true_type {};
+
+template <typename T, typename PropertyListT>
+struct is_property_key_of<alignment_key, annotated_arg<T, PropertyListT>>
+    : std::true_type {};
+
+namespace detail {
+
+template <> struct PropertyToKind<alignment_key> {
+  static constexpr PropKind Kind = PropKind::Alignment;
+};
+
+template <> struct IsCompileTimeProperty<alignment_key> : std::true_type {};
+
+template <int N> struct PropertyMetaInfo<alignment_key::value_t<N>> {
+  static constexpr const char *name = "sycl-alignment";
+  static constexpr int value = N;
+};
+
+} // namespace detail
+
 
 } // namespace experimental
 } // namespace oneapi


### PR DESCRIPTION
Move alignment from annotated_ptr specific property to a common property