### PR TITLE
[SYCL][Graph][E2E] Remove float usage from Graph tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/depends_on.cpp
+++ b/sycl/test-e2e/Graph/Explicit/depends_on.cpp
@@ -19,27 +19,27 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_device<float>(N, Queue);
+  int *Arr = malloc_device<int>(N, Queue);
 
   Graph.begin_recording(Queue);
   // `Event` corresponds to a graph node
   event Event = Queue.submit([&](handler &CGH) {
-    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Arr[idx] = 42.0f; });
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Arr[idx] = 42; });
   });
   Graph.end_recording(Queue);
 
   Graph.add([&](handler &CGH) {
     CGH.depends_on(Event); // creates edge to recorded graph node
-    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Arr[idx] *= 2.0f; });
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { Arr[idx] *= 2; });
   });
 
   auto ExecGraph = Graph.finalize();
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  constexpr float ref = 42.0f * 2.0f;
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  constexpr int ref = 42 * 2;
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == ref);
 

--- a/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
@@ -18,59 +18,59 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_shared<float>(N, Queue);
+  int *Arr = malloc_shared<int>(N, Queue);
 
-  // Buffer elements set to 0.5
+  // Buffer elements set to 3
   auto E1 = Queue.submit([&](handler &CGH) {
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Arr[i] = 0.5f;
+      Arr[i] = 3;
     });
   });
 
   Graph.add([&](handler &CGH) {
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Arr[i] += 0.25f;
+      Arr[i] += 2;
     });
   });
 
-  // Buffer elements set to 1.5
+  // Buffer elements set to 4
   auto E2 = Queue.submit([&](handler &CGH) {
     CGH.depends_on(E1);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Arr[i] += 1.0f;
+      Arr[i] += 1;
     });
   });
 
   auto ExecGraph = Graph.finalize();
 
-  // Buffer elements set to 3.0
+  // Buffer elements set to 8
   auto E3 = Queue.submit([&](handler &CGH) {
     CGH.depends_on(E2);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Arr[i] *= 2.0f;
+      Arr[i] *= 2;
     });
   });
 
-  // Buffer elements set to 3.25
+  // Buffer elements set to 10
   auto E4 = Queue.submit([&](handler &CGH) {
     CGH.depends_on(E3);
     CGH.ext_oneapi_graph(ExecGraph);
   });
 
-  // Buffer elements set to 6.5
+  // Buffer elements set to 20
   auto E5 = Queue.submit([&](handler &CGH) {
     CGH.depends_on(E4);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Arr[i] *= 2.0f;
+      Arr[i] *= 2;
     });
   });
 
-  // Buffer elements set to 6.75
+  // Buffer elements set to 22
   Queue.submit([&](handler &CGH) {
     CGH.depends_on(E5);
     CGH.ext_oneapi_graph(ExecGraph);
@@ -79,7 +79,7 @@ int main() {
   Queue.wait();
 
   for (size_t i = 0; i < N; i++) {
-    assert(Arr[i] == 6.75f);
+    assert(Arr[i] == 22);
   }
 
   // Free the allocated memory

--- a/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
@@ -18,18 +18,18 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
 
   auto Init = Graph.add([&](handler &CGH) {
-    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { X[idx] = 2.0f; });
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { X[idx] = 2; });
   });
 
   auto Add = Graph.add([&](handler &CGH) {
-    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { X[idx] += 2.0f; });
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { X[idx] += 2; });
   });
 
   auto Mult = Graph.add([&](handler &CGH) {
-    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { X[idx] *= 3.0f; });
+    CGH.parallel_for(range<1>{N}, [=](id<1> idx) { X[idx] *= 3; });
   });
 
   Graph.make_edge(Init, Mult);
@@ -39,11 +39,11 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), X, N * sizeof(float)).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), X, N * sizeof(int)).wait();
 
   for (int i = 0; i < N; i++)
-    assert(Output[i] == 8.0f);
+    assert(Output[i] == 8);
 
   sycl::free(X, Queue);
 

