### PR TITLE
[CI] Use GITHUB_TOKEN for drivers_install.sh during containers build

### DIFF
--- a/devops/actions/build_container/action.yml
+++ b/devops/actions/build_container/action.yml
@@ -39,4 +39,5 @@ runs:
       build-args: ${{ inputs.build-args }}
       context: ${{ github.workspace }}/devops
       file: ${{ github.workspace }}/devops/containers/${{ inputs.file }}.Dockerfile
-
+      secrets: |
+        github_token=${{ github.token }}

--- a/devops/containers/ubuntu2204_intel_drivers.Dockerfile
+++ b/devops/containers/ubuntu2204_intel_drivers.Dockerfile
@@ -20,7 +20,7 @@ COPY scripts/install_drivers.sh /
 
 RUN mkdir /runtimes
 ENV INSTALL_LOCATION=/runtimes
-RUN /install_drivers.sh --all
+RUN --mount=type=secret,id=github_token GITHUB_TOKEN=$(cat /run/secrets/github_token) /install_drivers.sh --all
 
 COPY scripts/drivers_entrypoint.sh /drivers_entrypoint.sh
 


### PR DESCRIPTION
So that we are not limited to 60 queries per IP per hour.