### PR TITLE
[SYCL][HIP][L0][NATIVECPU] `urAdapterGetLastError` fix so messages aren't lost.

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/hip/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/adapter.cpp
@@ -53,9 +53,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
+  std::ignore = pError;
   *ppMessage = ErrorMessage;
-  *pError = ErrorMessageCode;
-  return UR_RESULT_SUCCESS;
+  return ErrorMessageCode;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
@@ -179,7 +179,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     int32_t *Error ///< [out] pointer to an integer where the adapter specific
                    ///< error code will be stored.
 ) {
-  std::ignore = pError;
+  std::ignore = Error;
   *ppMessage = ErrorMessage;
   return ErrorMessageCode;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
@@ -179,11 +179,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     int32_t *Error ///< [out] pointer to an integer where the adapter specific
                    ///< error code will be stored.
 ) {
-  std::ignore = Adapter;
-  std::ignore = Message;
-  std::ignore = Error;
-  urPrint("[UR][L0] %s function not implemented!\n", __FUNCTION__);
-  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+  std::ignore = pError;
+  *ppMessage = ErrorMessage;
+  return ErrorMessageCode;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/adapter.cpp
@@ -179,8 +179,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     int32_t *Error ///< [out] pointer to an integer where the adapter specific
                    ///< error code will be stored.
 ) {
+  std::ignore = Adapter;
   std::ignore = Error;
-  *ppMessage = ErrorMessage;
+  *Message = ErrorMessage;
   return ErrorMessageCode;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
@@ -283,7 +283,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
   if (GlobalVarSize < Offset + Count) {
     setErrorMessage("Write device global variable is out of range.",
                     UR_RESULT_ERROR_INVALID_VALUE);
-    return UR_RESULT_ERROR_UNKNOWN;
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
 
   // Copy engine is preferred only for host to device transfer.
@@ -332,7 +332,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
   if (GlobalVarSize < Offset + Count) {
     setErrorMessage("Read from device global variable is out of range.",
                     UR_RESULT_ERROR_INVALID_VALUE);
-    return UR_RESULT_ERROR_UNKNOWN;
+    return UR_RESULT_ERROR_ADAPTER_SPECIFIC;
   }
 
   // Copy engine is preferred only for host to device transfer.

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/adapter.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/adapter.cpp
@@ -46,9 +46,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urAdapterRetain(ur_adapter_handle_t) {
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetLastError(
     ur_adapter_handle_t, const char **ppMessage, int32_t *pError) {
+  std::ignore = pError;
   *ppMessage = ErrorMessage;
-  *pError = ErrorMessageCode;
-  return UR_RESULT_SUCCESS;
+  return ErrorMessageCode;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urAdapterGetInfo(ur_adapter_handle_t,


### PR DESCRIPTION
`urAdapterGetLastError` is being called in l0 and hip plugins but just returning success, which means the messages were lost. I've implemented `urAdapterGetLastError` in these backends in the same way as in the CUDA backend (https://github.com/intel/llvm/pull/10626) to fix this. I also made the same change for nativeCPU: this backend does not yet call `urAdapterGetLastError` but it could in the future.

Fixed hip message:

adapters/hip/enqueue.cpp:        setErrorMessage(LocalMemSzPtrUR ? "Invalid value specified for "

Fixed l0 messages:

adapters/level_zero/kernel.cpp:    setErrorMessage("Write device global variable is out of range.",
adapters/level_zero/kernel.cpp:    setErrorMessage("Read from device global variable is out of range.",
adapters/level_zero/device.cpp:      setErrorMessage("Set ZES_ENABLE_SYSMAN=1 to obtain free memory",

The associated errors returned by UR for the adapters/level_zero/kernel.cpp have also been fixed: SYCL runtime will only retrieve the errors if `UR_RESULT_ERROR_ADAPTER_SPECIFIC` is returned.
