### PR TITLE
[SYCL][CUDA][Bindless] Add support for normalized channel types

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
@@ -181,9 +181,6 @@ enum class image_channel_type : /* unspecified */ {
   snorm_int16,
   unorm_int8,
   unorm_int16,
-  unorm_short_565,
-  unorm_short_555,
-  unorm_int_101010,
   signed_int8,
   signed_int16,
   signed_int32,
@@ -966,10 +963,19 @@ sampler handle is included in the `sampled_image_handle` as
 
 The returned data will be of templated type `DataT`, which is specified by the 
 user, and should map to the type that the image was created with (a combination 
-of `image_channel_type` and `image_channel_order`). For multi-channel types, the 
-resultant `DataT` should be a `sycl::vec` type. E.g., for a channel order of 
-`image_channel_order::rg` and channel type of `image_channel_type::fp16`, the 
-resultant `DataT` should be `sycl::vec<sycl::half, 2>`.
+of `image_channel_type` and `image_channel_order`). One exception to this are 
+normalized integer channel types which are read back as either 32-bit or 16-bit 
+floating point values.
+
+For multi-channel types, the resultant `DataT` should be a `sycl::vec` type. 
+E.g., for a channel order of `image_channel_order::rg` and channel type of 
+`image_channel_type::fp16`, the resultant `DataT` should be 
+`sycl::vec<sycl::half, 2>`.
+
+An example of reading a normalized channel type with a channel order of 
+`image_channel_order::rg` and channel type of `image_channel_type::unorm_int8`, 
+the user can read the data as a `sycl::vec<float, 2>` or 
+`sycl::vec<sycl::half, 2>`.
 
 It's possible to write to an unsampled image via `write_image` passing the 
 handle of the image to be written to, along with the coordinates to write to and 
@@ -1955,4 +1961,7 @@ These features still need to be handled:
                  - Updated code samples.
 |4.1|2023-07-21| - Made bindless image sampler member names snake-case
 |4.2|2023-08-18| - `write_image` now allows passing of user-defined types
+|4.3|2023-09-08| - Clarify how normalized image formats are read
+                 - Remove support for packed normalized image formats 
+                   (`unorm_short_555`, `unorm_short_565`, `unorm_int_101010`)
 |======================

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/image.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/image.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include <cuda.h>
+#include <map>
+#include <utility>
 
 #include "common.hpp"
 #include "context.hpp"
