### PR TITLE
[SYCL][NFC] Make UR_CHECK_ERROR a void return macro

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.cpp
@@ -33,10 +33,10 @@ ur_result_t mapErrorUR(CUresult Result) {
   }
 }
 
-ur_result_t checkErrorUR(CUresult Result, const char *Function, int Line,
-                         const char *File) {
+void checkErrorUR(CUresult Result, const char *Function, int Line,
+                  const char *File) {
   if (Result == CUDA_SUCCESS || Result == CUDA_ERROR_DEINITIALIZED) {
-    return UR_RESULT_SUCCESS;
+    return;
   }
 
   if (std::getenv("SYCL_PI_SUPPRESS_ERROR_MESSAGE") == nullptr &&
@@ -64,10 +64,10 @@ ur_result_t checkErrorUR(CUresult Result, const char *Function, int Line,
   throw mapErrorUR(Result);
 }
 
-ur_result_t checkErrorUR(ur_result_t Result, const char *Function, int Line,
-                         const char *File) {
+void checkErrorUR(ur_result_t Result, const char *Function, int Line,
+                  const char *File) {
   if (Result == UR_RESULT_SUCCESS) {
-    return UR_RESULT_SUCCESS;
+    return;
   }
 
   if (std::getenv("SYCL_PI_SUPPRESS_ERROR_MESSAGE") == nullptr &&

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/common.hpp
@@ -19,11 +19,11 @@ ur_result_t mapErrorUR(CUresult Result);
 /// \return UR_RESULT_SUCCESS if \param Result was CUDA_SUCCESS.
 /// \throw ur_result_t exception (integer) if input was not success.
 ///
-ur_result_t checkErrorUR(CUresult Result, const char *Function, int Line,
-                         const char *File);
+void checkErrorUR(CUresult Result, const char *Function, int Line,
+                  const char *File);
 
-ur_result_t checkErrorUR(ur_result_t Result, const char *Function, int Line,
-                         const char *File);
+void checkErrorUR(ur_result_t Result, const char *Function, int Line,
+                  const char *File);
 
 #define UR_CHECK_ERROR(Result)                                                 \
   checkErrorUR(Result, __func__, __LINE__, __FILE__)

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/enqueue.cpp
@@ -31,7 +31,8 @@ ur_result_t enqueueEventsWait(ur_queue_handle_t CommandQueue, CUstream Stream,
           if (Event->getStream() == Stream) {
             return UR_RESULT_SUCCESS;
           } else {
-            return UR_CHECK_ERROR(cuStreamWaitEvent(Stream, Event->get(), 0));
+            UR_CHECK_ERROR(cuStreamWaitEvent(Stream, Event->get(), 0));
+            return UR_RESULT_SUCCESS;
           }
         });
     return Result;
@@ -193,8 +194,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
     const ur_event_handle_t *phEventWaitList, ur_event_handle_t *phEvent) {
   // This function makes one stream work on the previous work (or work
   // represented by input events) and then all future work waits on that stream.
-  ur_result_t Result;
-
   try {
     ScopedContext Active(hQueue->getContext());
     uint32_t StreamToken;
@@ -228,22 +227,20 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueEventsWaitWithBarrier(
                                   Event->getComputeStreamToken())) {
                             return UR_RESULT_SUCCESS;
                           } else {
-                            return UR_CHECK_ERROR(
+                            UR_CHECK_ERROR(
                                 cuStreamWaitEvent(CuStream, Event->get(), 0));
+                            return UR_RESULT_SUCCESS;
                           }
                         });
       }
 
-      Result = UR_CHECK_ERROR(cuEventRecord(hQueue->BarrierEvent, CuStream));
+      UR_CHECK_ERROR(cuEventRecord(hQueue->BarrierEvent, CuStream));
       for (unsigned int i = 0; i < hQueue->ComputeAppliedBarrier.size(); i++) {
         hQueue->ComputeAppliedBarrier[i] = false;
       }
       for (unsigned int i = 0; i < hQueue->TransferAppliedBarrier.size(); i++) {
         hQueue->TransferAppliedBarrier[i] = false;
       }
-    }
-    if (Result != UR_RESULT_SUCCESS) {
-      return Result;
     }
 
     if (phEvent) {
@@ -430,7 +427,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
           Device->getMaxChosenLocalMem()));
     }
 
