### PR TITLE
[SYCL][Graph] Release CommandBuffer dummy handler used by Graph Unitests

### DIFF
--- a/sycl/unittests/helpers/PiMockPlugin.hpp
+++ b/sycl/unittests/helpers/PiMockPlugin.hpp
@@ -1279,11 +1279,13 @@ mock_piextCommandBufferCreate(pi_context context, pi_device device,
 
 inline pi_result
 mock_piextCommandBufferRetain(pi_ext_command_buffer command_buffer) {
+  retainDummyHandle(command_buffer);
   return PI_SUCCESS;
 }
 
 inline pi_result
 mock_piextCommandBufferRelease(pi_ext_command_buffer command_buffer) {
+  releaseDummyHandle(command_buffer);
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
Adds retrain/release for the CommandBuffer dummy handler in the unitest PI mock.

This fixes the CI fail in PR #10954. https://github.com/intel/llvm/actions/runs/5973326392/job/16205377150