### PR TITLE
Revert "[CI] Ignore E2E on AWS CUDA job in sycl-mlir branch (#10811)"

### DIFF
--- a/.github/workflows/sycl_precommit_aws.yml
+++ b/.github/workflows/sycl_precommit_aws.yml
@@ -13,8 +13,6 @@ on:
     workflows: [SYCL Pre Commit on Linux]
     types:
       - completed
-    branches-ignore:
-      - sycl-mlir
 
 jobs:
   create-check:


### PR DESCRIPTION
Revert commit 4e737e255eff3e095a4048fe04ff5c85daa9ab43 as dropping the job will be handled in the `sycl-mlir` branch instead (see #10956).