### PR TITLE
[mlir][spirv] Adapt downstream `client-api` option patch after upstreaming

### DIFF
--- a/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVMPass.cpp
+++ b/mlir/lib/Conversion/SPIRVToLLVM/SPIRVToLLVMPass.cpp
@@ -63,8 +63,9 @@ void ConvertSPIRVToLLVMPass::runOnOperation() {
 
   if (clientAPI != spirv::ClientAPI::OpenCL &&
       clientAPI != spirv::ClientAPI::Unknown)
-    getOperation()->emitWarning("address space mapping for client ")
-        << spirv::stringifyClientAPI(clientAPI) << " not implemented";
+    getOperation()->emitWarning()
+        << "address space mapping for client '"
+        << spirv::stringifyClientAPI(clientAPI) << "' not implemented";
 
   // Set `ModuleOp` as legal for `spirv.module` conversion.
   target.addLegalOp<ModuleOp>();

--- a/mlir/test/Conversion/SPIRVToLLVM/spirv-storage-class-mapping-unsupported.mlir
+++ b/mlir/test/Conversion/SPIRVToLLVM/spirv-storage-class-mapping-unsupported.mlir
@@ -2,4 +2,4 @@
 // RUN: mlir-opt -convert-spirv-to-llvm='client-api=Vulkan' -verify-diagnostics %s
 // RUN: mlir-opt -convert-spirv-to-llvm='client-api=WebGPU' -verify-diagnostics %s
 
-module {}  // expected-warning-re {{address space mapping for client {{.*}} not implemented}}
+module {}  // expected-warning-re {{address space mapping for client '{{.*}}' not implemented}}


### PR DESCRIPTION
d76fffc introduced a new option to `-convert-spirv-to-llvm`, upstreamed by https://github.com/llvm/llvm-project/commit/12ce9fd1248c6321b343601c1a2468ac7e00c9da. Adapt our code to avoid future merge conflicts.