### PR TITLE
[SYCL] Provide size in wchars (not bytes) to GetModuleFileName

### DIFF
--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -70,8 +70,8 @@ std::wstring getCurrentDSODir() {
   auto Handle = getOSModuleHandle(reinterpret_cast<void *>(&getCurrentDSODir));
   DWORD Ret = GetModuleFileName(
       reinterpret_cast<HMODULE>(ExeModuleHandle == Handle ? 0 : Handle), Path,
-      sizeof(Path));
-  assert(Ret < sizeof(Path) && "Path is longer than PATH_MAX?");
+      MAX_PATH);
+  assert(Ret < MAX_PATH && "Path is longer than MAX_PATH?");
   assert(Ret > 0 && "GetModuleFileName failed");
   (void)Ret;
 

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -455,7 +455,7 @@ static void initializePlugins(std::vector<PluginPtr> &Plugins) {
   std::vector<std::tuple<std::string, backend, void *>> LoadedPlugins =
       loadPlugins(std::move(PluginNames));
 
-  for (auto [Name, Backend, Library] : LoadedPlugins) {
+  for (auto &[Name, Backend, Library] : LoadedPlugins) {
     std::shared_ptr<PiPlugin> PluginInformation = std::make_shared<PiPlugin>(
         PiPlugin{_PI_H_VERSION_STRING, _PI_H_VERSION_STRING,
                  /*Targets=*/nullptr, /*FunctionPointers=*/{}});

--- a/sycl/source/detail/windows_pi.cpp
+++ b/sycl/source/detail/windows_pi.cpp
@@ -74,8 +74,8 @@ static std::filesystem::path getCurrentDSODirPath() {
       getOSModuleHandle(reinterpret_cast<void *>(&getCurrentDSODirPath));
   DWORD Ret = GetModuleFileName(
       reinterpret_cast<HMODULE>(ExeModuleHandle == Handle ? 0 : Handle), Path,
-      sizeof(Path));
-  assert(Ret < sizeof(Path) && "Path is longer than PATH_MAX?");
+      MAX_PATH);
+  assert(Ret < MAX_PATH && "Path is longer than MAX_PATH?");
   assert(Ret > 0 && "GetModuleFileName failed");
   (void)Ret;
 


### PR DESCRIPTION
Wrongfully size of the output buffer in bytes is provided to GetModuleFileName.
Provide size in wchars instead.