### PR TITLE
[Clang] Update LIT tests after typo was fixed in 54091d37f28c24fa810adf2914af9299c305dd83

### DIFF
--- a/clang/test/SemaSYCL/device_has_ast.cpp
+++ b/clang/test/SemaSYCL/device_has_ast.cpp
@@ -17,10 +17,10 @@ queue q;
 // CHECK-NEXT: SYCLDeviceHasAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'fp16' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'gpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 [[sycl::device_has(sycl::aspect::fp16, sycl::aspect::gpu)]] void func2() {}
 
 // CHECK: FunctionDecl {{.*}} func3 'void ()'
@@ -43,13 +43,13 @@ template <sycl::aspect Aspect>
 // CHECK-NEXT: SYCLDeviceHasAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 // CHECK-NEXT: FunctionDecl {{.*}} used func5 'void ()'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLDeviceHasAttr {{.*}} Inherited
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 [[sycl::device_has(sycl::aspect::cpu)]] void func5();
 void func5() {}
 

--- a/clang/test/SemaSYCL/uses_aspects_ast.cpp
+++ b/clang/test/SemaSYCL/uses_aspects_ast.cpp
@@ -11,7 +11,7 @@ queue q;
 // CHECK-NEXT: SYCLUsesAspectsAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] void func1() {}
 
 // CHECK: FunctionDecl {{.*}} func2 'void ()'
@@ -19,10 +19,10 @@ queue q;
 // CHECK-NEXT: SYCLUsesAspectsAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'fp16' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'gpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::fp16, sycl::aspect::gpu)]] void func2() {}
 
 // CHECK: FunctionDecl {{.*}} func3 'void ()'
@@ -45,13 +45,13 @@ template <sycl::aspect Aspect>
 // CHECK-NEXT: SYCLUsesAspectsAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 // CHECK-NEXT: FunctionDecl {{.*}} used func5 'void ()'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLUsesAspectsAttr {{.*}} Inherited
 // CHECK-NEXT: DeclRefExpr {{.*}} 'sycl::aspect' EnumConstant {{.*}} 'cpu' 'sycl::aspect'
 // CHECK-NEXT: NestedNameSpecifier TypeSpec 'sycl::aspect'
-// CHECK-NEXT: NestedNameSpecifier NamespaceNamespace {{.*}} 'sycl'
+// CHECK-NEXT: NestedNameSpecifier Namespace {{.*}} 'sycl'
 [[__sycl_detail__::__uses_aspects__(sycl::aspect::cpu)]] void func5();
 void func5() {}
 


### PR DESCRIPTION
Fixes the following LIT tests:

    Clang :: SemaSYCL/device_has_ast.cpp
    Clang :: SemaSYCL/uses_aspects_ast.cpp
