### PR TITLE
[SYCL] Add missing pragma once

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/alt_ui.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/alt_ui.hpp
@@ -8,6 +8,8 @@
 // "Alternative" convenience Explicit SIMD APIs.
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #include <sycl/ext/intel/esimd/simd.hpp>
 #include <sycl/ext/intel/esimd/simd_view.hpp>
 

--- a/sycl/include/sycl/property_list_conversion.hpp
+++ b/sycl/include/sycl/property_list_conversion.hpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 // This file contains conversion routines from property_list to
 // accessor_property_list. A separate file helps to avoid cyclic dependencies
 // between header files.

--- a/sycl/source/detail/builtins_helper.hpp
+++ b/sycl/source/detail/builtins_helper.hpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+#pragma once
+
 #include <sycl/detail/export.hpp>
 #include <sycl/detail/generic_type_traits.hpp>
 #include <sycl/exception.hpp>


### PR DESCRIPTION
While working on a patch in headers I noticed some SYCL include and source headers were missing guards. This fixes that.