### PR TITLE
[SYCL] Add arithmetic overloaded operators for annotated_arg

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -519,10 +519,10 @@ R operatorOP(const annotated_arg<T2, PropertyList2> &other) const;
 |
 Defines the overloaded operators for types `annotated_arg<T, ...>` and
 `annotated_arg<T2, ...>`. Let `operatorOP` denote the operator used.
-The overloaded operator `operatorOP` utilizes `operatorOP(T2)` of type `T`
-and is available only if `operatorOP(T2)` is valid for objects of type `T`.
-The value and result is the same as the result of `operatorOP(T2)` applied to the
-objects of type `T` and `T2`.
+The overloaded operator `operatorOP` utilizes `operatorOP(T, T2)` and
+is available only if `operatorOP(T, T2)` is well formed. The value and result
+is the same as the result of `operatorOP(T, T2)` applied to the objects of
+type `T` and `T2`.
 
 `operatorOP` is any of the following: `operator+`, `operator-`, `operator*`, `operator/`,
 `operator%`, `operator&`, `operator\|`, `operator^`, `operator>>`, and `operator<<`.
@@ -532,9 +532,8 @@ objects of type `T` and `T2`.
 Free functions of the following form are defined for the overloaded operators for types
 `annotated_arg<T, ...>` and raw type `T2`. Let `operatorOP` denote the operator used.
 The overloaded operator `operatorOP` utilizes `operatorOP(T, T2)` and is available only
-if `operatorOP(T, T2)` is valid for objects of type `T` and `T2`. The value and result
-is the same as the result of `operatorOP(T, T2)` applied to the underlying objects of
-type `T` and `T2`.
+if `operatorOP(T, T2)` is well formed. The value and result is the same as the result of
+`operatorOP(T, T2)` applied to the underlying objects of type `T` and `T2`.
 
 [source,c++]
 ----

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -518,12 +518,33 @@ of type `T` and is available only if `operatorOP(T2)` is valid for objects of ty
 The value and result is the same as the result of `operatorOP(T2)` applied to the
 objects of type `T` and `T2`.
 
+[frame="topbot",options="header"]
+|===
+|Function |Description
+
+a|
 [source,c++]
 ----
 template <typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() OP std::declval<T2>())>
 R operatorOP(const annotated_arg<T2, PropertyList2> &other) const;
 ----
+a|
+
+`operatorOP` can be any of the following:
+
+* `operator+`
+* `operator-`
+* `operator*`
+* `operator/`
+* `operator%`
+* `operator&`
+* `operator\|`
+* `operator^`
+* `operator>>`
+* `operator<<`
+
+|===
 
 Free functions of the following form are defined for the overloaded operators for types
 `annotated_arg<T, ...>` and raw type `T2`. Let `operatorOP` denote the operator used.
@@ -532,6 +553,11 @@ if `operatorOP(T, T2)` is valid for objects of type `T` and `T2`. The value and 
 is the same as the result of `operatorOP(T, T2)` applied to the underlying objects of
 type `T` and `T2`.
 
+[frame="topbot",options="header"]
+|===
+|Function |Description
+
+a|
 [source,c++]
 ----
 template <typename T, typename PropertyList, typename T2,
@@ -541,6 +567,23 @@ template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() OP std::declval<T2>())>
 R operatorOP(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
+a|
+
+`operatorOP` can be any of the following:
+
+* `operator+`
+* `operator-`
+* `operator*`
+* `operator/`
+* `operator%`
+* `operator&`
+* `operator\|`
+* `operator^`
+* `operator>>`
+* `operator<<`
+
+|===
+
 
 == Issues
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -511,270 +511,35 @@ constant property.
 
 |===
 
-The following table describes the overloaded operators for types `annotated_arg<T, ...>`
-and `annotated_arg<T2, ...>`. Let `operatorOP` denote the operator used.
-The overloaded operator `operatorOP` utilizes `operatorOP(T2)` of type `T`
-and is available only if `operatorOP(T2)` is valid for objects of type `T`.
+The following template implements the overloaded operators for types
+`annotated_arg<T, ...>` and `annotated_arg<T2, ...>`. Let `operatorOP` denote
+the operator used. The overloaded operator `operatorOP` utilizes `operatorOP(T2)`
+of type `T` and is available only if `operatorOP(T2)` is valid for objects of type `T`.
 The value and result is the same as the result of `operator+(T2)` applied to the
 objects of type `T` and `T2`.
 
-[frame="topbot",options="header"]
-|===
-|Overloaded Operators
-
-// --- ROW BREAK ---
-a|
 [source,c++]
 ----
 template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() + std::declval<T2>())>
