### PR TITLE
[SYCL][Joint Matrix] Add missing tests for SG=32

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_colA_rowB_colC.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_colA_rowB_colC.cpp
@@ -1,4 +1,4 @@
-//==-------- joint_matrix_down_convert.cpp  - DPC++ joint_matrix------------==//
+//==---------- joint_matrix_colA_rowB_colC.cpp - DPC++ joint_matrix---------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include "common.hpp"
+// XFAIL:*
 
-constexpr size_t SG_SZ = 16;
+#include "../common.hpp"
 
-#include "joint_matrix_down_convert_impl.hpp"
+constexpr size_t SG_SZ = 32;
+constexpr size_t TN = 16;
+
+#include "../joint_matrix_colA_rowB_colC_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_down_convert.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_down_convert.cpp
@@ -10,8 +10,8 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include "common.hpp"
+#include "../common.hpp"
 
-constexpr size_t SG_SZ = 16;
+constexpr size_t SG_SZ = 32;
 
-#include "joint_matrix_down_convert_impl.hpp"
+#include "../joint_matrix_down_convert_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_out_bounds.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_out_bounds.cpp
@@ -1,4 +1,4 @@
-//==-------- joint_matrix_down_convert.cpp  - DPC++ joint_matrix------------==//
+//==-------- joint_matrix_out_bounds.cpp  - DPC++ joint_matrix--------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,12 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include "common.hpp"
+// XFAIL:*
 
-constexpr size_t SG_SZ = 16;
+#include "../common.hpp"
 
-#include "joint_matrix_down_convert_impl.hpp"
+constexpr size_t SG_SZ = 32;
+constexpr size_t TN = 16;
+constexpr size_t MATRIX_K = 1024 + 24;
+
+#include "../joint_matrix_out_bounds_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_transposeC.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_transposeC.cpp
@@ -1,4 +1,4 @@
-//==-------- joint_matrix_down_convert.cpp  - DPC++ joint_matrix------------==//
+//==----------- joint_matrix_transposeC.cpp  - DPC++ joint_matrix-----------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include "common.hpp"
+// XFAIL:*
 
-constexpr size_t SG_SZ = 16;
+#include "../common.hpp"
 
-#include "joint_matrix_down_convert_impl.hpp"
+constexpr size_t SG_SZ = 32;
+constexpr size_t TN = 16;
+
+#include "../joint_matrix_transposeC_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_unaligned_k.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_unaligned_k.cpp
@@ -1,4 +1,4 @@
-//==-------- joint_matrix_down_convert.cpp  - DPC++ joint_matrix------------==//
+//==-------- joint_matrix_unaligned_k.cpp  - DPC++ joint_matrix-------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -10,8 +10,12 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include "common.hpp"
+// XFAIL:*
 
-constexpr size_t SG_SZ = 16;
+#include "../common.hpp"
 
-#include "joint_matrix_down_convert_impl.hpp"
+constexpr size_t SG_SZ = 32;
+constexpr size_t TN = 16;
+static constexpr size_t MATRIX_K = 1024 + 14;
+
+#include "../joint_matrix_out_bounds_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_down_convert_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_down_convert_impl.hpp
@@ -1,0 +1,85 @@
+//==-------- joint_matrix_down_convert_impl.hpp  - DPC++ joint_matrix-------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#include <iostream>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+
+constexpr size_t TM = 8;
+// TN and TK must be the same for this test.
+constexpr size_t TN = 16;
+constexpr size_t TK = 16;
+
+template <typename T1, typename T2, size_t M, size_t N, size_t K>
+void matrix_copy(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A) {
+  size_t NDRangeM = M / TM;
+  size_t NDRangeN = N / TN;
+  buffer<bfloat16, 2> bufA(A.get_data(), range<2>(M, K));
+  buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
+
+  queue q;
+  q.submit([&](handler &cgh) {
+     auto accC = bufC.get_access<access::mode::read_write>(cgh);
+     auto accA = bufA.get_access<access::mode::write>(cgh);
+
+     cgh.parallel_for(
+         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
+         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+           // The submatrix API has to be accessed by all the workitems in a
+           // subgroup these functions will be called once by the subgroup no
+           // code divergence between the workitems
+           const auto global_idx = spmd_item.get_global_id(0);
+           const auto global_idy = spmd_item.get_global_id(1);
+           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+
+           sub_group sg = spmd_item.get_sub_group();
+           joint_matrix<sub_group, bfloat16, use::a, TM, TK, layout::row_major>
+               sub_a;
+           joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
+
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
+           // This will be replaced by joint_matrix_copy API
+           // joint_matrix_copy(sg, sub_c, sub_ac);
+           auto wi_slice_c =
+               sycl::ext::intel::experimental::matrix::get_wi_data(sg, sub_c);
+           auto wi_slice_a =
+               sycl::ext::intel::experimental::matrix::get_wi_data(sg, sub_a);
+           for (int i = 0; i < wi_slice_c.length(); i++) {
+             wi_slice_a[i] = (bfloat16)wi_slice_c[i];
+           }
+           ext::intel::experimental::matrix::joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N);
+         }); // parallel for
+   }).wait();
+}
+
+int main() {
+  static constexpr size_t MATRIX_M = TM * 2;
+  static constexpr size_t MATRIX_N = TN * 2;
+  static constexpr size_t MATRIX_K = TK * 2;
+  bfloat16 A[MATRIX_M][MATRIX_K];
+  float C[MATRIX_M][MATRIX_N];
+
+  matrix_rand(MATRIX_M, MATRIX_N, *C, (float)5);
+
+  big_matrix<float, MATRIX_M, MATRIX_N> MC((float *)&C);
+  big_matrix<bfloat16, MATRIX_M, MATRIX_K> MA((bfloat16 *)&A);
+  matrix_copy(MC, MA);
+
+  bool res = matrix_compare(MATRIX_M, MATRIX_N, *A, *C);
+  std::cout << (res ? "passed" : "failed") << std::endl;
+  return !res;
+}


### PR DESCRIPTION
These tests were added for SG=16, but not for SG=32. Fixing that:
joint_matrix_colA_rowB_colC.cpp,
joint_matrix_down_convert.cpp,
joint_matrix_out_bounds.cpp,
joint_matrix_transposeC.cpp,
joint_matrix_unaligned_k.cpp