### PR TITLE
[NFC][Opaque Pointer][clang] Remove code within ifndef INTEL_SYCL_OPAQUEPOINTER_READY

### DIFF
--- a/clang/include/clang/Basic/CodeGenOptions.def
+++ b/clang/include/clang/Basic/CodeGenOptions.def
@@ -517,10 +517,6 @@ ENUM_CODEGENOPT(ZeroCallUsedRegs, llvm::ZeroCallUsedRegs::ZeroCallUsedRegsKind,
 /// checksum calculations or not.
 CODEGENOPT(SYCLUseMainFileName, 1, 0)
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-/// Whether to use opaque pointers.
-CODEGENOPT(OpaquePointers, 1, 0)
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
 /// Modify C++ ABI to returning `this` pointer from constructors and
 /// non-deleting destructors. (No effect on Microsoft ABI.)

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -7227,15 +7227,6 @@ defm enable_noundef_analysis : BoolOption<"",
   PosFlag<SetTrue, [], [ClangOption], "Enable">,
   NegFlag<SetFalse, [], [ClangOption], "Disable">,
   BothFlags<[], [ClangOption], " analyzing function argument and return types for mandatory definedness">>;
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-defm opaque_pointers : BoolOption<"",
-  "opaque-pointers",
-  CodeGenOpts<"OpaquePointers">,
-  DefaultTrue,
-  PosFlag<SetTrue, [], [ClangOption], "Enable">,
-  NegFlag<SetFalse, [], [ClangOption], "Disable">,
-  BothFlags<[], [ClangOption], " opaque pointers">>;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 def discard_value_names : Flag<["-"], "discard-value-names">,
   HelpText<"Discard value names in LLVM IR">,
   MarshallingInfoFlag<CodeGenOpts<"DiscardValueNames">>;

--- a/clang/lib/CodeGen/ABIInfoImpl.cpp
+++ b/clang/lib/CodeGen/ABIInfoImpl.cpp
@@ -170,11 +170,7 @@ CodeGen::emitVoidPtrDirectVAArg(CodeGenFunction &CGF, Address VAListAddr,
   // Cast the element type to i8* if necessary.  Some platforms define
   // va_list as a struct containing an i8* instead of just an i8*.
   if (VAListAddr.getElementType() != CGF.Int8PtrTy)
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    VAListAddr = CGF.Builder.CreateElementBitCast(VAListAddr, CGF.Int8PtrTy);
-#else
     VAListAddr = VAListAddr.withElementType(CGF.Int8PtrTy);
-#endif
 
   llvm::Value *Ptr = CGF.Builder.CreateLoad(VAListAddr, "argp.cur");
 
@@ -200,12 +196,7 @@ CodeGen::emitVoidPtrDirectVAArg(CodeGenFunction &CGF, Address VAListAddr,
     Addr = CGF.Builder.CreateConstInBoundsByteGEP(Addr, SlotSize - DirectSize);
   }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  Addr = CGF.Builder.CreateElementBitCast(Addr, DirectTy);
-  return Addr;
-#else
   return Addr.withElementType(DirectTy);
-#endif
 }
 
 Address CodeGen::emitVoidPtrVAArg(CodeGenFunction &CGF, Address VAListAddr,

--- a/clang/lib/CodeGen/CGAtomic.cpp
+++ b/clang/lib/CodeGen/CGAtomic.cpp
@@ -80,7 +80,6 @@ namespace {
         AtomicSizeInBits = C.toBits(
             C.toCharUnitsFromBits(Offset + OrigBFI.Size + C.getCharWidth() - 1)
                 .alignTo(lvalue.getAlignment()));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         llvm::Value *BitFieldPtr = lvalue.getBitFieldPointer();
         auto OffsetInChars =
             (C.toCharUnitsFromBits(OrigBFI.Offset) / lvalue.getAlignment()) *
@@ -90,33 +89,15 @@ namespace {
         StoragePtr = CGF.Builder.CreateAddrSpaceCast(
             StoragePtr, llvm::PointerType::getUnqual(CGF.getLLVMContext()),
             "atomic_bitfield_base");
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        auto VoidPtrAddr = CGF.EmitCastToVoidPtr(lvalue.getBitFieldPointer());
-        auto OffsetInChars =
-            (C.toCharUnitsFromBits(OrigBFI.Offset) / lvalue.getAlignment()) *
-            lvalue.getAlignment();
-        VoidPtrAddr = CGF.Builder.CreateConstGEP1_64(
-            CGF.Int8Ty, VoidPtrAddr, OffsetInChars.getQuantity());
-        llvm::Type *IntTy = CGF.Builder.getIntNTy(AtomicSizeInBits);
-        auto Addr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-
-            VoidPtrAddr, IntTy->getPointerTo(), "atomic_bitfield_base");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         BFI = OrigBFI;
         BFI.Offset = Offset;
         BFI.StorageSize = AtomicSizeInBits;
         BFI.StorageOffset += OffsetInChars;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         llvm::Type *StorageTy = CGF.Builder.getIntNTy(AtomicSizeInBits);
         LVal = LValue::MakeBitfield(
             Address(StoragePtr, StorageTy, lvalue.getAlignment()), BFI,
             lvalue.getType(), lvalue.getBaseInfo(), lvalue.getTBAAInfo());
 
-#else
-        LVal = LValue::MakeBitfield(Address(Addr, IntTy, lvalue.getAlignment()),
-                                    BFI, lvalue.getType(), lvalue.getBaseInfo(),
-                                    lvalue.getTBAAInfo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         AtomicTy = C.getIntTypeForBitwidth(AtomicSizeInBits, OrigBFI.IsSigned);
         if (AtomicTy.isNull()) {
           llvm::APInt Size(
@@ -817,12 +798,7 @@ AddDirectArgument(CodeGenFunction &CGF, CallArgList &Args,
     ValTy =
         CGF.getContext().getIntTypeForBitwidth(SizeInBits, /*Signed=*/false);
     llvm::Type *ITy = llvm::IntegerType::get(CGF.getLLVMContext(), SizeInBits);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address Ptr = Address(Val, ITy, Align);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address Ptr = Address(CGF.Builder.CreateBitCast(Val, ITy->getPointerTo()),
-                          ITy, Align);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Val = CGF.EmitLoadOfScalar(Ptr, false,
                                CGF.getContext().getPointerType(ValTy),
                                Loc);
@@ -830,12 +806,7 @@ AddDirectArgument(CodeGenFunction &CGF, CallArgList &Args,
     Args.add(RValue::get(Val), ValTy);
   } else {
     // Non-optimized functions always take a reference.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Args.add(RValue::get(Val), CGF.getContext().VoidPtrTy);
-#else
-    Args.add(RValue::get(CGF.EmitCastToVoidPtr(Val)),
-                         CGF.getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 }
 
@@ -1126,26 +1097,15 @@ RValue CodeGenFunction::EmitAtomicExpr(AtomicExpr *E) {
       if (AS == LangAS::opencl_generic)
         return V;
       auto DestAS = getContext().getTargetAddressSpace(LangAS::opencl_generic);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       auto *DestType = llvm::PointerType::get(getLLVMContext(), DestAS);
-#else
-      auto T = llvm::cast<llvm::PointerType>(V->getType());
-      auto *DestType = llvm::PointerType::getWithSamePointeeType(T, DestAS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       return getTargetHooks().performAddrSpaceCast(
           *this, V, AS, LangAS::opencl_generic, DestType, false);
     };
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Args.add(RValue::get(CastToGenericAddrSpace(Ptr.getPointer(),
                                                 E->getPtr()->getType())),
              getContext().VoidPtrTy);
-#else
-    Args.add(RValue::get(CastToGenericAddrSpace(
-                 EmitCastToVoidPtr(Ptr.getPointer()), E->getPtr()->getType())),
-             getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     std::string LibCallName;
     QualType LoweredMemTy =
@@ -1177,17 +1137,10 @@ RValue CodeGenFunction::EmitAtomicExpr(AtomicExpr *E) {
       LibCallName = "__atomic_compare_exchange";
       RetTy = getContext().BoolTy;
       HaveRetTy = true;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Args.add(RValue::get(CastToGenericAddrSpace(Val1.getPointer(),
                                                   E->getVal1()->getType())),
                getContext().VoidPtrTy);
 
-#else
-      Args.add(
-          RValue::get(CastToGenericAddrSpace(
-              EmitCastToVoidPtr(Val1.getPointer()), E->getVal1()->getType())),
-          getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       AddDirectArgument(*this, Args, UseOptimizedLibcall, Val2.getPointer(),
                         MemTy, E->getExprLoc(), TInfo.Width);
       Args.add(RValue::get(Order), getContext().IntTy);
@@ -1349,12 +1302,7 @@ RValue CodeGenFunction::EmitAtomicExpr(AtomicExpr *E) {
       } else {
         // Value is returned through parameter before the order.
         RetTy = getContext().VoidTy;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         Args.add(RValue::get(Dest.getPointer()), getContext().VoidPtrTy);
-#else
-        Args.add(RValue::get(EmitCastToVoidPtr(Dest.getPointer())),
-                 getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
     }
     // order is always the last parameter
@@ -1622,15 +1570,8 @@ void AtomicInfo::EmitAtomicLoadLibcall(llvm::Value *AddForLoaded,
   // void __atomic_load(size_t size, void *mem, void *return, int order);
   CallArgList Args;
   Args.add(RValue::get(getAtomicSizeValue()), CGF.getContext().getSizeType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Args.add(RValue::get(getAtomicPointer()), CGF.getContext().VoidPtrTy);
   Args.add(RValue::get(AddForLoaded), CGF.getContext().VoidPtrTy);
-#else
-  Args.add(RValue::get(CGF.EmitCastToVoidPtr(getAtomicPointer())),
-           CGF.getContext().VoidPtrTy);
-  Args.add(RValue::get(CGF.EmitCastToVoidPtr(AddForLoaded)),
-           CGF.getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Args.add(
       RValue::get(llvm::ConstantInt::get(CGF.IntTy, (int)llvm::toCABI(AO))),
       CGF.getContext().IntTy);
@@ -1824,18 +1765,9 @@ AtomicInfo::EmitAtomicCompareExchangeLibcall(llvm::Value *ExpectedAddr,
   // void *desired, int success, int failure);
   CallArgList Args;
   Args.add(RValue::get(getAtomicSizeValue()), CGF.getContext().getSizeType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Args.add(RValue::get(getAtomicPointer()), CGF.getContext().VoidPtrTy);
   Args.add(RValue::get(ExpectedAddr), CGF.getContext().VoidPtrTy);
   Args.add(RValue::get(DesiredAddr), CGF.getContext().VoidPtrTy);
-#else
-  Args.add(RValue::get(CGF.EmitCastToVoidPtr(getAtomicPointer())),
-           CGF.getContext().VoidPtrTy);
-  Args.add(RValue::get(CGF.EmitCastToVoidPtr(ExpectedAddr)),
-           CGF.getContext().VoidPtrTy);
-  Args.add(RValue::get(CGF.EmitCastToVoidPtr(DesiredAddr)),
-           CGF.getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Args.add(RValue::get(
                llvm::ConstantInt::get(CGF.IntTy, (int)llvm::toCABI(Success))),
            CGF.getContext().IntTy);
@@ -2138,15 +2070,8 @@ void CodeGenFunction::EmitAtomicStore(RValue rvalue, LValue dest,
       CallArgList args;
       args.add(RValue::get(atomics.getAtomicSizeValue()),
                getContext().getSizeType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       args.add(RValue::get(atomics.getAtomicPointer()), getContext().VoidPtrTy);
       args.add(RValue::get(srcAddr.getPointer()), getContext().VoidPtrTy);
-#else
-      args.add(RValue::get(EmitCastToVoidPtr(atomics.getAtomicPointer())),
-               getContext().VoidPtrTy);
-      args.add(RValue::get(EmitCastToVoidPtr(srcAddr.getPointer())),
-               getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       args.add(
           RValue::get(llvm::ConstantInt::get(IntTy, (int)llvm::toCABI(AO))),
           getContext().IntTy);

--- a/clang/lib/CodeGen/CGBlocks.cpp
+++ b/clang/lib/CodeGen/CGBlocks.cpp
@@ -941,11 +941,7 @@ llvm::Value *CodeGenFunction::EmitBlockLiteral(const CGBlockInfo &blockInfo) {
       if (CI.isNested())
         byrefPointer = Builder.CreateLoad(src, "byref.capture");
       else
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         byrefPointer = src.getPointer();
-#else
-        byrefPointer = Builder.CreateBitCast(src.getPointer(), VoidPtrTy);
-#endif
 
       // Write that void* into the capture field.
       Builder.CreateStore(byrefPointer, blockField);
@@ -1241,14 +1237,8 @@ Address CodeGenFunction::GetAddrOfBlockDecl(const VarDecl *variable) {
 
     auto &byrefInfo = getBlockByrefInfo(variable);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     addr = Address(Builder.CreateLoad(addr), byrefInfo.Type,
                    byrefInfo.ByrefAlignment);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    addr = Address(Builder.CreateLoad(addr), Int8Ty, byrefInfo.ByrefAlignment);
-
-    addr = Builder.CreateElementBitCast(addr, byrefInfo.Type, "byref.addr");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     addr = emitBlockByrefAddress(addr, byrefInfo, /*follow*/ true,
                                  variable->getName());
@@ -1414,12 +1404,8 @@ void CodeGenFunction::setBlockContextParameter(const ImplicitParamDecl *D,
   // directly as BlockPointer.
   BlockPointer = Builder.CreatePointerCast(
       arg,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::PointerType::get(
           getLLVMContext(),
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      BlockInfo->StructureType->getPointerTo(
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           getContext().getLangOpts().OpenCL
               ? getContext().getTargetAddressSpace(LangAS::opencl_generic)
               : 0),
@@ -1681,9 +1667,6 @@ struct CallBlockRelease final : EHScopeStack::Cleanup {
     llvm::Value *BlockVarAddr;
     if (LoadBlockVarAddr) {
       BlockVarAddr = CGF.Builder.CreateLoad(Addr);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-      BlockVarAddr = CGF.Builder.CreateBitCast(BlockVarAddr, CGF.VoidPtrTy);
-#endif
     } else {
       BlockVarAddr = Addr.getPointer();
     }
@@ -1928,24 +1911,12 @@ CodeGenFunction::GenerateCopyHelperFunction(const CGBlockInfo &blockInfo) {
   auto AL = ApplyDebugLocation::CreateArtificial(*this);
 
   Address src = GetAddrOfLocalVar(&SrcDecl);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   src = Address(Builder.CreateLoad(src), blockInfo.StructureType,
                 blockInfo.BlockAlign);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  src = Address(Builder.CreateLoad(src), Int8Ty, blockInfo.BlockAlign);
-  src = Builder.CreateElementBitCast(src, blockInfo.StructureType,
-                                     "block.source");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Address dst = GetAddrOfLocalVar(&DstDecl);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   dst = Address(Builder.CreateLoad(dst), blockInfo.StructureType,
                 blockInfo.BlockAlign);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  dst = Address(Builder.CreateLoad(dst), Int8Ty, blockInfo.BlockAlign);
-  dst =
-      Builder.CreateElementBitCast(dst, blockInfo.StructureType, "block.dest");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   for (auto &capture : blockInfo.SortedCaptures) {
     if (capture.isConstantOrTrivial())
@@ -2003,13 +1974,7 @@ CodeGenFunction::GenerateCopyHelperFunction(const CGBlockInfo &blockInfo) {
     }
     case BlockCaptureEntityKind::BlockObject: {
       llvm::Value *srcValue = Builder.CreateLoad(srcField, "blockcopy.src");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-      srcValue = Builder.CreateBitCast(srcValue, VoidPtrTy);
-      llvm::Value *dstAddr =
-          Builder.CreateBitCast(dstField.getPointer(), VoidPtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *dstAddr = dstField.getPointer();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *args[] = {
         dstAddr, srcValue, llvm::ConstantInt::get(Int32Ty, flags.getBitMask())
       };
@@ -2132,13 +2097,8 @@ CodeGenFunction::GenerateDestroyHelperFunction(const CGBlockInfo &blockInfo) {
   auto AL = ApplyDebugLocation::CreateArtificial(*this);
 
   Address src = GetAddrOfLocalVar(&SrcDecl);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   src = Address(Builder.CreateLoad(src), blockInfo.StructureType,
                 blockInfo.BlockAlign);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  src = Address(Builder.CreateLoad(src), Int8Ty, blockInfo.BlockAlign);
-  src = Builder.CreateElementBitCast(src, blockInfo.StructureType, "block");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   CodeGenFunction::RunCleanupsScope cleanups(*this);
 
@@ -2176,13 +2136,8 @@ public:
   void emitCopy(CodeGenFunction &CGF, Address destField,
                 Address srcField) override {
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     destField = destField.withElementType(CGF.Int8Ty);
     srcField = srcField.withElementType(CGF.Int8PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    destField = CGF.Builder.CreateElementBitCast(destField, CGF.Int8Ty);
-    srcField = CGF.Builder.CreateElementBitCast(srcField, CGF.Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *srcValue = CGF.Builder.CreateLoad(srcField);
 
     unsigned flags = (Flags | BLOCK_BYREF_CALLER).getBitMask();
@@ -2195,11 +2150,7 @@ public:
   }
 
   void emitDispose(CodeGenFunction &CGF, Address field) override {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     field = field.withElementType(CGF.Int8PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    field = CGF.Builder.CreateElementBitCast(field, CGF.Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *value = CGF.Builder.CreateLoad(field);
 
     CGF.BuildBlockRelease(value, Flags | BLOCK_BYREF_CALLER, false);
@@ -2391,27 +2342,15 @@ generateByrefCopyHelper(CodeGenFunction &CGF, const BlockByrefInfo &byrefInfo,
   if (generator.needsCopy()) {
     // dst->x
     Address destField = CGF.GetAddrOfLocalVar(&Dst);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     destField = Address(CGF.Builder.CreateLoad(destField), byrefInfo.Type,
                         byrefInfo.ByrefAlignment);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    destField = Address(CGF.Builder.CreateLoad(destField), CGF.Int8Ty,
-                        byrefInfo.ByrefAlignment);
-    destField = CGF.Builder.CreateElementBitCast(destField, byrefInfo.Type);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     destField =
         CGF.emitBlockByrefAddress(destField, byrefInfo, false, "dest-object");
 
     // src->x
     Address srcField = CGF.GetAddrOfLocalVar(&Src);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     srcField = Address(CGF.Builder.CreateLoad(srcField), byrefInfo.Type,
                        byrefInfo.ByrefAlignment);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    srcField = Address(CGF.Builder.CreateLoad(srcField), CGF.Int8Ty,
-                       byrefInfo.ByrefAlignment);
-    srcField = CGF.Builder.CreateElementBitCast(srcField, byrefInfo.Type);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     srcField =
         CGF.emitBlockByrefAddress(srcField, byrefInfo, false, "src-object");
 
@@ -2467,14 +2406,8 @@ generateByrefDisposeHelper(CodeGenFunction &CGF,
 
   if (generator.needsDispose()) {
     Address addr = CGF.GetAddrOfLocalVar(&Src);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     addr = Address(CGF.Builder.CreateLoad(addr), byrefInfo.Type,
                    byrefInfo.ByrefAlignment);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    addr = Address(CGF.Builder.CreateLoad(addr), CGF.Int8Ty,
-                   byrefInfo.ByrefAlignment);
-    addr = CGF.Builder.CreateElementBitCast(addr, byrefInfo.Type);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     addr = CGF.emitBlockByrefAddress(addr, byrefInfo, false, "object");
 
     generator.emitDispose(CGF, addr);
@@ -2838,15 +2771,8 @@ void CodeGenFunction::emitByrefStructureInit(const AutoVarEmission &emission) {
 void CodeGenFunction::BuildBlockRelease(llvm::Value *V, BlockFieldFlags flags,
                                         bool CanThrow) {
   llvm::FunctionCallee F = CGM.getBlockObjectDispose();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Value *args[] = {
-    Builder.CreateBitCast(V, Int8PtrTy),
-    llvm::ConstantInt::get(Int32Ty, flags.getBitMask())
-  };
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *args[] = {V,
                          llvm::ConstantInt::get(Int32Ty, flags.getBitMask())};
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   if (CanThrow)
     EmitRuntimeCallOrInvoke(F, args);

--- a/clang/lib/CodeGen/CGBuilder.h
+++ b/clang/lib/CodeGen/CGBuilder.h
@@ -155,16 +155,6 @@ public:
                             Addr.isKnownNonNull());
   }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  /// Cast the element type of the given address to a different type,
-  /// preserving information like the alignment and address space.
-  Address CreateElementBitCast(Address Addr, llvm::Type *Ty,
-                               const llvm::Twine &Name = "") {
-    auto *PtrTy = Ty->getPointerTo(Addr.getAddressSpace());
-    return Address(CreateBitCast(Addr.getPointer(), PtrTy, Name), Ty,
-                   Addr.getAlignment(), Addr.isKnownNonNull());
-  }
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   using CGBuilderBaseTy::CreatePointerBitCastOrAddrSpaceCast;
   Address CreatePointerBitCastOrAddrSpaceCast(Address Addr, llvm::Type *Ty,

--- a/clang/lib/CodeGen/CGBuilder.h
+++ b/clang/lib/CodeGen/CGBuilder.h
@@ -155,7 +155,6 @@ public:
                             Addr.isKnownNonNull());
   }
 
-
   using CGBuilderBaseTy::CreatePointerBitCastOrAddrSpaceCast;
   Address CreatePointerBitCastOrAddrSpaceCast(Address Addr, llvm::Type *Ty,
                                               llvm::Type *ElementTy,

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -313,7 +313,8 @@ static Value *MakeAtomicCmpXchgValue(CodeGenFunction &CGF, const CallExpr *E,
   llvm::IntegerType *IntType = llvm::IntegerType::get(
       CGF.getLLVMContext(), CGF.getContext().getTypeSize(T));
   Value *Args[3];
-  Args[0] = DestPtr;  Args[0] = DestPtr;
+  Args[0] = DestPtr;
+  Args[0] = DestPtr;
   Args[1] = CGF.EmitScalarExpr(E->getArg(1));
   llvm::Type *ValueType = Args[1]->getType();
   Args[1] = EmitToInt(CGF, Args[1], T, IntType);
@@ -406,7 +407,7 @@ static Value *EmitAtomicCmpXchg128ForMSIntrin(CodeGenFunction &CGF,
   // Convert to i128 pointers and values.
   llvm::Type *Int128Ty = llvm::IntegerType::get(CGF.getLLVMContext(), 128);
   Address ComparandResult(ComparandPtr, Int128Ty,
-                        CGF.getContext().toCharUnitsFromBits(128));
+                          CGF.getContext().toCharUnitsFromBits(128));
 
   // (((i128)hi) << 64) | ((i128)lo)
   ExchangeHigh = CGF.Builder.CreateZExt(ExchangeHigh, Int128Ty);
@@ -5258,25 +5259,21 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       llvm::Value *EventWaitList = nullptr;
       if (E->getArg(4)->isNullPointerConstant(
               getContext(), Expr::NPC_ValueDependentIsNotNull)) {
-        EventWaitList = llvm::ConstantPointerNull::get(
-          PtrTy);
+        EventWaitList = llvm::ConstantPointerNull::get(PtrTy);
       } else {
         EventWaitList = E->getArg(4)->getType()->isArrayType()
                         ? EmitArrayToPointerDecay(E->getArg(4)).getPointer()
                         : EmitScalarExpr(E->getArg(4));
         // Convert to generic address space.
-        EventWaitList = Builder.CreatePointerCast(EventWaitList,
-          PtrTy);
+        EventWaitList = Builder.CreatePointerCast(EventWaitList, PtrTy);
       }
       llvm::Value *EventRet = nullptr;
       if (E->getArg(5)->isNullPointerConstant(
               getContext(), Expr::NPC_ValueDependentIsNotNull)) {
-        EventRet = llvm::ConstantPointerNull::get(
-          PtrTy);
+        EventRet = llvm::ConstantPointerNull::get(PtrTy);
       } else {
         EventRet =
-            Builder.CreatePointerCast(EmitScalarExpr(E->getArg(5)),
-          PtrTy);
+            Builder.CreatePointerCast(EmitScalarExpr(E->getArg(5)), PtrTy);
       }
 
       auto Info =
@@ -5287,8 +5284,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
           Builder.CreatePointerCast(Info.BlockArg, GenericVoidPtrTy);
 
       std::vector<llvm::Type *> ArgTys = {
-          QueueTy,    Int32Ty,    RangeTy,          Int32Ty,
-          PtrTy, PtrTy, GenericVoidPtrTy, GenericVoidPtrTy};
+          QueueTy, Int32Ty, RangeTy,          Int32Ty,
+          PtrTy,   PtrTy,   GenericVoidPtrTy, GenericVoidPtrTy};
 
       std::vector<llvm::Value *> Args = {Queue,     Flags,         Range,
                                          NumEvents, EventWaitList, EventRet,
@@ -5613,8 +5610,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
           if (PtrTy->getAddressSpace() !=
               ArgValue->getType()->getPointerAddressSpace()) {
             ArgValue = Builder.CreateAddrSpaceCast(
-              ArgValue,
-              llvm::PointerType::get(getLLVMContext(), PtrTy->getAddressSpace()));
+                ArgValue, llvm::PointerType::get(getLLVMContext(),
+                                                 PtrTy->getAddressSpace()));
           }
         }
 
@@ -22146,8 +22143,8 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
     llvm::Value *Result = Builder.CreateCall(CGM.getIntrinsic(IntID), Ops);
     // The load intrinsics generate two results (Value, NewBase), stores
     // generate one (NewBase). The new base address needs to be stored.
-    llvm::Value *NewBase = IsLoad ? Builder.CreateExtractValue(Result, 1)
-                                  : Result;
+    llvm::Value *NewBase =
+        IsLoad ? Builder.CreateExtractValue(Result, 1) : Result;
     llvm::Value *LV = EmitScalarExpr(E->getArg(0));
     Address Dest = EmitPointerWithAlignment(E->getArg(0));
     llvm::Value *RetVal =

--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -217,24 +217,11 @@ static Value *MakeBinaryAtomicValue(
 
   llvm::Value *DestPtr = CheckAtomicAlignment(CGF, E);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::IntegerType *IntType = llvm::IntegerType::get(
       CGF.getLLVMContext(), CGF.getContext().getTypeSize(T));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  unsigned AddrSpace = DestPtr->getType()->getPointerAddressSpace();
-
-  llvm::IntegerType *IntType = llvm::IntegerType::get(
-      CGF.getLLVMContext(), CGF.getContext().getTypeSize(T));
-  llvm::Type *IntPtrType =
-      llvm::PointerType::get(CGF.getLLVMContext(), AddrSpace);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *Args[2];
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Args[0] = DestPtr;
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Args[0] = CGF.Builder.CreateBitCast(DestPtr, IntPtrType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Args[1] = CGF.EmitScalarExpr(E->getArg(1));
   llvm::Type *ValueType = Args[1]->getType();
   Args[1] = EmitToInt(CGF, Args[1], T, IntType);
@@ -248,17 +235,8 @@ static Value *EmitNontemporalStore(CodeGenFunction &CGF, const CallExpr *E) {
   Value *Val = CGF.EmitScalarExpr(E->getArg(0));
   Value *Address = CGF.EmitScalarExpr(E->getArg(1));
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Val = CGF.EmitToMemory(Val, E->getArg(0)->getType());
   LValue LV = CGF.MakeNaturalAlignAddrLValue(Address, E->getArg(0)->getType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  // Convert the type of the pointer to a pointer to the stored type.
-  Val = CGF.EmitToMemory(Val, E->getArg(0)->getType());
-  unsigned SrcAddrSpace = Address->getType()->getPointerAddressSpace();
-  Value *BC = CGF.Builder.CreateBitCast(
-      Address, llvm::PointerType::get(Val->getType(), SrcAddrSpace), "cast");
-  LValue LV = CGF.MakeNaturalAlignAddrLValue(BC, E->getArg(0)->getType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   LV.setNontemporal(true);
   CGF.EmitStoreOfScalar(Val, LV, false);
   return nullptr;
@@ -293,26 +271,14 @@ static RValue EmitBinaryAtomicPost(CodeGenFunction &CGF,
   assert(CGF.getContext().hasSameUnqualifiedType(T, E->getArg(1)->getType()));
 
   llvm::Value *DestPtr = CheckAtomicAlignment(CGF, E);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::IntegerType *IntType = llvm::IntegerType::get(
       CGF.getLLVMContext(), CGF.getContext().getTypeSize(T));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  unsigned AddrSpace = DestPtr->getType()->getPointerAddressSpace();
-  llvm::IntegerType *IntType =
-    llvm::IntegerType::get(CGF.getLLVMContext(),
-                           CGF.getContext().getTypeSize(T));
-  llvm::Type *IntPtrType = IntType->getPointerTo(AddrSpace);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *Args[2];
   Args[1] = CGF.EmitScalarExpr(E->getArg(1));
   llvm::Type *ValueType = Args[1]->getType();
   Args[1] = EmitToInt(CGF, Args[1], T, IntType);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Args[0] = DestPtr;
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Args[0] = CGF.Builder.CreateBitCast(DestPtr, IntPtrType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *Result = CGF.Builder.CreateAtomicRMW(
       Kind, Args[0], Args[1], llvm::AtomicOrdering::SequentiallyConsistent);
@@ -344,18 +310,10 @@ static Value *MakeAtomicCmpXchgValue(CodeGenFunction &CGF, const CallExpr *E,
   QualType T = ReturnBool ? E->getArg(1)->getType() : E->getType();
   llvm::Value *DestPtr = CheckAtomicAlignment(CGF, E);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  unsigned AddrSpace = DestPtr->getType()->getPointerAddressSpace();
-#endif
   llvm::IntegerType *IntType = llvm::IntegerType::get(
       CGF.getLLVMContext(), CGF.getContext().getTypeSize(T));
   Value *Args[3];
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Args[0] = DestPtr;  Args[0] = DestPtr;
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *IntPtrType = IntType->getPointerTo(AddrSpace);
-  Args[0] = CGF.Builder.CreateBitCast(DestPtr, IntPtrType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Args[1] = CGF.EmitScalarExpr(E->getArg(1));
   llvm::Type *ValueType = Args[1]->getType();
   Args[1] = EmitToInt(CGF, Args[1], T, IntType);
@@ -447,15 +405,8 @@ static Value *EmitAtomicCmpXchg128ForMSIntrin(CodeGenFunction &CGF,
 
   // Convert to i128 pointers and values.
   llvm::Type *Int128Ty = llvm::IntegerType::get(CGF.getLLVMContext(), 128);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address ComparandResult(ComparandPtr, Int128Ty,
                         CGF.getContext().toCharUnitsFromBits(128));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *Int128PtrTy = Int128Ty->getPointerTo();
-  Destination = CGF.Builder.CreateBitCast(Destination, Int128PtrTy);
-  Address ComparandResult(CGF.Builder.CreateBitCast(ComparandPtr, Int128PtrTy),
-                          Int128Ty, CGF.getContext().toCharUnitsFromBits(128));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // (((i128)hi) << 64) | ((i128)lo)
   ExchangeHigh = CGF.Builder.CreateZExt(ExchangeHigh, Int128Ty);
@@ -518,9 +469,6 @@ static Value *EmitISOVolatileLoad(CodeGenFunction &CGF, const CallExpr *E) {
   CharUnits LoadSize = CGF.getContext().getTypeSizeInChars(ElTy);
   llvm::Type *ITy =
       llvm::IntegerType::get(CGF.getLLVMContext(), LoadSize.getQuantity() * 8);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  Ptr = CGF.Builder.CreateBitCast(Ptr, ITy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::LoadInst *Load = CGF.Builder.CreateAlignedLoad(ITy, Ptr, LoadSize);
   Load->setVolatile(true);
   return Load;
@@ -532,11 +480,6 @@ static Value *EmitISOVolatileStore(CodeGenFunction &CGF, const CallExpr *E) {
   Value *Value = CGF.EmitScalarExpr(E->getArg(1));
   QualType ElTy = E->getArg(0)->getType()->getPointeeType();
   CharUnits StoreSize = CGF.getContext().getTypeSizeInChars(ElTy);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *ITy =
-      llvm::IntegerType::get(CGF.getLLVMContext(), StoreSize.getQuantity() * 8);
-  Ptr = CGF.Builder.CreateBitCast(Ptr, ITy->getPointerTo());
-#endif
   llvm::StoreInst *Store =
       CGF.Builder.CreateAlignedStore(Value, Ptr, StoreSize);
   Store->setVolatile(true);
@@ -924,12 +867,6 @@ EncompassingIntegerType(ArrayRef<struct WidthAndSignedness> Types) {
 }
 
 Value *CodeGenFunction::EmitVAStartEnd(Value *ArgValue, bool IsStart) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *DestType = Int8PtrTy;
-  if (ArgValue->getType() != DestType)
-    ArgValue =
-        Builder.CreateBitCast(ArgValue, DestType, ArgValue->getName().data());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Intrinsic::ID inst = IsStart ? Intrinsic::vastart : Intrinsic::vaend;
   return Builder.CreateCall(CGM.getIntrinsic(inst), ArgValue);
 }
@@ -1116,15 +1053,9 @@ static llvm::Value *EmitX86BitTestIntrinsic(CodeGenFunction &CGF,
   llvm::IntegerType *IntType = llvm::IntegerType::get(
       CGF.getLLVMContext(),
       CGF.getContext().getTypeSize(E->getArg(1)->getType()));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *PtrType = llvm::PointerType::getUnqual(CGF.getLLVMContext());
   llvm::FunctionType *FTy =
       llvm::FunctionType::get(CGF.Int8Ty, {PtrType, IntType}, false);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *IntPtrType = IntType->getPointerTo();
-  llvm::FunctionType *FTy =
-      llvm::FunctionType::get(CGF.Int8Ty, {IntPtrType, IntType}, false);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::InlineAsm *IA =
       llvm::InlineAsm::get(FTy, Asm, Constraints, /*hasSideEffects=*/true);
@@ -1263,14 +1194,8 @@ static llvm::Value *emitPPCLoadReserveIntrinsic(CodeGenFunction &CGF,
     Constraints += MachineClobbers;
   }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *PtrType = llvm::PointerType::getUnqual(CGF.getLLVMContext());
   llvm::FunctionType *FTy = llvm::FunctionType::get(RetType, {PtrType}, false);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *IntPtrType = RetType->getPointerTo();
-  llvm::FunctionType *FTy =
-      llvm::FunctionType::get(RetType, {IntPtrType}, false);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::InlineAsm *IA =
       llvm::InlineAsm::get(FTy, Asm, Constraints, /*hasSideEffects=*/true);
@@ -2056,12 +1981,7 @@ llvm::Function *CodeGenFunction::generateBuiltinOSLogHelperFunction(
 
     Address Arg = GetAddrOfLocalVar(Args[I]);
     Address Addr = Builder.CreateConstByteGEP(BufAddr, Offset, "argData");
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Addr = Addr.withElementType(Arg.getElementType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Addr =
-        Builder.CreateElementBitCast(Addr, Arg.getElementType(), "argDataCast");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateStore(Builder.CreateLoad(Arg), Addr);
     Offset += Size;
     ++I;
@@ -2824,12 +2744,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI__builtin_va_copy: {
     Value *DstPtr = EmitVAListRef(E->getArg(0)).getPointer();
     Value *SrcPtr = EmitVAListRef(E->getArg(1)).getPointer();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *Type = Int8PtrTy;
-
-    DstPtr = Builder.CreateBitCast(DstPtr, Type);
-    SrcPtr = Builder.CreateBitCast(SrcPtr, Type);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateCall(CGM.getIntrinsic(Intrinsic::vacopy), {DstPtr, SrcPtr});
     return RValue::get(nullptr);
   }
@@ -4144,9 +4058,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   }
   case Builtin::BI__builtin_longjmp: {
     Value *Buf = EmitScalarExpr(E->getArg(0));
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Buf = Builder.CreateBitCast(Buf, Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Call LLVM's EH longjmp, which is lightweight.
     Builder.CreateCall(CGM.getIntrinsic(Intrinsic::eh_sjlj_longjmp), Buf);
@@ -4312,14 +4223,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     Value *Ptr = CheckAtomicAlignment(*this, E);
     QualType ElTy = E->getArg(0)->getType()->getPointeeType();
     CharUnits StoreSize = getContext().getTypeSizeInChars(ElTy);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *ITy =
         llvm::IntegerType::get(getLLVMContext(), StoreSize.getQuantity() * 8);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *ITy = llvm::IntegerType::get(getLLVMContext(),
-                                             StoreSize.getQuantity() * 8);
-    Ptr = Builder.CreateBitCast(Ptr, ITy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::StoreInst *Store =
       Builder.CreateAlignedStore(llvm::Constant::getNullValue(ITy), Ptr,
                                  StoreSize);
@@ -4374,10 +4279,6 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
         PtrTy->castAs<PointerType>()->getPointeeType().isVolatileQualified();
 
     Value *Ptr = EmitScalarExpr(E->getArg(0));
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    unsigned AddrSpace = Ptr->getType()->getPointerAddressSpace();
-    Ptr = Builder.CreateBitCast(Ptr, Int8Ty->getPointerTo(AddrSpace));
-#endif
     Value *NewVal = Builder.getInt8(1);
     Value *Order = EmitScalarExpr(E->getArg(1));
     if (isa<llvm::ConstantInt>(Order)) {
@@ -4459,11 +4360,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
         PtrTy->castAs<PointerType>()->getPointeeType().isVolatileQualified();
 
     Address Ptr = EmitPointerWithAlignment(E->getArg(0));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Ptr = Ptr.withElementType(Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Ptr = Builder.CreateElementBitCast(Ptr, Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *NewVal = Builder.getInt8(0);
     Value *Order = EmitScalarExpr(E->getArg(1));
     if (isa<llvm::ConstantInt>(Order)) {
@@ -4899,20 +4796,10 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
   case Builtin::BI_InterlockedCompareExchangePointer:
   case Builtin::BI_InterlockedCompareExchangePointer_nf: {
     llvm::Type *RTy;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::IntegerType *IntType = IntegerType::get(
         getLLVMContext(), getContext().getTypeSize(E->getType()));
 
     llvm::Value *Destination = EmitScalarExpr(E->getArg(0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::IntegerType *IntType =
-      IntegerType::get(getLLVMContext(),
-                       getContext().getTypeSize(E->getType()));
-    llvm::Type *IntPtrType = IntType->getPointerTo();
-
-    llvm::Value *Destination =
-      Builder.CreateBitCast(EmitScalarExpr(E->getArg(0)), IntPtrType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     llvm::Value *Exchange = EmitScalarExpr(E->getArg(1));
     RTy = Exchange->getType();
@@ -5358,13 +5245,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
     }
     // Any calls now have event arguments passed.
     if (NumArgs >= 7) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::PointerType *PtrTy = llvm::PointerType::get(
           CGM.getLLVMContext(),
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      llvm::Type *EventTy = ConvertType(getContext().OCLClkEventTy);
-      llvm::PointerType *EventPtrTy = EventTy->getPointerTo(
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           CGM.getContext().getTargetAddressSpace(LangAS::opencl_generic));
 
       llvm::Value *NumEvents =
@@ -5377,40 +5259,24 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       if (E->getArg(4)->isNullPointerConstant(
               getContext(), Expr::NPC_ValueDependentIsNotNull)) {
         EventWaitList = llvm::ConstantPointerNull::get(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          EventPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       } else {
         EventWaitList = E->getArg(4)->getType()->isArrayType()
                         ? EmitArrayToPointerDecay(E->getArg(4)).getPointer()
                         : EmitScalarExpr(E->getArg(4));
         // Convert to generic address space.
         EventWaitList = Builder.CreatePointerCast(EventWaitList,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          EventPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
       llvm::Value *EventRet = nullptr;
       if (E->getArg(5)->isNullPointerConstant(
               getContext(), Expr::NPC_ValueDependentIsNotNull)) {
         EventRet = llvm::ConstantPointerNull::get(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          EventPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       } else {
         EventRet =
             Builder.CreatePointerCast(EmitScalarExpr(E->getArg(5)),
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          EventPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
 
       auto Info =
@@ -5422,11 +5288,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
 
       std::vector<llvm::Type *> ArgTys = {
           QueueTy,    Int32Ty,    RangeTy,          Int32Ty,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           PtrTy, PtrTy, GenericVoidPtrTy, GenericVoidPtrTy};
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          EventPtrTy, EventPtrTy, GenericVoidPtrTy, GenericVoidPtrTy};
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       std::vector<llvm::Value *> Args = {Queue,     Flags,         Range,
                                          NumEvents, EventWaitList, EventRet,
@@ -5752,11 +5614,7 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
               ArgValue->getType()->getPointerAddressSpace()) {
             ArgValue = Builder.CreateAddrSpaceCast(
               ArgValue,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
               llvm::PointerType::get(getLLVMContext(), PtrTy->getAddressSpace()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-              ArgValue->getType()->getPointerTo(PtrTy->getAddressSpace()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           }
         }
 
@@ -5786,12 +5644,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       if (auto *PtrTy = dyn_cast<llvm::PointerType>(RetTy)) {
         if (PtrTy->getAddressSpace() != V->getType()->getPointerAddressSpace()) {
           V = Builder.CreateAddrSpaceCast(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
               V, llvm::PointerType::get(getLLVMContext(),
                                         PtrTy->getAddressSpace()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-            V, V->getType()->getPointerTo(PtrTy->getAddressSpace()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         }
       }
 
@@ -7557,11 +7411,7 @@ Value *CodeGenFunction::EmitCommonNeonBuiltinExpr(
   case NEON::BI__builtin_neon_vld1_dup_v:
   case NEON::BI__builtin_neon_vld1q_dup_v: {
     Value *V = PoisonValue::get(Ty);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     PtrOp0 = PtrOp0.withElementType(VTy->getElementType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    PtrOp0 = Builder.CreateElementBitCast(PtrOp0, VTy->getElementType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     LoadInst *Ld = Builder.CreateLoad(PtrOp0);
     llvm::Constant *CI = ConstantInt::get(SizeTy, 0);
     Ops[0] = Builder.CreateInsertElement(V, Ld, CI);
@@ -8363,12 +8213,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     llvm::Type *RealResTy = ConvertType(Ty);
     llvm::Type *IntTy =
         llvm::IntegerType::get(getLLVMContext(), getContext().getTypeSize(Ty));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PtrTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PtrTy = IntTy->getPointerTo();
-    LoadAddr = Builder.CreateBitCast(LoadAddr, PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     Function *F = CGM.getIntrinsic(
         BuiltinID == clang::ARM::BI__builtin_arm_ldaex ? Intrinsic::arm_ldaex
@@ -8401,11 +8246,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     Value *Val = EmitScalarExpr(E->getArg(0));
     Builder.CreateStore(Val, Tmp);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address LdPtr = Tmp.withElementType(STy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address LdPtr = Builder.CreateElementBitCast(Tmp, STy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Val = Builder.CreateLoad(LdPtr);
 
     Value *Arg0 = Builder.CreateExtractValue(Val, 0);
@@ -8421,14 +8262,8 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
 
     QualType Ty = E->getArg(0)->getType();
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *StoreTy =
         llvm::IntegerType::get(getLLVMContext(), getContext().getTypeSize(Ty));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *StoreTy = llvm::IntegerType::get(getLLVMContext(),
-                                                 getContext().getTypeSize(Ty));
-    StoreAddr = Builder.CreateBitCast(StoreAddr, StoreTy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     if (StoreVal->getType()->isPointerTy())
       StoreVal = Builder.CreatePtrToInt(StoreVal, Int32Ty);
@@ -8786,11 +8621,7 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
     [[fallthrough]];
   case NEON::BI__builtin_neon_vld1_lane_v: {
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     PtrOp0 = PtrOp0.withElementType(VTy->getElementType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    PtrOp0 = Builder.CreateElementBitCast(PtrOp0, VTy->getElementType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Ld = Builder.CreateLoad(PtrOp0);
     return Builder.CreateInsertElement(Ops[1], Ld, Ops[2], "vld1_lane");
   }
@@ -8854,13 +8685,8 @@ Value *CodeGenFunction::EmitARMBuiltinExpr(unsigned BuiltinID,
   case NEON::BI__builtin_neon_vst1_lane_v: {
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
     Ops[1] = Builder.CreateExtractElement(Ops[1], Ops[2]);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateStore(Ops[1],
                                PtrOp0.withElementType(Ops[1]->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    return Builder.CreateStore(
-        Ops[1], Builder.CreateElementBitCast(PtrOp0, Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   case NEON::BI__builtin_neon_vtbl1_v:
     return EmitNeonCall(CGM.getIntrinsic(Intrinsic::arm_neon_vtbl1),
@@ -9586,10 +9412,6 @@ Value *CodeGenFunction::EmitSVEStructLoad(const SVETypeFlags &TypeFlags,
                                           SmallVectorImpl<Value*> &Ops,
                                           unsigned IntID) {
   llvm::ScalableVectorType *VTy = getSVEType(TypeFlags);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  auto VecPtrTy = llvm::PointerType::getUnqual(VTy);
-  auto EltPtrTy = llvm::PointerType::getUnqual(VTy->getElementType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   unsigned N;
   switch (IntID) {
@@ -9609,19 +9431,12 @@ Value *CodeGenFunction::EmitSVEStructLoad(const SVETypeFlags &TypeFlags,
                                      VTy->getElementCount() * N);
 
   Value *Predicate = EmitSVEPredicateCast(Ops[0], VTy);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Value *BasePtr = Ops[1];
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Value *BasePtr= Builder.CreateBitCast(Ops[1], VecPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Does the load have an offset?
   if (Ops.size() > 2)
     BasePtr = Builder.CreateGEP(VTy, BasePtr, Ops[2]);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  BasePtr = Builder.CreateBitCast(BasePtr, EltPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Function *F = CGM.getIntrinsic(IntID, {VTy});
   Value *Call = Builder.CreateCall(F, {Predicate, BasePtr});
   unsigned MinElts = VTy->getMinNumElements();
@@ -9638,10 +9453,6 @@ Value *CodeGenFunction::EmitSVEStructStore(const SVETypeFlags &TypeFlags,
                                            SmallVectorImpl<Value*> &Ops,
                                            unsigned IntID) {
   llvm::ScalableVectorType *VTy = getSVEType(TypeFlags);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  auto VecPtrTy = llvm::PointerType::getUnqual(VTy);
-  auto EltPtrTy = llvm::PointerType::getUnqual(VTy->getElementType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   unsigned N;
   switch (IntID) {
@@ -9659,19 +9470,12 @@ Value *CodeGenFunction::EmitSVEStructStore(const SVETypeFlags &TypeFlags,
   }
 
   Value *Predicate = EmitSVEPredicateCast(Ops[0], VTy);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Value *BasePtr = Ops[1];
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Value *BasePtr = Builder.CreateBitCast(Ops[1], VecPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Does the store have an offset?
   if (Ops.size() > 3)
     BasePtr = Builder.CreateGEP(VTy, BasePtr, Ops[2]);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  BasePtr = Builder.CreateBitCast(BasePtr, EltPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Value *Val = Ops.back();
 
   // The llvm.aarch64.sve.st2/3/4 intrinsics take legal part vectors, so we
@@ -9728,16 +9532,9 @@ Value *CodeGenFunction::EmitSVEPrefetchLoad(const SVETypeFlags &TypeFlags,
 
   // Implement the index operand if not omitted.
   if (Ops.size() > 3) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    BasePtr = Builder.CreateBitCast(BasePtr, MemoryTy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     BasePtr = Builder.CreateGEP(MemoryTy, BasePtr, Ops[2]);
   }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // Prefetch intriniscs always expect an i8*
-  BasePtr = Builder.CreateBitCast(BasePtr, llvm::PointerType::getUnqual(Int8Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Value *PrfOp = Ops.back();
 
   Function *F = CGM.getIntrinsic(BuiltinID, Predicate->getType());
@@ -10571,12 +10368,7 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
                              : Intrinsic::aarch64_ldxp);
 
     Value *LdPtr = EmitScalarExpr(E->getArg(0));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Val = Builder.CreateCall(F, LdPtr, "ldxp");
-#else  // INTEL_SYCL_OPAQUEPOINTER_READY
-    Value *Val =
-        Builder.CreateCall(F, Builder.CreateBitCast(LdPtr, Int8PtrTy), "ldxp");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     Value *Val0 = Builder.CreateExtractValue(Val, 1);
     Value *Val1 = Builder.CreateExtractValue(Val, 0);
@@ -10629,21 +10421,12 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     Address Tmp = CreateMemTemp(E->getArg(0)->getType());
     EmitAnyExprToMem(E->getArg(0), Tmp, Qualifiers(), /*init*/ true);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Tmp = Tmp.withElementType(STy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Tmp = Builder.CreateElementBitCast(Tmp, STy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *Val = Builder.CreateLoad(Tmp);
 
     Value *Arg0 = Builder.CreateExtractValue(Val, 0);
     Value *Arg1 = Builder.CreateExtractValue(Val, 1);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *StPtr = EmitScalarExpr(E->getArg(1));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Value *StPtr =
-        Builder.CreateBitCast(EmitScalarExpr(E->getArg(1)), Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateCall(F, {Arg0, Arg1, StPtr}, "stxp");
   }
 
@@ -11093,22 +10876,12 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   }
   case NEON::BI__builtin_neon_vldrq_p128: {
     llvm::Type *Int128Ty = llvm::Type::getIntNTy(getLLVMContext(), 128);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Ptr = EmitScalarExpr(E->getArg(0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *Int128PTy = llvm::PointerType::get(Int128Ty, 0);
-    Value *Ptr = Builder.CreateBitCast(EmitScalarExpr(E->getArg(0)), Int128PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateAlignedLoad(Int128Ty, Ptr,
                                      CharUnits::fromQuantity(16));
   }
   case NEON::BI__builtin_neon_vstrq_p128: {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *Int128PTy = llvm::Type::getIntNPtrTy(getLLVMContext(), 128);
-    Value *Ptr = Builder.CreateBitCast(Ops[0], Int128PTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Ptr = Ops[0];
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(EmitScalarExpr(E->getArg(1)), Ptr);
   }
   case NEON::BI__builtin_neon_vcvts_f32_u32:
@@ -12626,25 +12399,15 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   }
   case NEON::BI__builtin_neon_vld1_v:
   case NEON::BI__builtin_neon_vld1q_v: {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0], llvm::PointerType::getUnqual(VTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateAlignedLoad(VTy, Ops[0], PtrOp0.getAlignment());
   }
   case NEON::BI__builtin_neon_vst1_v:
   case NEON::BI__builtin_neon_vst1q_v:
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0], llvm::PointerType::getUnqual(VTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Ops[1] = Builder.CreateBitCast(Ops[1], VTy);
     return Builder.CreateAlignedStore(Ops[1], Ops[0], PtrOp0.getAlignment());
   case NEON::BI__builtin_neon_vld1_lane_v:
   case NEON::BI__builtin_neon_vld1q_lane_v: {
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ty = llvm::PointerType::getUnqual(VTy->getElementType());
-    Ops[0] = Builder.CreateBitCast(Ops[0], Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Ops[0] = Builder.CreateAlignedLoad(VTy->getElementType(), Ops[0],
                                        PtrOp0.getAlignment());
     return Builder.CreateInsertElement(Ops[1], Ops[0], Ops[2], "vld1_lane");
@@ -12661,10 +12424,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   case NEON::BI__builtin_neon_vld1_dup_v:
   case NEON::BI__builtin_neon_vld1q_dup_v: {
     Value *V = PoisonValue::get(Ty);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ty = llvm::PointerType::getUnqual(VTy->getElementType());
-    Ops[0] = Builder.CreateBitCast(Ops[0], Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Ops[0] = Builder.CreateAlignedLoad(VTy->getElementType(), Ops[0],
                                        PtrOp0.getAlignment());
     llvm::Constant *CI = ConstantInt::get(Int32Ty, 0);
@@ -12682,59 +12441,30 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   case NEON::BI__builtin_neon_vstl1q_lane_s64: {
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
     Ops[1] = Builder.CreateExtractElement(Ops[1], Ops[2]);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::StoreInst *SI =
         Builder.CreateAlignedStore(Ops[1], Ops[0], PtrOp0.getAlignment());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Ty = llvm::PointerType::getUnqual(Ops[1]->getType());
-    llvm::StoreInst *SI = Builder.CreateAlignedStore(
-        Ops[1], Builder.CreateBitCast(Ops[0], Ty), PtrOp0.getAlignment());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     SI->setAtomic(llvm::AtomicOrdering::Release);
     return SI;
   }
   case NEON::BI__builtin_neon_vld2_v:
   case NEON::BI__builtin_neon_vld2q_v: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PTy = llvm::PointerType::getUnqual(VTy);
-    Ops[1] = Builder.CreateBitCast(Ops[1], PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *Tys[2] = { VTy, PTy };
     Function *F = CGM.getIntrinsic(Intrinsic::aarch64_neon_ld2, Tys);
     Ops[1] = Builder.CreateCall(F, Ops[1], "vld2");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0],
-                llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld3_v:
   case NEON::BI__builtin_neon_vld3q_v: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PTy = llvm::PointerType::getUnqual(VTy);
-    Ops[1] = Builder.CreateBitCast(Ops[1], PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *Tys[2] = { VTy, PTy };
     Function *F = CGM.getIntrinsic(Intrinsic::aarch64_neon_ld3, Tys);
     Ops[1] = Builder.CreateCall(F, Ops[1], "vld3");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0],
-                llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld4_v:
   case NEON::BI__builtin_neon_vld4q_v: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PTy = llvm::PointerType::getUnqual(VTy);
-    Ops[1] = Builder.CreateBitCast(Ops[1], PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *Tys[2] = { VTy, PTy };
     Function *F = CGM.getIntrinsic(Intrinsic::aarch64_neon_ld4, Tys);
     Ops[1] = Builder.CreateCall(F, Ops[1], "vld4");
@@ -12744,56 +12474,26 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   }
   case NEON::BI__builtin_neon_vld2_dup_v:
   case NEON::BI__builtin_neon_vld2q_dup_v: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PTy =
-      llvm::PointerType::getUnqual(VTy->getElementType());
-    Ops[1] = Builder.CreateBitCast(Ops[1], PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *Tys[2] = { VTy, PTy };
     Function *F = CGM.getIntrinsic(Intrinsic::aarch64_neon_ld2r, Tys);
     Ops[1] = Builder.CreateCall(F, Ops[1], "vld2");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0],
-                llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld3_dup_v:
   case NEON::BI__builtin_neon_vld3q_dup_v: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PTy =
-      llvm::PointerType::getUnqual(VTy->getElementType());
-    Ops[1] = Builder.CreateBitCast(Ops[1], PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *Tys[2] = { VTy, PTy };
     Function *F = CGM.getIntrinsic(Intrinsic::aarch64_neon_ld3r, Tys);
     Ops[1] = Builder.CreateCall(F, Ops[1], "vld3");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0],
-                llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld4_dup_v:
   case NEON::BI__builtin_neon_vld4q_dup_v: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *PTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PTy =
-      llvm::PointerType::getUnqual(VTy->getElementType());
-    Ops[1] = Builder.CreateBitCast(Ops[1], PTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *Tys[2] = { VTy, PTy };
     Function *F = CGM.getIntrinsic(Intrinsic::aarch64_neon_ld4r, Tys);
     Ops[1] = Builder.CreateCall(F, Ops[1], "vld4");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0],
-                llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld2_lane_v:
@@ -12805,10 +12505,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     Ops[2] = Builder.CreateBitCast(Ops[2], Ty);
     Ops[3] = Builder.CreateZExt(Ops[3], Int64Ty);
     Ops[1] = Builder.CreateCall(F, ArrayRef(Ops).slice(1), "vld2_lane");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ty = llvm::PointerType::getUnqual(Ops[1]->getType());
-    Ops[0] = Builder.CreateBitCast(Ops[0], Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld3_lane_v:
@@ -12821,10 +12517,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     Ops[3] = Builder.CreateBitCast(Ops[3], Ty);
     Ops[4] = Builder.CreateZExt(Ops[4], Int64Ty);
     Ops[1] = Builder.CreateCall(F, ArrayRef(Ops).slice(1), "vld3_lane");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ty = llvm::PointerType::getUnqual(Ops[1]->getType());
-    Ops[0] = Builder.CreateBitCast(Ops[0], Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vld4_lane_v:
@@ -12838,10 +12530,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
     Ops[4] = Builder.CreateBitCast(Ops[4], Ty);
     Ops[5] = Builder.CreateZExt(Ops[5], Int64Ty);
     Ops[1] = Builder.CreateCall(F, ArrayRef(Ops).slice(1), "vld4_lane");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ty = llvm::PointerType::getUnqual(Ops[1]->getType());
-    Ops[0] = Builder.CreateBitCast(Ops[0], Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateDefaultAlignedStore(Ops[1], Ops[0]);
   }
   case NEON::BI__builtin_neon_vst2_v:
@@ -12891,9 +12579,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   }
   case NEON::BI__builtin_neon_vtrn_v:
   case NEON::BI__builtin_neon_vtrnq_v: {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0], llvm::PointerType::getUnqual(Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
     Ops[2] = Builder.CreateBitCast(Ops[2], Ty);
     Value *SV = nullptr;
@@ -12912,9 +12597,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   }
   case NEON::BI__builtin_neon_vuzp_v:
   case NEON::BI__builtin_neon_vuzpq_v: {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0], llvm::PointerType::getUnqual(Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
     Ops[2] = Builder.CreateBitCast(Ops[2], Ty);
     Value *SV = nullptr;
@@ -12932,9 +12614,6 @@ Value *CodeGenFunction::EmitAArch64BuiltinExpr(unsigned BuiltinID,
   }
   case NEON::BI__builtin_neon_vzip_v:
   case NEON::BI__builtin_neon_vzipq_v: {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Ops[0] = Builder.CreateBitCast(Ops[0], llvm::PointerType::getUnqual(Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Ops[1] = Builder.CreateBitCast(Ops[1], Ty);
     Ops[2] = Builder.CreateBitCast(Ops[2], Ty);
     Value *SV = nullptr;
@@ -13153,14 +12832,8 @@ static Value *getMaskVecValue(CodeGenFunction &CGF, Value *Mask,
 
 static Value *EmitX86MaskedStore(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
                                  Align Alignment) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // Cast the pointer to right type.
-  Value *Ptr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-      Ops[0], llvm::PointerType::getUnqual(Ops[1]->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
   Value *Ptr = CGF.Builder.CreateAddrSpaceCast(
       Ops[0], llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Value *MaskVec = getMaskVecValue(
       CGF, Ops[2],
@@ -13172,13 +12845,8 @@ static Value *EmitX86MaskedStore(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
 static Value *EmitX86MaskedLoad(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
                                 Align Alignment) {
   llvm::Type *Ty = Ops[1]->getType();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  Value *Ptr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-      Ops[0], llvm::PointerType::getUnqual(Ty));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
   Value *Ptr = CGF.Builder.CreateAddrSpaceCast(
       Ops[0], llvm::PointerType::getUnqual(Ops[1]->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Value *MaskVec = getMaskVecValue(
       CGF, Ops[2], cast<llvm::FixedVectorType>(Ty)->getNumElements());
@@ -13189,15 +12857,7 @@ static Value *EmitX86MaskedLoad(CodeGenFunction &CGF, ArrayRef<Value *> Ops,
 static Value *EmitX86ExpandLoad(CodeGenFunction &CGF,
                                 ArrayRef<Value *> Ops) {
   auto *ResultTy = cast<llvm::VectorType>(Ops[1]->getType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Value *Ptr = Ops[0];
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *PtrTy = ResultTy->getElementType();
-
-  // Cast the pointer to element type.
-  Value *Ptr = CGF.Builder.CreateBitCast(Ops[0],
-                                         llvm::PointerType::getUnqual(PtrTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Value *MaskVec = getMaskVecValue(
       CGF, Ops[2], cast<FixedVectorType>(ResultTy)->getNumElements());
@@ -13223,15 +12883,7 @@ static Value *EmitX86CompressExpand(CodeGenFunction &CGF,
 static Value *EmitX86CompressStore(CodeGenFunction &CGF,
                                    ArrayRef<Value *> Ops) {
   auto *ResultTy = cast<llvm::FixedVectorType>(Ops[1]->getType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Value *Ptr = Ops[0];
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *PtrTy = ResultTy->getElementType();
-
-  // Cast the pointer to element type.
-  Value *Ptr = CGF.Builder.CreateBitCast(Ops[0],
-                                         llvm::PointerType::getUnqual(PtrTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   Value *MaskVec = getMaskVecValue(CGF, Ops[2], ResultTy->getNumElements());
 
@@ -14043,21 +13695,13 @@ Value *CodeGenFunction::EmitX86BuiltinExpr(unsigned BuiltinID,
     Address Tmp = CreateMemTemp(E->getArg(0)->getType());
     Builder.CreateStore(Ops[0], Tmp);
     return Builder.CreateCall(CGM.getIntrinsic(Intrinsic::x86_sse_ldmxcsr),
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                               Tmp.getPointer());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-                          Builder.CreateBitCast(Tmp.getPointer(), Int8PtrTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   case X86::BI_mm_getcsr:
   case X86::BI__builtin_ia32_stmxcsr: {
     Address Tmp = CreateMemTemp(E->getType());
     Builder.CreateCall(CGM.getIntrinsic(Intrinsic::x86_sse_stmxcsr),
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                        Tmp.getPointer());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-                       Builder.CreateBitCast(Tmp.getPointer(), Int8PtrTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Builder.CreateLoad(Tmp, "stmxcsr");
   }
   case X86::BI__builtin_ia32_xsave:
@@ -16407,16 +16051,8 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
     SmallVector<Value *, 2> Ops;
     Ops.push_back(EmitScalarExpr(E->getArg(0)));
     Ops.push_back(EmitScalarExpr(E->getArg(1)));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     if (!(BuiltinID == PPC::BI__builtin_vsx_lxvl ||
           BuiltinID == PPC::BI__builtin_vsx_lxvll)) {
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    if(BuiltinID == PPC::BI__builtin_vsx_lxvl ||
-       BuiltinID == PPC::BI__builtin_vsx_lxvll){
-      Ops[0] = Builder.CreateBitCast(Ops[0], Int8PtrTy);
-    }else {
-      Ops[1] = Builder.CreateBitCast(Ops[1], Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       Ops[0] = Builder.CreateGEP(Int8Ty, Ops[1], Ops[0]);
       Ops.pop_back();
     }
@@ -16484,16 +16120,8 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
     Ops.push_back(EmitScalarExpr(E->getArg(0)));
     Ops.push_back(EmitScalarExpr(E->getArg(1)));
     Ops.push_back(EmitScalarExpr(E->getArg(2)));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     if (!(BuiltinID == PPC::BI__builtin_vsx_stxvl ||
           BuiltinID == PPC::BI__builtin_vsx_stxvll)) {
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    if(BuiltinID == PPC::BI__builtin_vsx_stxvl ||
-      BuiltinID == PPC::BI__builtin_vsx_stxvll ){
-      Ops[1] = Builder.CreateBitCast(Ops[1], Int8PtrTy);
-    }else {
-      Ops[2] = Builder.CreateBitCast(Ops[2], Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       Ops[1] = Builder.CreateGEP(Int8Ty, Ops[2], Ops[1]);
       Ops.pop_back();
     }
@@ -16604,9 +16232,6 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
       // Storing the whole vector, simply store it on BE and reverse bytes and
       // store on LE.
       if (Width == 16) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-        Value *BC = Builder.CreateBitCast(Op0, Op2->getType()->getPointerTo());
-#endif
         Value *StVec = Op2;
         if (IsLE) {
           SmallVector<int, 16> RevMask;
@@ -16615,11 +16240,7 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
           StVec = Builder.CreateShuffleVector(Op2, Op2, RevMask);
         }
         return Builder.CreateStore(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
             StVec, Address(Op0, Op2->getType(), CharUnits::fromQuantity(1)));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-            StVec, Address(BC, Op2->getType(), CharUnits::fromQuantity(1)));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
       auto *ConvTy = Int64Ty;
       unsigned NumElts = 0;
@@ -16647,20 +16268,13 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
           Op2, llvm::FixedVectorType::get(ConvTy, NumElts));
       Value *Ptr =
           Builder.CreateGEP(Int8Ty, Op0, ConstantInt::get(Int64Ty, Offset));
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-      Value *PtrBC = Builder.CreateBitCast(Ptr, ConvTy->getPointerTo());
-#endif
       Value *Elt = Builder.CreateExtractElement(Vec, EltNo);
       if (IsLE && Width > 1) {
         Function *F = CGM.getIntrinsic(Intrinsic::bswap, ConvTy);
         Elt = Builder.CreateCall(F, Elt);
       }
       return Builder.CreateStore(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           Elt, Address(Ptr, ConvTy, CharUnits::fromQuantity(1)));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          Elt, Address(PtrBC, ConvTy, CharUnits::fromQuantity(1)));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     };
     unsigned Stored = 0;
     unsigned RemainingBytes = NumBytes;
@@ -17269,11 +16883,7 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
 
   case PPC::BI__builtin_ppc_sthcx: {
     llvm::Function *F = CGM.getIntrinsic(Intrinsic::ppc_sthcx);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Op0 = EmitScalarExpr(E->getArg(0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Value *Op0 = Builder.CreateBitCast(EmitScalarExpr(E->getArg(0)), Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Op1 = Builder.CreateSExt(EmitScalarExpr(E->getArg(1)), Int32Ty);
     return Builder.CreateCall(F, {Op0, Op1});
   }
@@ -17312,11 +16922,7 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
       Value *Vec = Builder.CreateLoad(Addr);
       Value *Call = Builder.CreateCall(F, {Vec});
       llvm::Type *VTy = llvm::FixedVectorType::get(Int8Ty, 16);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Value *Ptr = Ops[0];
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      Value *Ptr = Builder.CreateBitCast(Ops[0], VTy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       for (unsigned i=0; i<NumVecs; i++) {
         Value *Vec = Builder.CreateExtractValue(Call, i);
         llvm::ConstantInt* Index = llvm::ConstantInt::get(IntTy, i);
@@ -17351,14 +16957,8 @@ Value *CodeGenFunction::EmitPPCBuiltinExpr(unsigned BuiltinID,
         BuiltinID == PPC::BI__builtin_mma_stxvp) {
       if (BuiltinID == PPC::BI__builtin_vsx_lxvp ||
           BuiltinID == PPC::BI__builtin_mma_lxvp) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-        Ops[1] = Builder.CreateBitCast(Ops[1], Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         Ops[0] = Builder.CreateGEP(Int8Ty, Ops[1], Ops[0]);
       } else {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-        Ops[2] = Builder.CreateBitCast(Ops[2], Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         Ops[1] = Builder.CreateGEP(Int8Ty, Ops[2], Ops[1]);
       }
       Ops.pop_back();
@@ -17635,16 +17235,8 @@ Value *EmitAMDGPUWorkGroupSize(CodeGenFunction &CGF, unsigned Index) {
         CGF.Int8Ty, EmitAMDGPUDispatchPtr(CGF), 4 + Index * 2);
 
     auto Result = CGF.Builder.CreateSelect(IsCOV5, ImplicitGEP, DispatchGEP);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     LD = CGF.Builder.CreateLoad(
         Address(Result, CGF.Int16Ty, CharUnits::fromQuantity(2)));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    auto *DstTy =
-        CGF.Int16Ty->getPointerTo(Result->getType()->getPointerAddressSpace());
-    auto *Cast = CGF.Builder.CreateBitCast(Result, DstTy);
-    LD = CGF.Builder.CreateLoad(
-        Address(Cast, CGF.Int16Ty, CharUnits::fromQuantity(2)));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   } else {
     Value *GEP = nullptr;
     if (Cov == clang::TargetOptions::COV_5) {
@@ -17656,16 +17248,8 @@ Value *EmitAMDGPUWorkGroupSize(CodeGenFunction &CGF, unsigned Index) {
       GEP = CGF.Builder.CreateConstGEP1_32(
           CGF.Int8Ty, EmitAMDGPUDispatchPtr(CGF), 4 + Index * 2);
     }
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     LD = CGF.Builder.CreateLoad(
         Address(GEP, CGF.Int16Ty, CharUnits::fromQuantity(2)));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    auto *DstTy =
-        CGF.Int16Ty->getPointerTo(GEP->getType()->getPointerAddressSpace());
-    auto *Cast = CGF.Builder.CreateBitCast(GEP, DstTy);
-    LD = CGF.Builder.CreateLoad(
-        Address(Cast, CGF.Int16Ty, CharUnits::fromQuantity(2)));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   llvm::MDBuilder MDHelper(CGF.getLLVMContext());
@@ -17686,16 +17270,8 @@ Value *EmitAMDGPUGridSize(CodeGenFunction &CGF, unsigned Index) {
   // Indexing the HSA kernel_dispatch_packet struct.
   auto *Offset = llvm::ConstantInt::get(CGF.Int32Ty, XOffset + Index * 4);
   auto *GEP = CGF.Builder.CreateGEP(CGF.Int8Ty, DP, Offset);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   auto *LD = CGF.Builder.CreateLoad(
       Address(GEP, CGF.Int32Ty, CharUnits::fromQuantity(4)));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  auto *DstTy =
-      CGF.Int32Ty->getPointerTo(GEP->getType()->getPointerAddressSpace());
-  auto *Cast = CGF.Builder.CreateBitCast(GEP, DstTy);
-  auto *LD = CGF.Builder.CreateLoad(
-      Address(Cast, CGF.Int32Ty, CharUnits::fromQuantity(4)));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   LD->setMetadata(llvm::LLVMContext::MD_invariant_load,
                   llvm::MDNode::get(CGF.getLLVMContext(), std::nullopt));
   return LD;
@@ -21838,7 +21414,6 @@ RValue CodeGenFunction::EmitBuiltinAlignTo(const CallExpr *E, bool AlignUp) {
     llvm::Value *Difference = Builder.CreateSub(Result, SrcAddr, "diff");
     // The result must point to the same underlying allocation. This means we
     // can use an inbounds GEP to enable better optimization.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     if (getLangOpts().isSignedOverflowDefined())
       Result =
           Builder.CreateGEP(Int8Ty, Args.Src, Difference, "aligned_result");
@@ -21848,17 +21423,6 @@ RValue CodeGenFunction::EmitBuiltinAlignTo(const CallExpr *E, bool AlignUp) {
                                       /*isSubtraction=*/!AlignUp,
                                       E->getExprLoc(), "aligned_result");
 
-#else
-    Value *Base = EmitCastToVoidPtr(Args.Src);
-    if (getLangOpts().isSignedOverflowDefined())
-      Result = Builder.CreateGEP(Int8Ty, Base, Difference, "aligned_result");
-    else
-      Result = EmitCheckedInBoundsGEP(Int8Ty, Base, Difference,
-                                      /*SignedIndices=*/true,
-                                      /*isSubtraction=*/!AlignUp,
-                                      E->getExprLoc(), "aligned_result");
-    Result = Builder.CreatePointerCast(Result, Args.SrcType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     // Emit an alignment assumption to ensure that the new alignment is
     // propagated to loads/stores, etc.
     emitAlignmentAssumption(Result, E, E->getExprLoc(), Args.Alignment);
@@ -22415,12 +21979,7 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
   }
   case WebAssembly::BI__builtin_wasm_table_get: {
     assert(E->getArg(0)->getType()->isArrayType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Table = EmitArrayToPointerDecay(E->getArg(0)).getPointer();
-#else
-    Value *Table =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(0)).getPointer());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Index = EmitScalarExpr(E->getArg(1));
     Function *Callee;
     if (E->getType().isWebAssemblyExternrefType())
@@ -22434,12 +21993,7 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
   }
   case WebAssembly::BI__builtin_wasm_table_set: {
     assert(E->getArg(0)->getType()->isArrayType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Table = EmitArrayToPointerDecay(E->getArg(0)).getPointer();
-#else
-    Value *Table =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(0)).getPointer());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Index = EmitScalarExpr(E->getArg(1));
     Value *Val = EmitScalarExpr(E->getArg(2));
     Function *Callee;
@@ -22454,23 +22008,13 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
   }
   case WebAssembly::BI__builtin_wasm_table_size: {
     assert(E->getArg(0)->getType()->isArrayType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Value = EmitArrayToPointerDecay(E->getArg(0)).getPointer();
-#else
-    Value *Value =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(0)).getPointer());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Function *Callee = CGM.getIntrinsic(Intrinsic::wasm_table_size);
     return Builder.CreateCall(Callee, Value);
   }
   case WebAssembly::BI__builtin_wasm_table_grow: {
     assert(E->getArg(0)->getType()->isArrayType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Table = EmitArrayToPointerDecay(E->getArg(0)).getPointer();
-#else
-    Value *Table =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(0)).getPointer());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Val = EmitScalarExpr(E->getArg(1));
     Value *NElems = EmitScalarExpr(E->getArg(2));
 
@@ -22487,12 +22031,7 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
   }
   case WebAssembly::BI__builtin_wasm_table_fill: {
     assert(E->getArg(0)->getType()->isArrayType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Table = EmitArrayToPointerDecay(E->getArg(0)).getPointer();
-#else
-    Value *Table =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(0)).getPointer());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *Index = EmitScalarExpr(E->getArg(1));
     Value *Val = EmitScalarExpr(E->getArg(2));
     Value *NElems = EmitScalarExpr(E->getArg(3));
@@ -22510,15 +22049,8 @@ Value *CodeGenFunction::EmitWebAssemblyBuiltinExpr(unsigned BuiltinID,
   }
   case WebAssembly::BI__builtin_wasm_table_copy: {
     assert(E->getArg(0)->getType()->isArrayType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *TableX = EmitArrayToPointerDecay(E->getArg(0)).getPointer();
     Value *TableY = EmitArrayToPointerDecay(E->getArg(1)).getPointer();
-#else
-    Value *TableX =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(0)).getPointer());
-    Value *TableY =
-        EmitCastToVoidPtr(EmitArrayToPointerDecay(E->getArg(1)).getPointer());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value *DstIdx = EmitScalarExpr(E->getArg(2));
     Value *SrcIdx = EmitScalarExpr(E->getArg(3));
     Value *NElems = EmitScalarExpr(E->getArg(4));
@@ -22597,12 +22129,7 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
   auto MakeCircOp = [this, E](unsigned IntID, bool IsLoad) {
     // The base pointer is passed by address, so it needs to be loaded.
     Address A = EmitPointerWithAlignment(E->getArg(0));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address BP = Address(A.getPointer(), Int8PtrTy, A.getAlignment());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address BP = Address(Builder.CreateBitCast(
-        A.getPointer(), Int8PtrPtrTy), Int8PtrTy, A.getAlignment());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *Base = Builder.CreateLoad(BP);
     // The treatment of both loads and stores is the same: the arguments for
     // the builtin are the same as the arguments for the intrinsic.
@@ -22621,12 +22148,7 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
     // generate one (NewBase). The new base address needs to be stored.
     llvm::Value *NewBase = IsLoad ? Builder.CreateExtractValue(Result, 1)
                                   : Result;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *LV = EmitScalarExpr(E->getArg(0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Value *LV = Builder.CreateBitCast(
-        EmitScalarExpr(E->getArg(0)), NewBase->getType()->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Address Dest = EmitPointerWithAlignment(E->getArg(0));
     llvm::Value *RetVal =
         Builder.CreateAlignedStore(NewBase, LV, Dest.getAlignment());
@@ -22642,23 +22164,13 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
     // The intrinsic generates one result, which is the new value for the base
     // pointer. It needs to be returned. The result of the load instruction is
     // passed to intrinsic by address, so the value needs to be stored.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *BaseAddress = EmitScalarExpr(E->getArg(0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Value *BaseAddress =
-        Builder.CreateBitCast(EmitScalarExpr(E->getArg(0)), Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Expressions like &(*pt++) will be incremented per evaluation.
     // EmitPointerWithAlignment and EmitScalarExpr evaluates the expression
     // per call.
     Address DestAddr = EmitPointerWithAlignment(E->getArg(1));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     DestAddr = Address(DestAddr.getPointer(), Int8Ty, DestAddr.getAlignment());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    DestAddr = Address(Builder.CreateBitCast(DestAddr.getPointer(), Int8PtrTy),
-                       Int8Ty, DestAddr.getAlignment());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *DestAddress = DestAddr.getPointer();
 
     // Operands are Base, Dest, Modifier.
@@ -22675,13 +22187,7 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
     // to be handled with stores of respective destination type.
     DestVal = Builder.CreateTrunc(DestVal, DestTy);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateAlignedStore(DestVal, DestAddress, DestAddr.getAlignment());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Value *DestForStore =
-        Builder.CreateBitCast(DestAddress, DestVal->getType()->getPointerTo());
-    Builder.CreateAlignedStore(DestVal, DestForStore, DestAddr.getAlignment());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     // The updated value of the base pointer is returned.
     return Builder.CreateExtractValue(Result, 1);
   };
@@ -22709,13 +22215,8 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
   case Hexagon::BI__builtin_HEXAGON_V6_vsubcarry_128B: {
     // Get the type from the 0-th argument.
     llvm::Type *VecType = ConvertType(E->getArg(0)->getType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address PredAddr =
         EmitPointerWithAlignment(E->getArg(2)).withElementType(VecType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address PredAddr = Builder.CreateElementBitCast(
-        EmitPointerWithAlignment(E->getArg(2)), VecType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *PredIn = V2Q(Builder.CreateLoad(PredAddr));
     llvm::Value *Result = Builder.CreateCall(CGM.getIntrinsic(ID),
         {EmitScalarExpr(E->getArg(0)), EmitScalarExpr(E->getArg(1)), PredIn});
@@ -22734,13 +22235,8 @@ Value *CodeGenFunction::EmitHexagonBuiltinExpr(unsigned BuiltinID,
   case Hexagon::BI__builtin_HEXAGON_V6_vsubcarryo_128B: {
     // Get the type from the 0-th argument.
     llvm::Type *VecType = ConvertType(E->getArg(0)->getType());
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Address PredAddr = Builder.CreateElementBitCast(
-        EmitPointerWithAlignment(E->getArg(2)), VecType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
     Address PredAddr =
         EmitPointerWithAlignment(E->getArg(2)).withElementType(VecType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *Result = Builder.CreateCall(CGM.getIntrinsic(ID),
         {EmitScalarExpr(E->getArg(0)), EmitScalarExpr(E->getArg(1))});
 

--- a/clang/lib/CodeGen/CGCXXABI.cpp
+++ b/clang/lib/CodeGen/CGCXXABI.cpp
@@ -46,16 +46,8 @@ CGCallee CGCXXABI::EmitLoadOfMemberFunctionPointer(
 
   ThisPtrForCall = This.getPointer();
   const auto *FPT = MPT->getPointeeType()->castAs<FunctionProtoType>();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Constant *FnPtr = llvm::Constant::getNullValue(
       llvm::PointerType::getUnqual(CGM.getLLVMContext()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  const auto *RD =
-      cast<CXXRecordDecl>(MPT->getClass()->castAs<RecordType>()->getDecl());
-  llvm::FunctionType *FTy = CGM.getTypes().GetFunctionType(
-      CGM.getTypes().arrangeCXXMethodType(RD, FPT, /*FD=*/nullptr));
-  llvm::Constant *FnPtr = llvm::Constant::getNullValue(FTy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return CGCallee::forDirect(FnPtr, FPT);
 }
 
@@ -64,13 +56,8 @@ CGCXXABI::EmitMemberDataPointerAddress(CodeGenFunction &CGF, const Expr *E,
                                        Address Base, llvm::Value *MemPtr,
                                        const MemberPointerType *MPT) {
   ErrorUnsupportedABI(CGF, "loads of member pointers");
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *Ty =
       llvm::PointerType::get(CGF.getLLVMContext(), Base.getAddressSpace());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *Ty = CGF.ConvertType(MPT->getPointeeType())
-                         ->getPointerTo(Base.getAddressSpace());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return llvm::Constant::getNullValue(Ty);
 }
 

--- a/clang/lib/CodeGen/CGCXXABI.h
+++ b/clang/lib/CodeGen/CGCXXABI.h
@@ -289,7 +289,6 @@ public:
                                                   QualType SrcRecordTy) = 0;
   virtual bool shouldEmitExactDynamicCast(QualType DestRecordTy) = 0;
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   virtual llvm::Value *emitDynamicCastCall(CodeGenFunction &CGF, Address Value,
                                            QualType SrcRecordTy,
                                            QualType DestTy,
@@ -299,17 +298,6 @@ public:
   virtual llvm::Value *emitDynamicCastToVoid(CodeGenFunction &CGF,
                                              Address Value,
                                              QualType SrcRecordTy) = 0;
-#else
-  virtual llvm::Value *
-  EmitDynamicCastCall(CodeGenFunction &CGF, Address Value,
-                      QualType SrcRecordTy, QualType DestTy,
-                      QualType DestRecordTy, llvm::BasicBlock *CastEnd) = 0;
-
-  virtual llvm::Value *EmitDynamicCastToVoid(CodeGenFunction &CGF,
-                                             Address Value,
-                                             QualType SrcRecordTy,
-                                             QualType DestTy) = 0;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   /// Emit a dynamic_cast from SrcRecordTy to DestRecordTy. The cast fails if
   /// the dynamic type of Value is not exactly DestRecordTy.

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1681,7 +1681,6 @@ CodeGenTypes::GetFunctionType(const CGFunctionInfo &FI) {
     ArgTypes[IRFunctionArgs.getInallocaArgNo()] =
         llvm::PointerType::getUnqual(getLLVMContext());
 
-
   // Add in all of the required arguments.
   unsigned ArgNo = 0;
   CGFunctionInfo::const_arg_iterator it = FI.arg_begin(),
@@ -3932,7 +3931,7 @@ void CodeGenFunction::EmitFunctionEpilog(const CGFunctionInfo &FI,
     auto coercionType = RetAI.getCoerceAndExpandType();
 
     // Load all of the coerced elements out into results.
-    llvm::SmallVector<llvm::Value*, 4> results;
+    llvm::SmallVector<llvm::Value *, 4> results;
     Address addr = ReturnValue.withElementType(coercionType);
     for (unsigned i = 0, e = coercionType->getNumElements(); i != e; ++i) {
       auto coercedEltType = coercionType->getElementType(i);

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1296,11 +1296,7 @@ static llvm::Value *CreateCoercedLoad(Address Src, llvm::Type *Ty,
     //
     // FIXME: Assert that we aren't truncating non-padding bits when have access
     // to that information.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Src = Src.withElementType(Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Src = CGF.Builder.CreateElementBitCast(Src, Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return CGF.Builder.CreateLoad(Src);
   }
 
@@ -1410,11 +1406,7 @@ static void CreateCoercedStore(llvm::Value *Src,
   if (isa<llvm::ScalableVectorType>(SrcTy) ||
       isa<llvm::ScalableVectorType>(DstTy) ||
       SrcSize.getFixedValue() <= DstSize.getFixedValue()) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Dst = Dst.withElementType(SrcTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Dst = CGF.Builder.CreateElementBitCast(Dst, SrcTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.EmitAggregateStore(Src, Dst, DstIsVolatile);
   } else {
     // Otherwise do coercion through memory. This is stupid, but
@@ -1438,17 +1430,10 @@ static void CreateCoercedStore(llvm::Value *Src,
 static Address emitAddressAtOffset(CodeGenFunction &CGF, Address addr,
                                    const ABIArgInfo &info) {
   if (unsigned offset = info.getDirectOffset()) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     addr = addr.withElementType(CGF.Int8Ty);
     addr = CGF.Builder.CreateConstInBoundsByteGEP(addr,
                                              CharUnits::fromQuantity(offset));
     addr = addr.withElementType(info.getCoerceToType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    addr = CGF.Builder.CreateElementBitCast(addr, CGF.Int8Ty);
-    addr = CGF.Builder.CreateConstInBoundsByteGEP(addr,
-                                             CharUnits::fromQuantity(offset));
-    addr = CGF.Builder.CreateElementBitCast(addr, info.getCoerceToType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   return addr;
 }
@@ -1664,11 +1649,7 @@ CodeGenTypes::GetFunctionType(const CGFunctionInfo &FI) {
       // sret things on win32 aren't void, they return the sret pointer.
       QualType ret = FI.getReturnType();
       unsigned addressSpace = CGM.getTypes().getTargetAddressSpace(ret);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       resultType = llvm::PointerType::get(getLLVMContext(), addressSpace);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      resultType = llvm::PointerType::get(ConvertType(ret), addressSpace);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     } else {
       resultType = llvm::Type::getVoidTy(getLLVMContext());
     }
@@ -1692,21 +1673,13 @@ CodeGenTypes::GetFunctionType(const CGFunctionInfo &FI) {
     QualType Ret = FI.getReturnType();
     unsigned AddressSpace = CGM.getTypes().getTargetAddressSpace(Ret);
     ArgTypes[IRFunctionArgs.getSRetArgNo()] =
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         llvm::PointerType::get(getLLVMContext(), AddressSpace);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        llvm::PointerType::get(ConvertType(Ret), AddressSpace);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   // Add type for inalloca argument.
   if (IRFunctionArgs.hasInallocaArg())
     ArgTypes[IRFunctionArgs.getInallocaArgNo()] =
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        FI.getArgStruct()->getPointerTo();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
 
   // Add in all of the required arguments.
@@ -1733,22 +1706,13 @@ CodeGenTypes::GetFunctionType(const CGFunctionInfo &FI) {
     case ABIArgInfo::Indirect:
       assert(NumIRArgs == 1);
       // indirect arguments are always on the stack, which is alloca addr space.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       ArgTypes[FirstIRArg] = llvm::PointerType::get(
           getLLVMContext(), CGM.getDataLayout().getAllocaAddrSpace());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      ArgTypes[FirstIRArg] = ConvertTypeForMem(it->type)->getPointerTo(
-          CGM.getDataLayout().getAllocaAddrSpace());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       break;
     case ABIArgInfo::IndirectAliased:
       assert(NumIRArgs == 1);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       ArgTypes[FirstIRArg] = llvm::PointerType::get(
           getLLVMContext(), ArgInfo.getIndirectAddrSpace());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      ArgTypes[FirstIRArg] = ConvertTypeForMem(it->type)->getPointerTo(ArgInfo.getIndirectAddrSpace());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       break;
     case ABIArgInfo::Extend:
     case ABIArgInfo::Direct: {
@@ -3323,11 +3287,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
 
           Address AddrToStoreInto = Address::invalid();
           if (SrcSize <= DstSize) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
             AddrToStoreInto = Ptr.withElementType(STy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-            AddrToStoreInto = Builder.CreateElementBitCast(Ptr, STy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           } else {
             AddrToStoreInto =
                 CreateTempAlloca(STy, Alloca.getAlignment(), "coerce");
@@ -3372,11 +3332,7 @@ void CodeGenFunction::EmitFunctionProlog(const CGFunctionInfo &FI,
       ArgVals.push_back(ParamValue::forIndirect(alloca));
 
       auto coercionType = ArgI.getCoerceAndExpandType();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       alloca = alloca.withElementType(coercionType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      alloca = Builder.CreateElementBitCast(alloca, coercionType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       unsigned argIndex = FirstIRArg;
       for (unsigned i = 0, e = coercionType->getNumElements(); i != e; ++i) {
         llvm::Type *eltType = coercionType->getElementType(i);
@@ -3977,11 +3933,7 @@ void CodeGenFunction::EmitFunctionEpilog(const CGFunctionInfo &FI,
 
     // Load all of the coerced elements out into results.
     llvm::SmallVector<llvm::Value*, 4> results;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address addr = ReturnValue.withElementType(coercionType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address addr = Builder.CreateElementBitCast(ReturnValue, coercionType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     for (unsigned i = 0, e = coercionType->getNumElements(); i != e; ++i) {
       auto coercedEltType = coercionType->getElementType(i);
       if (ABIArgInfo::isPaddingForCoerceAndExpand(coercedEltType))
@@ -4107,13 +4059,8 @@ static AggValueSlot createPlaceholderSlot(CodeGenFunction &CGF,
   // FIXME: Generate IR in one pass, rather than going back and fixing up these
   // placeholders.
   llvm::Type *IRTy = CGF.ConvertTypeForMem(Ty);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *IRPtrTy = llvm::PointerType::getUnqual(CGF.getLLVMContext());
   llvm::Value *Placeholder = llvm::PoisonValue::get(IRPtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *IRPtrTy = IRTy->getPointerTo();
-  llvm::Value *Placeholder = llvm::PoisonValue::get(IRPtrTy->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // FIXME: When we generate this IR in one pass, we shouldn't need
   // this win32-specific alignment hack.
@@ -5223,14 +5170,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         // Store the RValue into the argument struct.
         Address Addr =
             Builder.CreateStructGEP(ArgMemory, ArgInfo.getInAllocaFieldIndex());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         Addr = Addr.withElementType(ConvertTypeForMem(I->Ty));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        // There are some cases where a trivial bitcast is not avoidable.  The
-        // definition of a type later in a translation unit may change it's type
-        // from {}* to (%struct.foo*)*.
-        Addr = Builder.CreateElementBitCast(Addr, ConvertTypeForMem(I->Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         I->copyInto(*this, Addr);
       }
       break;
@@ -5326,14 +5266,8 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
           I->copyInto(*this, AI);
         } else {
           // Skip the extra memcpy call.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           auto *T = llvm::PointerType::get(
               CGM.getLLVMContext(), CGM.getDataLayout().getAllocaAddrSpace());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          auto *T = llvm::PointerType::getWithSamePointeeType(
-              cast<llvm::PointerType>(V->getType()),
-              CGM.getDataLayout().getAllocaAddrSpace());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           llvm::Value *Val = getTargetHooks().performAddrSpaceCast(
               *this, V, LangAS::Default, CGM.getASTAllocaAddressSpace(), T,
               true);
@@ -5444,11 +5378,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
             IRCallArgs[FirstIRArg + i] = Extract;
           }
         } else {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           Src = Src.withElementType(STy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          Src = Builder.CreateElementBitCast(Src, STy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           uint64_t SrcSize = SrcTypeSize.getFixedValue();
           uint64_t DstSize = DstTypeSize.getFixedValue();
 
@@ -5527,11 +5457,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         Builder.CreateStore(RV.getScalarVal(), addr);
       }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       addr = addr.withElementType(coercionType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      addr = Builder.CreateElementBitCast(addr, coercionType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       unsigned IRArgPos = FirstIRArg;
       for (unsigned i = 0, e = coercionType->getNumElements(); i != e; ++i) {
@@ -5904,12 +5830,7 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
     case ABIArgInfo::CoerceAndExpand: {
       auto coercionType = RetAI.getCoerceAndExpandType();
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address addr = SRetPtr.withElementType(coercionType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      Address addr = SRetPtr;
-      addr = Builder.CreateElementBitCast(addr, coercionType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       assert(CI->getType() == RetAI.getUnpaddedCoerceAndExpandType());
       bool requiresExtract = isa<llvm::StructType>(CI->getType());

--- a/clang/lib/CodeGen/CGCall.h
+++ b/clang/lib/CodeGen/CGCall.h
@@ -108,12 +108,6 @@ public:
             SpecialKind(reinterpret_cast<uintptr_t>(functionPtr))) {
     AbstractInfo = abstractInfo;
     assert(functionPtr && "configuring callee without function pointer");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    assert(functionPtr->getType()->isPointerTy());
-    assert(functionPtr->getType()->isOpaquePointerTy() ||
-           functionPtr->getType()->getNonOpaquePointerElementType()
-               ->isFunctionTy());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   static CGCallee forBuiltin(unsigned builtinID,

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -241,7 +241,6 @@ CodeGenFunction::GetAddressOfDirectBaseInCompleteClass(Address This,
     V = Builder.CreateConstInBoundsByteGEP(V, Offset);
   }
   return V.withElementType(ConvertType(Base));
-
 }
 
 static Address
@@ -436,7 +435,6 @@ CodeGenFunction::GetAddressOfDerivedClass(Address BaseAddr,
   llvm::Value *Value = BaseAddr.getPointer();
   Value = Builder.CreateInBoundsGEP(
       Int8Ty, Value, Builder.CreateNeg(NonVirtualOffset), "sub.ptr");
-
 
   // Produce a PHI if we had a null-check.
   if (NullCheckValue) {
@@ -2673,8 +2671,7 @@ void CodeGenFunction::InitializeVTablePointers(const CXXRecordDecl *RD) {
     CGM.getCXXABI().initializeHiddenVirtualInheritanceMembers(*this, RD);
 }
 
-llvm::Value *CodeGenFunction::GetVTablePtr(Address This,
-                                           llvm::Type *VTableTy,
+llvm::Value *CodeGenFunction::GetVTablePtr(Address This, llvm::Type *VTableTy,
                                            const CXXRecordDecl *RD) {
   Address VTablePtrSrc = This.withElementType(VTableTy);
   llvm::Instruction *VTable = Builder.CreateLoad(VTablePtrSrc, "vtable");

--- a/clang/lib/CodeGen/CGClass.cpp
+++ b/clang/lib/CodeGen/CGClass.cpp
@@ -236,22 +236,12 @@ CodeGenFunction::GetAddressOfDirectBaseInCompleteClass(Address This,
   // TODO: for complete types, this should be possible with a GEP.
   Address V = This;
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   if (!Offset.isZero()) {
     V = V.withElementType(Int8Ty);
     V = Builder.CreateConstInBoundsByteGEP(V, Offset);
   }
   return V.withElementType(ConvertType(Base));
 
-#else
-  if (!Offset.isZero()) {
-    V = Builder.CreateElementBitCast(V, Int8Ty);
-    V = Builder.CreateConstInBoundsByteGEP(V, Offset);
-  }
-  V = Builder.CreateElementBitCast(V, ConvertType(Base));
-
-  return V;
-#endif
 }
 
 static Address
@@ -354,11 +344,7 @@ Address CodeGenFunction::GetAddressOfBaseClass(
       EmitTypeCheck(TCK_Upcast, Loc, Value.getPointer(),
                     DerivedTy, DerivedAlign, SkippedChecks);
     }
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Value.withElementType(BaseValueTy);
-#else
-    return Builder.CreateElementBitCast(Value, BaseValueTy);
-#endif
   }
 
   llvm::BasicBlock *origBB = nullptr;
@@ -395,11 +381,7 @@ Address CodeGenFunction::GetAddressOfBaseClass(
                                           VirtualOffset, Derived, VBase);
 
   // Cast to the destination type.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Value = Value.withElementType(BaseValueTy);
-#else
-  Value = Builder.CreateElementBitCast(Value, BaseValueTy);
-#endif
 
   // Build a phi if we needed a null check.
   if (NullCheckValue) {
@@ -427,21 +409,13 @@ CodeGenFunction::GetAddressOfDerivedClass(Address BaseAddr,
   QualType DerivedTy =
       getContext().getCanonicalType(getContext().getTagDeclType(Derived));
   llvm::Type *DerivedValueTy = ConvertType(DerivedTy);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *DerivedPtrTy =
-      DerivedValueTy->getPointerTo(BaseAddr.getAddressSpace());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *NonVirtualOffset =
     CGM.GetNonVirtualBaseClassOffset(Derived, PathBegin, PathEnd);
 
   if (!NonVirtualOffset) {
     // No offset, we can just cast back.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return BaseAddr.withElementType(DerivedValueTy);
-#else
-    return Builder.CreateElementBitCast(BaseAddr, DerivedValueTy);
-#endif
   }
 
   llvm::BasicBlock *CastNull = nullptr;
@@ -459,18 +433,10 @@ CodeGenFunction::GetAddressOfDerivedClass(Address BaseAddr,
   }
 
   // Apply the offset.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *Value = BaseAddr.getPointer();
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Value *Value = Builder.CreateBitCast(BaseAddr.getPointer(), Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Value = Builder.CreateInBoundsGEP(
       Int8Ty, Value, Builder.CreateNeg(NonVirtualOffset), "sub.ptr");
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // Just cast.
-  Value = Builder.CreateBitCast(Value, DerivedPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Produce a PHI if we had a null-check.
   if (NullCheckValue) {
@@ -1028,13 +994,8 @@ namespace {
 
   private:
     void emitMemcpyIR(Address DestPtr, Address SrcPtr, CharUnits Size) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       DestPtr = DestPtr.withElementType(CGF.Int8Ty);
       SrcPtr = SrcPtr.withElementType(CGF.Int8Ty);
-#else
-      DestPtr = CGF.Builder.CreateElementBitCast(DestPtr, CGF.Int8Ty);
-      SrcPtr = CGF.Builder.CreateElementBitCast(SrcPtr, CGF.Int8Ty);
-#endif
       CGF.Builder.CreateMemCpy(DestPtr, SrcPtr, Size.getQuantity());
     }
 
@@ -1714,12 +1675,7 @@ namespace {
     CodeGenFunction::SanitizerScope SanScope(&CGF);
     // Pass in void pointer and size of region as arguments to runtime
     // function
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     SmallVector<llvm::Value *, 2> Args = {Ptr};
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    SmallVector<llvm::Value *, 2> Args = {
-        CGF.Builder.CreateBitCast(Ptr, CGF.VoidPtrTy)};
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     SmallVector<llvm::Type *, 2> ArgTypes = {CGF.VoidPtrTy};
 
     if (PoisonSize.has_value()) {
@@ -1798,15 +1754,8 @@ namespace {
       llvm::ConstantInt *OffsetSizePtr =
           llvm::ConstantInt::get(CGF.SizeTy, PoisonStart.getQuantity());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *OffsetPtr =
           CGF.Builder.CreateGEP(CGF.Int8Ty, CGF.LoadCXXThis(), OffsetSizePtr);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      llvm::Value *OffsetPtr = CGF.Builder.CreateGEP(
-          CGF.Int8Ty,
-          CGF.Builder.CreateBitCast(CGF.LoadCXXThis(), CGF.Int8PtrTy),
-          OffsetSizePtr);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       CharUnits PoisonEnd;
       if (EndIndex >= Layout.getFieldCount()) {
@@ -2176,13 +2125,8 @@ void CodeGenFunction::EmitCXXConstructorCall(const CXXConstructorDecl *D,
 
   if (SlotAS != ThisAS) {
     unsigned TargetThisAS = getContext().getTargetAddressSpace(ThisAS);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *NewType =
         llvm::PointerType::get(getLLVMContext(), TargetThisAS);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *NewType = llvm::PointerType::getWithSamePointeeType(
-        This.getType(), TargetThisAS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     ThisPtr = getTargetHooks().performAddrSpaceCast(*this, This.getPointer(),
                                                     ThisAS, SlotAS, NewType);
   }
@@ -2633,15 +2577,10 @@ void CodeGenFunction::InitializeVTablePointer(const VPtr &Vptr) {
       llvm::FunctionType::get(CGM.Int32Ty, /*isVarArg=*/true)
           ->getPointerTo(ProgAS)
           ->getPointerTo(GlobalsAS);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *PtrTy = llvm::PointerType::get(CGM.getLLVMContext(), GlobalsAS);
   // vtable field is derived from `this` pointer, therefore they should be in
   // the same addr space. Note that this might not be LLVM address space 0.
   VTableField = VTableField.withElementType(PtrTy);
-#else
-  VTableField = Builder.CreateElementBitCast(VTableField, VTablePtrTy);
-  VTableAddressPoint = Builder.CreateBitCast(VTableAddressPoint, VTablePtrTy);
-#endif
 
   llvm::StoreInst *Store = Builder.CreateStore(VTableAddressPoint, VTableField);
   TBAAAccessInfo TBAAInfo = CGM.getTBAAVTablePtrAccessInfo(VTablePtrTy);
@@ -2737,11 +2676,7 @@ void CodeGenFunction::InitializeVTablePointers(const CXXRecordDecl *RD) {
 llvm::Value *CodeGenFunction::GetVTablePtr(Address This,
                                            llvm::Type *VTableTy,
                                            const CXXRecordDecl *RD) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address VTablePtrSrc = This.withElementType(VTableTy);
-#else
-  Address VTablePtrSrc = Builder.CreateElementBitCast(This, VTableTy);
-#endif
   llvm::Instruction *VTable = Builder.CreateLoad(VTablePtrSrc, "vtable");
   TBAAAccessInfo TBAAInfo = CGM.getTBAAVTablePtrAccessInfo(VTableTy);
   CGM.DecorateInstructionWithTBAA(VTable, TBAAInfo);
@@ -2802,9 +2737,6 @@ void CodeGenFunction::EmitTypeMetadataCodeForVCall(const CXXRecordDecl *RD,
     llvm::Value *TypeId =
         llvm::MetadataAsValue::get(CGM.getLLVMContext(), MD);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Value *CastedVTable = Builder.CreateBitCast(VTable, Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     // If we already know that the call has hidden LTO visibility, emit
     // @llvm.type.test(). Otherwise emit @llvm.public.type.test(), which WPD
     // will convert to @llvm.type.test() if we assert at link time that we have
@@ -2813,11 +2745,7 @@ void CodeGenFunction::EmitTypeMetadataCodeForVCall(const CXXRecordDecl *RD,
                                   ? llvm::Intrinsic::type_test
                                   : llvm::Intrinsic::public_type_test;
     llvm::Value *TypeTest =
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         Builder.CreateCall(CGM.getIntrinsic(IID), {VTable, TypeId});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        Builder.CreateCall(CGM.getIntrinsic(IID), {CastedVTable, TypeId});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateCall(CGM.getIntrinsic(llvm::Intrinsic::assume), TypeTest);
   }
 }
@@ -2921,14 +2849,8 @@ void CodeGenFunction::EmitVTablePtrCheck(const CXXRecordDecl *RD,
       CGM.CreateMetadataIdentifierForType(QualType(RD->getTypeForDecl(), 0));
   llvm::Value *TypeId = llvm::MetadataAsValue::get(getLLVMContext(), MD);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *TypeTest = Builder.CreateCall(
       CGM.getIntrinsic(llvm::Intrinsic::type_test), {VTable, TypeId});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Value *CastedVTable = Builder.CreateBitCast(VTable, Int8PtrTy);
-  llvm::Value *TypeTest = Builder.CreateCall(
-      CGM.getIntrinsic(llvm::Intrinsic::type_test), {CastedVTable, TypeId});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Constant *StaticData[] = {
       llvm::ConstantInt::get(Int8Ty, TCK),
@@ -2938,11 +2860,7 @@ void CodeGenFunction::EmitVTablePtrCheck(const CXXRecordDecl *RD,
 
   auto CrossDsoTypeId = CGM.CreateCrossDsoCfiTypeId(MD);
   if (CGM.getCodeGenOpts().SanitizeCfiCrossDso && CrossDsoTypeId) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     EmitCfiSlowPathCheck(M, TypeTest, CrossDsoTypeId, VTable, StaticData);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    EmitCfiSlowPathCheck(M, TypeTest, CrossDsoTypeId, CastedVTable, StaticData);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return;
   }
 
@@ -2957,11 +2875,7 @@ void CodeGenFunction::EmitVTablePtrCheck(const CXXRecordDecl *RD,
   llvm::Value *ValidVtable = Builder.CreateCall(
       CGM.getIntrinsic(llvm::Intrinsic::type_test), {VTable, AllVtables});
   EmitCheck(std::make_pair(TypeTest, M), SanitizerHandler::CFICheckFail,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
             StaticData, {VTable, ValidVtable});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-            StaticData, {CastedVTable, ValidVtable});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 bool CodeGenFunction::ShouldEmitVTableTypeCheckedLoad(const CXXRecordDecl *RD) {
@@ -2992,17 +2906,9 @@ llvm::Value *CodeGenFunction::EmitVTableTypeCheckedLoad(
       CGM.CreateMetadataIdentifierForType(QualType(RD->getTypeForDecl(), 0));
   llvm::Value *TypeId = llvm::MetadataAsValue::get(CGM.getLLVMContext(), MD);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *CheckedLoad = Builder.CreateCall(
       CGM.getIntrinsic(llvm::Intrinsic::type_checked_load),
       {VTable, llvm::ConstantInt::get(Int32Ty, VTableByteOffset), TypeId});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Value *CastedVTable = Builder.CreateBitCast(VTable, Int8PtrTy);
-  llvm::Value *CheckedLoad = Builder.CreateCall(
-      CGM.getIntrinsic(llvm::Intrinsic::type_checked_load),
-      {CastedVTable, llvm::ConstantInt::get(Int32Ty, VTableByteOffset),
-       TypeId});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *CheckResult = Builder.CreateExtractValue(CheckedLoad, 1);
 
   std::string TypeName = RD->getQualifiedNameAsString();

--- a/clang/lib/CodeGen/CGDeclCXX.cpp
+++ b/clang/lib/CodeGen/CGDeclCXX.cpp
@@ -124,13 +124,8 @@ static void EmitDeclDestroy(CodeGenFunction &CGF, const VarDecl &D,
     if (CGF.getContext().getLangOpts().OpenCL) {
       auto DestAS =
           CGM.getTargetCodeGenInfo().getAddrSpaceOfCxaAtexitPtrParam();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       auto DestTy = llvm::PointerType::get(
           CGM.getLLVMContext(), CGM.getContext().getTargetAddressSpace(DestAS));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      auto DestTy = CGF.getTypes().ConvertType(Type)->getPointerTo(
-          CGM.getContext().getTargetAddressSpace(DestAS));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       auto SrcAS = D.getType().getQualifiers().getAddressSpace();
       if (DestAS == SrcAS)
         Argument = llvm::ConstantExpr::getBitCast(Addr.getPointer(), DestTy);
@@ -139,12 +134,7 @@ static void EmitDeclDestroy(CodeGenFunction &CGF, const VarDecl &D,
         // of the global destructor function should be adjusted accordingly.
         Argument = llvm::ConstantPointerNull::get(DestTy);
     } else {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Argument = Addr.getPointer();
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      Argument = llvm::ConstantExpr::getBitCast(
-          Addr.getPointer(), CGF.getTypes().ConvertType(Type)->getPointerTo());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     }
   // Otherwise, the standard logic requires a helper function.
   } else {
@@ -212,13 +202,8 @@ void CodeGenFunction::EmitCXXGlobalVarDeclInit(const VarDecl &D,
   unsigned ActualAddrSpace = GV->getAddressSpace();
   llvm::Constant *DeclPtr = GV;
   if (ActualAddrSpace != ExpectedAddrSpace) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::PointerType *PTy =
         llvm::PointerType::get(getLLVMContext(), ExpectedAddrSpace);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::PointerType *PTy = llvm::PointerType::getWithSamePointeeType(
-        GV->getType(), ExpectedAddrSpace);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     DeclPtr = llvm::ConstantExpr::getAddrSpaceCast(DeclPtr, PTy);
   }
 

--- a/clang/lib/CodeGen/CGException.cpp
+++ b/clang/lib/CodeGen/CGException.cpp
@@ -401,11 +401,7 @@ void CodeGenFunction::EmitAnyExprToExn(const Expr *e, Address addr) {
   // __cxa_allocate_exception returns a void*;  we need to cast this
   // to the appropriate type for the object.
   llvm::Type *ty = ConvertTypeForMem(e->getType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address typedAddr = addr.withElementType(ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address typedAddr = Builder.CreateElementBitCast(addr, ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // FIXME: this isn't quite right!  If there's a final unelided call
   // to a copy constructor, then according to [except.terminate]p1 we
@@ -2121,9 +2117,6 @@ void CodeGenFunction::EmitSEHExceptionCodeSave(CodeGenFunction &ParentCGF,
     // pointer is stored in the second field. So, GEP 20 bytes backwards and
     // load the pointer.
     SEHInfo = Builder.CreateConstInBoundsGEP1_32(Int8Ty, EntryFP, -20);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    SEHInfo = Builder.CreateBitCast(SEHInfo, Int8PtrTy->getPointerTo());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     SEHInfo = Builder.CreateAlignedLoad(Int8PtrTy, SEHInfo, getPointerAlign());
     SEHCodeSlotStack.push_back(recoverAddrOfEscapedLocal(
         ParentCGF, ParentCGF.SEHCodeSlotStack.back(), ParentFP));
@@ -2136,16 +2129,9 @@ void CodeGenFunction::EmitSEHExceptionCodeSave(CodeGenFunction &ParentCGF,
   //   CONTEXT *ContextRecord;
   // };
   // int exceptioncode = exception_pointers->ExceptionRecord->ExceptionCode;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *RecordTy = llvm::PointerType::getUnqual(getLLVMContext());
   llvm::Type *PtrsTy = llvm::StructType::get(RecordTy, CGM.VoidPtrTy);
   llvm::Value *Rec = Builder.CreateStructGEP(PtrsTy, SEHInfo, 0);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *RecordTy = CGM.Int32Ty->getPointerTo();
-  llvm::Type *PtrsTy = llvm::StructType::get(RecordTy, CGM.VoidPtrTy);
-  llvm::Value *Ptrs = Builder.CreateBitCast(SEHInfo, PtrsTy->getPointerTo());
-  llvm::Value *Rec = Builder.CreateStructGEP(PtrsTy, Ptrs, 0);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Rec = Builder.CreateAlignedLoad(RecordTy, Rec, getPointerAlign());
   llvm::Value *Code = Builder.CreateAlignedLoad(Int32Ty, Rec, getIntAlign());
   assert(!SEHCodeSlotStack.empty() && "emitting EH code outside of __except");

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -56,19 +56,6 @@ using namespace CodeGen;
 //                        Miscellaneous Helper Methods
 //===--------------------------------------------------------------------===//
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-llvm::Value *CodeGenFunction::EmitCastToVoidPtr(llvm::Value *value) {
-  unsigned addressSpace =
-      cast<llvm::PointerType>(value->getType())->getAddressSpace();
-
-  llvm::PointerType *destType = Int8PtrTy;
-  if (addressSpace)
-    destType = llvm::Type::getInt8PtrTy(getLLVMContext(), addressSpace);
-
-  if (value->getType() == destType) return value;
-  return Builder.CreateBitCast(value, destType);
-}
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
 /// CreateTempAlloca - This creates a alloca and inserts it into the entry
 /// block.
@@ -155,14 +142,8 @@ Address CodeGenFunction::CreateMemTemp(QualType Ty, CharUnits Align,
     auto *VectorTy = llvm::FixedVectorType::get(ArrayTy->getElementType(),
                                                 ArrayTy->getNumElements());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Result = Address(Result.getPointer(), VectorTy, Result.getAlignment(),
                      KnownNonNull);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Result = Address(
-        Builder.CreateBitCast(Result.getPointer(), VectorTy->getPointerTo()),
-        VectorTy, Result.getAlignment(), KnownNonNull);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   return Result;
 }
@@ -766,14 +747,8 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
       llvm::Value *Min = Builder.getFalse();
       llvm::Value *NullIsUnknown = Builder.getFalse();
       llvm::Value *Dynamic = Builder.getFalse();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *LargeEnough = Builder.CreateICmpUGE(
           Builder.CreateCall(F, {Ptr, Min, NullIsUnknown, Dynamic}), Size);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      llvm::Value *CastAddr = Builder.CreateBitCast(Ptr, Int8PtrTy);
-      llvm::Value *LargeEnough = Builder.CreateICmpUGE(
-          Builder.CreateCall(F, {CastAddr, Min, NullIsUnknown, Dynamic}), Size);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       Checks.push_back(std::make_pair(LargeEnough, SanitizerKind::ObjectSize));
     }
   }
@@ -850,13 +825,7 @@ void CodeGenFunction::EmitTypeCheck(TypeCheckKind TCK, SourceLocation Loc,
 
       // Load the vptr, and compute hash_16_bytes(TypeHash, vptr).
       llvm::Value *Low = llvm::ConstantInt::get(Int64Ty, TypeHash);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address VPtrAddr(Ptr, IntPtrTy, getPointerAlign());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      llvm::Type *VPtrTy = llvm::PointerType::get(IntPtrTy, 0);
-      Address VPtrAddr(Builder.CreateBitCast(Ptr, VPtrTy), IntPtrTy,
-                       getPointerAlign());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *VPtrVal = Builder.CreateLoad(VPtrAddr);
       llvm::Value *High = Builder.CreateZExt(VPtrVal, Int64Ty);
 
@@ -1118,11 +1087,7 @@ static Address EmitPointerWithAlignment(const Expr *E, LValueBaseInfo *BaseInfo,
 
         llvm::Type *ElemTy =
             CGF.ConvertTypeForMem(E->getType()->getPointeeType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         Addr = Addr.withElementType(ElemTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        Addr = CGF.Builder.CreateElementBitCast(Addr, ElemTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         if (CE->getCastKind() == CK_AddressSpaceConversion)
           Addr = CGF.Builder.CreateAddrSpaceCast(Addr,
                                                  CGF.ConvertType(E->getType()));
@@ -1778,12 +1743,7 @@ llvm::Value *CodeGenFunction::EmitLoadOfScalar(Address Addr, bool Volatile,
 
       llvm::VectorType *vec4Ty =
           llvm::FixedVectorType::get(VTy->getElementType(), 4);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address Cast = Addr.withElementType(vec4Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      // Bitcast to vec4 type.
-      Address Cast = Builder.CreateElementBitCast(Addr, vec4Ty, "castToVec4");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       // Now load value.
       llvm::Value *V = Builder.CreateLoad(Cast, Volatile, "loadVec4");
 
@@ -1867,11 +1827,7 @@ static Address MaybeConvertMatrixAddress(Address Addr, CodeGenFunction &CGF,
     auto *VectorTy = llvm::FixedVectorType::get(ArrayTy->getElementType(),
                                                 ArrayTy->getNumElements());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Addr.withElementType(VectorTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    return Address(CGF.Builder.CreateElementBitCast(Addr, VectorTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   auto *VectorTy = dyn_cast<llvm::VectorType>(Addr.getElementType());
   if (VectorTy && !IsVector) {
@@ -1879,11 +1835,7 @@ static Address MaybeConvertMatrixAddress(Address Addr, CodeGenFunction &CGF,
         VectorTy->getElementType(),
         cast<llvm::FixedVectorType>(VectorTy)->getNumElements());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Addr.withElementType(ArrayTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    return Address(CGF.Builder.CreateElementBitCast(Addr, ArrayTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   return Addr;
@@ -1931,11 +1883,7 @@ void CodeGenFunction::EmitStoreOfScalar(llvm::Value *Value, Address Addr,
         SrcTy = llvm::FixedVectorType::get(VecTy->getElementType(), 4);
       }
       if (Addr.getElementType() != SrcTy) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         Addr = Addr.withElementType(SrcTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        Addr = Builder.CreateElementBitCast(Addr, SrcTy, "storetmp");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
     }
   }
@@ -2117,13 +2065,7 @@ Address CodeGenFunction::EmitExtVectorElementLValue(LValue LV) {
   QualType EQT = LV.getType()->castAs<VectorType>()->getElementType();
   llvm::Type *VectorElementTy = CGM.getTypes().ConvertType(EQT);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address CastToPointerElement = VectorAddress.withElementType(VectorElementTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address CastToPointerElement =
-    Builder.CreateElementBitCast(VectorAddress, VectorElementTy,
-                                 "conv.ptr.element");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   const llvm::Constant *Elts = LV.getExtVectorElts();
   unsigned ix = getAccessedFieldNo(0, Elts);
@@ -2548,15 +2490,6 @@ static void setObjCGCLValueClass(const ASTContext &Ctx, const Expr *E,
   }
 }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-static llvm::Value *
-EmitBitCastOfLValueToProperType(CodeGenFunction &CGF,
-                                llvm::Value *V, llvm::Type *IRType,
-                                StringRef Name = StringRef()) {
-  unsigned AS = cast<llvm::PointerType>(V->getType())->getAddressSpace();
-  return CGF.Builder.CreateBitCast(V, IRType->getPointerTo(AS), Name);
-}
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
 static LValue EmitThreadPrivateVarDeclLValue(
     CodeGenFunction &CGF, const VarDecl *VD, QualType T, Address Addr,
@@ -2568,11 +2501,7 @@ static LValue EmitThreadPrivateVarDeclLValue(
     Addr =
         CGF.CGM.getOpenMPRuntime().getAddrOfThreadPrivate(CGF, VD, Addr, Loc);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Addr = Addr.withElementType(RealVarTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Addr = CGF.Builder.CreateElementBitCast(Addr, RealVarTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return CGF.MakeAddrLValue(Addr, T, AlignmentSource::Decl);
 }
 
@@ -2662,9 +2591,6 @@ static LValue EmitGlobalVarDeclLValue(CodeGenFunction &CGF,
     V = CGF.Builder.CreateThreadLocalAddress(V);
 
   llvm::Type *RealVarTy = CGF.getTypes().ConvertTypeForMem(VD->getType());
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  V = EmitBitCastOfLValueToProperType(CGF, V, RealVarTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   CharUnits Alignment = CGF.getContext().getDeclAlign(VD);
   Address Addr(V, RealVarTy, Alignment);
   // Emit reference to the private copy of the variable if it is an OpenMP
@@ -3426,11 +3352,7 @@ void CodeGenFunction::EmitCheck(
           CGM.getDataLayout().getDefaultGlobalsAddressSpace());
       InfoPtr->setUnnamedAddr(llvm::GlobalValue::UnnamedAddr::Global);
       CGM.getSanitizerMetadata()->disableSanitizerForGlobal(InfoPtr);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Args.push_back(InfoPtr);
-#else
-      Args.push_back(EmitCastToVoidPtr(InfoPtr));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       ArgTypes.push_back(Args.back()->getType());
     }
 
@@ -3496,12 +3418,7 @@ void CodeGenFunction::EmitCfiSlowPathCheck(
         "__cfi_slowpath_diag",
         llvm::FunctionType::get(VoidTy, {Int64Ty, Int8PtrTy, Int8PtrTy},
                                 false));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     CheckCall = Builder.CreateCall(SlowPathFn, {TypeId, Ptr, InfoPtr});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    CheckCall = Builder.CreateCall(
-        SlowPathFn, {TypeId, Ptr, Builder.CreateBitCast(InfoPtr, Int8PtrTy)});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   } else {
     SlowPathFn = CGM.getModule().getOrInsertFunction(
         "__cfi_slowpath",
@@ -3705,11 +3622,7 @@ Address CodeGenFunction::EmitArrayToPointerDecay(const Expr *E,
   // If the array type was an incomplete type, we need to make sure
   // the decay ends up being the right type.
   llvm::Type *NewTy = ConvertType(E->getType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Addr = Addr.withElementType(NewTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Addr = Builder.CreateElementBitCast(Addr, NewTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Note that VLA pointers are always decayed, so we don't need to do
   // anything here.
@@ -3728,11 +3641,7 @@ Address CodeGenFunction::EmitArrayToPointerDecay(const Expr *E,
   if (BaseInfo) *BaseInfo = LV.getBaseInfo();
   if (TBAAInfo) *TBAAInfo = CGM.getTBAAAccessInfo(EltType);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return Addr.withElementType(ConvertTypeForMem(EltType));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  return Builder.CreateElementBitCast(Addr, ConvertTypeForMem(EltType));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 /// isSimpleArrayDecayOperand - If the specified expr is a simple decay from an
@@ -3991,7 +3900,6 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
     // true?  A lot of other things in the fragile ABI would break...
     llvm::Type *OrigBaseElemTy = Addr.getElementType();
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     // Do the GEP.
     CharUnits EltAlign =
       getArrayElementAlign(Addr.getAlignment(), Idx, InterfaceSize);
@@ -3999,20 +3907,6 @@ LValue CodeGenFunction::EmitArraySubscriptExpr(const ArraySubscriptExpr *E,
         emitArraySubscriptGEP(*this, Int8Ty, Addr.getPointer(), ScaledIdx,
                               false, SignedIndices, E->getExprLoc());
     Addr = Address(EltPtr, OrigBaseElemTy, EltAlign);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Addr = Builder.CreateElementBitCast(Addr, Int8Ty);
-
-    // Do the GEP.
-    CharUnits EltAlign =
-      getArrayElementAlign(Addr.getAlignment(), Idx, InterfaceSize);
-    llvm::Value *EltPtr =
-        emitArraySubscriptGEP(*this, Addr.getElementType(), Addr.getPointer(),
-                              ScaledIdx, false, SignedIndices, E->getExprLoc());
-    Addr = Address(EltPtr, Addr.getElementType(), EltAlign);
-
-    // Cast back.
-    Addr = Builder.CreateElementBitCast(Addr, OrigBaseElemTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   } else if (const Expr *Array = isSimpleArrayDecayOperand(E->getBase())) {
     // If this is A[i] where A is an array, the frontend will have decayed the
     // base to be a ArrayToPointerDecay implicit cast.  While correct, it is
@@ -4105,11 +3999,7 @@ static Address emitOMPArraySectionBase(CodeGenFunction &CGF, const Expr *Base,
       // If the array type was an incomplete type, we need to make sure
       // the decay ends up being the right type.
       llvm::Type *NewTy = CGF.ConvertType(BaseTy);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Addr = Addr.withElementType(NewTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      Addr = CGF.Builder.CreateElementBitCast(Addr, NewTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       // Note that VLA pointers are always decayed, so we don't need to do
       // anything here.
@@ -4119,12 +4009,7 @@ static Address emitOMPArraySectionBase(CodeGenFunction &CGF, const Expr *Base,
         Addr = CGF.Builder.CreateConstArrayGEP(Addr, 0, "arraydecay");
       }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       return Addr.withElementType(CGF.ConvertTypeForMem(ElTy));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      return CGF.Builder.CreateElementBitCast(Addr,
-                                              CGF.ConvertTypeForMem(ElTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     }
     LValueBaseInfo TypeBaseInfo;
     TBAAAccessInfo TypeTBAAInfo;
@@ -4441,11 +4326,7 @@ static Address emitAddrOfZeroSizeField(CodeGenFunction &CGF, Address Base,
       CGF.getContext().getFieldOffset(Field));
   if (Offset.isZero())
     return Base;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Base = Base.withElementType(CGF.Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Base = CGF.Builder.CreateElementBitCast(Base, CGF.Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return CGF.Builder.CreateConstInBoundsByteGEP(Base, Offset);
 }
 
@@ -4533,12 +4414,7 @@ LValue CodeGenFunction::EmitLValueForField(LValue base,
         UseVolatile ? Info.VolatileStorageSize : Info.StorageSize;
     // Get the access type.
     llvm::Type *FieldIntTy = llvm::Type::getIntNTy(getLLVMContext(), SS);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Addr = Addr.withElementType(FieldIntTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    if (Addr.getElementType() != FieldIntTy)
-      Addr = Builder.CreateElementBitCast(Addr, FieldIntTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     if (UseVolatile) {
       const unsigned VolatileOffset = Info.VolatileStorageOffset.getQuantity();
       if (VolatileOffset)
@@ -4625,12 +4501,7 @@ LValue CodeGenFunction::EmitLValueForField(LValue base,
     }
 
     if (FieldType->isReferenceType())
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       addr = addr.withElementType(CGM.getTypes().ConvertTypeForMem(FieldType));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      addr = Builder.CreateElementBitCast(
-          addr, CGM.getTypes().ConvertTypeForMem(FieldType), field->getName());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   } else {
     if (!IsInPreservedAIRegion &&
         (!getDebugInfo() || !rec->hasAttr<BPFPreserveAccessIndexAttr>()))
@@ -4655,16 +4526,8 @@ LValue CodeGenFunction::EmitLValueForField(LValue base,
   }
 
   // Make sure that the address is pointing to the right type.  This is critical
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   // for both unions and structs.
   addr = addr.withElementType(CGM.getTypes().ConvertTypeForMem(FieldType));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  // for both unions and structs.  A union needs a bitcast, a struct element
-  // will need a bitcast if the LLVM type laid out doesn't match the desired
-  // type.
-  addr = Builder.CreateElementBitCast(
-      addr, CGM.getTypes().ConvertTypeForMem(FieldType), field->getName());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   if (field->hasAttr<AnnotateAttr>())
     addr = EmitFieldAnnotations(field, addr);
@@ -4702,11 +4565,7 @@ CodeGenFunction::EmitLValueForFieldInitialization(LValue Base,
 
   // Make sure that the address is pointing to the right type.
   llvm::Type *llvmType = ConvertTypeForMem(FieldType);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   V = V.withElementType(llvmType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  V = Builder.CreateElementBitCast(V, llvmType, Field->getName());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // TODO: Generate TBAA information that describes this access as a structure
   // member access and not just an access to an object of the field's type. This
@@ -4997,11 +4856,7 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
       if (V.isValid()) {
         llvm::Type *T = ConvertTypeForMem(E->getType());
         if (V.getElementType() != T)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           LV.setAddress(V.withElementType(T));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-          LV.setAddress(Builder.CreateElementBitCast(V, T));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
     }
     return LV;
@@ -5060,14 +4915,8 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
 
     CGM.EmitExplicitCastExprType(CE, this);
     LValue LV = EmitLValue(E->getSubExpr());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address V = LV.getAddress(*this).withElementType(
         ConvertTypeForMem(CE->getTypeAsWritten()->getPointeeType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address V = Builder.CreateElementBitCast(
-        LV.getAddress(*this),
-        ConvertTypeForMem(CE->getTypeAsWritten()->getPointeeType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     if (SanOpts.has(SanitizerKind::CFIUnrelatedCast))
       EmitVTablePtrCheckForCast(E->getType(), V,
@@ -5090,12 +4939,7 @@ LValue CodeGenFunction::EmitCastLValue(const CastExpr *E) {
   }
   case CK_ObjCObjectLValueCast: {
     LValue LV = EmitLValue(E->getSubExpr());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address V = LV.getAddress(*this).withElementType(ConvertType(E->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address V = Builder.CreateElementBitCast(LV.getAddress(*this),
-                                             ConvertType(E->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return MakeAddrLValue(V, E->getType(), LV.getBaseInfo(),
                           CGM.getTBAAInfoForSubobject(LV, E->getType()));
   }
@@ -5405,13 +5249,8 @@ CodeGenFunction::EmitCXXTypeidLValue(const CXXTypeidExpr *E) {
 }
 
 Address CodeGenFunction::EmitCXXUuidofExpr(const CXXUuidofExpr *E) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return CGM.GetAddrOfMSGuidDecl(E->getGuidDecl())
       .withElementType(ConvertType(E->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  return Builder.CreateElementBitCast(CGM.GetAddrOfMSGuidDecl(E->getGuidDecl()),
-                                      ConvertType(E->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 LValue CodeGenFunction::EmitCXXUuidofLValue(const CXXUuidofExpr *E) {
@@ -5558,12 +5397,7 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType, const CGCallee &OrigCallee
         AlignedCalleePtr = CalleePtr;
       }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *CalleePrefixStruct = AlignedCalleePtr;
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      llvm::Value *CalleePrefixStruct = Builder.CreateBitCast(
-          AlignedCalleePtr, llvm::PointerType::getUnqual(PrefixStructTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *CalleeSigPtr =
           Builder.CreateConstGEP2_32(PrefixStructTy, CalleePrefixStruct, -1, 0);
       llvm::Value *CalleeSig =
@@ -5610,14 +5444,8 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType, const CGCallee &OrigCallee
     llvm::Value *TypeId = llvm::MetadataAsValue::get(getLLVMContext(), MD);
 
     llvm::Value *CalleePtr = Callee.getFunctionPointer();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *TypeTest = Builder.CreateCall(
         CGM.getIntrinsic(llvm::Intrinsic::type_test), {CalleePtr, TypeId});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Value *CastedCallee = Builder.CreateBitCast(CalleePtr, Int8PtrTy);
-    llvm::Value *TypeTest = Builder.CreateCall(
-        CGM.getIntrinsic(llvm::Intrinsic::type_test), {CastedCallee, TypeId});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     auto CrossDsoTypeId = CGM.CreateCrossDsoCfiTypeId(MD);
     llvm::Constant *StaticData[] = {
@@ -5627,30 +5455,17 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType, const CGCallee &OrigCallee
     };
     if (CGM.getCodeGenOpts().SanitizeCfiCrossDso && CrossDsoTypeId) {
       EmitCfiSlowPathCheck(SanitizerKind::CFIICall, TypeTest, CrossDsoTypeId,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                            CalleePtr, StaticData);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-                           CastedCallee, StaticData);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     } else {
       EmitCheck(std::make_pair(TypeTest, SanitizerKind::CFIICall),
                 SanitizerHandler::CFICheckFail, StaticData,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                 {CalleePtr, llvm::UndefValue::get(IntPtrTy)});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-                {CastedCallee, llvm::UndefValue::get(IntPtrTy)});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     }
   }
 
   CallArgList Args;
   if (Chain)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Args.add(RValue::get(Chain), CGM.getContext().VoidPtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Args.add(RValue::get(Builder.CreateBitCast(Chain, CGM.VoidPtrTy)),
-             CGM.getContext().VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // C++17 requires that we evaluate arguments to a call using assignment syntax
   // right-to-left, and that we evaluate arguments to certain other operators
@@ -5721,15 +5536,8 @@ RValue CodeGenFunction::EmitCall(QualType CalleeType, const CGCallee &OrigCallee
       isa<CUDAKernelCallExpr>(E) &&
       (!TargetDecl || !isa<FunctionDecl>(TargetDecl))) {
     llvm::Value *Handle = Callee.getFunctionPointer();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     auto *Stub = Builder.CreateLoad(
         Address(Handle, Handle->getType(), CGM.getPointerAlign()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    auto *Cast =
-        Builder.CreateBitCast(Handle, Handle->getType()->getPointerTo());
-    auto *Stub = Builder.CreateLoad(
-        Address(Cast, Handle->getType(), CGM.getPointerAlign()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Callee.setFunctionPointer(Stub);
   }
   llvm::CallBase *CallOrInvoke = nullptr;

--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -56,7 +56,6 @@ using namespace CodeGen;
 //                        Miscellaneous Helper Methods
 //===--------------------------------------------------------------------===//
 
-
 /// CreateTempAlloca - This creates a alloca and inserts it into the entry
 /// block.
 Address CodeGenFunction::CreateTempAllocaWithoutCast(llvm::Type *Ty,
@@ -2489,7 +2488,6 @@ static void setObjCGCLValueClass(const ASTContext &Ctx, const Expr *E,
     return;
   }
 }
-
 
 static LValue EmitThreadPrivateVarDeclLValue(
     CodeGenFunction &CGF, const VarDecl *VD, QualType T, Address Addr,

--- a/clang/lib/CodeGen/CGExprCXX.cpp
+++ b/clang/lib/CodeGen/CGExprCXX.cpp
@@ -502,11 +502,7 @@ static void EmitNullBaseClassInitialization(CodeGenFunction &CGF,
   if (Base->isEmpty())
     return;
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   DestPtr = DestPtr.withElementType(CGF.Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  DestPtr = CGF.Builder.CreateElementBitCast(DestPtr, CGF.Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   const ASTRecordLayout &Layout = CGF.getContext().getASTRecordLayout(Base);
   CharUnits NVSize = Layout.getNonVirtualSize();
@@ -559,12 +555,7 @@ static void EmitNullBaseClassInitialization(CodeGenFunction &CGF,
         std::max(Layout.getNonVirtualAlignment(), DestPtr.getAlignment());
     NullVariable->setAlignment(Align.getAsAlign());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address SrcPtr(NullVariable, CGF.Int8Ty, Align);
-#else
-    Address SrcPtr =
-        Address(CGF.EmitCastToVoidPtr(NullVariable), CGF.Int8Ty, Align);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Get and call the appropriate llvm.memcpy overload.
     for (std::pair<CharUnits, CharUnits> Store : Stores) {
@@ -1085,11 +1076,7 @@ void CodeGenFunction::EmitNewArrayInitializer(
     if (const ConstantArrayType *CAT = dyn_cast_or_null<ConstantArrayType>(
             AllocType->getAsArrayTypeUnsafe())) {
       ElementTy = ConvertTypeForMem(AllocType);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       CurPtr = CurPtr.withElementType(ElementTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      CurPtr = Builder.CreateElementBitCast(CurPtr, ElementTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       InitListElements *= getContext().getConstantArrayElementCount(CAT);
     }
 
@@ -1146,11 +1133,7 @@ void CodeGenFunction::EmitNewArrayInitializer(
     }
 
     // Switch back to initializing one base element at a time.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     CurPtr = CurPtr.withElementType(BeginPtr.getElementType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    CurPtr = Builder.CreateElementBitCast(CurPtr, BeginPtr.getElementType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   // If all elements have already been initialized, skip any further
@@ -1732,11 +1715,7 @@ llvm::Value *CodeGenFunction::EmitCXXNewExpr(const CXXNewExpr *E) {
   }
 
   llvm::Type *elementTy = ConvertTypeForMem(allocType);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address result = allocation.withElementType(elementTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address result = Builder.CreateElementBitCast(allocation, elementTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Passing pointer through launder.invariant.group to avoid propagation of
   // vptrs information which may be included in previous type.
@@ -2215,21 +2194,12 @@ static llvm::Value *EmitTypeidFromVTable(CodeGenFunction &CGF, const Expr *E,
 }
 
 llvm::Value *CodeGenFunction::EmitCXXTypeidExpr(const CXXTypeidExpr *E) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *PtrTy = llvm::PointerType::getUnqual(getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *StdTypeInfoPtrTy =
-    ConvertType(E->getType())->getPointerTo();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   if (E->isTypeOperand()) {
     llvm::Constant *TypeInfo =
         CGM.GetAddrOfRTTIDescriptor(E->getTypeOperand(getContext()));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return TypeInfo;
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    return Builder.CreateBitCast(TypeInfo, StdTypeInfoPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   // C++ [expr.typeid]p2:
@@ -2239,20 +2209,10 @@ llvm::Value *CodeGenFunction::EmitCXXTypeidExpr(const CXXTypeidExpr *E) {
   //   type) to which the glvalue refers.
   // If the operand is already most derived object, no need to look up vtable.
   if (E->isPotentiallyEvaluated() && !E->isMostDerived(getContext()))
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return EmitTypeidFromVTable(*this, E->getExprOperand(), PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    return EmitTypeidFromVTable(*this, E->getExprOperand(),
-                                StdTypeInfoPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   QualType OperandTy = E->getExprOperand()->getType();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return CGM.GetAddrOfRTTIDescriptor(OperandTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  return Builder.CreateBitCast(CGM.GetAddrOfRTTIDescriptor(OperandTy),
-                               StdTypeInfoPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 static llvm::Value *EmitDynamicCastToNull(CodeGenFunction &CGF,
@@ -2342,7 +2302,6 @@ llvm::Value *CodeGenFunction::EmitDynamicCast(Address ThisAddr,
 
   llvm::Value *Value;
   if (IsDynamicCastToVoid) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value = CGM.getCXXABI().emitDynamicCastToVoid(*this, ThisAddr, SrcRecordTy);
   } else if (IsExact) {
     // If the destination type is effectively final, this pointer points to the
@@ -2354,20 +2313,6 @@ llvm::Value *CodeGenFunction::EmitDynamicCast(Address ThisAddr,
            "destination type must be a record type!");
     Value = CGM.getCXXABI().emitDynamicCastCall(*this, ThisAddr, SrcRecordTy,
                                                 DestTy, DestRecordTy, CastEnd);
-#else
-    Value = CGM.getCXXABI().EmitDynamicCastToVoid(*this, ThisAddr, SrcRecordTy,
-                                                  DestTy);
-  } else if (IsExact) {
-    // If the destination type is effectively final, this pointer points to the
-    // right type if and only if its vptr has the right value.
-    Value = CGM.getCXXABI().emitExactDynamicCast(
-        *this, ThisAddr, SrcRecordTy, DestTy, DestRecordTy, CastEnd, CastNull);
-  } else {
-    assert(DestRecordTy->isRecordType() &&
-           "destination type must be a record type!");
-    Value = CGM.getCXXABI().EmitDynamicCastCall(*this, ThisAddr, SrcRecordTy,
-                                                DestTy, DestRecordTy, CastEnd);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
   CastNotNull = Builder.GetInsertBlock();
 

--- a/clang/lib/CodeGen/CGExprComplex.cpp
+++ b/clang/lib/CodeGen/CGExprComplex.cpp
@@ -488,24 +488,14 @@ ComplexPairTy ComplexExprEmitter::EmitCast(CastKind CK, Expr *Op,
 
   case CK_LValueBitCast: {
     LValue origLV = CGF.EmitLValue(Op);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address V = origLV.getAddress(CGF).withElementType(CGF.ConvertType(DestTy));
-#else
-    Address V = origLV.getAddress(CGF);
-    V = Builder.CreateElementBitCast(V, CGF.ConvertType(DestTy));
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     return EmitLoadOfLValue(CGF.MakeAddrLValue(V, DestTy), Op->getExprLoc());
   }
 
   case CK_LValueToRValueBitCast: {
     LValue SourceLVal = CGF.EmitLValue(Op);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address Addr = SourceLVal.getAddress(CGF).withElementType(
         CGF.ConvertTypeForMem(DestTy));
-#else
-    Address Addr = Builder.CreateElementBitCast(SourceLVal.getAddress(CGF),
-                                                CGF.ConvertTypeForMem(DestTy));
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     LValue DestLV = CGF.MakeAddrLValue(Addr, DestTy);
     DestLV.setTBAAInfo(TBAAAccessInfo::getMayAliasInfo());
     return EmitLoadOfLValue(DestLV, Op->getExprLoc());

--- a/clang/lib/CodeGen/CGExprConstant.cpp
+++ b/clang/lib/CodeGen/CGExprConstant.cpp
@@ -1862,11 +1862,6 @@ private:
       return C;
 
     llvm::Type *origPtrTy = C->getType();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    unsigned AS = origPtrTy->getPointerAddressSpace();
-    llvm::Type *charPtrTy = CGM.Int8Ty->getPointerTo(AS);
-    C = llvm::ConstantExpr::getBitCast(C, charPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     C = llvm::ConstantExpr::getGetElementPtr(CGM.Int8Ty, C, getOffset());
     C = llvm::ConstantExpr::getPointerCast(C, origPtrTy);
     return C;
@@ -1976,20 +1971,8 @@ ConstantLValueEmitter::tryEmitBase(const APValue::LValueBase &base) {
   }
 
   // Handle typeid(T).
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   if (TypeInfoLValue TI = base.dyn_cast<TypeInfoLValue>())
     return CGM.GetAddrOfRTTIDescriptor(QualType(TI.getType(), 0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  if (TypeInfoLValue TI = base.dyn_cast<TypeInfoLValue>()) {
-    llvm::Type *StdTypeInfoPtrTy =
-        CGM.getTypes().ConvertType(base.getTypeInfoType())->getPointerTo();
-    llvm::Constant *TypeInfo =
-        CGM.GetAddrOfRTTIDescriptor(QualType(TI.getType(), 0));
-    if (TypeInfo->getType() != StdTypeInfoPtrTy)
-      TypeInfo = llvm::ConstantExpr::getBitCast(TypeInfo, StdTypeInfoPtrTy);
-    return TypeInfo;
-  }
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Otherwise, it must be an expression.
   return Visit(base.get<const Expr*>());

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2742,7 +2742,6 @@ ScalarExprEmitter::EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
                                        /*SignedIndices=*/false, isSubtraction,
                                        E->getExprLoc(), "incdec.funcptr");
 
-
     // For everything else, we can just do a simple increment.
     } else {
       llvm::Value *amt = Builder.getInt32(amount);

--- a/clang/lib/CodeGen/CGExprScalar.cpp
+++ b/clang/lib/CodeGen/CGExprScalar.cpp
@@ -2085,24 +2085,15 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
   case CK_LValueBitCast:
   case CK_ObjCObjectLValueCast: {
     Address Addr = EmitLValue(E).getAddress(CGF);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Addr = Addr.withElementType(CGF.ConvertTypeForMem(DestTy));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Addr = Builder.CreateElementBitCast(Addr, CGF.ConvertTypeForMem(DestTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     LValue LV = CGF.MakeAddrLValue(Addr, DestTy);
     return EmitLoadOfLValue(LV, CE->getExprLoc());
   }
 
   case CK_LValueToRValueBitCast: {
     LValue SourceLVal = CGF.EmitLValue(E);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address Addr = SourceLVal.getAddress(CGF).withElementType(
         CGF.ConvertTypeForMem(DestTy));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address Addr = Builder.CreateElementBitCast(SourceLVal.getAddress(CGF),
-                                                CGF.ConvertTypeForMem(DestTy));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     LValue DestLV = CGF.MakeAddrLValue(Addr, DestTy);
     DestLV.setTBAAInfo(TBAAAccessInfo::getMayAliasInfo());
     return EmitLoadOfLValue(DestLV, CE->getExprLoc());
@@ -2231,12 +2222,7 @@ Value *ScalarExprEmitter::VisitCastExpr(CastExpr *CE) {
       Address Addr = CGF.CreateDefaultAlignTempAlloca(SrcTy, "saved-value");
       LValue LV = CGF.MakeAddrLValue(Addr, E->getType());
       CGF.EmitStoreOfScalar(Src, LV);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Addr = Addr.withElementType(CGF.ConvertTypeForMem(DestTy));
-#else
-      Addr = Builder.CreateElementBitCast(Addr, CGF.ConvertTypeForMem(DestTy),
-                                          "castFixedSve");
-#endif
       LValue DestLV = CGF.MakeAddrLValue(Addr, DestTy);
       DestLV.setTBAAInfo(TBAAAccessInfo::getMayAliasInfo());
       return EmitLoadOfLValue(DestLV, CE->getExprLoc());
@@ -2748,7 +2734,6 @@ ScalarExprEmitter::EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
     } else if (type->isFunctionType()) {
       llvm::Value *amt = Builder.getInt32(amount);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       if (CGF.getLangOpts().isSignedOverflowDefined())
         value = Builder.CreateGEP(CGF.Int8Ty, value, amt, "incdec.funcptr");
       else
@@ -2757,17 +2742,6 @@ ScalarExprEmitter::EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
                                        /*SignedIndices=*/false, isSubtraction,
                                        E->getExprLoc(), "incdec.funcptr");
 
-#else
-      value = CGF.EmitCastToVoidPtr(value);
-      if (CGF.getLangOpts().isSignedOverflowDefined())
-        value = Builder.CreateGEP(CGF.Int8Ty, value, amt, "incdec.funcptr");
-      else
-        value = CGF.EmitCheckedInBoundsGEP(CGF.Int8Ty, value, amt,
-                                           /*SignedIndices=*/false,
-                                           isSubtraction, E->getExprLoc(),
-                                           "incdec.funcptr");
-      value = Builder.CreateBitCast(value, input->getType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // For everything else, we can just do a simple increment.
     } else {
@@ -2880,9 +2854,6 @@ ScalarExprEmitter::EmitScalarPrePostIncDec(const UnaryOperator *E, LValue LV,
   // Objective-C pointer types.
   } else {
     const ObjCObjectPointerType *OPT = type->castAs<ObjCObjectPointerType>();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    value = CGF.EmitCastToVoidPtr(value);
-#endif
 
     CharUnits size = CGF.getContext().getTypeSizeInChars(OPT->getObjectType());
     if (!isInc) size = -size;
@@ -3748,13 +3719,8 @@ static Value *emitPointerArithmetic(CodeGenFunction &CGF,
 
     index = CGF.Builder.CreateMul(index, objectSize);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Value *result =
         CGF.Builder.CreateGEP(CGF.Int8Ty, pointer, index, "add.ptr");
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Value *result = CGF.Builder.CreateBitCast(pointer, CGF.VoidPtrTy);
-    result = CGF.Builder.CreateGEP(CGF.Int8Ty, result, index, "add.ptr");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return CGF.Builder.CreateBitCast(result, pointer->getType());
   }
 
@@ -3784,16 +3750,8 @@ static Value *emitPointerArithmetic(CodeGenFunction &CGF,
   // Explicitly handle GNU void* and function pointer arithmetic extensions. The
   // GNU void* casts amount to no-ops since our void* type is i8*, but this is
   // future proof.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   if (elementType->isVoidType() || elementType->isFunctionType())
     return CGF.Builder.CreateGEP(CGF.Int8Ty, pointer, index, "add.ptr");
-#else
-  if (elementType->isVoidType() || elementType->isFunctionType()) {
-    Value *result = CGF.EmitCastToVoidPtr(pointer);
-    result = CGF.Builder.CreateGEP(CGF.Int8Ty, result, index, "add.ptr");
-    return CGF.Builder.CreateBitCast(result, pointer->getType());
-  }
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Type *elemTy = CGF.ConvertTypeForMem(elementType);
   if (CGF.getLangOpts().isSignedOverflowDefined())
@@ -5213,11 +5171,7 @@ LValue CodeGenFunction::EmitObjCIsaExpr(const ObjCIsaExpr *E) {
   }
 
   // Cast the address to Class*.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Addr = Addr.withElementType(ConvertType(E->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Addr = Builder.CreateElementBitCast(Addr, ConvertType(E->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return MakeAddrLValue(Addr, E->getType());
 }
 

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -1191,11 +1191,7 @@ CodeGenFunction::generateObjCGetterBody(const ObjCImplementationDecl *classImpl,
 
     // Perform an atomic load.  This does not impose ordering constraints.
     Address ivarAddr = LV.getAddress(*this);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     ivarAddr = ivarAddr.withElementType(bitcastType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    ivarAddr = Builder.CreateElementBitCast(ivarAddr, bitcastType);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::LoadInst *load = Builder.CreateLoad(ivarAddr, "load");
     load->setAtomic(llvm::AtomicOrdering::Unordered);
 
@@ -1209,12 +1205,7 @@ CodeGenFunction::generateObjCGetterBody(const ObjCImplementationDecl *classImpl,
       bitcastType = llvm::Type::getIntNTy(getLLVMContext(), retTySize);
       ivarVal = Builder.CreateTrunc(load, bitcastType);
     }
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateStore(ivarVal, ReturnValue.withElementType(bitcastType));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Builder.CreateStore(ivarVal,
-                        Builder.CreateElementBitCast(ReturnValue, bitcastType));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Make sure we don't do an autorelease.
     AutoreleaseResult = false;
@@ -1494,7 +1485,6 @@ CodeGenFunction::generateObjCSetterBody(const ObjCImplementationDecl *classImpl,
 
     // Currently, all atomic accesses have to be through integer
     // types, so there's no point in trying to pick a prettier type.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Type *castType = llvm::Type::getIntNTy(
         getLLVMContext(), getContext().toBits(strategy.getIvarSize()));
 
@@ -1502,17 +1492,6 @@ CodeGenFunction::generateObjCSetterBody(const ObjCImplementationDecl *classImpl,
     argAddr = argAddr.withElementType(castType);
     ivarAddr = ivarAddr.withElementType(castType);
 
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *bitcastType =
-      llvm::Type::getIntNTy(getLLVMContext(),
-                            getContext().toBits(strategy.getIvarSize()));
-
-    // Cast both arguments to the chosen operation type.
-    argAddr = Builder.CreateElementBitCast(argAddr, bitcastType);
-    ivarAddr = Builder.CreateElementBitCast(ivarAddr, bitcastType);
-
-    // This bitcast load is likely to cause some nasty IR.
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *load = Builder.CreateLoad(argAddr);
 
     // Perform an atomic store.  There are no memory ordering requirements.
@@ -2224,22 +2203,7 @@ static llvm::Value *emitARCLoadOperation(CodeGenFunction &CGF, Address addr,
   if (!fn)
     fn = getARCIntrinsic(IntID, CGF.CGM);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return CGF.EmitNounwindRuntimeCall(fn, addr.getPointer());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  // Cast the argument to 'id*'.
-  llvm::Type *origType = addr.getElementType();
-  addr = CGF.Builder.CreateElementBitCast(addr, CGF.Int8PtrTy);
-
-  // Call the function.
-  llvm::Value *result = CGF.EmitNounwindRuntimeCall(fn, addr.getPointer());
-
-  // Cast the result back to a dereference of the original type.
-  if (origType != CGF.Int8PtrTy)
-    result = CGF.Builder.CreateBitCast(result, origType);
-
-  return result;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 /// Perform an operation having the following signature:
@@ -2684,10 +2648,6 @@ void CodeGenFunction::EmitARCDestroyWeak(Address addr) {
   if (!fn)
     fn = getARCIntrinsic(llvm::Intrinsic::objc_destroyWeak, CGM);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // Cast the argument to 'id*'.
-  addr = Builder.CreateElementBitCast(addr, Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   EmitNounwindRuntimeCall(fn, addr.getPointer());
 }

--- a/clang/lib/CodeGen/CGObjC.cpp
+++ b/clang/lib/CodeGen/CGObjC.cpp
@@ -2648,7 +2648,6 @@ void CodeGenFunction::EmitARCDestroyWeak(Address addr) {
   if (!fn)
     fn = getARCIntrinsic(llvm::Intrinsic::objc_destroyWeak, CGM);
 
-
   EmitNounwindRuntimeCall(fn, addr.getPointer());
 }
 

--- a/clang/lib/CodeGen/CGObjCGNU.cpp
+++ b/clang/lib/CodeGen/CGObjCGNU.cpp
@@ -4123,15 +4123,9 @@ llvm::GlobalVariable *CGObjCGNU::ObjCIvarOffsetVariable(
   // when linked against code which isn't (most of the time).
   llvm::GlobalVariable *IvarOffsetPointer = TheModule.getNamedGlobal(Name);
   if (!IvarOffsetPointer)
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    IvarOffsetPointer = new llvm::GlobalVariable(TheModule,
-            llvm::Type::getInt32PtrTy(VMContext), false,
-            llvm::GlobalValue::ExternalLinkage, nullptr, Name);
-#else
     IvarOffsetPointer = new llvm::GlobalVariable(
         TheModule, llvm::PointerType::getUnqual(VMContext), false,
         llvm::GlobalValue::ExternalLinkage, nullptr, Name);
-#endif
   return IvarOffsetPointer;
 }
 
@@ -4175,18 +4169,11 @@ llvm::Value *CGObjCGNU::EmitIvarOffset(CodeGenFunction &CGF,
         CGF.CGM.getTarget().getTriple().isKnownWindowsMSVCEnvironment())
       return CGF.Builder.CreateZExtOrBitCast(
           CGF.Builder.CreateAlignedLoad(
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-              Int32Ty, CGF.Builder.CreateAlignedLoad(
-                           llvm::Type::getInt32PtrTy(VMContext),
-                           ObjCIvarOffsetVariable(Interface, Ivar),
-                           CGF.getPointerAlign(), "ivar"),
-#else
               Int32Ty,
               CGF.Builder.CreateAlignedLoad(
                   llvm::PointerType::getUnqual(VMContext),
                   ObjCIvarOffsetVariable(Interface, Ivar),
                   CGF.getPointerAlign(), "ivar"),
-#endif
               CharUnits::fromQuantity(4)),
           PtrDiffTy);
     std::string name = "__objc_ivar_offset_value_" +

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -5013,8 +5013,7 @@ void CGObjCMac::EmitObjCStrongCastAssign(CodeGen::CodeGenFunction &CGF,
 }
 
 void CGObjCMac::EmitGCMemmoveCollectable(CodeGen::CodeGenFunction &CGF,
-                                         Address DestPtr,
-                                         Address SrcPtr,
+                                         Address DestPtr, Address SrcPtr,
                                          llvm::Value *size) {
   llvm::Value *args[] = { DestPtr.getPointer(), SrcPtr.getPointer(), size };
   CGF.EmitNounwindRuntimeCall(ObjCTypes.GcMemmoveCollectableFn(), args);
@@ -7685,10 +7684,8 @@ void CGObjCNonFragileABIMac::EmitObjCStrongCastAssign(
 }
 
 void CGObjCNonFragileABIMac::EmitGCMemmoveCollectable(
-  CodeGen::CodeGenFunction &CGF,
-  Address DestPtr,
-  Address SrcPtr,
-  llvm::Value *Size) {
+    CodeGen::CodeGenFunction &CGF, Address DestPtr, Address SrcPtr,
+    llvm::Value *Size) {
   llvm::Value *args[] = { DestPtr.getPointer(), SrcPtr.getPointer(), Size };
   CGF.EmitNounwindRuntimeCall(ObjCTypes.GcMemmoveCollectableFn(), args);
 }

--- a/clang/lib/CodeGen/CGObjCMac.cpp
+++ b/clang/lib/CodeGen/CGObjCMac.cpp
@@ -5016,10 +5016,6 @@ void CGObjCMac::EmitGCMemmoveCollectable(CodeGen::CodeGenFunction &CGF,
                                          Address DestPtr,
                                          Address SrcPtr,
                                          llvm::Value *size) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  SrcPtr = CGF.Builder.CreateElementBitCast(SrcPtr, CGF.Int8Ty);
-  DestPtr = CGF.Builder.CreateElementBitCast(DestPtr, CGF.Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *args[] = { DestPtr.getPointer(), SrcPtr.getPointer(), size };
   CGF.EmitNounwindRuntimeCall(ObjCTypes.GcMemmoveCollectableFn(), args);
 }
@@ -7693,10 +7689,6 @@ void CGObjCNonFragileABIMac::EmitGCMemmoveCollectable(
   Address DestPtr,
   Address SrcPtr,
   llvm::Value *Size) {
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  SrcPtr = CGF.Builder.CreateElementBitCast(SrcPtr, CGF.Int8Ty);
-  DestPtr = CGF.Builder.CreateElementBitCast(DestPtr, CGF.Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *args[] = { DestPtr.getPointer(), SrcPtr.getPointer(), Size };
   CGF.EmitNounwindRuntimeCall(ObjCTypes.GcMemmoveCollectableFn(), args);
 }

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -372,7 +372,6 @@ CGObjCRuntime::getMessageSendInfo(const ObjCMethodDecl *method,
     const CGFunctionInfo &signature =
       CGM.getTypes().arrangeObjCMessageSendSignature(method, callArgs[0].Ty);
 
-
     const CGFunctionInfo &signatureForCall =
       CGM.getTypes().arrangeCall(signature, callArgs);
 

--- a/clang/lib/CodeGen/CGObjCRuntime.cpp
+++ b/clang/lib/CodeGen/CGObjCRuntime.cpp
@@ -107,16 +107,9 @@ LValue CGObjCRuntime::EmitValueForIvarAtOffset(CodeGen::CodeGenFunction &CGF,
                              CGF.CGM.getContext().toBits(StorageSize),
                              CharUnits::fromQuantity(0)));
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address Addr =
       Address(V, llvm::Type::getIntNTy(CGF.getLLVMContext(), Info->StorageSize),
               Alignment);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address Addr = Address(V, CGF.Int8Ty, Alignment);
-  Addr = CGF.Builder.CreateElementBitCast(Addr,
-                                   llvm::Type::getIntNTy(CGF.getLLVMContext(),
-                                                         Info->StorageSize));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   return LValue::MakeBitfield(Addr, *Info, IvarTy,
                               LValueBaseInfo(AlignmentSource::Decl),
@@ -371,20 +364,14 @@ CGObjCRuntime::getMessageSendInfo(const ObjCMethodDecl *method,
                                   CallArgList &callArgs) {
   unsigned ProgramAS = CGM.getDataLayout().getProgramAddressSpace();
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::PointerType *signatureType =
       llvm::PointerType::get(CGM.getLLVMContext(), ProgramAS);
-#endif
 
   // If there's a method, use information from that.
   if (method) {
     const CGFunctionInfo &signature =
       CGM.getTypes().arrangeObjCMessageSendSignature(method, callArgs[0].Ty);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::PointerType *signatureType =
-      CGM.getTypes().GetFunctionType(signature)->getPointerTo(ProgramAS);
-#endif
 
     const CGFunctionInfo &signatureForCall =
       CGM.getTypes().arrangeCall(signature, callArgs);
@@ -396,11 +383,6 @@ CGObjCRuntime::getMessageSendInfo(const ObjCMethodDecl *method,
   const CGFunctionInfo &argsInfo =
     CGM.getTypes().arrangeUnprototypedObjCMessageSend(resultType, callArgs);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // Derive the signature to call from that.
-  llvm::PointerType *signatureType =
-    CGM.getTypes().GetFunctionType(argsInfo)->getPointerTo(ProgramAS);
-#endif
   return MessageSendInfo(argsInfo, signatureType);
 }
 

--- a/clang/lib/CodeGen/CGOpenMPRuntime.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntime.cpp
@@ -685,12 +685,7 @@ static void EmitOMPAggregateInit(CodeGenFunction &CGF, Address DestAddr,
   const ArrayType *ArrayTy = Type->getAsArrayTypeUnsafe();
   llvm::Value *NumElements = CGF.emitArrayLength(ArrayTy, ElementTy, DestAddr);
   if (DRD)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     SrcAddr = SrcAddr.withElementType(DestAddr.getElementType());
-#else
-    SrcAddr =
-        CGF.Builder.CreateElementBitCast(SrcAddr, DestAddr.getElementType());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *SrcBegin = nullptr;
   if (DRD)
@@ -911,13 +906,8 @@ void ReductionCodeGen::emitCleanups(CodeGenFunction &CGF, unsigned N,
   QualType PrivateType = getPrivateType(N);
   QualType::DestructionKind DTorKind = PrivateType.isDestructedType();
   if (needCleanups(N)) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     PrivateAddr =
         PrivateAddr.withElementType(CGF.ConvertTypeForMem(PrivateType));
-#else
-    PrivateAddr = CGF.Builder.CreateElementBitCast(
-        PrivateAddr, CGF.ConvertTypeForMem(PrivateType));
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.pushDestroy(DTorKind, PrivateAddr, PrivateType);
   }
 }
@@ -936,12 +926,7 @@ static LValue loadToBegin(CodeGenFunction &CGF, QualType BaseTy, QualType ElTy,
     BaseTy = BaseTy->getPointeeType();
   }
   return CGF.MakeAddrLValue(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       BaseLV.getAddress(CGF).withElementType(CGF.ConvertTypeForMem(ElTy)),
-#else
-      CGF.Builder.CreateElementBitCast(BaseLV.getAddress(CGF),
-                                       CGF.ConvertTypeForMem(ElTy)),
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
       BaseLV.getType(), BaseLV.getBaseInfo(),
       CGF.CGM.getTBAAInfoForSubobject(BaseLV, BaseLV.getType()));
 }
@@ -1694,14 +1679,8 @@ llvm::Function *CGOpenMPRuntime::emitThreadPrivateVarDefinition(
       llvm::Value *ArgVal = CtorCGF.EmitLoadOfScalar(
           CtorCGF.GetAddrOfLocalVar(&Dst), /*Volatile=*/false,
           CGM.getContext().VoidPtrTy, Dst.getLocation());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address Arg(ArgVal, CtorCGF.ConvertTypeForMem(ASTTy),
                   VDAddr.getAlignment());
-#else
-      Address Arg(ArgVal, CtorCGF.Int8Ty, VDAddr.getAlignment());
-      Arg = CtorCGF.Builder.CreateElementBitCast(
-          Arg, CtorCGF.ConvertTypeForMem(ASTTy));
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
       CtorCGF.EmitAnyExprToMem(Init, Arg, Init->getType().getQualifiers(),
                                /*IsInitializer=*/true);
       ArgVal = CtorCGF.EmitLoadOfScalar(
@@ -1840,12 +1819,7 @@ bool CGOpenMPRuntime::emitDeclareTargetVarDefinition(const VarDecl *VD,
       llvm::Constant *AddrInAS0 = Addr;
       if (Addr->getAddressSpace() != 0)
         AddrInAS0 = llvm::ConstantExpr::getAddrSpaceCast(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
             Addr, llvm::PointerType::get(CGM.getLLVMContext(), 0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-            Addr, llvm::PointerType::getWithSamePointeeType(
-                      cast<llvm::PointerType>(Addr->getType()), 0));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       CtorCGF.EmitAnyExprToMem(Init,
                                Address(AddrInAS0, Addr->getValueType(),
                                        CGM.getContext().getDeclAlign(VD)),
@@ -1895,12 +1869,7 @@ bool CGOpenMPRuntime::emitDeclareTargetVarDefinition(const VarDecl *VD,
       llvm::Constant *AddrInAS0 = Addr;
       if (Addr->getAddressSpace() != 0)
         AddrInAS0 = llvm::ConstantExpr::getAddrSpaceCast(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
             Addr, llvm::PointerType::get(CGM.getLLVMContext(), 0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-            Addr, llvm::PointerType::getWithSamePointeeType(
-                      cast<llvm::PointerType>(Addr->getType()), 0));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       DtorCGF.emitDestroy(Address(AddrInAS0, Addr->getValueType(),
                                   CGM.getContext().getDeclAlign(VD)),
                           ASTTy, DtorCGF.getDestroyer(ASTTy.isDestructedType()),
@@ -4211,12 +4180,7 @@ CGOpenMPRuntime::getDepobjElements(CodeGenFunction &CGF, LValue DepobjLVal,
       cast<RecordDecl>(KmpDependInfoTy->getAsTagDecl());
   QualType KmpDependInfoPtrTy = C.getPointerType(KmpDependInfoTy);
   LValue Base = CGF.EmitLoadOfPointerLValue(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       DepobjLVal.getAddress(CGF).withElementType(
-#else
-      CGF.Builder.CreateElementBitCast(
-          DepobjLVal.getAddress(CGF),
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
           CGF.ConvertTypeForMem(KmpDependInfoPtrTy)),
       KmpDependInfoPtrTy->castAs<PointerType>());
   Address DepObjAddr = CGF.Builder.CreateGEP(
@@ -5442,12 +5406,7 @@ static llvm::Value *emitReduceInitFunction(CodeGenModule &CGM,
   CGF.StartFunction(GlobalDecl(), C.VoidTy, Fn, FnInfo, Args, Loc, Loc);
   QualType PrivateType = RCG.getPrivateType(N);
   Address PrivateAddr = CGF.EmitLoadOfPointer(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       CGF.GetAddrOfLocalVar(&Param).withElementType(
-#else
-      CGF.Builder.CreateElementBitCast(
-          CGF.GetAddrOfLocalVar(&Param),
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
           CGF.ConvertTypeForMem(PrivateType)->getPointerTo()),
       C.getPointerType(PrivateType)->castAs<PointerType>());
   llvm::Value *Size = nullptr;
@@ -5535,28 +5494,16 @@ static llvm::Value *emitReduceCombFunction(CodeGenModule &CGM,
       LHSVD,
       // Pull out the pointer to the variable.
       CGF.EmitLoadOfPointer(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           CGF.GetAddrOfLocalVar(&ParamInOut)
               .withElementType(
                   CGF.ConvertTypeForMem(LHSVD->getType())->getPointerTo()),
-#else
-          CGF.Builder.CreateElementBitCast(
-              CGF.GetAddrOfLocalVar(&ParamInOut),
-              CGF.ConvertTypeForMem(LHSVD->getType())->getPointerTo()),
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
           C.getPointerType(LHSVD->getType())->castAs<PointerType>()));
   PrivateScope.addPrivate(
       RHSVD,
       // Pull out the pointer to the variable.
       CGF.EmitLoadOfPointer(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
           CGF.GetAddrOfLocalVar(&ParamIn).withElementType(
               CGF.ConvertTypeForMem(RHSVD->getType())->getPointerTo()),
-#else
-          CGF.Builder.CreateElementBitCast(
-            CGF.GetAddrOfLocalVar(&ParamIn),
-            CGF.ConvertTypeForMem(RHSVD->getType())->getPointerTo()),
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
           C.getPointerType(RHSVD->getType())->castAs<PointerType>()));
   PrivateScope.Privatize();
   // Emit the combiner body:
@@ -5666,7 +5613,6 @@ llvm::Value *CGOpenMPRuntime::emitTaskReductionInit(
     // ElemLVal.reduce_shar = &Shareds[Cnt];
     LValue SharedLVal = CGF.EmitLValueForField(ElemLVal, SharedFD);
     RCG.emitSharedOrigLValue(CGF, Cnt);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *Shared = RCG.getSharedLValue(Cnt).getPointer(CGF);
     CGF.EmitStoreOfScalar(Shared, SharedLVal);
     // ElemLVal.reduce_orig = &Origs[Cnt];
@@ -5674,16 +5620,6 @@ llvm::Value *CGOpenMPRuntime::emitTaskReductionInit(
     llvm::Value *Orig = RCG.getOrigLValue(Cnt).getPointer(CGF);
     CGF.EmitStoreOfScalar(Orig, OrigLVal);
 
-#else
-    llvm::Value *CastedShared =
-        CGF.EmitCastToVoidPtr(RCG.getSharedLValue(Cnt).getPointer(CGF));
-    CGF.EmitStoreOfScalar(CastedShared, SharedLVal);
-    // ElemLVal.reduce_orig = &Origs[Cnt];
-    LValue OrigLVal = CGF.EmitLValueForField(ElemLVal, OrigFD);
-    llvm::Value *CastedOrig =
-        CGF.EmitCastToVoidPtr(RCG.getOrigLValue(Cnt).getPointer(CGF));
-    CGF.EmitStoreOfScalar(CastedOrig, OrigLVal);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     RCG.emitAggregateType(CGF, Cnt);
     llvm::Value *SizeValInChars;
     llvm::Value *SizeVal;
@@ -5700,37 +5636,20 @@ llvm::Value *CGOpenMPRuntime::emitTaskReductionInit(
     CGF.EmitStoreOfScalar(SizeValInChars, SizeLVal);
     // ElemLVal.reduce_init = init;
     LValue InitLVal = CGF.EmitLValueForField(ElemLVal, InitFD);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *InitAddr = emitReduceInitFunction(CGM, Loc, RCG, Cnt);
-#else
-    llvm::Value *InitAddr =
-        CGF.EmitCastToVoidPtr(emitReduceInitFunction(CGM, Loc, RCG, Cnt));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.EmitStoreOfScalar(InitAddr, InitLVal);
     // ElemLVal.reduce_fini = fini;
     LValue FiniLVal = CGF.EmitLValueForField(ElemLVal, FiniFD);
     llvm::Value *Fini = emitReduceFiniFunction(CGM, Loc, RCG, Cnt);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *FiniAddr =
         Fini ? Fini : llvm::ConstantPointerNull::get(CGM.VoidPtrTy);
-#else
-    llvm::Value *FiniAddr = Fini
-                                ? CGF.EmitCastToVoidPtr(Fini)
-                                : llvm::ConstantPointerNull::get(CGM.VoidPtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.EmitStoreOfScalar(FiniAddr, FiniLVal);
     // ElemLVal.reduce_comb = comb;
     LValue CombLVal = CGF.EmitLValueForField(ElemLVal, CombFD);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *CombAddr = emitReduceCombFunction(
         CGM, Loc, RCG, Cnt, Data.ReductionOps[Cnt], LHSExprs[Cnt],
         RHSExprs[Cnt], Data.ReductionCopies[Cnt]);
 
-#else
-    llvm::Value *CombAddr = CGF.EmitCastToVoidPtr(emitReduceCombFunction(
-        CGM, Loc, RCG, Cnt, Data.ReductionOps[Cnt], LHSExprs[Cnt],
-        RHSExprs[Cnt], Data.ReductionCopies[Cnt]));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.EmitStoreOfScalar(CombAddr, CombLVal);
     // ElemLVal.flags = 0;
     LValue FlagsLVal = CGF.EmitLValueForField(ElemLVal, FlagsFD);
@@ -7487,12 +7406,7 @@ private:
                           .getAddress(CGF);
                 }
                 Size = CGF.Builder.CreatePtrDiff(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                     CGF.Int8Ty, ComponentLB.getPointer(), LB.getPointer());
-#else
-                    CGF.Int8Ty, CGF.EmitCastToVoidPtr(ComponentLB.getPointer()),
-                    CGF.EmitCastToVoidPtr(LB.getPointer()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
                 break;
               }
             }
@@ -7517,11 +7431,7 @@ private:
           CombinedInfo.Pointers.push_back(LB.getPointer());
           Size = CGF.Builder.CreatePtrDiff(
               CGF.Int8Ty, CGF.Builder.CreateConstGEP(HB, 1).getPointer(),
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
               LB.getPointer());
-#else
-              CGF.EmitCastToVoidPtr(LB.getPointer()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
           CombinedInfo.Sizes.push_back(
               CGF.Builder.CreateIntCast(Size, CGF.Int64Ty, /*isSigned=*/true));
           CombinedInfo.Types.push_back(Flags);

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -2386,8 +2386,8 @@ static llvm::Value *emitListToGlobalReduceFunction(
     LValue GlobLVal = CGF.EmitLValueForField(
         CGF.MakeNaturalAlignAddrLValue(BufferArrPtr, StaticTy), FD);
     Address GlobAddr = GlobLVal.getAddress(CGF);
-    llvm::Value *BufferPtr = Bld.CreateInBoundsGEP(
-        GlobAddr.getElementType(), GlobAddr.getPointer(), Idxs);
+    llvm::Value *BufferPtr = Bld.CreateInBoundsGEP(GlobAddr.getElementType(),
+                                                   GlobAddr.getPointer(), Idxs);
     CGF.EmitStoreOfScalar(BufferPtr, Elem, /*Volatile=*/false, C.VoidPtrTy);
     if ((*IPriv)->getType()->isVariablyModifiedType()) {
       // Store array size.
@@ -2594,8 +2594,8 @@ static llvm::Value *emitGlobalToListReduceFunction(
     LValue GlobLVal = CGF.EmitLValueForField(
         CGF.MakeNaturalAlignAddrLValue(BufferArrPtr, StaticTy), FD);
     Address GlobAddr = GlobLVal.getAddress(CGF);
-    llvm::Value *BufferPtr = Bld.CreateInBoundsGEP(
-        GlobAddr.getElementType(), GlobAddr.getPointer(), Idxs);
+    llvm::Value *BufferPtr = Bld.CreateInBoundsGEP(GlobAddr.getElementType(),
+                                                   GlobAddr.getPointer(), Idxs);
     CGF.EmitStoreOfScalar(BufferPtr, Elem, /*Volatile=*/false, C.VoidPtrTy);
     if ((*IPriv)->getType()->isVariablyModifiedType()) {
       // Store array size.

--- a/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
+++ b/clang/lib/CodeGen/CGOpenMPRuntimeGPU.cpp
@@ -1576,16 +1576,9 @@ static void emitReductionListCopy(
     case RemoteLaneToThread: {
       // Step 1.1: Get the address for the src element in the Reduce list.
       Address SrcElementPtrAddr = Bld.CreateConstArrayGEP(SrcBase, Idx);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       SrcElementAddr = CGF.EmitLoadOfPointer(
           SrcElementPtrAddr.withElementType(PrivateLlvmPtrType),
           PrivatePtrType->castAs<PointerType>());
-#else
-      SrcElementAddr =
-          CGF.EmitLoadOfPointer(CGF.Builder.CreateElementBitCast(
-                                    SrcElementPtrAddr, PrivateLlvmPtrType),
-                                PrivatePtrType->castAs<PointerType>());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
       // Step 1.2: Create a temporary to store the element in the destination
       // Reduce list.
@@ -1599,45 +1592,24 @@ static void emitReductionListCopy(
     case ThreadCopy: {
       // Step 1.1: Get the address for the src element in the Reduce list.
       Address SrcElementPtrAddr = Bld.CreateConstArrayGEP(SrcBase, Idx);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       SrcElementAddr = CGF.EmitLoadOfPointer(
           SrcElementPtrAddr.withElementType(PrivateLlvmPtrType),
           PrivatePtrType->castAs<PointerType>());
-#else
-      SrcElementAddr =
-          CGF.EmitLoadOfPointer(CGF.Builder.CreateElementBitCast(
-                                    SrcElementPtrAddr, PrivateLlvmPtrType),
-                                PrivatePtrType->castAs<PointerType>());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
       // Step 1.2: Get the address for dest element.  The destination
       // element has already been created on the thread's stack.
       DestElementPtrAddr = Bld.CreateConstArrayGEP(DestBase, Idx);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       DestElementAddr = CGF.EmitLoadOfPointer(
           DestElementPtrAddr.withElementType(PrivateLlvmPtrType),
           PrivatePtrType->castAs<PointerType>());
-#else
-      DestElementAddr =
-          CGF.EmitLoadOfPointer(CGF.Builder.CreateElementBitCast(
-                                    DestElementPtrAddr, PrivateLlvmPtrType),
-                                PrivatePtrType->castAs<PointerType>());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
       break;
     }
     case ThreadToScratchpad: {
       // Step 1.1: Get the address for the src element in the Reduce list.
       Address SrcElementPtrAddr = Bld.CreateConstArrayGEP(SrcBase, Idx);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       SrcElementAddr = CGF.EmitLoadOfPointer(
           SrcElementPtrAddr.withElementType(PrivateLlvmPtrType),
           PrivatePtrType->castAs<PointerType>());
-#else
-      SrcElementAddr =
-          CGF.EmitLoadOfPointer(CGF.Builder.CreateElementBitCast(
-                                    SrcElementPtrAddr, PrivateLlvmPtrType),
-                                PrivatePtrType->castAs<PointerType>());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
       // Step 1.2: Get the address for dest element:
       // address = base + index * ElementSizeInChars.
@@ -1679,17 +1651,10 @@ static void emitReductionListCopy(
 
     // Regardless of src and dest of copy, we emit the load of src
     // element as this is required in all directions
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     SrcElementAddr = SrcElementAddr.withElementType(
         CGF.ConvertTypeForMem(Private->getType()));
     DestElementAddr =
         DestElementAddr.withElementType(SrcElementAddr.getElementType());
-#else
-    SrcElementAddr = Bld.CreateElementBitCast(
-        SrcElementAddr, CGF.ConvertTypeForMem(Private->getType()));
-    DestElementAddr = Bld.CreateElementBitCast(DestElementAddr,
-                                               SrcElementAddr.getElementType());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Now that all active lanes have read the element in the
     // Reduce list, shuffle over the value from the remote lane.
@@ -1918,12 +1883,7 @@ static llvm::Value *emitInterWarpCopyFunction(CodeGenModule &CGM,
       llvm::Value *ElemPtrPtr = CGF.EmitLoadOfScalar(
           ElemPtrPtrAddr, /*Volatile=*/false, C.VoidPtrTy, SourceLocation());
       // elemptr = ((CopyType*)(elemptrptr)) + I
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address ElemPtr(ElemPtrPtr, CopyType, Align);
-#else
-      Address ElemPtr(ElemPtrPtr, CGF.Int8Ty, Align);
-      ElemPtr = Bld.CreateElementBitCast(ElemPtr, CopyType);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
       if (NumIters > 1)
         ElemPtr = Bld.CreateGEP(ElemPtr, Cnt);
 
@@ -1997,12 +1957,7 @@ static llvm::Value *emitInterWarpCopyFunction(CodeGenModule &CGM,
       Address TargetElemPtrPtr = Bld.CreateConstArrayGEP(LocalReduceList, Idx);
       llvm::Value *TargetElemPtrVal = CGF.EmitLoadOfScalar(
           TargetElemPtrPtr, /*Volatile=*/false, C.VoidPtrTy, Loc);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address TargetElemPtr(TargetElemPtrVal, CopyType, Align);
-#else
-      Address TargetElemPtr(TargetElemPtrVal, CGF.Int8Ty, Align);
-      TargetElemPtr = Bld.CreateElementBitCast(TargetElemPtr, CopyType);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
       if (NumIters > 1)
         TargetElemPtr = Bld.CreateGEP(TargetElemPtr, Cnt);
 
@@ -2433,12 +2388,7 @@ static llvm::Value *emitListToGlobalReduceFunction(
     Address GlobAddr = GlobLVal.getAddress(CGF);
     llvm::Value *BufferPtr = Bld.CreateInBoundsGEP(
         GlobAddr.getElementType(), GlobAddr.getPointer(), Idxs);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.EmitStoreOfScalar(BufferPtr, Elem, /*Volatile=*/false, C.VoidPtrTy);
-#else
-    llvm::Value *Ptr = CGF.EmitCastToVoidPtr(BufferPtr);
-    CGF.EmitStoreOfScalar(Ptr, Elem, /*Volatile=*/false, C.VoidPtrTy);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     if ((*IPriv)->getType()->isVariablyModifiedType()) {
       // Store array size.
       ++Idx;
@@ -2454,12 +2404,7 @@ static llvm::Value *emitListToGlobalReduceFunction(
   }
 
   // Call reduce_function(GlobalReduceList, ReduceList)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *GlobalReduceList = ReductionList.getPointer();
-#else
-  llvm::Value *GlobalReduceList =
-      CGF.EmitCastToVoidPtr(ReductionList.getPointer());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
   Address AddrReduceListArg = CGF.GetAddrOfLocalVar(&ReduceListArg);
   llvm::Value *ReducedPtr = CGF.EmitLoadOfScalar(
       AddrReduceListArg, /*Volatile=*/false, C.VoidPtrTy, Loc);
@@ -2651,12 +2596,7 @@ static llvm::Value *emitGlobalToListReduceFunction(
     Address GlobAddr = GlobLVal.getAddress(CGF);
     llvm::Value *BufferPtr = Bld.CreateInBoundsGEP(
         GlobAddr.getElementType(), GlobAddr.getPointer(), Idxs);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.EmitStoreOfScalar(BufferPtr, Elem, /*Volatile=*/false, C.VoidPtrTy);
-#else
-    llvm::Value *Ptr = CGF.EmitCastToVoidPtr(BufferPtr);
-    CGF.EmitStoreOfScalar(Ptr, Elem, /*Volatile=*/false, C.VoidPtrTy);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     if ((*IPriv)->getType()->isVariablyModifiedType()) {
       // Store array size.
       ++Idx;
@@ -2672,12 +2612,7 @@ static llvm::Value *emitGlobalToListReduceFunction(
   }
 
   // Call reduce_function(ReduceList, GlobalReduceList)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *GlobalReduceList = ReductionList.getPointer();
-#else
-  llvm::Value *GlobalReduceList =
-      CGF.EmitCastToVoidPtr(ReductionList.getPointer());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
   Address AddrReduceListArg = CGF.GetAddrOfLocalVar(&ReduceListArg);
   llvm::Value *ReducedPtr = CGF.EmitLoadOfScalar(
       AddrReduceListArg, /*Volatile=*/false, C.VoidPtrTy, Loc);
@@ -3165,23 +3100,12 @@ CGOpenMPRuntimeGPU::getParameterAddress(CodeGenFunction &CGF,
       LocalAddr, /*Volatile=*/false, TargetTy, SourceLocation());
   // First cast to generic.
   TargetAddr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       TargetAddr,
       llvm::PointerType::get(CGF.getLLVMContext(), /*AddrSpace=*/0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      TargetAddr, llvm::PointerType::getWithSamePointeeType(
-          cast<llvm::PointerType>(TargetAddr->getType()), /*AddrSpace=*/0));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   // Cast from generic to native address space.
   TargetAddr = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       TargetAddr,
       llvm::PointerType::get(CGF.getLLVMContext(), NativePointeeAddrSpace));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      TargetAddr, llvm::PointerType::getWithSamePointeeType(
-          cast<llvm::PointerType>(TargetAddr->getType()),
-                                  NativePointeeAddrSpace));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   Address NativeParamAddr = CGF.CreateMemTemp(NativeParamType);
   CGF.EmitStoreOfScalar(TargetAddr, NativeParamAddr, /*Volatile=*/false,
                         NativeParamType);
@@ -3206,13 +3130,8 @@ void CGOpenMPRuntimeGPU::emitOutlinedFunctionCall(
       continue;
     }
     llvm::Value *TargetArg = CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         NativeArg,
         llvm::PointerType::get(CGF.getLLVMContext(), /*AddrSpace*/ 0));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        NativeArg, llvm::PointerType::getWithSamePointeeType(
-            cast<llvm::PointerType>(NativeArg->getType()), /*AddrSpace*/ 0));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     TargetArgs.emplace_back(
         CGF.Builder.CreatePointerBitCastOrAddrSpaceCast(TargetArg, TargetType));
   }

--- a/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
+++ b/clang/lib/CodeGen/CGRecordLayoutBuilder.cpp
@@ -662,14 +662,9 @@ void CGRecordLowering::accumulateVPtrs() {
         llvm::FunctionType::get(getIntNType(32), /*isVarArg=*/true)->
             getPointerTo()->getPointerTo()));
   if (Layout.hasOwnVBPtr())
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Members.push_back(
         MemberInfo(Layout.getVBPtrOffset(), MemberInfo::VBPtr,
                    llvm::PointerType::getUnqual(Types.getLLVMContext())));
-#else
-    Members.push_back(MemberInfo(Layout.getVBPtrOffset(), MemberInfo::VBPtr,
-        llvm::Type::getInt32PtrTy(Types.getLLVMContext())));
-#endif
 }
 
 void CGRecordLowering::accumulateVBases() {

--- a/clang/lib/CodeGen/CGStmt.cpp
+++ b/clang/lib/CodeGen/CGStmt.cpp
@@ -2198,15 +2198,9 @@ std::pair<llvm::Value*, llvm::Type *> CodeGenFunction::EmitAsmInputLValue(
         getTargetHooks().isScalarizableAsmOperand(*this, Ty)) {
       Ty = llvm::IntegerType::get(getLLVMContext(), Size);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       return {
           Builder.CreateLoad(InputValue.getAddress(*this).withElementType(Ty)),
           nullptr};
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      return {Builder.CreateLoad(Builder.CreateElementBitCast(
-                  InputValue.getAddress(*this), Ty)),
-              nullptr};
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     }
   }
 
@@ -2406,12 +2400,7 @@ EmitAsmStores(CodeGenFunction &CGF, const AsmStmt &S,
     // ResultTypeRequiresCast.size() elements of RegResults.
     if ((i < ResultTypeRequiresCast.size()) && ResultTypeRequiresCast[i]) {
       unsigned Size = CGF.getContext().getTypeSize(ResultRegQualTys[i]);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       Address A = Dest.getAddress(CGF).withElementType(ResultRegTypes[i]);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      Address A =
-          Builder.CreateElementBitCast(Dest.getAddress(CGF), ResultRegTypes[i]);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       if (CGF.getTargetHooks().isScalarizableAsmOperand(CGF, TruncTy)) {
         Builder.CreateStore(Tmp, A);
         continue;
@@ -2591,12 +2580,7 @@ void CodeGenFunction::EmitAsmStmt(const AsmStmt &S) {
       // Otherwise there will be a mis-match if the matrix is also an
       // input-argument which is represented as vector.
       if (isa<MatrixType>(OutExpr->getType().getCanonicalType()))
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         DestAddr = DestAddr.withElementType(ConvertType(OutExpr->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        DestAddr = Builder.CreateElementBitCast(
-            DestAddr, ConvertType(OutExpr->getType()));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       ArgTypes.push_back(DestAddr.getType());
       ArgElemTypes.push_back(DestAddr.getElementType());

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -7274,8 +7274,8 @@ void CodeGenFunction::EmitOMPUseDeviceAddrClause(
     // correct mapping, since the pointer to the data was passed to the runtime.
     if (isa<DeclRefExpr>(Ref->IgnoreParenImpCasts()) ||
         MatchingVD->getType()->isArrayType()) {
-      QualType PtrTy = getContext().getPointerType(
-          OrigVD->getType().getNonReferenceType());
+      QualType PtrTy =
+          getContext().getPointerType(OrigVD->getType().getNonReferenceType());
       PrivAddr =
           EmitLoadOfPointer(PrivAddr.withElementType(ConvertTypeForMem(PtrTy)),
                             PtrTy->castAs<PointerType>());

--- a/clang/lib/CodeGen/CGStmtOpenMP.cpp
+++ b/clang/lib/CodeGen/CGStmtOpenMP.cpp
@@ -704,11 +704,7 @@ void CodeGenFunction::EmitOMPAggregateAssign(
   // Drill down to the base element type on both arrays.
   const ArrayType *ArrayTy = OriginalType->getAsArrayTypeUnsafe();
   llvm::Value *NumElements = emitArrayLength(ArrayTy, ElementTy, DestAddr);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   SrcAddr = SrcAddr.withElementType(DestAddr.getElementType());
-#else
-  SrcAddr = Builder.CreateElementBitCast(SrcAddr, DestAddr.getElementType());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *SrcBegin = SrcAddr.getPointer();
   llvm::Value *DestBegin = DestAddr.getPointer();
@@ -1270,16 +1266,9 @@ void CodeGenFunction::EmitOMPReductionClauseInit(
       // implicit variable.
       PrivateScope.addPrivate(LHSVD,
                               RedCG.getSharedLValue(Count).getAddress(*this));
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       PrivateScope.addPrivate(RHSVD,
                               GetAddrOfLocalVar(PrivateVD).withElementType(
                                   ConvertTypeForMem(RHSVD->getType())));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      PrivateScope.addPrivate(RHSVD, Builder.CreateElementBitCast(
-                                         GetAddrOfLocalVar(PrivateVD),
-                                         ConvertTypeForMem(RHSVD->getType()),
-                                         "rhs.begin"));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     } else {
       QualType Type = PrivateVD->getType();
       bool IsArray = getContext().getAsArrayType(Type) != nullptr;
@@ -1287,25 +1276,13 @@ void CodeGenFunction::EmitOMPReductionClauseInit(
       // Store the address of the original variable associated with the LHS
       // implicit variable.
       if (IsArray) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         OriginalAddr =
             OriginalAddr.withElementType(ConvertTypeForMem(LHSVD->getType()));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        OriginalAddr = Builder.CreateElementBitCast(
-            OriginalAddr, ConvertTypeForMem(LHSVD->getType()), "lhs.begin");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
       PrivateScope.addPrivate(LHSVD, OriginalAddr);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       PrivateScope.addPrivate(
           RHSVD, IsArray ? GetAddrOfLocalVar(PrivateVD).withElementType(
                                ConvertTypeForMem(RHSVD->getType()))
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      PrivateScope.addPrivate(
-          RHSVD, IsArray ? Builder.CreateElementBitCast(
-                               GetAddrOfLocalVar(PrivateVD),
-                               ConvertTypeForMem(RHSVD->getType()), "rhs.begin")
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
                          : GetAddrOfLocalVar(PrivateVD));
     }
     ++ILHS;
@@ -7299,15 +7276,9 @@ void CodeGenFunction::EmitOMPUseDeviceAddrClause(
         MatchingVD->getType()->isArrayType()) {
       QualType PtrTy = getContext().getPointerType(
           OrigVD->getType().getNonReferenceType());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       PrivAddr =
           EmitLoadOfPointer(PrivAddr.withElementType(ConvertTypeForMem(PtrTy)),
                             PtrTy->castAs<PointerType>());
-#else
-      PrivAddr = EmitLoadOfPointer(
-          Builder.CreateElementBitCast(PrivAddr, ConvertTypeForMem(PtrTy)),
-          PtrTy->castAs<PointerType>());
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     }
 
     (void)PrivateScope.addPrivate(OrigVD, PrivAddr);

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -1104,7 +1104,6 @@ CodeGenAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
   if (BA != Backend_EmitNothing && !OS)
     return nullptr;
 
-
   // Load bitcode modules to link with, if we need to.
   if (loadLinkModules(CI))
     return nullptr;
@@ -1139,7 +1138,6 @@ std::unique_ptr<llvm::Module>
 CodeGenAction::loadModule(MemoryBufferRef MBRef) {
   CompilerInstance &CI = getCompilerInstance();
   SourceManager &SM = CI.getSourceManager();
-
 
   auto DiagErrors = [&](Error E) -> std::unique_ptr<llvm::Module> {
     unsigned DiagID =

--- a/clang/lib/CodeGen/CodeGenAction.cpp
+++ b/clang/lib/CodeGen/CodeGenAction.cpp
@@ -1104,9 +1104,6 @@ CodeGenAction::CreateASTConsumer(CompilerInstance &CI, StringRef InFile) {
   if (BA != Backend_EmitNothing && !OS)
     return nullptr;
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  VMContext->setOpaquePointers(CI.getCodeGenOpts().OpaquePointers);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Load bitcode modules to link with, if we need to.
   if (loadLinkModules(CI))
@@ -1143,9 +1140,6 @@ CodeGenAction::loadModule(MemoryBufferRef MBRef) {
   CompilerInstance &CI = getCompilerInstance();
   SourceManager &SM = CI.getSourceManager();
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  VMContext->setOpaquePointers(CI.getCodeGenOpts().OpaquePointers);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   auto DiagErrors = [&](Error E) -> std::unique_ptr<llvm::Module> {
     unsigned DiagID =

--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -2221,12 +2221,7 @@ static void emitNonZeroVLAInit(CodeGenFunction &CGF, QualType baseType,
   llvm::Value *baseSizeInChars
     = llvm::ConstantInt::get(CGF.IntPtrTy, baseSize.getQuantity());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address begin = dest.withElementType(CGF.Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address begin =
-    Builder.CreateElementBitCast(dest, CGF.Int8Ty, "vla.begin");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *end = Builder.CreateInBoundsGEP(
       begin.getElementType(), begin.getPointer(), sizeInChars, "vla.end");
 
@@ -2271,12 +2266,7 @@ CodeGenFunction::EmitNullInitialization(Address DestPtr, QualType Ty) {
   }
 
   if (DestPtr.getElementType() != Int8Ty)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     DestPtr = DestPtr.withElementType(Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    // Cast the dest ptr to the appropriate i8 pointer type.
-    DestPtr = Builder.CreateElementBitCast(DestPtr, Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Get size and alignment info for this aggregate.
   CharUnits size = getContext().getTypeSizeInChars(Ty);
@@ -2321,12 +2311,7 @@ CodeGenFunction::EmitNullInitialization(Address DestPtr, QualType Ty) {
                                NullConstant, Twine());
     CharUnits NullAlign = DestPtr.getAlignment();
     NullVariable->setAlignment(NullAlign.getAsAlign());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address SrcPtr(NullVariable, Builder.getInt8Ty(), NullAlign);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address SrcPtr(Builder.CreateBitCast(NullVariable, Builder.getInt8PtrTy()),
-                   Builder.getInt8Ty(), NullAlign);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     if (vla) return emitNonZeroVLAInit(*this, Ty, DestPtr, SrcPtr, SizeVal);
 
@@ -2440,11 +2425,7 @@ llvm::Value *CodeGenFunction::emitArrayLength(const ArrayType *origArrayType,
     }
 
     llvm::Type *baseType = ConvertType(eltType);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     addr = addr.withElementType(baseType);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    addr = Builder.CreateElementBitCast(addr, baseType, "array.begin");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   } else {
     // Create the actual GEP.
     addr = Address(Builder.CreateInBoundsGEP(
@@ -2808,11 +2789,7 @@ Address CodeGenFunction::EmitFieldAnnotations(const FieldDecl *D,
   auto *PTy = dyn_cast<llvm::PointerType>(VTy);
   unsigned AS = PTy ? PTy->getAddressSpace() : 0;
   llvm::PointerType *IntrinTy =
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::PointerType::get(CGM.getLLVMContext(), AS);
-#else
-      llvm::PointerType::getWithSamePointeeType(CGM.Int8PtrTy, AS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   // llvm.ptr.annotation intrinsic accepts a pointer to integer of any width -
   // don't perform bitcasts if value is integer
   if (Addr.getElementType()->isIntegerTy()) {
@@ -2872,11 +2849,7 @@ Address CodeGenFunction::EmitFieldSYCLAnnotations(const FieldDecl *D,
   unsigned AS = PTy ? PTy->getAddressSpace() : 0;
   llvm::Type *IntrType = VTy;
   if (!Addr.getElementType()->isIntegerTy())
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     IntrType = llvm::PointerType::get(CGM.getLLVMContext(), AS);
-#else
-    IntrType = llvm::PointerType::getWithSamePointeeType(CGM.Int8PtrTy, AS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Function *F = CGM.getIntrinsic(llvm::Intrinsic::ptr_annotation,
                                        {IntrType, CGM.ConstGlobalsPtrTy});
 

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2659,10 +2659,6 @@ public:
                                  AggValueSlot::DoesNotOverlap);
   }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  /// Emit a cast to void* in the appropriate address space.
-  llvm::Value *EmitCastToVoidPtr(llvm::Value *value);
-#endif
 
   /// EvaluateExprAsBool - Perform the usual unary conversions on the specified
   /// expression and compare the result against zero, returning an Int1Ty value.

--- a/clang/lib/CodeGen/CodeGenFunction.h
+++ b/clang/lib/CodeGen/CodeGenFunction.h
@@ -2659,7 +2659,6 @@ public:
                                  AggValueSlot::DoesNotOverlap);
   }
 
-
   /// EvaluateExprAsBool - Perform the usual unary conversions on the specified
   /// expression and compare the result against zero, returning an Int1Ty value.
   llvm::Value *EvaluateExprAsBool(const Expr *E);

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -125,99 +125,9 @@ bool CodeGenTypes::isRecordLayoutComplete(const Type *Ty) const {
   return I != RecordDeclTypes.end() && !I->second->isOpaque();
 }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-static bool
-isSafeToConvert(QualType T, CodeGenTypes &CGT,
-                llvm::SmallPtrSet<const RecordDecl*, 16> &AlreadyChecked);
-
-
-/// isSafeToConvert - Return true if it is safe to convert the specified record
-/// decl to IR and lay it out, false if doing so would cause us to get into a
-/// recursive compilation mess.
-static bool
-isSafeToConvert(const RecordDecl *RD, CodeGenTypes &CGT,
-                llvm::SmallPtrSet<const RecordDecl*, 16> &AlreadyChecked) {
-  // If we have already checked this type (maybe the same type is used by-value
-  // multiple times in multiple structure fields, don't check again.
-  if (!AlreadyChecked.insert(RD).second)
-    return true;
-
-  const Type *Key = CGT.getContext().getTagDeclType(RD).getTypePtr();
-
-  // If this type is already laid out, converting it is a noop.
-  if (CGT.isRecordLayoutComplete(Key)) return true;
-
-  // If this type is currently being laid out, we can't recursively compile it.
-  if (CGT.isRecordBeingLaidOut(Key))
-    return false;
-
-  // If this type would require laying out bases that are currently being laid
-  // out, don't do it.  This includes virtual base classes which get laid out
-  // when a class is translated, even though they aren't embedded by-value into
-  // the class.
-  if (const CXXRecordDecl *CRD = dyn_cast<CXXRecordDecl>(RD)) {
-    for (const auto &I : CRD->bases())
-      if (!isSafeToConvert(I.getType()->castAs<RecordType>()->getDecl(), CGT,
-                           AlreadyChecked))
-        return false;
-  }
-
-  // If this type would require laying out members that are currently being laid
-  // out, don't do it.
-  for (const auto *I : RD->fields())
-    if (!isSafeToConvert(I->getType(), CGT, AlreadyChecked))
-      return false;
-
-  // If there are no problems, lets do it.
-  return true;
-}
-
-/// isSafeToConvert - Return true if it is safe to convert this field type,
-/// which requires the structure elements contained by-value to all be
-/// recursively safe to convert.
-static bool
-isSafeToConvert(QualType T, CodeGenTypes &CGT,
-                llvm::SmallPtrSet<const RecordDecl*, 16> &AlreadyChecked) {
-  // Strip off atomic type sugar.
-  if (const auto *AT = T->getAs<AtomicType>())
-    T = AT->getValueType();
-
-  // If this is a record, check it.
-  if (const auto *RT = T->getAs<RecordType>())
-    return isSafeToConvert(RT->getDecl(), CGT, AlreadyChecked);
-
-  // If this is an array, check the elements, which are embedded inline.
-  if (const auto *AT = CGT.getContext().getAsArrayType(T))
-    return isSafeToConvert(AT->getElementType(), CGT, AlreadyChecked);
-
-  // Otherwise, there is no concern about transforming this.  We only care about
-  // things that are contained by-value in a structure that can have another
-  // structure as a member.
-  return true;
-}
-
-
-/// isSafeToConvert - Return true if it is safe to convert the specified record
-/// decl to IR and lay it out, false if doing so would cause us to get into a
-/// recursive compilation mess.
-static bool isSafeToConvert(const RecordDecl *RD, CodeGenTypes &CGT) {
-  // If no structs are being laid out, we can certainly do this one.
-  if (CGT.noRecordsBeingLaidOut()) return true;
-
-  llvm::SmallPtrSet<const RecordDecl*, 16> AlreadyChecked;
-  return isSafeToConvert(RD, CGT, AlreadyChecked);
-}
-
-/// isFuncParamTypeConvertible - Return true if the specified type in a
-/// function parameter or result position can be converted to an IR type at this
-/// point.  This boils down to being whether it is complete, as well as whether
-/// we've temporarily deferred expanding the type because we're in a recursive
-/// context.
-#else
 /// isFuncParamTypeConvertible - Return true if the specified type in a
 /// function parameter or result position can be converted to an IR type at this
 /// point. This boils down to being whether it is complete.
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
 bool CodeGenTypes::isFuncParamTypeConvertible(QualType Ty) {
   // Some ABIs cannot have their member pointers represented in IR unless
@@ -230,26 +140,8 @@ bool CodeGenTypes::isFuncParamTypeConvertible(QualType Ty) {
   if (!TT) return true;
 
   // Incomplete types cannot be converted.
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  if (TT->isIncompleteType())
-    return false;
-
-  // If this is an enum, then it is always safe to convert.
-  const RecordType *RT = dyn_cast<RecordType>(TT);
-  if (!RT) return true;
-
-  // Otherwise, we have to be careful.  If it is a struct that we're in the
-  // process of expanding, then we can't convert the function type.  That's ok
-  // though because we must be in a pointer context under the struct, so we can
-  // just convert it to a dummy type.
-  //
-  // We decide this by checking whether ConvertRecordDeclType returns us an
-  // opaque type for a struct that we know is defined.
-  return isSafeToConvert(RT->getDecl(), *this);
-#else
   // Incomplete types cannot be converted.
   return !TT->isIncompleteType();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
 }
 
@@ -350,9 +242,6 @@ static llvm::Type *getTypeForFormat(llvm::LLVMContext &VMContext,
 
 llvm::Type *CodeGenTypes::ConvertFunctionTypeInternal(QualType QFT) {
   assert(QFT.isCanonical());
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  const Type *Ty = QFT.getTypePtr();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   const FunctionType *FT = cast<FunctionType>(QFT.getTypePtr());
   // First, check whether we can build the full function type.  If the
   // function type depends on an incomplete type (e.g. a struct or enum), we
@@ -375,15 +264,6 @@ llvm::Type *CodeGenTypes::ConvertFunctionTypeInternal(QualType QFT) {
     return llvm::StructType::get(getLLVMContext());
   }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // While we're converting the parameter types for a function, we don't want
-  // to recursively convert any pointed-to structs.  Converting directly-used
-  // structs is ok though.
-  if (!RecordsBeingLaidOut.insert(Ty).second) {
-    SkippedLayout = true;
-    return llvm::StructType::get(getLLVMContext());
-  }
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   // The function type can be built; call the appropriate routines to
   // build it.
   const CGFunctionInfo *FI;
@@ -409,13 +289,6 @@ llvm::Type *CodeGenTypes::ConvertFunctionTypeInternal(QualType QFT) {
     ResultType = GetFunctionType(*FI);
   }
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  RecordsBeingLaidOut.erase(Ty);
-
-  if (RecordsBeingLaidOut.empty())
-    while (!DeferredRecords.empty())
-      ConvertRecordDeclType(DeferredRecords.pop_back_val());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return ResultType;
 }
 
@@ -514,29 +387,6 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
   if (const RecordType *RT = dyn_cast<RecordType>(Ty))
     return ConvertRecordDeclType(RT->getDecl());
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // The LLVM type we return for a given Clang type may not always be the same,
-  // most notably when dealing with recursive structs. We mark these potential
-  // cases with ShouldUseCache below. Builtin types cannot be recursive.
-  // TODO: when clang uses LLVM opaque pointers we won't be able to represent
-  // recursive types with LLVM types, making this logic much simpler.
-  llvm::Type *CachedType = nullptr;
-  bool ShouldUseCache =
-      Ty->isBuiltinType() ||
-      (noRecordsBeingLaidOut() && FunctionsBeingProcessed.empty());
-  if (ShouldUseCache) {
-    llvm::DenseMap<const Type *, llvm::Type *>::iterator TCI =
-        TypeCache.find(Ty);
-    if (TCI != TypeCache.end())
-      CachedType = TCI->second;
-      // With expensive checks, check that the type we compute matches the
-      // cached type.
-#ifndef EXPENSIVE_CHECKS
-    if (CachedType)
-      return CachedType;
-#endif
-  }
-#else
   llvm::Type *CachedType = nullptr;
   auto TCI = TypeCache.find(Ty);
   if (TCI != TypeCache.end())
@@ -547,7 +397,6 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
   if (CachedType)
     return CachedType;
 #endif
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // If we don't have it in the cache, convert it now.
   llvm::Type *ResultType = nullptr;
@@ -787,12 +636,7 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     const ReferenceType *RTy = cast<ReferenceType>(Ty);
     QualType ETy = RTy->getPointeeType();
     unsigned AS = getTargetAddressSpace(ETy);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     ResultType = llvm::PointerType::get(getLLVMContext(), AS);
-#else  // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PointeeType = ConvertTypeForMem(ETy);
-    ResultType = llvm::PointerType::get(PointeeType, AS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     break;
   }
@@ -813,15 +657,7 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     }
 
     unsigned AS = getTargetAddressSpace(ETy);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     ResultType = llvm::PointerType::get(getLLVMContext(), AS);
-#else  // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PointeeType = ConvertTypeForMem(ETy);
-    if (PointeeType->isVoidTy())
-      PointeeType = llvm::Type::getInt8Ty(getLLVMContext());
-
-    ResultType = llvm::PointerType::get(PointeeType, AS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     break;
   }
@@ -900,16 +736,7 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
   }
 
   case Type::ObjCObjectPointer: {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     ResultType = llvm::PointerType::getUnqual(getLLVMContext());
-#else  // INTEL_SYCL_OPAQUEPOINTER_READY
-    // Protocol qualifications do not influence the LLVM type, we just return a
-    // pointer to the underlying interface type. We don't need to worry about
-    // recursive conversion.
-    llvm::Type *T =
-        ConvertTypeForMem(cast<ObjCObjectPointerType>(Ty)->getPointeeType());
-    ResultType = T->getPointerTo();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     break;
   }
 
@@ -926,11 +753,6 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
 
   case Type::BlockPointer: {
     const QualType FTy = cast<BlockPointerType>(Ty)->getPointeeType();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Type *PointeeType = CGM.getLangOpts().OpenCL
-                                  ? CGM.getGenericBlockLiteralType()
-                                  : ConvertTypeForMem(FTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     // Block pointers lower to function type. For function type,
     // getTargetAddressSpace() returns default address space for
     // function pointer i.e. program address space. Therefore, for block
@@ -938,11 +760,7 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
     // calling getTargetAddressSpace(), to ensure that we get the LLVM IR
     // address space for data pointers and not function pointers.
     unsigned AS = Context.getTargetAddressSpace(FTy.getAddressSpace());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     ResultType = llvm::PointerType::get(getLLVMContext(), AS);
-#else  // INTEL_SYCL_OPAQUEPOINTER_READY
-    ResultType = llvm::PointerType::get(PointeeType, AS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     break;
   }
 
@@ -992,12 +810,7 @@ llvm::Type *CodeGenTypes::ConvertType(QualType T) {
   assert(ResultType && "Didn't convert a type?");
   assert((!CachedType || CachedType == ResultType) &&
          "Cached type doesn't match computed type");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  if (ShouldUseCache)
-    TypeCache[Ty] = ResultType;
-#else
   TypeCache[Ty] = ResultType;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return ResultType;
 }
 
@@ -1032,18 +845,6 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
   if (!RD || !RD->isCompleteDefinition() || !Ty->isOpaque())
     return Ty;
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // If converting this type would cause us to infinitely loop, don't do it!
-  if (!isSafeToConvert(RD, *this)) {
-    DeferredRecords.push_back(RD);
-    return Ty;
-  }
-
-  // Okay, this is a definition of a type.  Compile the implementation now.
-  bool InsertResult = RecordsBeingLaidOut.insert(Key).second;
-  (void)InsertResult;
-  assert(InsertResult && "Recursively compiling a struct?");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   // Force conversion of non-virtual base classes recursively.
   if (const CXXRecordDecl *CRD = dyn_cast<CXXRecordDecl>(RD)) {
     for (const auto &I : CRD->bases()) {
@@ -1056,24 +857,12 @@ llvm::StructType *CodeGenTypes::ConvertRecordDeclType(const RecordDecl *RD) {
   std::unique_ptr<CGRecordLayout> Layout = ComputeRecordLayout(RD, Ty);
   CGRecordLayouts[Key] = std::move(Layout);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // We're done laying out this struct.
-  bool EraseResult = RecordsBeingLaidOut.erase(Key); (void)EraseResult;
-  assert(EraseResult && "struct not in RecordsBeingLaidOut set?");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   // If this struct blocked a FunctionType conversion, then recompute whatever
   // was derived from that.
   // FIXME: This is hugely overconservative.
   if (SkippedLayout)
     TypeCache.clear();
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  // If we're done converting the outer-most record, then convert any deferred
-  // structs as well.
-  if (RecordsBeingLaidOut.empty())
-    while (!DeferredRecords.empty())
-      ConvertRecordDeclType(DeferredRecords.pop_back_val());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return Ty;
 }
 

--- a/clang/lib/CodeGen/CodeGenTypes.cpp
+++ b/clang/lib/CodeGen/CodeGenTypes.cpp
@@ -142,7 +142,6 @@ bool CodeGenTypes::isFuncParamTypeConvertible(QualType Ty) {
   // Incomplete types cannot be converted.
   // Incomplete types cannot be converted.
   return !TT->isIncompleteType();
-
 }
 
 

--- a/clang/lib/CodeGen/CodeGenTypes.h
+++ b/clang/lib/CodeGen/CodeGenTypes.h
@@ -78,13 +78,6 @@ class CodeGenTypes {
   /// Hold memoized CGFunctionInfo results.
   llvm::FoldingSet<CGFunctionInfo> FunctionInfos{FunctionInfosLog2InitSize};
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  /// This set keeps track of records that we're currently converting
-  /// to an IR type.  For example, when converting:
-  /// struct A { struct B { int x; } } when processing 'x', the 'A' and 'B'
-  /// types will be in this set.
-  llvm::SmallPtrSet<const Type*, 4> RecordsBeingLaidOut;
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::SmallPtrSet<const CGFunctionInfo*, 4> FunctionsBeingProcessed;
 
@@ -92,9 +85,6 @@ class CodeGenTypes {
   /// a recursive struct conversion, set this to true.
   bool SkippedLayout;
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  SmallVector<const RecordDecl *, 8> DeferredRecords;
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
   /// This map keeps cache of llvm::Types and maps clang::Type to
   /// corresponding llvm::Type.
@@ -310,14 +300,6 @@ public:  // These are internal details of CGT that shouldn't be used externally.
   bool isZeroInitializable(const RecordDecl *RD);
 
   bool isRecordLayoutComplete(const Type *Ty) const;
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  bool noRecordsBeingLaidOut() const {
-    return RecordsBeingLaidOut.empty();
-  }
-  bool isRecordBeingLaidOut(const Type *Ty) const {
-    return RecordsBeingLaidOut.count(Ty);
-  }
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
   unsigned getTargetAddressSpace(QualType T) const;
 };
 

--- a/clang/lib/CodeGen/CodeGenTypes.h
+++ b/clang/lib/CodeGen/CodeGenTypes.h
@@ -78,13 +78,11 @@ class CodeGenTypes {
   /// Hold memoized CGFunctionInfo results.
   llvm::FoldingSet<CGFunctionInfo> FunctionInfos{FunctionInfosLog2InitSize};
 
-
   llvm::SmallPtrSet<const CGFunctionInfo*, 4> FunctionsBeingProcessed;
 
   /// True if we didn't layout a function due to a being inside
   /// a recursive struct conversion, set this to true.
   bool SkippedLayout;
-
 
   /// This map keeps cache of llvm::Types and maps clang::Type to
   /// corresponding llvm::Type.

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -227,7 +227,6 @@ public:
     return hasUniqueVTablePointer(DestRecordTy);
   }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *emitDynamicCastCall(CodeGenFunction &CGF, Address Value,
                                    QualType SrcRecordTy, QualType DestTy,
                                    QualType DestRecordTy,
@@ -236,16 +235,6 @@ public:
   llvm::Value *emitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
                                      QualType SrcRecordTy) override;
 
-#else
-  llvm::Value *EmitDynamicCastCall(CodeGenFunction &CGF, Address Value,
-                                   QualType SrcRecordTy, QualType DestTy,
-                                   QualType DestRecordTy,
-                                   llvm::BasicBlock *CastEnd) override;
-
-  llvm::Value *EmitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
-                                     QualType SrcRecordTy,
-                                     QualType DestTy) override;
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *emitExactDynamicCast(CodeGenFunction &CGF, Address ThisAddr,
                                     QualType SrcRecordTy, QualType DestTy,
@@ -663,13 +652,7 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
   // Apply the adjustment and cast back to the original struct type
   // for consistency.
   llvm::Value *This = ThisAddr.getPointer();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   This = Builder.CreateInBoundsGEP(Builder.getInt8Ty(), This, Adj);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Value *Ptr = Builder.CreateBitCast(This, Builder.getInt8PtrTy());
-  Ptr = Builder.CreateInBoundsGEP(Builder.getInt8Ty(), Ptr, Adj);
-  This = Builder.CreateBitCast(Ptr, This->getType(), "this.adjusted");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   ThisPtrForCall = This;
 
   // Load the function pointer.
@@ -762,14 +745,8 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
                                       ? llvm::Intrinsic::type_test
                                       : llvm::Intrinsic::public_type_test;
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         CheckResult =
             Builder.CreateCall(CGM.getIntrinsic(IID), {VFPAddr, TypeId});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-        CheckResult = Builder.CreateCall(
-            CGM.getIntrinsic(IID),
-            {Builder.CreateBitCast(VFPAddr, CGF.Int8PtrTy), TypeId});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       }
 
       if (CGM.getItaniumVTableContext().isRelativeLayout()) {
@@ -777,9 +754,6 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
             CGM.getIntrinsic(llvm::Intrinsic::load_relative,
                              {VTableOffset->getType()}),
             {VTable, VTableOffset});
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-        VirtualFn = CGF.Builder.CreateBitCast(VirtualFn, FTy->getPointerTo());
-#endif
       } else {
         llvm::Value *VFPAddr =
             CGF.Builder.CreateGEP(CGF.Int8Ty, VTable, VTableOffset);
@@ -843,10 +817,6 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
       };
 
       llvm::Value *Bit = Builder.getFalse();
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-      llvm::Value *CastedNonVirtualFn =
-          Builder.CreateBitCast(NonVirtualFn, CGF.Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       for (const CXXRecordDecl *Base : CGM.getMostBaseClasses(RD)) {
         llvm::Metadata *MD = CGM.CreateMetadataIdentifierForType(
             getContext().getMemberPointerType(
@@ -857,21 +827,13 @@ CGCallee ItaniumCXXABI::EmitLoadOfMemberFunctionPointer(
 
         llvm::Value *TypeTest =
             Builder.CreateCall(CGM.getIntrinsic(llvm::Intrinsic::type_test),
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                                {NonVirtualFn, TypeId});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-                               {CastedNonVirtualFn, TypeId});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
         Bit = Builder.CreateOr(Bit, TypeTest);
       }
 
       CGF.EmitCheck(std::make_pair(Bit, SanitizerKind::CFIMFCall),
                     SanitizerHandler::CFICheckFail, StaticData,
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
                     {NonVirtualFn, llvm::UndefValue::get(CGF.IntPtrTy)});
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-                    {CastedNonVirtualFn, llvm::UndefValue::get(CGF.IntPtrTy)});
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
       FnNonVirtual = Builder.GetInsertBlock();
     }
@@ -1299,12 +1261,7 @@ void ItaniumCXXABI::emitVirtualObjectDelete(CodeGenFunction &CGF,
                                                         CGF.getPointerAlign());
 
     // Apply the offset.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *CompletePtr = Ptr.getPointer();
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::Value *CompletePtr =
-      CGF.Builder.CreateBitCast(Ptr.getPointer(), CGF.Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     CompletePtr =
         CGF.Builder.CreateInBoundsGEP(CGF.Int8Ty, CompletePtr, Offset);
 
@@ -1505,9 +1462,6 @@ llvm::Value *ItaniumCXXABI::EmitTypeid(CodeGenFunction &CGF,
 
   if (CGM.getItaniumVTableContext().isRelativeLayout()) {
     // Load the type info.
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    Value = CGF.Builder.CreateBitCast(Value, CGM.Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     Value = CGF.Builder.CreateCall(
         CGM.getIntrinsic(llvm::Intrinsic::load_relative, {CGM.Int32Ty}),
         {Value, llvm::ConstantInt::get(CGM.Int32Ty, -4)});
@@ -1528,18 +1482,11 @@ bool ItaniumCXXABI::shouldDynamicCastCallBeNullChecked(bool SrcIsPtr,
   return SrcIsPtr;
 }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
 llvm::Value *ItaniumCXXABI::emitDynamicCastCall(
-#else
-llvm::Value *ItaniumCXXABI::EmitDynamicCastCall(
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     CodeGenFunction &CGF, Address ThisAddr, QualType SrcRecordTy,
     QualType DestTy, QualType DestRecordTy, llvm::BasicBlock *CastEnd) {
   llvm::Type *PtrDiffLTy =
       CGF.ConvertType(CGF.getContext().getPointerDiffType());
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *DestLTy = CGF.ConvertType(DestTy);
-#endif
 
   llvm::Value *SrcRTTI =
       CGF.CGM.GetAddrOfRTTIDescriptor(SrcRecordTy.getUnqualifiedType());
@@ -1554,18 +1501,9 @@ llvm::Value *ItaniumCXXABI::EmitDynamicCastCall(
       computeOffsetHint(CGF.getContext(), SrcDecl, DestDecl).getQuantity());
 
   // Emit the call to __dynamic_cast.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *Args[] = {ThisAddr.getPointer(), SrcRTTI, DestRTTI, OffsetHint};
   llvm::Value *Value =
       CGF.EmitNounwindRuntimeCall(getItaniumDynamicCastFn(CGF), Args);
-#else
-  llvm::Value *Value = ThisAddr.getPointer();
-  Value = CGF.EmitCastToVoidPtr(Value);
-
-  llvm::Value *args[] = {Value, SrcRTTI, DestRTTI, OffsetHint};
-  Value = CGF.EmitNounwindRuntimeCall(getItaniumDynamicCastFn(CGF), args);
-  Value = CGF.Builder.CreateBitCast(Value, DestLTy);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 
   /// C++ [expr.dynamic.cast]p9:
   ///   A failed cast to reference type throws std::bad_cast
@@ -1628,13 +1566,8 @@ llvm::Value *ItaniumCXXABI::emitExactDynamicCast(
       // object and see if it's a DestDecl. Note that the most-derived object
       // must be at least as aligned as this base class subobject, and must
       // have a vptr at offset 0.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       ThisAddr = Address(emitDynamicCastToVoid(CGF, ThisAddr, SrcRecordTy),
                          CGF.VoidPtrTy, ThisAddr.getAlignment());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      ThisAddr = Address(EmitDynamicCastToVoid(CGF, ThisAddr, SrcRecordTy, DestRecordTy),
-                         CGF.VoidPtrTy, ThisAddr.getAlignment());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       SrcDecl = DestDecl;
       Offset = CharUnits::Zero();
       break;
@@ -1666,20 +1599,10 @@ llvm::Value *ItaniumCXXABI::emitExactDynamicCast(
   return Result;
 }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
 llvm::Value *ItaniumCXXABI::emitDynamicCastToVoid(CodeGenFunction &CGF,
                                                   Address ThisAddr,
                                                   QualType SrcRecordTy) {
 
-#else
-llvm::Value *ItaniumCXXABI::EmitDynamicCastToVoid(CodeGenFunction &CGF,
-                                                  Address ThisAddr,
-                                                  QualType SrcRecordTy,
-                                                  QualType DestTy) {
-  llvm::Type *DestLTy = CGF.ConvertType(DestTy);
-  if (!DestLTy->isPointerTy())
-    DestLTy = DestLTy->getPointerTo();
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
   auto *ClassDecl =
       cast<CXXRecordDecl>(SrcRecordTy->castAs<RecordType>()->getDecl());
   llvm::Value *OffsetToTop;
@@ -1708,15 +1631,8 @@ llvm::Value *ItaniumCXXABI::EmitDynamicCastToVoid(CodeGenFunction &CGF,
         PtrDiffLTy, OffsetToTop, CGF.getPointerAlign(), "offset.to.top");
   }
   // Finally, add the offset to the pointer.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return CGF.Builder.CreateInBoundsGEP(CGF.Int8Ty, ThisAddr.getPointer(),
                                        OffsetToTop);
-#else
-  llvm::Value *Value = ThisAddr.getPointer();
-  Value = CGF.EmitCastToVoidPtr(Value);
-  Value = CGF.Builder.CreateInBoundsGEP(CGF.Int8Ty, Value, OffsetToTop);
-  return CGF.Builder.CreateBitCast(Value, DestLTy);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 bool ItaniumCXXABI::EmitBadCastCall(CodeGenFunction &CGF) {
@@ -2116,28 +2032,15 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
                                                   Address This,
                                                   llvm::Type *Ty,
                                                   SourceLocation Loc) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Type *PtrTy = CGM.GlobalsInt8PtrTy;
-#else  // INTEL_SYCL_OPAQUEPOINTER_READY
-  llvm::Type *TyPtr = Ty->getPointerTo();
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   auto *MethodDecl = cast<CXXMethodDecl>(GD.getDecl());
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *VTable = CGF.GetVTablePtr(This, PtrTy, MethodDecl->getParent());
-#else
-  llvm::Value *VTable = CGF.GetVTablePtr(
-      This, TyPtr->getPointerTo(), MethodDecl->getParent());
-#endif
 
   uint64_t VTableIndex = CGM.getItaniumVTableContext().getMethodVTableIndex(GD);
   llvm::Value *VFunc;
   if (CGF.ShouldEmitVTableTypeCheckedLoad(MethodDecl->getParent())) {
     VFunc = CGF.EmitVTableTypeCheckedLoad(
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
         MethodDecl->getParent(), VTable, PtrTy,
-#else
-        MethodDecl->getParent(), VTable, TyPtr,
-#endif
         VTableIndex *
             CGM.getContext().getTargetInfo().getPointerWidth(LangAS::Default) /
             8);
@@ -2146,33 +2049,14 @@ CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
 
     llvm::Value *VFuncLoad;
     if (CGM.getItaniumVTableContext().isRelativeLayout()) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       VFuncLoad = CGF.Builder.CreateCall(
           CGM.getIntrinsic(llvm::Intrinsic::load_relative, {CGM.Int32Ty}),
           {VTable, llvm::ConstantInt::get(CGM.Int32Ty, 4 * VTableIndex)});
-#else
-      VTable = CGF.Builder.CreateBitCast(VTable, CGM.Int8PtrTy);
-      llvm::Value *Load = CGF.Builder.CreateCall(
-          CGM.getIntrinsic(llvm::Intrinsic::load_relative, {CGM.Int32Ty}),
-          {VTable, llvm::ConstantInt::get(CGM.Int32Ty, 4 * VTableIndex)});
-
-      VFuncLoad = CGF.Builder.CreateBitCast(Load, TyPtr);
-#endif
     } else {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       llvm::Value *VTableSlotPtr = CGF.Builder.CreateConstInBoundsGEP1_64(
           PtrTy, VTable, VTableIndex, "vfn");
       VFuncLoad = CGF.Builder.CreateAlignedLoad(PtrTy, VTableSlotPtr,
                                                 CGF.getPointerAlign());
-#else
-      VTable =
-          CGF.Builder.CreateBitCast(VTable, TyPtr->getPointerTo());
-      llvm::Value *VTableSlotPtr = CGF.Builder.CreateConstInBoundsGEP1_64(
-          TyPtr, VTable, VTableIndex, "vfn");
-      VFuncLoad =
-          CGF.Builder.CreateAlignedLoad(TyPtr, VTableSlotPtr,
-                                        CGF.getPointerAlign());
-#endif
     }
 
     // Add !invariant.load md to virtual function load to indicate that
@@ -2295,11 +2179,7 @@ static llvm::Value *performTypeAdjustment(CodeGenFunction &CGF,
   if (!NonVirtualAdjustment && !VirtualAdjustment)
     return InitialPtr.getPointer();
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address V = InitialPtr.withElementType(CGF.Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address V = CGF.Builder.CreateElementBitCast(InitialPtr, CGF.Int8Ty);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // In a base-to-derived cast, the non-virtual adjustment is applied first.
   if (NonVirtualAdjustment && !IsReturnAdjustment) {
@@ -2310,11 +2190,7 @@ static llvm::Value *performTypeAdjustment(CodeGenFunction &CGF,
   // Perform the virtual adjustment if we have one.
   llvm::Value *ResultPtr;
   if (VirtualAdjustment) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address VTablePtrPtr = V.withElementType(CGF.Int8PtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address VTablePtrPtr = CGF.Builder.CreateElementBitCast(V, CGF.Int8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::Value *VTablePtr = CGF.Builder.CreateLoad(VTablePtrPtr);
 
     llvm::Value *Offset;
@@ -2352,12 +2228,7 @@ static llvm::Value *performTypeAdjustment(CodeGenFunction &CGF,
                                                        NonVirtualAdjustment);
   }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return ResultPtr;
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  // Cast back to the original type.
-  return CGF.Builder.CreateBitCast(ResultPtr, InitialPtr.getType());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 llvm::Value *ItaniumCXXABI::performThisAdjustment(CodeGenFunction &CGF,
@@ -2420,12 +2291,7 @@ Address ItaniumCXXABI::InitializeArrayCookie(CodeGenFunction &CGF,
     CookiePtr = CGF.Builder.CreateConstInBoundsByteGEP(CookiePtr, CookieOffset);
 
   // Write the number of elements into the appropriate slot.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address NumElementsPtr = CookiePtr.withElementType(CGF.SizeTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address NumElementsPtr =
-      CGF.Builder.CreateElementBitCast(CookiePtr, CGF.SizeTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Instruction *SI = CGF.Builder.CreateStore(NumElements, NumElementsPtr);
 
   // Handle the array cookie specially in ASan.
@@ -2457,11 +2323,7 @@ llvm::Value *ItaniumCXXABI::readArrayCookieImpl(CodeGenFunction &CGF,
       CGF.Builder.CreateConstInBoundsByteGEP(numElementsPtr, numElementsOffset);
 
   unsigned AS = allocPtr.getAddressSpace();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   numElementsPtr = numElementsPtr.withElementType(CGF.SizeTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  numElementsPtr = CGF.Builder.CreateElementBitCast(numElementsPtr, CGF.SizeTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   if (!CGM.getLangOpts().Sanitize.has(SanitizerKind::Address) || AS != 0)
     return CGF.Builder.CreateLoad(numElementsPtr);
   // In asan mode emit a function call instead of a regular load and let the
@@ -2500,11 +2362,7 @@ Address ARMCXXABI::InitializeArrayCookie(CodeGenFunction &CGF,
   Address cookie = newPtr;
 
   // The first element is the element size.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   cookie = cookie.withElementType(CGF.SizeTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  cookie = CGF.Builder.CreateElementBitCast(cookie, CGF.SizeTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *elementSize = llvm::ConstantInt::get(CGF.SizeTy,
                  getContext().getTypeSizeInChars(elementType).getQuantity());
   CGF.Builder.CreateStore(elementSize, cookie);
@@ -2527,11 +2385,7 @@ llvm::Value *ARMCXXABI::readArrayCookieImpl(CodeGenFunction &CGF,
   Address numElementsPtr
     = CGF.Builder.CreateConstInBoundsByteGEP(allocPtr, CGF.getSizeSize());
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   numElementsPtr = numElementsPtr.withElementType(CGF.SizeTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  numElementsPtr = CGF.Builder.CreateElementBitCast(numElementsPtr, CGF.SizeTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return CGF.Builder.CreateLoad(numElementsPtr);
 }
 
@@ -2698,13 +2552,8 @@ void ItaniumCXXABI::EmitGuardedInit(CodeGenFunction &CGF,
   llvm::BasicBlock *EndBlock = CGF.createBasicBlock("init.end");
   if (!threadsafe || MaxInlineWidthInBits) {
     // Load the first byte of the guard variable.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     llvm::LoadInst *LI =
         Builder.CreateLoad(guardAddr.withElementType(CGM.Int8Ty));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    llvm::LoadInst *LI =
-        Builder.CreateLoad(Builder.CreateElementBitCast(guardAddr, CGM.Int8Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Itanium ABI:
     //   An implementation supporting thread-safety on multiprocessor
@@ -2784,13 +2633,8 @@ void ItaniumCXXABI::EmitGuardedInit(CodeGenFunction &CGF,
     // For non-local variables, store 1 into the first byte of the guard
     // variable before the object initialization begins so that references
     // to the variable during initialization don't restart initialization.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateStore(llvm::ConstantInt::get(CGM.Int8Ty, 1),
                         guardAddr.withElementType(CGM.Int8Ty));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Builder.CreateStore(llvm::ConstantInt::get(CGM.Int8Ty, 1),
-                        Builder.CreateElementBitCast(guardAddr, CGM.Int8Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   // Emit the initializer and add a global destructor if appropriate.
@@ -2807,13 +2651,8 @@ void ItaniumCXXABI::EmitGuardedInit(CodeGenFunction &CGF,
     // For local variables, store 1 into the first byte of the guard variable
     // after the object initialization completes so that initialization is
     // retried if initialization is interrupted by an exception.
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Builder.CreateStore(llvm::ConstantInt::get(CGM.Int8Ty, 1),
                         guardAddr.withElementType(CGM.Int8Ty));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Builder.CreateStore(llvm::ConstantInt::get(CGM.Int8Ty, 1),
-                        Builder.CreateElementBitCast(guardAddr, CGM.Int8Ty));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   CGF.EmitBlock(EndBlock);
@@ -3886,9 +3725,6 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
     // The vtable address point is 8 bytes after its start:
     // 4 for the offset to top + 4 for the relative offset to rtti.
     llvm::Constant *Eight = llvm::ConstantInt::get(CGM.Int32Ty, 8);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-    VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.DefaultInt8PtrTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     VTable =
         llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.Int8Ty, VTable, Eight);
   } else {
@@ -3896,9 +3732,6 @@ void ItaniumRTTIBuilder::BuildVTablePointer(const Type *Ty) {
     VTable = llvm::ConstantExpr::getInBoundsGetElementPtr(CGM.DefaultInt8PtrTy,
                                                           VTable, Two);
   }
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  VTable = llvm::ConstantExpr::getBitCast(VTable, CGM.DefaultInt8PtrTy);
-#endif
 
   Fields.push_back(VTable);
 }

--- a/clang/lib/CodeGen/ItaniumCXXABI.cpp
+++ b/clang/lib/CodeGen/ItaniumCXXABI.cpp
@@ -235,7 +235,6 @@ public:
   llvm::Value *emitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
                                      QualType SrcRecordTy) override;
 
-
   llvm::Value *emitExactDynamicCast(CodeGenFunction &CGF, Address ThisAddr,
                                     QualType SrcRecordTy, QualType DestTy,
                                     QualType DestRecordTy,
@@ -2028,8 +2027,7 @@ llvm::GlobalVariable *ItaniumCXXABI::getAddrOfVTable(const CXXRecordDecl *RD,
 }
 
 CGCallee ItaniumCXXABI::getVirtualFunctionPointer(CodeGenFunction &CGF,
-                                                  GlobalDecl GD,
-                                                  Address This,
+                                                  GlobalDecl GD, Address This,
                                                   llvm::Type *Ty,
                                                   SourceLocation Loc) {
   llvm::Type *PtrTy = CGM.GlobalsInt8PtrTy;

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -173,8 +173,6 @@ public:
   llvm::Value *emitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
                                      QualType SrcRecordTy) override;
 
-
-
   bool EmitBadCastCall(CodeGenFunction &CGF) override;
   bool canSpeculativelyEmitVTable(const CXXRecordDecl *RD) const override {
     return false;

--- a/clang/lib/CodeGen/MicrosoftCXXABI.cpp
+++ b/clang/lib/CodeGen/MicrosoftCXXABI.cpp
@@ -165,7 +165,6 @@ public:
     llvm_unreachable("unsupported");
   }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *emitDynamicCastCall(CodeGenFunction &CGF, Address Value,
                                    QualType SrcRecordTy, QualType DestTy,
                                    QualType DestRecordTy,
@@ -175,16 +174,6 @@ public:
                                      QualType SrcRecordTy) override;
 
 
-#else
-  llvm::Value *EmitDynamicCastCall(CodeGenFunction &CGF, Address Value,
-                                   QualType SrcRecordTy, QualType DestTy,
-                                   QualType DestRecordTy,
-                                   llvm::BasicBlock *CastEnd) override;
-
-  llvm::Value *EmitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
-                                     QualType SrcRecordTy,
-                                     QualType DestTy) override;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   bool EmitBadCastCall(CodeGenFunction &CGF) override;
   bool canSpeculativelyEmitVTable(const CXXRecordDecl *RD) const override {
@@ -1035,16 +1024,9 @@ bool MicrosoftCXXABI::shouldDynamicCastCallBeNullChecked(bool SrcIsPtr,
          !getContext().getASTRecordLayout(SrcDecl).hasExtendableVFPtr();
 }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
 llvm::Value *MicrosoftCXXABI::emitDynamicCastCall(
     CodeGenFunction &CGF, Address This, QualType SrcRecordTy, QualType DestTy,
     QualType DestRecordTy, llvm::BasicBlock *CastEnd) {
-#else
-llvm::Value *MicrosoftCXXABI::EmitDynamicCastCall(
-    CodeGenFunction &CGF, Address This, QualType SrcRecordTy,
-    QualType DestTy, QualType DestRecordTy, llvm::BasicBlock *CastEnd) {
-  llvm::Type *DestLTy = CGF.ConvertType(DestTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   llvm::Value *SrcRTTI =
       CGF.CGM.GetAddrOfRTTIDescriptor(SrcRecordTy.getUnqualifiedType());
@@ -1071,24 +1053,12 @@ llvm::Value *MicrosoftCXXABI::EmitDynamicCastCall(
   llvm::Value *Args[] = {
       ThisPtr, Offset, SrcRTTI, DestRTTI,
       llvm::ConstantInt::get(CGF.Int32Ty, DestTy->isReferenceType())};
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return CGF.EmitRuntimeCallOrInvoke(Function, Args);
-#else
-  ThisPtr = CGF.EmitRuntimeCallOrInvoke(Function, Args);
-  return CGF.Builder.CreateBitCast(ThisPtr, DestLTy);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
 llvm::Value *MicrosoftCXXABI::emitDynamicCastToVoid(CodeGenFunction &CGF,
                                                     Address Value,
                                                     QualType SrcRecordTy) {
-#else
-llvm::Value *
-MicrosoftCXXABI::EmitDynamicCastToVoid(CodeGenFunction &CGF, Address Value,
-                                       QualType SrcRecordTy,
-                                       QualType DestTy) {
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   std::tie(Value, std::ignore, std::ignore) =
       performBaseAdjustment(CGF, Value, SrcRecordTy);
 
@@ -1333,11 +1303,7 @@ void MicrosoftCXXABI::EmitCXXConstructors(const CXXConstructorDecl *D) {
 void MicrosoftCXXABI::EmitVBPtrStores(CodeGenFunction &CGF,
                                       const CXXRecordDecl *RD) {
   Address This = getThisAddress(CGF);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   This = This.withElementType(CGM.Int8Ty);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  This = CGF.Builder.CreateElementBitCast(This, CGM.Int8Ty, "this.int8");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   const ASTContext &Context = getContext();
   const ASTRecordLayout &Layout = Context.getASTRecordLayout(RD);
 
@@ -1354,12 +1320,7 @@ void MicrosoftCXXABI::EmitVBPtrStores(CodeGenFunction &CGF,
     Address VBPtr = CGF.Builder.CreateConstInBoundsByteGEP(This, Offs);
     llvm::Value *GVPtr =
         CGF.Builder.CreateConstInBoundsGEP2_32(GV->getValueType(), GV, 0, 0);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     VBPtr = VBPtr.withElementType(GVPtr->getType());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    VBPtr = CGF.Builder.CreateElementBitCast(VBPtr, GVPtr->getType(),
-                                      "vbptr." + VBT->ObjectWithVPtr->getName());
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     CGF.Builder.CreateStore(GVPtr, VBPtr);
   }
 }
@@ -1630,16 +1591,8 @@ void MicrosoftCXXABI::EmitInstanceFunctionProlog(CodeGenFunction &CGF) {
   // 1) getThisValue is currently protected
   // 2) in theory, an ABI could implement 'this' returns some other way;
   //    HasThisReturn only specifies a contract, not the implementation
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   if (HasThisReturn(CGF.CurGD) || hasMostDerivedReturn(CGF.CurGD))
     CGF.Builder.CreateStore(getThisValue(CGF), CGF.ReturnValue);
-#else
-  if (HasThisReturn(CGF.CurGD))
-    CGF.Builder.CreateStore(getThisValue(CGF), CGF.ReturnValue);
-  else if (hasMostDerivedReturn(CGF.CurGD))
-    CGF.Builder.CreateStore(CGF.EmitCastToVoidPtr(getThisValue(CGF)),
-                            CGF.ReturnValue);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   if (isa<CXXConstructorDecl>(MD) && MD->getParent()->getNumVBases()) {
     assert(getStructorImplicitParamDecl(CGF) &&

--- a/clang/lib/CodeGen/Targets/AMDGPU.cpp
+++ b/clang/lib/CodeGen/Targets/AMDGPU.cpp
@@ -35,11 +35,7 @@ private:
     // Single value types.
     auto *PtrTy = llvm::dyn_cast<llvm::PointerType>(Ty);
     if (PtrTy && PtrTy->getAddressSpace() == FromAS)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       return llvm::PointerType::get(Ty->getContext(), ToAS);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      return llvm::PointerType::getWithSamePointeeType(PtrTy, ToAS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     return Ty;
   }
 
@@ -463,13 +459,8 @@ llvm::Constant *AMDGPUTargetCodeGenInfo::getNullPointer(
     return llvm::ConstantPointerNull::get(PT);
 
   auto &Ctx = CGM.getContext();
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   auto NPT = llvm::PointerType::get(
       PT->getContext(), Ctx.getTargetAddressSpace(LangAS::opencl_generic));
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  auto NPT = llvm::PointerType::getWithSamePointeeType(
-      PT, Ctx.getTargetAddressSpace(LangAS::opencl_generic));
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   return llvm::ConstantExpr::getAddrSpaceCast(
       llvm::ConstantPointerNull::get(NPT), PT);
 }

--- a/clang/lib/CodeGen/Targets/CSKY.cpp
+++ b/clang/lib/CodeGen/Targets/CSKY.cpp
@@ -63,15 +63,8 @@ Address CSKYABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
 
   // Empty records are ignored for parameter passing purposes.
   if (isEmptyRecord(getContext(), Ty, true)) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Address(CGF.Builder.CreateLoad(VAListAddr),
                    CGF.ConvertTypeForMem(Ty), SlotSize);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address Addr = Address(CGF.Builder.CreateLoad(VAListAddr),
-                           getVAListElementType(CGF), SlotSize);
-    Addr = CGF.Builder.CreateElementBitCast(Addr, CGF.ConvertTypeForMem(Ty));
-    return Addr;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   auto TInfo = getContext().getTypeInfoInChars(Ty);

--- a/clang/lib/CodeGen/Targets/Hexagon.cpp
+++ b/clang/lib/CodeGen/Targets/Hexagon.cpp
@@ -234,11 +234,7 @@ Address HexagonABIInfo::EmitVAArgForHexagon(CodeGenFunction &CGF,
   // FIXME: Need to handle alignment
   llvm::Type *BP = CGF.Int8PtrTy;
   CGBuilderTy &Builder = CGF.Builder;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address VAListAddrAsBPP = VAListAddr.withElementType(BP);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address VAListAddrAsBPP = Builder.CreateElementBitCast(VAListAddr, BP, "ap");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   llvm::Value *Addr = Builder.CreateLoad(VAListAddrAsBPP, "ap.cur");
   // Handle address alignment for type alignment > 32 bits
   uint64_t TyAlign = CGF.getContext().getTypeAlign(Ty) / 8;

--- a/clang/lib/CodeGen/Targets/PPC.cpp
+++ b/clang/lib/CodeGen/Targets/PPC.cpp
@@ -431,11 +431,7 @@ Address PPC32_SVR4_ABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAList,
 
   llvm::Type *DirectTy = CGF.ConvertType(Ty), *ElementTy = DirectTy;
   if (isIndirect)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     DirectTy = llvm::PointerType::getUnqual(CGF.getLLVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    DirectTy = DirectTy->getPointerTo(0);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Case 1: consume registers.
   Address RegAddr = Address::invalid();

--- a/clang/lib/CodeGen/Targets/RISCV.cpp
+++ b/clang/lib/CodeGen/Targets/RISCV.cpp
@@ -474,15 +474,8 @@ Address RISCVABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
 
   // Empty records are ignored for parameter passing purposes.
   if (isEmptyRecord(getContext(), Ty, true)) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     return Address(CGF.Builder.CreateLoad(VAListAddr),
                    CGF.ConvertTypeForMem(Ty), SlotSize);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address Addr = Address(CGF.Builder.CreateLoad(VAListAddr),
-                           getVAListElementType(CGF), SlotSize);
-    Addr = CGF.Builder.CreateElementBitCast(Addr, CGF.ConvertTypeForMem(Ty));
-    return Addr;
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   }
 
   auto TInfo = getContext().getTypeInfoInChars(Ty);

--- a/clang/lib/CodeGen/Targets/SPIR.cpp
+++ b/clang/lib/CodeGen/Targets/SPIR.cpp
@@ -209,11 +209,7 @@ ABIArgInfo SPIRVABIInfo::classifyKernelArgumentType(QualType Ty) const {
     auto GlobalAS = getContext().getTargetAddressSpace(LangAS::cuda_device);
     auto *PtrTy = llvm::dyn_cast<llvm::PointerType>(LTy);
     if (PtrTy && PtrTy->getAddressSpace() == DefaultAS) {
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
       LTy = llvm::PointerType::get(PtrTy->getContext(), GlobalAS);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-      LTy = llvm::PointerType::getWithSamePointeeType(PtrTy, GlobalAS);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
       return ABIArgInfo::getDirect(LTy, 0, nullptr, false);
     }
 

--- a/clang/lib/CodeGen/Targets/Sparc.cpp
+++ b/clang/lib/CodeGen/Targets/Sparc.cpp
@@ -315,11 +315,7 @@ Address SparcV9ABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
   case ABIArgInfo::Indirect:
   case ABIArgInfo::IndirectAliased:
     Stride = SlotSize;
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     ArgAddr = Addr.withElementType(ArgPtrTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    ArgAddr = Builder.CreateElementBitCast(Addr, ArgPtrTy, "indirect");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
     ArgAddr = Address(Builder.CreateLoad(ArgAddr, "indirect.arg"), ArgTy,
                       TypeInfo.Align);
     break;
@@ -332,11 +328,7 @@ Address SparcV9ABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
   Address NextPtr = Builder.CreateConstInBoundsByteGEP(Addr, Stride, "ap.next");
   Builder.CreateStore(NextPtr.getPointer(), VAListAddr);
 
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   return ArgAddr.withElementType(ArgTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  return Builder.CreateElementBitCast(ArgAddr, ArgTy, "arg.addr");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 }
 
 void SparcV9ABIInfo::computeInfo(CGFunctionInfo &FI) const {

--- a/clang/lib/CodeGen/Targets/SystemZ.cpp
+++ b/clang/lib/CodeGen/Targets/SystemZ.cpp
@@ -302,12 +302,7 @@ Address SystemZABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
     Address OverflowArgArea =
         Address(CGF.Builder.CreateLoad(OverflowArgAreaPtr, "overflow_arg_area"),
                 CGF.Int8Ty, TyInfo.Align);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Address MemAddr = OverflowArgArea.withElementType(DirectTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    Address MemAddr =
-        CGF.Builder.CreateElementBitCast(OverflowArgArea, DirectTy, "mem_addr");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
     // Update overflow_arg_area_ptr pointer
     llvm::Value *NewOverflowArgArea = CGF.Builder.CreateGEP(
@@ -364,12 +359,7 @@ Address SystemZABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
   Address RawRegAddr(
       CGF.Builder.CreateGEP(CGF.Int8Ty, RegSaveArea, RegOffset, "raw_reg_addr"),
       CGF.Int8Ty, PaddedSize);
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address RegAddr = RawRegAddr.withElementType(DirectTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address RegAddr =
-      CGF.Builder.CreateElementBitCast(RawRegAddr, DirectTy, "reg_addr");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Update the register count
   llvm::Value *One = llvm::ConstantInt::get(IndexTy, 1);
@@ -389,12 +379,7 @@ Address SystemZABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
               CGF.Int8Ty, PaddedSize);
   Address RawMemAddr =
       CGF.Builder.CreateConstByteGEP(OverflowArgArea, Padding, "raw_mem_addr");
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
   Address MemAddr = RawMemAddr.withElementType(DirectTy);
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-  Address MemAddr =
-    CGF.Builder.CreateElementBitCast(RawMemAddr, DirectTy, "mem_addr");
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
 
   // Update overflow_arg_area_ptr pointer
   llvm::Value *NewOverflowArgArea =

--- a/clang/lib/CodeGen/Targets/X86.cpp
+++ b/clang/lib/CodeGen/Targets/X86.cpp
@@ -1015,11 +1015,7 @@ X86_32ABIInfo::addFieldToArgStruct(SmallVector<llvm::Type *, 6> &FrameFields,
   Info = ABIArgInfo::getInAlloca(FrameFields.size(), IsIndirect);
   llvm::Type *LLTy = CGT.ConvertTypeForMem(Type);
   if (IsIndirect)
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     LLTy = llvm::PointerType::getUnqual(getVMContext());
-#else // INTEL_SYCL_OPAQUEPOINTER_READY
-    LLTy = LLTy->getPointerTo(0);
-#endif // INTEL_SYCL_OPAQUEPOINTER_READY
   FrameFields.push_back(LLTy);
   StackOffset += IsIndirect ? WordSize : getContext().getTypeSizeInChars(Type);
 

--- a/clang/lib/CodeGen/Targets/XCore.cpp
+++ b/clang/lib/CodeGen/Targets/XCore.cpp
@@ -164,22 +164,14 @@ Address XCoreABIInfo::EmitVAArg(CodeGenFunction &CGF, Address VAListAddr,
     break;
   case ABIArgInfo::Extend:
   case ABIArgInfo::Direct:
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Val = AP.withElementType(ArgTy);
-#else
-    Val = Builder.CreateElementBitCast(AP, ArgTy);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     ArgSize = CharUnits::fromQuantity(
         getDataLayout().getTypeAllocSize(AI.getCoerceToType()));
     ArgSize = ArgSize.alignTo(SlotSize);
     break;
   case ABIArgInfo::Indirect:
   case ABIArgInfo::IndirectAliased:
-#ifdef INTEL_SYCL_OPAQUEPOINTER_READY
     Val = AP.withElementType(ArgPtrTy);
-#else
-    Val = Builder.CreateElementBitCast(AP, ArgPtrTy);
-#endif //INTEL_SYCL_OPAQUEPOINTER_READY
     Val = Address(Builder.CreateLoad(Val), ArgTy, TypeAlign);
     ArgSize = SlotSize;
     break;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7572,13 +7572,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                    false))
     CmdArgs.push_back("-fmodules-debuginfo");
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  if (!CLANG_ENABLE_OPAQUE_POINTERS_INTERNAL)
-    CmdArgs.push_back("-no-opaque-pointers");
-  else if ((Triple.isSPIRV() || Triple.isSPIR()) &&
-           !SPIRV_ENABLE_OPAQUE_POINTERS)
-    CmdArgs.push_back("-no-opaque-pointers");
-#endif
 
   ObjCRuntime Runtime = AddObjCRuntimeArgs(Args, Inputs, CmdArgs, rewriteKind);
   RenderObjCOptions(TC, D, RawTriple, Args, Runtime, rewriteKind != RK_None,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -7572,7 +7572,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                    false))
     CmdArgs.push_back("-fmodules-debuginfo");
 
-
   ObjCRuntime Runtime = AddObjCRuntimeArgs(Args, Inputs, CmdArgs, rewriteKind);
   RenderObjCOptions(TC, D, RawTriple, Args, Runtime, rewriteKind != RK_None,
                     Input, CmdArgs);

--- a/clang/lib/Driver/ToolChains/CommonArgs.cpp
+++ b/clang/lib/Driver/ToolChains/CommonArgs.cpp
@@ -694,10 +694,6 @@ void tools::addLTOOptions(const ToolChain &ToolChain, const ArgList &Args,
     CmdArgs.push_back(
         Args.MakeArgString(Twine(PluginOptPrefix) + "jobs=" + Parallelism));
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  if (!CLANG_ENABLE_OPAQUE_POINTERS_INTERNAL)
-    CmdArgs.push_back(Args.MakeArgString("-plugin-opt=no-opaque-pointers"));
-#endif
   // If an explicit debugger tuning argument appeared, pass it along.
   if (Arg *A =
           Args.getLastArg(options::OPT_gTune_Group, options::OPT_ggdbN_Group)) {

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -240,12 +240,6 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
     // know it is an unbundled generated list.
     if (LinkSYCLDeviceLibs) {
       Opts.push_back("-only-needed");
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-      // FIXME remove this when opaque pointers are supported for SPIR-V
-      if (!this->getToolChain().getTriple().isSPIR()) {
-        Opts.push_back("-opaque-pointers");
-      }
-#endif
     }
     for (const auto &II : InputFiles) {
       std::string FileName = getToolChain().getInputFilename(II);

--- a/clang/tools/clang-linker-wrapper/OffloadWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/OffloadWrapper.cpp
@@ -368,15 +368,6 @@ GlobalVariable *createFatbinDesc(Module &M, ArrayRef<char> Image, bool IsHIP) {
 Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
   LLVMContext &C = M.getContext();
   // Get the __cudaRegisterFunction function declaration.
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  auto *RegFuncTy = FunctionType::get(
-      Type::getInt32Ty(C),
-      {Type::getInt8PtrTy(C)->getPointerTo(), Type::getInt8PtrTy(C),
-       Type::getInt8PtrTy(C), Type::getInt8PtrTy(C), Type::getInt32Ty(C),
-       Type::getInt8PtrTy(C), Type::getInt8PtrTy(C), Type::getInt8PtrTy(C),
-       Type::getInt8PtrTy(C), Type::getInt32PtrTy(C)},
-
-#else
   PointerType *Int8PtrTy = PointerType::get(C, 0);
   PointerType *Int8PtrPtrTy = PointerType::get(C, 0);
   PointerType *Int32PtrTy = PointerType::get(C, 0);
@@ -384,7 +375,6 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
       Type::getInt32Ty(C),
       {Int8PtrPtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, Type::getInt32Ty(C),
        Int8PtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, Int32PtrTy},
-#endif
       /*isVarArg*/ false);
   FunctionCallee RegFunc = M.getOrInsertFunction(
       IsHIP ? "__hipRegisterFunction" : "__cudaRegisterFunction", RegFuncTy);
@@ -392,12 +382,7 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
   // Get the __cudaRegisterVar function declaration.
   auto *RegVarTy = FunctionType::get(
       Type::getVoidTy(C),
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-      {Type::getInt8PtrTy(C)->getPointerTo(), Type::getInt8PtrTy(C),
-       Type::getInt8PtrTy(C), Type::getInt8PtrTy(C), Type::getInt32Ty(C),
-#else
       {Int8PtrPtrTy, Int8PtrTy, Int8PtrTy, Int8PtrTy, Type::getInt32Ty(C),
-#endif
        getSizeTTy(M), Type::getInt32Ty(C), Type::getInt32Ty(C)},
       /*isVarArg*/ false);
   FunctionCallee RegVar = M.getOrInsertFunction(
@@ -419,14 +404,8 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
                                : "__stop_cuda_offloading_entries");
   EntriesE->setVisibility(GlobalValue::HiddenVisibility);
 
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  auto *RegGlobalsTy = FunctionType::get(Type::getVoidTy(C),
-                                         Type::getInt8PtrTy(C)->getPointerTo(),
-                                         /*isVarArg*/ false);
-#else
   auto *RegGlobalsTy = FunctionType::get(Type::getVoidTy(C), Int8PtrPtrTy,
                                          /*isVarArg*/ false);
-#endif
   auto *RegGlobalsFn =
       Function::Create(RegGlobalsTy, GlobalValue::InternalLinkage,
                        IsHIP ? ".hip.globals_reg" : ".cuda.globals_reg", &M);
@@ -452,20 +431,12 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
       Builder.CreateInBoundsGEP(getEntryTy(M), Entry,
                                 {ConstantInt::get(getSizeTTy(M), 0),
                                  ConstantInt::get(Type::getInt32Ty(C), 0)});
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  auto *Addr = Builder.CreateLoad(Type::getInt8PtrTy(C), AddrPtr, "addr");
-#else
   auto *Addr = Builder.CreateLoad(Int8PtrTy, AddrPtr, "addr");
-#endif
   auto *NamePtr =
       Builder.CreateInBoundsGEP(getEntryTy(M), Entry,
                                 {ConstantInt::get(getSizeTTy(M), 0),
                                  ConstantInt::get(Type::getInt32Ty(C), 1)});
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  auto *Name = Builder.CreateLoad(Type::getInt8PtrTy(C), NamePtr, "name");
-#else
   auto *Name = Builder.CreateLoad(Int8PtrTy, NamePtr, "name");
-#endif
   auto *SizePtr =
       Builder.CreateInBoundsGEP(getEntryTy(M), Entry,
                                 {ConstantInt::get(getSizeTTy(M), 0),
@@ -482,16 +453,6 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
 
   // Create kernel registration code.
   Builder.SetInsertPoint(IfThenBB);
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-  Builder.CreateCall(RegFunc,
-                     {RegGlobalsFn->arg_begin(), Addr, Name, Name,
-                      ConstantInt::get(Type::getInt32Ty(C), -1),
-                      ConstantPointerNull::get(Type::getInt8PtrTy(C)),
-                      ConstantPointerNull::get(Type::getInt8PtrTy(C)),
-                      ConstantPointerNull::get(Type::getInt8PtrTy(C)),
-                      ConstantPointerNull::get(Type::getInt8PtrTy(C)),
-                      ConstantPointerNull::get(Type::getInt32PtrTy(C))});
-#else
   Builder.CreateCall(RegFunc, {RegGlobalsFn->arg_begin(), Addr, Name, Name,
                                ConstantInt::get(Type::getInt32Ty(C), -1),
                                ConstantPointerNull::get(Int8PtrTy),
@@ -499,7 +460,6 @@ Function *createRegisterGlobalsFunction(Module &M, bool IsHIP) {
                                ConstantPointerNull::get(Int8PtrTy),
                                ConstantPointerNull::get(Int8PtrTy),
                                ConstantPointerNull::get(Int32PtrTy)});
-#endif
   Builder.CreateBr(IfEndBB);
   Builder.SetInsertPoint(IfElseBB);
 

--- a/clang/unittests/CodeGen/TBAAMetadataTest.cpp
+++ b/clang/unittests/CodeGen/TBAAMetadataTest.cpp
@@ -112,27 +112,19 @@ TEST(TBAAMetadataTest, BasicTypes) {
   ASSERT_TRUE(I);
 
   I = matchNext(I,
-      MInstruction(Instruction::Store,
-        MValType(PointerType::getUnqual(Compiler.Context)),
-        MMTuple(
-          MMTuple(
-            MMString("any pointer"),
-            OmnipotentCharC,
-            MConstInt(0)),
-          MSameAs(0),
-          MConstInt(0))));
+                MInstruction(Instruction::Store,
+                             MValType(PointerType::getUnqual(Compiler.Context)),
+                             MMTuple(MMTuple(MMString("any pointer"),
+                                             OmnipotentCharC, MConstInt(0)),
+                                     MSameAs(0), MConstInt(0))));
   ASSERT_TRUE(I);
 
   I = matchNext(I,
-      MInstruction(Instruction::Store,
-        MValType(PointerType::getUnqual(Compiler.Context)),
-        MMTuple(
-          MMTuple(
-            MMString("any pointer"),
-            OmnipotentCharC,
-            MConstInt(0)),
-          MSameAs(0),
-          MConstInt(0))));
+                MInstruction(Instruction::Store,
+                             MValType(PointerType::getUnqual(Compiler.Context)),
+                             MMTuple(MMTuple(MMString("any pointer"),
+                                             OmnipotentCharC, MConstInt(0)),
+                                     MSameAs(0), MConstInt(0))));
   ASSERT_TRUE(I);
 }
 

--- a/clang/unittests/CodeGen/TBAAMetadataTest.cpp
+++ b/clang/unittests/CodeGen/TBAAMetadataTest.cpp
@@ -113,11 +113,7 @@ TEST(TBAAMetadataTest, BasicTypes) {
 
   I = matchNext(I,
       MInstruction(Instruction::Store,
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-        MValType(Type::getInt8PtrTy(Compiler.Context)),
-#else
         MValType(PointerType::getUnqual(Compiler.Context)),
-#endif
         MMTuple(
           MMTuple(
             MMString("any pointer"),
@@ -129,11 +125,7 @@ TEST(TBAAMetadataTest, BasicTypes) {
 
   I = matchNext(I,
       MInstruction(Instruction::Store,
-#ifndef INTEL_SYCL_OPAQUEPOINTER_READY
-        MValType(Type::getInt32PtrTy(Compiler.Context)),
-#else
         MValType(PointerType::getUnqual(Compiler.Context)),
-#endif
         MMTuple(
           MMTuple(
             MMString("any pointer"),


### PR DESCRIPTION
- Remove code in INTEL_SYCL_OPAQUEPOINTER_READY==0
- clang-format

This should be NFC, as INTEL_SYCL_OPAQUEPOINTER_READY is always 1 since #10888 .