### PR TITLE
[SYCL] Check if Plugin before all calls to a plugin API

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -87,11 +87,9 @@ device_impl::~device_impl() {
   if (!MIsHostDevice) {
     // TODO catch an exception and put it to list of asynchronous exceptions
     const PluginPtr &Plugin = getPlugin();
-    if (!Plugin->pluginReleased) {
-      sycl::detail::pi::PiResult Err =
-          Plugin->call_nocheck<PiApiKind::piDeviceRelease>(MDevice);
-      __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
-    }
+    sycl::detail::pi::PiResult Err =
+        Plugin->call_nocheck<PiApiKind::piDeviceRelease>(MDevice);
+    __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
   }
 }
 

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -193,19 +193,27 @@ public:
           static_cast<uint32_t>(PiApiOffset), PIFnName, ArgsDataPtr, *MPlugin);
     }
 #endif
-    sycl::detail::pi::PiResult R;
+    sycl::detail::pi::PiResult R = PI_SUCCESS;
     if (pi::trace(pi::TraceLevel::PI_TRACE_CALLS)) {
       std::lock_guard<std::mutex> Guard(*TracingMutex);
       const char *FnName = PiCallInfo.getFuncName();
       std::cout << "---> " << FnName << "(" << std::endl;
       sycl::detail::pi::printArgs(Args...);
-      R = PiCallInfo.getFuncPtr(*MPlugin)(Args...);
-      std::cout << ") ---> ";
-      sycl::detail::pi::printArgs(R);
-      sycl::detail::pi::printOuts(Args...);
-      std::cout << std::endl;
+      if (!pluginReleased) {
+        R = PiCallInfo.getFuncPtr(*MPlugin)(Args...);
+        std::cout << ") ---> ";
+        sycl::detail::pi::printArgs(R);
+        sycl::detail::pi::printOuts(Args...);
+        std::cout << std::endl;
+      } else {
+        std::cout << ") ---> ";
+        std::cout << "API Called After Plugin Teardown, Functon Call ignored.";
+        std::cout << std::endl;
+      }
     } else {
-      R = PiCallInfo.getFuncPtr(*MPlugin)(Args...);
+      if (!pluginReleased) {
+        R = PiCallInfo.getFuncPtr(*MPlugin)(Args...);
+      }
     }
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Close the function begin with a call to function end
@@ -240,7 +248,10 @@ public:
 
   void *getLibraryHandle() const { return MLibraryHandle; }
   void *getLibraryHandle() { return MLibraryHandle; }
-  int unload() { return sycl::detail::pi::unloadPlugin(MLibraryHandle); }
+  int unload() {
+    this->pluginReleased = true;
+    return sycl::detail::pi::unloadPlugin(MLibraryHandle);
+  }
 
   // return the index of PiPlatforms.
   // If not found, add it and return its index.


### PR DESCRIPTION
- Using Teardown tracking of "pluginReleased", check if the plugin is released before each call to a plugin's functions.