@@ -52,30 +54,33 @@ ur_result_t urCalculateNumChannels(ur_image_channel_order_t order,
 /// Convert a UR image format to a CUDA image format and
 /// get the pixel size in bytes.
 /// /param image_channel_type is the ur_image_channel_type_t.
+/// /param image_channel_order is the ur_image_channel_order_t.
+///        this is used for normalized channel formats, as CUDA
+///        combines the channel format and order for normalized
+///        channel types.
 /// /param return_cuda_format will be set to the equivalent cuda
-/// format if not nullptr.
-/// /param return_pixel_types_size_bytes will be set to the pixel
-/// byte size if not nullptr.
+///        format if not nullptr.
+/// /param return_pixel_size_bytes will be set to the pixel
+///        byte size if not nullptr.
 ur_result_t
 urToCudaImageChannelFormat(ur_image_channel_type_t image_channel_type,
+                           ur_image_channel_order_t image_channel_order,
                            CUarray_format *return_cuda_format,
-                           size_t *return_pixel_types_size_bytes) {
+                           size_t *return_pixel_size_bytes) {
 
   CUarray_format cuda_format;
-  size_t PixelTypeSizeBytes;
+  size_t pixel_size_bytes = 0;
+  unsigned int num_channels = 0;
+  UR_CHECK_ERROR(urCalculateNumChannels(image_channel_order, &num_channels));
 
   switch (image_channel_type) {
 #define CASE(FROM, TO, SIZE)                                                   \
   case FROM: {                                                                 \
     cuda_format = TO;                                                          \
-    PixelTypeSizeBytes = SIZE;                                                 \
+    pixel_size_bytes = SIZE * num_channels;                                    \
     break;                                                                     \
   }
-// These new formats were brought in in CUDA 11.5
-#if CUDA_VERSION >= 11050
-    CASE(UR_IMAGE_CHANNEL_TYPE_UNORM_INT8, CU_AD_FORMAT_UNORM_INT8X1, 1)
-    CASE(UR_IMAGE_CHANNEL_TYPE_UNORM_INT16, CU_AD_FORMAT_UNORM_INT16X1, 2)
-#endif
+
     CASE(UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT8, CU_AD_FORMAT_UNSIGNED_INT8, 1)
     CASE(UR_IMAGE_CHANNEL_TYPE_SIGNED_INT8, CU_AD_FORMAT_SIGNED_INT8, 1)
     CASE(UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT16, CU_AD_FORMAT_UNSIGNED_INT16, 2)
@@ -84,16 +89,73 @@ urToCudaImageChannelFormat(ur_image_channel_type_t image_channel_type,
     CASE(UR_IMAGE_CHANNEL_TYPE_UNSIGNED_INT32, CU_AD_FORMAT_UNSIGNED_INT32, 4)
     CASE(UR_IMAGE_CHANNEL_TYPE_SIGNED_INT32, CU_AD_FORMAT_SIGNED_INT32, 4)
     CASE(UR_IMAGE_CHANNEL_TYPE_FLOAT, CU_AD_FORMAT_FLOAT, 4)
+
 #undef CASE
   default:
-    return UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED;
+    break;
   }
+
+  // These new formats were brought in in CUDA 11.5
+#if CUDA_VERSION >= 11050
+
+  // If none of the above channel types were passed, check those below
+  if (pixel_size_bytes == 0) {
+
+    // We can't use a switch statement here because these single
+    // UR_IMAGE_CHANNEL_TYPEs can correspond to multiple [u/s]norm CU_AD_FORMATs
+    // depending on the number of channels. We use a std::map instead to
+    // retrieve the correct CUDA format
+
+    // map < <channel type, num channels> , <CUDA format, data type byte size> >
+    const std::map<std::pair<ur_image_channel_type_t, uint32_t>,
+                   std::pair<CUarray_format, uint32_t>>
+        norm_channel_type_map{
+            {{UR_IMAGE_CHANNEL_TYPE_UNORM_INT8, 1},
+             {CU_AD_FORMAT_UNORM_INT8X1, 1}},
+            {{UR_IMAGE_CHANNEL_TYPE_UNORM_INT8, 2},
+             {CU_AD_FORMAT_UNORM_INT8X2, 2}},
+            {{UR_IMAGE_CHANNEL_TYPE_UNORM_INT8, 4},
+             {CU_AD_FORMAT_UNORM_INT8X4, 4}},
+
+            {{UR_IMAGE_CHANNEL_TYPE_SNORM_INT8, 1},
+             {CU_AD_FORMAT_SNORM_INT8X1, 1}},
+            {{UR_IMAGE_CHANNEL_TYPE_SNORM_INT8, 2},
+             {CU_AD_FORMAT_SNORM_INT8X2, 2}},
+            {{UR_IMAGE_CHANNEL_TYPE_SNORM_INT8, 4},
+             {CU_AD_FORMAT_SNORM_INT8X4, 4}},
+
+            {{UR_IMAGE_CHANNEL_TYPE_UNORM_INT16, 1},
+             {CU_AD_FORMAT_UNORM_INT16X1, 2}},
+            {{UR_IMAGE_CHANNEL_TYPE_UNORM_INT16, 2},
+             {CU_AD_FORMAT_UNORM_INT16X2, 4}},
+            {{UR_IMAGE_CHANNEL_TYPE_UNORM_INT16, 4},
+             {CU_AD_FORMAT_UNORM_INT16X4, 8}},
+
+            {{UR_IMAGE_CHANNEL_TYPE_SNORM_INT16, 1},
+             {CU_AD_FORMAT_SNORM_INT16X1, 2}},
+            {{UR_IMAGE_CHANNEL_TYPE_SNORM_INT16, 2},
+             {CU_AD_FORMAT_SNORM_INT16X2, 4}},
+            {{UR_IMAGE_CHANNEL_TYPE_SNORM_INT16, 4},
+             {CU_AD_FORMAT_SNORM_INT16X4, 8}},
+        };
+
+    try {
+      auto cuda_format_and_size = norm_channel_type_map.at(
+          std::make_pair(image_channel_type, num_channels));
+      cuda_format = cuda_format_and_size.first;
+      pixel_size_bytes = cuda_format_and_size.second;
+    } catch (std::out_of_range &e) {
+      return UR_RESULT_ERROR_IMAGE_FORMAT_NOT_SUPPORTED;
+    }
+  }
+
+#endif
 
   if (return_cuda_format) {
     *return_cuda_format = cuda_format;
   }
-  if (return_pixel_types_size_bytes) {
-    *return_pixel_types_size_bytes = PixelTypeSizeBytes;
+  if (return_pixel_size_bytes) {
+    *return_pixel_size_bytes = pixel_size_bytes;
   }
   return UR_RESULT_SUCCESS;
 }
@@ -125,10 +187,42 @@ cudaToUrImageChannelFormat(CUarray_format cuda_format,
     CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_FLOAT,
                                   UR_IMAGE_CHANNEL_TYPE_FLOAT);
 #if CUDA_VERSION >= 11050
+
+    // Note that the CUDA UNORM and SNORM formats also encode the number of
+    // channels.
+    // Since UR does not encode this, we map different CUDA formats to the same
+    // UR channel type.
+    // Since this function is only called from `urBindlessImagesImageGetInfoExp`
+    // which has access to `CUDA_ARRAY3D_DESCRIPTOR`, we can determine the
+    // number of channels in the calling function.
+
     CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_UNORM_INT8X1,
                                   UR_IMAGE_CHANNEL_TYPE_UNORM_INT8);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_UNORM_INT8X2,
+                                  UR_IMAGE_CHANNEL_TYPE_UNORM_INT8);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_UNORM_INT8X4,
+                                  UR_IMAGE_CHANNEL_TYPE_UNORM_INT8);
+
     CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_UNORM_INT16X1,
                                   UR_IMAGE_CHANNEL_TYPE_UNORM_INT16);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_UNORM_INT16X2,
