### PR TITLE
[SYCL] Add early exit for devices that don't support size 32 subgroups

### DIFF
--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
@@ -16,6 +16,7 @@ template <size_t PartitionSize> void test() {
   if (std::find(SGSizes.begin(), SGSizes.end(), 32) == SGSizes.end()) {
     std::cout << "Test skipped due to missing support for sub-group size 32."
               << std::endl;
+    return;
   }
 
   sycl::buffer<bool, 1> MatchBuf{sycl::range{32}};

--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
@@ -18,6 +18,7 @@ template <size_t PartitionSize> void test() {
   if (std::find(SGSizes.begin(), SGSizes.end(), SGSize) == SGSizes.end()) {
     std::cout << "Test skipped due to missing support for sub-group size 32."
               << std::endl;
+    return;
   }
 
   sycl::buffer<size_t, 1> TmpBuf{sycl::range{SGSize}};

--- a/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
@@ -21,6 +21,7 @@ int main() {
   if (std::find(SGSizes.begin(), SGSizes.end(), SGSize) == SGSizes.end()) {
     std::cout << "Test skipped due to missing support for sub-group size 32."
               << std::endl;
+    return 0;
   }
 
   sycl::buffer<size_t, 1> TmpBuf{sycl::range{SGSize}};

--- a/sycl/test-e2e/SubGroupMask/Basic.cpp
+++ b/sycl/test-e2e/SubGroupMask/Basic.cpp
@@ -24,6 +24,14 @@ int main() {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
   queue Queue;
 
+  auto sgsizes =
+      Queue.get_device().get_info<sycl::info::device::sub_group_sizes>();
+  if (std::find(sgsizes.begin(), sgsizes.end(), 32) == sgsizes.end()) {
+    std::cout << "test skipped due to missing support for sub-group size 32."
+              << std::endl;
+    return 0;
+  }
+
   try {
     nd_range<1> NdRange(global_size, local_size);
     int Res = 0;


### PR DESCRIPTION
Some tests weren't exiting early if size 32 sgs are not supported on device. This fixes this behaviour.