### PR TITLE
[SYCL-MLIR] Use properties as storage for attributes

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLBase.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLBase.td
@@ -51,6 +51,7 @@ def SYCL_Dialect : Dialect {
     llvm::Optional<llvm::StringRef> findMethod(::mlir::TypeID Type,
                                                llvm::StringRef Name) const;
   }];
+  let usePropertiesForAttributes = 1;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistBase.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistBase.td
@@ -15,6 +15,7 @@ def Polygeist_Dialect : Dialect {
   let name = "polygeist";
   let cppNamespace = "::mlir::polygeist";
   let useDefaultTypePrinterParser = 1;
+  let usePropertiesForAttributes = 1;
 }
 
 #endif // POLYGEIST_BASE

--- a/polygeist/tools/cgeist/Test/Verification/alignof.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/alignof.cpp
@@ -14,7 +14,7 @@ unsigned create2() {
 }
 
 // CHECK:   func @_Z6createv() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:     %0 = "polygeist.typeAlign"() {source = !llvm.struct<(memref<?xf32>, i8)>} : () -> index
+// CHECK-NEXT:     %0 = "polygeist.typeAlign"() <{source = !llvm.struct<(memref<?xf32>, i8)>}> : () -> index
 // CHECK-NEXT:     %1 = arith.index_cast %0 : index to i64
 // CHECK-NEXT:     %2 = arith.trunci %1 : i64 to i32
 // CHECK-NEXT:     return %2 : i32

--- a/polygeist/tools/cgeist/Test/Verification/sizeof.c
+++ b/polygeist/tools/cgeist/Test/Verification/sizeof.c
@@ -12,7 +12,7 @@ struct Meta* create() {
 }
 
 // CHECK-LABEL:   func.func @create() -> !llvm.ptr attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:      %[[VAL_0:.*]] = "polygeist.typeSize"() {source = !llvm.struct<(memref<?xf32>, i8)>} : () -> index
+// CHECK-NEXT:      %[[VAL_0:.*]] = "polygeist.typeSize"() <{source = !llvm.struct<(memref<?xf32>, i8)>}> : () -> index
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.index_cast %[[VAL_0]] : index to i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.call @malloc(%[[VAL_1]]) : (i64) -> !llvm.ptr
 // CHECK-NEXT:      return %[[VAL_2]] : !llvm.ptr

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -103,7 +103,7 @@ extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
 // CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %cast = memref.cast %alloca : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %0 = "polygeist.memref2pointer"(%alloca) : (memref<1x!sycl_id_2_>) -> !llvm.ptr
-// CHECK-NEXT: %1 = "polygeist.typeSize"() {source = !sycl_id_2_} : () -> index
+// CHECK-NEXT: %1 = "polygeist.typeSize"() <{source = !sycl_id_2_}> : () -> index
 // CHECK-NEXT: %2 = arith.index_cast %1 : index to i64
 // CHECK-NEXT: "llvm.intr.memset"(%0, %c0_i8, %2) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
 // CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
@@ -268,7 +268,7 @@ extern "C" SYCL_EXTERNAL void cons_10(const sycl::long8 &A,
 // CHECK-DAG:     %[[C0_I8:.*]] = arith.constant 0 : i8
 // CHECK-NEXT:    %[[ALLOCA:.*]] = memref.alloca() : memref<1x!sycl_vec_i32_4_>
 // CHECK-NEXT:    %[[VAL0:.*]] = "polygeist.memref2pointer"(%[[ALLOCA]]) : (memref<1x!sycl_vec_i32_4_>) -> !llvm.ptr
-// CHECK-NEXT:    %[[VAL1:.*]] = "polygeist.typeSize"() {source = !sycl_vec_i32_4_} : () -> index
+// CHECK-NEXT:    %[[VAL1:.*]] = "polygeist.typeSize"() <{source = !sycl_vec_i32_4_}> : () -> index
 // CHECK-NEXT:    %[[VAL2:.*]] = arith.index_cast %[[VAL1]] : index to i64
 // CHECK-NEXT:    "llvm.intr.memset"(%[[VAL0]], %[[C0_I8]], %[[VAL2]]) <{isVolatile = false}> : (!llvm.ptr, i8, i64) -> ()
 


### PR DESCRIPTION
Prepare for https://github.com/llvm/llvm-project/commit/863c346209e27d22157fad21d0fd730e710a3441, which will set this by default.

After that commit is in our branch, `usePropertiesForAttributes` will no longer be needed in dialect definitions.