### PR TITLE
[SYCL][Graphs] Correct assert usage

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -137,7 +137,8 @@ std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
         auto Successor = NodesMap[NextNode];
         NodeCopy->registerSuccessor(Successor, NodeCopy);
       } else {
-        assert("Node duplication failed. A duplicated node is missing.");
+        assert(false &&
+               "Node duplication failed. A duplicated node is missing.");
       }
     }
   }


### PR DESCRIPTION
Fix [macOS CI fail in post-commit CI](https://github.com/intel/llvm/actions/runs/5975037762/job/16210261083) by asserting on `false`, then providing the error string.

Error 
```
/Users/runner/work/llvm/llvm/src/sycl/source/detail/graph_impl.cpp:140:16: error: implicit conversion turns string literal into bool: 'const char[55]' to 'bool' [-Werror,-Wstring-conversion]
        assert("Node duplication failed. A duplicated node is missing.");
        ~~~~~~~^~~~~~~~~~~~~~~~~~~
```