### PR TITLE
[SYCL][Driver] Add hidden option to preserve device metadata in SPIR-V

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3738,6 +3738,9 @@ def fsycl_max_parallel_jobs_EQ : Joined<["-"], "fsycl-max-parallel-link-jobs=">,
   HelpText<"Experimental feature: Controls the maximum parallelism of actions performed "
   "on SYCL device code post-link, i.e. the generation of SPIR-V device images "
   "or AOT compilation of each device image.">;
+def fsycl_preserve_device_nonsemantic_metadata : Flag<["-"], "fsycl-preserve-device-nonsemantic-metadata">,
+  Visibility<[ClangOption, CLOption, DXCOption]>, Flags<[HelpHidden]>, HelpText<"Preserve non-semantic "
+  "metadata in SPIR-V device images.">;
 def ftarget_compile_fast : Flag<["-"], "ftarget-compile-fast">,
   Visibility<[ClangOption, CLOption, DXCOption]>, HelpText<"Experimental feature: Reduce target "
   "compilation time, with potential runtime performance trade-off.">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9839,7 +9839,11 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
         TCArgs.getLastArgValue(options::OPT_fsycl_device_obj_EQ)
             .equals_insensitive("spirv") &&
         !TCArgs.hasArg(options::OPT_fsycl_device_only);
-    if (CreatingSyclSPIRVFatObj)
+    bool ShouldPreserveMetadataInFinalImage =
+        TCArgs.hasArg(options::OPT_fsycl_preserve_device_nonsemantic_metadata);
+    bool ShouldPreserveMetadata =
+        CreatingSyclSPIRVFatObj || ShouldPreserveMetadataInFinalImage;
+    if (ShouldPreserveMetadata)
       TranslatorArgs.push_back("--spirv-preserve-auxdata");
 
     // Disable all the extensions by default
@@ -9884,7 +9888,7 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
                 ",+SPV_KHR_uniform_group_instructions"
                 ",+SPV_INTEL_masked_gather_scatter"
                 ",+SPV_INTEL_tensor_float32_conversion";
-    if (CreatingSyclSPIRVFatObj)
+    if (ShouldPreserveMetadata)
       ExtArg += ",+SPV_KHR_non_semantic_info";
 
     TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));

--- a/clang/test/Driver/sycl-spirv-metadata.cpp
+++ b/clang/test/Driver/sycl-spirv-metadata.cpp
@@ -1,0 +1,17 @@
+///
+/// Tests for -fsycl-preserve-device-nonsemantic-metadata
+///
+
+// RUN: touch %tfoo.o
+// RUN: %clangxx -fsycl -fsycl-preserve-device-nonsemantic-metadata -### %tfoo.o 2>&1 | \
+// RUN:  FileCheck -check-prefix CHECK-WITH %s
+// RUN: %clangxx -fsycl -### %tfoo.o 2>&1 | \
+// RUN:  FileCheck -check-prefix CHECK-WITHOUT %s
+
+// CHECK-WITH: llvm-spirv{{.*}} "--spirv-preserve-auxdata"
+// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_KHR_non_semantic_info"
+
+// CHECK-WITHOUT: "{{.*}}llvm-spirv"
+// CHECK-WITHOUT-NOT: --spirv-preserve-auxdata
+// CHECK-WITHOUT:-spirv-ext=
+// CHECK-WITHOUT-NOT: +SPV_KHR_non_semantic_info


### PR DESCRIPTION
Preserving this nonsemantic metadata can have value for internal testing, as it contains some extra information about kernel data types that may be lost otherwise.