### PR TITLE
[SYCL-MLIR][NFC] Refactor SYCL analyses

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h
@@ -149,8 +149,7 @@ private:
     if (!constructor)
       return false;
 
-    return isa<SYCLType...>(
-        constructor.getType().getValue());
+    return isa<SYCLType...>(constructor.getType().getValue());
   }
 
   template <typename... SYCLType>

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h
@@ -1,0 +1,158 @@
+//===- ConstructorBaseAnalysis.h - Base analysis for SYCL types -*- C++ -*-===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Base class for analyses that determine properties of instances of SYCL types
+// based on their construction.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef MLIR_DIALECT_SYCL_ANALYSIS_CONSTRUCTORBASEANALYSIS_H
+#define MLIR_DIALECT_SYCL_ANALYSIS_CONSTRUCTORBASEANALYSIS_H
+
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/Polygeist/Analysis/DataFlowSolverWrapper.h"
+#include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Pass/AnalysisManager.h"
+
+namespace mlir {
+namespace sycl {
+
+/// CRTP base class for analyses deriving properties of interest for SYCL
+/// objects from their construction. The analyses derived from this class, i.e.,
+/// `ConcreteAnalysis` must implement the following methods:
+/// * `void finalizeInitialization(bool useRelaxedAliasing)`
+/// * `bool isConstructorImpl(const polygeist::Definition &def)`
+/// * `AnalysisResult getInformationImpl(const polygeist::Definition &def)`
+///
+/// The class representing information derived by the analysis, i.e.,
+/// `AnalysisResult` must define a default constructor and must implement the
+/// following methods:
+/// * `bool isTop()` to indicate the top of the lattice has been reached.
+/// * `AnalysisResult join(const AnalysisResult& other)` to join two results at
+/// a merge point.
+///
+template <typename ConcreteAnalysis, typename AnalysisResult>
+class ConstructorBaseAnalysis {
+public:
+  ConcreteAnalysis &initialize(bool useRelaxedAliasing = false) {
+
+    // Initialize the dataflow solver
+    aliasAnalysis = &am.getAnalysis<mlir::AliasAnalysis>();
+    aliasAnalysis->addAnalysisImplementation(
+        sycl::AliasAnalysis(useRelaxedAliasing));
+
+    solver = std::make_unique<polygeist::DataFlowSolverWrapper>(*aliasAnalysis);
+
+    // Populate the solver and run the analyses needed by this analysis.
+    solver->loadWithRequiredAnalysis<polygeist::ReachingDefinitionAnalysis>(
+        *aliasAnalysis);
+
+    if (failed(solver->initializeAndRun(operation))) {
+      operation->emitError("Failed to run required dataflow analyses");
+      return *static_cast<ConcreteAnalysis *>(this);
+    }
+
+    // Let the derived class perform more initialization of necessary.
+    static_cast<ConcreteAnalysis *>(this)->finalizeInitialization(
+        useRelaxedAliasing);
+
+    initialized = true;
+
+    return *static_cast<ConcreteAnalysis *>(this);
+  }
+
+  ConstructorBaseAnalysis(Operation *op, AnalysisManager &mgr)
+      : operation{op}, am{mgr}, solver{nullptr}, aliasAnalysis{nullptr} {}
+
+protected:
+  template <typename SYCLType>
+  std::optional<AnalysisResult> getInformationFromConstruction(Operation *op,
+                                                               Value operand) {
+    assert(initialized &&
+           "Analysis only available after successful initialization");
+    assert(isa<LLVM::LLVMPointerType>(operand.getType()) &&
+           "Expecting an LLVM pointer");
+    assert(aliasAnalysis != nullptr && "Alias analysis not initialized");
+
+    const polygeist::ReachingDefinition *reachingDef =
+        solver->lookupState<polygeist::ReachingDefinition>(op);
+    assert(reachingDef && "expected a reaching definition");
+
+    auto mods = reachingDef->getModifiers(operand, *solver);
+    if (!mods || mods->empty())
+      return std::nullopt;
+
+    if (!llvm::all_of(*mods, [&](const polygeist::Definition &def) {
+          return isConstructor<SYCLType>(def);
+        }))
+      return std::nullopt;
+
+    auto pMods = reachingDef->getPotentialModifiers(operand, *solver);
+    if (pMods) {
+      if (!llvm::all_of(*pMods, [&](const polygeist::Definition &def) {
+            return isConstructor<SYCLType>(def);
+          }))
+        return std::nullopt;
+    }
+
+    bool first = true;
+    AnalysisResult info;
+    for (const polygeist::Definition &def : *mods) {
+      if (first) {
+        info = getInformation<SYCLType>(def);
+        first = false;
+      } else {
+        info = info.join(getInformation<SYCLType>(def), *aliasAnalysis);
+        if (info.isTop())
+          // Early return: As soon as joining the different information has
+          // reached the top of the lattice, we can end processing.
+          return info;
+      }
+    }
+
+    if (pMods) {
+      for (const polygeist::Definition &def : *pMods) {
+        info = info.join(getInformation<SYCLType>(def), *aliasAnalysis);
+        if (info.isTop())
+          // Early return: As soon as joining the different information has
+          // reached the top of the lattice, we can end processing.
+          return info;
+      }
+    }
+
+    return info;
+  }
+
+  Operation *operation;
+
+  AnalysisManager &am;
+
+  std::unique_ptr<polygeist::DataFlowSolverWrapper> solver;
+
+  mlir::AliasAnalysis *aliasAnalysis;
+
+private:
+  template <typename SYCLType>
+  bool isConstructor(const polygeist::Definition &def) {
+    return static_cast<ConcreteAnalysis *>(this)
+        ->template isConstructorImpl<SYCLType>(def);
+  }
+
+  template <typename SYCLType>
+  AnalysisResult getInformation(const polygeist::Definition &def) {
+    return static_cast<ConcreteAnalysis *>(this)
+        ->template getInformationImpl<SYCLType>(def);
+  }
+
+  bool initialized = false;
+};
+} // namespace sycl
+} // namespace mlir
+
+#endif // MLIR_DIALECT_SYCL_ANALYSIS_CONSTRUCTORBASEANALYSIS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h
@@ -36,8 +36,8 @@ public:
                       bool hasRange, llvm::ArrayRef<size_t> constRange,
                       bool hasOffset, llvm::ArrayRef<size_t> constOffset)
       : buffer{buf}, bufferInfo{bufInfo}, needRange{hasRange},
-        constantRange{constRange}, needOffset{hasOffset}, constantOffset{
-                                                              constOffset} {}
+        constantRange{constRange}, needOffset{hasOffset},
+        constantOffset{constOffset} {}
 
   AccessorInformation(bool hasRange, llvm::ArrayRef<size_t> constRange)
       : isLocal{true}, needRange{hasRange}, constantRange{constRange},
@@ -67,14 +67,14 @@ public:
 
   /// Returns false if the range can be omitted for this accessor, true
   /// otherwise.
-  bool needsRange() const { return needRange; }
+  bool needsSubRange() const { return needRange; }
 
   /// Returns true if the range of this accessor is known to be constant.
