### PR TITLE
[SYCL][COMPAT] Added constant memory_region for read_only memory

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -42,6 +42,7 @@ Specifically, this library depends on the following SYCL extensions:
     ../extensions/supported/sycl_ext_oneapi_assert.asciidoc)
 * [sycl_ext_oneapi_enqueue_barrier](
     ../extensions/supported/sycl_ext_oneapi_enqueue_barrier.asciidoc)
+* [sycl_ext_oneapi_usm_device_read_only](../extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc)
 
 ## Usage
 
@@ -265,7 +266,7 @@ void vectorAdd(const float *A, const float *B, float *C, int n,
 Then, `vectorAdd` can be launched like this:
 
 ``` c++
-syclcompat::launch<vectorAdd>(blocksPerGrid, threadsPerBlock, mem_size, d_A, 
+syclcompat::launch<vectorAdd>(blocksPerGrid, threadsPerBlock, mem_size, d_A,
                               d_B, d_C, n);
 ```
 

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -867,12 +867,14 @@ public:
   using value_t = typename detail::memory_traits<Memory, T>::value_t;
   using compat_accessor_t = syclcompat::accessor<T, Memory, Dimension>;
 
-  device_memory() : device_memory(sycl::range<Dimension>(1)) {}
+  device_memory(sycl::queue q = get_default_queue())
+      : device_memory(sycl::range<Dimension>(1), q) {}
 
   /// Constructor of 1-D array with initializer list
   device_memory(const sycl::range<Dimension> &in_range,
-                std::initializer_list<value_t> &&init_list)
-      : device_memory(in_range) {
+                std::initializer_list<value_t> &&init_list,
+                sycl::queue q = get_default_queue())
+      : device_memory(in_range, q) {
     assert(init_list.size() <= in_range.size());
     _host_ptr = (value_t *)std::malloc(_size);
     std::memset(_host_ptr, 0, _size);
@@ -883,8 +885,9 @@ public:
   template <size_t D = Dimension>
   device_memory(
       const typename std::enable_if<D == 2, sycl::range<2>>::type &in_range,
-      std::initializer_list<std::initializer_list<value_t>> &&init_list)
-      : device_memory(in_range) {
+      std::initializer_list<std::initializer_list<value_t>> &&init_list,
+      sycl::queue q = get_default_queue())
+      : device_memory(in_range, q) {
     assert(init_list.size() <= in_range[0]);
     _host_ptr = (value_t *)std::malloc(_size);
     std::memset(_host_ptr, 0, _size);
@@ -897,9 +900,10 @@ public:
   }
 
   /// Constructor with range
-  device_memory(const sycl::range<Dimension> &range_in)
+  device_memory(const sycl::range<Dimension> &range_in,
+                sycl::queue q = get_default_queue())
       : _size(range_in.size() * sizeof(T)), _range(range_in), _reference(false),
-        _host_ptr(nullptr), _device_ptr(nullptr) {
+        _host_ptr(nullptr), _device_ptr(nullptr), _q(q) {
     static_assert((Memory == memory_region::global) ||
                       (Memory == memory_region::constant) ||
                       (Memory == memory_region::usm_shared),
@@ -909,19 +913,28 @@ public:
   }
 
   /// Constructor with range
-  template <class... Args>
+  // enable_if_t SFINAE to avoid ambiguity with
+  // device_memory(Args... Arguments, sycl::queue q)
+  template <class... Args, size_t D = Dimension,
+            typename = std::enable_if_t<sizeof...(Args) == D>>
   device_memory(Args... Arguments)
-      : device_memory(sycl::range<Dimension>(Arguments...)) {}
+      : device_memory(sycl::range<Dimension>(Arguments...),
+                      get_default_queue()) {}
+
+  /// Constructor with range and queue
+  template <class... Args>
+  device_memory(Args... Arguments, sycl::queue q)
+      : device_memory(sycl::range<Dimension>(Arguments...), q) {}
 
   ~device_memory() {
     if (_device_ptr && !_reference)
-      free(_device_ptr);
+      syclcompat::free(_device_ptr, _q);
     if (_host_ptr)
       std::free(_host_ptr);
   }
 
   /// Allocate memory with default queue, and init memory if has initial value.
-  void init() { init(get_default_queue()); }
+  void init() { init(_q); }
   /// Allocate memory with specified queue, and init memory if has initial
   /// value.
   void init(sycl::queue q) {
@@ -937,12 +950,12 @@ public:
   /// The variable is assigned to a device pointer.
   void assign(value_t *src, size_t size) {
     this->~device_memory();
-    new (this) device_memory(src, size);
+    new (this) device_memory(src, size, _q);
   }
 
   /// Get memory pointer of the memory object, which is virtual pointer when
   /// usm is not used, and device pointer when usm is used.
-  value_t *get_ptr() { return get_ptr(get_default_queue()); }
+  value_t *get_ptr() { return get_ptr(_q); }
   /// Get memory pointer of the memory object, which is virtual pointer when
   /// usm is not used, and device pointer when usm is used.
   value_t *get_ptr(sycl::queue q) {
@@ -968,9 +981,10 @@ public:
   }
 
 private:
-  device_memory(value_t *memory_ptr, size_t size)
+  device_memory(value_t *memory_ptr, size_t size,
+                sycl::queue q = get_default_queue())
       : _size(size), _range(size / sizeof(T)), _reference(true),
-        _device_ptr(memory_ptr) {}
+        _device_ptr(memory_ptr), _q(q) {}
 
   void allocate_device(sycl::queue q) {
     if (Memory == memory_region::usm_shared) {
@@ -986,6 +1000,7 @@ private:
   bool _reference;
   value_t *_host_ptr;
   value_t *_device_ptr;
+  sycl::queue _q;
 };
 template <class T, memory_region Memory>
 class device_memory<T, Memory, 0> : public device_memory<T, Memory, 1> {

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -992,6 +992,14 @@ private:
                                                    q.get_context());
       return;
     }
+#ifdef SYCL_EXT_ONEAPI_USM_DEVICE_READ_ONLY
+    if (Memory == memory_region::constant) {
+      _device_ptr = (value_t *)sycl::malloc_device(
+          _size, q.get_device(), q.get_context(),
+          sycl::ext::oneapi::property::usm::device_read_only());
+      return;
+    }
+#endif
     _device_ptr = (value_t *)detail::malloc(_size, q);
   }
 

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
@@ -374,74 +374,15 @@ void test_constant_memcpy() {
   constexpr size_t size = 2000;
   constexpr size_t offset = 1000;
 
-  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float));
-  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float));
+  syclcompat::constant_memory<float, 1> d_A(size);
+  syclcompat::constant_memory<float, 1> d_B(size);
 
-  float h_A[size];
-  float h_B[size];
-  float h_C[size];
-  float h_D[size];
+  float *h_A = (float *)malloc(size / 2 * sizeof(float));
+  float *h_B = (float *)malloc(size / 2 * sizeof(float));
+  float *h_C = (float *)malloc(size * sizeof(float));
+  float *h_D = (float *)malloc(size * sizeof(float));
 
-  for (int i = 0; i < size; i++) {
-    h_A[i] = 1.0f;
-    h_B[i] = 2.0f;
-  }
-
-  for (int i = 0; i < size; i++) {
-    h_A[i] = 1.0f;
-    h_B[i] = 2.0f;
-  }
-
-  // hostA[0..999] -> deviceA[0..999]
-  // hostB[0..1999] -> deviceA[1000..1999]
-  // deviceA[0..1999] -> hostC[0..1999]
-  // deviceA[0..999] -> deviceB[0..999]
-  // deviceA[1000..1999] -> deviceB[1000..1999]
-  // deviceB[0..1999] -> hostD[0..1999]
-
-  syclcompat::memcpy((void *)d_A.get_ptr(), (void *)&h_A[0],
-                     offset * sizeof(float));
-  syclcompat::memcpy((char *)d_A.get_ptr() + offset * sizeof(float),
-                     (void *)h_B, (size - offset) * sizeof(float));
-  syclcompat::memcpy((void *)h_C, (void *)d_A.get_ptr(), size * sizeof(float));
-  syclcompat::memcpy((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
-                     offset * sizeof(float));
-  syclcompat::memcpy((char *)d_B.get_ptr() + offset * sizeof(float),
-                     (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
-                     (size - offset) * sizeof(float));
-  syclcompat::memcpy((void *)h_D, (void *)d_B.get_ptr(), size * sizeof(float));
-
-  // verify hostD
-  for (int i = 0; i < offset; i++) {
-    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
-  }
-
-  for (int i = offset; i < size; i++) {
-    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
-  }
-}
-
-void test_constant_memcpy_q() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-
-  sycl::queue q{{sycl::property::queue::in_order()}};
-
-  constexpr size_t size = 2000;
-  constexpr size_t offset = 1000;
-  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float), q);
-  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float), q);
-
-  float h_A[size];
-  float h_B[size];
-  float h_C[size];
-  float h_D[size];
-
-  for (int i = 0; i < size; i++) {
-    h_A[i] = 1.0f;
-    h_B[i] = 2.0f;
-  }
-
-  for (int i = 0; i < size; i++) {
+  for (int i = 0; i < size / 2; i++) {
     h_A[i] = 1.0f;
     h_B[i] = 2.0f;
   }
@@ -453,23 +394,15 @@ void test_constant_memcpy_q() {
   // deviceA[1000..1999] -> deviceB[1000..1999]
   // deviceB[0..1999] -> hostD[0..1999]
 
-  syclcompat::memcpy((void *)d_A.get_ptr(), (void *)&h_A[0],
-                     offset * sizeof(float), q);
-
-  syclcompat::memcpy((char *)d_A.get_ptr() + offset * sizeof(float),
-                     (void *)h_B, (size - offset) * sizeof(float), q);
-  syclcompat::memcpy((void *)h_C, (void *)d_A.get_ptr(), size * sizeof(float),
-                     q);
-
-  syclcompat::memcpy((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
-                     offset * sizeof(float), q);
-
+  syclcompat::memcpy(d_A.get_ptr(), h_A, offset * sizeof(float));
+  syclcompat::memcpy((char *)d_A.get_ptr() + offset * sizeof(float), h_B,
+                     (size - offset) * sizeof(float));
+  syclcompat::memcpy(h_C, d_A.get_ptr(), size * sizeof(float));
+  syclcompat::memcpy(d_B.get_ptr(), d_A.get_ptr(), offset * sizeof(float));
   syclcompat::memcpy((char *)d_B.get_ptr() + offset * sizeof(float),
                      (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
-                     (size - offset) * sizeof(float), q);
-
-  syclcompat::memcpy((void *)h_D, (void *)d_B.get_ptr(), size * sizeof(float),
-                     q);
+                     (size - offset) * sizeof(float));
+  syclcompat::memcpy(h_D, d_B.get_ptr(), size * sizeof(float));
 
   // verify hostD
   for (int i = 0; i < offset; i++) {
@@ -477,8 +410,69 @@ void test_constant_memcpy_q() {
   }
 
   for (int i = offset; i < size; i++) {
-    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
+    assert(fabs(h_B[i - offset] - h_D[i]) <= 1e-5);
   }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+  free(h_D);
+}
+
+void test_constant_memcpy_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+
+  constexpr size_t size = 2000;
+  constexpr size_t offset = 1000;
+  syclcompat::constant_memory<float, 1> d_A(size, q);
+  syclcompat::constant_memory<float, 1> d_B(size, q);
+
+  float *h_A = (float *)malloc(size / 2 * sizeof(float));
+  float *h_B = (float *)malloc(size / 2 * sizeof(float));
+  float *h_C = (float *)malloc(size * sizeof(float));
+  float *h_D = (float *)malloc(size * sizeof(float));
+
+  for (int i = 0; i < size / 2; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..999] -> deviceA[1000..1999]
+  // deviceA[0..1999] -> hostC[0..1999]
+  // deviceA[0..999] -> deviceB[0..999]
+  // deviceA[1000..1999] -> deviceB[1000..1999]
+  // deviceB[0..1999] -> hostD[0..1999]
+
+  syclcompat::memcpy(d_A.get_ptr(), h_A, offset * sizeof(float), q);
+
+  syclcompat::memcpy((char *)d_A.get_ptr() + offset * sizeof(float), h_B,
+                     (size - offset) * sizeof(float), q);
+  syclcompat::memcpy(h_C, d_A.get_ptr(), size * sizeof(float), q);
+
+  syclcompat::memcpy(d_B.get_ptr(), d_A.get_ptr(), offset * sizeof(float), q);
+
+  syclcompat::memcpy((char *)d_B.get_ptr() + offset * sizeof(float),
+                     (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
+                     (size - offset) * sizeof(float), q);
+
+  syclcompat::memcpy(h_D, d_B.get_ptr(), size * sizeof(float), q);
+
+  // verify hostD
+  for (int i = 0; i < offset; i++) {
+    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
+  }
+
+  for (int i = offset; i < size; i++) {
+    assert(fabs(h_B[i - offset] - h_D[i]) <= 1e-5);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+  free(h_D);
 }
 
 int main() {

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
@@ -368,11 +368,126 @@ template <typename T> void test_fill_q() {
   free(h_A);
 }
 
+void test_constant_memcpy() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr size_t size = 2000;
+  constexpr size_t offset = 1000;
+
+  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float));
+  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float));
+
+  float h_A[size];
+  float h_B[size];
+  float h_C[size];
+  float h_D[size];
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..1999] -> deviceA[1000..1999]
+  // deviceA[0..1999] -> hostC[0..1999]
+  // deviceA[0..999] -> deviceB[0..999]
+  // deviceA[1000..1999] -> deviceB[1000..1999]
+  // deviceB[0..1999] -> hostD[0..1999]
+
+  syclcompat::memcpy((void *)d_A.get_ptr(), (void *)&h_A[0],
+                     offset * sizeof(float));
+  syclcompat::memcpy((char *)d_A.get_ptr() + offset * sizeof(float),
+                     (void *)h_B, (size - offset) * sizeof(float));
+  syclcompat::memcpy((void *)h_C, (void *)d_A.get_ptr(), size * sizeof(float));
+  syclcompat::memcpy((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
+                     offset * sizeof(float));
+  syclcompat::memcpy((char *)d_B.get_ptr() + offset * sizeof(float),
+                     (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
+                     (size - offset) * sizeof(float));
+  syclcompat::memcpy((void *)h_D, (void *)d_B.get_ptr(), size * sizeof(float));
+
+  // verify hostD
+  for (int i = 0; i < offset; i++) {
+    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
+  }
+
+  for (int i = offset; i < size; i++) {
+    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
+  }
+}
+
+void test_constant_memcpy_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+
+  constexpr size_t size = 2000;
+  constexpr size_t offset = 1000;
+  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float), q);
+  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float), q);
+
+  float h_A[size];
+  float h_B[size];
+  float h_C[size];
+  float h_D[size];
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..999] -> deviceA[1000..1999]
+  // deviceA[0..1999] -> hostC[0..1999]
+  // deviceA[0..999] -> deviceB[0..999]
+  // deviceA[1000..1999] -> deviceB[1000..1999]
+  // deviceB[0..1999] -> hostD[0..1999]
+
+  syclcompat::memcpy((void *)d_A.get_ptr(), (void *)&h_A[0],
+                     offset * sizeof(float), q);
+
+  syclcompat::memcpy((char *)d_A.get_ptr() + offset * sizeof(float),
+                     (void *)h_B, (size - offset) * sizeof(float), q);
+  syclcompat::memcpy((void *)h_C, (void *)d_A.get_ptr(), size * sizeof(float),
+                     q);
+
+  syclcompat::memcpy((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
+                     offset * sizeof(float), q);
+
+  syclcompat::memcpy((char *)d_B.get_ptr() + offset * sizeof(float),
+                     (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
+                     (size - offset) * sizeof(float), q);
+
+  syclcompat::memcpy((void *)h_D, (void *)d_B.get_ptr(), size * sizeof(float),
+                     q);
+
+  // verify hostD
+  for (int i = 0; i < offset; i++) {
+    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
+  }
+
+  for (int i = offset; i < size; i++) {
+    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
+  }
+}
+
 int main() {
   test_memcpy();
   test_memcpy_q();
   test_memset();
   test_memset_q();
+  test_constant_memcpy();
+  test_constant_memcpy_q();
 
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_t);
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_t_q);

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -482,84 +482,21 @@ template <typename T> void test_fill_async_q() {
   free(h_A);
 }
 
