### PR TITLE
[SYCL-MLIR] Fix wrong bitcast in cgeist code-gen

### DIFF
--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -776,6 +776,11 @@ struct BarePointer2MemrefOpLowering
                   ConversionPatternRewriter &rewriter) const override {
     if (!canBeLoweredToBarePtr(op.getType()))
       return failure();
+    assert(cast<LLVM::LLVMPointerType>(adaptor.getSource().getType())
+                   .getAddressSpace() ==
+               cast<MemRefType>(op.getType()).getMemorySpaceAsInt() &&
+           "Expecting Pointer2MemrefOp source and result types to have the "
+           "same address space");
 
     const auto convertedType = getTypeConverter()->convertType(op.getType());
     if (!convertedType)

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1464,8 +1464,8 @@ Value MLIRScanner::GetAddressOfBaseClass(
       if (!PT)
         Val = Builder.create<polygeist::Pointer2MemrefOp>(Loc, NT, Val);
       else {
-        if (Val.getType() != NT)
-          Val = Builder.create<LLVM::BitcastOp>(Loc, PT, Val);
+        if (Opt.getAddressSpace() != PT.getAddressSpace())
+          Val = Builder.create<LLVM::AddrSpaceCastOp>(Loc, PT, Val);
       }
     } else {
       assert(isa<MemRefType>(Val.getType()) &&


### PR DESCRIPTION
Use address-space cast instead of illegal bitcast to convert between pointers in different address spaces in codegen.