### PR TITLE
[SYCL][UR][L0] Use uint8_t instead of uint32_t for 2 cases of urContextGetInfo

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/context.cpp
@@ -106,10 +106,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urContextGetInfo(
     return ReturnValue(uint32_t{Context->RefCount.load()});
   case UR_CONTEXT_INFO_USM_MEMCPY2D_SUPPORT:
     // 2D USM memcpy is supported.
-    return ReturnValue(uint32_t{UseMemcpy2DOperations});
+    return ReturnValue(uint8_t{UseMemcpy2DOperations});
   case UR_CONTEXT_INFO_USM_FILL2D_SUPPORT:
     // 2D USM fill is not supported.
-    return ReturnValue(uint32_t{false});
+    return ReturnValue(uint8_t{false});
   case UR_CONTEXT_INFO_ATOMIC_MEMORY_ORDER_CAPABILITIES: {
 
     ur_memory_order_capability_flags_t Capabilities =


### PR DESCRIPTION
Modified the return value for UR_CONTEXT_INFO_USM_FILL2D_SUPPORT and UR_CONTEXT_INFO_USM_MEMCPY_2D_SUPPORT to return uint8_t instead of uint32_t to comply with unified-runtime conformance test.