### PR TITLE
[SYCL] Use default initializer for variables to fix Coverity warnings

### DIFF
--- a/sycl/source/detail/builtins_helper.hpp
+++ b/sycl/source/detail/builtins_helper.hpp
@@ -331,7 +331,7 @@ template <> struct helper<0> {
   template <typename Res, typename Op, typename T1, typename T2>
   inline void run_1v_2p(Res &r, Op op, T1 x, T2 y) {
     // TODO avoid creating a temporary variable
-    typename std::remove_pointer<T2>::type::element_type temp;
+    typename std::remove_pointer<T2>::type::element_type temp{};
     r.template swizzle<0>() = op(x.template swizzle<0>(), &temp);
     y->template swizzle<0>() = temp;
   }
@@ -339,7 +339,7 @@ template <> struct helper<0> {
   template <typename Res, typename Op, typename T1, typename T2, typename T3>
   inline void run_1v_2v_3p(Res &r, Op op, T1 x, T2 y, T3 z) {
     // TODO avoid creating a temporary variable
-    typename std::remove_pointer<T3>::type::element_type temp;
+    typename std::remove_pointer<T3>::type::element_type temp{};
     r.template swizzle<0>() =
         op(x.template swizzle<0>(), y.template swizzle<0>(), &temp);
     z->template swizzle<0>() = temp;


### PR DESCRIPTION
Follow up for https://github.com/intel/llvm/pull/10913