-R operator+(const annotated_arg<T2, PropertyList2> &other) const;
+          typename R = decltype(std::declval<T>() OP std::declval<T2>())>
+R operatorOP(const annotated_arg<T2, PropertyList2> &other) const;
 ----
 
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() - std::declval<T2>())>
-R operator-(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2
-          typename R = decltype(std::declval<T>() * std::declval<T2>())>
-R operator*(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() / std::declval<T2>())>
-R operator/(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() % std::declval<T2>())>
-R operator%(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() & std::declval<T2>())>
-R operator&(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() \| std::declval<T2>())>
-R operator\|(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
-R operator^(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
-R operator>>(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() << std::declval<T2>())>
-R operator<<(const annotated_arg<T2, PropertyList2> &other) const;
-----
-
-|===
-
-The following table describes the overloaded operators for types `annotated_arg<T, ...>`
+The following templates implement the overloaded operators for types `annotated_arg<T, ...>`
 and raw type `T2`. Let `operatorOP` denote the operator used. The overloaded operator
 `operatorOP` utilizes `operatorOP(T, T2)` and is available only if `operatorOP(T, T2)`
 is valid for objects of type `T` and `T2`. The value and result is the same as the result
 of `operator+(T, T2)` applied to the underlying objects of type `T` and `T2`.
 
-[frame="topbot",options="header"]
-|===
-|`annotated_arg<T, ...>` on LHS |`annotated_arg<T2, ...>` on RHS
-
-// --- ROW BREAK ---
-a|
 [source,c++]
 ----
 template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() + std::declval<T2>())>
-R operator+(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
+          typename R = decltype(std::declval<T>() OP std::declval<T2>())>
+R operatorOP(const annotated_arg<T, PropertyList> &a, const T2 &b);
 template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() + std::declval<T2>())>
-R operator+(const T &a, const annotated_arg<T2, PropertyList2> &b);
+          typename R = decltype(std::declval<T>() OP std::declval<T2>())>
+R operatorOP(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() - std::declval<T2>())>
-R operator-(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() - std::declval<T2>())>
-R operator-(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() * std::declval<T2>())>
-R operator*(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() * std::declval<T2>())>
-R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() / std::declval<T2>())>
-R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() / std::declval<T2>())>
-R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() % std::declval<T2>())>
-R operator%(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() % std::declval<T2>())>
-R operator%(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() & std::declval<T2>())>
-R operator&(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() & std::declval<T2>())>
-R operator&(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() \| std::declval<T2>())>
-R operator\|(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() \| std::declval<T2>())>
-R operator\|(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
-R operator^(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
-R operator^(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
-R operator>>(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
-R operator>>(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-// --- ROW BREAK ---
-a|
-[source,c++]
-----
-template <typename T, typename PropertyList, typename T2,
-          typename R = decltype(std::declval<T>() << std::declval<T2>())>
-R operator<<(const annotated_arg<T, PropertyList> &a, const T2 &b);
-a|
-[source,c++]
-----
-template <typename T, typename T2, typename PropertyList2,
-          typename R = decltype(std::declval<T>() << std::declval<T2>())>
-R operator<<(const T &a, const annotated_arg<T2, PropertyList2> &b);
-----
-
-|===
 
 == Issues
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -248,6 +248,30 @@ class annotated_arg {
     template <typename T2, typename PropertyList2,
               typename R = decltype(std::declval<T>() / std::declval<T2>())>
     R operator/(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() % std::declval<T2>())>
+    R operator%(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() & std::declval<T2>())>
+    R operator&(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() | std::declval<T2>())>
+    R operator|(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+    R operator^(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+    R operator>>(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() << std::declval<T2>())>
+    R operator<<(const annotated_arg<T2, PropertyList2> &other) const;
 };
 
 //Deduction guides
@@ -276,6 +300,30 @@ template <typename T, typename PropertyList, typename T2,
           typename R = decltype(std::declval<T>() / std::declval<T2>())>
 R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b);
 
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() | std::declval<T2>())>
+R operator|(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() + std::declval<T2>())>
 R operator+(const T &a, const annotated_arg<T2, PropertyList2> &b);
@@ -291,6 +339,31 @@ R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b);
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() / std::declval<T2>())>
 R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() | std::declval<T2>())>
+R operator|(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
 } // namespace sycl::ext::oneapi::experimental
 ----
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -436,6 +436,19 @@ a compile error if `PropertyListT` does not contain a property with the
 Available only if `propertyT` is the property key class of a compile-time
 constant property.
 
+|===
+
+The following table describes the overloaded operators for types `annotated_arg<T, ...>`
+and `annotated_arg<T2, ...>`. Let `operatorOP` denote the operator used.
+The overloaded operator `operatorOP` utilizes `operatorOP(T2)` of type `T`
+and is available only if `operatorOP(T2)` is valid for objects of type `T`.
+The value and result is the same as the result of `operator+(T2)` applied to the
+objects of type `T` and `T2`.
+
+[frame="topbot",options="header"]
+|===
+|Overloaded Operators
+
 // --- ROW BREAK ---
 a|
 [source,c++]
@@ -444,12 +457,6 @@ template <typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() + std::declval<T2>())>
 R operator+(const annotated_arg<T2, PropertyList2> &other) const;
 ----
-|
-Overloaded `operator+` that utilizes `operator+(T2)` of type `T`.
-
-Available only if `operator+(T2)` is valid for objects of type `T`.
-The value and type of the result is the same as the result of `operator+(T2)`
-applied to the underlying objects of type `T` and `T2`.
 
 // --- ROW BREAK ---
 a|
@@ -459,12 +466,6 @@ template <typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() - std::declval<T2>())>
 R operator-(const annotated_arg<T2, PropertyList2> &other) const;
 ----
-|
-Overloaded `operator-` that utilizes `operator-(T2)` of type `T`.
-
-Available only if `operator-(T2)` is valid for objects of type `T`.
-The value and type of the result is the same as the result of `operator-(T2)`
-applied to the underlying objects of type `T` and `T2`.
 
 // --- ROW BREAK ---
 a|
