### PR TITLE
[SYCL] Improve accuracy of double tanpi host implementation

### DIFF
--- a/sycl/source/detail/builtins_math.cpp
+++ b/sycl/source/detail/builtins_math.cpp
@@ -87,7 +87,12 @@ template <typename T> inline T __sincos(T x, T *cosval) {
 
 template <typename T> inline T __sinpi(T x) { return std::sin(M_PI * x); }
 
-template <typename T> inline T __tanpi(T x) { return std::tan(M_PI * x); }
+template <typename T> inline T __tanpi(T x) {
+  // For uniformity, place in range [0.0, 1.0).
+  double y = x - std::floor(x);
+  // Flip for better accuracy.
+  return 1.0 / std::tan((0.5 - y) * M_PI);
+}
 
 } // namespace
 
@@ -1078,7 +1083,7 @@ __SYCL_EXPORT s::cl_double sycl_host_tanpi(s::cl_double x) __NOEXC {
   return __tanpi(x);
 }
 __SYCL_EXPORT s::cl_half sycl_host_tanpi(s::cl_half x) __NOEXC {
-  return __tanpi(x);
+  return __tanpi<float>(x);
 }
 MAKE_1V(sycl_host_tanpi, s::cl_float, s::cl_float)
 MAKE_1V(sycl_host_tanpi, s::cl_double, s::cl_double)

--- a/sycl/test/regression/host_tanpi_double_accuracy.cpp
+++ b/sycl/test/regression/host_tanpi_double_accuracy.cpp
@@ -1,0 +1,47 @@
+// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %t.out
+//
+// Checks that sycl::tanpi with double has the accuracy required by the
+// specification. Reference results are taken from SYCL-CTS.
+
+#include <cmath>
+#include <iomanip>
+#include <sycl/sycl.hpp>
+
+double get_ulp(double X) {
+  double Inf = std::numeric_limits<double>::infinity();
+  double Negative = std::fabs(std::nextafter(X, -Inf) - X);
+  double Positive = std::fabs(std::nextafter(X, Inf) - X);
+  return std::fmin(Negative, Positive);
+}
+
+int check_tanpi(double input, double ReferenceRes, unsigned int Acc = 6) {
+  double Value = sycl::tanpi(input);
+
+  double Difference = std::fabs(Value - ReferenceRes);
+  double DifferenceExpected = Acc * get_ulp(ReferenceRes);
+
+  if (Difference > DifferenceExpected) {
+    std::cout << "sycl::tanpi(" << input << "): " << Value
+              << " is not the required accuracy compared to " << ReferenceRes
+              << std::endl;
+    return 1;
+  }
+  return 0;
+}
+
+int main() {
+  int Failures = 0;
+  std::cout << std::setprecision(64);
+  Failures += check_tanpi(0.5090197771,
+                          -35.2807704551884313559639849700033664703369140625);
+  Failures += check_tanpi(0.4812775633,
+                          16.98190960997280996025438071228563785552978515625);
+  Failures += check_tanpi(0.5037494847,
+                          -84.8903754371682879309446434490382671356201171875);
+  Failures += check_tanpi(0.4948622932,
+                          61.95025450742041783769309404306113719940185546875);
+  Failures += check_tanpi(0.506352514,
+                          -50.10105070167288232596547459252178668975830078125);
+  return Failures;
+}

--- a/sycl/test/regression/host_tanpi_double_accuracy.cpp
+++ b/sycl/test/regression/host_tanpi_double_accuracy.cpp
@@ -2,7 +2,7 @@
 // RUN: %t.out
 //
 // Checks that sycl::tanpi with double has the accuracy required by the
-// specification. Reference results are taken from SYCL-CTS.
+// specification.
 
 #include <cmath>
 #include <iomanip>
@@ -15,6 +15,10 @@ double get_ulp(double X) {
   return std::fmin(Negative, Positive);
 }
 
+// NOTE: Acc is the expected accuracy in ULPs. For non-half builtins, the
+// SYCL 2020 specification specifies that it should follow the accuracy required
+// by the OpenCL specification, which for tanpi means <= 6 ULP. See
+// https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#relative-error-as-ulps.
 int check_tanpi(double input, double ReferenceRes, unsigned int Acc = 6) {
   double Value = sycl::tanpi(input);
 
@@ -33,6 +37,7 @@ int check_tanpi(double input, double ReferenceRes, unsigned int Acc = 6) {
 int main() {
   int Failures = 0;
   std::cout << std::setprecision(64);
+  // Reference results are taken from SYCL-CTS.
   Failures += check_tanpi(0.5090197771,
                           -35.2807704551884313559639849700033664703369140625);
   Failures += check_tanpi(0.4812775633,


### PR DESCRIPTION
This commit improves the accuracy of the host-side tanpi implementation for double by reducing the argument to the [0.0, 1.0) range for uniformity and flipping the computation of tan.