### PR TITLE
[SYCL][COMPAT] Added id_query and launch headers

### DIFF
--- a/sycl/include/syclcompat/id_query.hpp
+++ b/sycl/include/syclcompat/id_query.hpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  id_query.hpp
+ *
+ *  Description:
+ *    id_query functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/nd_item.hpp>
+
+namespace syclcompat {
+
+using sycl::ext::oneapi::experimental::this_nd_item;
+
+inline void wg_barrier() { this_nd_item<3>().barrier(); }
+
+namespace local_id {
+inline size_t x() { return this_nd_item<3>().get_local_id(2); }
+inline size_t y() { return this_nd_item<3>().get_local_id(1); }
+inline size_t z() { return this_nd_item<3>().get_local_id(0); }
+} // namespace local_id
+
+namespace local_range {
+inline size_t x() { return this_nd_item<3>().get_local_range(2); }
+inline size_t y() { return this_nd_item<3>().get_local_range(1); }
+inline size_t z() { return this_nd_item<3>().get_local_range(0); }
+} // namespace local_range
+
+namespace work_group_id {
+inline size_t x() { return this_nd_item<3>().get_group(2); }
+inline size_t y() { return this_nd_item<3>().get_group(1); }
+inline size_t z() { return this_nd_item<3>().get_group(0); }
+} // namespace work_group_id
+
+namespace work_group_range {
+inline size_t x() { return this_nd_item<3>().get_group_range(2); }
+inline size_t y() { return this_nd_item<3>().get_group_range(1); }
+inline size_t z() { return this_nd_item<3>().get_group_range(0); }
+} // namespace work_group_range
+
+namespace global_range {
+inline size_t x() { return this_nd_item<3>().get_global_range(2); }
+inline size_t y() { return this_nd_item<3>().get_global_range(1); }
+inline size_t z() { return this_nd_item<3>().get_global_range(0); }
+} // namespace global_range
+
+namespace global_id {
+inline size_t x() { return this_nd_item<3>().get_global_id(2); }
+inline size_t y() { return this_nd_item<3>().get_global_id(1); }
+inline size_t z() { return this_nd_item<3>().get_global_id(0); }
+} // namespace global_id
+
+} // namespace syclcompat

