### PR TITLE
[SYCL] Prevent call to Device Release in plugins after piTearDown

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -722,7 +722,8 @@ mapPIMetadataToUR(const pi_device_binary_property *pi_metadata,
 namespace pi2ur {
 
 inline pi_result piTearDown(void *PluginParameter) {
-  std::ignore = PluginParameter;
+  bool *pluginTeardown = static_cast<bool *>(PluginParameter);
+  *pluginTeardown = true;
   // Fetch the single known adapter (the one which is statically linked) so we
   // can release it. Fetching it for a second time (after piPlatformsGet)
   // increases the reference count, so we need to release it twice.

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -87,9 +87,11 @@ device_impl::~device_impl() {
   if (!MIsHostDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
     const PluginPtr &Plugin = getPlugin();
-    sycl::detail::pi::PiResult Err =
-        Plugin->call_nocheck<PiApiKind::piDeviceRelease>(MDevice);
-    __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
+    if (!Plugin->pluginReleased) {
+      sycl::detail::pi::PiResult Err =
+          Plugin->call_nocheck<PiApiKind::piDeviceRelease>(MDevice);
+      __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
+    }
   }
 }
 

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -259,11 +259,11 @@ void GlobalHandler::unloadPlugins() {
   // there's no need to load and unload plugins.
   if (MPlugins.Inst) {
     for (const PluginPtr &Plugin : getPlugins()) {
-      // PluginParameter is reserved for future use that can control
-      // some parameters in the plugin tear-down process.
-      // Currently, it is not used.
-      void *PluginParameter = nullptr;
-      Plugin->call<PiApiKind::piTearDown>(PluginParameter);
+      // PluginParameter for Teardown is the boolean tracking if a
+      // given plugin has been teardown successfully.
+      // This tracking prevents usage of this plugin after teardown
+      // has been completed to avoid invalid resource access.
+      Plugin->call<PiApiKind::piTearDown>(&Plugin->pluginReleased);
       Plugin->unload();
     }
   }

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -290,6 +290,7 @@ public:
   }
 
   std::shared_ptr<std::mutex> getPluginMutex() { return MPluginMutex; }
+  bool pluginReleased = false;
 
 private:
   std::shared_ptr<sycl::detail::pi::PiPlugin> MPlugin;


### PR DESCRIPTION
- Track when a plugin has been teardown and prevent calls to Device Release after teardown during device destruction.