--- a/sycl/test-e2e/Graph/Explicit/single_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/single_node.cpp
@@ -17,34 +17,34 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_device<float>(N, Queue);
+  int *Arr = malloc_device<int>(N, Queue);
 
-  float ZeroPattern = 0.0f;
+  int ZeroPattern = 0;
   Queue.fill(Arr, ZeroPattern, N).wait();
 
   Graph.add([&](handler &CGH) {
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Arr[i] = 3.14f;
+      Arr[i] = 3;
     });
   });
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == 0);
 
   auto ExecGraph = Graph.finalize();
 
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == 0);
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
-    assert(Output[i] == 3.14f);
+    assert(Output[i] == 3);
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
@@ -21,17 +21,17 @@ int main() {
       {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
 
   const size_t N = 10;
-  std::vector<float> Arr(N, 0.0f);
+  std::vector<int> Arr(N, 0);
 
-  buffer<float> Buf{N};
+  buffer<int> Buf{N};
   Buf.set_write_back(false);
 
-  // Buffer elements set to 0.5
+  // Buffer elements set to 3
   Queue.submit([&](handler &CGH) {
     auto Acc = Buf.get_access(CGH);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Acc[i] = 0.5f;
+      Acc[i] = 3;
     });
   });
 
@@ -39,51 +39,51 @@ int main() {
     auto Acc = Buf.get_access(CGH);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Acc[i] += 0.25f;
+      Acc[i] += 2;
     });
   });
 
   for (size_t i = 0; i < N; i++) {
-    assert(Arr[i] == 0.0f);
+    assert(Arr[i] == 0);
   }
 
-  // Buffer elements set to 1.5
+  // Buffer elements set to 4
   Queue.submit([&](handler &CGH) {
     auto Acc = Buf.get_access(CGH);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Acc[i] += 1.0f;
+      Acc[i] += 1;
     });
   });
 
   auto ExecGraph = Graph.finalize();
 
   for (size_t i = 0; i < N; i++) {
-    assert(Arr[i] == 0.0f);
+    assert(Arr[i] == 0);
   }
 
-  // Buffer elements set to 3.0
+  // Buffer elements set to 8
   Queue.submit([&](handler &CGH) {
     auto Acc = Buf.get_access(CGH);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Acc[i] *= 2.0f;
+      Acc[i] *= 2;
     });
   });
 
-  // Buffer elements set to 3.25
+  // Buffer elements set to 10
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  // Buffer elements set to 6.5
+  // Buffer elements set to 20
   Queue.submit([&](handler &CGH) {
     auto Acc = Buf.get_access(CGH);
     CGH.parallel_for(range<1>{N}, [=](id<1> idx) {
       size_t i = idx;
-      Acc[i] *= 2.0f;
+      Acc[i] *= 2;
     });
   });
 