+                                  UR_IMAGE_CHANNEL_TYPE_UNORM_INT16);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_UNORM_INT16X4,
+                                  UR_IMAGE_CHANNEL_TYPE_UNORM_INT16);
+
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_SNORM_INT8X1,
+                                  UR_IMAGE_CHANNEL_TYPE_SNORM_INT8);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_SNORM_INT8X2,
+                                  UR_IMAGE_CHANNEL_TYPE_SNORM_INT8);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_SNORM_INT8X4,
+                                  UR_IMAGE_CHANNEL_TYPE_SNORM_INT8);
+
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_SNORM_INT16X1,
+                                  UR_IMAGE_CHANNEL_TYPE_SNORM_INT16);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_SNORM_INT16X2,
+                                  UR_IMAGE_CHANNEL_TYPE_SNORM_INT16);
+    CUDA_TO_UR_IMAGE_CHANNEL_TYPE(CU_AD_FORMAT_SNORM_INT16X4,
+                                  UR_IMAGE_CHANNEL_TYPE_SNORM_INT16);
 #endif
 #undef MAP
   default:
@@ -283,6 +377,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageAllocateExp(
                                         &array_desc.NumChannels));
 
   UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType,
+                                            pImageFormat->channelOrder,
                                             &array_desc.Format, nullptr));
 
   array_desc.Flags = 0; // No flags required
@@ -365,9 +460,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesUnsampledImageCreateExp(
       urCalculateNumChannels(pImageFormat->channelOrder, &NumChannels));
 
   CUarray_format format;
-  size_t PixelTypeSizeBytes;
-  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType, &format,
-                                            &PixelTypeSizeBytes));
+  size_t PixelSizeBytes;
+  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType,
+                                            pImageFormat->channelOrder, &format,
+                                            &PixelSizeBytes));
 
   try {
 
@@ -418,9 +514,10 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
       urCalculateNumChannels(pImageFormat->channelOrder, &NumChannels));
 
   CUarray_format format;