--- a/sycl/include/syclcompat/launch.hpp
+++ b/sycl/include/syclcompat/launch.hpp
@@ -1,0 +1,222 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  launch.hpp
+ *
+ *  Description:
+ *    launch functionality for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/accessor.hpp>
+#include <sycl/event.hpp>
+#include <sycl/nd_range.hpp>
+#include <sycl/queue.hpp>
+#include <sycl/range.hpp>
+#include <sycl/reduction.hpp>
+
+#include <syclcompat/device.hpp>
+#include <syclcompat/dims.hpp>
+
+namespace syclcompat {
+
+namespace detail {
+
+template <typename R, typename... Types>
+constexpr size_t getArgumentCount(R (*f)(Types...)) {
+  return sizeof...(Types);
+}
+
+template <int Dim>
+sycl::nd_range<3> transform_nd_range(const sycl::nd_range<Dim> &range) {
+  sycl::range<Dim> global_range = range.get_global_range();
+  sycl::range<Dim> local_range = range.get_local_range();
+  if constexpr (Dim == 3) {
+    return range;
+  } else if constexpr (Dim == 2) {
+    return sycl::nd_range<3>{{1, global_range[0], global_range[1]},
+                             {1, local_range[0], local_range[1]}};
+  }
+  return sycl::nd_range<3>{{1, 1, global_range[0]}, {1, 1, local_range[0]}};
+}
+
+template <auto F, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const sycl::nd_range<3> &range, sycl::queue q, Args... args) {
+  static_assert(detail::getArgumentCount(F) == sizeof...(args),
+                "Wrong number of arguments to SYCL kernel");
+  static_assert(
+      std::is_same<std::invoke_result_t<decltype(F), Args...>, void>::value,
+      "SYCL kernels should return void");
+
+  return q.parallel_for(range, [=](sycl::nd_item<3>) { F(args...); });
+}
+
+template <auto F, typename... Args>
+sycl::event launch(const sycl::nd_range<3> &range, size_t mem_size,
+                   sycl::queue q, Args... args) {
+  static_assert(detail::getArgumentCount(F) == sizeof...(args) + 1,
+                "Wrong number of arguments to SYCL kernel");
+
+  using F_t = decltype(F);
+  using f_return_t = typename std::invoke_result_t<F_t, Args..., char *>;
+  static_assert(std::is_same<f_return_t, void>::value,
+                "SYCL kernels should return void");
+
+  return q.submit([&](sycl::handler &cgh) {
+    auto local_acc = sycl::local_accessor<char, 1>(mem_size, cgh);
+    cgh.parallel_for(range, [=](sycl::nd_item<3>) {
+      auto local_mem = local_acc.get_pointer();
+      F(args..., local_mem);
+    });
+  });
+}
+
+} // namespace detail
+
+template <int Dim>
+sycl::nd_range<Dim> compute_nd_range(sycl::range<Dim> global_size_in,
+                                     sycl::range<Dim> work_group_size) {
+
+  if (global_size_in.size() == 0 || work_group_size.size() == 0) {
+    throw std::invalid_argument("Global or local size is zero!");
+  }
+  for (size_t i = 0; i < Dim; ++i) {
+    if (global_size_in[i] < work_group_size[i])
+      throw std::invalid_argument("Work group size larger than global size");
+  }
+
+  auto global_size =
+      ((global_size_in + work_group_size - 1) / work_group_size) *
+      work_group_size;
+  return {global_size, work_group_size};
+}
+
+inline sycl::nd_range<1> compute_nd_range(int global_size_in,
+                                          int work_group_size) {
+  return compute_nd_range<1>(global_size_in, work_group_size);
+}
+
+template <auto F, int Dim, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const sycl::nd_range<Dim> &range, sycl::queue q, Args... args) {
+  return detail::launch<F>(detail::transform_nd_range<Dim>(range), q, args...);
+}
+
+template <auto F, int Dim, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const sycl::nd_range<Dim> &range, Args... args) {
+  return launch<F>(range, get_default_queue(), args...);
+}
+
+// Alternative launch through dim3 objects
+template <auto F, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const dim3 &grid, const dim3 &threads, sycl::queue q, Args... args) {
+  return launch<F>(sycl::nd_range<3>{grid * threads, threads}, q, args...);
+}
+
+template <auto F, typename... Args>
+std::enable_if_t<std::is_invocable_v<decltype(F), Args...>, sycl::event>
+launch(const dim3 &grid, const dim3 &threads, Args... args) {
+  return launch<F>(grid, threads, get_default_queue(), args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device specified by the given nd_range and SYCL queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param range Nd_range specifying the work group and global sizes for the
+/// kernel.
+/// @param q The SYCL queue on which to execute the kernel.
+/// @param mem_size The size, in number of bytes, of the local
+/// memory to be allocated for kernel.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, int Dim, typename... Args>
+sycl::event launch(const sycl::nd_range<Dim> &range, size_t mem_size,
+                   sycl::queue q, Args... args) {
+  return detail::launch<F>(detail::transform_nd_range<Dim>(range), mem_size, q,
+                           args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device specified by the given nd_range using theSYCL default queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param range Nd_range specifying the work group and global sizes for the
+/// kernel.
+/// @param mem_size The size, in number of bytes, of the local
+/// memory to be allocated for kernel.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, int Dim, typename... Args>
+sycl::event launch(const sycl::nd_range<Dim> &range, size_t mem_size,
+                   Args... args) {
+  return launch<F>(range, mem_size, get_default_queue(), args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device with a user-specified grid and block dimensions following the
+/// standard of other programming models using a user-defined SYCL queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param grid Grid dimensions represented with an (x, y, z) iteration space.
+/// @param threads Block dimensions represented with an (x, y, z) iteration
+/// space.
+/// @param mem_size The size, in number of bytes, of the local
+/// memory to be allocated for kernel.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, typename... Args>
+sycl::event launch(const dim3 &grid, const dim3 &threads, size_t mem_size,
+                   sycl::queue q, Args... args) {
+  return launch<F>(sycl::nd_range<3>{grid * threads, threads}, mem_size, q,
+                   args...);
+}
+
+/// Launches a kernel with the templated F param and arguments on a
+/// device with a user-specified grid and block dimensions following the
+/// standard of other programming models using the default SYCL queue.
+/// @tparam F SYCL kernel to be executed, expects signature F(T* local_mem,
+/// Args... args).
+/// @tparam Dim nd_range dimension number.
+/// @tparam Args Types of the arguments to be passed to the kernel.
+/// @param grid Grid dimensions represented with an (x, y, z) iteration space.
+/// @param threads Block dimensions represented with an (x, y, z) iteration
+/// space.
+/// @param mem_size The size, in number of bytes, of the
+/// local memory to be allocated.
+/// @param args The arguments to be passed to the kernel.
+/// @return A SYCL event object that can be used to synchronize with the
+/// kernel's execution.
+template <auto F, typename... Args>
+sycl::event launch(const dim3 &grid, const dim3 &threads, size_t mem_size,
+                   Args... args) {
+  return launch<F>(grid, threads, mem_size, get_default_queue(), args...);
+}
+
+} // namespace syclcompat

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -42,6 +42,7 @@
 #include <utility>
 
 #include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/group_local_memory.hpp>
 #include <sycl/usm.hpp>
 
 #include <syclcompat/device.hpp>
@@ -56,6 +57,14 @@
 #endif
 
 namespace syclcompat {
+
+template <typename AllocT> auto *local_mem() {
+  sycl::multi_ptr<AllocT, sycl::access::address_space::local_space>
+      As_multi_ptr = sycl::ext::oneapi::group_local_memory<AllocT>(
+          sycl::ext::oneapi::experimental::this_nd_item<3>().get_group());
+  auto *As = *As_multi_ptr;
+  return As;
+}
 
 namespace detail {
 enum memcpy_direction {

--- a/sycl/include/syclcompat/syclcompat.hpp
+++ b/sycl/include/syclcompat/syclcompat.hpp
@@ -25,7 +25,7 @@
 #include <syclcompat/defs.hpp>
 #include <syclcompat/device.hpp>
 #include <syclcompat/dims.hpp>
-#include <syclcompat/kernel.hpp>
-#include <syclcompat/memory.hpp>
 #include <syclcompat/id_query.hpp>
+#include <syclcompat/kernel.hpp>
 #include <syclcompat/launch.hpp>
+#include <syclcompat/memory.hpp>

--- a/sycl/include/syclcompat/syclcompat.hpp
+++ b/sycl/include/syclcompat/syclcompat.hpp
@@ -27,3 +27,5 @@
 #include <syclcompat/dims.hpp>
 #include <syclcompat/kernel.hpp>
 #include <syclcompat/memory.hpp>
+#include <syclcompat/id_query.hpp>
+#include <syclcompat/launch.hpp>

--- a/sycl/test-e2e/syclcompat/common.hpp
+++ b/sycl/test-e2e/syclcompat/common.hpp
@@ -22,6 +22,9 @@
 
 #pragma once
 
+#include <sycl/half_type.hpp>
+#include <tuple>
+
 // Typed call helper
 // Iterates over all types and calls Functor f for each of them
 template <typename tuple, typename Functor>
@@ -34,3 +37,7 @@ void instantiate_all_types(Functor &&f) {
 
 #define INSTANTIATE_ALL_TYPES(tuple, f)                                        \
   instantiate_all_types<tuple>([]<typename T>() { f<T>(); });
+
+using value_type_list =
+    std::tuple<int, unsigned int, short, unsigned short, long, unsigned long,
+               long long, unsigned long long, float, double, sycl::half>;

--- a/sycl/test-e2e/syclcompat/id_query/id_query.cpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query.cpp
@@ -1,0 +1,131 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  id_query.cpp
+ *
+ *  Description:
+ *    global_id query tests
+ **************************************************************************/
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <algorithm>
+#include <numeric>
+
+#include <syclcompat/device.hpp>
+#include <syclcompat/launch.hpp>
+
+#include "id_query_fixt.hpp"
+
+void global_id_x_query(int *data) {
+  data[syclcompat::global_id::x()] = syclcompat::global_id::x();
+}
+void global_id_y_query(int *data) {
+  data[syclcompat::global_id::y()] = syclcompat::global_id::y();
+}
+void global_id_z_query(int *data) {
+  data[syclcompat::global_id::z()] = syclcompat::global_id::z();
+}
+
+void global_id_query() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  auto checker = [](std::vector<int> input) {
+    std::vector<int> expected(input.size());
+    std::iota(expected.begin(), expected.end(), 0);
+    assert(std::equal(expected.begin(), expected.end(), input.begin()));
+  };
+  // Check we can query x, y, z components of global_id
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1}).launch_dim3(checker);
+  QueryLauncher<global_id_y_query>({1, 4, 1}, {1, 32, 1}).launch_dim3(checker);
+  QueryLauncher<global_id_z_query>({1, 1, 4}, {1, 1, 32}).launch_dim3(checker);
+
+  // Check that we can query x component, irrespective of the kernel dimension
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1})
+      .launch_ndrange<3>(checker);
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1})
+      .launch_ndrange<2>(checker);
+  QueryLauncher<global_id_x_query>({4, 1, 1}, {32, 1, 1})
+      .launch_ndrange<1>(checker);
+
+  // Check we can query y component for 2D kernel
+  QueryLauncher<global_id_y_query>({1, 4, 1}, {1, 32, 1})
+      .launch_ndrange<2>(checker);
+}
+
+void range_x_query(int *data) {
+  data[syclcompat::global_id::x()] = syclcompat::global_range::x() *
+                                     syclcompat::work_group_range::x() *
+                                     syclcompat::local_range::x();
+}
+
+void ranges_query() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  // global_range::x() * work_group_range::x() * local_range::x();
+  int target = grid.x * threads.x * grid.x * threads.x;
+
+  auto checker = [&](std::vector<int> input) {
+    assert(std::all_of(input.begin(), input.end(),
+                       [=](int a) { return a == target; }));
+  };
+  QueryLauncher<range_x_query>(grid, threads).launch_dim3(checker);
+}
+
+void wgroup_id_x_query(int *data) {
+  data[syclcompat::global_id::x()] = syclcompat::work_group_id::x();
+}
+void local_id_x_query(int *data) {
+  data[syclcompat::global_id::x()] = syclcompat::local_id::x();
+}
+
+void ids_query() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  auto wgroup_checker = [&](std::vector<int> input) {
+    for (int i = 0; i < input.size(); ++i) {
+      if (input[i] != i / threads.x)
+        assert(false); // FAIL();
+    }
+  };
+  QueryLauncher<wgroup_id_x_query>(grid, threads).launch_dim3(wgroup_checker);
+
+  auto local_checker = [&](std::vector<int> input) {
+    for (int i = 0; i < input.size(); ++i) {
+      if (input[i] != i % threads.x)
+        assert(false); // FAIL();
+    }
+  };
+  QueryLauncher<local_id_x_query>(grid, threads).launch_dim3(local_checker);
+}
+
+int main() {
+  global_id_query();
+  ranges_query();
+  ids_query();
+
+  return 0;
+}

