### PR TITLE
[CI] Improve devops/scripts/install_drivers.sh

### DIFF
--- a/.github/workflows/sycl_linux_run_tests.yml
+++ b/.github/workflows/sycl_linux_run_tests.yml
@@ -163,9 +163,10 @@ jobs:
         git -C khronos_sycl_cts submodule update --init
     - name: Install drivers
       if: inputs.install_drivers == 'true'
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
       run: |
-        sudo apt install curl
-        echo "$GITHUB_TOKEN" | sudo -E devops/scripts/install_drivers.sh llvm/devops/dependencies.json --all
+        sudo -E bash devops/scripts/install_drivers.sh llvm/devops/dependencies.json --all
     - name: Source OneAPI TBB vars.sh
       shell: bash
       run: |

--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+set -e
+set -x
+
 if [ -f "$1" ]; then
     # Read data from the dependencies.json passed as the first argument.
     CONFIG_FILE=$1
@@ -20,20 +23,17 @@ else
     CPU_TAG=$cpu_tag
 fi
 
-if [ -t 0 ]; then
-    # Interactive run (?), no token expected. Might be changed later.
-    TOKEN=""
-else
-    TOKEN=$(</dev/stdin)
-fi
-
 function get_release() {
     REPO=$1
     TAG=$2
-    URL="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
+    if [ "$TAG" == "latest" ]; then
+        URL="https://api.github.com/repos/${REPO}/releases/latest"
+    else
+        URL="https://api.github.com/repos/${REPO}/releases/tags/${TAG}"
+    fi
     HEADER=""
-    if [ "$TOKEN" != "" ]; then
-        HEADER="Authorization: Bearer $TOKEN"
+    if [ "$GITHUB_TOKEN" != "" ]; then
+        HEADER="Authorization: Bearer $GITHUB_TOKEN"
     fi
     curl -s -L -H "$HEADER" $URL \
         | jq -r '. as $raw | try .assets[].browser_download_url catch error($raw)'


### PR DESCRIPTION
* Use GITHUB_TOKEN from env instead of passing via stdin
* Exit on error
* Use "set -x" to make logs more useful. Github replaces the token with
  '***' so no security issue here.

It doesn't change the CI containers job yet, I plan to work on that in a
separate PR (to avoid unnecessary pre-commit CI jobs)