### PR TITLE
[SYCL] Don't spoil MDeviceHostBaseTime during isGetDeviceAndHostTimerSupported

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -630,9 +630,10 @@ uint64_t device_impl::getCurrentDeviceTime() {
 
 bool device_impl::isGetDeviceAndHostTimerSupported() {
   const auto &Plugin = getPlugin();
+  uint64_t DeviceTime = 0, HostTime = 0;
   auto Result =
       Plugin->call_nocheck<detail::PiApiKind::piGetDeviceAndHostTimer>(
-          MDevice, &MDeviceHostBaseTime.first, &MDeviceHostBaseTime.second);
+          MDevice, &DeviceTime, &HostTime);
   return Result != PI_ERROR_INVALID_OPERATION;
 }
 

--- a/sycl/test-e2e/Basic/submit_time.cpp
+++ b/sycl/test-e2e/Basic/submit_time.cpp
@@ -1,0 +1,26 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main(void) {
+  sycl::queue queue(
+      sycl::property_list{sycl::property::queue::enable_profiling()});
+  sycl::event event = queue.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for<class set_value>(sycl::range<1>{1024},
+                                      [=](sycl::id<1> idx) {});
+  });
+  auto submit =
+      event.get_profiling_info<sycl::info::event_profiling::command_submit>();
+  auto start =
+      event.get_profiling_info<sycl::info::event_profiling::command_start>();
+  auto end =
+      event.get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  if (!(submit <= start) || !(start <= end))
+    return -1;
+
+  return 0;
+}

--- a/sycl/test-e2e/Basic/submit_time.cpp
+++ b/sycl/test-e2e/Basic/submit_time.cpp
@@ -1,6 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Check that device_impl::isGetDeviceAndHostTimerSupported() is not spoiling
+// device_impl::MDeviceHostBaseTime values used for submit timestamp
+// calculation.
+
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
@@ -12,6 +16,10 @@ int main(void) {
     cgh.parallel_for<class set_value>(sycl::range<1>{1024},
                                       [=](sycl::id<1> idx) {});
   });
+
+  // SYCL RT internally calls device_impl::isGetDeviceAndHostTimerSupported()
+  // to decide how to calculate "submit" timestamp - either using backend API
+  // call or using fallback implementation.
   auto submit =
       event.get_profiling_info<sycl::info::event_profiling::command_submit>();
   auto start =


### PR DESCRIPTION
`MDeviceHostBaseTime` data member of `device_impl` is supposed to be properly updated/calculated using `getCurrentDeviceTime()`. Currently it is also used to check `piGetDeviceAndHostTimer` support in
`isGetDeviceAndHostTimerSupported()` which results in wrong values stored in `MDeviceHostBaseTime` and wrong calculation of submit time. That's why use temp variables to check support of
`piGetDeviceAndHostTimer` to avoid spoiling `MDeviceHostBaseTime`.