### PR TITLE
[SYCL] Add missing cmath builtin

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -32,6 +32,9 @@ DEVICE_EXTERN_C_INLINE
 float roundf(float x) { return __devicelib_roundf(x); }
 
 DEVICE_EXTERN_C_INLINE
+float floorf(float x) { return __devicelib_floorf(x); }
+
+DEVICE_EXTERN_C_INLINE
 float scalbnf(float x, int n) { return __devicelib_scalbnf(x, n); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -22,6 +22,9 @@ DEVICE_EXTERN_C_INLINE
 double round(double x) { return __devicelib_round(x); }
 
 DEVICE_EXTERN_C_INLINE
+double floor(double x) { return __devicelib_floor(x); }
+
+DEVICE_EXTERN_C_INLINE
 double exp(double x) { return __devicelib_exp(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/device_math.h
+++ b/libdevice/device_math.h
@@ -56,6 +56,12 @@ DEVICE_EXTERN_C
 float __devicelib_roundf(float x);
 
 DEVICE_EXTERN_C
+double __devicelib_floor(double x);
+
+DEVICE_EXTERN_C
+float __devicelib_floorf(float x);
+
+DEVICE_EXTERN_C
 double __devicelib_log(double x);
 
 DEVICE_EXTERN_C

--- a/libdevice/fallback-cmath-fp64.cpp
+++ b/libdevice/fallback-cmath-fp64.cpp
@@ -42,6 +42,9 @@ DEVICE_EXTERN_C_INLINE
 double __devicelib_round(double x) { return __spirv_ocl_round(x); }
 
 DEVICE_EXTERN_C_INLINE
+double __devicelib_floor(double x) { return __spirv_ocl_floor(x); }
+
+DEVICE_EXTERN_C_INLINE
 double __devicelib_exp2(double x) { return __spirv_ocl_exp2(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -41,6 +41,9 @@ DEVICE_EXTERN_C_INLINE
 float __devicelib_roundf(float x) { return __spirv_ocl_round(x); }
 
 DEVICE_EXTERN_C_INLINE
+float __devicelib_floorf(float x) { return __spirv_ocl_floor(x); }
+
+DEVICE_EXTERN_C_INLINE
 float __devicelib_logf(float x) { return __spirv_ocl_log(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -19,12 +19,12 @@ namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;
 constexpr s::access::mode sycl_write = s::access::mode::write;
 
-#define TEST_NUM 62
+#define TEST_NUM 63
 
 double ref[TEST_NUM] = {
-    1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 0.5, 0, 2, 0, 0,   1,   0,   2,   0, 0, 0,
-    0, 0, 1, 0, 1, 2, 0, 1, 2, 5, 0,   0, 0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   0, 0, 0, 0,   0,   0,   0,   0, 0};
+    1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0.5, 0, 2, 0, 0,   1,   0,   2,   0, 0,
+    0, 0, 0, 1, 0, 1, 2, 0, 1, 2, 5, 0,   0, 0, 0, 0.5, 0.5, NAN, NAN, 2, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   0, 0, 0, 0,   0,   0,   0,   0, 0};
 
 double refIptr = 1;
 
@@ -62,6 +62,7 @@ template <class T> void device_cmath_test(s::queue &deviceQueue) {
         res_access[i++] = std::cos(0.0);
         res_access[i++] = std::sin(0.0);
         res_access[i++] = std::round(1.0);
+        res_access[i++] = std::floor(1.0);
         res_access[i++] = std::log(1.0);
         res_access[i++] = std::acos(1.0);
         res_access[i++] = std::asin(0.0);

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -21,12 +21,12 @@ namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;
 constexpr s::access::mode sycl_write = s::access::mode::write;
 
-#define TEST_NUM 60
+#define TEST_NUM 61
 
-float ref[TEST_NUM] = {1, 0, 1, 0,   0,   0,   0,   0, 1, 1, 0.5, 0, 0, 1, 0,
-                       2, 0, 0, 0,   0,   0,   1,   0, 1, 2, 0,   1, 2, 5, 0,
-                       0, 0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0, 0,   0, 0, 0, 0,
-                       0, 0, 0, 0,   0,   0,   0,   0, 0, 0, 0,   0, 0, 0, 0};
+float ref[TEST_NUM] = {1, 0, 1,   1,   0,   0,   0, 0, 0, 1, 1, 0.5, 0, 0, 1, 0,
+                       2, 0, 0,   0,   0,   0,   1, 0, 1, 2, 0, 1,   2, 5, 0, 0,
+                       0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0, 0, 0, 0,   0, 0, 0, 0,
+                       0, 0, 0,   0,   0,   0,   0, 0, 0, 0, 0, 0,   0};
 
 float refIptr = 1;
 
@@ -59,6 +59,7 @@ template <class T> void device_cmath_test_1(s::queue &deviceQueue) {
         res_access[i++] = std::cos(0.0f);
         res_access[i++] = std::sin(0.0f);
         res_access[i++] = std::round(1.0f);
+        res_access[i++] = std::floor(1.0f);
         res_access[i++] = std::log(1.0f);
         res_access[i++] = std::acos(1.0f);
         res_access[i++] = std::asin(0.0f);


### PR DESCRIPTION
Same as https://github.com/intel/llvm/pull/10904 for cmath func `floor`