### PR TITLE
[SYCL][Graph] Fix switch statement for Clang build

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -64,9 +64,10 @@ UnsupportedFeatureToString(UnsupportedGraphFeatures Feature) {
     return "sycl_ext_oneapi_device_global";
   case UGF::sycl_ext_oneapi_bindless_images:
     return "sycl_ext_oneapi_bindless_images";
-  default:
-    return {};
   }
+
+  assert(false && "Unhandled graphs feature");
+  return {};
 }
 
 class node_impl;


### PR DESCRIPTION
After the merge of https://github.com/intel/llvm/pull/10789 post-commit CI is failing on clang builds:

* [MacOS build](https://github.com/intel/llvm/actions/runs/5935599091/job/16094354219)
* [Linux build](https://github.com/intel/llvm/actions/runs/5935599091/job/16094354500)

```
/Users/runner/work/llvm/llvm/build/include/sycl/ext/oneapi/experimental/graph.hpp:67:3: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
  default:
```

Fixed by removing the default label from the `switch`, and replacing with an assert `false` afterwards, which seems consistent with other places in the sycl runtime.

I haven't done a clang build yet to verify this fix.