-void constant_memcpy_async() {
+void test_constant_memcpy_async() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   constexpr size_t size = 2000;
   constexpr size_t offset = 1000;
 
-  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float));
-  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float));
+  syclcompat::constant_memory<float, 1> d_A(size);
+  syclcompat::constant_memory<float, 1> d_B(size);
 
-  float h_A[size];
-  float h_B[size];
-  float h_C[size];
-  float h_D[size];
+  float *h_A = (float *)malloc(size / 2 * sizeof(float));
+  float *h_B = (float *)malloc(size / 2 * sizeof(float));
+  float *h_C = (float *)malloc(size * sizeof(float));
+  float *h_D = (float *)malloc(size * sizeof(float));
 
-  for (int i = 0; i < size; i++) {
-    h_A[i] = 1.0f;
-    h_B[i] = 2.0f;
-  }
-
-  for (int i = 0; i < size; i++) {
-    h_A[i] = 1.0f;
-    h_B[i] = 2.0f;
-  }
-
-  // hostA[0..999] -> deviceA[0..999]
-  // hostB[0..1999] -> deviceA[1000..1999]
-  // deviceA[0..1999] -> hostC[0..1999]
-  // deviceA[0..999] -> deviceB[0..999]
-  // deviceA[1000..1999] -> deviceB[1000..1999]
-  // deviceB[0..1999] -> hostD[0..1999]
-
-  syclcompat::memcpy_async((void *)d_A.get_ptr(), (void *)&h_A[0],
-                           offset * sizeof(float));
-  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float),
-                           (void *)h_B, (size - offset) * sizeof(float));
-  syclcompat::memcpy_async((void *)h_C, (void *)d_A.get_ptr(),
-                           size * sizeof(float));
-  syclcompat::memcpy_async((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
-                           offset * sizeof(float));
-  syclcompat::memcpy_async(
-      (char *)d_B.get_ptr() + offset * sizeof(float),
-      (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
-      (size - offset) * sizeof(float));
-  syclcompat::memcpy_async((void *)h_D, (void *)d_B.get_ptr(),
-                           size * sizeof(float));
-  syclcompat::get_default_queue().wait_and_throw();
-
-  // verify hostD
-  for (int i = 0; i < offset; i++) {
-    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
-  }
-
-  for (int i = offset; i < size; i++) {
-    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
-  }
-}
-
-void constant_memcpy_async_q() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-
-  sycl::queue q{{sycl::property::queue::in_order()}};
-
-  constexpr size_t size = 2000;
-  constexpr size_t offset = 1000;
-  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float), q);
-  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float), q);
-
-  float h_A[size];
-  float h_B[size];
-  float h_C[size];
-  float h_D[size];
-
-  for (int i = 0; i < size; i++) {
-    h_A[i] = 1.0f;
-    h_B[i] = 2.0f;
-  }
-
-  for (int i = 0; i < size; i++) {
+  for (int i = 0; i < size / 2; i++) {
     h_A[i] = 1.0f;
     h_B[i] = 2.0f;
   }
@@ -571,24 +508,82 @@ void constant_memcpy_async_q() {
   // deviceA[1000..1999] -> deviceB[1000..1999]
   // deviceB[0..1999] -> hostD[0..1999]
 
-  syclcompat::memcpy_async((void *)d_A.get_ptr(), (void *)&h_A[0],
-                           offset * sizeof(float), q);
-
-  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float),
-                           (void *)h_B, (size - offset) * sizeof(float), q);
+  syclcompat::memcpy_async(d_A.get_ptr(), h_A, offset * sizeof(float));
+  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float), h_B,
+                           (size - offset) * sizeof(float));
+  syclcompat::memcpy_async(h_C, d_A.get_ptr(), size * sizeof(float));
+  syclcompat::memcpy_async(d_B.get_ptr(), d_A.get_ptr(),
+                           offset * sizeof(float));
+  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float), h_B,
+                           (size - offset) * sizeof(float));
   syclcompat::memcpy_async((void *)h_C, (void *)d_A.get_ptr(),
-                           size * sizeof(float), q);
-
+                           size * sizeof(float));
   syclcompat::memcpy_async((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
-                           offset * sizeof(float), q);
+                           offset * sizeof(float));
+  syclcompat::memcpy_async(
+      (char *)d_B.get_ptr() + offset * sizeof(float),
+      (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
+      (size - offset) * sizeof(float));
+  syclcompat::memcpy_async(h_D, d_B.get_ptr(), size * sizeof(float));
+  syclcompat::get_default_queue().wait_and_throw();
+
+  // verify hostD
+  for (int i = 0; i < offset; i++) {
+    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
+  }
+
+  for (int i = offset; i < size; i++) {
+    assert(fabs(h_B[i - offset] - h_D[i]) <= 1e-5);
+  }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+  free(h_D);
+}
+
+void test_constant_memcpy_async_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+
+  constexpr size_t size = 2000;
+  constexpr size_t offset = 1000;
+  syclcompat::constant_memory<float, 1> d_A(size, q);
+  syclcompat::constant_memory<float, 1> d_B(size, q);
+
+  float *h_A = (float *)malloc(size / 2 * sizeof(float));
+  float *h_B = (float *)malloc(size / 2 * sizeof(float));
+  float *h_C = (float *)malloc(size * sizeof(float));
+  float *h_D = (float *)malloc(size * sizeof(float));
+
+  for (int i = 0; i < size / 2; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..999] -> deviceA[1000..1999]
+  // deviceA[0..1999] -> hostC[0..1999]
+  // deviceA[0..999] -> deviceB[0..999]
+  // deviceA[1000..1999] -> deviceB[1000..1999]
+  // deviceB[0..1999] -> hostD[0..1999]
+
+  syclcompat::memcpy_async(d_A.get_ptr(), h_A, offset * sizeof(float), q);
+
+  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float), h_B,
+                           (size - offset) * sizeof(float), q);
+  syclcompat::memcpy_async(h_C, d_A.get_ptr(), size * sizeof(float), q);
+
+  syclcompat::memcpy_async(d_B.get_ptr(), d_A.get_ptr(), offset * sizeof(float),
+                           q);
 
   syclcompat::memcpy_async(
       (char *)d_B.get_ptr() + offset * sizeof(float),
       (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
       (size - offset) * sizeof(float), q);
 
-  syclcompat::memcpy_async((void *)h_D, (void *)d_B.get_ptr(),
-                           size * sizeof(float), q);
+  syclcompat::memcpy_async(h_D, d_B.get_ptr(), size * sizeof(float), q);
   q.wait_and_throw();
 
   // verify hostD
@@ -597,8 +592,13 @@ void constant_memcpy_async_q() {
   }
 
   for (int i = offset; i < size; i++) {
-    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
+    assert(fabs(h_B[i - offset] - h_D[i]) <= 1e-5);
   }
+
+  free(h_A);
+  free(h_B);
+  free(h_C);
+  free(h_D);
 }
 
 int main() {
@@ -610,6 +610,8 @@ int main() {
   test_memcpy_async_pitched_q();
   test_memset_async();
   test_memset_async_q();
+  test_constant_memcpy_async();
+  test_constant_memcpy_async_q();
 
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_async_t);
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_async_t_q);

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -482,6 +482,125 @@ template <typename T> void test_fill_async_q() {
   free(h_A);
 }
 
