### PR TITLE
[SYCL][Joint Matrix] Update xfail marking for SG32/joint_matrix_tf32.cpp

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_tf32.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_tf32.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-// XFAIL:*
+// XFAIL:cpu
 
 #include <iostream>
 #include <random>


### PR DESCRIPTION
Enabled test on GPU. The test is expected to fail on CPU still due to functionality not yet implemented.