### PR TITLE
[SYCL] Fix crash on a stream with zero-sized buffer

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2936,7 +2936,8 @@ pi_int32 ExecCGCommand::enqueueImpQueue() {
         Requirement *Req = static_cast<Requirement *>(Arg.MPtr);
         AllocaCommandBase *AllocaCmd = getAllocaForReq(Req);
 
-        Req->MData = AllocaCmd->getMemAllocation();
+        if (AllocaCmd)
+          Req->MData = AllocaCmd->getMemAllocation();
         break;
       }
       default:

--- a/sycl/source/detail/stream_impl.cpp
+++ b/sycl/source/detail/stream_impl.cpp
@@ -112,7 +112,22 @@ void stream_impl::flush(const EventImplPtr &LeadEvent) {
             .get_access<access::mode::read_write, access::target::host_buffer>(
                 cgh);
     cgh.host_task([=] {
-      printf("%s", &(BufHostAcc[0]));
+      if (!BufHostAcc.empty()) {
+        // SYCL 2020, 4.16:
+        // > If the totalBufferSize or workItemBufferSize limits are exceeded,
+        // > it is implementation-defined whether the streamed characters
+        // > exceeding the limit are output, or silently ignored/discarded, and
+        // > if output it is implementation-defined whether those extra
+        // > characters exceeding the workItemBufferSize limit count toward the
+        // > totalBufferSize limit. Regardless of this implementation defined
+        // > behavior of output exceeding the limits, no undefined or erroneous
+        // > behavior is permitted of an implementation when the limits are
+        // > exceeded.
+        //
+        // Defend against zero-sized buffers (although they'd have no practical
+        // use).
+        printf("%s", &(BufHostAcc[0]));
+      }
       fflush(stdout);
     });
   });

--- a/sycl/test-e2e/Basic/accessor/empty_acc_host_task.cpp
+++ b/sycl/test-e2e/Basic/accessor/empty_acc_host_task.cpp
@@ -1,0 +1,17 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  sycl::buffer<int, 1> b(1);
+  q.submit([&](sycl::handler &cgh) {
+     sycl::accessor acc{b, cgh, sycl::range<1>{0}, sycl::id<1>{0}};
+     assert(acc.empty());
+     cgh.host_task([=]() {
+       if (!acc.empty())
+         acc[0] = 1;
+     });
+   }).wait_and_throw();
+  return 0;
+}

--- a/sycl/test-e2e/Basic/stream/zero_buffer_size.cpp
+++ b/sycl/test-e2e/Basic/stream/zero_buffer_size.cpp
@@ -1,0 +1,13 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  q.submit([&](sycl::handler &cgh) {
+     sycl::stream s{0, 0, cgh};
+     cgh.single_task([=]() { s << 42 << sycl::flush; });
+   }).wait_and_throw();
+  return 0;
+}


### PR DESCRIPTION
Follow-up fix for https://github.com/intel/llvm/pull/10797. Has to be merged after https://github.com/intel/llvm/pull/10911.