-  // Buffer elements set to 6.75
+  // Buffer elements set to 22
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
   Queue.submit([&](handler &CGH) {
@@ -93,7 +93,7 @@ int main() {
   Queue.wait();
 
   for (size_t i = 0; i < N; i++) {
-    assert(Arr[i] == 6.75f);
+    assert(Arr[i] == 22);
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
@@ -6,12 +6,12 @@ int main() {
 
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
-  float DotpData = 0.f;
+  int DotpData = 0;
 
   const size_t N = 10;
-  std::vector<float> XData(N);
-  std::vector<float> YData(N);
-  std::vector<float> ZData(N);
+  std::vector<int> XData(N);
+  std::vector<int> YData(N);
+  std::vector<int> ZData(N);
 
   buffer DotpBuf(&DotpData, range<1>(1));
   DotpBuf.set_write_back(false);
@@ -33,9 +33,9 @@ int main() {
       auto Y = YBuf.get_access(CGH);
       auto Z = ZBuf.get_access(CGH);
       CGH.parallel_for(N, [=](id<1> it) {
-        X[it] = 1.0f;
-        Y[it] = 2.0f;
-        Z[it] = 3.0f;
+        X[it] = 1;
+        Y[it] = 2;
+        Z[it] = 3;
       });
     });
 
@@ -67,8 +67,7 @@ int main() {
           auto Dotp = DotpBuf.get_access(CGH);
           auto X = XBuf.get_access(CGH);
           auto Z = ZBuf.get_access(CGH);
-          CGH.parallel_for(range<1>{N},
-                           reduction(DotpBuf, CGH, 0.0f, std::plus()),
+          CGH.parallel_for(range<1>{N}, reduction(DotpBuf, CGH, 0, std::plus()),
                            [=](id<1> it, auto &Sum) { Sum += X[it] * Z[it]; });
         },
         NodeA, NodeB);

--- a/sycl/test-e2e/Graph/Inputs/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_usm_reduction.cpp
@@ -8,18 +8,18 @@ int main() {
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
-  float *Dotp = malloc_device<float>(1, Queue);
+  int *Dotp = malloc_device<int>(1, Queue);
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
-  float *Y = malloc_device<float>(N, Queue);
-  float *Z = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
+  int *Y = malloc_device<int>(N, Queue);
+  int *Z = malloc_device<int>(N, Queue);
 
   auto NodeI = add_node(Graph, Queue, [&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] = 1.0f;
-      Y[it] = 2.0f;
-      Z[it] = 3.0f;
+      X[it] = 1;
+      Y[it] = 2;
+      Z[it] = 3;
     });
   });
 
@@ -47,7 +47,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, {NodeA, NodeB});
-        CGH.parallel_for(range<1>{N}, reduction(Dotp, 0.0f, std::plus()),
+        CGH.parallel_for(range<1>{N}, reduction(Dotp, 0, std::plus()),
                          [=](id<1> it, auto &Sum) { Sum += X[it] * Z[it]; });
       },
       NodeA, NodeB);
@@ -57,8 +57,8 @@ int main() {
   // Using shortcut for executing a graph of commands
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  float Output;
-  Queue.memcpy(&Output, Dotp, sizeof(float)).wait();
+  int Output;
+  Queue.memcpy(&Output, Dotp, sizeof(int)).wait();
 
   assert(Output == dotp_reference_result(N));
 

--- a/sycl/test-e2e/Graph/Inputs/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Inputs/empty_node.cpp
@@ -11,7 +11,7 @@ int main() {
                                MyProperties};
 
   const size_t N = 10;
-  float *Arr = malloc_device<float>(N, Queue);
+  int *Arr = malloc_device<int>(N, Queue);
 
   auto Start = add_empty_node(Graph, Queue);
 
@@ -47,11 +47,11 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  std::vector<float> HostData(N);
-  Queue.memcpy(HostData.data(), Arr, N * sizeof(float)).wait();
+  std::vector<int> HostData(N);
+  Queue.memcpy(HostData.data(), Arr, N * sizeof(int)).wait();
 
   for (int i = 0; i < N; i++)
-    assert(HostData[i] == 1.f);
+    assert(HostData[i] == 1);
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
@@ -9,8 +9,8 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_device<float>(N, Queue);
-  float ZeroPattern = 0.0f;
+  int *Arr = malloc_device<int>(N, Queue);
+  int ZeroPattern = 0;
   Queue.fill(Arr, ZeroPattern, N).wait();
 
   add_node(Graph, Queue, [&](handler &CGH) {
@@ -20,26 +20,26 @@ int main() {
     });
   });
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == 0);
 
   auto ExecGraph = Graph.finalize();
 
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == 0);
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == 1);
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == 2);
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
@@ -10,24 +10,24 @@ int main() {
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
 
   auto S1 = add_node(SubGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 3.14f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 3; });
   });
 
   add_node(
       SubGraph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, S1);
-        CGH.parallel_for(N, [=](id<1> it) { X[it] += 0.5f; });
+        CGH.parallel_for(N, [=](id<1> it) { X[it] += 2; });
       },
       S1);
 
   auto ExecSubGraph = SubGraph.finalize();
 
   auto G1 = add_node(Graph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2; });
   });
 
   auto G2 = add_node(
@@ -42,15 +42,14 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, G2);
-        CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] *= -1.0f; });
+        CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] *= -1; });
       },
       G2);
 
   auto ExecGraph = Graph.finalize();
 