+void constant_memcpy_async() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr size_t size = 2000;
+  constexpr size_t offset = 1000;
+
+  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float));
+  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float));
+
+  float h_A[size];
+  float h_B[size];
+  float h_C[size];
+  float h_D[size];
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..1999] -> deviceA[1000..1999]
+  // deviceA[0..1999] -> hostC[0..1999]
+  // deviceA[0..999] -> deviceB[0..999]
+  // deviceA[1000..1999] -> deviceB[1000..1999]
+  // deviceB[0..1999] -> hostD[0..1999]
+
+  syclcompat::memcpy_async((void *)d_A.get_ptr(), (void *)&h_A[0],
+                           offset * sizeof(float));
+  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float),
+                           (void *)h_B, (size - offset) * sizeof(float));
+  syclcompat::memcpy_async((void *)h_C, (void *)d_A.get_ptr(),
+                           size * sizeof(float));
+  syclcompat::memcpy_async((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
+                           offset * sizeof(float));
+  syclcompat::memcpy_async(
+      (char *)d_B.get_ptr() + offset * sizeof(float),
+      (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
+      (size - offset) * sizeof(float));
+  syclcompat::memcpy_async((void *)h_D, (void *)d_B.get_ptr(),
+                           size * sizeof(float));
+  syclcompat::get_default_queue().wait_and_throw();
+
+  // verify hostD
+  for (int i = 0; i < offset; i++) {
+    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
+  }
+
+  for (int i = offset; i < size; i++) {
+    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
+  }
+}
+
+void constant_memcpy_async_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  sycl::queue q{{sycl::property::queue::in_order()}};
+
+  constexpr size_t size = 2000;
+  constexpr size_t offset = 1000;
+  syclcompat::constant_memory<float, 1> d_A(size * sizeof(float), q);
+  syclcompat::constant_memory<float, 1> d_B(size * sizeof(float), q);
+
+  float h_A[size];
+  float h_B[size];
+  float h_C[size];
+  float h_D[size];
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  for (int i = 0; i < size; i++) {
+    h_A[i] = 1.0f;
+    h_B[i] = 2.0f;
+  }
+
+  // hostA[0..999] -> deviceA[0..999]
+  // hostB[0..999] -> deviceA[1000..1999]
+  // deviceA[0..1999] -> hostC[0..1999]
+  // deviceA[0..999] -> deviceB[0..999]
+  // deviceA[1000..1999] -> deviceB[1000..1999]
+  // deviceB[0..1999] -> hostD[0..1999]
+
+  syclcompat::memcpy_async((void *)d_A.get_ptr(), (void *)&h_A[0],
+                           offset * sizeof(float), q);
+
+  syclcompat::memcpy_async((char *)d_A.get_ptr() + offset * sizeof(float),
+                           (void *)h_B, (size - offset) * sizeof(float), q);
+  syclcompat::memcpy_async((void *)h_C, (void *)d_A.get_ptr(),
+                           size * sizeof(float), q);
+
+  syclcompat::memcpy_async((void *)d_B.get_ptr(), (void *)d_A.get_ptr(),
+                           offset * sizeof(float), q);
+
+  syclcompat::memcpy_async(
+      (char *)d_B.get_ptr() + offset * sizeof(float),
+      (void *)((size_t)d_A.get_ptr() + offset * sizeof(float)),
+      (size - offset) * sizeof(float), q);
+
+  syclcompat::memcpy_async((void *)h_D, (void *)d_B.get_ptr(),
+                           size * sizeof(float), q);
+  q.wait_and_throw();
+
+  // verify hostD
+  for (int i = 0; i < offset; i++) {
+    assert(fabs(h_A[i] - h_D[i]) <= 1e-5);
+  }
+
+  for (int i = offset; i < size; i++) {
+    assert(fabs(h_B[i] - h_D[i]) <= 1e-5);
+  }
+}
+
 int main() {
   test_free_memory();
   test_free_memory_q();


### PR DESCRIPTION
This PR extends the memory wrapper of SYCLcompat to support allocating read only memory.

To allow the allocation of `device_memory` directly for source to source translation:
- Extended `device_memory` to support a queue parameter in its constructor, which defaults to `syclcompat::get_default_queue`
- Added device_read_only property to device memory if usm device read only extension is available for `memory_region::constant`

Documentation was already updated, except for the usm device read only extension