### PR TITLE
[SYCL] Release xpti objects after plugins unloading

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -322,10 +322,11 @@ void shutdown() {
   Handler->MProgramManager.Inst.reset(nullptr);
 
   // Clear the plugins and reset the instance if it was there.
-  Handler->MXPTIRegistry.Inst.reset(nullptr);
   Handler->unloadPlugins();
   if (Handler->MPlugins.Inst)
     Handler->MPlugins.Inst.reset(nullptr);
+
+  Handler->MXPTIRegistry.Inst.reset(nullptr);
 
   // Release the rest of global resources.
   delete Handler;


### PR DESCRIPTION
in unloadPlugins we call piTearDown. all pi calls in sycl RT are wrapped with xpti begin/end trace if xpti tracing is enabled. It means that we could call xpti methods in unloadPlugins that requires to keep xpti objects alive.