-  auto Event1 = Queue.submit([&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] = 1.f; });
-  });
+  auto Event1 = Queue.submit(
+      [&](handler &CGH) { CGH.parallel_for(N, [=](id<1> it) { X[it] = 1; }); });
 
   auto Event2 = Queue.submit([&](handler &CGH) {
     CGH.depends_on(Event1);
@@ -62,10 +61,10 @@ int main() {
     CGH.ext_oneapi_graph(ExecGraph);
   });
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), X, N * sizeof(float), Event3).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), X, N * sizeof(int), Event3).wait();
 
-  const float ref = ((1.f * 3.14f + 0.5f) * 2.0f * 3.14f + 0.5f) * -1.f;
+  const int ref = ((1 * 3 + 2) * 2 * 3 + 2) * -1;
   for (size_t i = 0; i < N; i++) {
     assert(Output[i] == ref);
   }

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
@@ -10,24 +10,24 @@ int main() {
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
 
   auto S1 = add_node(SubGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2; });
   });
 
   add_node(
       SubGraph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, S1);
-        CGH.parallel_for(N, [=](id<1> it) { X[it] += 0.5f; });
+        CGH.parallel_for(N, [=](id<1> it) { X[it] += 1; });
       },
       S1);
 
   auto ExecSubGraph = SubGraph.finalize();
 
   auto P1 = add_node(Graph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] = 1.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] = 1; });
   });
 
   auto P2 = add_node(
@@ -42,7 +42,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, P2);
-        CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] *= -1.0f; });
+        CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] *= -1; });
       },
       P2);
 
@@ -58,11 +58,11 @@ int main() {
 
   auto E = Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), X, N * sizeof(float), E).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), X, N * sizeof(int), E).wait();
 
   for (size_t i = 0; i < N; i++) {
-    assert(Output[i] == -4.5f);
+    assert(Output[i] == -5);
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
@@ -4,13 +4,13 @@
 
 namespace {
 // Calculates reference result at index i
-float reference(size_t i) {
-  float x = static_cast<float>(i);
-  float y = static_cast<float>(i);
-  float z = static_cast<float>(i);
+int reference(size_t i) {
+  int x = static_cast<int>(i);
+  int y = static_cast<int>(i);
+  int z = static_cast<int>(i);
 
-  x = x * 2.0f + 0.5f;  // XSubSubGraph
-  y = y * 3.0f + 0.14f; // YSubSubGraph
+  x = x * 2 + 0.5f;  // XSubSubGraph
+  y = y * 3 + 0.14f; // YSubSubGraph
 
   // SubGraph
   x = -x;
@@ -32,13 +32,13 @@ int main() {
   exp_ext::command_graph YSubSubGraph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
-  float *Y = malloc_device<float>(N, Queue);
-  float *Z = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
+  int *Y = malloc_device<int>(N, Queue);
+  int *Z = malloc_device<int>(N, Queue);
 
   // XSubSubGraph is a multiply-add operation on USM allocation X
   auto XSS1 = add_node(XSubSubGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2; });
   });
 
   add_node(
@@ -53,7 +53,7 @@ int main() {
 
   // YSubSubGraph is a multiply-add operation on USM allocation Y
   auto YSS1 = add_node(YSubSubGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { Y[it] *= 3.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { Y[it] *= 3; });
   });
 
   add_node(
@@ -70,8 +70,8 @@ int main() {
   // the results
   auto S1 = add_node(SubGraph, Queue, [&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] = static_cast<float>(it);
-      Y[it] = static_cast<float>(it);
+      X[it] = static_cast<int>(it);
+      Y[it] = static_cast<int>(it);
     });
   });
 
@@ -108,7 +108,7 @@ int main() {
   // does a multiply add with X & Y allocation results.
   auto G1 = add_node(Graph, Queue, [&](handler &CGH) {
     CGH.parallel_for(range<1>{N},
-                     [=](id<1> it) { Z[it] = static_cast<float>(it); });
+                     [=](id<1> it) { Z[it] = static_cast<int>(it); });
   });
 
   auto G2 = add_node(Graph, Queue,
@@ -127,11 +127,11 @@ int main() {
 
   auto E = Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), Z, N * sizeof(float), E).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Z, N * sizeof(int), E).wait();
 
   for (size_t i = 0; i < N; i++) {
-    float ref = reference(i);
+    int ref = reference(i);
     assert(Output[i] == ref);
   }
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_reduction.cpp
@@ -9,18 +9,18 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 
-  float *Dotp = malloc_device<float>(1, Queue);
+  int *Dotp = malloc_device<int>(1, Queue);
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
-  float *Y = malloc_device<float>(N, Queue);
-  float *Z = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
+  int *Y = malloc_device<int>(N, Queue);
+  int *Z = malloc_device<int>(N, Queue);
 
   auto NodeI = add_node(Graph, Queue, [&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] = 1.0f;
-      Y[it] = 2.0f;
-      Z[it] = 3.0f;
+      X[it] = 1;
+      Y[it] = 2;
+      Z[it] = 3;
     });
   });
 
