### PR TITLE
[SYCL-Web][ESIMD] Don't consider annotation intrinsics as escapes in ESIMDOptimizeVecArgCallConv

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/ESIMDOptimizeVecArgCallConv.cpp
@@ -25,6 +25,7 @@
 
 #include "llvm/IR/Function.h"
 #include "llvm/IR/IRBuilder.h"
+#include "llvm/IR/IntrinsicInst.h"
 #include "llvm/IR/Module.h"
 #include "llvm/InitializePasses.h"
 #include "llvm/Pass.h"
@@ -240,6 +241,10 @@ Type *getPointedToTypeIfOptimizeable(const Argument &FormalParam) {
     // Handler for the case when non-memory access use instruction is met.
     NonMemUseHandlerT NonMemUseMetF = [&](const Use *AUse) {
       if (auto CI = dyn_cast<CallInst>(AUse->getUser())) {
+        auto IntrinsicI = dyn_cast<IntrinsicInst>(CI);
+        // Ignore annotation intrinsics.
+        if (IntrinsicI && IntrinsicI->isAssumeLikeIntrinsic())
+          return true;
         // if not equal, alloca escapes to some other function
         return CI->getCalledFunction() == F;
       }


### PR DESCRIPTION
In the latest pulldown we started seeing `llvm.lifetime` intrinsics which previously weren't there.

The escape check was too conservative and skipping optimization if these intrinsics were present.

Skip all annotation intrinsics.

This is already locked down by vec_arg_call_conv_ext.cpp and vec_arg_call_conv_smoke.cpp, they are currently failing.