@@ -474,12 +475,6 @@ template <typename T2, typename PropertyList2
           typename R = decltype(std::declval<T>() * std::declval<T2>())>
 R operator*(const annotated_arg<T2, PropertyList2> &other) const;
 ----
-|
-Overloaded `operator*` that utilizes `operator*(T2)` of type `T`.
-
-Available only if `operator*(T2)` is valid for objects of type `T`.
-The value and type of the result is the same as the result of `operator*(T2)`
-applied to the underlying objects of type `T` and `T2`.
 
 // --- ROW BREAK ---
 a|
@@ -489,21 +484,72 @@ template <typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() / std::declval<T2>())>
 R operator/(const annotated_arg<T2, PropertyList2> &other) const;
 ----
-|
-Overloaded `operator/` that utilizes `operator/(T2)` of type `T`.
 
-Available only if `operator/(T2)` is valid for objects of type `T`.
-The value and type of the result is the same as the result of `operator/(T2)`
-applied to the underlying objects of type `T` and `T2`.
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const annotated_arg<T2, PropertyList2> &other) const;
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const annotated_arg<T2, PropertyList2> &other) const;
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() \| std::declval<T2>())>
+R operator\|(const annotated_arg<T2, PropertyList2> &other) const;
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const annotated_arg<T2, PropertyList2> &other) const;
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const annotated_arg<T2, PropertyList2> &other) const;
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const annotated_arg<T2, PropertyList2> &other) const;
+----
 
 |===
 
-The following table describes the additional free functions that are added
-by this extension:
+The following table describes the overloaded operators for types `annotated_arg<T, ...>`
+and raw type `T2`. Let `operatorOP` denote the operator used. The overloaded operator
+`operatorOP` utilizes `operatorOP(T, T2)` and is available only if `operatorOP(T, T2)`
+is valid for objects of type `T` and `T2`. The value and result is the same as the result
+of `operator+(T, T2)` applied to the underlying objects of type `T` and `T2`.
 
 [frame="topbot",options="header"]
 |===
-|Functions |Description
+|`annotated_arg<T, ...>` on LHS |`annotated_arg<T2, ...>` on RHS
 
 // --- ROW BREAK ---
 a|
@@ -512,18 +558,13 @@ a|
 template <typename T, typename PropertyList, typename T2,
           typename R = decltype(std::declval<T>() + std::declval<T2>())>
 R operator+(const annotated_arg<T, PropertyList> &a, const T2 &b);
-
+a|
+[source,c++]
+----
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() + std::declval<T2>())>
 R operator+(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
-|
-Overloaded `operator+` for annotated_arg and raw type objects that utilizes
-`operator+(T, T2)`.
-
-Available only if `operator+(T, T2)` is valid for objects of type `T` and `T2`.
-The value and type of the result is the same as the result of `operator+(T, T2)`
-applied to the underlying objects of type `T` and `T2`.
 
 // --- ROW BREAK ---
 a|
@@ -532,18 +573,13 @@ a|
 template <typename T, typename PropertyList, typename T2,
           typename R = decltype(std::declval<T>() - std::declval<T2>())>
 R operator-(const annotated_arg<T, PropertyList> &a, const T2 &b);
-
+a|
+[source,c++]
+----
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() - std::declval<T2>())>
 R operator-(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
-|
-Overloaded `operator-` for annotated_arg and raw type objects that utilizes
-`operator-(T, T2)`.
-
-Available only if `operator-(T, T2)` is valid for objects of type `T` and `T2`.
-The value and type of the result is the same as the result of `operator-(T, T2)`
-applied to the underlying objects of type `T` and `T2`.
 
 // --- ROW BREAK ---
 a|
@@ -552,18 +588,13 @@ a|
 template <typename T, typename PropertyList, typename T2,
           typename R = decltype(std::declval<T>() * std::declval<T2>())>
 R operator*(const annotated_arg<T, PropertyList> &a, const T2 &b);
-
+a|
+[source,c++]
+----
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() * std::declval<T2>())>
 R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
-|
-Overloaded `operator*` for annotated_arg and raw type objects that utilizes
-`operator*(T, T2)`.
-
-Available only if `operator*(T, T2)` is valid for objects of type `T` and `T2`.
-The value and type of the result is the same as the result of `operator*(T, T2)`
-applied to the underlying objects of type `T` and `T2`.
 
 // --- ROW BREAK ---
 a|
@@ -572,18 +603,103 @@ a|
 template <typename T, typename PropertyList, typename T2,
           typename R = decltype(std::declval<T>() / std::declval<T2>())>
 R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b);
-
+a|
+[source,c++]
+----
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() / std::declval<T2>())>
 R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
-|
-Overloaded `operator/` for annotated_arg and raw type objects that utilizes
-`operator/(T, T2)`.
 
