### PR TITLE
[SYCL]Replaced LoadLibraryA() with LoadLibraryEx()

### DIFF
--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -151,26 +151,26 @@ void preloadLibraries() {
   MapT &dllMap = getDllMap();
 
   std::string ocl_path = LibSYCLDir + __SYCL_OPENCL_PLUGIN_NAME;
-  dllMap.emplace(ocl_path, LoadLibraryEx(ocl_path.c_str(), NULL, NULL));
+  dllMap.emplace(ocl_path, LoadLibraryExA(ocl_path.c_str(), NULL, NULL));
 
   std::string l0_path = LibSYCLDir + __SYCL_LEVEL_ZERO_PLUGIN_NAME;
-  dllMap.emplace(l0_path, LoadLibraryEx(l0_path.c_str(), NULL, NULL));
+  dllMap.emplace(l0_path, LoadLibraryExA(l0_path.c_str(), NULL, NULL));
 
   std::string cuda_path = LibSYCLDir + __SYCL_CUDA_PLUGIN_NAME;
-  dllMap.emplace(cuda_path, LoadLibraryEx(cuda_path.c_str(), NULL, NULL));
+  dllMap.emplace(cuda_path, LoadLibraryExA(cuda_path.c_str(), NULL, NULL));
 
   std::string esimd_path = LibSYCLDir + __SYCL_ESIMD_EMULATOR_PLUGIN_NAME;
-  dllMap.emplace(esimd_path, LoadLibraryEx(esimd_path.c_str(), NULL, NULL));
+  dllMap.emplace(esimd_path, LoadLibraryExA(esimd_path.c_str(), NULL, NULL));
 
   std::string hip_path = LibSYCLDir + __SYCL_HIP_PLUGIN_NAME;
-  dllMap.emplace(hip_path, LoadLibraryEx(hip_path.c_str(), NULL, NULL));
+  dllMap.emplace(hip_path, LoadLibraryExA(hip_path.c_str(), NULL, NULL));
 
   std::string ur_path = LibSYCLDir + __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME;
-  dllMap.emplace(ur_path, LoadLibraryEx(ur_path.c_str(), NULL, NULL));
+  dllMap.emplace(ur_path, LoadLibraryExA(ur_path.c_str(), NULL, NULL));
 
   std::string nativecpu_path = LibSYCLDir + __SYCL_NATIVE_CPU_PLUGIN_NAME;
   dllMap.emplace(nativecpu_path,
-                 LoadLibraryEx(nativecpu_path.c_str(), NULL, NULL));
+                 LoadLibraryExA(nativecpu_path.c_str(), NULL, NULL));
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -151,25 +151,26 @@ void preloadLibraries() {
   MapT &dllMap = getDllMap();
 
   std::string ocl_path = LibSYCLDir + __SYCL_OPENCL_PLUGIN_NAME;
-  dllMap.emplace(ocl_path, LoadLibraryA(ocl_path.c_str()));
+  dllMap.emplace(ocl_path, LoadLibraryEx(ocl_path.c_str(), NULL, NULL));
 
   std::string l0_path = LibSYCLDir + __SYCL_LEVEL_ZERO_PLUGIN_NAME;
-  dllMap.emplace(l0_path, LoadLibraryA(l0_path.c_str()));
+  dllMap.emplace(l0_path, LoadLibraryEx(l0_path.c_str(), NULL, NULL));
 
   std::string cuda_path = LibSYCLDir + __SYCL_CUDA_PLUGIN_NAME;
-  dllMap.emplace(cuda_path, LoadLibraryA(cuda_path.c_str()));
+  dllMap.emplace(cuda_path, LoadLibraryEx(cuda_path.c_str(), NULL, NULL));
 
   std::string esimd_path = LibSYCLDir + __SYCL_ESIMD_EMULATOR_PLUGIN_NAME;
-  dllMap.emplace(esimd_path, LoadLibraryA(esimd_path.c_str()));
+  dllMap.emplace(esimd_path, LoadLibraryEx(esimd_path.c_str(), NULL, NULL));
 
   std::string hip_path = LibSYCLDir + __SYCL_HIP_PLUGIN_NAME;
-  dllMap.emplace(hip_path, LoadLibraryA(hip_path.c_str()));
+  dllMap.emplace(hip_path, LoadLibraryEx(hip_path.c_str(), NULL, NULL));
 
   std::string ur_path = LibSYCLDir + __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME;
-  dllMap.emplace(ur_path, LoadLibraryA(ur_path.c_str()));
+  dllMap.emplace(ur_path, LoadLibraryEx(ur_path.c_str(), NULL, NULL));
 
   std::string nativecpu_path = LibSYCLDir + __SYCL_NATIVE_CPU_PLUGIN_NAME;
-  dllMap.emplace(nativecpu_path, LoadLibraryA(nativecpu_path.c_str()));
+  dllMap.emplace(nativecpu_path,
+                 LoadLibraryEx(nativecpu_path.c_str(), NULL, NULL));
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -32,7 +32,7 @@ void *loadOsLibrary(const std::string &LibraryPath) {
     assert(false && "Failed to update DLL search path");
   }
   // auto Result = (void *)LoadLibraryA(LibraryPath.c_str());
-  auto Result = (void *)LoadLibraryEx(LibraryPath.c_str(), NULL, NULL);
+  auto Result = (void *)LoadLibraryExA(LibraryPath.c_str(), NULL, NULL);
   (void)SetErrorMode(SavedMode);
   if (!SetDllDirectoryA(nullptr)) {
     assert(false && "Failed to restore DLL search path");

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -31,7 +31,7 @@ void *loadOsLibrary(const std::string &LibraryPath) {
   if (!SetDllDirectoryA("")) {
     assert(false && "Failed to update DLL search path");
   }
-  // auto Result = (void *)LoadLibraryA(LibraryPath.c_str());
+
   auto Result = (void *)LoadLibraryExA(LibraryPath.c_str(), NULL, NULL);
   (void)SetErrorMode(SavedMode);
   if (!SetDllDirectoryA(nullptr)) {

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -31,7 +31,8 @@ void *loadOsLibrary(const std::string &LibraryPath) {
   if (!SetDllDirectoryA("")) {
     assert(false && "Failed to update DLL search path");
   }
-  auto Result = (void *)LoadLibraryA(LibraryPath.c_str());
+  // auto Result = (void *)LoadLibraryA(LibraryPath.c_str());
+  auto Result = (void *)LoadLibraryEx(LibraryPath.c_str(), NULL, NULL);
   (void)SetErrorMode(SavedMode);
   if (!SetDllDirectoryA(nullptr)) {
     assert(false && "Failed to restore DLL search path");

--- a/xpti/include/xpti/xpti_trace_framework.hpp
+++ b/xpti/include/xpti/xpti_trace_framework.hpp
@@ -233,7 +233,7 @@ public:
     if (!SetDllDirectoryA("")) {
       assert(false && "Failed to update DLL search path");
     }
-    handle = LoadLibraryEx(path, NULL, NULL);
+    handle = LoadLibraryExA(path, NULL, NULL);
     if (!handle) {
       error = getLastError();
     }

--- a/xpti/include/xpti/xpti_trace_framework.hpp
+++ b/xpti/include/xpti/xpti_trace_framework.hpp
@@ -228,9 +228,18 @@ public:
   xpti_plugin_handle_t loadLibrary(const char *path, std::string &error) {
     xpti_plugin_handle_t handle = 0;
 #if defined(_WIN32) || defined(_WIN64)
-    handle = LoadLibraryA(path);
+    UINT SavedMode = SetErrorMode(SEM_FAILCRITICALERRORS);
+    // Exclude current directory from DLL search path
+    if (!SetDllDirectoryA("")) {
+      assert(false && "Failed to update DLL search path");
+    }
+    handle = LoadLibraryEx(path, NULL, NULL);
     if (!handle) {
       error = getLastError();
+    }
+    (void)SetErrorMode(SavedMode);
+    if (!SetDllDirectoryA(nullptr)) {
+      assert(false && "Failed to restore DLL search path");
     }
 #else
     handle = dlopen(path, RTLD_LAZY);


### PR DESCRIPTION
Replaced LoadLibraryA() with LoadLibraryEx() and added SetDllDirectoryA() to remove the working directory from the standard search path. LoadLibraryExA() was used because "path" is of type c-string.

- LoadLibraryExA() <-- for ANSI (ASCII)
- LoadLibraryExW() <-- for Unicode

The libloaderapi.h header defines LoadLibraryEx as an alias which automatically selects the ANSI or Unicode version of this function based on the definition of the UNICODE preprocessor constant.
https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexw

HMODULE LoadLibraryEx(
[in] LPCSTR lpLibFileName, //==> library path as a string
HANDLE hFile, //==> reserved as NULL for future use
[in] DWORD dwFlags //==> dwFlags determine the behavior of LoadLibaryEx(). When it is NULL, it behaves same as LoadLibaryA()
);
https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa