### PR TITLE
[SYCL] annotated_ptr API fixes part 2

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -288,7 +288,6 @@ class annotated_ptr {
 
     T* get() const noexcept;
 
-    annotated_ptr& operator=(T*) noexcept;
     annotated_ptr& operator=(const annotated_ptr&) noexcept = default;
 
     annotated_ptr& operator++() noexcept;
@@ -446,15 +445,6 @@ T* get() const noexcept;
 |
 Returns the underlying raw pointer. The raw pointer will not retain the
 annotations.
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-annotated_ptr& operator=(T*) noexcept;
-----
-|
-Allows assignment from a pointer to type `T`.
 
 // --- ROW BREAK ---
 a|

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -238,7 +238,7 @@ public:
 
   annotated_ptr() noexcept = default;
   annotated_ptr(const annotated_ptr &) = default;
-  annotated_ptr &operator=(annotated_ptr &) = default;
+  annotated_ptr &operator=(const annotated_ptr &) = default;
 
   annotated_ptr(T *Ptr, const property_list_t & = properties{}) noexcept
       : m_Ptr(global_pointer_t(Ptr)) {}
@@ -320,10 +320,6 @@ public:
   operator T *() const noexcept = delete;
 
   T *get() const noexcept { return m_Ptr; }
-
-  annotated_ptr &operator=(T *) noexcept {
-    return annotated_ptr<T, property_list_t>(m_Ptr);
-  }
 
   annotated_ptr &operator++() noexcept {
     m_Ptr += 1;

--- a/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
@@ -1,5 +1,4 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
-// expected-no-diagnostics
 
 #include "sycl/sycl.hpp"
 #include <sycl/ext/intel/fpga_extensions.hpp>
@@ -109,6 +108,11 @@ void TestVectorAddWithAnnotatedMMHosts() {
   // annotated_ptr<float> tmp21;
   // annotated_ptr<int, decltype(properties{dwidth<32>})> arg24(tmp21,
   // properties{dwidth<32>});   // ERR
+
+  // Deprecated
+  // Implicit conversion
+  // expected-warning@+1 {{'annotated_ptr<void>' is deprecated}}
+  a1 = raw;
 
   // Property merge
   auto arg31 = annotated_ptr_t3(raw, buffer_location<0>, awidth<32>);     // OK

--- a/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
@@ -1,4 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+// expected-no-diagnostics
 
 #include "sycl/sycl.hpp"
 #include <sycl/ext/intel/fpga_extensions.hpp>
@@ -109,9 +110,7 @@ void TestVectorAddWithAnnotatedMMHosts() {
   // annotated_ptr<int, decltype(properties{dwidth<32>})> arg24(tmp21,
   // properties{dwidth<32>});   // ERR
 
-  // Deprecated
   // Implicit conversion
-  // expected-warning@+1 {{'annotated_ptr<void>' is deprecated}}
   a1 = raw;
 
   // Property merge


### PR DESCRIPTION
Remove `operator=(const T*)`. This one isn't deprecated because it was broken (trying to return temp as reference) and therefore can't have users.

Also add missing `const` for copy constructor.