-    Result = UR_CHECK_ERROR(cuLaunchKernel(
+    UR_CHECK_ERROR(cuLaunchKernel(
         CuFunc, BlocksPerGrid[0], BlocksPerGrid[1], BlocksPerGrid[2],
         ThreadsPerBlock[0], ThreadsPerBlock[1], ThreadsPerBlock[2], LocalSize,
         CuStream, const_cast<void **>(ArgIndices.data()), nullptr));
@@ -502,7 +499,9 @@ static ur_result_t commonEnqueueMemBufferCopyRect(
   params.dstPitch = dst_row_pitch;
   params.dstHeight = dst_slice_pitch / dst_row_pitch;
 
-  return UR_CHECK_ERROR(cuMemcpy3DAsync(&params, cu_stream));
+  UR_CHECK_ERROR(cuMemcpy3DAsync(&params, cu_stream));
+
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
@@ -540,7 +539,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferReadRect(
     }
 
     if (blockingRead) {
-      Result = UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
+      UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
     }
 
     if (phEvent) {
@@ -587,7 +586,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferWriteRect(
     }
 
     if (blockingWrite) {
-      Result = UR_CHECK_ERROR(cuStreamSynchronize(cuStream));
+      UR_CHECK_ERROR(cuStreamSynchronize(cuStream));
     }
 
     if (phEvent) {
@@ -614,7 +613,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
 
   try {
     ScopedContext Active(hQueue->getContext());
-    ur_result_t Result;
+    ur_result_t Result = UR_RESULT_SUCCESS;
 
     auto Stream = hQueue->getNextTransferStream();
     Result =
@@ -630,7 +629,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferCopy(
     auto Src = hBufferSrc->Mem.BufferMem.get() + srcOffset;
     auto Dst = hBufferDst->Mem.BufferMem.get() + dstOffset;
 
-    Result = UR_CHECK_ERROR(cuMemcpyDtoDAsync(Dst, Src, size, Stream));
+    UR_CHECK_ERROR(cuMemcpyDtoDAsync(Dst, Src, size, Stream));
 
     if (phEvent) {
       UR_CHECK_ERROR(RetImplEvent->record());
@@ -705,10 +704,7 @@ ur_result_t commonMemSetLargePattern(CUstream Stream, uint32_t PatternSize,
 
   // Get 4-byte chunk of the pattern and call cuMemsetD32Async
   auto Value = *(static_cast<const uint32_t *>(pPattern));
-  auto Result = UR_CHECK_ERROR(cuMemsetD32Async(Ptr, Value, Count32, Stream));
-  if (Result != UR_RESULT_SUCCESS) {
-    return Result;
-  }
+  UR_CHECK_ERROR(cuMemsetD32Async(Ptr, Value, Count32, Stream));
   for (auto step = 4u; step < NumberOfSteps; ++step) {
     // take 1 byte of the pattern
     Value = *(static_cast<const uint8_t *>(pPattern) + step);
@@ -737,8 +733,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     ScopedContext Active(hQueue->getContext());
 
     auto Stream = hQueue->getNextTransferStream();
-    ur_result_t Result;
-    Result =
+    ur_result_t Result =
         enqueueEventsWait(hQueue, Stream, numEventsInWaitList, phEventWaitList);
 
     if (phEvent) {
@@ -755,17 +750,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemBufferFill(
     switch (patternSize) {
     case 1: {
       auto Value = *static_cast<const uint8_t *>(pPattern);
-      Result = UR_CHECK_ERROR(cuMemsetD8Async(DstDevice, Value, N, Stream));
+      UR_CHECK_ERROR(cuMemsetD8Async(DstDevice, Value, N, Stream));
       break;
     }
     case 2: {
       auto Value = *static_cast<const uint16_t *>(pPattern);
-      Result = UR_CHECK_ERROR(cuMemsetD16Async(DstDevice, Value, N, Stream));
+      UR_CHECK_ERROR(cuMemsetD16Async(DstDevice, Value, N, Stream));
       break;
     }
     case 4: {
       auto Value = *static_cast<const uint32_t *>(pPattern);
-      Result = UR_CHECK_ERROR(cuMemsetD32Async(DstDevice, Value, N, Stream));
+      UR_CHECK_ERROR(cuMemsetD32Async(DstDevice, Value, N, Stream));
       break;
     }
     default: {
@@ -843,7 +838,8 @@ static ur_result_t commonEnqueueMemImageNDCopy(
     }
     CpyDesc.WidthInBytes = Region.width;
     CpyDesc.Height = Region.height;
-    return UR_CHECK_ERROR(cuMemcpy2DAsync(&CpyDesc, CuStream));
+    UR_CHECK_ERROR(cuMemcpy2DAsync(&CpyDesc, CuStream));
+    return UR_RESULT_SUCCESS;
   }
   if (ImgType == UR_MEM_TYPE_IMAGE3D) {
     CUDA_MEMCPY3D CpyDesc;
@@ -869,7 +865,8 @@ static ur_result_t commonEnqueueMemImageNDCopy(
     CpyDesc.WidthInBytes = Region.width;
     CpyDesc.Height = Region.height;
     CpyDesc.Depth = Region.depth;
-    return UR_CHECK_ERROR(cuMemcpy3DAsync(&CpyDesc, CuStream));
+    UR_CHECK_ERROR(cuMemcpy3DAsync(&CpyDesc, CuStream));
+    return UR_RESULT_SUCCESS;
   }
   return UR_RESULT_ERROR_INVALID_VALUE;
 }
@@ -896,7 +893,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     CUarray Array = hImage->Mem.SurfaceMem.getArray();
 
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
-    Result = UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
+    UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
 
     int ElementByteSize = imageElementByteSize(ArrayDesc);
 
@@ -913,7 +910,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
       UR_CHECK_ERROR(RetImplEvent->start());
     }
     if (ImgType == UR_MEM_TYPE_IMAGE1D) {
-      Result = UR_CHECK_ERROR(
+      UR_CHECK_ERROR(
           cuMemcpyAtoHAsync(pDst, Array, ByteOffsetX, BytesToCopy, CuStream));
     } else {
       ur_rect_region_t AdjustedRegion = {BytesToCopy, region.height,
@@ -923,7 +920,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
       Result = commonEnqueueMemImageNDCopy(
           CuStream, ImgType, AdjustedRegion, &Array, CU_MEMORYTYPE_ARRAY,
           SrcOffset, pDst, CU_MEMORYTYPE_HOST, ur_rect_offset_t{});
-
       if (Result != UR_RESULT_SUCCESS) {
         return Result;
       }
@@ -935,7 +931,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageRead(
     }
 
     if (blockingRead) {
-      Result = UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
+      UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
     }
   } catch (ur_result_t Err) {
     return Err;
@@ -969,7 +965,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
     CUarray Array = hImage->Mem.SurfaceMem.getArray();
 
     CUDA_ARRAY_DESCRIPTOR ArrayDesc;
-    Result = UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
+    UR_CHECK_ERROR(cuArrayGetDescriptor(&ArrayDesc, Array));
 
     int ElementByteSize = imageElementByteSize(ArrayDesc);
 
@@ -986,7 +982,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageWrite(
 
     ur_mem_type_t ImgType = hImage->Mem.SurfaceMem.getImageType();
     if (ImgType == UR_MEM_TYPE_IMAGE1D) {
-      Result = UR_CHECK_ERROR(
+      UR_CHECK_ERROR(
           cuMemcpyHtoAAsync(Array, ByteOffsetX, pSrc, BytesToCopy, CuStream));
     } else {
       ur_rect_region_t AdjustedRegion = {BytesToCopy, region.height,
@@ -1041,9 +1037,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
     CUarray DstArray = hImageDst->Mem.SurfaceMem.getArray();
 
     CUDA_ARRAY_DESCRIPTOR SrcArrayDesc;
-    Result = UR_CHECK_ERROR(cuArrayGetDescriptor(&SrcArrayDesc, SrcArray));
+    UR_CHECK_ERROR(cuArrayGetDescriptor(&SrcArrayDesc, SrcArray));
     CUDA_ARRAY_DESCRIPTOR DstArrayDesc;
-    Result = UR_CHECK_ERROR(cuArrayGetDescriptor(&DstArrayDesc, DstArray));
+    UR_CHECK_ERROR(cuArrayGetDescriptor(&DstArrayDesc, DstArray));
 
     UR_ASSERT(SrcArrayDesc.Format == DstArrayDesc.Format,
               UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -1069,8 +1065,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
 
     ur_mem_type_t ImgType = hImageSrc->Mem.SurfaceMem.getImageType();
     if (ImgType == UR_MEM_TYPE_IMAGE1D) {
-      Result = UR_CHECK_ERROR(cuMemcpyAtoA(DstArray, DstByteOffsetX, SrcArray,
-                                           SrcByteOffsetX, BytesToCopy));
+      UR_CHECK_ERROR(cuMemcpyAtoA(DstArray, DstByteOffsetX, SrcArray,
+                                  SrcByteOffsetX, BytesToCopy));
     } else {
       ur_rect_region_t AdjustedRegion = {BytesToCopy, region.height,
                                          region.depth};
@@ -1080,7 +1076,6 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueMemImageCopy(
       Result = commonEnqueueMemImageNDCopy(
           CuStream, ImgType, AdjustedRegion, &SrcArray, CU_MEMORYTYPE_ARRAY,
           SrcOffset, &DstArray, CU_MEMORYTYPE_ARRAY, DstOffset);
-
       if (Result != UR_RESULT_SUCCESS) {
         return Result;
       }
@@ -1282,13 +1277,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy(
               UR_COMMAND_USM_MEMCPY, hQueue, CuStream));
       UR_CHECK_ERROR(EventPtr->start());
     }
-    Result = UR_CHECK_ERROR(
+    UR_CHECK_ERROR(
         cuMemcpyAsync((CUdeviceptr)pDst, (CUdeviceptr)pSrc, size, CuStream));
     if (phEvent) {
       UR_CHECK_ERROR(EventPtr->record());
     }
     if (blocking) {
-      Result = UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
+      UR_CHECK_ERROR(cuStreamSynchronize(CuStream));
     }
     if (phEvent) {
       *phEvent = EventPtr.release();
@@ -1347,7 +1342,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMPrefetch(
               UR_COMMAND_MEM_BUFFER_COPY, hQueue, CuStream));
       UR_CHECK_ERROR(EventPtr->start());
     }
-    Result = UR_CHECK_ERROR(
+    UR_CHECK_ERROR(
         cuMemPrefetchAsync((CUdeviceptr)pMem, size, Device->get(), CuStream));
     if (phEvent) {
       UR_CHECK_ERROR(EventPtr->record());
@@ -1485,14 +1480,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueUSMMemcpy2D(
     CpyDesc.WidthInBytes = width;
     CpyDesc.Height = height;
 
-    result = UR_CHECK_ERROR(cuMemcpy2DAsync(&CpyDesc, cuStream));
+    UR_CHECK_ERROR(cuMemcpy2DAsync(&CpyDesc, cuStream));
 
     if (phEvent) {
       UR_CHECK_ERROR(RetImplEvent->record());
       *phEvent = RetImplEvent.release();
     }
     if (blocking) {
-      result = UR_CHECK_ERROR(cuStreamSynchronize(cuStream));
+      UR_CHECK_ERROR(cuStreamSynchronize(cuStream));
     }
   } catch (ur_result_t err) {
     result = err;
@@ -1608,9 +1603,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableWrite(
   try {
     CUdeviceptr DeviceGlobal = 0;
     size_t DeviceGlobalSize = 0;
-    Result = UR_CHECK_ERROR(cuModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
-                                              hProgram->get(),
-                                              DeviceGlobalName.c_str()));
+    UR_CHECK_ERROR(cuModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
+                                     hProgram->get(),
+                                     DeviceGlobalName.c_str()));
 
     if (offset + count > DeviceGlobalSize)
       return UR_RESULT_ERROR_INVALID_VALUE;
@@ -1640,9 +1635,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueDeviceGlobalVariableRead(
   try {
     CUdeviceptr DeviceGlobal = 0;
     size_t DeviceGlobalSize = 0;
-    Result = UR_CHECK_ERROR(cuModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
-                                              hProgram->get(),
-                                              DeviceGlobalName.c_str()));
+    UR_CHECK_ERROR(cuModuleGetGlobal(&DeviceGlobal, &DeviceGlobalSize,
+                                     hProgram->get(),
+                                     DeviceGlobalName.c_str()));
 
     if (offset + count > DeviceGlobalSize)
       return UR_RESULT_ERROR_INVALID_VALUE;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/event.cpp
@@ -63,8 +63,8 @@ ur_result_t ur_event_handle_t_::start() {
   try {
     if (Queue->URFlags & UR_QUEUE_FLAG_PROFILING_ENABLE) {
       // NOTE: This relies on the default stream to be unused.
-      Result = UR_CHECK_ERROR(cuEventRecord(EvQueued, 0));
-      Result = UR_CHECK_ERROR(cuEventRecord(EvStart, Stream));
+      UR_CHECK_ERROR(cuEventRecord(EvQueued, 0));
+      UR_CHECK_ERROR(cuEventRecord(EvStart, Stream));
     }
   } catch (ur_result_t Err) {
     Result = Err;
@@ -112,7 +112,7 @@ ur_result_t ur_event_handle_t_::record() {
     return UR_RESULT_ERROR_INVALID_EVENT;
   }
 
-  ur_result_t Result = UR_RESULT_ERROR_INVALID_OPERATION;
+  ur_result_t Result = UR_RESULT_SUCCESS;
 
   UR_ASSERT(Queue, UR_RESULT_ERROR_INVALID_QUEUE);
 
@@ -122,7 +122,7 @@ ur_result_t ur_event_handle_t_::record() {
       detail::ur::die(
           "Unrecoverable program state reached in event identifier overflow");
     }
-    Result = UR_CHECK_ERROR(cuEventRecord(EvEnd, Stream));
+    UR_CHECK_ERROR(cuEventRecord(EvEnd, Stream));
   } catch (ur_result_t error) {
     Result = error;
   }
@@ -135,9 +135,9 @@ ur_result_t ur_event_handle_t_::record() {
 }
 
 ur_result_t ur_event_handle_t_::wait() {
-  ur_result_t Result;
+  ur_result_t Result = UR_RESULT_SUCCESS;
   try {
-    Result = UR_CHECK_ERROR(cuEventSynchronize(EvEnd));
+    UR_CHECK_ERROR(cuEventSynchronize(EvEnd));
     HasBeenWaitedOn = true;
   } catch (ur_result_t error) {
     Result = error;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/image.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/image.cpp
@@ -331,9 +331,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMPitchedAllocExp(
   ur_result_t Result = UR_RESULT_SUCCESS;
   try {
     ScopedContext Active(hDevice->getContext());
-    Result =
-        UR_CHECK_ERROR(cuMemAllocPitch((CUdeviceptr *)ppMem, pResultPitch,
-                                       widthInBytes, height, elementSizeBytes));
+    UR_CHECK_ERROR(cuMemAllocPitch((CUdeviceptr *)ppMem, pResultPitch,
+                                   widthInBytes, height, elementSizeBytes));
   } catch (ur_result_t error) {
     Result = error;
   } catch (...) {
@@ -350,7 +349,8 @@ urBindlessImagesUnsampledImageHandleDestroyExp(ur_context_handle_t hContext,
   UR_ASSERT((hContext->getDevice()->get() == hDevice->get()),
             UR_RESULT_ERROR_INVALID_CONTEXT);
 
-  return UR_CHECK_ERROR(cuSurfObjectDestroy((CUsurfObject)hImage));
+  UR_CHECK_ERROR(cuSurfObjectDestroy((CUsurfObject)hImage));
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL
@@ -360,7 +360,8 @@ urBindlessImagesSampledImageHandleDestroyExp(ur_context_handle_t hContext,
   UR_ASSERT((hContext->getDevice()->get() == hDevice->get()),
             UR_RESULT_ERROR_INVALID_CONTEXT);
 
-  return UR_CHECK_ERROR(cuTexObjectDestroy((CUtexObject)hImage));
+  UR_CHECK_ERROR(cuTexObjectDestroy((CUtexObject)hImage));
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/kernel.cpp
@@ -28,7 +28,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     if (FunctionResult == CUDA_ERROR_NOT_FOUND) {
       throw UR_RESULT_ERROR_INVALID_KERNEL_NAME;
     } else {
-      Result = UR_CHECK_ERROR(FunctionResult);
+      UR_CHECK_ERROR(FunctionResult);
     }
 
     std::string KernelNameWithOffset =
@@ -41,7 +41,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     if (OffsetRes == CUDA_ERROR_NOT_FOUND) {
       CuFuncWithOffsetParam = nullptr;
     } else {
-      Result = UR_CHECK_ERROR(OffsetRes);
+      UR_CHECK_ERROR(OffsetRes);
     }
     Kernel = std::unique_ptr<ur_kernel_handle_t_>(
         new ur_kernel_handle_t_{CuFunc, CuFuncWithOffsetParam, pKernelName,

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/memory.cpp
@@ -46,16 +46,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
         ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::Classic;
 
     if ((flags & UR_MEM_FLAG_USE_HOST_POINTER) && EnableUseHostPtr) {
-      Result = UR_CHECK_ERROR(
+      UR_CHECK_ERROR(
           cuMemHostRegister(HostPtr, size, CU_MEMHOSTREGISTER_DEVICEMAP));
-      Result = UR_CHECK_ERROR(cuMemHostGetDevicePointer(&Ptr, HostPtr, 0));
+      UR_CHECK_ERROR(cuMemHostGetDevicePointer(&Ptr, HostPtr, 0));
       AllocMode = ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::UseHostPtr;
     } else if (flags & UR_MEM_FLAG_ALLOC_HOST_POINTER) {
-      Result = UR_CHECK_ERROR(cuMemAllocHost(&HostPtr, size));
-      Result = UR_CHECK_ERROR(cuMemHostGetDevicePointer(&Ptr, HostPtr, 0));
+      UR_CHECK_ERROR(cuMemAllocHost(&HostPtr, size));
+      UR_CHECK_ERROR(cuMemHostGetDevicePointer(&Ptr, HostPtr, 0));
       AllocMode = ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr;
     } else {
-      Result = UR_CHECK_ERROR(cuMemAlloc(&Ptr, size));
+      UR_CHECK_ERROR(cuMemAlloc(&Ptr, size));
       if (flags & UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER) {
         AllocMode = ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::CopyIn;
       }
@@ -70,13 +70,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
         MemObj = URMemObj.release();
         if (PerformInitialCopy) {
           // Operates on the default stream of the current CUDA context.
-          Result = UR_CHECK_ERROR(cuMemcpyHtoD(Ptr, HostPtr, size));
+          UR_CHECK_ERROR(cuMemcpyHtoD(Ptr, HostPtr, size));
           // Synchronize with default stream implicitly used by cuMemcpyHtoD
           // to make buffer data available on device before any other UR call
           // uses it.
           if (Result == UR_RESULT_SUCCESS) {
             CUstream defaultStream = 0;
-            Result = UR_CHECK_ERROR(cuStreamSynchronize(defaultStream));
+            UR_CHECK_ERROR(cuStreamSynchronize(defaultStream));
           }
         }
       } else {
@@ -126,21 +126,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
       switch (MemObjPtr->Mem.BufferMem.MemAllocMode) {
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::CopyIn:
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::Classic:
-        Result = UR_CHECK_ERROR(cuMemFree(MemObjPtr->Mem.BufferMem.Ptr));
+        UR_CHECK_ERROR(cuMemFree(MemObjPtr->Mem.BufferMem.Ptr));
         break;
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::UseHostPtr:
-        Result = UR_CHECK_ERROR(
-            cuMemHostUnregister(MemObjPtr->Mem.BufferMem.HostPtr));
+        UR_CHECK_ERROR(cuMemHostUnregister(MemObjPtr->Mem.BufferMem.HostPtr));
         break;
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr:
-        Result =
-            UR_CHECK_ERROR(cuMemFreeHost(MemObjPtr->Mem.BufferMem.HostPtr));
+        UR_CHECK_ERROR(cuMemFreeHost(MemObjPtr->Mem.BufferMem.HostPtr));
       };
     } else if (hMem->MemType == ur_mem_handle_t_::Type::Surface) {
-      Result = UR_CHECK_ERROR(
+      UR_CHECK_ERROR(
           cuSurfObjectDestroy(MemObjPtr->Mem.SurfaceMem.getSurface()));
-      Result =
-          UR_CHECK_ERROR(cuArrayDestroy(MemObjPtr->Mem.SurfaceMem.getArray()));
+      UR_CHECK_ERROR(cuArrayDestroy(MemObjPtr->Mem.SurfaceMem.getArray()));
     }
 
   } catch (ur_result_t Err) {
@@ -324,7 +321,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
   ScopedContext Active(hContext);
   CUarray ImageArray = nullptr;
   try {
-    Result = UR_CHECK_ERROR(cuArray3DCreate(&ImageArray, &ArrayDesc));
+    UR_CHECK_ERROR(cuArray3DCreate(&ImageArray, &ArrayDesc));
   } catch (ur_result_t Err) {
     if (Err == UR_RESULT_ERROR_INVALID_VALUE) {
       return UR_RESULT_ERROR_INVALID_IMAGE_SIZE;
@@ -338,8 +335,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     if (PerformInitialCopy) {
       // We have to use a different copy function for each image dimensionality
       if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
-        Result =
-            UR_CHECK_ERROR(cuMemcpyHtoA(ImageArray, 0, pHost, ImageSizeBytes));
+        UR_CHECK_ERROR(cuMemcpyHtoA(ImageArray, 0, pHost, ImageSizeBytes));
       } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
         CUDA_MEMCPY2D CpyDesc;
         memset(&CpyDesc, 0, sizeof(CpyDesc));
@@ -349,7 +345,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
         CpyDesc.dstArray = ImageArray;
         CpyDesc.WidthInBytes = PixelSizeBytes * pImageDesc->width;
         CpyDesc.Height = pImageDesc->height;
-        Result = UR_CHECK_ERROR(cuMemcpy2D(&CpyDesc));
+        UR_CHECK_ERROR(cuMemcpy2D(&CpyDesc));
       } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
         CUDA_MEMCPY3D CpyDesc;
         memset(&CpyDesc, 0, sizeof(CpyDesc));
@@ -360,7 +356,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
         CpyDesc.WidthInBytes = PixelSizeBytes * pImageDesc->width;
         CpyDesc.Height = pImageDesc->height;
         CpyDesc.Depth = pImageDesc->depth;
-        Result = UR_CHECK_ERROR(cuMemcpy3D(&CpyDesc));
+        UR_CHECK_ERROR(cuMemcpy3D(&CpyDesc));
       }
     }
 
@@ -379,7 +375,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     ImageResDesc.flags = 0;
 
     CUsurfObject Surface;
-    Result = UR_CHECK_ERROR(cuSurfObjectCreate(&Surface, &ImageResDesc));
+    UR_CHECK_ERROR(cuSurfObjectCreate(&Surface, &ImageResDesc));
 
     auto MemObj = std::unique_ptr<ur_mem_handle_t_>(new ur_mem_handle_t_(
         hContext, ImageArray, Surface, flags, pImageDesc->type, phMem));

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
@@ -97,19 +97,13 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
                 const auto &Dev = Platforms[i].Devices.back().get();
                 size_t MaxWorkGroupSize = 0u;
                 size_t MaxThreadsPerBlock[3] = {};
-                ur_result_t RetError = urDeviceGetInfo(
+                UR_CHECK_ERROR(urDeviceGetInfo(
                     Dev, UR_DEVICE_INFO_MAX_WORK_ITEM_SIZES,
-                    sizeof(MaxThreadsPerBlock), MaxThreadsPerBlock, nullptr);
-                if (RetError != UR_RESULT_SUCCESS) {
-                  throw RetError;
-                }
+                    sizeof(MaxThreadsPerBlock), MaxThreadsPerBlock, nullptr));
 
-                RetError = urDeviceGetInfo(
+                UR_CHECK_ERROR(urDeviceGetInfo(
                     Dev, UR_DEVICE_INFO_MAX_WORK_GROUP_SIZE,
-                    sizeof(MaxWorkGroupSize), &MaxWorkGroupSize, nullptr);
-                if (RetError != UR_RESULT_SUCCESS) {
-                  throw RetError;
-                }
+                    sizeof(MaxWorkGroupSize), &MaxWorkGroupSize, nullptr));
 
                 Dev->saveMaxWorkItemSizes(sizeof(MaxThreadsPerBlock),
                                           MaxThreadsPerBlock);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/platform.cpp
@@ -123,13 +123,16 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
             }
             Platforms.clear();
             Result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-          } catch (...) {
+          } catch (ur_result_t Err) {
             // Clear and rethrow to allow retry
             for (int i = 0; i < NumDevices; ++i) {
               Platforms[i].Devices.clear();
             }
             Platforms.clear();
-            Result = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
+            Result = Err;
+            throw Err;
+          } catch (...) {
+            Result = UR_RESULT_ERROR_OUT_OF_RESOURCES;
             throw;
           }
         },

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/program.cpp
@@ -142,17 +142,14 @@ ur_result_t ur_program_handle_t_::buildProgram(const char *BuildOptions) {
     }
   }
 
-  auto result = UR_CHECK_ERROR(
-      cuModuleLoadDataEx(&Module, static_cast<const void *>(Binary),
-                         Options.size(), Options.data(), OptionVals.data()));
+  UR_CHECK_ERROR(cuModuleLoadDataEx(&Module, static_cast<const void *>(Binary),
+                                    Options.size(), Options.data(),
+                                    OptionVals.data()));
 
-  const auto Success = (result == UR_RESULT_SUCCESS);
-
-  BuildStatus =
-      Success ? UR_PROGRAM_BUILD_STATUS_SUCCESS : UR_PROGRAM_BUILD_STATUS_ERROR;
+  BuildStatus = UR_PROGRAM_BUILD_STATUS_SUCCESS;
 
   // If no exception, result is correct
-  return Success ? UR_RESULT_SUCCESS : UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE;
+  return UR_RESULT_SUCCESS;
 }
 
 /// Finds kernel names by searching for entry points in the PTX source, as the
@@ -226,17 +223,17 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
     std::unique_ptr<ur_program_handle_t_> RetProgram{
         new ur_program_handle_t_{hContext}};
 
-    Result = UR_CHECK_ERROR(cuLinkCreate(0, nullptr, nullptr, &State));
+    UR_CHECK_ERROR(cuLinkCreate(0, nullptr, nullptr, &State));
     try {
       for (size_t i = 0; i < count; ++i) {
         ur_program_handle_t Program = phPrograms[i];
-        Result = UR_CHECK_ERROR(cuLinkAddData(
+        UR_CHECK_ERROR(cuLinkAddData(
             State, CU_JIT_INPUT_PTX, const_cast<char *>(Program->Binary),
             Program->BinarySizeInBytes, nullptr, 0, nullptr, nullptr));
       }
       void *CuBin = nullptr;
       size_t CuBinSize = 0;
-      Result = UR_CHECK_ERROR(cuLinkComplete(State, &CuBin, &CuBinSize));
+      UR_CHECK_ERROR(cuLinkComplete(State, &CuBin, &CuBinSize));
 
       Result =
           RetProgram->setBinary(static_cast<const char *>(CuBin), CuBinSize);
@@ -248,7 +245,7 @@ urProgramLink(ur_context_handle_t hContext, uint32_t count,
       throw;
     }
 
-    Result = UR_CHECK_ERROR(cuLinkDestroy(State));
+    UR_CHECK_ERROR(cuLinkDestroy(State));
     *phProgram = RetProgram.release();
 
   } catch (ur_result_t Err) {
@@ -357,7 +354,8 @@ urProgramRelease(ur_program_handle_t hProgram) {
       // actually loaded a module and need to unload it is to look at the build
       // status.
       if (hProgram->BuildStatus == UR_PROGRAM_BUILD_STATUS_SUCCESS) {
-        Result = UR_CHECK_ERROR(cuModuleUnload(cuModule));
+        UR_CHECK_ERROR(cuModuleUnload(cuModule));
+        Result = UR_RESULT_SUCCESS;
       } else if (hProgram->BuildStatus == UR_PROGRAM_BUILD_STATUS_NONE) {
         // Nothing to free.
         Result = UR_RESULT_SUCCESS;
@@ -444,7 +442,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   ur_result_t Result = UR_RESULT_SUCCESS;
 
   if (Ret != CUDA_SUCCESS && Ret != CUDA_ERROR_NOT_FOUND)
-    Result = UR_CHECK_ERROR(Ret);
+    UR_CHECK_ERROR(Ret);
   if (Ret == CUDA_ERROR_NOT_FOUND) {
     *ppFunctionPointer = 0;
     Result = UR_RESULT_ERROR_INVALID_FUNCTION_NAME;

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/queue.cpp
@@ -203,9 +203,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
   try {
     ScopedContext active(hQueue->getContext());
 
-    hQueue->syncStreams</*ResetUsed=*/true>([&Result](CUstream s) {
-      Result = UR_CHECK_ERROR(cuStreamSynchronize(s));
-    });
+    hQueue->syncStreams</*ResetUsed=*/true>(
+        [&Result](CUstream s) { UR_CHECK_ERROR(cuStreamSynchronize(s)); });
 
   } catch (ur_result_t Err) {
 
@@ -247,7 +246,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   unsigned int CuFlags;
   CUstream CuStream = reinterpret_cast<CUstream>(hNativeQueue);
 
-  auto Return = UR_CHECK_ERROR(cuStreamGetFlags(CuStream, &CuFlags));
+  UR_CHECK_ERROR(cuStreamGetFlags(CuStream, &CuFlags));
 
   ur_queue_flags_t Flags = 0;
   if (CuFlags == CU_STREAM_DEFAULT)
@@ -272,7 +271,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
                              /*backend_owns*/ pProperties->isNativeHandleOwned};
   (*phQueue)->NumComputeStreams = 1;
 
-  return Return;
+  return UR_RESULT_SUCCESS;
 }
 
 UR_APIEXPORT ur_result_t UR_APICALL urQueueGetInfo(ur_queue_handle_t hQueue,

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
@@ -207,7 +207,7 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
         // pointer not known to the CUDA subsystem
         return ReturnValue(UR_USM_TYPE_UNKNOWN);
       }
-      Result = checkErrorUR(Ret, __func__, __LINE__ - 5, __FILE__);
+      checkErrorUR(Ret, __func__, __LINE__ - 5, __FILE__);
       if (Value) {
         // pointer to managed memory
         return ReturnValue(UR_USM_TYPE_SHARED);

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/usm.cpp
@@ -101,17 +101,17 @@ ur_result_t USMFreeImpl(ur_context_handle_t Context, void *Pointer) {
     void *AttributeValues[2] = {&IsManaged, &Type};
     CUpointer_attribute Attributes[2] = {CU_POINTER_ATTRIBUTE_IS_MANAGED,
                                          CU_POINTER_ATTRIBUTE_MEMORY_TYPE};
-    Result = UR_CHECK_ERROR(cuPointerGetAttributes(
-        2, Attributes, AttributeValues, (CUdeviceptr)Pointer));
+    UR_CHECK_ERROR(cuPointerGetAttributes(2, Attributes, AttributeValues,
+                                          (CUdeviceptr)Pointer));
     UR_ASSERT(Type == CU_MEMORYTYPE_DEVICE || Type == CU_MEMORYTYPE_HOST,
               UR_RESULT_ERROR_INVALID_MEM_OBJECT);
     if (IsManaged || Type == CU_MEMORYTYPE_DEVICE) {
       // Memory allocated with cuMemAlloc and cuMemAllocManaged must be freed
       // with cuMemFree
-      Result = UR_CHECK_ERROR(cuMemFree((CUdeviceptr)Pointer));
+      UR_CHECK_ERROR(cuMemFree((CUdeviceptr)Pointer));
     } else {
       // Memory allocated with cuMemAllocHost must be freed with cuMemFreeHost
-      Result = UR_CHECK_ERROR(cuMemFreeHost(Pointer));
+      UR_CHECK_ERROR(cuMemFreeHost(Pointer));
     }
   } catch (ur_result_t Err) {
     Result = Err;
@@ -212,7 +212,7 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
         // pointer to managed memory
         return ReturnValue(UR_USM_TYPE_SHARED);
       }
-      Result = UR_CHECK_ERROR(cuPointerGetAttribute(
+      UR_CHECK_ERROR(cuPointerGetAttribute(
           &Value, CU_POINTER_ATTRIBUTE_MEMORY_TYPE, (CUdeviceptr)pMem));
       UR_ASSERT(Value == CU_MEMORYTYPE_DEVICE || Value == CU_MEMORYTYPE_HOST,
                 UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -235,7 +235,7 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
 #if CUDA_VERSION >= 10020
       // CU_POINTER_ATTRIBUTE_RANGE_START_ADDR was introduced in CUDA 10.2
       void *Base;
-      Result = UR_CHECK_ERROR(cuPointerGetAttribute(
+      UR_CHECK_ERROR(cuPointerGetAttribute(
           &Base, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR, (CUdeviceptr)pMem));
       return ReturnValue(Base);
 #else
@@ -246,7 +246,7 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
 #if CUDA_VERSION >= 10020
       // CU_POINTER_ATTRIBUTE_RANGE_SIZE was introduced in CUDA 10.2
       size_t Value;
-      Result = UR_CHECK_ERROR(cuPointerGetAttribute(
+      UR_CHECK_ERROR(cuPointerGetAttribute(
           &Value, CU_POINTER_ATTRIBUTE_RANGE_SIZE, (CUdeviceptr)pMem));
       return ReturnValue(Value);
 #else
@@ -256,9 +256,9 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
     case UR_USM_ALLOC_INFO_DEVICE: {
       // get device index associated with this pointer
       unsigned int DeviceIndex;
-      Result = UR_CHECK_ERROR(cuPointerGetAttribute(
-          &DeviceIndex, CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
-          (CUdeviceptr)pMem));
+      UR_CHECK_ERROR(cuPointerGetAttribute(&DeviceIndex,
+                                           CU_POINTER_ATTRIBUTE_DEVICE_ORDINAL,
+                                           (CUdeviceptr)pMem));
 
       // currently each device is in its own platform, so find the platform at
       // the same index

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/common.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/common.cpp
@@ -28,10 +28,10 @@ ur_result_t mapErrorUR(hipError_t Result) {
   }
 }
 
-ur_result_t checkErrorUR(hipError_t Result, const char *Function, int Line,
-                         const char *File) {
+void checkErrorUR(hipError_t Result, const char *Function, int Line,
+                  const char *File) {
   if (Result == hipSuccess) {
-    return UR_RESULT_SUCCESS;
+    return;
   }
 
   if (std::getenv("SYCL_PI_SUPPRESS_ERROR_MESSAGE") == nullptr ||
@@ -56,10 +56,10 @@ ur_result_t checkErrorUR(hipError_t Result, const char *Function, int Line,
   throw mapErrorUR(Result);
 }
 
-ur_result_t checkErrorUR(ur_result_t Result, const char *Function, int Line,
-                         const char *File) {
+void checkErrorUR(ur_result_t Result, const char *Function, int Line,
+                  const char *File) {
   if (Result == UR_RESULT_SUCCESS) {
-    return UR_RESULT_SUCCESS;
+    return;
   }
 
   if (std::getenv("SYCL_PI_SUPPRESS_ERROR_MESSAGE") == nullptr ||

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/common.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/common.hpp
@@ -67,10 +67,10 @@ typedef hipArray *hipCUarray;
 
 ur_result_t mapErrorUR(hipError_t Result);
 
-ur_result_t checkErrorUR(hipError_t Result, const char *Function, int Line,
-                         const char *File);
-ur_result_t checkErrorUR(ur_result_t Result, const char *Function, int Line,
-                         const char *File);
+void checkErrorUR(hipError_t Result, const char *Function, int Line,
+                  const char *File);
+void checkErrorUR(ur_result_t Result, const char *Function, int Line,
+                  const char *File);
 
 #define UR_CHECK_ERROR(result)                                                 \
   checkErrorUR(result, __func__, __LINE__, __FILE__)

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/event.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/event.cpp
@@ -144,7 +144,8 @@ ur_result_t ur_event_handle_t_::record() {
       detail::ur::die(
           "Unrecoverable program state reached in event identifier overflow");
     }
-    Result = UR_CHECK_ERROR(hipEventRecord(EvEnd, Stream));
+    UR_CHECK_ERROR(hipEventRecord(EvEnd, Stream));
+    Result = UR_RESULT_SUCCESS;
   } catch (ur_result_t Error) {
     Result = Error;
   }
@@ -157,9 +158,9 @@ ur_result_t ur_event_handle_t_::record() {
 }
 
 ur_result_t ur_event_handle_t_::wait() {
-  ur_result_t Result;
+  ur_result_t Result = UR_RESULT_SUCCESS;
   try {
-    Result = UR_CHECK_ERROR(hipEventSynchronize(EvEnd));
+    UR_CHECK_ERROR(hipEventSynchronize(EvEnd));
     HasBeenWaitedOn = true;
   } catch (ur_result_t Error) {
     Result = Error;

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/kernel.cpp
@@ -20,7 +20,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     ScopedContext Active(hProgram->getContext()->getDevice());
 
     hipFunction_t HIPFunc;
-    Result = UR_CHECK_ERROR(
+    UR_CHECK_ERROR(
         hipModuleGetFunction(&HIPFunc, hProgram->get(), pKernelName));
 
     std::string KernelNameWoffset = std::string(pKernelName) + "_with_offset";
@@ -32,7 +32,7 @@ urKernelCreate(ur_program_handle_t hProgram, const char *pKernelName,
     if (OffsetRes == hipErrorNotFound) {
       HIPFuncWithOffsetParam = nullptr;
     } else {
-      Result = UR_CHECK_ERROR(OffsetRes);
+      UR_CHECK_ERROR(OffsetRes);
     }
     RetKernel = std::unique_ptr<ur_kernel_handle_t_>(
         new ur_kernel_handle_t_{HIPFunc, HIPFuncWithOffsetParam, pKernelName,

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/memory.cpp
@@ -36,24 +36,21 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemRelease(ur_mem_handle_t hMem) {
       switch (uniqueMemObj->Mem.BufferMem.MemAllocMode) {
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::CopyIn:
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::Classic:
-        Result =
-            UR_CHECK_ERROR(hipFree((void *)uniqueMemObj->Mem.BufferMem.Ptr));
+        UR_CHECK_ERROR(hipFree((void *)uniqueMemObj->Mem.BufferMem.Ptr));
         break;
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::UseHostPtr:
-        Result = UR_CHECK_ERROR(
-            hipHostUnregister(uniqueMemObj->Mem.BufferMem.HostPtr));
+        UR_CHECK_ERROR(hipHostUnregister(uniqueMemObj->Mem.BufferMem.HostPtr));
         break;
       case ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr:
-        Result =
-            UR_CHECK_ERROR(hipFreeHost(uniqueMemObj->Mem.BufferMem.HostPtr));
+        UR_CHECK_ERROR(hipFreeHost(uniqueMemObj->Mem.BufferMem.HostPtr));
       };
     }
 
     else if (hMem->MemType == ur_mem_handle_t_::Type::Surface) {
-      Result = UR_CHECK_ERROR(
+      UR_CHECK_ERROR(
           hipDestroySurfaceObject(uniqueMemObj->Mem.SurfaceMem.getSurface()));
       auto Array = uniqueMemObj->Mem.SurfaceMem.getArray();
-      Result = UR_CHECK_ERROR(hipFreeArray(Array));
+      UR_CHECK_ERROR(hipFreeArray(Array));
     }
 
   } catch (ur_result_t Err) {
@@ -108,16 +105,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
         ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::Classic;
 
     if ((flags & UR_MEM_FLAG_USE_HOST_POINTER) && EnableUseHostPtr) {
-      Result =
-          UR_CHECK_ERROR(hipHostRegister(pHost, size, hipHostRegisterMapped));
-      Result = UR_CHECK_ERROR(hipHostGetDevicePointer(&Ptr, pHost, 0));
+      UR_CHECK_ERROR(hipHostRegister(pHost, size, hipHostRegisterMapped));
+      UR_CHECK_ERROR(hipHostGetDevicePointer(&Ptr, pHost, 0));
       AllocMode = ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::UseHostPtr;
     } else if (flags & UR_MEM_FLAG_ALLOC_HOST_POINTER) {
-      Result = UR_CHECK_ERROR(hipHostMalloc(&pHost, size));
-      Result = UR_CHECK_ERROR(hipHostGetDevicePointer(&Ptr, pHost, 0));
+      UR_CHECK_ERROR(hipHostMalloc(&pHost, size));
+      UR_CHECK_ERROR(hipHostGetDevicePointer(&Ptr, pHost, 0));
       AllocMode = ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::AllocHostPtr;
     } else {
-      Result = UR_CHECK_ERROR(hipMalloc(&Ptr, size));
+      UR_CHECK_ERROR(hipMalloc(&Ptr, size));
       if (flags & UR_MEM_FLAG_ALLOC_COPY_HOST_POINTER) {
         AllocMode = ur_mem_handle_t_::MemImpl::BufferMem::AllocMode::CopyIn;
       }
@@ -135,13 +131,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemBufferCreate(
         RetMemObj = URMemObj.release();
         if (PerformInitialCopy) {
           // Operates on the default stream of the current HIP context.
-          Result = UR_CHECK_ERROR(hipMemcpyHtoD(DevPtr, pHost, size));
+          UR_CHECK_ERROR(hipMemcpyHtoD(DevPtr, pHost, size));
           // Synchronize with default stream implicitly used by hipMemcpyHtoD
           // to make buffer data available on device before any other UR call
           // uses it.
           if (Result == UR_RESULT_SUCCESS) {
             hipStream_t defaultStream = 0;
-            Result = UR_CHECK_ERROR(hipStreamSynchronize(defaultStream));
+            UR_CHECK_ERROR(hipStreamSynchronize(defaultStream));
           }
         }
       } else {
@@ -427,15 +423,14 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
 
   ScopedContext Active(hContext->getDevice());
   hipArray *ImageArray;
-  Result = UR_CHECK_ERROR(hipArray3DCreate(
-      reinterpret_cast<hipCUarray *>(&ImageArray), &ArrayDesc));
+  UR_CHECK_ERROR(hipArray3DCreate(reinterpret_cast<hipCUarray *>(&ImageArray),
+                                  &ArrayDesc));
 
   try {
     if (PerformInitialCopy) {
       // We have to use a different copy function for each image dimensionality
       if (pImageDesc->type == UR_MEM_TYPE_IMAGE1D) {
-        Result =
-            UR_CHECK_ERROR(hipMemcpyHtoA(ImageArray, 0, pHost, ImageSizeBytes));
+        UR_CHECK_ERROR(hipMemcpyHtoA(ImageArray, 0, pHost, ImageSizeBytes));
       } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
         hip_Memcpy2D CpyDesc;
         memset(&CpyDesc, 0, sizeof(CpyDesc));
@@ -445,7 +440,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
         CpyDesc.dstArray = reinterpret_cast<hipCUarray>(ImageArray);
         CpyDesc.WidthInBytes = PixelSizeBytes * pImageDesc->width;
         CpyDesc.Height = pImageDesc->height;
-        Result = UR_CHECK_ERROR(hipMemcpyParam2D(&CpyDesc));
+        UR_CHECK_ERROR(hipMemcpyParam2D(&CpyDesc));
       } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE3D) {
         HIP_MEMCPY3D CpyDesc;
         memset(&CpyDesc, 0, sizeof(CpyDesc));
@@ -456,7 +451,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
         CpyDesc.WidthInBytes = PixelSizeBytes * pImageDesc->width;
         CpyDesc.Height = pImageDesc->height;
         CpyDesc.Depth = pImageDesc->depth;
-        Result = UR_CHECK_ERROR(hipDrvMemcpy3D(&CpyDesc));
+        UR_CHECK_ERROR(hipDrvMemcpy3D(&CpyDesc));
       }
     }
 
@@ -472,7 +467,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urMemImageCreate(
     ImageResDesc.resType = hipResourceTypeArray;
 
     hipSurfaceObject_t Surface;
-    Result = UR_CHECK_ERROR(hipCreateSurfaceObject(&Surface, &ImageResDesc));
+    UR_CHECK_ERROR(hipCreateSurfaceObject(&Surface, &ImageResDesc));
 
     auto URMemObj = std::unique_ptr<ur_mem_handle_t_>(new ur_mem_handle_t_{
         hContext, ImageArray, Surface, flags, pImageDesc->type, pHost});

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/platform.cpp
@@ -69,7 +69,8 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
             return;
           }
           int NumDevices = 0;
-          Err = UR_CHECK_ERROR(hipGetDeviceCount(&NumDevices));
+          Err = UR_RESULT_SUCCESS;
+          UR_CHECK_ERROR(hipGetDeviceCount(&NumDevices));
           if (NumDevices == 0) {
             NumPlatforms = 0;
             return;
@@ -81,9 +82,9 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
 
             for (int i = 0; i < NumDevices; ++i) {
               hipDevice_t Device;
-              Err = UR_CHECK_ERROR(hipDeviceGet(&Device, i));
+              UR_CHECK_ERROR(hipDeviceGet(&Device, i));
               hipCtx_t Context;
-              Err = UR_CHECK_ERROR(hipDevicePrimaryCtxRetain(&Context, Device));
+              UR_CHECK_ERROR(hipDevicePrimaryCtxRetain(&Context, Device));
               PlatformIds[i].Devices.emplace_back(
                   new ur_device_handle_t_{Device, Context, &PlatformIds[i]});
             }
@@ -100,6 +101,7 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
               PlatformIds[i].Devices.clear();
             }
             PlatformIds.clear();
+            Err = UR_RESULT_ERROR_UNKNOWN;
             throw;
           }
         },

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/platform.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/platform.cpp
@@ -95,13 +95,16 @@ urPlatformGet(ur_adapter_handle_t *, uint32_t, uint32_t NumEntries,
             }
             PlatformIds.clear();
             Err = UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
-          } catch (...) {
+          } catch (ur_result_t CatchErr) {
             // Clear and rethrow to allow retry
             for (int i = 0; i < NumDevices; ++i) {
               PlatformIds[i].Devices.clear();
             }
             PlatformIds.clear();
-            Err = UR_RESULT_ERROR_UNKNOWN;
+            Err = CatchErr;
+            throw CatchErr;
+          } catch (...) {
+            Err = UR_RESULT_ERROR_OUT_OF_RESOURCES;
             throw;
           }
         },

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/program.cpp
@@ -49,17 +49,13 @@ ur_result_t ur_program_handle_t_::buildProgram(const char *BuildOptions) {
   Options[3] = hipJitOptionErrorLogBufferSizeBytes;
   OptionVals[3] = (void *)(long)MAX_LOG_SIZE;
 
-  auto Result = UR_CHECK_ERROR(
-      hipModuleLoadDataEx(&Module, static_cast<const void *>(Binary),
-                          NumberOfOptions, Options, OptionVals));
+  UR_CHECK_ERROR(hipModuleLoadDataEx(&Module, static_cast<const void *>(Binary),
+                                     NumberOfOptions, Options, OptionVals));
 
-  const bool Success = (Result == UR_RESULT_SUCCESS);
-
-  BuildStatus =
-      Success ? UR_PROGRAM_BUILD_STATUS_SUCCESS : UR_PROGRAM_BUILD_STATUS_ERROR;
+  BuildStatus = UR_PROGRAM_BUILD_STATUS_SUCCESS;
 
   // If no exception, result is correct
-  return Success ? UR_RESULT_SUCCESS : UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE;
+  return UR_RESULT_SUCCESS;
 }
 
 /// Finds kernel names by searching for entry points in the PTX source, as the
@@ -212,7 +208,8 @@ urProgramRelease(ur_program_handle_t hProgram) {
       ScopedContext Active(hProgram->getContext()->getDevice());
       auto HIPModule = hProgram->get();
       if (HIPModule) {
-        Result = UR_CHECK_ERROR(hipModuleUnload(HIPModule));
+        UR_CHECK_ERROR(hipModuleUnload(HIPModule));
+        Result = UR_RESULT_SUCCESS;
       } else {
         // no module to unload
         Result = UR_RESULT_SUCCESS;
@@ -296,7 +293,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
   ur_result_t Result = UR_RESULT_SUCCESS;
 
   if (Ret != hipSuccess && Ret != hipErrorNotFound)
-    Result = UR_CHECK_ERROR(Ret);
+    UR_CHECK_ERROR(Ret);
   if (Ret == hipErrorNotFound) {
     *ppFunctionPointer = 0;
     Result = UR_RESULT_ERROR_INVALID_FUNCTION_NAME;

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/queue.cpp
@@ -220,7 +220,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueFinish(ur_queue_handle_t hQueue) {
     ScopedContext Active(hQueue->getContext()->getDevice());
 
     hQueue->syncStreams<true>([&Result](hipStream_t S) {
-      Result = UR_CHECK_ERROR(hipStreamSynchronize(S));
+      UR_CHECK_ERROR(hipStreamSynchronize(S));
+      Result = UR_RESULT_SUCCESS;
     });
 
   } catch (ur_result_t Err) {
@@ -269,7 +270,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
   unsigned int HIPFlags;
   hipStream_t HIPStream = reinterpret_cast<hipStream_t>(hNativeQueue);
 
-  auto Return = UR_CHECK_ERROR(hipStreamGetFlags(HIPStream, &HIPFlags));
+  UR_CHECK_ERROR(hipStreamGetFlags(HIPStream, &HIPFlags));
 
   ur_queue_flags_t Flags = 0;
   if (HIPFlags == hipStreamDefault)
@@ -294,5 +295,5 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreateWithNativeHandle(
                              /*backend_owns*/ pProperties->isNativeHandleOwned};
   (*phQueue)->NumComputeStreams = 1;
 
-  return Return;
+  return UR_RESULT_SUCCESS;
 }

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
@@ -70,8 +70,7 @@ UR_APIEXPORT ur_result_t UR_APICALL USMFreeImpl(ur_context_handle_t hContext,
   try {
     ScopedContext Active(hContext->getDevice());
     hipPointerAttribute_t hipPointerAttributeType;
-    Result =
-        UR_CHECK_ERROR(hipPointerGetAttributes(&hipPointerAttributeType, pMem));
+    UR_CHECK_ERROR(hipPointerGetAttributes(&hipPointerAttributeType, pMem));
     unsigned int Type = hipPointerAttributeType.memoryType;
     UR_ASSERT(Type == hipMemoryTypeDevice || Type == hipMemoryTypeHost,
               UR_RESULT_ERROR_INVALID_MEM_OBJECT);

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
@@ -76,10 +76,10 @@ UR_APIEXPORT ur_result_t UR_APICALL USMFreeImpl(ur_context_handle_t hContext,
     UR_ASSERT(Type == hipMemoryTypeDevice || Type == hipMemoryTypeHost,
               UR_RESULT_ERROR_INVALID_MEM_OBJECT);
     if (Type == hipMemoryTypeDevice) {
-      Result = UR_CHECK_ERROR(hipFree(pMem));
+      UR_CHECK_ERROR(hipFree(pMem));
     }
     if (Type == hipMemoryTypeHost) {
-      Result = UR_CHECK_ERROR(hipHostFree(pMem));
+      UR_CHECK_ERROR(hipHostFree(pMem));
     }
   } catch (ur_result_t Error) {
     Result = Error;
@@ -161,14 +161,15 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
         // pointer not known to the HIP subsystem
         return ReturnValue(UR_USM_TYPE_UNKNOWN);
       }
-      Result = checkErrorUR(Ret, __func__, __LINE__ - 5, __FILE__);
+      // Direct usage of the function, instead of UR_CHECK_ERROR, so we can get
+      // the line offset.
+      checkErrorUR(Ret, __func__, __LINE__ - 5, __FILE__);
       Value = hipPointerAttributeType.isManaged;
       if (Value) {
         // pointer to managed memory
         return ReturnValue(UR_USM_TYPE_SHARED);
       }
-      Result = UR_CHECK_ERROR(
-          hipPointerGetAttributes(&hipPointerAttributeType, pMem));
+      UR_CHECK_ERROR(hipPointerGetAttributes(&hipPointerAttributeType, pMem));
       Value = hipPointerAttributeType.memoryType;
       UR_ASSERT(Value == hipMemoryTypeDevice || Value == hipMemoryTypeHost,
                 UR_RESULT_ERROR_INVALID_MEM_OBJECT);
@@ -193,8 +194,7 @@ urUSMGetMemAllocInfo(ur_context_handle_t hContext, const void *pMem,
       return UR_RESULT_ERROR_INVALID_VALUE;
     case UR_USM_ALLOC_INFO_DEVICE: {
       // get device index associated with this pointer
-      Result = UR_CHECK_ERROR(
-          hipPointerGetAttributes(&hipPointerAttributeType, pMem));
+      UR_CHECK_ERROR(hipPointerGetAttributes(&hipPointerAttributeType, pMem));
 
       int DeviceIdx = hipPointerAttributeType.device;
 


### PR DESCRIPTION
`UR_CHECK_ERROR` was designed to return `ur_result_t`, however in practice it was guaranteed to only ever return `UR_RESULT_SUCCESS`, as other paths would either terminate, abort or throw.

This in turns leads to poor quality/error prone code, as the codebase was littered with:
* statements not checking the return value - depending on the compiler generating a warning,
* extra check on the return which was only ever going to be true.

Some care was required, as the codebase has a habit of accumulating err codes across branches, so depending on the use case the initial value of `ur_result_t Result`s had to be set accordingly (now that `UR_CHECK_ERROR` does not return).