### PR TITLE
[SYCL][Graph] Fix unit test multithread finalize bug

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1737,18 +1737,21 @@ TEST_F(MultiThreadGraphTest, RecordAddNodesInOrderQueue) {
 TEST_F(MultiThreadGraphTest, Finalize) {
   addKernels(Graph);
 
+  std::mutex MutexMap;
+
   std::map<int,
            experimental::command_graph<experimental::graph_state::executable>>
       GraphsExecMap;
   auto FinalizeGraph = [&](int ThreadNum) {
     SyncPoint.wait();
     auto GraphExec = Graph.finalize();
+    Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
 
+    std::lock_guard<std::mutex> Guard(MutexMap);
     GraphsExecMap.insert(
         std::map<int, experimental::command_graph<
                           experimental::graph_state::executable>>::
             value_type(ThreadNum, GraphExec));
-    Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   };
 
   for (unsigned i = 0; i < NumThreads; ++i) {


### PR DESCRIPTION
Adds a mutex to prevent races when inserting data into the STL map.

This PR addresses issue https://github.com/intel/llvm/issues/10985 
(i.e. it fixes the post-commit CI fail of PR https://github.com/intel/llvm/pull/10964 (https://github.com/intel/llvm/actions/runs/6001360490/job/16275376437)