-  bool hasConstantRange() const { return !constantRange.empty(); }
+  bool hasConstantSubRange() const { return !constantRange.empty(); }
 
   /// Returns the constant values for the range of this accessor.
   ArrayRef<size_t> getConstantRange() const {
-    assert(hasConstantRange() && "Range not constant");
+    assert(hasConstantSubRange() && "Range not constant");
     return constantRange;
   }
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h
@@ -128,17 +128,14 @@ class SYCLAccessorAnalysis
     : public ConstructorBaseAnalysis<SYCLAccessorAnalysis,
                                      AccessorInformation> {
 public:
-  SYCLAccessorAnalysis(Operation *op, AnalysisManager &am);
+  SYCLAccessorAnalysis(Operation *op, AnalysisManager &mgr);
 
   void finalizeInitialization(bool useRelaxedAliasing = false);
 
   std::optional<AccessorInformation>
   getAccessorInformationFromConstruction(Operation *op, Value operand);
 
-  template <typename SYCLType>
-  bool isConstructorImpl(const polygeist::Definition &def);
-
-  template <typename SYCLType>
+  template <typename... SYCLType>
   AccessorInformation getInformationImpl(const polygeist::Definition &def);
 
 private:

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h
@@ -11,32 +11,33 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
-#define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
+#ifndef MLIR_DIALECT_SYCL_ANALYSIS_SYCLACCESSORANALYSIS_H
+#define MLIR_DIALECT_SYCL_ANALYSIS_SYCLACCESSORANALYSIS_H
 
 #include "mlir/Dialect/Polygeist/Analysis/DataFlowSolverWrapper.h"
 #include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLBufferAnalysis.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLBufferAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/Pass/AnalysisManager.h"
 
 namespace mlir {
-namespace polygeist {
+namespace sycl {
 
 /// Represents information about a `sycl::accessor` gathered from its
 /// construction.
 class AccessorInformation {
 public:
-  AccessorInformation() : isTop{true} {}
+  AccessorInformation() : isTopAcc{true} {}
 
   AccessorInformation(Value buf, std::optional<BufferInformation> bufInfo,
                       bool hasRange, llvm::ArrayRef<size_t> constRange,
                       bool hasOffset, llvm::ArrayRef<size_t> constOffset)
       : buffer{buf}, bufferInfo{bufInfo}, needRange{hasRange},
-        constantRange{constRange}, needOffset{hasOffset},
-        constantOffset{constOffset} {}
+        constantRange{constRange}, needOffset{hasOffset}, constantOffset{
+                                                              constOffset} {}
 
   AccessorInformation(bool hasRange, llvm::ArrayRef<size_t> constRange)
       : isLocal{true}, needRange{hasRange}, constantRange{constRange},
@@ -92,18 +93,18 @@ public:
 
   /// Returns true if the top of the lattice has been reached, i.e., it is not
   /// possible to further refine the information known about this accessor.
-  bool isTopAccessor() const { return isTop; }
+  bool isTop() const { return isTopAcc; }
 
   const AccessorInformation join(const AccessorInformation &other,
-                                 AliasAnalysis &aliasAnalysis) const;
+                                 mlir::AliasAnalysis &aliasAnalysis) const;
 
   /// Returns an AliasResult indicating whether this accessor and the given
   /// accessor must, may or do not alias.
   AliasResult alias(const AccessorInformation &other,
-                    AliasAnalysis &aliasAnalysis) const;
+                    mlir::AliasAnalysis &aliasAnalysis) const;
 
 private:
-  bool isTop = false;
+  bool isTopAcc = false;
   bool isLocal = false;
 
   Value buffer;
@@ -123,44 +124,34 @@ private:
 
 /// Analysis to determine properties of interest about a `sycl::accessor` from
 /// its construction.
-class SYCLAccessorAnalysis {
+class SYCLAccessorAnalysis
+    : public ConstructorBaseAnalysis<SYCLAccessorAnalysis,
+                                     AccessorInformation> {
 public:
   SYCLAccessorAnalysis(Operation *op, AnalysisManager &am);
 
-  /// Consumers of the analysis must call this member function immediately after
-  /// construction and before requesting any information from the analysis.
-  SYCLAccessorAnalysis &initialize(bool useRelaxedAliasing = false);
+  void finalizeInitialization(bool useRelaxedAliasing = false);
 
   std::optional<AccessorInformation>
   getAccessorInformationFromConstruction(Operation *op, Value operand);
 
+  template <typename SYCLType>
+  bool isConstructorImpl(const polygeist::Definition &def);
+
+  template <typename SYCLType>
+  AccessorInformation getInformationImpl(const polygeist::Definition &def);
+
 private:
-  void initialize();
-
-  bool isConstructor(const Definition &def);
-
-  AccessorInformation getInformation(const Definition &def);
-
   template <typename OperandType>
   std::optional<IDRangeInformation>
   getOperandInfo(sycl::SYCLHostConstructorOp constructor,
                  ArrayRef<size_t> possibleIndices);
 
-  Operation *operation;
-
-  AnalysisManager &am;
-
-  std::unique_ptr<DataFlowSolverWrapper> solver;
-
-  bool initialized = false;
-
-  AliasAnalysis *aliasAnalysis;
-
   SYCLIDAndRangeAnalysis idRangeAnalysis;
 
   SYCLBufferAnalysis bufferAnalysis;
 };
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir
 
-#endif // MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLACCESSORANALYSIS_H
+#endif // MLIR_DIALECT_SYCL_ANALYSIS_SYCLACCESSORANALYSIS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLBufferAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLBufferAnalysis.h
@@ -11,17 +11,19 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLBUFFERANALYSIS_H
-#define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLBUFFERANALYSIS_H
+#ifndef MLIR_DIALECT_SYCL_ANALYSIS_SYCLBUFFERANALYSIS_H
+#define MLIR_DIALECT_SYCL_ANALYSIS_SYCLBUFFERANALYSIS_H
 
+#include "ConstructorBaseAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/DataFlowSolverWrapper.h"
 #include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/Pass/AnalysisManager.h"
 
 namespace mlir {
-namespace polygeist {
+namespace sycl {
 
 /// YES indicates that the buffer is definitely a sub-buffer
 /// NO indicates that the buffer is definitely not a sub-buffer.
@@ -82,8 +84,13 @@ public:
     return subBufOffset;
   }
 
+  /// Returns true if the top of the lattice has been reached.
+  bool isTop() const {
+    return !hasConstantSize() && getSubBuffer() == SubBufferLattice::MAYBE;
+  }
+
   const BufferInformation join(const BufferInformation &other,
-                               AliasAnalysis &aliasAnalysis) const;
+                               mlir::AliasAnalysis &aliasAnalysis) const;
 
 private:
   SmallVector<size_t, 3> constantSize;
@@ -101,37 +108,28 @@ private:
 
 /// Analysis to determine properties of interest about a `sycl::buffer` from its
 /// construction.
-class SYCLBufferAnalysis {
+class SYCLBufferAnalysis
+    : public ConstructorBaseAnalysis<SYCLBufferAnalysis, BufferInformation> {
 public:
-  SYCLBufferAnalysis(Operation *op, AnalysisManager &am);
+  SYCLBufferAnalysis(Operation *op, AnalysisManager &mgr);
 
   /// Consumers of the analysis must call this member function immediately after
   /// construction and before requesting any information from the analysis.
-  SYCLBufferAnalysis &initialize(bool useRelaxedAliasing = false);
+  void finalizeInitialization(bool useRelaxedAliasing = false);
 
   std::optional<BufferInformation>
   getBufferInformationFromConstruction(Operation *op, Value operand);
 
+  template <typename SYCLType>
+  bool isConstructorImpl(const polygeist::Definition &def);
+
+  template <typename SYCLType>
+  BufferInformation getInformationImpl(const polygeist::Definition &def);
+
 private:
-  void initialize();
-
-  bool isConstructor(const Definition &def);
-
-  BufferInformation getInformation(const Definition &def);
-
-  Operation *operation;
-
-  AnalysisManager &am;
-
-  std::unique_ptr<DataFlowSolverWrapper> solver;
-
-  bool initialized = false;
-
-  AliasAnalysis *aliasAnalysis;
-
   SYCLIDAndRangeAnalysis idRangeAnalysis;
 };
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir
 
-#endif // MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLBUFFERANALYSIS_H
+#endif // MLIR_DIALECT_SYCL_ANALYSIS_SYCLBUFFERANALYSIS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLBufferAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLBufferAnalysis.h
@@ -37,7 +37,7 @@ class BufferInformation {
 public:
   BufferInformation();
 
-  BufferInformation(ArrayRef<size_t> constRange, SubBufferLattice IsSubBuffer,
+  BufferInformation(ArrayRef<size_t> constRange, SubBufferLattice isSubBuffer,
                     Value baseBuffer, ArrayRef<size_t> constBaseBufferSize,
                     ArrayRef<size_t> constSubBufferOffset);
 
@@ -119,9 +119,6 @@ public:
 
   std::optional<BufferInformation>
   getBufferInformationFromConstruction(Operation *op, Value operand);
-
-  template <typename SYCLType>
-  bool isConstructorImpl(const polygeist::Definition &def);
 
   template <typename SYCLType>
   BufferInformation getInformationImpl(const polygeist::Definition &def);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h
@@ -11,15 +11,17 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
-#define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
+#ifndef MLIR_DIALECT_SYCL_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
+#define MLIR_DIALECT_SYCL_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
 
+#include "ConstructorBaseAnalysis.h"
+#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/DataFlowSolverWrapper.h"
+#include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
 #include "mlir/Pass/AnalysisManager.h"
 
 namespace mlir {
-namespace polygeist {
-class Definition;
+namespace sycl {
 /// Represents information about a `sycl::id` or `sycl::range` gathered from its
 /// construction.
 class IDRangeInformation {
@@ -42,11 +44,15 @@ public:
   /// values.
   bool isConstant() const;
 
+  /// Returns true if the top of the lattice was reached.
+  bool isTop() const;
+
   /// Returns the constant values with which this id/range is constructed, in
   /// case it is always constructed with the same constant values.
   const llvm::SmallVector<size_t, 3> &getConstantValues() const;
 
-  const IDRangeInformation join(const IDRangeInformation &other) const;
+  const IDRangeInformation join(const IDRangeInformation &other,
+                                mlir::AliasAnalysis &) const;
 
 private:
   std::optional<size_t> dimensions;
@@ -58,31 +64,26 @@ private:
 
 /// Analysis to determine properties of interest about `sycl::id` or
 /// `sycl::range` from their construction.
-class SYCLIDAndRangeAnalysis {
+class SYCLIDAndRangeAnalysis
+    : public ConstructorBaseAnalysis<SYCLIDAndRangeAnalysis,
+                                     IDRangeInformation> {
 public:
-  SYCLIDAndRangeAnalysis(Operation *op, AnalysisManager &am);
-
-  /// Consumers of the analysis must call this member function immediately after
-  /// construction and before requesting any information from the analysis.
-  SYCLIDAndRangeAnalysis &initialize(bool useRelaxedAliasing);
+  using ConstructorBaseAnalysis<SYCLIDAndRangeAnalysis,
+                                IDRangeInformation>::ConstructorBaseAnalysis;
 
   template <typename Type>
   std::optional<IDRangeInformation>
   getIDRangeInformationFromConstruction(Operation *op, Value operand);
 
-private:
+  void finalizeInitialization(bool){};
+
   template <typename IDRange>
-  IDRangeInformation getInformation(const Definition &def);
+  bool isConstructorImpl(const polygeist::Definition &def);
 
-  Operation *operation;
-
-  AnalysisManager &am;
-
-  std::unique_ptr<DataFlowSolverWrapper> solver;
-
-  bool initialized = false;
+  template <typename IDRange>
+  IDRangeInformation getInformationImpl(const polygeist::Definition &def);
 };
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir
 
-#endif // MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLIDANDRANGEANALYSIS_H
+#endif // MLIR_DIALECT_SYCL_ANALYSIS_SYCLIDANDRANGEANALYSIS_H

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h
@@ -71,14 +71,12 @@ public:
   using ConstructorBaseAnalysis<SYCLIDAndRangeAnalysis,
                                 IDRangeInformation>::ConstructorBaseAnalysis;
 
-  template <typename Type>
+  template <typename Type, typename = std::enable_if_t<llvm::is_one_of<
+                               Type, sycl::IDType, sycl::RangeType>::value>>
   std::optional<IDRangeInformation>
   getIDRangeInformationFromConstruction(Operation *op, Value operand);
 
   void finalizeInitialization(bool){};
-
-  template <typename IDRange>
-  bool isConstructorImpl(const polygeist::Definition &def);
 
   template <typename IDRange>
   IDRangeInformation getInformationImpl(const polygeist::Definition &def);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.h
@@ -70,9 +70,6 @@ public:
   getNDRangeInformationFromConstruction(Operation *op, Value operand);
 
   template <typename SYCLType>
-  bool isConstructorImpl(const polygeist::Definition &def);
-
-  template <typename SYCLType>
   NDRangeInformation getInformationImpl(const polygeist::Definition &def);
 
 private:

--- a/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.h
@@ -11,22 +11,24 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLNDRANGEANALYSIS_H
-#define MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLNDRANGEANALYSIS_H
+#ifndef MLIR_DIALECT_SYCL_ANALYSIS_SYCLNDRANGEANALYSIS_H
+#define MLIR_DIALECT_SYCL_ANALYSIS_SYCLNDRANGEANALYSIS_H
 
+#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/DataFlowSolverWrapper.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Pass/AnalysisManager.h"
 
 namespace mlir {
-namespace polygeist {
-class Definition;
+namespace sycl {
 /// Represents information about a `sycl::nd_range` gathered from its
 /// construction.
 class NDRangeInformation {
 public:
-  static NDRangeInformation join(const NDRangeInformation &lhs,
-                                 const NDRangeInformation &rhs);
+  const NDRangeInformation join(const NDRangeInformation &other,
+                                mlir::AliasAnalysis &);
 
   NDRangeInformation() = default;
 
@@ -57,31 +59,26 @@ private:
 
 /// Analysis to determine properties of interest about `sycl::nd_range` from its
 /// construction.
-class SYCLNDRangeAnalysis {
+class SYCLNDRangeAnalysis
+    : public ConstructorBaseAnalysis<SYCLNDRangeAnalysis, NDRangeInformation> {
 public:
   SYCLNDRangeAnalysis(Operation *op, AnalysisManager &am);
 
-  /// Consumers of the analysis must call this member function immediately after
-  /// construction and before requesting any information from the analysis.
-  SYCLNDRangeAnalysis &initialize(bool useRelaxedAliasing);
+  void finalizeInitialization(bool useRelaxedAliasing);
 
   std::optional<NDRangeInformation>
   getNDRangeInformationFromConstruction(Operation *op, Value operand);
 
+  template <typename SYCLType>
+  bool isConstructorImpl(const polygeist::Definition &def);
+
+  template <typename SYCLType>
+  NDRangeInformation getInformationImpl(const polygeist::Definition &def);
+
 private:
-  NDRangeInformation getInformation(const Definition &def);
-
-  Operation *operation;
-
-  AnalysisManager &am;
-
-  std::unique_ptr<DataFlowSolverWrapper> solver;
-
-  bool initialized = false;
-
   SYCLIDAndRangeAnalysis idRangeAnalysis;
 };
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir
 
-#endif // MLIR_DIALECT_POLYGEIST_ANALYSIS_SYCLNDRANGEANALYSIS_H
+#endif // MLIR_DIALECT_SYCL_ANALYSIS_SYCLNDRANGEANALYSIS_H

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/CMakeLists.txt
@@ -1,5 +1,9 @@
 add_mlir_dialect_library(MLIRSYCLAnalysis
   AliasAnalysis.cpp
+  SYCLIDAndRangeAnalysis.cpp
+  SYCLAccessorAnalysis.cpp
+  SYCLBufferAnalysis.cpp
+  SYCLNDRangeAnalysis.cpp
   
   ADDITIONAL_HEADER_DIRS
   ${MLIR_SYCL_INCLUDE_DIR}/mlir/Analysis
@@ -7,4 +11,5 @@ add_mlir_dialect_library(MLIRSYCLAnalysis
   LINK_LIBS PUBLIC
   MLIRAnalysis
   MLIRSYCLDialect
+  MLIRPolygeistAnalysis
   )

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.cpp
@@ -267,26 +267,14 @@ void SYCLAccessorAnalysis::finalizeInitialization(bool useRelaxedAliasing) {
 std::optional<AccessorInformation>
 SYCLAccessorAnalysis::getAccessorInformationFromConstruction(Operation *op,
                                                              Value operand) {
-  return getInformationFromConstruction<sycl::AccessorType>(op, operand);
-}
-
-template <>
-bool SYCLAccessorAnalysis::isConstructorImpl<sycl::AccessorType>(
-    const polygeist::Definition &def) {
-  if (!def.isOperation())
-    return false;
-
-  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
-  if (!constructor)
-    return false;
-
-  return isa<sycl::AccessorType, sycl::LocalAccessorType>(
-      constructor.getType().getValue());
+  return getInformationFromConstruction<sycl::AccessorType,
+                                        sycl::LocalAccessorType>(op, operand);
 }
 
 template <>
 AccessorInformation
-SYCLAccessorAnalysis::getInformationImpl<sycl::AccessorType>(
+SYCLAccessorAnalysis::getInformationImpl<sycl::AccessorType,
+                                         sycl::LocalAccessorType>(
     const polygeist::Definition &def) {
   assert(def.isOperation() && "Expecting operation");
   auto constructor = cast<sycl::SYCLHostConstructorOp>(def.getOperation());

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLBufferAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLBufferAnalysis.cpp
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Polygeist/Analysis/SYCLBufferAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLBufferAnalysis.h"
 
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
+#include "mlir/Dialect/Bufferization/Transforms/OneShotModuleBufferize.h"
 #include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLDialect.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
@@ -19,7 +20,7 @@
 #define DEBUG_TYPE "sycl-buffer-analysis"
 
 namespace mlir {
-namespace polygeist {
+namespace sycl {
 
 //===----------------------------------------------------------------------===//
 // BufferInformation
@@ -87,7 +88,7 @@ BufferInformation::BufferInformation(
 
 const BufferInformation
 BufferInformation::join(const BufferInformation &other,
-                        AliasAnalysis &aliasAnalysis) const {
+                        mlir::AliasAnalysis &aliasAnalysis) const {
   auto jointSize = (constantSize == other.constantSize)
                        ? constantSize
                        : SmallVector<size_t, 3>{};
@@ -127,94 +128,22 @@ BufferInformation::join(const BufferInformation &other,
 //===----------------------------------------------------------------------===//
 
 SYCLBufferAnalysis::SYCLBufferAnalysis(Operation *op, AnalysisManager &mgr)
-    : operation(op), am(mgr), aliasAnalysis(nullptr), idRangeAnalysis(op, mgr) {
-}
+    : ConstructorBaseAnalysis<SYCLBufferAnalysis, BufferInformation>(op, mgr),
+      idRangeAnalysis(op, mgr) {}
 
-SYCLBufferAnalysis &SYCLBufferAnalysis::initialize(bool useRelaxedAliasing) {
-
-  // Initialize the dataflow solver
-  aliasAnalysis = &am.getAnalysis<mlir::AliasAnalysis>();
-  aliasAnalysis->addAnalysisImplementation(
-      sycl::AliasAnalysis(useRelaxedAliasing));
-
-  solver = std::make_unique<DataFlowSolverWrapper>(*aliasAnalysis);
-
-  // Populate the solver and run the analyses needed by this analysis.
-  solver->loadWithRequiredAnalysis<ReachingDefinitionAnalysis>(*aliasAnalysis);
-
-  if (failed(solver->initializeAndRun(operation))) {
-    operation->emitError("Failed to run required dataflow analyses");
-    return *this;
-  }
-
+void SYCLBufferAnalysis::finalizeInitialization(bool useRelaxedAliasing) {
   idRangeAnalysis.initialize(useRelaxedAliasing);
-
-  initialized = true;
-
-  return *this;
 }
 
 std::optional<BufferInformation>
 SYCLBufferAnalysis::getBufferInformationFromConstruction(Operation *op,
                                                          Value operand) {
-  assert(initialized &&
-         "Analysis only available after successful initialization");
-  assert(isa<LLVM::LLVMPointerType>(operand.getType()) &&
-         "Expecting an LLVM pointer");
-  assert(aliasAnalysis != nullptr && "Alias analysis not initialized");
-
-  const polygeist::ReachingDefinition *reachingDef =
-      solver->lookupState<polygeist::ReachingDefinition>(op);
-  assert(reachingDef && "expected a reaching definition");
-
-  auto mods = reachingDef->getModifiers(operand, *solver);
-  if (!mods || mods->empty())
-    return std::nullopt;
-
-  if (!llvm::all_of(*mods,
-                    [&](const Definition &def) { return isConstructor(def); }))
-    return std::nullopt;
-
-  auto pMods = reachingDef->getPotentialModifiers(operand, *solver);
-  if (pMods) {
-    if (!llvm::all_of(
-            *pMods, [&](const Definition &def) { return isConstructor(def); }))
-      return std::nullopt;
-  }
-
-  bool first = true;
-  BufferInformation info;
-  for (const Definition &def : *mods) {
-    if (first) {
-      info = getInformation(def);
-      first = false;
-    } else {
-      info = info.join(getInformation(def), *aliasAnalysis);
-      if (!info.hasConstantSize() &&
-          info.getSubBuffer() == SubBufferLattice::MAYBE)
-        // Early return: As soon as joining of the different information has led
-        // to an info with no fixed size and no definitive sub-buffer
-        // information, we can end the processing.
-        return info;
-    }
-  }
-
-  if (pMods) {
-    for (const Definition &def : *pMods) {
-      info = info.join(getInformation(def), *aliasAnalysis);
-      if (!info.hasConstantSize() &&
-          info.getSubBuffer() == SubBufferLattice::MAYBE)
-        // Early return: As soon as joining of the different information has led
-        // to an info with no fixed size and no definitive sub-buffer
-        // information, we can end the processing.
-        return info;
-    }
-  }
-
-  return info;
+  return getInformationFromConstruction<sycl::BufferType>(op, operand);
 }
 
-bool SYCLBufferAnalysis::isConstructor(const Definition &def) {
+template <>
+bool SYCLBufferAnalysis::isConstructorImpl<sycl::BufferType>(
+    const polygeist::Definition &def) {
   if (!def.isOperation())
     return false;
 
@@ -225,7 +154,9 @@ bool SYCLBufferAnalysis::isConstructor(const Definition &def) {
   return isa<sycl::BufferType>(constructor.getType().getValue());
 }
 
-BufferInformation SYCLBufferAnalysis::getInformation(const Definition &def) {
+template <>
+BufferInformation SYCLBufferAnalysis::getInformationImpl<sycl::BufferType>(
+    const polygeist::Definition &def) {
   assert(def.isOperation() && "Expecting operation");
 
   auto constructor = cast<sycl::SYCLHostConstructorOp>(def.getOperation());
@@ -297,5 +228,5 @@ BufferInformation SYCLBufferAnalysis::getInformation(const Definition &def) {
   return BufferInformation(constantSize, SubBufferLattice::NO, nullptr, {}, {});
 }
 
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLBufferAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLBufferAnalysis.cpp
@@ -142,19 +142,6 @@ SYCLBufferAnalysis::getBufferInformationFromConstruction(Operation *op,
 }
 
 template <>
-bool SYCLBufferAnalysis::isConstructorImpl<sycl::BufferType>(
-    const polygeist::Definition &def) {
-  if (!def.isOperation())
-    return false;
-
-  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
-  if (!constructor)
-    return false;
-
-  return isa<sycl::BufferType>(constructor.getType().getValue());
-}
-
-template <>
 BufferInformation SYCLBufferAnalysis::getInformationImpl<sycl::BufferType>(
     const polygeist::Definition &def) {
   assert(def.isOperation() && "Expecting operation");

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h"
 
+#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
 #include "mlir/Analysis/DataFlow/DeadCodeAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
@@ -20,7 +21,7 @@
 #define DEBUG_TYPE "sycl-id-range-analysis"
 
 namespace mlir {
-namespace polygeist {
+namespace sycl {
 
 //===----------------------------------------------------------------------===//
 // IDRangeInformation
@@ -66,6 +67,8 @@ bool IDRangeInformation::isConstant() const {
   return constantValues.has_value();
 }
 
+bool IDRangeInformation::isTop() const { return !hasFixedDimensions(); }
+
 const llvm::SmallVector<size_t, 3> &
 IDRangeInformation::getConstantValues() const {
   assert(isConstant() &&
@@ -74,7 +77,8 @@ IDRangeInformation::getConstantValues() const {
 }
 
 const IDRangeInformation
-IDRangeInformation::join(const IDRangeInformation &other) const {
+IDRangeInformation::join(const IDRangeInformation &other,
+                         mlir::AliasAnalysis &) const {
   if (isConstant() && other.isConstant()) {
     if (getConstantValues() == other.getConstantValues())
       return *this;
@@ -117,7 +121,22 @@ static std::optional<int> getConstantUInt(Value v) {
   return cast<IntegerAttr>(folded.front().get<Attribute>()).getInt();
 }
 
-template <typename Type> bool isConstructor(const Definition &def) {
+} // namespace
+
+//===----------------------------------------------------------------------===//
+// SYCLIDAndRangeAnalysis
+//===----------------------------------------------------------------------===//
+
+template <typename Type>
+std::optional<IDRangeInformation>
+SYCLIDAndRangeAnalysis::getIDRangeInformationFromConstruction(Operation *op,
+                                                              Value operand) {
+  return getInformationFromConstruction<Type>(op, operand);
+}
+
+template <typename Type>
+bool SYCLIDAndRangeAnalysis::isConstructorImpl(
+    const polygeist::Definition &def) {
   if (!def.isOperation())
     return false;
 
@@ -129,96 +148,9 @@ template <typename Type> bool isConstructor(const Definition &def) {
   return isa<Type>(constructor.getType().getValue());
 }
 
-} // namespace
-
-//===----------------------------------------------------------------------===//
-// SYCLIDAndRangeAnalysis
-//===----------------------------------------------------------------------===//
-
-SYCLIDAndRangeAnalysis::SYCLIDAndRangeAnalysis(Operation *op,
-                                               AnalysisManager &mgr)
-    : operation(op), am(mgr) {}
-
-SYCLIDAndRangeAnalysis &
-SYCLIDAndRangeAnalysis::initialize(bool useRelaxedAliasing) {
-  // Initialize the dataflow solver
-  AliasAnalysis &aliasAnalysis = am.getAnalysis<mlir::AliasAnalysis>();
-  aliasAnalysis.addAnalysisImplementation(
-      sycl::AliasAnalysis(useRelaxedAliasing));
-  solver = std::make_unique<DataFlowSolverWrapper>(aliasAnalysis);
-
-  // Populate the solver and run the analyses needed by this analysis.
-  solver->loadWithRequiredAnalysis<ReachingDefinitionAnalysis>(aliasAnalysis);
-
-  if (failed(solver->initializeAndRun(operation))) {
-    operation->emitError("Failed to run required dataflow analyses");
-    return *this;
-  }
-
-  initialized = true;
-
-  return *this;
-}
-
-template <typename Type>
-std::optional<IDRangeInformation>
-SYCLIDAndRangeAnalysis::getIDRangeInformationFromConstruction(Operation *op,
-                                                              Value operand) {
-  assert(initialized &&
-         "Analysis only available after successful initialization");
-  assert(isa<LLVM::LLVMPointerType>(operand.getType()) &&
-         "Expecting an LLVM pointer");
-
-  const polygeist::ReachingDefinition *reachingDef =
-      solver->lookupState<polygeist::ReachingDefinition>(op);
-  assert(reachingDef && "expected a reaching definition");
-
-  auto mods = reachingDef->getModifiers(operand, *solver);
-  if (!mods || mods->empty())
-    return std::nullopt;
-
-  if (!llvm::all_of(*mods, isConstructor<Type>))
-    return std::nullopt;
-
-  auto pMods = reachingDef->getPotentialModifiers(operand, *solver);
-  if (pMods) {
-    if (!llvm::all_of(*pMods, isConstructor<Type>))
-      return std::nullopt;
-  }
-
-  bool first = true;
-  IDRangeInformation info;
-  for (const Definition &def : *mods) {
-    if (first) {
-      info = getInformation<Type>(def);
-      first = false;
-    } else {
-      info = info.join(getInformation<Type>(def));
-      if (!info.hasFixedDimensions())
-        // Early return: As soon as joining of the different information has led
-        // to an info with no fixed dimension (and therefore also non-constant
-        // values), we can end the processing.
-        return info;
-    }
-  }
-
-  if (pMods) {
-    for (const Definition &def : *pMods) {
-      info = info.join(getInformation<Type>(def));
-      if (!info.hasFixedDimensions())
-        // Early return: As soon as joining of the different information has led
-        // to an info with no fixed dimension (and therefore also non-constant
-        // values), we can end the processing.
-        return info;
-    }
-  }
-
-  return info;
-}
-
 template <typename IDRange>
 IDRangeInformation
-SYCLIDAndRangeAnalysis::getInformation(const Definition &def) {
+SYCLIDAndRangeAnalysis::getInformationImpl(const polygeist::Definition &def) {
   assert(def.isOperation() && "Expecting operation");
 
   auto constructor = cast<sycl::SYCLHostConstructorOp>(def.getOperation());
@@ -276,5 +208,5 @@ template std::optional<IDRangeInformation>
 SYCLIDAndRangeAnalysis::getIDRangeInformationFromConstruction<sycl::RangeType>(
     Operation *, Value);
 
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.cpp
@@ -127,25 +127,11 @@ static std::optional<int> getConstantUInt(Value v) {
 // SYCLIDAndRangeAnalysis
 //===----------------------------------------------------------------------===//
 
-template <typename Type>
+template <typename Type, typename>
 std::optional<IDRangeInformation>
 SYCLIDAndRangeAnalysis::getIDRangeInformationFromConstruction(Operation *op,
                                                               Value operand) {
   return getInformationFromConstruction<Type>(op, operand);
-}
-
-template <typename Type>
-bool SYCLIDAndRangeAnalysis::isConstructorImpl(
-    const polygeist::Definition &def) {
-  if (!def.isOperation())
-    return false;
-
-  // NOTE: This could be extended to also handle `SYCLConstructorOp`.
-  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
-  if (!constructor)
-    return false;
-
-  return isa<Type>(constructor.getType().getValue());
 }
 
 template <typename IDRange>

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.cpp
@@ -6,15 +6,18 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Polygeist/Analysis/SYCLNDRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.h"
 
+#include "mlir/Analysis/AliasAnalysis.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.h"
 #include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/ConstructorBaseAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
+#include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 
 using namespace mlir;
-using namespace mlir::polygeist;
+using namespace mlir::sycl;
 
 //===----------------------------------------------------------------------===//
 // NDRangeInformation
@@ -54,20 +57,8 @@ static LogicalResult joinDimsInfo(IDRangeInformation &globalSizeInfo,
   return success();
 }
 
-static bool isConstructor(const Definition &def) {
-  if (!def.isOperation())
-    return false;
-
-  // NOTE: This could be extended to also handle `SYCLConstructorOp`.
-  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
-  if (!constructor)
-    return false;
-
-  return isa<sycl::NdRangeType>(constructor.getType().getValue());
-}
-
 namespace mlir {
-namespace polygeist {
+namespace sycl {
 NDRangeInformation::NDRangeInformation(size_t dimensions)
     : globalSizeInfo(dimensions), localSizeInfo(dimensions),
       offsetInfo(dimensions) {
@@ -100,11 +91,12 @@ const IDRangeInformation &NDRangeInformation::getOffsetInfo() const {
   return offsetInfo;
 }
 
-NDRangeInformation NDRangeInformation::join(const NDRangeInformation &lhs,
-                                            const NDRangeInformation &rhs) {
-  return {lhs.globalSizeInfo.join(rhs.globalSizeInfo),
-          lhs.localSizeInfo.join(rhs.localSizeInfo),
-          lhs.offsetInfo.join(rhs.offsetInfo)};
+const NDRangeInformation
+NDRangeInformation::join(const NDRangeInformation &other,
+                         mlir::AliasAnalysis &alias) {
+  return {globalSizeInfo.join(other.globalSizeInfo, alias),
+          localSizeInfo.join(other.localSizeInfo, alias),
+          offsetInfo.join(other.offsetInfo, alias)};
 }
 
 raw_ostream &operator<<(raw_ostream &os, const NDRangeInformation &ndr) {
@@ -124,85 +116,36 @@ bool NDRangeInformation::isTop() const {
 //===----------------------------------------------------------------------===//
 
 SYCLNDRangeAnalysis::SYCLNDRangeAnalysis(Operation *op, AnalysisManager &am)
-    : operation(op), am(am), idRangeAnalysis(op, am) {}
+    : ConstructorBaseAnalysis<SYCLNDRangeAnalysis, NDRangeInformation>(op, am),
+      idRangeAnalysis(op, am) {}
 
-SYCLNDRangeAnalysis &SYCLNDRangeAnalysis::initialize(bool useRelaxedAliasing) {
-  // Initialize the dataflow solver
-  AliasAnalysis &aliasAnalysis = am.getAnalysis<mlir::AliasAnalysis>();
-  aliasAnalysis.addAnalysisImplementation(
-      sycl::AliasAnalysis(useRelaxedAliasing));
-  solver = std::make_unique<DataFlowSolverWrapper>(aliasAnalysis);
-
-  // Populate the solver and run the analyses needed by this analysis.
-  solver->loadWithRequiredAnalysis<ReachingDefinitionAnalysis>(aliasAnalysis);
-
-  if (failed(solver->initializeAndRun(operation))) {
-    operation->emitError("Failed to run required dataflow analyses");
-    return *this;
-  }
-
+void SYCLNDRangeAnalysis::finalizeInitialization(bool useRelaxedAliasing) {
   idRangeAnalysis.initialize(useRelaxedAliasing);
-
-  initialized = true;
-
-  return *this;
 }
 
 std::optional<NDRangeInformation>
 SYCLNDRangeAnalysis::getNDRangeInformationFromConstruction(Operation *op,
                                                            Value operand) {
-  assert(initialized &&
-         "Analysis only available after successful initialization");
-  assert(isa<LLVM::LLVMPointerType>(operand.getType()) &&
-         "Expecting an LLVM pointer");
-
-  const polygeist::ReachingDefinition *reachingDef =
-      solver->lookupState<polygeist::ReachingDefinition>(op);
-  assert(reachingDef && "expected a reaching definition");
-
-  auto mods = reachingDef->getModifiers(operand, *solver);
-  if (!mods || mods->empty())
-    return std::nullopt;
-
-  if (!llvm::all_of(*mods, isConstructor))
-    return std::nullopt;
-
-  auto pMods = reachingDef->getPotentialModifiers(operand, *solver);
-  if (pMods) {
-    if (!llvm::all_of(*pMods, isConstructor))
-      return std::nullopt;
-  }
-
-  bool first = true;
-  NDRangeInformation info;
-  for (const Definition &def : *mods) {
-    if (first) {
-      info = getInformation(def);
-      first = false;
-      continue;
-    }
-
-    info = NDRangeInformation::join(info, getInformation(def));
-    // Early return: As soon as joining of the different information has led to
-    // top, we can end the processing.
-    if (info.isTop())
-      return info;
-  }
-
-  if (pMods) {
-    for (const Definition &def : *pMods) {
-      info = NDRangeInformation::join(info, getInformation(def));
-      // Early return: As soon as joining of the different information has led
-      // to top, we can end the processing.
-      if (info.isTop())
-        return info;
-    }
-  }
-
-  return info;
+  return getInformationFromConstruction<sycl::NdRangeType>(op, operand);
 }
 
-NDRangeInformation SYCLNDRangeAnalysis::getInformation(const Definition &def) {
+template <>
+bool SYCLNDRangeAnalysis::isConstructorImpl<sycl::NdRangeType>(
+    const polygeist::Definition &def) {
+  if (!def.isOperation())
+    return false;
+
+  // NOTE: This could be extended to also handle `SYCLConstructorOp`.
+  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
+  if (!constructor)
+    return false;
+
+  return isa<sycl::NdRangeType>(constructor.getType().getValue());
+}
+
+template <>
+NDRangeInformation SYCLNDRangeAnalysis::getInformationImpl<sycl::NdRangeType>(
+    const polygeist::Definition &def) {
   assert(def.isOperation() && "Expecting operation");
 
   auto constructor = cast<sycl::SYCLHostConstructorOp>(def.getOperation());
@@ -252,5 +195,5 @@ NDRangeInformation SYCLNDRangeAnalysis::getInformation(const Definition &def) {
   }
   }
 }
-} // namespace polygeist
+} // namespace sycl
 } // namespace mlir

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.cpp
@@ -130,20 +130,6 @@ SYCLNDRangeAnalysis::getNDRangeInformationFromConstruction(Operation *op,
 }
 
 template <>
-bool SYCLNDRangeAnalysis::isConstructorImpl<sycl::NdRangeType>(
-    const polygeist::Definition &def) {
-  if (!def.isOperation())
-    return false;
-
-  // NOTE: This could be extended to also handle `SYCLConstructorOp`.
-  auto constructor = dyn_cast<sycl::SYCLHostConstructorOp>(def.getOperation());
-  if (!constructor)
-    return false;
-
-  return isa<sycl::NdRangeType>(constructor.getType().getValue());
-}
-
-template <>
 NDRangeInformation SYCLNDRangeAnalysis::getInformationImpl<sycl::NdRangeType>(
     const polygeist::Definition &def) {
   assert(def.isOperation() && "Expecting operation");

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/CMakeLists.txt
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/CMakeLists.txt
@@ -10,7 +10,7 @@ add_mlir_library(MLIRSYCLTransforms
 
   LINK_LIBS PUBLIC
   MLIRPass
-  MLIRPolygeistAnalysis
+  MLIRSYCLAnalysis
   MLIRTransforms  
   MLIRTransformUtils
   MLIRSYCLDialect

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -10,9 +10,9 @@
 
 #include "mlir/Dialect/GPU/IR/GPUDialect.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
-#include "mlir/Dialect/Polygeist/Analysis/SYCLNDRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLNDRangeAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h"
 #include "mlir/IR/BuiltinOps.h"
 #include "mlir/IR/Matchers.h"
@@ -61,7 +61,7 @@ private:
       SmallVectorImpl<std::unique_ptr<ConstantArg>> &constants,
       SYCLHostScheduleKernel op, ArrayRef<Type> argumentTypes,
       ArrayAttr argAttrs, SymbolTableCollection &symbolTable,
-      polygeist::SYCLAccessorAnalysis &accessorAnalysis);
+      SYCLAccessorAnalysis &accessorAnalysis);
 
   /// Inserts in \p constants all of the constant implicit arguments of \p op.
   ///
@@ -69,16 +69,16 @@ private:
   /// constant values of arguments.
   static SmallVectorImpl<std::unique_ptr<ConstantArg>> &getConstantImplicitArgs(
       SmallVectorImpl<std::unique_ptr<ConstantArg>> &constants,
-      SYCLHostScheduleKernel op, polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
-      polygeist::SYCLIDAndRangeAnalysis &idrAnalysis);
+      SYCLHostScheduleKernel op, SYCLNDRangeAnalysis &ndrAnalysis,
+      SYCLIDAndRangeAnalysis &idrAnalysis);
 
   /// Returns a list with all constant arguments (both implicit and explicit).
   static SmallVector<std::unique_ptr<ConstantArg>>
   getConstantArgs(SYCLHostScheduleKernel op, ArrayRef<Type> argumentTypes,
                   ArrayAttr argAttrs, SymbolTableCollection &symbolTable,
-                  polygeist::SYCLAccessorAnalysis &accessorAnalysis,
-                  polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
-                  polygeist::SYCLIDAndRangeAnalysis &idrAnalysis);
+                  SYCLAccessorAnalysis &accessorAnalysis,
+                  SYCLNDRangeAnalysis &ndrAnalysis,
+                  SYCLIDAndRangeAnalysis &idrAnalysis);
 
   /// Propagate constants in \p constants to the function launched by \p launch.
   void propagateConstantArgs(
@@ -253,7 +253,7 @@ static Value createIDRange(OpBuilder &builder, Location loc, Type type,
 
 class OffsetInfo {
 public:
-  OffsetInfo(polygeist::IDRangeInformation &&info) : info(std::move(info)) {}
+  OffsetInfo(IDRangeInformation &&info) : info(std::move(info)) {}
   OffsetInfo(DefaultOffset) {}
 
   bool isConstant() const { return !info || info->isConstant(); }
@@ -273,18 +273,17 @@ public:
 
 private:
   /// Offset information.
-  std::optional<polygeist::IDRangeInformation> info;
+  std::optional<IDRangeInformation> info;
 };
 
 class RangeAndOffsetInfo {
 public:
   /// Provide only range info
-  RangeAndOffsetInfo(polygeist::IDRangeInformation &&rangeInfo)
+  RangeAndOffsetInfo(IDRangeInformation &&rangeInfo)
       : rangeInfo(std::move(rangeInfo)) {}
 
   /// Provide range and offset info
-  RangeAndOffsetInfo(polygeist::IDRangeInformation &&rangeInfo,
-                     OffsetInfo &&offsetInfo)
+  RangeAndOffsetInfo(IDRangeInformation &&rangeInfo, OffsetInfo &&offsetInfo)
       : rangeInfo(std::move(rangeInfo)), offsetInfo(std::move(offsetInfo)) {}
 
   /// Provide range and offset info
@@ -309,13 +308,13 @@ public:
   }
 
 private:
-  std::optional<polygeist::IDRangeInformation> rangeInfo;
+  std::optional<IDRangeInformation> rangeInfo;
   std::optional<OffsetInfo> offsetInfo;
 };
 
 class NDRInfo {
 public:
-  NDRInfo(polygeist::NDRangeInformation &&info) : info(std::move(info)) {}
+  NDRInfo(NDRangeInformation &&info) : info(std::move(info)) {}
 
   template <typename... Args>
   NDRInfo(Args &&...args)
@@ -325,7 +324,7 @@ public:
   bool hasConstantGlobalSizeInfo() const {
     return info &&
            std::visit(overloaded{
-                          [](const polygeist::NDRangeInformation &info) {
+                          [](const NDRangeInformation &info) {
                             return info.getGlobalSizeInfo().isConstant();
                           },
                           [](const RangeAndOffsetInfo &info) {
@@ -340,7 +339,7 @@ public:
     assert(hasConstantGlobalSizeInfo() &&
            "Constant global size information not present");
     return std::visit(
-        overloaded{[&](const polygeist::NDRangeInformation &info) {
+        overloaded{[&](const NDRangeInformation &info) {
                      return createIDRange<SYCLRangeConstructorOp>(
                          builder, loc, type,
                          info.getGlobalSizeInfo().getConstantValues());
@@ -354,7 +353,7 @@ public:
   bool hasConstantLocalSizeInfo() const {
     return info &&
            std::visit(overloaded{
-                          [](const polygeist::NDRangeInformation &info) {
+                          [](const NDRangeInformation &info) {
                             return info.getLocalSizeInfo().isConstant();
                           },
                           [](const RangeAndOffsetInfo &) { return false; },
@@ -367,7 +366,7 @@ public:
     assert(hasConstantLocalSizeInfo() &&
            "Constant local size information not present");
     return std::visit(
-        overloaded{[&](const polygeist::NDRangeInformation &info) {
+        overloaded{[&](const NDRangeInformation &info) {
                      return createIDRange<SYCLRangeConstructorOp>(
                          builder, loc, type,
                          info.getLocalSizeInfo().getConstantValues());
@@ -379,16 +378,15 @@ public:
   }
 
   bool hasConstantOffsetInfo() const {
-    return info &&
-           std::visit(overloaded{
-                          [](const polygeist::NDRangeInformation &info) {
-                            return info.getOffsetInfo().isConstant();
-                          },
-                          [](const RangeAndOffsetInfo &info) {
-                            return info.hasConstantOffset();
-                          },
-                      },
-                      *info);
+    return info && std::visit(overloaded{
+                                  [](const NDRangeInformation &info) {
+                                    return info.getOffsetInfo().isConstant();
+                                  },
+                                  [](const RangeAndOffsetInfo &info) {
+                                    return info.hasConstantOffset();
+                                  },
+                              },
+                              *info);
   }
 
   Value getConstantOffsetValue(OpBuilder &builder, Location loc,
@@ -396,7 +394,7 @@ public:
     assert(hasConstantOffsetInfo() &&
            "Constant offset information not present");
     return std::visit(
-        overloaded{[&](const polygeist::NDRangeInformation &info) {
+        overloaded{[&](const NDRangeInformation &info) {
                      return createIDRange<SYCLIDConstructorOp>(
                          builder, loc, type,
                          info.getOffsetInfo().getConstantValues());
@@ -408,17 +406,16 @@ public:
   }
 
   bool isNDRange() const {
-    return info && std::holds_alternative<polygeist::NDRangeInformation>(*info);
+    return info && std::holds_alternative<NDRangeInformation>(*info);
   }
 
-  const polygeist::NDRangeInformation &getNDRange() const {
+  const NDRangeInformation &getNDRange() const {
     assert(isNDRange() && "Not an nd-range");
-    return std::get<polygeist::NDRangeInformation>(*info);
+    return std::get<NDRangeInformation>(*info);
   }
 
 private:
-  std::optional<std::variant<polygeist::NDRangeInformation, RangeAndOffsetInfo>>
-      info;
+  std::optional<std::variant<NDRangeInformation, RangeAndOffsetInfo>> info;
 };
 
 class ConstantSYCLGridArgs : public ConstantImplicitArgBase {
@@ -523,8 +520,8 @@ private:
 /// Class representing an accessor with constant members.
 class ConstantAccessorArg : public ConstantExplicitArgBase {
 public:
-  static std::unique_ptr<ConstantAccessorArg>
-  get(unsigned index, polygeist::AccessorInformation &&info) {
+  static std::unique_ptr<ConstantAccessorArg> get(unsigned index,
+                                                  AccessorInformation &&info) {
     return std::unique_ptr<ConstantAccessorArg>(
         isValidInfo(info) ? new ConstantAccessorArg(index, std::move(info))
                           : nullptr);
@@ -539,13 +536,13 @@ public:
 
 private:
   /// Return whether \p can be used to replace arguments.
-  static bool isValidInfo(const polygeist::AccessorInformation &info);
+  static bool isValidInfo(const AccessorInformation &info);
 
-  ConstantAccessorArg(unsigned index, polygeist::AccessorInformation &&info)
+  ConstantAccessorArg(unsigned index, AccessorInformation &&info)
       : ConstantExplicitArgBase(ConstantArg::Kind::ConstantAccessorArg, index),
         info(std::move(info)) {}
 
-  polygeist::AccessorInformation info;
+  AccessorInformation info;
 };
 } // namespace
 
@@ -566,8 +563,8 @@ void ConstantSYCLGridArgs::RewriterBase::rewrite(Operation *op,
   TypeSwitch<const RewriterBase *>(this)
       .Case<NumWorkItemsRewriter, NumWorkGroupsRewriter, WorkGroupSizeRewriter,
             GlobalOffsetRewriter>([&](const auto *rewriter) {
-        return rewriter->rewrite(cast<typename std::remove_pointer_t<
-                                     decltype(rewriter)>::operation_type>(op),
+        return rewriter->rewrite(cast<typename std::remove_pointer_t<decltype(
+                                     rewriter)>::operation_type>(op),
                                  info, builder);
       });
 }
@@ -609,7 +606,7 @@ Value ConstantSYCLGridArgs::NumWorkItemsRewriter::getNewValue(
 template <>
 Value ConstantSYCLGridArgs::NumWorkGroupsRewriter::getNewValue(
     OpBuilder &builder, Location loc, const NDRInfo &info, Type type) const {
-  const polygeist::NDRangeInformation &ndrInfo = info.getNDRange();
+  const NDRangeInformation &ndrInfo = info.getNDRange();
   return createIDRange<SYCLRangeConstructorOp>(
       builder, loc, type,
       llvm::map_range(llvm::zip(ndrInfo.getGlobalSizeInfo().getConstantValues(),
@@ -792,8 +789,7 @@ void ConstantSYCLGridArgs::rewrite(Operation *op, OpBuilder &builder) const {
 // ConstantAccessorArg
 //===----------------------------------------------------------------------===//
 
-bool ConstantAccessorArg::isValidInfo(
-    const polygeist::AccessorInformation &info) {
+bool ConstantAccessorArg::isValidInfo(const AccessorInformation &info) {
   return !info.needsRange() || info.hasConstantRange() ||
          (info.hasBufferInformation() &&
           info.getBufferInfo().hasConstantSize()) ||
@@ -858,7 +854,7 @@ void ConstantAccessorArg::propagate(OpBuilder &builder, Region &region) {
                                                    dimensions);
     });
   } else if (info.hasBufferInformation()) {
-    const polygeist::BufferInformation &bufferInfo = info.getBufferInfo();
+    const BufferInformation &bufferInfo = info.getBufferInfo();
     if (bufferInfo.hasConstantSize()) {
       ArrayRef<size_t> memoryRange = bufferInfo.getConstantSize();
       LLVM_DEBUG({
@@ -937,8 +933,8 @@ template <typename OpTy> static OpTy getUniqueUserOp(Value range) {
 }
 
 static std::optional<NDRInfo>
-getNDRangeInformation(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
-                      polygeist::SYCLIDAndRangeAnalysis &idrAnalysis,
+getNDRangeInformation(SYCLNDRangeAnalysis &ndrAnalysis,
+                      SYCLIDAndRangeAnalysis &idrAnalysis,
                       SYCLHostScheduleKernel op) {
   Value range = op.getRange();
   if (!range)
@@ -954,7 +950,7 @@ getNDRangeInformation(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
 
   if (op.getNdRange()) {
     // `parallel_for(nd_range, ...)` case
-    std::optional<polygeist::NDRangeInformation> ndrInfo =
+    std::optional<NDRangeInformation> ndrInfo =
         ndrAnalysis.getNDRangeInformationFromConstruction(setNDRangeOp, range);
     if (!ndrInfo)
       return std::nullopt;
@@ -964,7 +960,7 @@ getNDRangeInformation(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
   }
 
   // `parallel_for(range, [offset], ...)` case
-  std::optional<polygeist::IDRangeInformation> rangeInfo =
+  std::optional<IDRangeInformation> rangeInfo =
       idrAnalysis.getIDRangeInformationFromConstruction<RangeType>(setNDRangeOp,
                                                                    range);
 
@@ -996,8 +992,8 @@ getNDRangeInformation(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
 }
 
 static std::optional<ConstantSYCLGridArgs>
-getSYCLGridPropagator(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
-                      polygeist::SYCLIDAndRangeAnalysis &idrAnalysis,
+getSYCLGridPropagator(SYCLNDRangeAnalysis &ndrAnalysis,
+                      SYCLIDAndRangeAnalysis &idrAnalysis,
                       SYCLHostScheduleKernel op) {
   LLVM_DEBUG(llvm::dbgs().indent(4)
              << "Searching for constant SYCL grid arguments\n");
@@ -1012,8 +1008,8 @@ getSYCLGridPropagator(polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
 
 static std::unique_ptr<ConstantAccessorArg>
 getConstantAccessorArg(SYCLHostScheduleKernel op,
-                       polygeist::SYCLAccessorAnalysis &accessorAnalysis,
-                       unsigned index, Value value) {
+                       SYCLAccessorAnalysis &accessorAnalysis, unsigned index,
+                       Value value) {
   LLVM_DEBUG(llvm::dbgs().indent(2)
              << "Handling accessor at operand #" << index << "\n");
 
@@ -1024,7 +1020,7 @@ getConstantAccessorArg(SYCLHostScheduleKernel op,
     return nullptr;
   }
 
-  std::optional<polygeist::AccessorInformation> accInfo =
+  std::optional<AccessorInformation> accInfo =
       accessorAnalysis.getAccessorInformationFromConstruction(setCapturedOp,
                                                               value);
   if (!accInfo) {
@@ -1105,7 +1101,7 @@ ConstantPropagationPass::getConstantExplicitArgs(
     SmallVectorImpl<std::unique_ptr<ConstantArg>> &constants,
     SYCLHostScheduleKernel op, ArrayRef<Type> argumentTypes, ArrayAttr argAttrs,
     SymbolTableCollection &symbolTable,
-    polygeist::SYCLAccessorAnalysis &accessorAnalysis) {
+    SYCLAccessorAnalysis &accessorAnalysis) {
   // Map each argument to a ConstantExplicitArgBase
   auto isConstant = m_Constant();
   auto types = op.getSyclTypes().getAsRange<TypeAttr>();
@@ -1153,8 +1149,8 @@ ConstantPropagationPass::getConstantExplicitArgs(
 SmallVectorImpl<std::unique_ptr<ConstantArg>> &
 ConstantPropagationPass::getConstantImplicitArgs(
     SmallVectorImpl<std::unique_ptr<ConstantArg>> &constants,
-    SYCLHostScheduleKernel op, polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
-    polygeist::SYCLIDAndRangeAnalysis &idrAnalysis) {
+    SYCLHostScheduleKernel op, SYCLNDRangeAnalysis &ndrAnalysis,
+    SYCLIDAndRangeAnalysis &idrAnalysis) {
   LLVM_DEBUG(llvm::dbgs().indent(2)
              << "Searching for constant implicit arguments\n");
   if (std::optional<ConstantSYCLGridArgs> gridConstantPropagation =
@@ -1171,10 +1167,8 @@ ConstantPropagationPass::getConstantImplicitArgs(
 SmallVector<std::unique_ptr<ConstantArg>>
 ConstantPropagationPass::getConstantArgs(
     SYCLHostScheduleKernel op, ArrayRef<Type> argumentTypes, ArrayAttr argAttrs,
-    SymbolTableCollection &symbolTable,
-    polygeist::SYCLAccessorAnalysis &accessorAnalysis,
-    polygeist::SYCLNDRangeAnalysis &ndrAnalysis,
-    polygeist::SYCLIDAndRangeAnalysis &idrAnalysis) {
+    SymbolTableCollection &symbolTable, SYCLAccessorAnalysis &accessorAnalysis,
+    SYCLNDRangeAnalysis &ndrAnalysis, SYCLIDAndRangeAnalysis &idrAnalysis) {
   SmallVector<std::unique_ptr<ConstantArg>> constants;
   getConstantExplicitArgs(constants, op, argumentTypes, argAttrs, symbolTable,
                           accessorAnalysis);
@@ -1208,13 +1202,11 @@ void ConstantPropagationPass::propagateConstantArgs(
 void ConstantPropagationPass::runOnOperation() {
   SymbolTableCollection symbolTable;
   auto &ndrAnalysis =
-      getAnalysis<polygeist::SYCLNDRangeAnalysis>().initialize(relaxedAliasing);
+      getAnalysis<SYCLNDRangeAnalysis>().initialize(relaxedAliasing);
   auto &idrAnalysis =
-      getAnalysis<polygeist::SYCLIDAndRangeAnalysis>().initialize(
-          relaxedAliasing);
+      getAnalysis<SYCLIDAndRangeAnalysis>().initialize(relaxedAliasing);
   auto &accessorAnalysis =
-      getAnalysis<polygeist::SYCLAccessorAnalysis>().initialize(
-          relaxedAliasing);
+      getAnalysis<SYCLAccessorAnalysis>().initialize(relaxedAliasing);
   getOperation()->walk([&](gpu::GPUFuncOp op) {
     LLVM_DEBUG(llvm::dbgs()
                << "Performing constant propagation on function '"

--- a/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Transforms/ConstantPropagation.cpp
@@ -563,8 +563,8 @@ void ConstantSYCLGridArgs::RewriterBase::rewrite(Operation *op,
   TypeSwitch<const RewriterBase *>(this)
       .Case<NumWorkItemsRewriter, NumWorkGroupsRewriter, WorkGroupSizeRewriter,
             GlobalOffsetRewriter>([&](const auto *rewriter) {
-        return rewriter->rewrite(cast<typename std::remove_pointer_t<decltype(
-                                     rewriter)>::operation_type>(op),
+        return rewriter->rewrite(cast<typename std::remove_pointer_t<
+                                     decltype(rewriter)>::operation_type>(op),
                                  info, builder);
       });
 }
@@ -790,7 +790,7 @@ void ConstantSYCLGridArgs::rewrite(Operation *op, OpBuilder &builder) const {
 //===----------------------------------------------------------------------===//
 
 bool ConstantAccessorArg::isValidInfo(const AccessorInformation &info) {
-  return !info.needsRange() || info.hasConstantRange() ||
+  return !info.needsSubRange() || info.hasConstantSubRange() ||
          (info.hasBufferInformation() &&
           info.getBufferInfo().hasConstantSize()) ||
          !info.needsOffset() || info.hasConstantOffset();
@@ -823,8 +823,8 @@ void ConstantAccessorArg::propagate(OpBuilder &builder, Region &region) {
     llvm::dbgs() << "accessor at position #" << index << "\n";
   });
 
-  if (info.needsRange()) {
-    if (info.hasConstantRange()) {
+  if (info.needsSubRange()) {
+    if (info.hasConstantSubRange()) {
       ArrayRef<size_t> accessRange = info.getConstantRange();
       LLVM_DEBUG({
         llvm::dbgs().indent(4)

--- a/mlir-sycl/test/CMakeLists.txt
+++ b/mlir-sycl/test/CMakeLists.txt
@@ -1,3 +1,5 @@
+add_subdirectory(lib)
+
 configure_lit_site_cfg(
   ${CMAKE_CURRENT_SOURCE_DIR}/lit.site.cfg.py.in
   ${CMAKE_CURRENT_BINARY_DIR}/lit.site.cfg.py

--- a/mlir-sycl/test/lib/CMakeLists.txt
+++ b/mlir-sycl/test/lib/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Dialect)

--- a/mlir-sycl/test/lib/Dialect/CMakeLists.txt
+++ b/mlir-sycl/test/lib/Dialect/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(SYCL)

--- a/mlir-sycl/test/lib/Dialect/SYCL/CMakeLists.txt
+++ b/mlir-sycl/test/lib/Dialect/SYCL/CMakeLists.txt
@@ -1,13 +1,14 @@
 if(MLIR_INCLUDE_TESTS)
-  add_mlir_library(MLIRPolygeistTestAnalysis
-    TestMemoryAccessAnalysis.cpp
-    TestReachingDefinitionsAnalysis.cpp
-    TestUniformityAnalysis.cpp
+  add_mlir_library(MLIRSYCLTestAnalysis
+    TestAccessorAnalysis.cpp
+    TestBufferAnalysis.cpp
+    TestIDAndRangeAnalysis.cpp
+    TestNDRangeAnalysis.cpp
 
     EXCLUDE_FROM_LIBMLIR
 
     ADDITIONAL_HEADER_DIRS
-    ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Polygeist
+    ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/SYCL
     ${MLIR_MAIN_INCLUDE_DIR}/mlir/IR
 
     LINK_COMPONENTS
@@ -17,7 +18,6 @@ if(MLIR_INCLUDE_TESTS)
     MLIRAnalysis
     MLIRIR
     MLIRPass
-    MLIRPolygeistAnalysis
     MLIRSupport
     MLIRSYCLAnalysis
   )

--- a/mlir-sycl/test/lib/Dialect/SYCL/TestAccessorAnalysis.cpp
+++ b/mlir-sycl/test/lib/Dialect/SYCL/TestAccessorAnalysis.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Polygeist/Analysis/SYCLAccessorAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLAccessorAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/Pass/Pass.h"
 
@@ -27,8 +27,7 @@ struct TestAccessorAnalysisPass
     aliasAnalysis.addAnalysisImplementation(
         sycl::AliasAnalysis(relaxedAliasing));
     auto &AccessorAnalysis =
-        getAnalysis<polygeist::SYCLAccessorAnalysis>().initialize(
-            relaxedAliasing);
+        getAnalysis<sycl::SYCLAccessorAnalysis>().initialize(relaxedAliasing);
 
     op->walk([&](Operation *op) {
       auto tag = op->getAttrOfType<StringAttr>("tag");

--- a/mlir-sycl/test/lib/Dialect/SYCL/TestIDAndRangeAnalysis.cpp
+++ b/mlir-sycl/test/lib/Dialect/SYCL/TestIDAndRangeAnalysis.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Dialect/Polygeist/Analysis/SYCLIDAndRangeAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/SYCLIDAndRangeAnalysis.h"
 #include "mlir/Dialect/SYCL/IR/SYCLTypes.h"
 #include "mlir/Pass/Pass.h"
 
@@ -24,8 +24,7 @@ struct TestIDAndRangeAnalysisPass
     Operation *op = getOperation();
     bool relaxedAliasing = true;
     auto &IDRangeAnalysis =
-        getAnalysis<polygeist::SYCLIDAndRangeAnalysis>().initialize(
-            relaxedAliasing);
+        getAnalysis<sycl::SYCLIDAndRangeAnalysis>().initialize(relaxedAliasing);
 
     op->walk([&](Operation *op) {
       auto tag = op->getAttrOfType<StringAttr>("tag");

--- a/polygeist/lib/Dialect/Polygeist/Analysis/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/CMakeLists.txt
@@ -1,10 +1,6 @@
 add_mlir_dialect_library(MLIRPolygeistAnalysis
   MemoryAccessAnalysis.cpp
   ReachingDefinitionAnalysis.cpp
-  SYCLAccessorAnalysis.cpp
-  SYCLBufferAnalysis.cpp
-  SYCLIDAndRangeAnalysis.cpp
-  SYCLNDRangeAnalysis.cpp
   UniformityAnalysis.cpp
   
   ADDITIONAL_HEADER_DIRS
@@ -14,7 +10,6 @@ add_mlir_dialect_library(MLIRPolygeistAnalysis
   MLIRPass
   MLIRAnalysis
   MLIRPolygeistUtils
-  MLIRSYCLAnalysis
   MLIRAffineAnalysis  
 )
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -1055,7 +1055,8 @@ void LoopInternalization::runOnGPUModule(gpu::GPUModuleOp gpuModule) {
   ModuleAnalysisManager mam(gpuModule, /*passInstrumentor=*/nullptr);
   AnalysisManager am = mam;
   auto &memAccessAnalysis =
-      am.getAnalysis<MemoryAccessAnalysis>().initialize(relaxedAliasing);
+      am.getAnalysis<MemoryAccessAnalysis>().initialize<sycl::AliasAnalysis>(
+          relaxedAliasing);
   AliasAnalysis &aliasAnalysis = getAnalysis<AliasAnalysis>();
   aliasAnalysis.addAnalysisImplementation(sycl::AliasAnalysis(relaxedAliasing));
 

--- a/polygeist/test/lib/Dialect/Polygeist/TestMemoryAccessAnalysis.cpp
+++ b/polygeist/test/lib/Dialect/Polygeist/TestMemoryAccessAnalysis.cpp
@@ -8,6 +8,7 @@
 
 #include "mlir/Dialect/Affine/Analysis/AffineAnalysis.h"
 #include "mlir/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.h"
+#include "mlir/Dialect/SYCL/Analysis/AliasAnalysis.h"
 #include "mlir/Pass/Pass.h"
 
 using namespace mlir;
@@ -31,7 +32,8 @@ struct TestMemoryAccessAnalysisPass
     AnalysisManager am = mam;
     bool relaxedAliasing = true;
     auto &memAccessAnalysis =
-        am.getAnalysis<MemoryAccessAnalysis>().initialize(relaxedAliasing);
+        am.getAnalysis<MemoryAccessAnalysis>().initialize<sycl::AliasAnalysis>(
+            relaxedAliasing);
 
     op->walk([&](Operation *op) {
       // Only operations with the "tag" attribute are interesting.

--- a/polygeist/tools/polygeist-opt/CMakeLists.txt
+++ b/polygeist/tools/polygeist-opt/CMakeLists.txt
@@ -5,6 +5,7 @@ get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 if(MLIR_INCLUDE_TESTS)
   set(test_libs
     MLIRPolygeistTestAnalysis
+    MLIRSYCLTestAnalysis
   )
 endif()
 


### PR DESCRIPTION
Refactor the analyses deriving properties of interest about SYCL objects from their construction in host code. 

* Move the analyses from the `polygeist` folder to the `mlir-sycl` directory.
* To that end, invert the dependency relation between the libraries. The more specialized SYCL analysis library (`MLIRSYCLAnalysis`) now depends on the less specialized Polygeist analysis library (`MLIRPolygeistAnalysis`). Transforms from both Polygeist and SYCL can still use the SYCL-specific analyses if required.
* Factor out common code shared by the four analyses into a CRTP base class.

Tests for the analysis have not been moved, as this would require `sycl-mlir-opt` to be significantly extended and define the same interface extensions (e.g., for `memref`) as `polygeist-opt`.