### PR TITLE
[SYCL][ESIMD] Disable build and testing for ESIMD Emulator

### DIFF
--- a/.github/workflows/linux_matrix_e2e_on_nightly.yml
+++ b/.github/workflows/linux_matrix_e2e_on_nightly.yml
@@ -43,12 +43,6 @@ jobs:
             image_options: -u 1001
             target_devices: opencl:cpu
 
-          - name: ESIMD Emu
-            runner: '["Linux", "x86-cpu"]'
-            image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:latest
-            image_options: -u 1001
-            target_devices: ext_intel_esimd_emulator:gpu
-
           - name: Self-hosted CUDA
             runner: '["Linux", "cuda"]'
             image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build

--- a/.github/workflows/sycl_linux_build.yml
+++ b/.github/workflows/sycl_linux_build.yml
@@ -28,7 +28,7 @@ on:
       build_configure_extra_args:
         type: string
         required: false
-        default: "--hip --cuda --enable-esimd-emulator"
+        default: "--hip --cuda"
       build_artifact_suffix:
         type: string
         required: true
@@ -82,7 +82,7 @@ on:
       build_configure_extra_args:
         type: choice
         options:
-          - "--hip --cuda --enable-esimd-emulator"
+          - "--hip --cuda"
       # Cache properties need to match CC/CXX/CMake opts. Any additional choices
       # would need extra care.
       build_cache_root:

--- a/.github/workflows/sycl_linux_build_and_test.yml
+++ b/.github/workflows/sycl_linux_build_and_test.yml
@@ -28,7 +28,7 @@ on:
       build_configure_extra_args:
         type: string
         required: false
-        default: "--hip --cuda --enable-esimd-emulator"
+        default: "--hip --cuda"
       build_artifact_suffix:
         type: string
         required: true
@@ -90,7 +90,7 @@ on:
       build_configure_extra_args:
         type: choice
         options:
-          - "--hip --cuda --enable-esimd-emulator"
+          - "--hip --cuda"
       # Cache properties need to match CC/CXX/CMake opts. Any additional choices
       # would need extra care.
       build_cache_root:

--- a/.github/workflows/sycl_linux_run_tests.yml
+++ b/.github/workflows/sycl_linux_run_tests.yml
@@ -96,7 +96,6 @@ on:
           - 'opencl:acc'
           - 'ext_oneapi_level_zero:gpu'
           - 'ext_oneapi_hip:gpu'
-          - 'ext_intel_esimd_emulator:gpu'
       tests_selector:
         type: choice
         options:

--- a/.github/workflows/sycl_nightly.yml
+++ b/.github/workflows/sycl_nightly.yml
@@ -13,7 +13,7 @@ jobs:
     with:
       build_cache_root: "/__w/"
       build_artifact_suffix: default
-      build_configure_extra_args: '--hip --cuda --enable-esimd-emulator'
+      build_configure_extra_args: '--hip --cuda'
       merge_ref: ''
       retention-days: 90
 
@@ -53,12 +53,6 @@ jobs:
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001
             target_devices: opencl:cpu
-
-          - name: ESIMD Emu
-            runner: '["Linux", "x86-cpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
-            image_options: -u 1001
-            target_devices: ext_intel_esimd_emulator:gpu
 
           - name: Self-hosted CUDA
             runner: '["Linux", "cuda"]'

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -27,7 +27,7 @@ jobs:
       build_cache_root: "/__w/llvm"
       build_cache_suffix: sprod_shared
       build_artifact_suffix: sprod_shared
-      build_configure_extra_args: --shared-libs --no-assertions --hip --cuda --enable-esimd-emulator --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
+      build_configure_extra_args: --shared-libs --no-assertions --hip --cuda --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
       # Docker image has last nightly pre-installed and added to the PATH
       build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
       cc: clang

--- a/.github/workflows/sycl_precommit_linux.yml
+++ b/.github/workflows/sycl_precommit_linux.yml
@@ -71,12 +71,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: ESIMD Emu
-            runner: '["Linux", "x86-cpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
-            image_options: -u 1001
-            target_devices: ext_intel_esimd_emulator:gpu
-            install_drivers: ${{ contains(needs.detect_changes.outputs.filters, 'drivers') }}
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2204_build:latest

--- a/devops/test_configs.json
+++ b/devops/test_configs.json
@@ -60,19 +60,6 @@
       "cmake_args": ""
     },
     {
-      "config": "esimd_emu",
-      "name": "ESIMD Emu LLVM Test Suite",
-      "runs-on": [
-        "Linux",
-        "x64",
-        "x86-cpu"
-      ],
-      "image": "${{ inputs.intel_drivers_image }}",
-      "container_options": "-u 1001",
-      "targets": "ext_intel_esimd_emulator:gpu",
-      "cmake_args": ""
-    },
-    {
       "config": "hip_amdgpu",
       "name": "HIP AMDGPU LLVM Test Suite",
       "runs-on": [


### PR DESCRIPTION
ESIMD Emulator has been deprecated and is in the process of being removed.