--- a/sycl/test-e2e/syclcompat/id_query/id_query.cpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query.cpp
@@ -107,16 +107,14 @@ void test_ids_query() {
 
   auto wgroup_checker = [&](std::vector<int> input) {
     for (int i = 0; i < input.size(); ++i) {
-      if (input[i] != i / threads.x)
-        assert(false); // FAIL();
+      assert(input[i] == i / threads.x);
     }
   };
   QueryLauncher<wgroup_id_x_query>(grid, threads).launch_dim3(wgroup_checker);
 
   auto local_checker = [&](std::vector<int> input) {
     for (int i = 0; i < input.size(); ++i) {
-      if (input[i] != i % threads.x)
-        assert(false); // FAIL();
+      assert(input[i] == i % threads.x);
     }
   };
   QueryLauncher<local_id_x_query>(grid, threads).launch_dim3(local_checker);

--- a/sycl/test-e2e/syclcompat/id_query/id_query.cpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query.cpp
@@ -41,7 +41,7 @@ void global_id_z_query(int *data) {
   data[syclcompat::global_id::z()] = syclcompat::global_id::z();
 }
 
-void global_id_query() {
+void test_global_id_query() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   constexpr syclcompat::dim3 grid{4};
@@ -76,7 +76,7 @@ void range_x_query(int *data) {
                                      syclcompat::local_range::x();
 }
 
-void ranges_query() {
+void test_ranges_query() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   constexpr syclcompat::dim3 grid{4};
@@ -99,7 +99,7 @@ void local_id_x_query(int *data) {
   data[syclcompat::global_id::x()] = syclcompat::local_id::x();
 }
 
-void ids_query() {
+void test_ids_query() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   constexpr syclcompat::dim3 grid{4};
@@ -123,9 +123,9 @@ void ids_query() {
 }
 
 int main() {
-  global_id_query();
-  ranges_query();
-  ids_query();
+  test_global_id_query();
+  test_ranges_query();
+  test_ids_query();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/id_query/id_query_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query_fixt.hpp
@@ -1,0 +1,61 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat
+ *
+ *  id_query_fixt.hpp
+ *
+ *  Description:
+ *     Fixtures and helpers for to tests the id_query functionality
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include <syclcompat.hpp>
+
+// Class to launch a kernel and run a lambda on output data
+template <auto F> class QueryLauncher {
+protected:
+  syclcompat::dim3 grid_;
+  syclcompat::dim3 threads_;
+  size_t size_;
+  int *data_;
+  std::vector<int> host_data_;
+  using CheckLambda = std::function<void(std::vector<int>)>;
+
+public:
+  QueryLauncher(syclcompat::dim3 grid, syclcompat::dim3 threads)
+      : grid_{grid}, threads_{threads}, size_{grid_.size() * threads_.size()},
+        host_data_(size_) {
+    data_ = (int *)syclcompat::malloc(size_ * sizeof(int));
+    syclcompat::memset(data_, 0, size_ * sizeof(int));
+  };
+  ~QueryLauncher() { syclcompat::free(data_); }
+  template <typename... Args>
+  void launch_dim3(CheckLambda checker, Args... args) {
+    syclcompat::launch<F>(grid_, threads_, data_, args...);
+    syclcompat::memcpy(host_data_.data(), data_, size_ * sizeof(int));
+    syclcompat::wait();
+    checker(host_data_);
+  }
+  template <int Dim, typename... Args>
+  void launch_ndrange(CheckLambda checker, Args... args) {
+    sycl::nd_range<Dim> range = {grid_ * threads_, grid_};
+    syclcompat::launch<F>(range, data_, args...);
+    syclcompat::memcpy(host_data_.data(), data_, size_ * sizeof(int));
+    syclcompat::wait();
+    checker(host_data_);
+  }
+};

--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -43,7 +43,7 @@ inline void dynamic_local_mem_basicdt_kernel(T value, char *local_mem){};
 
 template <typename T>
 void dynamic_local_mem_typed_kernel(T *data, char *local_mem) {
-  constexpr size_t memsize = LaunchTest1WithArgs<T>::LOCAL_MEM_SIZE;
+  constexpr size_t memsize = LaunchTestWithArgs<T>::LOCAL_MEM_SIZE;
   constexpr size_t num_elements = memsize / sizeof(T);
   T *typed_local_mem = reinterpret_cast<T *>(local_mem);
 
@@ -78,7 +78,7 @@ void compute_nd_range_3d(RangeParams<Dim> range_param, std::string test_name) {
   }
 }
 
-void launch_compute_nd_range_3d() {
+void test_launch_compute_nd_range_3d() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   compute_nd_range_3d(RangeParams<3>{{11, 1, 1}, {2, 1, 1}, {12, 1, 1}, true},
@@ -101,9 +101,9 @@ void launch_compute_nd_range_3d() {
                       "local > global 3");
 }
 
-void no_arg_launch() {
+void test_no_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
-  LaunchTest1 lt;
+  LaunchTest lt;
 
   syclcompat::launch<empty_kernel>(lt.range_1_);
   syclcompat::launch<empty_kernel>(lt.range_2_);
@@ -116,9 +116,9 @@ void no_arg_launch() {
   syclcompat::launch<empty_kernel>(lt.grid_, lt.thread_, lt.q_);
 }
 
-void one_arg_launch() {
+void test_one_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
-  LaunchTest1 lt;
+  LaunchTest lt;
 
   int my_int;
 
@@ -133,9 +133,9 @@ void one_arg_launch() {
   syclcompat::launch<int_kernel>(lt.grid_, lt.thread_, lt.q_, my_int);
 }
 
-void ptr_arg_launch() {
+void test_ptr_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
-  LaunchTest1 lt;
+  LaunchTest lt;
 
   int *int_ptr;
 
@@ -150,9 +150,9 @@ void ptr_arg_launch() {
   syclcompat::launch<int_ptr_kernel>(lt.grid_, lt.thread_, lt.q_, int_ptr);
 }
 
-void dynamic_mem_no_arg_launch() {
+void test_dynamic_mem_no_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
-  LaunchTest1 lt;
+  LaunchTest lt;
 
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_1_, 1);
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_2_, 1);
@@ -160,9 +160,9 @@ void dynamic_mem_no_arg_launch() {
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_, 1);
 }
 
-void dynamic_mem_no_arg_launch_q() {
+void test_dynamic_mem_no_arg_launch_q() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
-  LaunchTest1 lt;
+  LaunchTest lt;
 
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_1_, 1, lt.q_);
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_2_, 1, lt.q_);
@@ -171,11 +171,11 @@ void dynamic_mem_no_arg_launch_q() {
                                                      lt.q_);
 }
 
-template <typename T> void basic_dt_launch() {
+template <typename T> void test_basic_dt_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   T d_a = T(1);
-  LaunchTest1WithArgs<T> ltt;
+  LaunchTestWithArgs<T> ltt;
 
   if (ltt.skip) // Unsupported aspect
     return;
@@ -190,11 +190,11 @@ template <typename T> void basic_dt_launch() {
       ltt.grid_, ltt.thread_, ltt.memsize_, d_a);
 }
 
-template <typename T> void basic_dt_launch_q() {
+template <typename T> void test_basic_dt_launch_q() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   T d_a = T(1);
-  LaunchTest1WithArgs<T> ltt;
+  LaunchTestWithArgs<T> ltt;
 
   if (ltt.skip) // Unsupported aspect
     return;
@@ -209,10 +209,10 @@ template <typename T> void basic_dt_launch_q() {
       ltt.grid_, ltt.thread_, ltt.memsize_, ltt.in_order_q_, d_a);
 }
 
-template <typename T> void arg_launch() {
+template <typename T> void test_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  LaunchTest1WithArgs<T> ltt;
+  LaunchTestWithArgs<T> ltt;
   if (ltt.skip) // Unsupported aspect
     return;
 
@@ -230,10 +230,10 @@ template <typename T> void arg_launch() {
   syclcompat::free((void *)d_a);
 }
 
-template <typename T> void arg_launch_q() {
+template <typename T> void test_arg_launch_q() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  LaunchTest1WithArgs<T> ltt;
+  LaunchTestWithArgs<T> ltt;
   if (ltt.skip) // Unsupported aspect
     return;
 
@@ -251,10 +251,10 @@ template <typename T> void arg_launch_q() {
   syclcompat::free((void *)d_a, ltt.in_order_q_);
 }
 
-template <typename T> void local_mem_usage() {
+template <typename T> void test_local_mem_usage() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  LaunchTest1WithArgs<T> ltt;
+  LaunchTestWithArgs<T> ltt;
   if (ltt.skip) // Unsupported aspect
     return;
 
@@ -276,10 +276,10 @@ template <typename T> void local_mem_usage() {
   syclcompat::free(h_a);
 }
 
-template <typename T> void local_mem_usage_q() {
+template <typename T> void test_local_mem_usage_q() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  LaunchTest1WithArgs<T> ltt;
+  LaunchTestWithArgs<T> ltt;
   if (ltt.skip) // Unsupported aspect
     return;
 
@@ -303,20 +303,20 @@ template <typename T> void local_mem_usage_q() {
   syclcompat::free(h_a);
 }
 
-template <typename T> void memsize_no_arg_launch() {
+template <typename T> void test_memsize_no_arg_launch() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  LaunchTest1 lt;
+  LaunchTest lt;
   T memsize = static_cast<T>(8);
 
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_,
                                                      memsize);
 }
 
-template <typename T> void memsize_no_arg_launch_q() {
+template <typename T> void test_memsize_no_arg_launch_q() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  LaunchTest1 lt;
+  LaunchTest lt;
   T memsize = static_cast<T>(8);
 
   syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_,
@@ -324,30 +324,30 @@ template <typename T> void memsize_no_arg_launch_q() {
 }
 
 int main() {
-  launch_compute_nd_range_3d();
-  no_arg_launch();
-  one_arg_launch();
-  ptr_arg_launch();
+  test_launch_compute_nd_range_3d();
+  test_no_arg_launch();
+  test_one_arg_launch();
+  test_ptr_arg_launch();
 
-  dynamic_mem_no_arg_launch();
-  dynamic_mem_no_arg_launch_q();
+  test_dynamic_mem_no_arg_launch();
+  test_dynamic_mem_no_arg_launch_q();
 
   using value_type_list_t =
       std::tuple<int, unsigned int, short, unsigned short, long, unsigned long,
                  long long, unsigned long long, float, double, sycl::half>;
 
-  INSTANTIATE_ALL_TYPES(value_type_list_t, basic_dt_launch);
-  INSTANTIATE_ALL_TYPES(value_type_list_t, basic_dt_launch_q);
-  INSTANTIATE_ALL_TYPES(value_type_list_t, arg_launch);
-  INSTANTIATE_ALL_TYPES(value_type_list_t, arg_launch_q);
-  INSTANTIATE_ALL_TYPES(value_type_list_t, local_mem_usage);
-  INSTANTIATE_ALL_TYPES(value_type_list_t, local_mem_usage_q);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, test_basic_dt_launch);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, test_basic_dt_launch_q);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, test_arg_launch);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, test_arg_launch_q);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, test_local_mem_usage);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, test_local_mem_usage_q);
 
   using memsize_type_list =
       std::tuple<int, unsigned int, short, unsigned short, long, unsigned long>;
 
-  INSTANTIATE_ALL_TYPES(memsize_type_list, memsize_no_arg_launch);
-  INSTANTIATE_ALL_TYPES(memsize_type_list, memsize_no_arg_launch_q);
+  INSTANTIATE_ALL_TYPES(memsize_type_list, test_memsize_no_arg_launch);
+  INSTANTIATE_ALL_TYPES(memsize_type_list, test_memsize_no_arg_launch_q);
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -1,0 +1,353 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  launch.cpp
+ *
+ *  Description:
+ *     launch<F> and launch<F> with dinamyc local memory tests
+ **************************************************************************/
+
+// RUN: %clangxx -std=c++20 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+#include <syclcompat/device.hpp>
+#include <syclcompat/launch.hpp>
+
+#include <type_traits>
+
+#include "../common.hpp"
+#include "launch_fixt.hpp"
+
+// Dummy kernel functions for testing
+inline void empty_kernel(){};
+inline void int_kernel(int a){};
+inline void int_ptr_kernel(int *a){};
+inline void dynamic_local_mem_empty_kernel(char *a){};
+
+template <typename T>
+inline void dynamic_local_mem_basicdt_kernel(T value, char *local_mem){};
+
+template <typename T>
+void dynamic_local_mem_typed_kernel(T *data, char *local_mem) {
+  constexpr size_t memsize = LaunchTest1WithArgs<T>::LOCAL_MEM_SIZE;
+  constexpr size_t num_elements = memsize / sizeof(T);
+  T *typed_local_mem = reinterpret_cast<T *>(local_mem);
+
+  const int id = sycl::ext::oneapi::experimental::this_item<1>();
+  if (id < num_elements) {
+    typed_local_mem[id] = static_cast<T>(id);
+  }
+  sycl::group_barrier(sycl::ext::oneapi::experimental::this_group<1>());
+  if (id < num_elements) {
+    data[id] = typed_local_mem[num_elements - id - 1];
+  }
+};
+
+template <int Dim>
+void compute_nd_range_3d(RangeParams<Dim> range_param, std::string test_name) {
+  std::cout << __PRETTY_FUNCTION__ << " " << test_name << std::endl;
+
+  try {
+    auto g_out = syclcompat::compute_nd_range(range_param.global_range_in_,
+                                              range_param.local_range_in_);
+    sycl::nd_range<Dim> x_out = {range_param.expect_global_range_out_,
+                                 range_param.local_range_in_};
+    if (range_param.shouldPass_) {
+      assert(g_out == x_out);
+    } else {
+      assert(false); // Trigger failure, expected std::invalid_argument
+    }
+  } catch (std::invalid_argument const &err) {
+    if (range_param.shouldPass_) {
+      assert(false); // Trigger failure, unexpected std::invalid_argument
+    }
+  }
+}
+
+void launch_compute_nd_range_3d() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  compute_nd_range_3d(RangeParams<3>{{11, 1, 1}, {2, 1, 1}, {12, 1, 1}, true},
+                      "Round up");
+  compute_nd_range_3d(
+      RangeParams<3>{{320, 1, 1}, {32, 1, 1}, {320, 1, 1}, true}, "Even size");
+  compute_nd_range_3d(
+      RangeParams<3>{{32, 193, 1}, {16, 32, 1}, {32, 224, 1}, true},
+      "Round up 2");
+  compute_nd_range_3d(RangeParams<3>{{10, 0, 0}, {1, 0, 0}, {10, 0, 0}, false},
+                      "zero size");
+  compute_nd_range_3d(
+      RangeParams<3>{{0, 10, 10}, {0, 10, 10}, {0, 10, 10}, false},
+      "zero size 2");
+  compute_nd_range_3d(RangeParams<3>{{2, 1, 1}, {32, 1, 1}, {32, 1, 1}, false},
+                      "local > global");
+  compute_nd_range_3d(RangeParams<3>{{1, 2, 1}, {1, 32, 1}, {1, 32, 1}, false},
+                      "local > global 2");
+  compute_nd_range_3d(RangeParams<3>{{1, 1, 2}, {1, 1, 32}, {1, 1, 32}, false},
+                      "local > global 3");
+}
+
+void no_arg_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  LaunchTest1 lt;
+
+  syclcompat::launch<empty_kernel>(lt.range_1_);
+  syclcompat::launch<empty_kernel>(lt.range_2_);
+  syclcompat::launch<empty_kernel>(lt.range_3_);
+  syclcompat::launch<empty_kernel>(lt.grid_, lt.thread_);
+
+  syclcompat::launch<empty_kernel>(lt.range_1_, lt.q_);
+  syclcompat::launch<empty_kernel>(lt.range_2_, lt.q_);
+  syclcompat::launch<empty_kernel>(lt.range_3_, lt.q_);
+  syclcompat::launch<empty_kernel>(lt.grid_, lt.thread_, lt.q_);
+}
+
+void one_arg_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  LaunchTest1 lt;
+
+  int my_int;
+
+  syclcompat::launch<int_kernel>(lt.range_1_, my_int);
+  syclcompat::launch<int_kernel>(lt.range_2_, my_int);
+  syclcompat::launch<int_kernel>(lt.range_3_, my_int);
+  syclcompat::launch<int_kernel>(lt.grid_, lt.thread_, my_int);
+
+  syclcompat::launch<int_kernel>(lt.range_1_, lt.q_, my_int);
+  syclcompat::launch<int_kernel>(lt.range_2_, lt.q_, my_int);
+  syclcompat::launch<int_kernel>(lt.range_3_, lt.q_, my_int);
+  syclcompat::launch<int_kernel>(lt.grid_, lt.thread_, lt.q_, my_int);
+}
+
+void ptr_arg_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  LaunchTest1 lt;
+
+  int *int_ptr;
+
+  syclcompat::launch<int_ptr_kernel>(lt.range_1_, int_ptr);
+  syclcompat::launch<int_ptr_kernel>(lt.range_2_, int_ptr);
+  syclcompat::launch<int_ptr_kernel>(lt.range_3_, int_ptr);
+  syclcompat::launch<int_ptr_kernel>(lt.grid_, lt.thread_, int_ptr);
+
+  syclcompat::launch<int_ptr_kernel>(lt.range_1_, lt.q_, int_ptr);
+  syclcompat::launch<int_ptr_kernel>(lt.range_2_, lt.q_, int_ptr);
+  syclcompat::launch<int_ptr_kernel>(lt.range_3_, lt.q_, int_ptr);
+  syclcompat::launch<int_ptr_kernel>(lt.grid_, lt.thread_, lt.q_, int_ptr);
+}
+
+void dynamic_mem_no_arg_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  LaunchTest1 lt;
+
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_1_, 1);
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_2_, 1);
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_3_, 1);
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_, 1);
+}
+
+void dynamic_mem_no_arg_launch_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  LaunchTest1 lt;
+
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_1_, 1, lt.q_);
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_2_, 1, lt.q_);
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.range_3_, 1, lt.q_);
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_, 1,
+                                                     lt.q_);
+}
+
+template <typename T> void basic_dt_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  T d_a = T(1);
+  LaunchTest1WithArgs<T> ltt;
+
+  if (ltt.skip) // Unsupported aspect
+    return;
+
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(ltt.range_1_,
+                                                          ltt.memsize_, d_a);
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(ltt.range_2_,
+                                                          ltt.memsize_, d_a);
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(ltt.range_3_,
+                                                          ltt.memsize_, d_a);
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(
+      ltt.grid_, ltt.thread_, ltt.memsize_, d_a);
+}
+
+template <typename T> void basic_dt_launch_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  T d_a = T(1);
+  LaunchTest1WithArgs<T> ltt;
+
+  if (ltt.skip) // Unsupported aspect
+    return;
+
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(
+      ltt.range_1_, ltt.memsize_, ltt.in_order_q_, d_a);
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(
+      ltt.range_2_, ltt.memsize_, ltt.in_order_q_, d_a);
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(
+      ltt.range_3_, ltt.memsize_, ltt.in_order_q_, d_a);
+  syclcompat::launch<dynamic_local_mem_basicdt_kernel<T>>(
+      ltt.grid_, ltt.thread_, ltt.memsize_, ltt.in_order_q_, d_a);
+}
+
+template <typename T> void arg_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  LaunchTest1WithArgs<T> ltt;
+  if (ltt.skip) // Unsupported aspect
+    return;
+
+  T *d_a = (T *)syclcompat::malloc<T>(ltt.memsize_);
+
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(ltt.range_1_,
+                                                        ltt.memsize_, d_a);
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(ltt.range_2_,
+                                                        ltt.memsize_, d_a);
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(ltt.range_3_,
+                                                        ltt.memsize_, d_a);
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(ltt.grid_, ltt.thread_,
+                                                        ltt.memsize_, d_a);
+
+  syclcompat::free((void *)d_a);
+}
+
+template <typename T> void arg_launch_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  LaunchTest1WithArgs<T> ltt;
+  if (ltt.skip) // Unsupported aspect
+    return;
+
+  T *d_a = (T *)syclcompat::malloc<T>(ltt.memsize_, ltt.in_order_q_);
+
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(
+      ltt.range_1_, ltt.memsize_, ltt.in_order_q_, d_a);
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(
+      ltt.range_2_, ltt.memsize_, ltt.in_order_q_, d_a);
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(
+      ltt.range_3_, ltt.memsize_, ltt.in_order_q_, d_a);
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(
+      ltt.grid_, ltt.thread_, ltt.memsize_, ltt.in_order_q_, d_a);
+
+  syclcompat::free((void *)d_a, ltt.in_order_q_);
+}
+
+template <typename T> void local_mem_usage() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  LaunchTest1WithArgs<T> ltt;
+  if (ltt.skip) // Unsupported aspect
+    return;
+
+  size_t num_elements = ltt.memsize_ / sizeof(T);
+
+  T *h_a = (T *)syclcompat::malloc_host(ltt.memsize_);
+  T *d_a = (T *)syclcompat::malloc<T>(num_elements);
+
+  // d_a is the kernel output, no memcpy needed
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(ltt.grid_, ltt.thread_,
+                                                        ltt.memsize_, d_a);
+
+  syclcompat::memcpy((void *)h_a, (void *)d_a, ltt.memsize_);
+  syclcompat::free((void *)d_a);
+
+  for (int i = 0; i < num_elements; i++) {
+    assert(h_a[i] == static_cast<T>(num_elements - i - 1));
+  }
+  syclcompat::free(h_a);
+}
+
+template <typename T> void local_mem_usage_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  LaunchTest1WithArgs<T> ltt;
+  if (ltt.skip) // Unsupported aspect
+    return;
+
+  size_t num_elements = ltt.memsize_ / sizeof(T);
+  auto &q = ltt.in_order_q_;
+
+  T *h_a = (T *)syclcompat::malloc_host(ltt.memsize_);
+  T *d_a = (T *)syclcompat::malloc<T>(num_elements, q);
+
+  // d_a is the kernel output, no memcpy needed
+  syclcompat::launch<dynamic_local_mem_typed_kernel<T>>(ltt.grid_, ltt.thread_,
+                                                        ltt.memsize_, q, d_a);
+
+  syclcompat::memcpy((void *)h_a, (void *)d_a, ltt.memsize_, q);
+  syclcompat::free((void *)d_a, q);
+
+  for (size_t i = 0; i < num_elements; i++) {
+    assert(h_a[i] == static_cast<T>(num_elements - i - 1));
+  }
+
+  syclcompat::free(h_a);
+}
+
+template <typename T> void memsize_no_arg_launch() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  LaunchTest1 lt;
+  T memsize = static_cast<T>(8);
+
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_,
+                                                     memsize);
+}
+
+template <typename T> void memsize_no_arg_launch_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  LaunchTest1 lt;
+  T memsize = static_cast<T>(8);
+
+  syclcompat::launch<dynamic_local_mem_empty_kernel>(lt.grid_, lt.thread_,
+                                                     memsize, lt.q_);
+}
+
+int main() {
+  launch_compute_nd_range_3d();
+  no_arg_launch();
+  one_arg_launch();
+  ptr_arg_launch();
+
+  dynamic_mem_no_arg_launch();
+  dynamic_mem_no_arg_launch_q();
+
+  using value_type_list_t =
+      std::tuple<int, unsigned int, short, unsigned short, long, unsigned long,
+                 long long, unsigned long long, float, double, sycl::half>;
+
+  INSTANTIATE_ALL_TYPES(value_type_list_t, basic_dt_launch);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, basic_dt_launch_q);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, arg_launch);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, arg_launch_q);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, local_mem_usage);
+  INSTANTIATE_ALL_TYPES(value_type_list_t, local_mem_usage_q);
+
+  using memsize_type_list =
+      std::tuple<int, unsigned int, short, unsigned short, long, unsigned long>;
+
+  INSTANTIATE_ALL_TYPES(memsize_type_list, memsize_no_arg_launch);
+  INSTANTIATE_ALL_TYPES(memsize_type_list, memsize_no_arg_launch_q);
+
+  return 0;
+}

