### PR TITLE
[SYCL] Fix an assert in sycl/source/detail/graph_impl.cpp

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -133,12 +133,10 @@ std::shared_ptr<node_impl> graph_impl::addSubgraphNodes(
     *NewNodesIt = NodeCopy;
     NodesMap.insert({Node, NodeCopy});
     for (auto &NextNode : Node->MSuccessors) {
-      if (NodesMap.find(NextNode) != NodesMap.end()) {
-        auto Successor = NodesMap[NextNode];
-        NodeCopy->registerSuccessor(Successor, NodeCopy);
-      } else {
-        assert("Node duplication failed. A duplicated node is missing.");
-      }
+      assert(NodesMap.find(NextNode) != NodesMap.end() &&
+             "Node duplication failed. A duplicated node is missing.");
+      auto Successor = NodesMap[NextNode];
+      NodeCopy->registerSuccessor(Successor, NodeCopy);
     }
   }
 


### PR DESCRIPTION
1) String literal is always true, it should have been

```
assert(false && "Message");
```

2) Avoid unnecessary `if/else`