### PR TITLE
[SYCL] Add more cleanup points close to the shutdown

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -52,8 +52,8 @@ public:
     if (!MModifyCounter)
       return;
 
-    MCounter--;
     LockGuard Guard(GlobalHandler::MSyclGlobalHandlerProtector);
+    MCounter--;
     GlobalHandler *RTGlobalObjHandler = GlobalHandler::getInstancePtr();
     if (RTGlobalObjHandler) {
       RTGlobalObjHandler->prepareSchedulerToRelease(!MCounter);

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -79,7 +79,7 @@ public:
   void unloadPlugins();
   void releaseDefaultContexts();
   void drainThreadPool();
-  void prepareSchedulerToRelease();
+  void prepareSchedulerToRelease(bool Blocking);
 
   void InitXPTI();
   void TraceEventXPTI(const char *Message);

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -401,13 +401,13 @@ Scheduler::Scheduler() {
 
 Scheduler::~Scheduler() { DefaultHostQueue.reset(); }
 
-void Scheduler::releaseResources() {
+void Scheduler::releaseResources(BlockingT Blocking) {
   //  There might be some commands scheduled for post enqueue cleanup that
   //  haven't been freed because of the graph mutex being locked at the time,
   //  clean them up now.
   cleanupCommands({});
 
-  cleanupAuxiliaryResources(BlockingT::BLOCKING);
+  cleanupAuxiliaryResources(Blocking);
   // We need loop since sometimes we may need new objects to be added to
   // deferred mem objects storage during cleanup. Known example is: we cleanup
   // existing deferred mem objects under write lock, during this process we
@@ -416,7 +416,7 @@ void Scheduler::releaseResources() {
   // with size only so all confitions for deferred release are satisfied) is
   // added to deferred mem obj storage. So we may end up with leak.
   while (!isDeferredMemObjectsEmpty())
-    cleanupDeferredMemObjects(BlockingT::BLOCKING);
+    cleanupDeferredMemObjects(Blocking);
 }
 
 MemObjRecord *Scheduler::getMemObjRecord(const Requirement *const Req) {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -457,7 +457,7 @@ public:
 
   Scheduler();
   ~Scheduler();
-  void releaseResources();
+  void releaseResources(BlockingT Blocking = BlockingT::BLOCKING);
   bool isDeferredMemObjectsEmpty();
 
   void enqueueCommandForCG(EventImplPtr NewEvent,


### PR DESCRIPTION
Previously we tried to release internal resources only when the last (likely main) thread exits. For multi threaded applications it could be not functional. e.g. threads are closed during module unload and when main thread exits - other threads are still alive. Adding logic to try non blocking release for every thread exit and blocking for the last one.