### PR TITLE
[SYCL][FPGA] Disallow 'max_interleaving' attribute argument > 1

### DIFF
--- a/clang/include/clang/Basic/AttrDocs.td
+++ b/clang/include/clang/Basic/AttrDocs.td
@@ -3427,13 +3427,13 @@ This attribute applies to a loop. Places a maximum limit N on the number of
 interleaved invocations of an inner loop by an outer loop (note, this does not
 mean that this attribute can only be applied to inner loops in user code - outer
 loops in user code may still be contained in an implicit loop due to NDRange).
-Parameter N is mandatory, and shall be non-negative integer.
+Parameter N is mandatory, and may either be 0, or 1.
 
 .. code-block:: c++
 
   void foo() {
     int a[10];
-    [[intel::max_interleaving(4)]] for (int i = 0; i != 10; ++i) a[i] = 0;
+    [[intel::max_interleaving(1)]] for (int i = 0; i != 10; ++i) a[i] = 0;
   }
 
   template<int N>

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12092,6 +12092,8 @@ def err_sycl_add_ir_attribute_invalid_filter : Error<
 def warn_sycl_old_and_new_kernel_attributes : Warning<
   "kernel has both attribute %0 and kernel properties; conflicting properties "
   "are ignored">, InGroup<IgnoredAttributes>;
+def err_attribute_argument_is_not_valid : Error<
+  "%0 attribute requires integer constant value 0 or 1">;
 
 // errors of expect.with.probability
 def err_probability_not_constant_float : Error<

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -139,8 +139,8 @@ Sema::BuildSYCLIntelMaxInterleavingAttr(const AttributeCommonInfo &CI,
 
     // This attribute accepts values 0 and 1 only.
     if (ArgVal < 0 || ArgVal > 1) {
-      Diag(E->getBeginLoc(), diag::err_attribute_argument_out_of_range)
-          << CI << 0 << 1 << E->getSourceRange();
+      Diag(E->getBeginLoc(), diag::err_attribute_argument_is_not_valid)
+          << CI;
       return nullptr;
     }
   }

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -137,10 +137,10 @@ Sema::BuildSYCLIntelMaxInterleavingAttr(const AttributeCommonInfo &CI,
       return nullptr;
     E = Res.get();
 
-    // This attribute requires a non-negative value.
-    if (ArgVal < 0) {
-      Diag(E->getExprLoc(), diag::err_attribute_requires_positive_integer)
-          << CI << /*non-negative*/ 1;
+    // This attribute accepts values 0 and 1 only.
+    if (ArgVal < 0 || ArgVal > 1) {
+      Diag(E->getBeginLoc(), diag::err_attribute_argument_out_of_range)
+          << CI << 0 << 1 << E->getSourceRange();
       return nullptr;
     }
   }

--- a/clang/lib/Sema/SemaStmtAttr.cpp
+++ b/clang/lib/Sema/SemaStmtAttr.cpp
@@ -139,8 +139,7 @@ Sema::BuildSYCLIntelMaxInterleavingAttr(const AttributeCommonInfo &CI,
 
     // This attribute accepts values 0 and 1 only.
     if (ArgVal < 0 || ArgVal > 1) {
-      Diag(E->getBeginLoc(), diag::err_attribute_argument_is_not_valid)
-          << CI;
+      Diag(E->getBeginLoc(), diag::err_attribute_argument_is_not_valid) << CI;
       return nullptr;
     }
   }

--- a/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-loops.cpp
@@ -11,8 +11,7 @@
 // CHECK: br label %for.cond2,  !llvm.loop ![[MD_LC_2:[0-9]+]]
 // CHECK: br label %for.cond13, !llvm.loop ![[MD_LC_3:[0-9]+]]
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_MI:[0-9]+]]
-// CHECK: br label %for.cond2,  !llvm.loop ![[MD_MI_2:[0-9]+]]
-// CHECK: br label %for.cond13, !llvm.loop ![[MD_MI_3:[0-9]+]]
+// CHECK: br label %for.cond2,  !llvm.loop ![[MD_MI_1:[0-9]+]]
 // CHECK: br label %for.cond,   !llvm.loop ![[MD_SI:[0-9]+]]
 // CHECK: br label %for.cond2,  !llvm.loop ![[MD_SI_2:[0-9]+]]
 // CHECK: br label %for.cond13, !llvm.loop ![[MD_SI_3:[0-9]+]]
