### PR TITLE
[SYCL][COMPAT] Added kernel.hpp and tests

### DIFF
--- a/sycl/include/syclcompat/kernel.hpp
+++ b/sycl/include/syclcompat/kernel.hpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  kernel.hpp
+ *
+ *  Description:
+ *    kernel functionality for the SYCL compatibility extension.
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- kernel.hpp -------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/info/info_desc.hpp>
+#include <sycl/nd_range.hpp>
+#include <sycl/queue.hpp>
+
+namespace syclcompat {
+
+typedef void (*kernel_functor)(sycl::queue &, const sycl::nd_range<3> &,
+                               unsigned int, void **, void **);
+
+struct kernel_function_info {
+  int max_work_group_size = 0;
+};
+
+static void get_kernel_function_info(kernel_function_info *kernel_info,
+                                     const void *function) {
+  kernel_info->max_work_group_size =
+      detail::dev_mgr::instance()
+          .current_device()
+          .get_info<sycl::info::device::max_work_group_size>();
+}
+static kernel_function_info get_kernel_function_info(const void *function) {
+  kernel_function_info kernel_info;
+  kernel_info.max_work_group_size =
+      detail::dev_mgr::instance()
+          .current_device()
+          .get_info<sycl::info::device::max_work_group_size>();
+  return kernel_info;
+}
+
+} // namespace syclcompat

--- a/sycl/include/syclcompat/syclcompat.hpp
+++ b/sycl/include/syclcompat/syclcompat.hpp
@@ -25,3 +25,4 @@
 #include <syclcompat/defs.hpp>
 #include <syclcompat/device.hpp>
 #include <syclcompat/dims.hpp>
+#include <syclcompat/kernel.hpp>

--- a/sycl/test-e2e/syclcompat/kernel/Inputs/kernel_module_lin.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/Inputs/kernel_module_lin.cpp
@@ -1,0 +1,53 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  kernel_module_lin.cpp
+ *
+ *  Description:
+ *    function implementation used in kernel_function header API tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ kernel_module_lin.cpp------------------------ -*- C++ -* ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+#include <sycl/sycl.hpp>
+
+void foo(int *k, sycl::nd_item<3> item_ct1, uint8_t *local_mem) {
+  k[item_ct1.get_global_linear_id()] = item_ct1.get_global_linear_id();
+}
+
+extern "C" {
+void foo_wrapper(sycl::queue &queue, const sycl::nd_range<3> &nr,
+                 unsigned int localMemSize, void **kernelParams, void **extra) {
+  int *k;
+  k = (int *)kernelParams[0];
+  queue.submit([&](sycl::handler &cgh) {
+    sycl::local_accessor<uint8_t, 1> local_acc_ct1(sycl::range<1>(localMemSize),
+                                                   cgh);
+    cgh.parallel_for(nr, [=](sycl::nd_item<3> item_ct1) {
+      foo(k, item_ct1,
+          local_acc_ct1.get_multi_ptr<sycl::access::decorated::no>().get());
+    });
+  });
+}
+}

--- a/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
@@ -33,7 +33,7 @@
 // REQUIRES: linux
 
 // RUN: %clangxx -fPIC -shared -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/kernel_module_lin.cpp -o %t.so
-// RUN: %clangxx -D__TEST_SHARED_LIB='"%t.so"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.shared %s -o %t.out
+// RUN: %clangxx -D__TEST_SHARED_LIB='"%t.so"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.so %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <dlfcn.h>

--- a/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
@@ -32,8 +32,8 @@
 
 // REQUIRES: linux
 
-// RUN: %clangxx -fPIC -shared -fsycl %S/Inputs/kernel_module_lin.cpp -o %t.shared
-// RUN: %clangxx -D__TEST_SHARED_LIB='"%t.shared"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.shared %s -o %t.out
+// RUN: %clangxx -fPIC -shared -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/kernel_module_lin.cpp -o %t.so
+// RUN: %clangxx -D__TEST_SHARED_LIB='"%t.so"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.shared %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <dlfcn.h>

