### PR TITLE
[SYCL] Verify Device Valid in Unified Runtime Teardown

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -918,10 +918,10 @@ inline pi_result piDeviceRetain(pi_device Device) {
 }
 
 inline pi_result piDeviceRelease(pi_device Device) {
-  PI_ASSERT(Device, PI_ERROR_INVALID_DEVICE);
-
-  auto UrDevice = reinterpret_cast<ur_device_handle_t>(Device);
-  HANDLE_ERRORS(urDeviceRelease(UrDevice));
+  if (Device) {
+    auto UrDevice = reinterpret_cast<ur_device_handle_t>(Device);
+    HANDLE_ERRORS(urDeviceRelease(UrDevice));
+  }
   return PI_SUCCESS;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/device.cpp
@@ -1049,9 +1049,12 @@ ur_result_t urDeviceRetain(ur_device_handle_t Device) {
 
 ur_result_t urDeviceRelease(ur_device_handle_t Device) {
   // Root devices are destroyed during the piTearDown process.
-  if (Device->isSubDevice()) {
-    if (Device->RefCount.decrementAndTest()) {
-      delete Device;
+  if (Device) {
+    if (Device->isSubDevice()) {
+      if (Device->RefCount.decrementAndTest()) {
+        delete Device;
+        Device = nullptr;
+      }
     }
   }
 


### PR DESCRIPTION
- Fix sporadic crashes in teardown by verifiying a valid device handle during device teardown.
- Set the device handle to nullptr during teardown after delete.