@@ -95,23 +94,17 @@ void loop_coalesce() {
       a[i] = 0;
 }
 
-template <int A, int B>
+template <int A>
 void max_interleaving() {
   int a[10];
   // CHECK: ![[MD_MI]] = distinct !{![[MD_MI]], ![[MP]], ![[MD_max_interleaving:[0-9]+]]}
-  // CHECK-NEXT: ![[MD_max_interleaving]] = !{!"llvm.loop.max_interleaving.count", i32 3}
+  // CHECK-NEXT: ![[MD_max_interleaving]] = !{!"llvm.loop.max_interleaving.count", i32 0}
   [[intel::max_interleaving(A)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // CHECK: ![[MD_MI_2]] = distinct !{![[MD_MI_2]], ![[MP]], ![[MD_max_interleaving_2:[0-9]+]]}
-  // CHECK-NEXT: ![[MD_max_interleaving_2]] = !{!"llvm.loop.max_interleaving.count", i32 2}
-  [[intel::max_interleaving(2)]] for (int i = 0; i != 10; ++i)
+  // CHECK: ![[MD_MI_1]] = distinct !{![[MD_MI_1]], ![[MP]], ![[MD_max_interleaving_2:[0-9]+]]}
+  // CHECK-NEXT: ![[MD_max_interleaving_2]] = !{!"llvm.loop.max_interleaving.count", i32 1}
+  [[intel::max_interleaving(1)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-
-  // CHECK: ![[MD_MI_3]] = distinct !{![[MD_MI_3]], ![[MP]], ![[MD_max_interleaving_3:[0-9]+]]}
-  // CHECK-NEXT: ![[MD_max_interleaving_3]] = !{!"llvm.loop.max_interleaving.count", i32 0}
-  [[intel::max_interleaving(B)]] for (int i = 0; i != 10; ++i)
-      a[i] = 0;
-
 }
 
 template <int A, int B>
@@ -207,7 +200,7 @@ int main() {
     initiation_interval<6>();
     max_concurrency<0>();
     loop_coalesce<2>();
-    max_interleaving<3, 0>();
+    max_interleaving<0>();
     speculated_iterations<4, 0>();
     loop_count_control<12>();
     max_reinvocation_delay<3, 1>();

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -155,8 +155,11 @@ void goo() {
   // expected-error@+1 {{'loop_coalesce' attribute requires a positive integral compile time constant expression}}
   [[intel::loop_coalesce(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'max_interleaving' attribute requires a non-negative integral compile time constant expression}}
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
   [[intel::max_interleaving(-1)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
+  [[intel::max_interleaving(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'speculated_iterations' attribute requires a non-negative integral compile time constant expression}}
   [[intel::speculated_iterations(-1)]] for (int i = 0; i != 10; ++i)
@@ -285,7 +288,7 @@ void zoo() {
   [[intel::max_interleaving(1)]]
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
   [[intel::speculated_iterations(1)]]
-  [[intel::max_interleaving(4)]] for (int i = 0; i != 10; ++i)
+  [[intel::max_interleaving(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   [[intel::speculated_iterations(1)]]
   // expected-error@+2 {{duplicate Intel FPGA loop attribute 'speculated_iterations'}}
@@ -486,18 +489,23 @@ void max_concurrency_dependent() {
 template <int A, int B, int C, int D>
 void max_interleaving_dependent() {
   int a[10];
-  // expected-error@+1 {{'max_interleaving' attribute requires a non-negative integral compile time constant expression}}
-  [[intel::max_interleaving(C)]] for (int i = 0; i != 10; ++i)
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
+  [[intel::max_interleaving(A)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
-  [[intel::max_interleaving(A)]]
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
   [[intel::max_interleaving(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
   // max_interleaving attribute accepts value 0.
+  [[intel::max_interleaving(C)]] for (int i = 0; i != 10; ++i)
+      a[i] = 0;
+
+  // expected-error@+2 {{duplicate Intel FPGA loop attribute 'max_interleaving'}}
+  [[intel::max_interleaving(C)]]
   [[intel::max_interleaving(D)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
+
 }
 
 template <int A, int B, int C, int D>
@@ -619,7 +627,7 @@ void check_max_interleaving_expression() {
 
   // Test that checks expression is a constant expression.
   constexpr int bar = 0;
-  [[intel::max_interleaving(bar + 2)]] for (int i = 0; i != 10; ++i) // OK
+  [[intel::max_interleaving(bar + 1)]] for (int i = 0; i != 10; ++i) // OK
       a[i] = 0;
 }
 
@@ -768,7 +776,7 @@ int main() {
       ii_dependent<2, 4, -1>();
       //expected-note@-1 +{{in instantiation of function template specialization}}
       max_concurrency_dependent<1, 4, -2, 0>(); // expected-note{{in instantiation of function template specialization 'max_concurrency_dependent<1, 4, -2, 0>' requested here}}
-      max_interleaving_dependent<1, 4, -1, 0>(); // expected-note{{in instantiation of function template specialization 'max_interleaving_dependent<1, 4, -1, 0>' requested here}}
+      max_interleaving_dependent<-1, 4, 0, 1>(); // expected-note{{in instantiation of function template specialization 'max_interleaving_dependent<-1, 4, 0, 1>' requested here}}
       speculated_iterations_dependent<1, 8, -3, 0>(); // expected-note{{in instantiation of function template specialization 'speculated_iterations_dependent<1, 8, -3, 0>' requested here}}
       loop_coalesce_dependent<-1, 4,  0>(); // expected-note{{in instantiation of function template specialization 'loop_coalesce_dependent<-1, 4, 0>' requested here}}
       loop_count_control_dependent<3, 2, -1>(); // expected-note{{in instantiation of function template specialization 'loop_count_control_dependent<3, 2, -1>' requested here}}

--- a/clang/test/SemaSYCL/intel-fpga-loops.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loops.cpp
@@ -155,10 +155,10 @@ void goo() {
   // expected-error@+1 {{'loop_coalesce' attribute requires a positive integral compile time constant expression}}
   [[intel::loop_coalesce(0)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant value 0 or 1}}
   [[intel::max_interleaving(-1)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
-  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant value 0 or 1}}
   [[intel::max_interleaving(2)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
   // expected-error@+1 {{'speculated_iterations' attribute requires a non-negative integral compile time constant expression}}
@@ -489,11 +489,11 @@ void max_concurrency_dependent() {
 template <int A, int B, int C, int D>
 void max_interleaving_dependent() {
   int a[10];
-  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant value 0 or 1}}
   [[intel::max_interleaving(A)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 
-  // expected-error@+1 {{'max_interleaving' attribute requires integer constant between 0 and 1 inclusive}}
+  // expected-error@+1 {{'max_interleaving' attribute requires integer constant value 0 or 1}}
   [[intel::max_interleaving(B)]] for (int i = 0; i != 10; ++i)
       a[i] = 0;
 


### PR DESCRIPTION
The backend doesn't support max_interleaving attribute argument > 1 at the moment.

This patch adds error diagnostic for [[intel::max_interleaving(int_argument > 1)]].

Also this patch updates max_interleaving tests based on requirement and non-neagive diagnostic messages to avoid any confusion.