### PR TITLE
multidevice kernel

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -4,7 +4,7 @@ if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
   message(STATUS "Download Level Zero loader and headers from github.com")
 
   set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-  set(LEVEL_ZERO_LOADER_TAG v1.11.0)
+  set(LEVEL_ZERO_LOADER_TAG v1.14.0)
 
   # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
   set(CMAKE_INCLUDE_CURRENT_DIR OFF)

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
@@ -12,6 +12,11 @@
 #include <unordered_set>
 
 struct ur_kernel_handle_t_ : _ur_object {
+  ur_kernel_handle_t_(bool OwnZeHandle, ur_program_handle_t Program)
+      : Program{Program}, SubmissionsCount{0}, MemAllocs{} {
+    OwnNativeHandle = OwnZeHandle;
+  }
+
   ur_kernel_handle_t_(ze_kernel_handle_t Kernel, bool OwnZeHandle,
                       ur_program_handle_t Program)
       : Program{Program}, ZeKernel{Kernel}, SubmissionsCount{0}, MemAllocs{} {
@@ -32,6 +37,8 @@ struct ur_kernel_handle_t_ : _ur_object {
 
   // Level Zero function handle.
   ze_kernel_handle_t ZeKernel;
+
+  std::unordered_map<ze_device_handle_t, ze_kernel_handle_t> ZeKernelMap;
 
   // Counter to track the number of submissions of the kernel.
   // When this value is zero, it means that kernel is not submitted for an

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.hpp
@@ -128,7 +128,10 @@ struct ur_program_handle_t_ : _ur_object {
 
   // The Level Zero module handle.  Used primarily in Exe state.
   ze_module_handle_t ZeModule{};
+  std::unordered_map<ze_device_handle_t, ze_module_handle_t> ZeModuleMap;
 
   // The Level Zero build log from the last call to zeModuleCreate().
   ze_module_build_log_handle_t ZeBuildLog{};
+  std::unordered_map<ze_device_handle_t, ze_module_build_log_handle_t>
+      ZeBuildLogMap;
 };

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
@@ -279,6 +279,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
     ur_queue_handle_t
         *Queue ///< [out] pointer to handle of queue object created
 ) {
+  Context->Devices[0] = Device;
+
   ur_queue_flags_t Flags{};
   if (Props) {
     Flags = Props->flags;

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/queue.cpp
@@ -279,7 +279,18 @@ UR_APIEXPORT ur_result_t UR_APICALL urQueueCreate(
     ur_queue_handle_t
         *Queue ///< [out] pointer to handle of queue object created
 ) {
-  Context->Devices[0] = Device;
+
+  ze_device_handle_t rootdevice = nullptr;
+  zeDeviceGetRootDevice(Device->ZeDevice, &rootdevice);
+
+  // fprintf(stderr, "%s %s %d Context->Devices[0] %lx Device %lx rootdevice %lx
+  // ZeDevice %lx\n",
+  //   __FILE__, __FUNCTION__, __LINE__,
+  //     (unsigned long int)Context->Devices[0],
+  //     (unsigned long int)Device,
+  //     (unsigned long int)rootdevice,
+  //     (unsigned long int)Device->ZeDevice);
+  // Context->Devices[0] = Device;
 
   ur_queue_flags_t Flags{};
   if (Props) {


### PR DESCRIPTION
urProgramBuild and alike dont accept device as parameters, so
it is expected the programs and kernels are built for all devices
in the context.

With this patch, the L0 modules and L0 kernels are created
for all L0 devices in the context, and then on enqueue operations,
the correct kernel is used matching the device in the queue.

Signed-off-by: Jaime Arteaga <jaime.a.arteaga.molina@intel.com>