-Available only if `operator/(T, T2)` is valid for objects of type `T` and `T2`.
-The value and type of the result is the same as the result of `operator/(T, T2)`
-applied to the underlying objects of type `T` and `T2`.
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const annotated_arg<T, PropertyList> &a, const T2 &b);
+a|
+[source,c++]
+----
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const annotated_arg<T, PropertyList> &a, const T2 &b);
+a|
+[source,c++]
+----
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() \| std::declval<T2>())>
+R operator\|(const annotated_arg<T, PropertyList> &a, const T2 &b);
+a|
+[source,c++]
+----
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() \| std::declval<T2>())>
+R operator\|(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const annotated_arg<T, PropertyList> &a, const T2 &b);
+a|
+[source,c++]
+----
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const annotated_arg<T, PropertyList> &a, const T2 &b);
+a|
+[source,c++]
+----
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const annotated_arg<T, PropertyList> &a, const T2 &b);
+a|
+[source,c++]
+----
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
 
 |===
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -231,6 +231,23 @@ class annotated_arg {
     // instances of propertyT
     template<typename propertyT>
     static constexpr /*unspecified*/ get_property();
+
+    // Overloaded arithmetic operators
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() + std::declval<T2>())>
+    R operator+(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() - std::declval<T2>())>
+    R operator-(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() * std::declval<T2>())>
+    R operator*(const annotated_arg<T2, PropertyList2> &other) const;
+
+    template <typename T2, typename PropertyList2,
+              typename R = decltype(std::declval<T>() / std::declval<T2>())>
+    R operator/(const annotated_arg<T2, PropertyList2> &other) const;
 };
 
 //Deduction guides
@@ -241,8 +258,43 @@ annotated_arg(T, PropertyValueTs... values) ->
 template <typename T, typename PropertiesA, typename PropertiesB>
 annotated_arg(annotated_arg<T, PropertiesA>, PropertiesB>) ->
     annotated_arg<T, /* a type that combines the properties of PropertiesA and PropertiesB */>;
+
+// Overloaded operators for raw type
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b);
 } // namespace sycl::ext::oneapi::experimental
 ----
+
+The following table describes the member functions of the `annotated_arg` class:
 
 [frame="topbot",options="header"]
 |===
@@ -383,6 +435,155 @@ a compile error if `PropertyListT` does not contain a property with the
 
 Available only if `propertyT` is the property key class of a compile-time
 constant property.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const annotated_arg<T2, PropertyList2> &other) const;
+----
+|
+Overloaded `operator+` that utilizes `operator+(T2)` of type `T`.
+
+Available only if `operator+(T2)` is valid for objects of type `T`.
+The value and type of the result is the same as the result of `operator+(T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const annotated_arg<T2, PropertyList2> &other) const;
+----
+|
+Overloaded `operator-` that utilizes `operator-(T2)` of type `T`.
+
+Available only if `operator-(T2)` is valid for objects of type `T`.
+The value and type of the result is the same as the result of `operator-(T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const annotated_arg<T2, PropertyList2> &other) const;
+----
+|
+Overloaded `operator*` that utilizes `operator*(T2)` of type `T`.
+
+Available only if `operator*(T2)` is valid for objects of type `T`.
+The value and type of the result is the same as the result of `operator*(T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+R operator/(const annotated_arg<T2, PropertyList2> &other) const;
+----
+|
+Overloaded `operator/` that utilizes `operator/(T2)` of type `T`.
+
+Available only if `operator/(T2)` is valid for objects of type `T`.
+The value and type of the result is the same as the result of `operator/(T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+|===
+
+The following table describes the additional free functions that are added
+by this extension:
+
+[frame="topbot",options="header"]
+|===
+|Functions |Description
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+|
+Overloaded `operator+` for annotated_arg and raw type objects that utilizes
+`operator+(T, T2)`.
+
+Available only if `operator+(T, T2)` is valid for objects of type `T` and `T2`.
+The value and type of the result is the same as the result of `operator+(T, T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+|
+Overloaded `operator-` for annotated_arg and raw type objects that utilizes
+`operator-(T, T2)`.
+
+Available only if `operator-(T, T2)` is valid for objects of type `T` and `T2`.
+The value and type of the result is the same as the result of `operator-(T, T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+|
+Overloaded `operator*` for annotated_arg and raw type objects that utilizes
+`operator*(T, T2)`.
+
+Available only if `operator*(T, T2)` is valid for objects of type `T` and `T2`.
+The value and type of the result is the same as the result of `operator*(T, T2)`
+applied to the underlying objects of type `T` and `T2`.
+
+// --- ROW BREAK ---
+a|
+[source,c++]
+----
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b);
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b);
+----
+|
+Overloaded `operator/` for annotated_arg and raw type objects that utilizes
+`operator/(T, T2)`.
+
+Available only if `operator/(T, T2)` is valid for objects of type `T` and `T2`.
+The value and type of the result is the same as the result of `operator/(T, T2)`
+applied to the underlying objects of type `T` and `T2`.
 
 |===
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -509,19 +509,6 @@ a compile error if `PropertyListT` does not contain a property with the
 Available only if `propertyT` is the property key class of a compile-time
 constant property.
 
-|===
-
-Free functions of the following form are defined for the overloaded operators for
-types `annotated_arg<T, ...>` and `annotated_arg<T2, ...>`. Let `operatorOP` denote
-the operator used. The overloaded operator `operatorOP` utilizes `operatorOP(T2)`
-of type `T` and is available only if `operatorOP(T2)` is valid for objects of type `T`.
-The value and result is the same as the result of `operatorOP(T2)` applied to the
-objects of type `T` and `T2`.
-
-[frame="topbot",options="header"]
-|===
-|Function |Description
-
 a|
 [source,c++]
 ----
@@ -529,20 +516,16 @@ template <typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() OP std::declval<T2>())>
 R operatorOP(const annotated_arg<T2, PropertyList2> &other) const;
 ----
