### PR TITLE
[SYCL][Joint Matrix] All sizes MAD and elem wise tf32 pass

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
@@ -10,8 +10,6 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-// XFAIL:gpu
-
 #include <iostream>
 #include <random>
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_all_sizes.cpp
@@ -9,7 +9,6 @@
 
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
-// XFAIL: gpu
 
 #include <iostream>
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
All sizes MAD and TF32 element wise ops with sub group size 32 pass on PVC now. Removing xfail.