--- a/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
@@ -1,0 +1,104 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat
+ *
+ *  launch_fixt.hpp
+ *
+ *  Description:
+ *     Fixtures and helpers for to tests the launch functionality
+ **************************************************************************/
+
+#pragma once
+
+#include <sycl/sycl.hpp>
+#include <syclcompat.hpp>
+
+// Struct containing test case data (local & global ranges)
+template <int Dim> struct RangeParams {
+  RangeParams(sycl::range<Dim> global_range_in, sycl::range<Dim> local_range,
+              sycl::range<Dim> expect_global_range_out, bool pass)
+      : global_range_in_{global_range_in}, local_range_in_{local_range},
+        expect_global_range_out_{expect_global_range_out}, shouldPass_{pass} {}
+
+  sycl::range<Dim> local_range_in_;
+  sycl::range<Dim> global_range_in_;
+  sycl::range<Dim> expect_global_range_out_;
+  bool shouldPass_;
+
+  // Pretty printing of RangeParams
+  friend std::ostream &operator<<(std::ostream &os, const RangeParams &range) {
+    auto print_range = [](std::ostream &os, const sycl::range<Dim> range) {
+      os << " {";
+      for (int i = 0; i < Dim; ++i) {
+        os << range[i];
+        os << ((Dim - i == 1) ? "} " : ", ");
+      }
+    };
+    os << "Local:";
+    print_range(os, range.local_range_in_);
+    os << "Global (in): ";
+    print_range(os, range.global_range_in_);
+    os << "Global (out): ";
+    print_range(os, range.expect_global_range_out_);
+    os << (range.shouldPass_ ? "Should Work" : "Should Throw");
+    return os;
+  }
+};
+
+// Fixture for launch tests - initializes a few different
+// range-like members & a queue.
+struct LaunchTest1 {
+  LaunchTest1()
+      : q_{syclcompat::get_default_queue()}, grid_{4, 2, 2}, thread_{32, 2, 2},
+        range_1_{128, 32}, range_2_{{4, 128}, {2, 32}}, range_3_{{2, 4, 64},
+                                                                 {2, 2, 32}} {}
+  sycl::queue const q_;
+  syclcompat::dim3 const grid_;
+  syclcompat::dim3 const thread_;
+  sycl::nd_range<1> const range_1_;
+  sycl::nd_range<2> const range_2_;
+  sycl::nd_range<3> const range_3_;
+};
+
+// Typed tests
+template <typename T> struct LaunchTest1WithArgs : public LaunchTest1 {
+  LaunchTest1WithArgs()
+      : LaunchTest1(), memsize_{LOCAL_MEM_SIZE},
+        in_order_q_{{sycl::property::queue::in_order()}}, skip{false} {
+    set_up();
+  }
+
+  void set_up() {
+    if (!syclcompat::get_current_device().has(sycl::aspect::fp64) &&
+        std::is_same_v<T, double>) {
+      std::cout << "  sycl::aspect::fp64 not supported by the SYCL device."
+                << std::endl;
+      skip = true;
+    }
+    if (!syclcompat::get_current_device().has(sycl::aspect::fp16) &&
+        std::is_same_v<T, sycl::half>) {
+
+      std::cout << "  sycl::aspect::fp16 not supported by the SYCL device."
+                << std::endl;
+      skip = true;
+    }
+  }
+
+  constexpr static size_t LOCAL_MEM_SIZE = 64;
+
+  size_t const memsize_;
+  sycl::queue const in_order_q_;
+  bool skip;
+};