-a|
+|
+Defines the overloaded operators for types `annotated_arg<T, ...>` and
+`annotated_arg<T2, ...>`. Let `operatorOP` denote the operator used.
+The overloaded operator `operatorOP` utilizes `operatorOP(T2)` of type `T`
+and is available only if `operatorOP(T2)` is valid for objects of type `T`.
+The value and result is the same as the result of `operatorOP(T2)` applied to the
+objects of type `T` and `T2`.
 
-`operatorOP` can be any of the following:
-
-* `operator+`
-* `operator-`
-* `operator*`
-* `operator/`
-* `operator%`
-* `operator&`
-* `operator\|`
-* `operator^`
-* `operator>>`
-* `operator<<`
+`operatorOP` is any of the following: `operator+`, `operator-`, `operator*`, `operator/`,
+`operator%`, `operator&`, `operator\|`, `operator^`, `operator>>`, and `operator<<`.
 
 |===
 
@@ -553,11 +536,6 @@ if `operatorOP(T, T2)` is valid for objects of type `T` and `T2`. The value and 
 is the same as the result of `operatorOP(T, T2)` applied to the underlying objects of
 type `T` and `T2`.
 
-[frame="topbot",options="header"]
-|===
-|Function |Description
-
-a|
 [source,c++]
 ----
 template <typename T, typename PropertyList, typename T2,
@@ -567,23 +545,9 @@ template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() OP std::declval<T2>())>
 R operatorOP(const T &a, const annotated_arg<T2, PropertyList2> &b);
 ----
-a|
 
-`operatorOP` can be any of the following:
-
-* `operator+`
-* `operator-`
-* `operator*`
-* `operator/`
-* `operator%`
-* `operator&`
-* `operator\|`
-* `operator^`
-* `operator>>`
-* `operator<<`
-
-|===
-
+`operatorOP` is any of the following: `operator+`, `operator-`, `operator*`, `operator/`,
+`operator%`, `operator&`, `operator\|`, `operator^`, `operator>>`, and `operator<<`.
 
 == Issues
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -511,11 +511,11 @@ constant property.
 
 |===
 
-The following template implements the overloaded operators for types
-`annotated_arg<T, ...>` and `annotated_arg<T2, ...>`. Let `operatorOP` denote
+Free functions of the following form are defined for the overloaded operators for
+types `annotated_arg<T, ...>` and `annotated_arg<T2, ...>`. Let `operatorOP` denote
 the operator used. The overloaded operator `operatorOP` utilizes `operatorOP(T2)`
 of type `T` and is available only if `operatorOP(T2)` is valid for objects of type `T`.
-The value and result is the same as the result of `operator+(T2)` applied to the
+The value and result is the same as the result of `operatorOP(T2)` applied to the
 objects of type `T` and `T2`.
 
 [source,c++]
@@ -525,11 +525,12 @@ template <typename T2, typename PropertyList2,
 R operatorOP(const annotated_arg<T2, PropertyList2> &other) const;
 ----
 
-The following templates implement the overloaded operators for types `annotated_arg<T, ...>`
-and raw type `T2`. Let `operatorOP` denote the operator used. The overloaded operator
-`operatorOP` utilizes `operatorOP(T, T2)` and is available only if `operatorOP(T, T2)`
-is valid for objects of type `T` and `T2`. The value and result is the same as the result
-of `operator+(T, T2)` applied to the underlying objects of type `T` and `T2`.
+Free functions of the following form are defined for the overloaded operators for types
+`annotated_arg<T, ...>` and raw type `T2`. Let `operatorOP` denote the operator used.
+The overloaded operator `operatorOP` utilizes `operatorOP(T, T2)` and is available only
+if `operatorOP(T, T2)` is valid for objects of type `T` and `T2`. The value and result
+is the same as the result of `operatorOP(T, T2)` applied to the underlying objects of
+type `T` and `T2`.
 
 [source,c++]
 ----

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -307,10 +307,45 @@ public:
   R operator/(const annotated_arg<T2, PropertyList2> &other) const {
     return obj / other.obj;
   }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() % std::declval<T2>())>
+  R operator%(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj % other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() & std::declval<T2>())>
+  R operator&(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj & other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() | std::declval<T2>())>
+  R operator|(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj | other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+  R operator^(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj ^ other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+  R operator>>(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj >> other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() << std::declval<T2>())>
+  R operator<<(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj << other.obj;
+  }
 };
 
 template <typename T, typename PropertyList, typename T2,
-
           typename R = decltype(std::declval<T>() + std::declval<T2>())>
 R operator+(const annotated_arg<T, PropertyList> &a, const T2 &b) {
   T a1 = a;
@@ -336,6 +371,48 @@ template <typename T, typename PropertyList, typename T2,
 R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b) {
   T a1 = a;
   return a1 / b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 % b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 & b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() | std::declval<T2>())>
+R operator|(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 | b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 ^ b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 >> b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 << b;
 }
 
 template <typename T, typename T2, typename PropertyList2,
@@ -364,6 +441,48 @@ template <typename T, typename T2, typename PropertyList2,
   R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b) {
   T2 b1 = b;
   return a / b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() % std::declval<T2>())>
+R operator%(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a % b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() & std::declval<T2>())>
+R operator&(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a & b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() | std::declval<T2>())>
+R operator|(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a | b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() ^ std::declval<T2>())>
+R operator^(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a ^ b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() >> std::declval<T2>())>
+R operator>>(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a >> b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() << std::declval<T2>())>
+R operator<<(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a << b1;
 }
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -438,7 +438,7 @@ R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b) {
 
 template <typename T, typename T2, typename PropertyList2,
           typename R = decltype(std::declval<T>() / std::declval<T2>())>
-  R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b) {
   T2 b1 = b;
   return a / b1;
 }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -283,7 +283,88 @@ public:
   template <typename PropertyT> static constexpr auto get_property() {
     return property_list_t::template get_property<PropertyT>();
   }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() + std::declval<T2>())>
