### PR TITLE
[SYCL] Remove `return *this` from joint_matrix constructor.

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -67,7 +67,6 @@ struct joint_matrix {
   // combination of InstCombine + SROA + mem2reg can remove it
   joint_matrix(const joint_matrix &other) {
     spvm = other.spvm;
-    return *this;
   }
 
   joint_matrix &operator=(const joint_matrix &rhs) {

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-unified.hpp
@@ -65,9 +65,7 @@ struct joint_matrix {
   // memcpy from being generated.
   // TODO: to remove, when either IGC can handle alloca JointMatrix or
   // combination of InstCombine + SROA + mem2reg can remove it
-  joint_matrix(const joint_matrix &other) {
-    spvm = other.spvm;
-  }
+  joint_matrix(const joint_matrix &other) { spvm = other.spvm; }
 
   joint_matrix &operator=(const joint_matrix &rhs) {
     spvm = rhs.spvm;


### PR DESCRIPTION
Constructors do not return a value -- this causes a compile error when
instantiated.

Seen when running the following compile command:

    clang++ -fsycl -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4 \
        sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache.cpp \
        -fsycl-device-only -o test.bc
