### PR TITLE
[SYCL][NATIVECPU] Use declarations for SPIRV work item builtins

### DIFF
--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -258,7 +258,6 @@ SmallVector<Function *> getFunctionsFromUse(Use &U) {
 
 PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
                                                 ModuleAnalysisManager &MAM) {
-  llvm::errs() << "[ptrdbg] module pre: " << M << "\n";
   bool ModuleChanged = false;
   SmallVector<Function *> OldKernels;
   for (auto &F : M) {
@@ -303,9 +302,9 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
       auto I = dyn_cast<CallInst>(Use.getUser());
       //todo error check
       if(I->getFunction()->getCallingConv() != llvm::CallingConv::SPIR_KERNEL)
-        report_fatal_error("ayyyy\n");
-      auto Arg = ConstantInt::get(Type::getInt32Ty(M.getContext()), Entry.second.second);
-      auto NewI = CallInst::Create(ReplaceFunc->getFunctionType(), ReplaceFunc, {Arg, getStateArg(I->getFunction())}, "ncpu_call", I);
+        report_fatal_error("SYCL Native CPU currently doesn't support unlined functions, try increasing the inlining threshold");
+      auto *Arg = ConstantInt::get(Type::getInt32Ty(M.getContext()), Entry.second.second);
+      auto *NewI = CallInst::Create(ReplaceFunc->getFunctionType(), ReplaceFunc, {Arg, getStateArg(I->getFunction())}, "ncpu_call", I);
       I->replaceAllUsesWith(NewI);
       ToRemove.push_back(I);
     }
@@ -321,6 +320,5 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
   for (auto &F : M) {
     fixCallingConv(&F);
   }
-  llvm::errs() << "[ptrdbg] module post: " << M << "\n";
   return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -233,7 +233,7 @@ static std::map<std::string, std::pair<std::string, unsigned int>>
         {"_Z21__spirv_WorkgroupId_yv", {"__dpcpp_nativecpu_get_wg_id", 1}},
         {"_Z21__spirv_WorkgroupId_zv", {"__dpcpp_nativecpu_get_wg_id", 2}}};
 