@@ -48,7 +48,7 @@ int main() {
       Graph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, NodeSub);
-        CGH.parallel_for(range<1>{N}, reduction(Dotp, 0.0f, std::plus()),
+        CGH.parallel_for(range<1>{N}, reduction(Dotp, 0, std::plus()),
                          [=](id<1> it, auto &Sum) { Sum += X[it] * Z[it]; });
       },
       NodeSub);
@@ -58,8 +58,8 @@ int main() {
   // Using shortcut for executing a graph of commands
   Queue.ext_oneapi_graph(ExecGraph).wait();
 
-  float Output;
-  Queue.memcpy(&Output, Dotp, sizeof(float)).wait();
+  int Output;
+  Queue.memcpy(&Output, Dotp, sizeof(int)).wait();
   assert(Output == dotp_reference_result(N));
 
   sycl::free(Dotp, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
@@ -11,24 +11,24 @@ int main() {
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
 
   auto S1 = add_node(SubGraph, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2; });
   });
 
   add_node(
       SubGraph, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, S1);
-        CGH.parallel_for(N, [=](id<1> it) { X[it] += 0.5f; });
+        CGH.parallel_for(N, [=](id<1> it) { X[it] += 1; });
       },
       S1);
 
   auto ExecSubGraph = SubGraph.finalize();
 
   auto A1 = add_node(GraphA, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] = 1.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] = 1; });
   });
 
   auto A2 = add_node(
@@ -43,14 +43,14 @@ int main() {
       GraphA, Queue,
       [&](handler &CGH) {
         depends_on_helper(CGH, A2);
-        CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] *= -1.0f; });
+        CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] *= -1; });
       },
       A2);
 
   auto ExecGraphA = GraphA.finalize();
 
   auto B1 = add_node(GraphB, Queue, [&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] = static_cast<float>(it); });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] = static_cast<int>(it); });
   });
 
   auto B2 = add_node(
@@ -73,26 +73,26 @@ int main() {
 
   auto EventA1 =
       Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraphA); });
-  std::vector<float> OutputA(N);
-  auto EventA2 = Queue.memcpy(OutputA.data(), X, N * sizeof(float), EventA1);
+  std::vector<int> OutputA(N);
+  auto EventA2 = Queue.memcpy(OutputA.data(), X, N * sizeof(int), EventA1);
 
   auto EventB1 = Queue.submit([&](handler &CGH) {
     CGH.depends_on(EventA2);
     CGH.ext_oneapi_graph(ExecGraphB);
   });
