### PR TITLE
[SYCL] Add device copyable trait for annotated_arg

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -179,7 +179,12 @@ The properties supported with `annotated_arg` may be defined in
 separate extensions. Please note that there cannot be duplicated property in a 
 properties list. Otherwise, a compiler time error is triggered.
 
-The type `annotated_arg<T, ...>` is device copyable given that the type `T` is device copyable.
+If the type `T` is trivially copyable, then `annotated_arg<T, ...>` is also
+trivially copyable.
+
+If the type `T` is device copyable, then `annotated_arg<T, ...>` is also device
+copyable and the implementation sets the `is_device_copyable_v` trait to `true`
+for this type.
 
 The section below describes the constructors and member functions for
 `annotated_arg`.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -179,6 +179,19 @@ The properties supported with `annotated_arg` may be defined in
 separate extensions. Please note that there cannot be duplicated property in a 
 properties list. Otherwise, a compiler time error is triggered.
 
+The type `annoated_arg<T, ...>` is device copyable given that the type `T` is device copyable,
+as defined by the following:
+
+[source,c++]
+----
+template <typename T, typename PropertyList>
+struct is_device_copyable<
+    ext::oneapi::experimental::annotated_arg<T, PropertyList>,
+    std::enable_if_t<!std::is_trivially_copyable_v<
+        ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
+    : is_device_copyable<T> {};
+----
+
 The section below describes the constructors and member functions for
 `annotated_arg`.
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -179,18 +179,7 @@ The properties supported with `annotated_arg` may be defined in
 separate extensions. Please note that there cannot be duplicated property in a 
 properties list. Otherwise, a compiler time error is triggered.
 
-The type `annotated_arg<T, ...>` is device copyable given that the type `T` is device copyable,
-as defined by the following:
-
-[source,c++]
-----
-template <typename T, typename PropertyList>
-struct is_device_copyable<
-    ext::oneapi::experimental::annotated_arg<T, PropertyList>,
-    std::enable_if_t<!std::is_trivially_copyable_v<
-        ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
-    : is_device_copyable<T> {};
-----
+The type `annotated_arg<T, ...>` is device copyable given that the type `T` is device copyable.
 
 The section below describes the constructors and member functions for
 `annotated_arg`.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -179,7 +179,7 @@ The properties supported with `annotated_arg` may be defined in
 separate extensions. Please note that there cannot be duplicated property in a 
 properties list. Otherwise, a compiler time error is triggered.
 
-The type `annoated_arg<T, ...>` is device copyable given that the type `T` is device copyable,
+The type `annotated_arg<T, ...>` is device copyable given that the type `T` is device copyable,
 as defined by the following:
 
 [source,c++]

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -51,6 +51,13 @@ class annotated_arg {
                 "Property list is invalid.");
 };
 