-Function *getReplaceFunc(Module &M, Type *T, StringRef Name) {
+Function *getReplaceFunc(Module &M, StringRef Name) {
   Function *F = M.getFunction(Name);
   assert(F && "Error retrieving replace function");
   return F;
@@ -286,7 +286,7 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
     auto *Glob = M.getFunction(Entry.first);
     if (!Glob)
       continue;
-    auto *ReplaceFunc = getReplaceFunc(M, StatePtrType, Entry.second.first);
+    auto *ReplaceFunc = getReplaceFunc(M, Entry.second.first);
     SmallVector<Instruction *> ToRemove;
     for (auto &Use : Glob->uses()) {
       auto I = dyn_cast<CallInst>(Use.getUser());
@@ -294,7 +294,7 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
         report_fatal_error("Unsupported Value in SYCL Native CPU\n");
       if (I->getFunction()->getCallingConv() != llvm::CallingConv::SPIR_KERNEL)
         report_fatal_error(
-            "SYCL Native CPU currently doesn't support unlined "
+            "SYCL Native CPU currently doesn't support non-inlined "
             "functions yet, try increasing the inlining threshold. Support for "
             "unlined functions is planned.");
       auto *Arg = ConstantInt::get(Type::getInt32Ty(M.getContext()),

--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -314,8 +314,10 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
       if (!I)
         report_fatal_error("Unsupported Value in SYCL Native CPU\n");
       if (I->getFunction()->getCallingConv() != llvm::CallingConv::SPIR_KERNEL)
-        report_fatal_error("SYCL Native CPU currently doesn't support unlined "
-                           "functions, try increasing the inlining threshold");
+        report_fatal_error(
+            "SYCL Native CPU currently doesn't support unlined "
+            "functions yet, try increasing the inlining threshold. Support for "
+            "unlined functions is planned.");
       auto *Arg = ConstantInt::get(Type::getInt32Ty(M.getContext()),
                                    Entry.second.second);
       auto *NewI = CallInst::Create(ReplaceFunc->getFunctionType(), ReplaceFunc,

--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -296,7 +296,7 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
         report_fatal_error(
             "SYCL Native CPU currently doesn't support non-inlined "
             "functions yet, try increasing the inlining threshold. Support for "
-            "unlined functions is planned.");
+            "non-inlined functions is planned.");
       auto *Arg = ConstantInt::get(Type::getInt32Ty(M.getContext()),
                                    Entry.second.second);
       auto *NewI = CallInst::Create(ReplaceFunc->getFunctionType(), ReplaceFunc,

--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -300,7 +300,8 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
     SmallVector<Instruction*> ToRemove;
     for (auto &Use : Glob->uses()) {
       auto I = dyn_cast<CallInst>(Use.getUser());
-      //todo error check
+      if(!I)
+        report_fatal_error("Unsupported Value in SYCL Native CPU\n");
       if(I->getFunction()->getCallingConv() != llvm::CallingConv::SPIR_KERNEL)
         report_fatal_error("SYCL Native CPU currently doesn't support unlined functions, try increasing the inlining threshold");
       auto *Arg = ConstantInt::get(Type::getInt32Ty(M.getContext()), Entry.second.second);

--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -244,27 +244,6 @@ Value *getStateArg(const Function *F) {
   return F->getArg(FT->getNumParams() - 1);
 }
 
-SmallVector<Function *> getFunctionsFromUse(Use &U) {
-  // This function returns a vector since an operator may be used by
-  // instructions in multiple functions
-  User *Usr = U.getUser();
-  if (auto *I = dyn_cast<Instruction>(Usr)) {
-    if (I->getParent())
-      return {I->getFunction()};
-  }
-  if (auto *Op = dyn_cast<Operator>(Usr)) {
-    SmallVector<Function *> Res;
-    for (auto &Use : Op->uses()) {
-      if (auto *I = dyn_cast<Instruction>(Use.getUser())) {
-        if (I->getParent())
-          Res.push_back(I->getFunction());
-      }
-    }
-    return Res;
-  }
-  return {};
-}
-
 } // namespace
 
 PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,

--- a/sycl/doc/design/SYCLNativeCPU.md
+++ b/sycl/doc/design/SYCLNativeCPU.md
@@ -173,3 +173,4 @@ The information produced by the device compiler is then employed to correctly lo
 * Performance optimizations
 * Support for multiple SYCL targets alongside native_cpu
 
+### Please note that Windows support is temporarily disabled due to some implementation details, it will be reinstantiated soon.

--- a/sycl/include/CL/__spirv/spirv_vars.hpp
+++ b/sycl/include/CL/__spirv/spirv_vars.hpp
@@ -17,7 +17,7 @@
 
 #define __SPIRV_VAR_QUALIFIERS extern "C" const
 
-#if defined(__NVPTX__) || defined(__AMDGCN__)
+#if defined(__NVPTX__) || defined(__AMDGCN__) || defined(__SYCL_NATIVE_CPU__)
 
 __DPCPP_SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_x();
 __DPCPP_SYCL_EXTERNAL size_t __spirv_GlobalInvocationId_y();

--- a/sycl/include/sycl/detail/native_cpu.hpp
+++ b/sycl/include/sycl/detail/native_cpu.hpp
@@ -26,13 +26,13 @@ struct NativeCPUArgDesc {
 } // namespace sycl
 
 struct __nativecpu_state {
-   size_t MGlobal_id[3];
-   size_t MGlobal_range[3];
-   size_t MWorkGroup_size[3];
-   size_t MWorkGroup_id[3];
-   size_t MLocal_id[3];
-   size_t MNumGroups[3];
-   size_t MGlobalOffset[3];
+  size_t MGlobal_id[3];
+  size_t MGlobal_range[3];
+  size_t MWorkGroup_size[3];
+  size_t MWorkGroup_id[3];
+  size_t MLocal_id[3];
+  size_t MNumGroups[3];
+  size_t MGlobalOffset[3];
   __nativecpu_state(size_t globalR0, size_t globalR1, size_t globalR2,
                     size_t localR0, size_t localR1, size_t localR2,
                     size_t globalO0, size_t globalO1, size_t globalO2)
@@ -72,45 +72,38 @@ struct __nativecpu_state {
   __attribute__((weak)) __attribute((alwaysinline))                            \
   [[intel::device_indirectly_callable]]
 
-extern "C" __SYCL_HC_ATTRS  size_t 
-__dpcpp_nativecpu_global_id(unsigned dim, __attribute((address_space(0)))
-                            __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_global_id(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobal_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS  size_t 
-__dpcpp_nativecpu_global_range(unsigned dim, __attribute((address_space(0)))
-                               __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_global_range(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobal_range[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS  size_t 
-__dpcpp_nativecpu_get_wg_size(unsigned dim, __attribute((address_space(0)))
-                              __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_wg_size(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MWorkGroup_size[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS  size_t 
-__dpcpp_nativecpu_get_wg_id(unsigned dim, __attribute((address_space(0)))
-                            __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_wg_id(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MWorkGroup_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t 
-__dpcpp_nativecpu_get_local_id(unsigned dim, __attribute((address_space(0)))
-                               __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_local_id(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MLocal_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS  size_t 
-__dpcpp_nativecpu_get_num_groups(unsigned dim, __attribute((address_space(0)))
-                                 __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_num_groups(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MNumGroups[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS  size_t 
-__dpcpp_nativecpu_get_global_offset(unsigned dim, __attribute((address_space(0)))
-                                    __nativecpu_state *s) {
+extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_global_offset(
+    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobalOffset[dim];
 }
 #undef __SYCL_HC_ATTRS

--- a/sycl/include/sycl/detail/native_cpu.hpp
+++ b/sycl/include/sycl/detail/native_cpu.hpp
@@ -26,13 +26,13 @@ struct NativeCPUArgDesc {
 } // namespace sycl
 
 struct __nativecpu_state {
-  alignas(16) size_t MGlobal_id[3];
-  alignas(16) size_t MGlobal_range[3];
-  alignas(16) size_t MWorkGroup_size[3];
-  alignas(16) size_t MWorkGroup_id[3];
-  alignas(16) size_t MLocal_id[3];
-  alignas(16) size_t MNumGroups[3];
-  alignas(16) size_t MGlobalOffset[3];
+   size_t MGlobal_id[3];
+   size_t MGlobal_range[3];
+   size_t MWorkGroup_size[3];
+   size_t MWorkGroup_id[3];
+   size_t MLocal_id[3];
+   size_t MNumGroups[3];
+   size_t MGlobalOffset[3];
   __nativecpu_state(size_t globalR0, size_t globalR1, size_t globalR2,
                     size_t localR0, size_t localR1, size_t localR2,
                     size_t globalO0, size_t globalO1, size_t globalO2)
@@ -72,46 +72,46 @@ struct __nativecpu_state {
   __attribute__((weak)) __attribute((alwaysinline))                            \
   [[intel::device_indirectly_callable]]
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_global_id(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS  size_t 
+__dpcpp_nativecpu_global_id(unsigned dim, __attribute((address_space(0)))
                             __nativecpu_state *s) {
-  return &(s->MGlobal_id[0]);
+  return s->MGlobal_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_global_range(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS  size_t 
+__dpcpp_nativecpu_global_range(unsigned dim, __attribute((address_space(0)))
                                __nativecpu_state *s) {
-  return &(s->MGlobal_range[0]);
+  return s->MGlobal_range[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_get_wg_size(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS  size_t 
+__dpcpp_nativecpu_get_wg_size(unsigned dim, __attribute((address_space(0)))
                               __nativecpu_state *s) {
-  return &(s->MWorkGroup_size[0]);
+  return s->MWorkGroup_size[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_get_wg_id(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS  size_t 
+__dpcpp_nativecpu_get_wg_id(unsigned dim, __attribute((address_space(0)))
                             __nativecpu_state *s) {
-  return &(s->MWorkGroup_id[0]);
+  return s->MWorkGroup_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_get_local_id(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS size_t 
+__dpcpp_nativecpu_get_local_id(unsigned dim, __attribute((address_space(0)))
                                __nativecpu_state *s) {
-  return &(s->MLocal_id[0]);
+  return s->MLocal_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_get_num_groups(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS  size_t 
+__dpcpp_nativecpu_get_num_groups(unsigned dim, __attribute((address_space(0)))
                                  __nativecpu_state *s) {
-  return &(s->MNumGroups[0]);
+  return s->MNumGroups[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS __attribute((address_space(0))) size_t *
-__dpcpp_nativecpu_get_global_offset(__attribute((address_space(0)))
+extern "C" __SYCL_HC_ATTRS  size_t 
+__dpcpp_nativecpu_get_global_offset(unsigned dim, __attribute((address_space(0)))
                                     __nativecpu_state *s) {
-  return &(s->MGlobalOffset[0]);
+  return s->MGlobalOffset[dim];
 }
 #undef __SYCL_HC_ATTRS
 #endif

--- a/sycl/include/sycl/detail/native_cpu.hpp
+++ b/sycl/include/sycl/detail/native_cpu.hpp
@@ -69,42 +69,43 @@ struct __nativecpu_state {
 };
 #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_HC_ATTRS                                                        \
-  __attribute__((weak)) __attribute((alwaysinline))                            \
+  extern "C" __attribute__((weak)) __attribute((always_inline))                \
   [[intel::device_indirectly_callable]]
+#define __NCPU_ATTRS extern "C" __SYCL_HC_ATTRS
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_global_id(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_global_id(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobal_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_global_range(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_global_range(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobal_range[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_wg_size(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_get_wg_size(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MWorkGroup_size[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_wg_id(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_get_wg_id(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MWorkGroup_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_local_id(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_get_local_id(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MLocal_id[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_num_groups(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_get_num_groups(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MNumGroups[dim];
 }
 
-extern "C" __SYCL_HC_ATTRS size_t __dpcpp_nativecpu_get_global_offset(
+ __NCPU_ATTRS size_t __dpcpp_nativecpu_get_global_offset(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobalOffset[dim];
 }
-#undef __SYCL_HC_ATTRS
+#undef __NCPU_ATTRS
 #endif

--- a/sycl/include/sycl/detail/native_cpu.hpp
+++ b/sycl/include/sycl/detail/native_cpu.hpp
@@ -73,37 +73,39 @@ struct __nativecpu_state {
   [[intel::device_indirectly_callable]]
 #define __NCPU_ATTRS extern "C" __SYCL_HC_ATTRS
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_global_id(
-    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
+__NCPU_ATTRS size_t __dpcpp_nativecpu_global_id(unsigned dim,
+                                                __attribute((address_space(0)))
+                                                __nativecpu_state *s) {
   return s->MGlobal_id[dim];
 }
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_global_range(
+__NCPU_ATTRS size_t __dpcpp_nativecpu_global_range(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobal_range[dim];
 }
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_get_wg_size(
+__NCPU_ATTRS size_t __dpcpp_nativecpu_get_wg_size(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MWorkGroup_size[dim];
 }
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_get_wg_id(
-    unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
+__NCPU_ATTRS size_t __dpcpp_nativecpu_get_wg_id(unsigned dim,
+                                                __attribute((address_space(0)))
+                                                __nativecpu_state *s) {
   return s->MWorkGroup_id[dim];
 }
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_get_local_id(
+__NCPU_ATTRS size_t __dpcpp_nativecpu_get_local_id(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MLocal_id[dim];
 }
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_get_num_groups(
+__NCPU_ATTRS size_t __dpcpp_nativecpu_get_num_groups(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MNumGroups[dim];
 }
 
- __NCPU_ATTRS size_t __dpcpp_nativecpu_get_global_offset(
+__NCPU_ATTRS size_t __dpcpp_nativecpu_get_global_offset(
     unsigned dim, __attribute((address_space(0))) __nativecpu_state *s) {
   return s->MGlobalOffset[dim];
 }

--- a/sycl/include/sycl/detail/native_cpu.hpp
+++ b/sycl/include/sycl/detail/native_cpu.hpp
@@ -26,13 +26,13 @@ struct NativeCPUArgDesc {
 } // namespace sycl
 
 struct __nativecpu_state {
-  size_t MGlobal_id[3];
-  size_t MGlobal_range[3];
-  size_t MWorkGroup_size[3];
-  size_t MWorkGroup_id[3];
-  size_t MLocal_id[3];
-  size_t MNumGroups[3];
-  size_t MGlobalOffset[3];
+  alignas(16) size_t MGlobal_id[3];
+  alignas(16) size_t MGlobal_range[3];
+  alignas(16) size_t MWorkGroup_size[3];
+  alignas(16) size_t MWorkGroup_id[3];
+  alignas(16) size_t MLocal_id[3];
+  alignas(16) size_t MNumGroups[3];
+  alignas(16) size_t MGlobalOffset[3];
   __nativecpu_state(size_t globalR0, size_t globalR1, size_t globalR2,
                     size_t localR0, size_t localR1, size_t localR2,
                     size_t globalO0, size_t globalO1, size_t globalO2)

--- a/sycl/test/check_device_code/native_cpu/native_cpu_builtins.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_builtins.cpp
@@ -1,4 +1,5 @@
-// Temporarily marking this as unsupported until mangling issues are fixed on windows
+// Temporarily marking this as unsupported until mangling issues are fixed on
+// windows
 // UNSUPPORTED: windows
 // RUN: %clangxx -fsycl-device-only  -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-opt -mllvm -inline-threshold=500 -S -emit-llvm  -o - %s | FileCheck %s
 

--- a/sycl/test/check_device_code/native_cpu/native_cpu_builtins.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_builtins.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only  -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-opt -S -emit-llvm  -o - %s | FileCheck %s
+// RUN: %clangxx -fsycl-device-only  -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-opt -mllvm -inline-threshold=500 -S -emit-llvm  -o - %s | FileCheck %s
 
 // check that we added the state struct as a function argument, and that we
 // inject the calls to our builtins. We disable index flipping for SYCL Native
@@ -16,7 +16,7 @@ int main() {
   deviceQueue.submit([&](sycl::handler &h) {
     h.parallel_for<Test1>(r, [=](sycl::id<1> id) { acc[id[0]] = 42; });
     // CHECK: @_ZTS5Test1.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr %2)
-    // CHECK: call{{.*}}__dpcpp_nativecpu_global_id(ptr %2)
+    // CHECK: call{{.*}}__dpcpp_nativecpu_global_id(i32 0, ptr %2)
   });
   sycl::nd_range<2> r2({1, 1}, {
                                    1,
@@ -25,15 +25,20 @@ int main() {
   deviceQueue.submit([&](sycl::handler &h) {
     h.parallel_for<Test2>(r2, [=](sycl::id<2> id) { acc[id[1]] = 42; });
     // CHECK: @_ZTS5Test2.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr %2)
-    // CHECK: call{{.*}}__dpcpp_nativecpu_global_id(ptr %2)
+    // CHECK: call{{.*}}__dpcpp_nativecpu_global_id(i32 1, ptr %2)
+    // CHECK: call{{.*}}__dpcpp_nativecpu_global_id(i32 0, ptr %2)
   });
   sycl::nd_range<3> r3({1, 1, 1}, {1, 1, 1});
   deviceQueue.submit([&](sycl::handler &h) {
     h.parallel_for<Test3>(
         r3, [=](sycl::item<3> item) { acc[item[2]] = item.get_range(0); });
     // CHECK: @_ZTS5Test3.NativeCPUKernel(ptr {{.*}}%0, ptr {{.*}}%1, ptr %2)
-    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_range(ptr %2)
-    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_id(ptr %2)
+    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_range(i32 2, ptr %2)
+    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_range(i32 1, ptr %2)
+    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_range(i32 0, ptr %2)
+    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_id(i32 2, ptr %2)
+    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_id(i32 1, ptr %2)
+    // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_global_id(i32 0, ptr %2)
   });
 
   const size_t dim = 2;
@@ -61,9 +66,9 @@ int main() {
       auto rangeZ = id.get_local_range(2);
       Accessor[groupX * rangeX + localX][groupY * rangeY + localY]
               [groupZ * rangeZ + localZ] = {rangeX, rangeY, rangeZ};
-      // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_get_local_id(ptr %{{[0-9]*}})
-      // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_get_wg_size(ptr %{{[0-9]*}})
-      // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_get_wg_id(ptr %{{[0-9]*}})
+      // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_get_local_id(i32 0, ptr %{{[0-9]*}})
+      // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_get_wg_size(i32 0, ptr %{{[0-9]*}})
+      // CHECK-DAG: call{{.*}}__dpcpp_nativecpu_get_wg_id(i32 0, ptr %{{[0-9]*}})
     });
   });
 }

--- a/sycl/test/check_device_code/native_cpu/native_cpu_builtins.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_builtins.cpp
@@ -1,3 +1,5 @@
+// Temporarily marking this as unsupported until mangling issues are fixed on windows
+// UNSUPPORTED: windows
 // RUN: %clangxx -fsycl-device-only  -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-opt -mllvm -inline-threshold=500 -S -emit-llvm  -o - %s | FileCheck %s
 
 // check that we added the state struct as a function argument, and that we

--- a/sycl/test/native_cpu/local-id-range.cpp
+++ b/sycl/test/native_cpu/local-id-range.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: native_cpu_be
-// RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
+// RUN: %clangxx -fsycl -fsycl-targets=native_cpu -mllvm -inline-threshold=500 %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 
 #include <clocale>


### PR DESCRIPTION
This PR makes it so we are using the function declarations for SPIRV work item builtins, the same as the NVIDIA and AMD targets. This greatly simplifies processing the builtins in our passes.
Due to differences in mangling, this PR temporary disable windows support for SYCL Native CPU, we will address this ASAP in a follow up PR.