### PR TITLE
[SYCL][Graph] Unitest bugfix

### DIFF
--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -1273,7 +1273,7 @@ inline pi_result
 mock_piextCommandBufferCreate(pi_context context, pi_device device,
                               const pi_ext_command_buffer_desc *desc,
                               pi_ext_command_buffer *ret_command_buffer) {
-
+  *ret_command_buffer = createDummyHandle<pi_ext_command_buffer>();
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
Returns a dummy commandbuffer handler in piextCommandBufferCreate Mock function