--- a/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
@@ -1,0 +1,122 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  kernel_function_lin.cpp
+ *
+ *  Description:
+ *    kernel_function header API tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ kernel_function_lin.cpp---------- -*- C++ -* ----------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===---------------------------------------------------------------------===//
+
+// REQUIRES: linux
+
+// RUN: %clangxx -fPIC -shared -fsycl %S/Inputs/kernel_module_lin.cpp -o %t.shared
+// RUN: %clangxx -D__TEST_SHARED_LIB='"%t.shared"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.shared %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <dlfcn.h>
+#include <iostream>
+#include <string>
+
+#include <sycl/sycl.hpp>
+
+#include <syclcompat/device.hpp>
+#include <syclcompat/kernel.hpp>
+
+template <class T> void testTemplateKernel(T *data) {}
+
+void testKernel(void *data) {}
+
+template <class T> int getTemplateFuncAttrs() {
+  syclcompat::kernel_function_info attrs;
+  syclcompat::get_kernel_function_info(&attrs,
+                                       (const void *)testTemplateKernel<T>);
+  int threadPerBlock = attrs.max_work_group_size;
+  return threadPerBlock;
+}
+
+int getFuncAttrs() {
+  syclcompat::kernel_function_info attrs;
+  syclcompat::get_kernel_function_info(&attrs, (const void *)testKernel);
+  int threadPerBlock = attrs.max_work_group_size;
+  return threadPerBlock;
+}
+
+void kernel_functor_ptr() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
+  sycl::queue *q_ct1 = dev_ct1.default_queue();
+
+  int Size = dev_ct1.get_info<sycl::info::device::max_work_group_size>();
+  assert(getTemplateFuncAttrs<int>() == Size);
+  assert(getFuncAttrs() == Size);
+
+  void *M;
+  syclcompat::kernel_functor F;
+
+  // TODO: change library path to a compile defined macro
+  M = dlopen(__TEST_SHARED_LIB, RTLD_LAZY);
+  if (M == NULL) {
+    std::cout << "Could not load the library" << std::endl;
+    std::cout << "  " << __TEST_SHARED_LIB << std::endl << std::flush;
+    assert(false); // FAIL
+  }
+
+  std::string FunctionName = "foo_wrapper";
+  F = (syclcompat::kernel_functor)dlsym(M, FunctionName.c_str());
+  if (F == NULL) {
+    std::cout << "Could not load function pointer" << std::endl << std::flush;
+    dlclose(M);
+    assert(false); // FAIL
+  }
+
+  int sharedSize = 10;
+  void **param = nullptr, **extra = nullptr;
+
+  int *dev = sycl::malloc_shared<int>(16, *q_ct1);
+  for (int i = 0; i < 16; i++) {
+    dev[i] = 0;
+  }
+  param = (void **)(&dev);
+  F(*q_ct1,
+    sycl::nd_range<3>(sycl::range<3>(1, 1, 2) * sycl::range<3>(1, 1, 8),
+                      sycl::range<3>(1, 1, 8)),
+    sharedSize, param, extra);
+  q_ct1->wait_and_throw();
+
+  for (int i = 0; i < 16; i++) {
+    assert(dev[i] == i);
+  }
+
+  sycl::free(dev, *q_ct1);
+  dlclose(M);
+}
+
+int main() {
+  kernel_functor_ptr();
+
+  return 0;
+}

--- a/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_function_lin.cpp
@@ -33,7 +33,7 @@
 // REQUIRES: linux
 
 // RUN: %clangxx -fPIC -shared -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/kernel_module_lin.cpp -o %t.so
-// RUN: %clangxx -D__TEST_SHARED_LIB='"%t.so"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.so %s -o %t.out
+// RUN: %clangxx -DTEST_SHARED_LIB='"%t.so"' -ldl -fsycl -fsycl-targets=%{sycl_triple} %t.so %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <dlfcn.h>
@@ -77,11 +77,10 @@ void kernel_functor_ptr() {
   void *M;
   syclcompat::kernel_functor F;
 
-  // TODO: change library path to a compile defined macro
-  M = dlopen(__TEST_SHARED_LIB, RTLD_LAZY);
+  M = dlopen(TEST_SHARED_LIB, RTLD_LAZY);
   if (M == NULL) {
     std::cout << "Could not load the library" << std::endl;
-    std::cout << "  " << __TEST_SHARED_LIB << std::endl << std::flush;
+    std::cout << "  " << TEST_SHARED_LIB << std::endl << std::flush;
     assert(false); // FAIL
   }
 


### PR DESCRIPTION
SYCLcompat primary goals and features are documented [here](https://intel.github.io/llvm-docs/syclcompat/README.html).

The PR includes the helper code to assist with kernel source-to-source translation. 
This PR only includes tests for linux environments . 