+  R operator+(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj + other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() - std::declval<T2>())>
+  R operator-(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj - other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() * std::declval<T2>())>
+  R operator*(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj * other.obj;
+  }
+
+  template <typename T2, typename PropertyList2,
+            typename R = decltype(std::declval<T>() / std::declval<T2>())>
+  R operator/(const annotated_arg<T2, PropertyList2> &other) const {
+    return obj / other.obj;
+  }
 };
+
+template <typename T, typename PropertyList, typename T2,
+
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 + b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 - b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 * b;
+}
+
+template <typename T, typename PropertyList, typename T2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+R operator/(const annotated_arg<T, PropertyList> &a, const T2 &b) {
+  T a1 = a;
+  return a1 / b;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() + std::declval<T2>())>
+R operator+(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a + b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() - std::declval<T2>())>
+R operator-(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a - b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() * std::declval<T2>())>
+R operator*(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a * b1;
+}
+
+template <typename T, typename T2, typename PropertyList2,
+          typename R = decltype(std::declval<T>() / std::declval<T2>())>
+  R operator/(const T &a, const annotated_arg<T2, PropertyList2> &b) {
+  T2 b1 = b;
+  return a / b1;
+}
 
 } // namespace experimental
 } // namespace oneapi

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: gpu
+// REQUIRES: accelerator
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -1,3 +1,5 @@
+// UNSUPPORTED: gpu
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -108,8 +108,10 @@ int main() {
   auto *r3 = malloc_shared<MyStruct<int>>(5, Q);
 
   // testing logical overloaded operators
-  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> m = MyStruct(true);
-  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> n = MyStruct(false);
+  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> m =
+      MyStruct(true);
+  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> n =
+      MyStruct(false);
 
   auto *r4 = malloc_shared<MyStruct<bool>>(3, Q);
   auto *r5 = malloc_shared<MyStruct<bool>>(3, Q);

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -29,17 +29,50 @@ template <typename T>
 MyStruct<T> operator+(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
   return MyStruct<T>(lhs.data + rhs.data);
 }
+
 template <typename T>
 MyStruct<T> operator-(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
   return MyStruct<T>(lhs.data - rhs.data);
 }
+
 template <typename T>
 MyStruct<T> operator*(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
   return MyStruct<T>(lhs.data * rhs.data);
 }
+
 template <typename T>
 MyStruct<T> operator/(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
   return MyStruct<T>(lhs.data / rhs.data);
+}
+
+template <typename T>
+MyStruct<T> operator%(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data % rhs.data);
+}
+
+template <typename T>
+MyStruct<T> operator&(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data & rhs.data);
+}
+
+template <typename T>
+MyStruct<T> operator|(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data | rhs.data);
+}
+
+template <typename T>
+MyStruct<T> operator^(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data ^ rhs.data);
+}
+
+template <typename T>
+MyStruct<T> operator>>(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data >> rhs.data);
+}
+
+template <typename T>
+MyStruct<T> operator<<(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data << rhs.data);
 }
 
 int main() {
@@ -64,6 +97,7 @@ int main() {
   for (int i = 0; i < 4; i++)
     d_ptr[i] = i;
 
+  // testing arithmetic overloaded operators
   annotated_arg<MyStruct<int>, decltype(properties{conduit})> e = MyStruct(5);
   annotated_arg<MyStruct<int>, decltype(properties{conduit})> f = MyStruct(6);
   annotated_arg<MyStruct<int>, decltype(properties{conduit})> g = MyStruct(3);
@@ -72,6 +106,23 @@ int main() {
   auto *r1 = malloc_shared<MyStruct<int>>(4, Q);
   auto *r2 = malloc_shared<MyStruct<int>>(4, Q);
   auto *r3 = malloc_shared<MyStruct<int>>(4, Q);
+
+  // testing logical overloaded operators
+  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> m = MyStruct(true);
+  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> n = MyStruct(false);
+
+  auto *r4 = malloc_shared<MyStruct<bool>>(3, Q);
+  auto *r5 = malloc_shared<MyStruct<bool>>(3, Q);
+  auto *r6 = malloc_shared<MyStruct<bool>>(3, Q);
+
+  // testing bit shift overloaded operators
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> x = MyStruct(1);
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> y = MyStruct(2);
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> z = MyStruct(4);
+
+  auto *r7 = malloc_shared<MyStruct<int>>(2, Q);
+  auto *r8 = malloc_shared<MyStruct<int>>(2, Q);
+  auto *r9 = malloc_shared<MyStruct<int>>(2, Q);
 
   Q.single_task([=]() {
      a_ptr[0] += 1;
@@ -117,6 +168,27 @@ int main() {
      r3[1] = MyStruct(7) - f;
      r3[2] = MyStruct(2) * g;
      r3[3] = MyStruct(9) / g;
+
+     r4[0] = m & n;
+     r4[1] = m | n;
+     r4[2] = m ^ n;
+
+     r5[0] = m & MyStruct(true);
+     r5[1] = n | MyStruct(false);
+     r5[2] = m ^ MyStruct(true);
+
+     r6[0] = MyStruct(false) & n;
+     r6[1] = MyStruct(false) | m;
+     r6[2] = MyStruct(true) ^ n;
+
+     r7[0] = z >> y;
+     r7[1] = y << x;
+
+     r8[0] = z >> MyStruct(1);
+     r8[1] = x << MyStruct(3);
+
+     r9[0] = MyStruct(8) >> y;
+     r9[1] = MyStruct(2) << x;
    }).wait();
 
   assert(a_ptr[0] == -1 && "a_ptr[0] value does not match.");
@@ -151,6 +223,27 @@ int main() {
   assert(r3[2].data == 6 && "r3[2] value does not match.");
   assert(r3[3].data == 3 && "r3[3] value does not match.");
 
+  assert(r4[0].data == false && "r4[0] value does not match.");
+  assert(r4[1].data == true && "r4[1] value does not match.");
+  assert(r4[2].data == true && "r4[2] value does not match.");
+
+  assert(r5[0].data == true && "r5[0] value does not match.");
+  assert(r5[1].data == false && "r5[1] value does not match.");
+  assert(r5[2].data == false && "r5[2] value does not match.");
+
+  assert(r6[0].data == false && "r6[0] value does not match.");
+  assert(r6[1].data == true && "r6[1] value does not match.");
+  assert(r6[2].data == true && "r6[2] value does not match.");
+
+  assert(r7[0].data == 1 && "r7[0] value does not match.");
+  assert(r7[1].data == 4 && "r7[1] value does not match.");
+
+  assert(r8[0].data == 2 && "r8[0] value does not match.");
+  assert(r8[1].data == 8 && "r8[1] value does not match.");
+
+  assert(r9[0].data == 2 && "r9[0] value does not match.");
+  assert(r9[1].data == 4 && "r9[1] value does not match.");
+
   assert(!std::is_trivially_copyable<device_copyable_class>::value &&
          "device_copyable_class must not be trivially_copyable.");
   assert(is_device_copyable<device_copyable_class>::value &&
@@ -173,6 +266,12 @@ int main() {
   free(r1, Q);
   free(r2, Q);
   free(r3, Q);
+  free(r4, Q);
+  free(r5, Q);
+  free(r6, Q);
+  free(r7, Q);
+  free(r8, Q);
+  free(r9, Q);
 
   return 0;
 }

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -103,9 +103,9 @@ int main() {
   annotated_arg<MyStruct<int>, decltype(properties{conduit})> g = MyStruct(3);
   annotated_arg<MyStruct<int>, decltype(properties{conduit})> h = MyStruct(2);
 
-  auto *r1 = malloc_shared<MyStruct<int>>(4, Q);
-  auto *r2 = malloc_shared<MyStruct<int>>(4, Q);
-  auto *r3 = malloc_shared<MyStruct<int>>(4, Q);
+  auto *r1 = malloc_shared<MyStruct<int>>(5, Q);
+  auto *r2 = malloc_shared<MyStruct<int>>(5, Q);
+  auto *r3 = malloc_shared<MyStruct<int>>(5, Q);
 
   // testing logical overloaded operators
   annotated_arg<MyStruct<bool>, decltype(properties{conduit})> m = MyStruct(true);
@@ -158,16 +158,19 @@ int main() {
      r1[1] = e - g;
      r1[2] = g * h;
      r1[3] = f / h;
+     r1[4] = e % g;
 
      r2[0] = e + MyStruct(3);
      r2[1] = f - MyStruct(5);
      r2[2] = g * MyStruct(2);
      r2[3] = f / MyStruct(3);
+     r2[4] = f % MyStruct(4);
 
      r3[0] = MyStruct(3) + e;
      r3[1] = MyStruct(7) - f;
      r3[2] = MyStruct(2) * g;
      r3[3] = MyStruct(9) / g;
+     r3[4] = MyStruct(9) % f;
 
      r4[0] = m & n;
      r4[1] = m | n;
@@ -212,16 +215,19 @@ int main() {
   assert(r1[1].data == 2 && "r1[1] value does not match.");
   assert(r1[2].data == 6 && "r1[2] value does not match.");
   assert(r1[3].data == 3 && "r1[3] value does not match.");
+  assert(r1[4].data == 2 && "r1[4] value does not match.");
 
   assert(r2[0].data == 8 && "r2[0] value does not match.");
   assert(r2[1].data == 1 && "r2[1] value does not match.");
   assert(r2[2].data == 6 && "r2[2] value does not match.");
   assert(r2[3].data == 2 && "r2[3] value does not match.");
+  assert(r2[4].data == 2 && "r2[4] value does not match.");
 
   assert(r3[0].data == 8 && "r3[0] value does not match.");
   assert(r3[1].data == 1 && "r3[1] value does not match.");
   assert(r3[2].data == 6 && "r3[2] value does not match.");
   assert(r3[3].data == 3 && "r3[3] value does not match.");
+  assert(r3[4].data == 3 && "r3[4] value does not match.");
 
   assert(r4[0].data == false && "r4[0] value does not match.");
   assert(r4[1].data == true && "r4[1] value does not match.");

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -26,52 +26,52 @@ template <typename T> struct MyStruct {
 };
 
 template <typename T>
-MyStruct<T> operator+(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator+(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data + rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator-(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator-(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data - rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator*(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator*(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data * rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator/(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator/(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data / rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator%(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator%(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data % rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator&(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator&(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data & rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator|(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator|(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data | rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator^(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator^(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data ^ rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator>>(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator>>(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data >> rhs.data);
 }
 
 template <typename T>
-MyStruct<T> operator<<(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+MyStruct<T> operator<<(const MyStruct<T> &lhs, const MyStruct<T> &rhs) {
   return MyStruct<T>(lhs.data << rhs.data);
 }
 

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -19,6 +19,29 @@ class device_copyable_class {
 template <>
 struct is_device_copyable<device_copyable_class> : std::true_type {};
 
+template <typename T> struct MyStruct {
+  T data;
+  MyStruct(){};
+  MyStruct(T data) : data(data){};
+};
+
+template <typename T>
+MyStruct<T> operator+(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data + rhs.data);
+}
+template <typename T>
+MyStruct<T> operator-(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data - rhs.data);
+}
+template <typename T>
+MyStruct<T> operator*(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data * rhs.data);
+}
+template <typename T>
+MyStruct<T> operator/(const MyStruct<T> &lhs, const MyStruct<int> &rhs) {
+  return MyStruct<T>(lhs.data / rhs.data);
+}
+
 int main() {
   queue Q;
 
@@ -40,6 +63,15 @@ int main() {
   auto d_ptr = annotated_arg{d};
   for (int i = 0; i < 4; i++)
     d_ptr[i] = i;
+
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> e = MyStruct(5);
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> f = MyStruct(6);
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> g = MyStruct(3);
+  annotated_arg<MyStruct<int>, decltype(properties{conduit})> h = MyStruct(2);
+
+  auto *r1 = malloc_shared<MyStruct<int>>(4, Q);
+  auto *r2 = malloc_shared<MyStruct<int>>(4, Q);
+  auto *r3 = malloc_shared<MyStruct<int>>(4, Q);
 
   Q.single_task([=]() {
      a_ptr[0] += 1;
@@ -70,6 +102,21 @@ int main() {
      };
 
      func(d_ptr[0], d_ptr[1], d_ptr[2], &d_ptr[3]);
+
+     r1[0] = e + h;
+     r1[1] = e - g;
+     r1[2] = g * h;
+     r1[3] = f / h;
+
+     r2[0] = e + MyStruct(3);
+     r2[1] = f - MyStruct(5);
+     r2[2] = g * MyStruct(2);
+     r2[3] = f / MyStruct(3);
+
+     r3[0] = MyStruct(3) + e;
+     r3[1] = MyStruct(7) - f;
+     r3[2] = MyStruct(2) * g;
+     r3[3] = MyStruct(9) / g;
    }).wait();
 
   assert(a_ptr[0] == -1 && "a_ptr[0] value does not match.");
@@ -88,6 +135,21 @@ int main() {
   assert(*c_ptr->b == 5 && "c_ptr[0].b value does not match.");
 
   assert(d_ptr[3] == -1 && "d_ptr[3] value does not match.");
+
+  assert(r1[0].data == 7 && "r1[0] value does not match.");
+  assert(r1[1].data == 2 && "r1[1] value does not match.");
+  assert(r1[2].data == 6 && "r1[2] value does not match.");
+  assert(r1[3].data == 3 && "r1[3] value does not match.");
+
+  assert(r2[0].data == 8 && "r2[0] value does not match.");
+  assert(r2[1].data == 1 && "r2[1] value does not match.");
+  assert(r2[2].data == 6 && "r2[2] value does not match.");
+  assert(r2[3].data == 2 && "r2[3] value does not match.");
+
+  assert(r3[0].data == 8 && "r3[0] value does not match.");
+  assert(r3[1].data == 1 && "r3[1] value does not match.");
+  assert(r3[2].data == 6 && "r3[2] value does not match.");
+  assert(r3[3].data == 3 && "r3[3] value does not match.");
 
   assert(!std::is_trivially_copyable<device_copyable_class>::value &&
          "device_copyable_class must not be trivially_copyable.");
@@ -108,6 +170,9 @@ int main() {
   free(c->b, Q);
   free(c, Q);
   free(d, Q);
+  free(r1, Q);
+  free(r2, Q);
+  free(r3, Q);
 
   return 0;
 }


### PR DESCRIPTION
Adding arithmetic overloaded operators for annotated_arg.

The motivation for adding these is to improve user experience when templating `annotated_arg` with other templated classes that support arithmetic operators. Example, without this change. the following SYCL code results in errors:
```c++
// Some class that has arithmetic operators as member functions.
template<int W, bool S>
class ac_int;

struct MyKernel {
annotated_arg<ac_int<5, true>, ...> arg_a;
annotated_arg<ac_int<5, true>, ...> arg_b;
annotated_arg<ac_int<5, true>*, ...> arg_c;
void operator()() const {
  *arg_c = arg_a + arg_b; // error!
}
};
```
After this change, the above code will not result in errors as the new operators will kick in and invoke the add operator from `ac_int`.
Alternatively, we considered what if we direct users to create free floating operators for such cases. Eg, if we had:
```c++
template<...>
...   operator+(ac_int<...> a, ac_int<...> b) { ... }
```
This style still doesn't despite `annotated_arg` having an implicit conversion operator (due to some C++ rules about implicit conversion I think):
https://godbolt.org/z/h5cTTr17K

We are adding these generic operators here so that users do not have to create these operators themselves.