### PR TITLE
[SYCL] Don't construct the full call graph in copySYCLKernelAttrs

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -4089,7 +4089,7 @@ void Sema::copySYCLKernelAttrs(CXXMethodDecl *CallOperator) {
   FunctionDecl *KernelBody = nullptr;
 
   CallGraph SYCLCG;
-  SYCLCG.addToCallGraph(getASTContext().getTranslationUnitDecl());
+  SYCLCG.addToCallGraph(CallOperator);
   while (!WorkList.empty()) {
     FunctionDecl *FD = WorkList.back().first;
     FunctionDecl *ParentFD = WorkList.back().second;


### PR DESCRIPTION
This PR improves compilation time when there are many simple range (i.e. not nd_range) parallel_for kernels and range rounding is enabled. 

More background: for the range rounding functionality, the user provided lambda is wrapped within another lambda. However, there could be attributes applied on the user lambda which are then not present on the wrapped lambda. `copySYCLKernelAttrs` is given the declaration of the wrapped lambda's `operator()` and needs to recurse through the definition to find the `operator()` declaration of the user provided lambda, and then copy the attributes up. Clearly, this does not require constructing the call graph of the whole translation unit, but only the call graph starting from the wrapped lambda.

E.g. consider the (somewhat silly) example:

```c++
#include <sycl/sycl.hpp>

using namespace sycl;

template <int N>
class foo;

template <int... Ns>
void kernels(std::integer_sequence<int, Ns...>, queue &q) {
  (q.parallel_for<foo<Ns>>(1, [](auto){}), ...);
}

int x() {
  queue q;
  kernels(std::make_integer_sequence<int, 256>(), q);
}
```
I did a quick test and without this PR, the total amount of time doing `SYCLCG.addToCallGraph(getASTContext().getTranslationUnitDecl())` calls was around 13 seconds , while with the change, the total amount of time doing `SYCLCG.addToCallGraph(CallOperator)` calls was less than a millisecond.