### PR TITLE
[SYCL-MLIR] Fix image type handling

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -173,6 +173,11 @@ MLIRScanner::VisitImplicitValueInitExpr(clang::ImplicitValueInitExpr *Decl) {
     return ValueCategory(Builder.create<mlir::LLVM::NullOp>(Loc, PT), false,
                          Builder.getI8Type());
 
+  if (auto PT = dyn_cast<mlir::LLVM::LLVMTargetExtType>(MLIRTy))
+    return ValueCategory(Builder.create<mlir::LLVM::ConstantOp>(
+                             Loc, PT, Builder.getI64IntegerAttr(0)),
+                         false, Builder.getI8Type());
+
   for (auto *Child : Decl->children())
     Child->dump();
 

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1545,7 +1545,7 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
 
     if (!MemRefABI ||
         isa<LLVM::LLVMArrayType, LLVM::LLVMStructType, LLVM::LLVMPointerType,
-            LLVM::LLVMFunctionType>(SubType)) {
+            LLVM::LLVMFunctionType, LLVM::LLVMTargetExtType>(SubType)) {
       // JLE_QUEL::THOUGHTS
       // When generating the sycl_halide_kernel, If a struct type contains
       // SYCL types, that means that this is the functor, and we can't create

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_cache.cpp
@@ -1,21 +1,16 @@
 // RUN: clang++  -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 
-// TODO: This test is currently not yet working with opaque pointers, 
-// as the MLIR LLVM dialect is lacking support for the LLVM IR 'TargetExtType'
-// that is used for OpenCL/SPIR-V image types.
-// XFAIL: *
-
 #include <sycl/sycl.hpp>
 using namespace sycl;
 
 // CHECK-LABEL:     func.func @_Z6callee38__spirv_SampledImage__image1d_array_ro
-// CHECK-SAME:          (%[[VAL_151:.*]]: !llvm.ptr<1>)
+// CHECK-SAME:          (%[[VAL_151:.*]]: !llvm.target<"spirv.SampledImage", !llvm.void, 0, 0, 1, 0, 0, 0, 0>) 
 // CHECK-NEXT:        return
 // CHECK-NEXT:      }
 
 // CHECK-LABEL:     func.func @_Z6caller38__spirv_SampledImage__image1d_array_ro
-// CHECK-SAME:          (%[[VAL_152:.*]]: !llvm.ptr<1>)
-// CHECK-NEXT:        call @_Z6callee38__spirv_SampledImage__image1d_array_ro(%[[VAL_152]]) : (!llvm.ptr<1>) -> ()
+// CHECK-SAME:          (%[[VAL_152:.*]]: !llvm.target<"spirv.SampledImage", !llvm.void, 0, 0, 1, 0, 0, 0, 0>) 
+// CHECK-NEXT:        call @_Z6callee38__spirv_SampledImage__image1d_array_ro(%[[VAL_152]]) : (!llvm.target<"spirv.SampledImage", !llvm.void, 0, 0, 1, 0, 0, 0, 0>) -> ()
 // CHECK-NEXT:        return
 // CHECK-NEXT:      }
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/builtin_types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/builtin_types.cpp
@@ -1,10 +1,5 @@
 // RUN: clang++  -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s
 
-// TODO: This test is currently not yet working with opaque pointers, 
-// as the MLIR LLVM dialect is lacking support for the LLVM IR 'TargetExtType'
-// that is used for OpenCL/SPIR-V image types.
-// XFAIL: *
-
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
@@ -33,34 +28,35 @@ SYCL_EXTERNAL void float128(__float128 var) {}
 // CHECK:         %arg0: i128 {llvm.noundef})
 SYCL_EXTERNAL void int128(__int128 var) {}
 
-// CHECK-LABEL: func.func @_Z19opencl_image1d_ro_t14ocl_image1d_ro(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK-LABEL: func.func @_Z19opencl_image1d_ro_t14ocl_image1d_ro
+// CHECK:           (%[[VAL_157:.*]]: !llvm.target<"spirv.Image", !llvm.void, 0, 0, 0, 0, 0, 0, 0>) 
 SYCL_EXTERNAL void opencl_image1d_ro_t(detail::opencl_image_type<1, access::mode::read, access::target::image>::type var) {}
 
-// CHECK-LABEL: func.func @_Z19opencl_image1d_wo_t14ocl_image1d_wo(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK-LABEL: func.func @_Z19opencl_image1d_wo_t14ocl_image1d_wo
+// CHECK:           (%[[VAL_158:.*]]: !llvm.target<"spirv.Image", !llvm.void, 0, 0, 0, 0, 0, 0, 1>) 
 SYCL_EXTERNAL void opencl_image1d_wo_t(detail::opencl_image_type<1, access::mode::write, access::target::image>::type var) {}
 
-// CHECK-LABEL: func.func @_Z25opencl_image1d_array_ro_t20ocl_image1d_array_ro(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK-LABEL: func.func @_Z25opencl_image1d_array_ro_t20ocl_image1d_array_ro
+// CHECK:           (%[[VAL_159:.*]]: !llvm.target<"spirv.Image", !llvm.void, 0, 0, 1, 0, 0, 0, 0>) 
 SYCL_EXTERNAL void opencl_image1d_array_ro_t(detail::opencl_image_type<1, access::mode::read, access::target::image_array>::type var) {}
 
-// CHECK-LABEL: func.func @_Z25opencl_image1d_array_wo_t20ocl_image1d_array_wo(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK-LABEL: func.func @_Z25opencl_image1d_array_wo_t20ocl_image1d_array_wo
+// CHECK:           (%[[VAL_160:.*]]: !llvm.target<"spirv.Image", !llvm.void, 0, 0, 1, 0, 0, 0, 1>) 
 SYCL_EXTERNAL void opencl_image1d_array_wo_t(detail::opencl_image_type<1, access::mode::write, access::target::image_array>::type var) {}
 
-// CHECK-LABEL: func.func @_Z16opencl_sampler_t11ocl_sampler(
-// CHECK:         %arg0: !llvm.ptr<2>)
+// CHECK-LABEL: func.func @_Z16opencl_sampler_t11ocl_sampler
+// CHECK:           (%[[VAL_161:.*]]: !llvm.target<"spirv.Sampler">) 
 SYCL_EXTERNAL void opencl_sampler_t(__ocl_sampler_t var) {}
 
-// CHECK-LABEL: func.func @_Z33opencl_sampled_image_array1d_ro_t38__spirv_SampledImage__image1d_array_ro(
-// CHECK:         %arg0: !llvm.ptr<1>)
+// CHECK-LABEL: func.func @_Z33opencl_sampled_image_array1d_ro_t38__spirv_SampledImage__image1d_array_ro
+// CHECK:           (%[[VAL_162:.*]]: !llvm.target<"spirv.SampledImage", !llvm.void, 0, 0, 1, 0, 0, 0, 0>) 
 SYCL_EXTERNAL void opencl_sampled_image_array1d_ro_t(__ocl_sampled_image1d_array_ro_t var) {}
 
-// CHECK-LABEL: func.func @_Z12opencl_vec_tDv4_j(
-// CHECK:         %arg0: vector<4xi32> {llvm.noundef})
+// CHECK-LABEL: func.func @_Z12opencl_vec_tDv4_j
+// CHECK:           (%[[VAL_163:.*]]: vector<4xi32> {llvm.noundef}) 
 SYCL_EXTERNAL void opencl_vec_t(__ocl_vec_t<uint32_t, 4> var) {}
 
-// CHECK-LABEL: func.func @_Z14opencl_event_t9ocl_event(
-// CHECK:         %arg0: !llvm.ptr<4>)
+// CHECK-LABEL: func.func @_Z14opencl_event_t9ocl_event
+// CHECK:           (%[[VAL_164:.*]]: !llvm.target<"spirv.Event">) 
 SYCL_EXTERNAL void opencl_event_t(__ocl_event_t var) {}
+

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -1,21 +1,16 @@
 // RUN: clang++  -fsycl -fsycl-device-only -O0 -w -emit-mlir -o - %s | FileCheck %s 
 
-// TODO: This test is currently not yet working with opaque pointers, 
-// as the MLIR LLVM dialect is lacking support for the LLVM IR 'TargetExtType'
-// that is used for OpenCL/SPIR-V image types.
-// XFAIL: *
-
-#include <sycl/accessor.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
 static constexpr unsigned N = 8;
-
-// CHECK-LABEL:  func.func @_ZN4sycl3_V18accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS4_6targetE2017ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initE14ocl_image1d_ro(%arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 32 : i64, llvm.noundef}, %arg1: !llvm.ptr<1>)
-// CHECK-NEXT:    %0 = "polygeist.memref2pointer"(%arg0) : (memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4>) -> !llvm.ptr<4>
-// CHECK-NEXT:    sycl.call @imageAccessorInit(%0, %arg1) {MangledFunctionName = @_ZN4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE17imageAccessorInitE14ocl_image1d_ro, TypeName = @image_accessor} : (!llvm.ptr<4>, !llvm.ptr<1>) -> ()
-// CHECK-NEXT:    return
-// CHECK-NEXT:  }
+// CHECK-LABEL:           func.func @_ZN4sycl3_V18accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS4_6targetE2017ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initE14ocl_image1d_ro(
+// CHECK-SAME:                  %[[VAL_183:.*]]: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 32 : i64, llvm.noundef}
+// CHECK-SAME:                  %[[VAL_184:.*]]: !llvm.target<"spirv.Image", !llvm.void, 0, 0, 0, 0, 0, 0, 0>)
+// CHECK-NEXT:              %[[VAL_185:.*]] = "polygeist.memref2pointer"(%[[VAL_183]]) : (memref<?x!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i, 4>) -> !llvm.ptr<4>
+// CHECK-NEXT:              sycl.call @imageAccessorInit(%[[VAL_185]], %[[VAL_184]]) {MangledFunctionName = @_ZN4sycl3_V16detail14image_accessorINS0_3vecIfLi4EEELi1ELNS0_6access4modeE1024ELNS5_6targetE2017ELNS5_11placeholderE0EE17imageAccessorInitE14ocl_image1d_ro, TypeName = @image_accessor} : (!llvm.ptr<4>, !llvm.target<"spirv.Image", !llvm.void, 0, 0, 0, 0, 0, 0, 0>) -> ()
+// CHECK-NEXT:              return
+// CHECK-NEXT:            }
 
 // CHECK-LABEL: func.func private @_ZZZ9testImagevENKUlRN4sycl3_V17handlerEE_clES2_ENKUlNS0_4itemILi1ELb1EEEE_clES5_(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_21sycl2Evec3C5Bf322C_45D2C_28vector3C4xf323E293E_r_i)>, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 32 : i64, llvm.noundef}, %arg1: memref<?x!sycl_item_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_item_1_, llvm.noundef})
 // CHECK-DAG:     %c0_i32 = arith.constant 0 : i32

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -460,11 +460,8 @@ OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
 OptionalKernelFeatures/large-reqd-work-group-size.cpp
 OptionalKernelFeatures/no-fp64-optimization-declared-aspects.cpp
 OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
-Plugin/enqueue-arg-order-image.cpp
 Plugin/interop-level-zero-buffer-multi-dim.cpp
-Plugin/interop-level-zero-image.cpp
 Plugin/interop-level-zero-image-get-native-mem.cpp
-Plugin/interop-level-zero-image-ownership.cpp
 Printf/char.cpp
 Printf/double.cpp
 Printf/float.cpp


### PR DESCRIPTION
With the switch to opaque pointers, image types are now represented by LLVM TargetExtensionTypes. These are not allowed as element type of a `memref`. 

This therefore changes the handling to use `llvm.ptr` instead, to avoid this error. 

It re-enables three SYCL end-to-end tests that were put on the list of expected failures as part of #10941.