-  size_t PixelTypeSizeBytes;
-  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType, &format,
-                                            &PixelTypeSizeBytes));
+  size_t PixelSizeBytes;
+  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType,
+                                            pImageFormat->channelOrder, &format,
+                                            &PixelSizeBytes));
 
   try {
     CUDA_RESOURCE_DESC image_res_desc = {};
@@ -451,7 +548,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesSampledImageCreateExp(
         image_res_desc.res.linear.format = format;
         image_res_desc.res.linear.numChannels = NumChannels;
         image_res_desc.res.linear.sizeInBytes =
-            pImageDesc->width * PixelTypeSizeBytes * NumChannels;
+            pImageDesc->width * PixelSizeBytes;
       } else if (pImageDesc->type == UR_MEM_TYPE_IMAGE2D) {
         image_res_desc.resType = CU_RESOURCE_TYPE_PITCH2D;
         image_res_desc.res.pitch2D.devPtr = (CUdeviceptr)hImageMem;
@@ -503,17 +600,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesImageCopyExp(
             UR_RESULT_ERROR_INVALID_VALUE);
 
   unsigned int NumChannels = 0;
-  size_t PixelTypeSizeBytes = 0;
+  size_t PixelSizeBytes = 0;
 
   UR_CHECK_ERROR(
       urCalculateNumChannels(pImageFormat->channelOrder, &NumChannels));
 
   // We need to get this now in bytes for calculating the total image size
   // later.
-  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType, nullptr,
-                                            &PixelTypeSizeBytes));
-
-  size_t PixelSizeBytes = PixelTypeSizeBytes * NumChannels;
+  UR_CHECK_ERROR(urToCudaImageChannelFormat(pImageFormat->channelType,
+                                            pImageFormat->channelOrder, nullptr,
+                                            &PixelSizeBytes));
 
   try {
     ScopedContext Active(hQueue->getContext());
@@ -789,8 +885,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urBindlessImagesMapExternalArrayExp(
       urCalculateNumChannels(pImageFormat->channelOrder, &NumChannels));
 
   CUarray_format format;
-  UR_CHECK_ERROR(
-      urToCudaImageChannelFormat(pImageFormat->channelType, &format, nullptr));
+  UR_CHECK_ERROR(urToCudaImageChannelFormat(
+      pImageFormat->channelType, pImageFormat->channelOrder, &format, nullptr));
 
   try {
     ScopedContext Active(hDevice->getContext());

--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/image.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/image.hpp
@@ -17,6 +17,7 @@ ur_result_t urCalculateNumChannels(ur_image_channel_order_t order,
 
 ur_result_t
 urToCudaImageChannelFormat(ur_image_channel_type_t image_channel_type,
+                           ur_image_channel_order_t image_channel_order,
                            CUarray_format *return_cuda_format,
                            size_t *return_pixel_types_size_bytes);
 

--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -13,8 +13,6 @@
 
 static sycl::device dev;
 
-class kernel_read_norm_type;
-
 template <int NDims, typename DType, int NChannels,
           sycl::image_channel_type CType, sycl::image_channel_order COrder,
           typename KernelName>
@@ -88,6 +86,9 @@ bool run_test(sycl::range<NDims> globalSize, sycl::range<NDims> localSize) {
     syclexp::destroy_image_handle(imgIn, q);
     syclexp::destroy_image_handle(imgOut, q);
 
+    syclexp::free_image_mem(imgMemIn, dev, ctxt);
+    syclexp::free_image_mem(imgMemOut, dev, ctxt);
+
   } catch (sycl::exception e) {
     std::cerr << "SYCL exception caught! : " << e.what() << "\n";
     return false;
@@ -107,8 +108,8 @@ bool run_test(sycl::range<NDims> globalSize, sycl::range<NDims> localSize) {
 
     if (mismatch) {
 #ifdef VERBOSE_PRINT
-      std::cout << "Result mismatch! Expected: " << expected[i]
-                << ", Actual: " << dataOut[i] << std::endl;
+      std::cout << "Result mismatch! Expected: " << expected[i][0]
+                << ", Actual: " << dataOut[i][0] << std::endl;
 #else
       break;
 #endif
@@ -121,50 +122,67 @@ bool run_test(sycl::range<NDims> globalSize, sycl::range<NDims> localSize) {
   return false;
 }
 
+void verbose_println(std::string message) {
+#ifdef VERBOSE_PRINT
+  std::cout << message << "\n";
+#endif
+}
+
 int main() {
 
   bool validated = true;
 
   // 1D tests
-
+  verbose_println("Running kernel unorm_int8_1d_1c");
   validated &=
       run_test<1, uint8_t, 1, sycl::image_channel_type::unorm_int8,
                sycl::image_channel_order::r, class unorm_int8_1d_1c>({32}, {2});
+  verbose_println("Running kernel snorm_int8_1d_1c");
   validated &=
       run_test<1, int8_t, 1, sycl::image_channel_type::snorm_int8,
                sycl::image_channel_order::r, class snorm_int8_1d_1c>({32}, {2});
+  verbose_println("Running kernel unorm_int16_1d_1c");
   validated &= run_test<1, uint16_t, 1, sycl::image_channel_type::unorm_int16,
                         sycl::image_channel_order::r, class unorm_int16_1d_1c>(
       {32}, {2});
+  verbose_println("Running kernel snorm_int16_1d_1c");
   validated &= run_test<1, int16_t, 1, sycl::image_channel_type::snorm_int16,
                         sycl::image_channel_order::r, class snorm_int16_1d_1c>(
       {32}, {2});
 
+  verbose_println("Running kernel unorm_int8_1d_2c");
   validated &= run_test<1, uint8_t, 2, sycl::image_channel_type::unorm_int8,
                         sycl::image_channel_order::rg, class unorm_int8_1d_2c>(
       {32}, {2});
+  verbose_println("Running kernel snorm_int8_1d_2c");
   validated &= run_test<1, int8_t, 2, sycl::image_channel_type::snorm_int8,
                         sycl::image_channel_order::rg, class snorm_int8_1d_2c>(
       {32}, {2});
+  verbose_println("Running kernel unorm_int16_1d_2c");
   validated &= run_test<1, uint16_t, 2, sycl::image_channel_type::unorm_int16,
                         sycl::image_channel_order::rg, class unorm_int16_1d_2c>(
       {32}, {2});
+  verbose_println("Running kernel snorm_int16_1d_2c");
   validated &= run_test<1, int16_t, 2, sycl::image_channel_type::snorm_int16,
                         sycl::image_channel_order::rg, class snorm_int16_1d_2c>(
       {32}, {2});
 
+  verbose_println("Running kernel unorm_int8_1d_4c");
   validated &=
       run_test<1, uint8_t, 4, sycl::image_channel_type::unorm_int8,
                sycl::image_channel_order::rgba, class unorm_int8_1d_4c>({32},
                                                                         {2});
+  verbose_println("Running kernel snorm_int8_1d_4c");
   validated &=
       run_test<1, int8_t, 4, sycl::image_channel_type::snorm_int8,
                sycl::image_channel_order::rgba, class snorm_int8_1d_4c>({32},
                                                                         {2});
+  verbose_println("Running kernel unorm_int16_1d_4c");
   validated &=
       run_test<1, uint16_t, 4, sycl::image_channel_type::unorm_int16,
                sycl::image_channel_order::rgba, class unorm_int16_1d_4c>({32},
                                                                          {2});
+  verbose_println("Running kernel snorm_int16_1d_4c");
   validated &=
       run_test<1, int16_t, 4, sycl::image_channel_type::snorm_int16,
                sycl::image_channel_order::rgba, class snorm_int16_1d_4c>({32},
@@ -172,44 +190,56 @@ int main() {
 
   // 2D tests
 
+  verbose_println("Running kernel unorm_int8_2d_1c");
   validated &= run_test<2, uint8_t, 1, sycl::image_channel_type::unorm_int8,
                         sycl::image_channel_order::r, class unorm_int8_2d_1c>(
       {32, 32}, {16, 16});
+  verbose_println("Running kernel snorm_int8_2d_1c");
   validated &= run_test<2, int8_t, 1, sycl::image_channel_type::snorm_int8,
                         sycl::image_channel_order::r, class snorm_int8_2d_1c>(
       {32, 32}, {16, 16});
+  verbose_println("Running kernel unorm_int16_2d_1c");
   validated &= run_test<2, uint16_t, 1, sycl::image_channel_type::unorm_int16,
                         sycl::image_channel_order::r, class unorm_int16_2d_1c>(
       {32, 32}, {16, 16});
+  verbose_println("Running kernel snorm_int16_2d_1c");
   validated &= run_test<2, int16_t, 1, sycl::image_channel_type::snorm_int16,
                         sycl::image_channel_order::r, class snorm_int16_2d_1c>(
       {32, 32}, {16, 16});
 
+  verbose_println("Running kernel unorm_int8_2d_2c");
   validated &= run_test<2, uint8_t, 2, sycl::image_channel_type::unorm_int8,
                         sycl::image_channel_order::rg, class unorm_int8_2d_2c>(
       {32, 32}, {16, 16});
+  verbose_println("Running kernel snorm_int8_2d_2c");
   validated &= run_test<2, int8_t, 2, sycl::image_channel_type::snorm_int8,
                         sycl::image_channel_order::rg, class snorm_int8_2d_2c>(
       {32, 32}, {16, 16});
+  verbose_println("Running kernel unorm_int16_2d_2c");
   validated &= run_test<2, uint16_t, 2, sycl::image_channel_type::unorm_int16,
                         sycl::image_channel_order::rg, class unorm_int16_2d_2c>(
       {32, 32}, {16, 16});
+  verbose_println("Running kernel snorm_int16_2d_2c");
   validated &= run_test<2, int16_t, 2, sycl::image_channel_type::snorm_int16,
                         sycl::image_channel_order::rg, class snorm_int16_2d_2c>(
       {32, 32}, {16, 16});
 
+  verbose_println("Running kernel unorm_int8_2d_4c");
   validated &=
       run_test<2, uint8_t, 4, sycl::image_channel_type::unorm_int8,
                sycl::image_channel_order::rgba, class unorm_int8_2d_4c>(
           {32, 32}, {16, 16});
+  verbose_println("Running kernel snorm_int8_2d_4c");
   validated &=
       run_test<2, int8_t, 4, sycl::image_channel_type::snorm_int8,
                sycl::image_channel_order::rgba, class snorm_int8_2d_4c>(
           {32, 32}, {16, 16});
+  verbose_println("Running kernel unorm_int16_2d_4c");
   validated &=
       run_test<2, uint16_t, 4, sycl::image_channel_type::unorm_int16,
                sycl::image_channel_order::rgba, class unorm_int16_2d_4c>(
           {32, 32}, {16, 16});
+  verbose_println("Running kernel snorm_int16_2d_4c");
   validated &=
       run_test<2, int16_t, 4, sycl::image_channel_type::snorm_int16,
                sycl::image_channel_order::rgba, class snorm_int16_2d_4c>(
@@ -217,44 +247,56 @@ int main() {
 
   // 3D tests
 
+  verbose_println("Running kernel unorm_int8_3d_1c");
   validated &= run_test<3, uint8_t, 1, sycl::image_channel_type::unorm_int8,
                         sycl::image_channel_order::r, class unorm_int8_3d_1c>(
       {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel snorm_int8_3d_1c");
   validated &= run_test<3, int8_t, 1, sycl::image_channel_type::snorm_int8,
                         sycl::image_channel_order::r, class snorm_int8_3d_1c>(
       {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel unorm_int16_3d_1c");
   validated &= run_test<3, uint16_t, 1, sycl::image_channel_type::unorm_int16,
                         sycl::image_channel_order::r, class unorm_int16_3d_1c>(
       {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel snorm_int16_3d_1c");
   validated &= run_test<3, int16_t, 1, sycl::image_channel_type::snorm_int16,
                         sycl::image_channel_order::r, class snorm_int16_3d_1c>(
       {32, 32, 32}, {16, 16, 4});
 
+  verbose_println("Running kernel unorm_int8_3d_2c");
   validated &= run_test<3, uint8_t, 2, sycl::image_channel_type::unorm_int8,
                         sycl::image_channel_order::rg, class unorm_int8_3d_2c>(
       {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel snorm_int8_3d_2c");
   validated &= run_test<3, int8_t, 2, sycl::image_channel_type::snorm_int8,
                         sycl::image_channel_order::rg, class snorm_int8_3d_2c>(
       {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel unorm_int16_3d_2c");
   validated &= run_test<3, uint16_t, 2, sycl::image_channel_type::unorm_int16,
                         sycl::image_channel_order::rg, class unorm_int16_3d_2c>(
       {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel snorm_int16_3d_2c");
   validated &= run_test<3, int16_t, 2, sycl::image_channel_type::snorm_int16,
                         sycl::image_channel_order::rg, class snorm_int16_3d_2c>(
       {32, 32, 32}, {16, 16, 4});
 
+  verbose_println("Running kernel unorm_int8_3d_4c");
   validated &=
       run_test<3, uint8_t, 4, sycl::image_channel_type::unorm_int8,
                sycl::image_channel_order::rgba, class unorm_int8_3d_4c>(
           {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel snorm_int8_3d_4c");
   validated &=
       run_test<3, int8_t, 4, sycl::image_channel_type::snorm_int8,
                sycl::image_channel_order::rgba, class snorm_int8_3d_4c>(
           {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel unorm_int16_3d_4c");
   validated &=
       run_test<3, uint16_t, 4, sycl::image_channel_type::unorm_int16,
                sycl::image_channel_order::rgba, class unorm_int16_3d_4c>(
           {32, 32, 32}, {16, 16, 4});
+  verbose_println("Running kernel snorm_int16_3d_4c");
   validated &=
       run_test<3, int16_t, 4, sycl::image_channel_type::snorm_int16,
                sycl::image_channel_order::rgba, class snorm_int16_3d_4c>(

--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -1,0 +1,269 @@
+// REQUIRES: linux
+// REQUIRES: cuda
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <limits>
+#include <sycl/sycl.hpp>
+
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
+static sycl::device dev;
+
+class kernel_read_norm_type;
+
+template <int NDims, typename DType, int NChannels,
+          sycl::image_channel_type CType, sycl::image_channel_order COrder,
+          typename KernelName>
+bool run_test(sycl::range<NDims> globalSize, sycl::range<NDims> localSize) {
+  using InputType = sycl::vec<DType, NChannels>;
+  using OutputType = sycl::vec<float, NChannels>;
+
+  sycl::queue q(dev);
+  auto ctxt = q.get_context();
+
+  size_t numElems = globalSize.size();
+
+  constexpr auto dtypeMaxVal = std::numeric_limits<DType>::max();
+
+  std::vector<InputType> dataIn(numElems, InputType((DType)dtypeMaxVal));
+  std::vector<OutputType> dataOut(numElems);
+  std::vector<OutputType> expected(numElems, OutputType(1.f));
+
+  try {
+
+    namespace syclexp = sycl::ext::oneapi::experimental;
+
+    syclexp::image_descriptor descIn(globalSize, COrder, CType);
+    syclexp::image_descriptor descOut(globalSize, COrder,
+                                      sycl::image_channel_type::fp32);
+
+    syclexp::image_mem_handle imgMemIn = syclexp::alloc_image_mem(descIn, q);
+    syclexp::image_mem_handle imgMemOut = syclexp::alloc_image_mem(descOut, q);
+
+    syclexp::bindless_image_sampler sampler{
+        sycl::addressing_mode::repeat,
+        sycl::coordinate_normalization_mode::normalized,
+        sycl::filtering_mode::nearest};
+
+    auto imgIn = syclexp::create_image(imgMemIn, sampler, descIn, q);
+    auto imgOut = syclexp::create_image(imgMemOut, descOut, q);
+
+    q.ext_oneapi_copy(dataIn.data(), imgMemIn, descIn);
+    q.wait_and_throw();
+
+    q.submit([&](sycl::handler &cgh) {
+      cgh.parallel_for<KernelName>(
+          sycl::nd_range<NDims>{globalSize, localSize},
+          [=](sycl::nd_item<NDims> it) {
+            size_t dim0 = it.get_global_id(0);
+            size_t dim1 = it.get_global_id(1);
+            size_t dim2 = it.get_global_id(2);
+
+            if constexpr (NDims == 1) {
+              OutputType pixel =
+                  syclexp::read_image<OutputType>(imgIn, float(dim0));
+              syclexp::write_image(imgOut, int(dim0), pixel);
+            } else if constexpr (NDims == 2) {
+              OutputType pixel = syclexp::read_image<OutputType>(
+                  imgIn, sycl::float2(dim0, dim1));
+              syclexp::write_image(imgOut, sycl::int2(dim0, dim1), pixel);
+            } else if constexpr (NDims == 3) {
+              OutputType pixel = syclexp::read_image<OutputType>(
+                  imgIn, sycl::float4(dim0, dim1, dim2, 0));
+              syclexp::write_image(imgOut, sycl::int4(dim0, dim1, dim2, 0),
+                                   pixel);
+            }
+          });
+    });
+
+    q.wait_and_throw();
+
+    q.ext_oneapi_copy(imgMemOut, dataOut.data(), descOut);
+    q.wait_and_throw();
+
+    syclexp::destroy_image_handle(imgIn, q);
+    syclexp::destroy_image_handle(imgOut, q);
+
+  } catch (sycl::exception e) {
+    std::cerr << "SYCL exception caught! : " << e.what() << "\n";
+    return false;
+  } catch (...) {
+    std::cerr << "Unknown exception caught!\n";
+    return false;
+  }
+
+  // collect and validate output
+  bool validated = true;
+  for (int i = 0; i < localSize[0]; i++) {
+    bool mismatch = false;
+    if (dataOut[i][0] != expected[i][0]) {
+      mismatch = true;
+      validated = false;
+    }
+
+    if (mismatch) {
+#ifdef VERBOSE_PRINT
+      std::cout << "Result mismatch! Expected: " << expected[i]
+                << ", Actual: " << dataOut[i] << std::endl;
+#else
+      break;
+#endif
+    }
+  }
+  if (validated) {
+    return true;
+  }
+
+  return false;
+}
+
+int main() {
+
+  bool validated = true;
+
+  // 1D tests
+
+  validated &=
+      run_test<1, uint8_t, 1, sycl::image_channel_type::unorm_int8,
+               sycl::image_channel_order::r, class unorm_int8_1d_1c>({32}, {2});
+  validated &=
+      run_test<1, int8_t, 1, sycl::image_channel_type::snorm_int8,
+               sycl::image_channel_order::r, class snorm_int8_1d_1c>({32}, {2});
+  validated &= run_test<1, uint16_t, 1, sycl::image_channel_type::unorm_int16,
+                        sycl::image_channel_order::r, class unorm_int16_1d_1c>(
+      {32}, {2});
+  validated &= run_test<1, int16_t, 1, sycl::image_channel_type::snorm_int16,
+                        sycl::image_channel_order::r, class snorm_int16_1d_1c>(
+      {32}, {2});
+
+  validated &= run_test<1, uint8_t, 2, sycl::image_channel_type::unorm_int8,
+                        sycl::image_channel_order::rg, class unorm_int8_1d_2c>(
+      {32}, {2});
+  validated &= run_test<1, int8_t, 2, sycl::image_channel_type::snorm_int8,
+                        sycl::image_channel_order::rg, class snorm_int8_1d_2c>(
+      {32}, {2});
+  validated &= run_test<1, uint16_t, 2, sycl::image_channel_type::unorm_int16,
+                        sycl::image_channel_order::rg, class unorm_int16_1d_2c>(
+      {32}, {2});
+  validated &= run_test<1, int16_t, 2, sycl::image_channel_type::snorm_int16,
+                        sycl::image_channel_order::rg, class snorm_int16_1d_2c>(
+      {32}, {2});
+
+  validated &=
+      run_test<1, uint8_t, 4, sycl::image_channel_type::unorm_int8,
+               sycl::image_channel_order::rgba, class unorm_int8_1d_4c>({32},
+                                                                        {2});
+  validated &=
+      run_test<1, int8_t, 4, sycl::image_channel_type::snorm_int8,
+               sycl::image_channel_order::rgba, class snorm_int8_1d_4c>({32},
+                                                                        {2});
+  validated &=
+      run_test<1, uint16_t, 4, sycl::image_channel_type::unorm_int16,
+               sycl::image_channel_order::rgba, class unorm_int16_1d_4c>({32},
+                                                                         {2});
+  validated &=
+      run_test<1, int16_t, 4, sycl::image_channel_type::snorm_int16,
+               sycl::image_channel_order::rgba, class snorm_int16_1d_4c>({32},
+                                                                         {2});
+
+  // 2D tests
+
+  validated &= run_test<2, uint8_t, 1, sycl::image_channel_type::unorm_int8,
+                        sycl::image_channel_order::r, class unorm_int8_2d_1c>(
+      {32, 32}, {16, 16});
+  validated &= run_test<2, int8_t, 1, sycl::image_channel_type::snorm_int8,
+                        sycl::image_channel_order::r, class snorm_int8_2d_1c>(
+      {32, 32}, {16, 16});
+  validated &= run_test<2, uint16_t, 1, sycl::image_channel_type::unorm_int16,
+                        sycl::image_channel_order::r, class unorm_int16_2d_1c>(
+      {32, 32}, {16, 16});
+  validated &= run_test<2, int16_t, 1, sycl::image_channel_type::snorm_int16,
+                        sycl::image_channel_order::r, class snorm_int16_2d_1c>(
+      {32, 32}, {16, 16});
+
+  validated &= run_test<2, uint8_t, 2, sycl::image_channel_type::unorm_int8,
+                        sycl::image_channel_order::rg, class unorm_int8_2d_2c>(
+      {32, 32}, {16, 16});
+  validated &= run_test<2, int8_t, 2, sycl::image_channel_type::snorm_int8,
+                        sycl::image_channel_order::rg, class snorm_int8_2d_2c>(
+      {32, 32}, {16, 16});
+  validated &= run_test<2, uint16_t, 2, sycl::image_channel_type::unorm_int16,
+                        sycl::image_channel_order::rg, class unorm_int16_2d_2c>(
+      {32, 32}, {16, 16});
+  validated &= run_test<2, int16_t, 2, sycl::image_channel_type::snorm_int16,
+                        sycl::image_channel_order::rg, class snorm_int16_2d_2c>(
+      {32, 32}, {16, 16});
+
+  validated &=
+      run_test<2, uint8_t, 4, sycl::image_channel_type::unorm_int8,
+               sycl::image_channel_order::rgba, class unorm_int8_2d_4c>(
+          {32, 32}, {16, 16});
+  validated &=
+      run_test<2, int8_t, 4, sycl::image_channel_type::snorm_int8,
+               sycl::image_channel_order::rgba, class snorm_int8_2d_4c>(
+          {32, 32}, {16, 16});
+  validated &=
+      run_test<2, uint16_t, 4, sycl::image_channel_type::unorm_int16,
+               sycl::image_channel_order::rgba, class unorm_int16_2d_4c>(
+          {32, 32}, {16, 16});
+  validated &=
+      run_test<2, int16_t, 4, sycl::image_channel_type::snorm_int16,
+               sycl::image_channel_order::rgba, class snorm_int16_2d_4c>(
+          {32, 32}, {16, 16});
+
+  // 3D tests
+
+  validated &= run_test<3, uint8_t, 1, sycl::image_channel_type::unorm_int8,
+                        sycl::image_channel_order::r, class unorm_int8_3d_1c>(
+      {32, 32, 32}, {16, 16, 4});
+  validated &= run_test<3, int8_t, 1, sycl::image_channel_type::snorm_int8,
+                        sycl::image_channel_order::r, class snorm_int8_3d_1c>(
+      {32, 32, 32}, {16, 16, 4});
+  validated &= run_test<3, uint16_t, 1, sycl::image_channel_type::unorm_int16,
+                        sycl::image_channel_order::r, class unorm_int16_3d_1c>(
+      {32, 32, 32}, {16, 16, 4});
+  validated &= run_test<3, int16_t, 1, sycl::image_channel_type::snorm_int16,
+                        sycl::image_channel_order::r, class snorm_int16_3d_1c>(
+      {32, 32, 32}, {16, 16, 4});
+
+  validated &= run_test<3, uint8_t, 2, sycl::image_channel_type::unorm_int8,
+                        sycl::image_channel_order::rg, class unorm_int8_3d_2c>(
+      {32, 32, 32}, {16, 16, 4});
+  validated &= run_test<3, int8_t, 2, sycl::image_channel_type::snorm_int8,
+                        sycl::image_channel_order::rg, class snorm_int8_3d_2c>(
+      {32, 32, 32}, {16, 16, 4});
+  validated &= run_test<3, uint16_t, 2, sycl::image_channel_type::unorm_int16,
+                        sycl::image_channel_order::rg, class unorm_int16_3d_2c>(
+      {32, 32, 32}, {16, 16, 4});
+  validated &= run_test<3, int16_t, 2, sycl::image_channel_type::snorm_int16,
+                        sycl::image_channel_order::rg, class snorm_int16_3d_2c>(
+      {32, 32, 32}, {16, 16, 4});
+
+  validated &=
+      run_test<3, uint8_t, 4, sycl::image_channel_type::unorm_int8,
+               sycl::image_channel_order::rgba, class unorm_int8_3d_4c>(
+          {32, 32, 32}, {16, 16, 4});
+  validated &=
+      run_test<3, int8_t, 4, sycl::image_channel_type::snorm_int8,
+               sycl::image_channel_order::rgba, class snorm_int8_3d_4c>(
+          {32, 32, 32}, {16, 16, 4});
+  validated &=
+      run_test<3, uint16_t, 4, sycl::image_channel_type::unorm_int16,
+               sycl::image_channel_order::rgba, class unorm_int16_3d_4c>(
+          {32, 32, 32}, {16, 16, 4});
+  validated &=
+      run_test<3, int16_t, 4, sycl::image_channel_type::snorm_int16,
+               sycl::image_channel_order::rgba, class snorm_int16_3d_4c>(
+          {32, 32, 32}, {16, 16, 4});
+
+  if (validated)
+    std::cout << "All test cases passed!\n";
+  else
+    std::cerr << "Some test cases failed\n";
+
+  return !validated;
+}


### PR DESCRIPTION
- Support was added for the following image channel types:
  - `unorm_int8`
  - `unorm_int16`
  - `snorm_int8`
  - `snorm_int16`

- Reading these types through `read_image` returns the denormalized floating point data.

- A test was added for these new types.

- Support for the following packed normalized image channel types was removed from the proposal:
  - `unorm_short_565`
  - `unorm_short_555`
  - `unorm_int_101010`

- This was done due to lack of device support. If the need for these types arises in the future, we can revisit support for these types.