--- a/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
@@ -62,8 +62,8 @@ template <int Dim> struct RangeParams {
 struct LaunchTest {
   LaunchTest()
       : q_{syclcompat::get_default_queue()}, grid_{4, 2, 2}, thread_{32, 2, 2},
-        range_1_{128, 32}, range_2_{{4, 128}, {2, 32}}, range_3_{{2, 4, 64},
-                                                                 {2, 2, 32}} {}
+        range_1_{128, 32}, range_2_{{4, 128}, {2, 32}},
+        range_3_{{2, 4, 64}, {2, 2, 32}} {}
   sycl::queue const q_;
   syclcompat::dim3 const grid_;
   syclcompat::dim3 const thread_;

--- a/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
@@ -76,23 +76,23 @@ struct LaunchTest {
 template <typename T> struct LaunchTestWithArgs : public LaunchTest {
   LaunchTestWithArgs()
       : LaunchTest(), memsize_{LOCAL_MEM_SIZE},
-        in_order_q_{{sycl::property::queue::in_order()}}, skip{false} {
-    set_up();
+        in_order_q_{{sycl::property::queue::in_order()}}, skip_{false} {
+    should_skip();
   }
 
-  void set_up() {
+  void should_skip() {
     if (!syclcompat::get_current_device().has(sycl::aspect::fp64) &&
         std::is_same_v<T, double>) {
       std::cout << "  sycl::aspect::fp64 not supported by the SYCL device."
                 << std::endl;
-      skip = true;
+      skip_ = true;
     }
     if (!syclcompat::get_current_device().has(sycl::aspect::fp16) &&
         std::is_same_v<T, sycl::half>) {
 
       std::cout << "  sycl::aspect::fp16 not supported by the SYCL device."
                 << std::endl;
-      skip = true;
+      skip_ = true;
     }
   }
 
@@ -100,5 +100,8 @@ template <typename T> struct LaunchTestWithArgs : public LaunchTest {
 
   size_t const memsize_;
   sycl::queue const in_order_q_;
-  bool skip;
+  bool skip_;
 };
+
+using memsize_type_list =
+    std::tuple<int, unsigned int, short, unsigned short, long, unsigned long>;

--- a/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
@@ -59,8 +59,8 @@ template <int Dim> struct RangeParams {
 
 // Fixture for launch tests - initializes a few different
 // range-like members & a queue.
-struct LaunchTest1 {
-  LaunchTest1()
+struct LaunchTest {
+  LaunchTest()
       : q_{syclcompat::get_default_queue()}, grid_{4, 2, 2}, thread_{32, 2, 2},
         range_1_{128, 32}, range_2_{{4, 128}, {2, 32}}, range_3_{{2, 4, 64},
                                                                  {2, 2, 32}} {}
@@ -73,9 +73,9 @@ struct LaunchTest1 {
 };
 
 // Typed tests
-template <typename T> struct LaunchTest1WithArgs : public LaunchTest1 {
-  LaunchTest1WithArgs()
-      : LaunchTest1(), memsize_{LOCAL_MEM_SIZE},
+template <typename T> struct LaunchTestWithArgs : public LaunchTest {
+  LaunchTestWithArgs()
+      : LaunchTest(), memsize_{LOCAL_MEM_SIZE},
         in_order_q_{{sycl::property::queue::in_order()}}, skip{false} {
     set_up();
   }

--- a/sycl/test-e2e/syclcompat/memory/local_memory.cpp
+++ b/sycl/test-e2e/syclcompat/memory/local_memory.cpp
@@ -43,7 +43,7 @@ template <int BLOCK_SIZE> void local_mem_1d(int *d_A) {
   d_A[syclcompat::global_id::x()] = val;
 }
 
-void local_1d() {
+void test_local_1d() {
   auto checker = [](std::vector<int> input) {
     std::vector<int> expected(input.size());
     std::iota(expected.rbegin(), expected.rend(), 0);
@@ -65,7 +65,7 @@ template <int BLOCK_SIZE> void local_mem_2d(int *d_A) {
       val;
 }
 
-void local_2d() {
+void test_local_2d() {
   constexpr int TILE_SIZE = 16;
   auto checker = [](std::vector<int> input) {
     for (int y = 0; y < TILE_SIZE; ++y) {
@@ -97,7 +97,7 @@ template <int BLOCK_SIZE> void local_mem_3d(int *d_A) {
       val;
 }
 
-void local_3d() {
+void test_local_3d() {
   constexpr int TILE_SIZE = 4;
   auto checker = [](std::vector<int> input) {
     for (int z = 0; z < TILE_SIZE; ++z) {
@@ -118,9 +118,9 @@ void local_3d() {
 }
 
 int main() {
-  local_1d();
-  local_2d();
-  local_3d();
+  test_local_1d();
+  test_local_2d();
+  test_local_3d();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/memory/local_memory.cpp
+++ b/sycl/test-e2e/syclcompat/memory/local_memory.cpp
@@ -1,0 +1,126 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  local_memory.cpp
+ *
+ *  Description:
+ *    launch<F> tests with static local memory
+ **************************************************************************/
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <numeric>
+
+#include <syclcompat/device.hpp>
+#include <syclcompat/id_query.hpp>
+#include <syclcompat/launch.hpp>
+#include <syclcompat/memory.hpp>
+
+#include "memory_fixt.hpp"
+
+// 1D test
+// Write id to linear block, then reverse order
+template <int BLOCK_SIZE> void local_mem_1d(int *d_A) {
+  int *as = syclcompat::local_mem<int[BLOCK_SIZE]>();
+  int id = syclcompat::local_id::x();
+  as[id] = id;
+  syclcompat::wg_barrier();
+  int val = as[BLOCK_SIZE - id - 1];
+  d_A[syclcompat::global_id::x()] = val;
+}
+
+void local_1d() {
+  auto checker = [](std::vector<int> input) {
+    std::vector<int> expected(input.size());
+    std::iota(expected.rbegin(), expected.rend(), 0);
+    assert(std::equal(expected.begin(), expected.end(), input.begin()));
+  };
+  LocalMemTest<local_mem_1d<32>>(1, 32).launch_test(checker);
+}
+
+// 2D test
+// Write id to 2D block, then reverse order
+template <int BLOCK_SIZE> void local_mem_2d(int *d_A) {
+  auto as = syclcompat::local_mem<int[BLOCK_SIZE][BLOCK_SIZE]>();
+  int id_x = syclcompat::local_id::x();
+  int id_y = syclcompat::local_id::y();
+  as[id_y][id_x] = id_x * BLOCK_SIZE + id_y;
+  syclcompat::wg_barrier();
+  int val = as[BLOCK_SIZE - id_y - 1][BLOCK_SIZE - id_x - 1];
+  d_A[syclcompat::global_id::y() * BLOCK_SIZE + syclcompat::global_id::x()] =
+      val;
+}
+
+void local_2d() {
+  constexpr int TILE_SIZE = 16;
+  auto checker = [](std::vector<int> input) {
+    for (int y = 0; y < TILE_SIZE; ++y) {
+      for (int x = 0; x < TILE_SIZE; ++x) {
+        int linear_id = y * TILE_SIZE + x;
+        int expected = ((TILE_SIZE - x - 1) * TILE_SIZE) + (TILE_SIZE - y - 1);
+        assert(input[linear_id] == expected);
+      }
+    }
+  };
+  LocalMemTest<local_mem_2d<TILE_SIZE>>({1, 1}, {TILE_SIZE, TILE_SIZE})
+      .launch_test(checker);
+}
+
+// 3D test
+// Write id to 3D block, then reverse order
+template <int BLOCK_SIZE> void local_mem_3d(int *d_A) {
+  auto as = syclcompat::local_mem<int[BLOCK_SIZE][BLOCK_SIZE][BLOCK_SIZE]>();
+  int id_x = syclcompat::local_id::x();
+  int id_y = syclcompat::local_id::y();
+  int id_z = syclcompat::local_id::z();
+  as[id_z][id_y][id_x] =
+      (id_x * (BLOCK_SIZE * BLOCK_SIZE)) + (id_y * BLOCK_SIZE) + id_z;
+  syclcompat::wg_barrier();
+  int val =
+      as[BLOCK_SIZE - id_z - 1][BLOCK_SIZE - id_y - 1][BLOCK_SIZE - id_x - 1];
+  d_A[syclcompat::global_id::z() * BLOCK_SIZE * BLOCK_SIZE +
+      syclcompat::global_id::y() * BLOCK_SIZE + syclcompat::global_id::x()] =
+      val;
+}
+
+void local_3d() {
+  constexpr int TILE_SIZE = 4;
+  auto checker = [](std::vector<int> input) {
+    for (int z = 0; z < TILE_SIZE; ++z) {
+      for (int y = 0; y < TILE_SIZE; ++y) {
+        for (int x = 0; x < TILE_SIZE; ++x) {
+          int linear_id = z * TILE_SIZE * TILE_SIZE + y * TILE_SIZE + x;
+          int expected = ((TILE_SIZE - x - 1) * TILE_SIZE * TILE_SIZE) +
+                         ((TILE_SIZE - y - 1) * TILE_SIZE) +
+                         (TILE_SIZE - z - 1);
+          assert(input[linear_id] == expected);
+        }
+      }
+    }
+  };
+  LocalMemTest<local_mem_3d<TILE_SIZE>>({1, 1, 1},
+                                        {TILE_SIZE, TILE_SIZE, TILE_SIZE})
+      .launch_test(checker);
+}
+
+int main() {
+  local_1d();
+  local_2d();
+  local_3d();
+
+  return 0;
+}

--- a/sycl/test-e2e/syclcompat/memory/memory_common.hpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_common.hpp
@@ -34,7 +34,3 @@ inline void check(float *h_data, float *h_ref, size_t size) {
     assert(diff <= 1.e-6);
   }
 }
-
-using value_type_list =
-    std::tuple<int, unsigned int, short, unsigned short, long, unsigned long,
-               long long, unsigned long long, float, double, sycl::half>;


### PR DESCRIPTION
SYCLcompat primary goals and features are documented [here](https://intel.github.io/llvm-docs/syclcompat/README.html).

The PR includes the helper code to launch device code through the `launch<F>` mechanism, and the wrappers to the free function queries.