### PR TITLE
[PI][UR][HIP] Fix issues in HIP adapter to address CTS pass rate

### DIFF
--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -122,6 +122,7 @@ add_sycl_plugin(hip
     "../unified_runtime/ur/adapters/hip/usm.cpp"
     "../unified_runtime/ur/adapters/hip/usm.hpp"
     "../unified_runtime/ur/adapters/hip/usm_p2p.cpp"
+    "../unified_runtime/ur/adapters/hip/virtual_memory.cpp"
     "${sycl_inc_dir}/sycl/detail/pi.h"
     "${sycl_inc_dir}/sycl/detail/pi.hpp"
     "pi_hip.hpp"

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -225,6 +225,7 @@ if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
       "ur/adapters/hip/usm.cpp"
       "ur/adapters/hip/usm.hpp"
       "ur/adapters/hip/usm_p2p.cpp"
+      "ur/adapters/hip/virtual_memory.cpp"
     INCLUDE_DIRS
       ${sycl_inc_dir}
     LIBRARIES

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/context.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/context.hpp
@@ -75,7 +75,10 @@ struct ur_context_handle_t_ {
     urDeviceRetain(DeviceId);
   };
 
-  ~ur_context_handle_t_() { urDeviceRelease(DeviceId); }
+  ~ur_context_handle_t_() {
+    urDeviceRelease(DeviceId);
+    invokeExtendedDeleters();
+  }
 
   void invokeExtendedDeleters() {
     std::lock_guard<std::mutex> Guard(Mutex);

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/device.cpp
@@ -813,6 +813,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
   // TODO: Investigate if this information is available on HIP.
   case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT:
     return ReturnValue(ur_bool_t{false});
+  case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
+    return ReturnValue(ur_bool_t{false});
   case UR_DEVICE_INFO_GPU_EU_COUNT:
   case UR_DEVICE_INFO_GPU_EU_SIMD_WIDTH:
   case UR_DEVICE_INFO_GPU_EU_SLICES:

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/device.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/device.cpp
@@ -9,7 +9,6 @@
 #include "device.hpp"
 #include "context.hpp"
 #include "event.hpp"
-#include "memory.hpp"
 
 #include <sstream>
 
@@ -812,7 +811,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urDeviceGetInfo(ur_device_handle_t hDevice,
     return ReturnValue(false);
   // TODO: Investigate if this information is available on HIP.
   case UR_DEVICE_INFO_VIRTUAL_MEMORY_SUPPORT:
-    return ReturnValue(ur_bool_t{false});
+    return ReturnValue(ur_bool_t{true});
   case UR_DEVICE_INFO_KERNEL_SET_SPECIALIZATION_CONSTANTS:
     return ReturnValue(ur_bool_t{false});
   case UR_DEVICE_INFO_GPU_EU_COUNT:

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/enqueue.cpp
@@ -449,15 +449,19 @@ static ur_result_t commonEnqueueMemBufferCopyRect(
     size_t SrcSlicePitch, void *DstPtr, const hipMemoryType DstType,
     ur_rect_offset_t DstOffset, size_t DstRowPitch, size_t DstSlicePitch) {
 
-  assert(SrcType == hipMemoryTypeDevice || SrcType == hipMemoryTypeHost);
-  assert(DstType == hipMemoryTypeDevice || DstType == hipMemoryTypeHost);
+  UR_ASSERT(SrcType == hipMemoryTypeDevice || SrcType == hipMemoryTypeHost,
+            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
+  UR_ASSERT(DstType == hipMemoryTypeDevice || DstType == hipMemoryTypeHost,
+            UR_RESULT_ERROR_INVALID_MEM_OBJECT);
 
   SrcRowPitch = (!SrcRowPitch) ? Region.width : SrcRowPitch;
-  SrcSlicePitch =
-      (!SrcSlicePitch) ? (Region.height * SrcRowPitch) : SrcSlicePitch;
+  SrcSlicePitch = (!SrcSlicePitch)
+                      ? ((Region.height + SrcOffset.x) * SrcRowPitch)
+                      : SrcSlicePitch;
   DstRowPitch = (!DstRowPitch) ? Region.width : DstRowPitch;
-  DstSlicePitch =
-      (!DstSlicePitch) ? (Region.height * DstRowPitch) : DstSlicePitch;
+  DstSlicePitch = (!DstSlicePitch)
+                      ? ((Region.height + DstOffset.x) * DstRowPitch)
+                      : DstSlicePitch;
 
   HIP_MEMCPY3D Params;
 
@@ -885,7 +889,6 @@ static ur_result_t commonEnqueueMemImageNDCopy(
     CpyDesc.Height = Region[1];
     CpyDesc.Depth = Region[2];
     return UR_CHECK_ERROR(hipDrvMemcpy3DAsync(&CpyDesc, HipStream));
-    return UR_RESULT_ERROR_UNKNOWN;
   }
 
   return UR_RESULT_ERROR_INVALID_VALUE;

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.hpp
@@ -171,7 +171,7 @@ struct ur_kernel_handle_t_ {
   /// Note this only returns the current known number of arguments, not the
   /// real one required by the kernel, since this cannot be queried from
   /// the HIP Driver API
-  uint32_t getNumArgs() const noexcept { return Args.Indices.size() - 1; }
+  size_t getNumArgs() const noexcept { return Args.Indices.size() - 1; }
 
   void setKernelArg(int Index, size_t Size, const void *Arg) {
     Args.addArg(Index, Size, Arg);

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
@@ -494,7 +494,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
   return Result;
 }
 
-/// \TODO Not implemented
 UR_APIEXPORT ur_result_t UR_APICALL urMemImageGetInfo(
     ur_mem_handle_t hMemory, ur_image_info_t propName, size_t propSize,
     void *pPropValue, size_t *pPropValueSizeRet) {

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
@@ -131,13 +131,21 @@ struct ur_mem_handle_t_ {
     struct SurfaceMem {
       hipArray *Array;
       hipSurfaceObject_t SurfObj;
-      ur_mem_type_t ImageType;
+      ur_image_desc_t ImageInfo;
+      ur_image_format_t ImageFormat;
 
       hipArray *getArray() const noexcept { return Array; }
 
       hipSurfaceObject_t getSurface() const noexcept { return SurfObj; }
-
-      ur_mem_type_t getImageType() const noexcept { return ImageType; }
+      ur_image_format_t getImageFormat() const noexcept { return ImageFormat; }
+      ur_mem_type_t getImageType() const noexcept { return ImageInfo.type; }
+      size_t getImageWidth() const noexcept { return ImageInfo.width; }
+      size_t getImageHeight() const noexcept { return ImageInfo.height; }
+      size_t getImageDepth() const noexcept { return ImageInfo.depth; }
+      size_t getImageRowPitch() const noexcept { return ImageInfo.rowPitch; }
+      size_t getImageSlicePitch() const noexcept {
+        return ImageInfo.slicePitch;
+      }
     } SurfaceMem;
   } Mem;
 
@@ -164,11 +172,15 @@ struct ur_mem_handle_t_ {
 
   /// Constructs the UR allocation for an Image object
   ur_mem_handle_t_(ur_context Ctxt, hipArray *Array, hipSurfaceObject_t Surf,
-                   ur_mem_flags_t MemFlags, ur_mem_type_t ImageType, void *)
+                   ur_mem_flags_t MemFlags, ur_image_desc_t ImageDesc,
+                   ur_image_format_t ImageFormat, void *)
       : Context{Ctxt}, RefCount{1}, MemType{Type::Surface}, MemFlags{MemFlags} {
     Mem.SurfaceMem.Array = Array;
-    Mem.SurfaceMem.ImageType = ImageType;
     Mem.SurfaceMem.SurfObj = Surf;
+    // disable pNext for ImageInfo
+    ImageDesc.pNext = nullptr;
+    Mem.SurfaceMem.ImageInfo = ImageDesc;
+    Mem.SurfaceMem.ImageFormat = ImageFormat;
     urContextRetain(Context);
   }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.hpp
@@ -131,20 +131,20 @@ struct ur_mem_handle_t_ {
     struct SurfaceMem {
       hipArray *Array;
       hipSurfaceObject_t SurfObj;
-      ur_image_desc_t ImageInfo;
+      ur_image_desc_t ImageDesc;
       ur_image_format_t ImageFormat;
 
       hipArray *getArray() const noexcept { return Array; }
 
       hipSurfaceObject_t getSurface() const noexcept { return SurfObj; }
       ur_image_format_t getImageFormat() const noexcept { return ImageFormat; }
-      ur_mem_type_t getImageType() const noexcept { return ImageInfo.type; }
-      size_t getImageWidth() const noexcept { return ImageInfo.width; }
-      size_t getImageHeight() const noexcept { return ImageInfo.height; }
-      size_t getImageDepth() const noexcept { return ImageInfo.depth; }
-      size_t getImageRowPitch() const noexcept { return ImageInfo.rowPitch; }
+      ur_mem_type_t getImageType() const noexcept { return ImageDesc.type; }
+      size_t getImageWidth() const noexcept { return ImageDesc.width; }
+      size_t getImageHeight() const noexcept { return ImageDesc.height; }
+      size_t getImageDepth() const noexcept { return ImageDesc.depth; }
+      size_t getImageRowPitch() const noexcept { return ImageDesc.rowPitch; }
       size_t getImageSlicePitch() const noexcept {
-        return ImageInfo.slicePitch;
+        return ImageDesc.slicePitch;
       }
     } SurfaceMem;
   } Mem;
@@ -177,9 +177,9 @@ struct ur_mem_handle_t_ {
       : Context{Ctxt}, RefCount{1}, MemType{Type::Surface}, MemFlags{MemFlags} {
     Mem.SurfaceMem.Array = Array;
     Mem.SurfaceMem.SurfObj = Surf;
-    // disable pNext for ImageInfo
+    // disable pNext for ImageDesc
     ImageDesc.pNext = nullptr;
-    Mem.SurfaceMem.ImageInfo = ImageDesc;
+    Mem.SurfaceMem.ImageDesc = ImageDesc;
     Mem.SurfaceMem.ImageFormat = ImageFormat;
     urContextRetain(Context);
   }

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
@@ -139,7 +139,6 @@ UR_APIEXPORT ur_result_t UR_APICALL
 urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t,
                       ur_program_build_info_t propName, size_t propSize,
                       void *pPropValue, size_t *pPropSizeRet) {
-  // Ignore unused parameter
   UrReturnHelper ReturnValue(propSize, pPropValue, pPropSizeRet);
 
   switch (propName) {
@@ -150,10 +149,11 @@ urProgramGetBuildInfo(ur_program_handle_t hProgram, ur_device_handle_t,
     return ReturnValue(hProgram->BuildOptions.c_str());
   case UR_PROGRAM_BUILD_INFO_LOG:
     return ReturnValue(hProgram->InfoLog, hProgram->MAX_LOG_SIZE);
+  case UR_PROGRAM_BUILD_INFO_BINARY_TYPE:
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
-    break;
+    return UR_RESULT_ERROR_INVALID_ENUMERATION;
   }
-  return UR_RESULT_ERROR_INVALID_ENUMERATION;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -176,8 +176,9 @@ urProgramGetInfo(ur_program_handle_t hProgram, ur_program_info_t propName,
     return ReturnValue(&hProgram->BinarySizeInBytes, 1);
   case UR_PROGRAM_INFO_BINARIES:
     return ReturnValue(&hProgram->Binary, 1);
+  case UR_PROGRAM_INFO_NUM_KERNELS:
   case UR_PROGRAM_INFO_KERNEL_NAMES:
-    return getKernelNames(hProgram);
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
   default:
     break;
   }

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/sampler.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/sampler.cpp
@@ -78,3 +78,21 @@ ur_result_t urSamplerRelease(ur_sampler_handle_t hSampler) {
 
   return UR_RESULT_SUCCESS;
 }
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerCreateWithNativeHandle(
+    ur_native_handle_t hNativeSampler, ur_context_handle_t hContext,
+    const ur_sampler_native_properties_t *pProperties,
+    ur_sampler_handle_t *phSampler) {
+  std::ignore = hNativeSampler;
+  std::ignore = hContext;
+  std::ignore = pProperties;
+  std::ignore = phSampler;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urSamplerGetNativeHandle(
+    ur_sampler_handle_t hSampler, ur_native_handle_t *phNativeSampler) {
+  std::ignore = hSampler;
+  std::ignore = phNativeSampler;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/ur_interface_loader.cpp
@@ -121,7 +121,7 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetKernelProcAddrTable(
   pDdiTable->pfnSetArgSampler = urKernelSetArgSampler;
   pDdiTable->pfnSetArgValue = urKernelSetArgValue;
   pDdiTable->pfnSetExecInfo = urKernelSetExecInfo;
-  pDdiTable->pfnSetSpecializationConstants = nullptr;
+  pDdiTable->pfnSetSpecializationConstants = urKernelSetSpecializationConstants;
   return UR_RESULT_SUCCESS;
 }
 

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/ur_interface_loader.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/ur_interface_loader.cpp
@@ -36,11 +36,11 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetPlatformProcAddrTable(
   if (UR_RESULT_SUCCESS != result) {
     return result;
   }
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urPlatformCreateWithNativeHandle;
   pDdiTable->pfnGet = urPlatformGet;
   pDdiTable->pfnGetApiVersion = urPlatformGetApiVersion;
   pDdiTable->pfnGetInfo = urPlatformGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urPlatformGetNativeHandle;
   pDdiTable->pfnGetBackendOption = urPlatformGetBackendOption;
   return UR_RESULT_SUCCESS;
 }
@@ -132,9 +132,9 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetSamplerProcAddrTable(
     return result;
   }
   pDdiTable->pfnCreate = urSamplerCreate;
-  pDdiTable->pfnCreateWithNativeHandle = nullptr;
+  pDdiTable->pfnCreateWithNativeHandle = urSamplerCreateWithNativeHandle;
   pDdiTable->pfnGetInfo = urSamplerGetInfo;
-  pDdiTable->pfnGetNativeHandle = nullptr;
+  pDdiTable->pfnGetNativeHandle = urSamplerGetNativeHandle;
   pDdiTable->pfnRelease = urSamplerRelease;
   pDdiTable->pfnRetain = urSamplerRetain;
   return UR_RESULT_SUCCESS;
@@ -303,6 +303,23 @@ UR_DLLEXPORT ur_result_t UR_APICALL urGetUsmP2PExpProcAddrTable(
   pDdiTable->pfnPeerAccessGetInfoExp = urUsmP2PPeerAccessGetInfoExp;
 
   return retVal;
+}
+
+UR_DLLEXPORT ur_result_t UR_APICALL urGetVirtualMemProcAddrTable(
+    ur_api_version_t version, ur_virtual_mem_dditable_t *pDdiTable) {
+  auto retVal = validateProcInputs(version, pDdiTable);
+  if (UR_RESULT_SUCCESS != retVal) {
+    return retVal;
+  }
+  pDdiTable->pfnGranularityGetInfo = urVirtualMemGranularityGetInfo;
+  pDdiTable->pfnReserve = urVirtualMemReserve;
+  pDdiTable->pfnFree = urVirtualMemFree;
+  pDdiTable->pfnMap = urVirtualMemMap;
+  pDdiTable->pfnUnmap = urVirtualMemUnmap;
+  pDdiTable->pfnSetAccess = urVirtualMemSetAccess;
+  pDdiTable->pfnGetInfo = urVirtualMemGetInfo;
+
+  return UR_RESULT_SUCCESS;
 }
 
 #if defined(__cplusplus)

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
@@ -187,9 +187,6 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
 #endif
       return ReturnValue(UR_USM_TYPE_UNKNOWN);
     }
-    case UR_USM_ALLOC_INFO_BASE_PTR:
-    case UR_USM_ALLOC_INFO_SIZE:
-      return UR_RESULT_ERROR_INVALID_VALUE;
     case UR_USM_ALLOC_INFO_DEVICE: {
       // get device index associated with this pointer
       Result = UR_CHECK_ERROR(
@@ -220,6 +217,9 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
       }
       return ReturnValue(Pool);
     }
+    case UR_USM_ALLOC_INFO_BASE_PTR:
+    case UR_USM_ALLOC_INFO_SIZE:
+      return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
     default:
       return UR_RESULT_ERROR_INVALID_ENUMERATION;
     }

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/virtual_memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/virtual_memory.cpp
@@ -1,0 +1,109 @@
+//===--------- virtual_memory.cpp - HIP Adapter ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "common.hpp"
+
+UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemGranularityGetInfo(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice,
+    ur_virtual_mem_granularity_info_t propName, size_t propSize,
+    void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hContext;
+  std::ignore = hDevice;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urVirtualMemReserve(ur_context_handle_t hContext, const void *pStart,
+                    size_t size, void **ppStart) {
+  std::ignore = hContext;
+  std::ignore = pStart;
+  std::ignore = size;
+  std::ignore = ppStart;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemFree(
+    ur_context_handle_t hContext, const void *pStart, size_t size) {
+  std::ignore = hContext;
+  std::ignore = pStart;
+  std::ignore = size;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urVirtualMemMap(ur_context_handle_t hContext, const void *pStart, size_t size,
+                ur_physical_mem_handle_t hPhysicalMem, size_t offset,
+                ur_virtual_mem_access_flags_t flags) {
+  std::ignore = hContext;
+  std::ignore = pStart;
+  std::ignore = size;
+  std::ignore = hPhysicalMem;
+  std::ignore = offset;
+  std::ignore = flags;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urVirtualMemUnmap(
+    ur_context_handle_t hContext, const void *pStart, size_t size) {
+  std::ignore = hContext;
+  std::ignore = pStart;
+  std::ignore = size;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urVirtualMemSetAccess(ur_context_handle_t hContext, const void *pStart,
+                      size_t size, ur_virtual_mem_access_flags_t flags) {
+  std::ignore = hContext;
+  std::ignore = pStart;
+  std::ignore = size;
+  std::ignore = flags;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urVirtualMemGetInfo(ur_context_handle_t hContext, const void *pStart,
+                    size_t size, ur_virtual_mem_info_t propName,
+                    size_t propSize, void *pPropValue, size_t *pPropSizeRet) {
+  std::ignore = hContext;
+  std::ignore = pStart;
+  std::ignore = size;
+  std::ignore = propName;
+  std::ignore = propSize;
+  std::ignore = pPropValue;
+  std::ignore = pPropSizeRet;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL urPhysicalMemCreate(
+    ur_context_handle_t hContext, ur_device_handle_t hDevice, size_t size,
+    const ur_physical_mem_properties_t *pProperties,
+    ur_physical_mem_handle_t *phPhysicalMem) {
+  std::ignore = hContext;
+  std::ignore = hDevice;
+  std::ignore = size;
+  std::ignore = pProperties;
+  std::ignore = phPhysicalMem;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urPhysicalMemRetain(ur_physical_mem_handle_t hPhysicalMem) {
+  std::ignore = hPhysicalMem;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}
+
+UR_APIEXPORT ur_result_t UR_APICALL
+urPhysicalMemRelease(ur_physical_mem_handle_t hPhysicalMem) {
+  std::ignore = hPhysicalMem;
+  return UR_RESULT_ERROR_UNSUPPORTED_FEATURE;
+}


### PR DESCRIPTION
This PR:
* Addresses issues found when running the unified-runtime CTS against the HIP adapter.

Notable fixes:
* Return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION when an info query does not support this enum
* Return UR_RESULT_ERROR_UNSUPPORTED_FEATURE for unimplemented entry-points
* Invoke context deleters
* Device info queries were returning the wrong types
* Implement urMemImageGetInfo
* Set the EvBase counter during platform initialization