### PR TITLE
[SYCL] Fix Level Zero tests on machines with multiple GPUs

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/level-zero-link-flags.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-link-flags.cpp
@@ -19,9 +19,11 @@ class MyKernel;
 void test() {
   sycl::queue Queue;
   sycl::context Context = Queue.get_context();
+  sycl::device Device = Queue.get_device();
 
   auto BundleInput =
-      sycl::get_kernel_bundle<MyKernel, sycl::bundle_state::input>(Context);
+      sycl::get_kernel_bundle<MyKernel, sycl::bundle_state::input>(Context,
+                                                                   {Device});
   auto BundleObject = sycl::compile(BundleInput);
 
   try {

--- a/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
+++ b/sycl/test-e2e/KernelAndProgram/level-zero-static-link-flow.cpp
@@ -32,9 +32,11 @@ class MyKernel;
 void test() {
   sycl::queue Queue;
   sycl::context Context = Queue.get_context();
+  sycl::device Device = Queue.get_device();
 
   auto BundleInput =
-      sycl::get_kernel_bundle<MyKernel, sycl::bundle_state::input>(Context);
+      sycl::get_kernel_bundle<MyKernel, sycl::bundle_state::input>(Context,
+                                                                   {Device});
   auto BundleObject = sycl::compile(BundleInput);
   sycl::link(BundleObject);
 


### PR DESCRIPTION
Level Zero adapter does not support building programs with multiple devices yet. Modify the test to always use a single device to avoid failures on multi-GPU machines.