### PR TITLE
[SYCL][Graph] Using no immediate command list for test by default

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/add_node_while_recording.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_node_while_recording.cpp
@@ -15,7 +15,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   bool Success = false;
 

--- a/sycl/test-e2e/Graph/Explicit/depends_on.cpp
+++ b/sycl/test-e2e/Graph/Explicit/depends_on.cpp
@@ -14,7 +14,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
@@ -13,7 +13,7 @@
 #include "../graph_common.hpp"
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
@@ -13,7 +13,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/single_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/single_node.cpp
@@ -12,7 +12,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
@@ -5,7 +5,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = unsigned int;
 

--- a/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = unsigned short;
 

--- a/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
@@ -5,7 +5,7 @@
 #include <thread>
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   if (!Queue.get_device().has(sycl::aspect::usm_host_allocations)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   if (!Queue.get_device().has(sycl::aspect::usm_system_allocations)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
@@ -3,7 +3,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
@@ -13,7 +13,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_usm_reduction.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/double_buffer.cpp
@@ -5,7 +5,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Inputs/empty_node.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   auto MyProperties = property_list{exp_ext::property::graph::no_cycle_check()};
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device(),

--- a/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
@@ -34,7 +34,7 @@ std::string event_status_name(sycl::info::event_command_status status) {
 }
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Inputs/executable_graph_update.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/executable_graph_update_ordering.cpp
@@ -5,7 +5,7 @@
 #include <thread>
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/host_task.cpp
+++ b/sycl/test-e2e/Graph/Inputs/host_task.cpp
@@ -3,7 +3,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Inputs/queue_shortcuts.cpp
@@ -3,7 +3,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/stream.cpp
+++ b/sycl/test-e2e/Graph/Inputs/stream.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = short;
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
@@ -24,7 +24,7 @@ float reference(size_t i) {
 } // namespace
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_reduction.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph GraphA{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph GraphB{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
@@ -6,7 +6,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
@@ -3,7 +3,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
   if (!Queue.get_device().has(sycl::aspect::usm_host_allocations)) {
     return 0;
   }

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/RecordReplay/concurrent_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/concurrent_queue.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   bool Success = false;
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
@@ -11,8 +11,10 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list properties{property::queue::in_order()};
-  queue Queue{properties};
+  property_list Properties{
+      property::queue::in_order{},
+      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  queue Queue{Properties};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
@@ -13,7 +13,9 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list Properties{property::queue::in_order()};
+  property_list Properties{
+      property::queue::in_order{},
+      sycl::ext::intel::property::queue::no_immediate_command_list{}};
   queue Queue{Properties};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -12,9 +12,11 @@
 
 int main() {
 
-  property_list properties{property::queue::in_order()};
-  queue QueueA{properties};
-  queue QueueB{QueueA.get_context(), QueueA.get_device(), properties};
+  property_list Properties{
+      property::queue::in_order{},
+      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  queue QueueA{Properties};
+  queue QueueB{QueueA.get_context(), QueueA.get_device(), Properties};
 
   exp_ext::command_graph Graph{QueueA.get_context(), QueueA.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
@@ -10,7 +10,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   context InOrderContext;
 

--- a/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   Graph.begin_recording(Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   bool ChangedState = Graph.end_recording();

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
@@ -11,8 +11,10 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list properties{property::queue::in_order()};
-  queue Queue{properties};
+  property_list Properties{
+      property::queue::in_order{},
+      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  queue Queue{Properties};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -15,7 +15,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
@@ -27,7 +27,8 @@ void run_some_kernel(queue Queue, float *Data) {
 
 int main() {
 
-  queue Queue{default_selector_v};
+  queue Queue{default_selector_v,
+              {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -11,8 +11,10 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list properties{property::queue::in_order()};
-  queue Queue{properties};
+  property_list Properties{
+      property::queue::in_order{},
+      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  queue Queue{Properties};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   {

--- a/sycl/test-e2e/Graph/Threading/finalize.cpp
+++ b/sycl/test-e2e/Graph/Threading/finalize.cpp
@@ -14,7 +14,7 @@
 #include <thread>
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -14,7 +14,7 @@
 #include <thread>
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/device_query.cpp
+++ b/sycl/test-e2e/Graph/device_query.cpp
@@ -7,7 +7,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   auto Device = Queue.get_device();
 

--- a/sycl/test-e2e/Graph/device_query.cpp
+++ b/sycl/test-e2e/Graph/device_query.cpp
@@ -7,7 +7,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   auto Device = Queue.get_device();
 

--- a/sycl/test-e2e/Graph/empty_graph.cpp
+++ b/sycl/test-e2e/Graph/empty_graph.cpp
@@ -8,7 +8,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/finalize_twice.cpp
+++ b/sycl/test-e2e/Graph/finalize_twice.cpp
@@ -7,7 +7,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
+++ b/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// UNSUPPORTED: gpu-intel-pvc
 // The test checks that invalid exception is thrown
 // when trying to use sycl_ext_oneapi_device_global
 // along with Graph.

--- a/sycl/test-e2e/Graph/invalid_depends_on.cpp
+++ b/sycl/test-e2e/Graph/invalid_depends_on.cpp
@@ -8,7 +8,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/invalid_event_wait.cpp
+++ b/sycl/test-e2e/Graph/invalid_event_wait.cpp
@@ -8,7 +8,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/invalid_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/invalid_queue_wait.cpp
@@ -7,7 +7,7 @@
 #include "graph_common.hpp"
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};


### PR DESCRIPTION
This patch should fix test failures on PVC by using a queue property to explicitly disable use of immediate command list.