-  std::vector<float> OutputB(N);
-  Queue.memcpy(OutputB.data(), X, N * sizeof(float), EventB1);
+  std::vector<int> OutputB(N);
+  Queue.memcpy(OutputB.data(), X, N * sizeof(int), EventB1);
   Queue.wait();
 
   auto refB = [](size_t i) {
-    float result = static_cast<float>(i);
-    result = result * 2.0f + 0.5f;
+    int result = static_cast<int>(i);
+    result = result * 2 + 1;
     result *= result;
     return result;
   };
 
   for (size_t i = 0; i < N; i++) {
-    assert(OutputA[i] == -2.5f);
+    assert(OutputA[i] == -3);
     assert(OutputB[i] == refB(i));
   }
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
@@ -9,9 +9,9 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_device<float>(N, Queue);
+  int *Arr = malloc_device<int>(N, Queue);
 
-  float Pattern = 3.14f;
+  int Pattern = 3.14f;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 
@@ -19,8 +19,8 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (int i = 0; i < N; i++)
     assert(Output[i] == Pattern);
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
@@ -12,9 +12,9 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_host<float>(N, Queue);
+  int *Arr = malloc_host<int>(N, Queue);
 
-  float Pattern = 3.14f;
+  int Pattern = 3.14f;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
@@ -13,9 +13,9 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *Arr = malloc_shared<float>(N, Queue);
+  int *Arr = malloc_shared<int>(N, Queue);
 
-  float Pattern = 3.14f;
+  int Pattern = 3.14f;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
@@ -18,20 +18,20 @@ int main() {
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
-  float *Dotp = malloc_device<float>(1, Queue);
+  int *Dotp = malloc_device<int>(1, Queue);
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
-  float *Y = malloc_device<float>(N, Queue);
-  float *Z = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
+  int *Y = malloc_device<int>(N, Queue);
+  int *Z = malloc_device<int>(N, Queue);
 
   Graph.begin_recording(Queue);
 
   auto InitEvent = Queue.submit([&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] = 1.0f;
-      Y[it] = 2.0f;
-      Z[it] = 3.0f;
+      X[it] = 1;
+      Y[it] = 2;
+      Z[it] = 3;
     });
   });
 
@@ -59,8 +59,8 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  float Output;
-  Queue.memcpy(&Output, Dotp, sizeof(float)).wait();
+  int Output;
+  Queue.memcpy(&Output, Dotp, sizeof(int)).wait();
 
   assert(Output == dotp_reference_result(N));
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
@@ -20,20 +20,20 @@ int main() {
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
-  float *Dotp = malloc_device<float>(1, Queue);
+  int *Dotp = malloc_device<int>(1, Queue);
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
-  float *Y = malloc_device<float>(N, Queue);
-  float *Z = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
+  int *Y = malloc_device<int>(N, Queue);
+  int *Z = malloc_device<int>(N, Queue);
 
   Graph.begin_recording(Queue);
 
   auto InitEvent = Queue.submit([&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] = 1.0f;
-      Y[it] = 2.0f;
-      Z[it] = 3.0f;
+      X[it] = 1;
+      Y[it] = 2;
+      Z[it] = 3;
     });
   });
 
@@ -65,8 +65,8 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  float Output;
-  Queue.memcpy(&Output, Dotp, sizeof(float)).wait();
+  int Output;
+  Queue.memcpy(&Output, Dotp, sizeof(int)).wait();
 
   assert(Output == dotp_reference_result(N));
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -20,21 +20,21 @@ int main() {
 
   exp_ext::command_graph Graph{QueueA.get_context(), QueueA.get_device()};
 
-  float *Dotp = malloc_device<float>(1, QueueA);
+  int *Dotp = malloc_device<int>(1, QueueA);
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, QueueA);
-  float *Y = malloc_device<float>(N, QueueA);
-  float *Z = malloc_device<float>(N, QueueA);
+  int *X = malloc_device<int>(N, QueueA);
+  int *Y = malloc_device<int>(N, QueueA);
+  int *Z = malloc_device<int>(N, QueueA);
 
   Graph.begin_recording(QueueA);
   Graph.begin_recording(QueueB);
 
   QueueA.submit([&](handler &CGH) {
     CGH.parallel_for(N, [=](id<1> it) {
-      X[it] = 1.0f;
-      Y[it] = 2.0f;
-      Z[it] = 3.0f;
+      X[it] = 1;
+      Y[it] = 2;
+      Z[it] = 3;
     });
   });
 
