### PR TITLE
[CI] Avoid duplicate run for pulldown PR

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -5,7 +5,6 @@ on:
     branches:
     - sycl
     - sycl-devops-pr/**
-    - llvmspirv_pulldown
 
   pull_request:
     branches:


### PR DESCRIPTION
for LLVM and SPIRV pulldown PR like https://github.com/intel/llvm/pull/11031
We are running duplicate post-commit tests,
one triggered on `push`, the other triggered on `pull request`.

This is to remove the branch from `push` trigger, and only do the test
on `pull request`.