+// device_copyable trait
+template <typename T, typename... Props>
+struct is_device_copyable<
+  annotated_arg<T, detail::properties_t<Props...>>,
+  std::enable_if_t<!std::is_trivially_copyable_v<annotated_arg<T, detail::properties_t<Props...>>>>>
+  : is_device_copyable<T> {};
+
 // Partial specialization for pointer type
 template <typename T, typename... Props>
 class __SYCL_SPECIAL_CLASS

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -24,7 +24,8 @@ namespace sycl {
 template <typename T, typename PropertyList>
 struct is_device_copyable<
   ext::oneapi::experimental::annotated_arg<T, PropertyList>,
-  std::enable_if_t<!std::is_trivially_copyable_v<ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
+  std::enable_if_t<!std::is_trivially_copyable_v<
+    ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
   : is_device_copyable<T> {};
 
 inline namespace _V1 {

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -19,6 +19,14 @@
 #include <variant>
 
 namespace sycl {
+
+// device_copyable trait
+template <typename T, typename PropertyList>
+struct is_device_copyable<
+  ext::oneapi::experimental::annotated_arg<T, PropertyList>,
+  std::enable_if_t<!std::is_trivially_copyable_v<ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
+  : is_device_copyable<T> {};
+
 inline namespace _V1 {
 namespace ext {
 namespace oneapi {
@@ -50,13 +58,6 @@ class annotated_arg {
   static_assert(is_property_list<PropertyListT>::value,
                 "Property list is invalid.");
 };
-
-// device_copyable trait
-template <typename T, typename... Props>
-struct is_device_copyable<
-  annotated_arg<T, detail::properties_t<Props...>>,
-  std::enable_if_t<!std::is_trivially_copyable_v<annotated_arg<T, detail::properties_t<Props...>>>>>
-  : is_device_copyable<T> {};
 
 // Partial specialization for pointer type
 template <typename T, typename... Props>

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -23,10 +23,10 @@ namespace sycl {
 // device_copyable trait
 template <typename T, typename PropertyList>
 struct is_device_copyable<
-  ext::oneapi::experimental::annotated_arg<T, PropertyList>,
-  std::enable_if_t<!std::is_trivially_copyable_v<
-    ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
-  : is_device_copyable<T> {};
+    ext::oneapi::experimental::annotated_arg<T, PropertyList>,
+    std::enable_if_t<!std::is_trivially_copyable_v<
+        ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
+    : is_device_copyable<T> {};
 
 inline namespace _V1 {
 namespace ext {

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -23,15 +23,6 @@
 #include <variant>
 
 namespace sycl {
-
-// device_copyable trait
-template <typename T, typename PropertyList>
-struct is_device_copyable<
-    ext::oneapi::experimental::annotated_ptr<T, PropertyList>,
-    std::enable_if_t<!std::is_trivially_copyable_v<
-        ext::oneapi::experimental::annotated_ptr<T, PropertyList>>>>
-    : is_device_copyable<T> {};
-
 inline namespace _V1 {
 namespace ext {
 namespace oneapi {

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -23,6 +23,14 @@
 #include <variant>
 
 namespace sycl {
+
+// device_copyable trait
+template <typename T, typename PropertyList>
+struct is_device_copyable<
+  ext::oneapi::experimental::annotated_ptr<T, PropertyList>,
+  std::enable_if_t<!std::is_trivially_copyable_v<ext::oneapi::experimental::annotated_ptr<T, PropertyList>>>>
+  : is_device_copyable<T> {};
+
 inline namespace _V1 {
 namespace ext {
 namespace oneapi {
@@ -184,13 +192,6 @@ class annotated_ptr {
   static_assert(is_property_list<PropertyListT>::value,
                 "Property list is invalid.");
 };
-
-// device_copyable trait
-template <typename T, typename... Props>
-struct is_device_copyable<
-  annotated_arg<T, detail::properties_t<Props...>>,
-  std::enable_if_t<!std::is_trivially_copyable_v<annotated_arg<T, detail::properties_t<Props...>>>>>
-  : is_device_copyable<T> {};
 
 template <typename T, typename... Props>
 class __SYCL_SPECIAL_CLASS

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -27,10 +27,10 @@ namespace sycl {
 // device_copyable trait
 template <typename T, typename PropertyList>
 struct is_device_copyable<
-  ext::oneapi::experimental::annotated_ptr<T, PropertyList>,
-  std::enable_if_t<!std::is_trivially_copyable_v<
-    ext::oneapi::experimental::annotated_ptr<T, PropertyList>>>>
-  : is_device_copyable<T> {};
+    ext::oneapi::experimental::annotated_ptr<T, PropertyList>,
+    std::enable_if_t<!std::is_trivially_copyable_v<
+        ext::oneapi::experimental::annotated_ptr<T, PropertyList>>>>
+    : is_device_copyable<T> {};
 
 inline namespace _V1 {
 namespace ext {

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -28,7 +28,8 @@ namespace sycl {
 template <typename T, typename PropertyList>
 struct is_device_copyable<
   ext::oneapi::experimental::annotated_ptr<T, PropertyList>,
-  std::enable_if_t<!std::is_trivially_copyable_v<ext::oneapi::experimental::annotated_ptr<T, PropertyList>>>>
+  std::enable_if_t<!std::is_trivially_copyable_v<
+    ext::oneapi::experimental::annotated_ptr<T, PropertyList>>>>
   : is_device_copyable<T> {};
 
 inline namespace _V1 {

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -185,6 +185,13 @@ class annotated_ptr {
                 "Property list is invalid.");
 };
 
+// device_copyable trait
+template <typename T, typename... Props>
+struct is_device_copyable<
+  annotated_arg<T, detail::properties_t<Props...>>,
+  std::enable_if_t<!std::is_trivially_copyable_v<annotated_arg<T, detail::properties_t<Props...>>>>>
+  : is_device_copyable<T> {};
+
 template <typename T, typename... Props>
 class __SYCL_SPECIAL_CLASS
 __SYCL_TYPE(annotated_ptr) annotated_ptr<T, detail::properties_t<Props...>> {

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -9,6 +9,14 @@ struct test {
   int *b;
 };
 
+class device_copyable_class {
+  int a;
+  device_copyable_class(const device_copyable_class &other) : a(other.a) {};
+};
+
+template <>
+struct is_device_copyable<device_copyable_class> : std::true_type {};
+
 int main() {
   queue Q;
 
@@ -78,6 +86,12 @@ int main() {
   assert(*c_ptr->b == 5 && "c_ptr[0].b value does not match.");
 
   assert(d_ptr[3] == -1 && "d_ptr[3] value does not match.");
+
+  assert(!std::is_trivially_copyable<device_copyable_class>::value && "device_copyable_class should not be trivially_copyable.");
+  using device_copyable_annotated_arg = annotated_arg<device_copyable_class>;
+  assert(is_device_copyable<device_copyable_annotated_arg>::value && "annotated_arg<device_copyable_class> is not device copyable.");
+  using device_copyable_annotated_arg_with_properties = annotated_arg<device_copyable_class, decltype(properties{conduit})>;
+  assert(is_device_copyable<device_copyable_annotated_arg_with_properties>::value && "annotated_arg<device_copyable_class, properties> is not device copyable.");
 
   free(a, Q);
   free(b, Q);

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -97,7 +97,7 @@ int main() {
   using device_copyable_annotated_arg_with_properties =
       annotated_arg<device_copyable_class, decltype(properties{conduit})>;
   assert(is_device_copyable<
-            device_copyable_annotated_arg_with_properties>::value &&
+             device_copyable_annotated_arg_with_properties>::value &&
          "annotated_arg<device_copyable_class, properties> is not device "
          "copyable.");
 

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -11,10 +11,10 @@ struct test {
 
 class device_copyable_class {
   int a;
-  device_copyable_class(const device_copyable_class &other) : a(other.a) {};
+  device_copyable_class(const device_copyable_class &other) : a(other.a){};
 };
 
-template<>
+template <>
 struct is_device_copyable<device_copyable_class> : std::true_type {};
 
 int main() {
@@ -87,12 +87,19 @@ int main() {
 
   assert(d_ptr[3] == -1 && "d_ptr[3] value does not match.");
 
-  assert(!std::is_trivially_copyable<device_copyable_class>::value && "device_copyable_class must not be trivially_copyable.");
-  assert(is_device_copyable<device_copyable_class>::value && "device_copyable_class is not device copyable.");
+  assert(!std::is_trivially_copyable<device_copyable_class>::value &&
+         "device_copyable_class must not be trivially_copyable.");
+  assert(is_device_copyable<device_copyable_class>::value &&
+         "device_copyable_class is not device copyable.");
   using device_copyable_annotated_arg = annotated_arg<device_copyable_class>;
-  assert(is_device_copyable<device_copyable_annotated_arg>::value && "annotated_arg<device_copyable_class> is not device copyable.");
-  using device_copyable_annotated_arg_with_properties = annotated_arg<device_copyable_class, decltype(properties{conduit})>;
-  assert(is_device_copyable<device_copyable_annotated_arg_with_properties>::value && "annotated_arg<device_copyable_class, properties> is not device copyable.");
+  assert(is_device_copyable<device_copyable_annotated_arg>::value &&
+         "annotated_arg<device_copyable_class> is not device copyable.");
+  using device_copyable_annotated_arg_with_properties =
+      annotated_arg<device_copyable_class, decltype(properties{conduit})>;
+  assert(is_device_copyable<
+            device_copyable_annotated_arg_with_properties>::value &&
+         "annotated_arg<device_copyable_class, properties> is not device "
+         "copyable.");
 
   free(a, Q);
   free(b, Q);

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -14,7 +14,7 @@ class device_copyable_class {
   device_copyable_class(const device_copyable_class &other) : a(other.a) {};
 };
 
-template <>
+template<>
 struct is_device_copyable<device_copyable_class> : std::true_type {};
 
 int main() {
@@ -87,7 +87,8 @@ int main() {
 
   assert(d_ptr[3] == -1 && "d_ptr[3] value does not match.");
 
-  assert(!std::is_trivially_copyable<device_copyable_class>::value && "device_copyable_class should not be trivially_copyable.");
+  assert(!std::is_trivially_copyable<device_copyable_class>::value && "device_copyable_class must not be trivially_copyable.");
+  assert(is_device_copyable<device_copyable_class>::value && "device_copyable_class is not device copyable.");
   using device_copyable_annotated_arg = annotated_arg<device_copyable_class>;
   assert(is_device_copyable<device_copyable_annotated_arg>::value && "annotated_arg<device_copyable_class> is not device copyable.");
   using device_copyable_annotated_arg_with_properties = annotated_arg<device_copyable_class, decltype(properties{conduit})>;


### PR DESCRIPTION
Added device copyable traits for annotated_arg. If the type `T` is device copyable, then the type `annotated_arg<T, ...>` is also device copyable.

For example, consider the following code: 

```c++
#include <sycl/sycl.hpp>
#include <sycl/ext/intel/fpga_extensions.hpp>
#include <sycl/ext/intel/ac_types/ac_fixed.hpp>
#include "ExceptionHandler.h"
#include "TestConfigSelector.h"

using namespace sycl;
using namespace ext::intel::experimental;
using namespace ext::oneapi::experimental;

using ac_fixed_type = ac_fixed<10, 5, true>;

int main() {
    struct MyIP {
        annotated_arg<ac_fixed_type> a;
        void operator()() const {};
    };
    queue q(testconfig_selector_v, &m_exception_handler);
    ac_fixed_type a = 5;
    q.single_task(MyIP{a}).wait();
    return 0;
}
```

This code generates the following static assertion failure without the device copyable trait for `annotated_arg`: 

```
/nfs/site/disks/swbld_rel_hld/r/sycl/trunk/20230620/linux64/bin-llvm/../include/sycl/types.hpp:2385:17: error: static assertion failed due to requirement 'is_device_copyable<sycl::ext::oneapi::experimental::annotated_arg<ac_fixed<10, 5, true, AC_TRN, AC_WRAP>, sycl::ext::oneapi::experimental::properties<std::tuple<>>>, void>::value || detail::IsDeprecatedDeviceCopyable<sycl::ext::oneapi::experimental::annotated_arg<ac_fixed<10, 5, true, AC_TRN, AC_WRAP>, sycl::ext::oneapi::experimental::properties<std::tuple<>>>, void>::value': The specified type is not device copyable                        
 2385 |   static_assert(is_device_copyable<FieldT>::value ||
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2386 |                     detail::IsDeprecatedDeviceCopyable<FieldT>::value,
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```