@@ -63,8 +63,8 @@ int main() {
 
   QueueA.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  float Output;
-  QueueA.memcpy(&Output, Dotp, sizeof(float)).wait();
+  int Output;
+  QueueA.memcpy(&Output, Dotp, sizeof(int)).wait();
 
   assert(Output == dotp_reference_result(N));
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
@@ -20,16 +20,16 @@ int main() {
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
-  float *X = malloc_device<float>(N, Queue);
+  int *X = malloc_device<int>(N, Queue);
 
   SubGraph.begin_recording(Queue);
 
   Queue.submit([&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2.0f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] *= 2; });
   });
 
   Queue.submit([&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] += 0.5f; });
+    CGH.parallel_for(N, [=](id<1> it) { X[it] += 1; });
   });
 
   SubGraph.end_recording(Queue);
@@ -38,14 +38,13 @@ int main() {
 
   Graph.begin_recording(Queue);
 
-  Queue.submit([&](handler &CGH) {
-    CGH.parallel_for(N, [=](id<1> it) { X[it] = 1.0f; });
-  });
+  Queue.submit(
+      [&](handler &CGH) { CGH.parallel_for(N, [=](id<1> it) { X[it] = 1; }); });
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecSubGraph); });
 
   Queue.submit([&](handler &CGH) {
-    CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] += 3.0f; });
+    CGH.parallel_for(range<1>{N}, [=](id<1> it) { X[it] += 3; });
   });
 
   Graph.end_recording();
@@ -54,10 +53,10 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); });
 
-  float Output;
-  Queue.memcpy(&Output, X, sizeof(float)).wait();
+  int Output;
+  Queue.memcpy(&Output, X, sizeof(int)).wait();
 
-  assert(Output == 5.5f);
+  assert(Output == 6);
 
   sycl::free(X, Queue);
 

--- a/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
@@ -12,9 +12,9 @@
 #include "../graph_common.hpp"
 
 const size_t N = 10;
-const float ExpectedValue = 42.0f;
+const int ExpectedValue = 42;
 
-void run_some_kernel(queue Queue, float *Data) {
+void run_some_kernel(queue Queue, int *Data) {
   // 'Data' is captured by ref here but will have gone out of scope when the
   // CGF is later run when the graph is executed.
   Queue.submit([&](handler &CGH) {
@@ -32,7 +32,7 @@ int main() {
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
-  float *Arr = malloc_device<float>(N, Queue);
+  int *Arr = malloc_device<int>(N, Queue);
 
   Graph.begin_recording(Queue);
   run_some_kernel(Queue, Arr);
@@ -42,8 +42,8 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  std::vector<float> Output(N);
-  Queue.memcpy(Output.data(), Arr, N * sizeof(float)).wait();
+  std::vector<int> Output(N);
+  Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++) {
     assert(Output[i] == ExpectedValue);
   }

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -401,13 +401,13 @@ auto add_empty_node(
 }
 
 // Values for dotp tests
-constexpr float Alpha = 1.0f;
-constexpr float Beta = 2.0f;
-constexpr float Gamma = 3.0f;
+constexpr int Alpha = 1;
+constexpr int Beta = 2;
+constexpr int Gamma = 3;
 
 // Reference function for dotp
-float dotp_reference_result(size_t N) {
-  return N * (Alpha * 1.0f + Beta * 2.0f) * (Gamma * 3.0f + Beta * 2.0f);
+int dotp_reference_result(size_t N) {
+  return N * (Alpha * 1 + Beta * 2) * (Gamma * 3 + Beta * 2);
 }
 
 /* Single use thread barrier which makes threads wait until defined number of


### PR DESCRIPTION
- Removes usage of float from graph E2E tests to avoid precision differences between host and some GPUs

Addresses issue reported in #10860 