### PR TITLE
[SYCL][COMPAT] Updated atomic ops with memoryOrder template parameter

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -864,8 +864,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_add(T *addr, arith_t<T> operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_add(T *addr, arith_t<T> operand,
                    sycl::memory_order memoryOrder);
 
@@ -875,8 +877,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_sub(T *addr, arith_t<T> operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_sub(T *addr, arith_t<T> operand,
                           sycl::memory_order memoryOrder);
 
@@ -886,8 +890,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_and(T *addr, T operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_and(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <typename T,
@@ -896,8 +902,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_or(T *addr, T operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_or(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <typename T,
@@ -906,8 +914,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_xor(T *addr, T operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_xor(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <typename T,
@@ -916,8 +926,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_min(T *addr, T operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_min(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <typename T,
@@ -926,8 +938,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_max(T *addr, T operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_fetch_max(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <sycl::access::address_space addressSpace =
@@ -937,7 +951,8 @@ template <sycl::access::address_space addressSpace =
 unsigned int atomic_fetch_compare_inc(unsigned int *addr,
                                       unsigned int operand);
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space>
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 unsigned int atomic_fetch_compare_inc(unsigned int *addr,
                                       unsigned int operand,
                                       sycl::memory_order memoryOrder);
@@ -948,8 +963,10 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_exchange(T *addr, T operand);
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_exchange(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <typename T,
@@ -971,6 +988,76 @@ T atomic_compare_exchange_strong(
     T *addr, T expected, T desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed);
+
+} // namespace syclcompat
+```
+
+SYCLcompat also provides an atomic class with the `store`, `load`, `exchange`,
+`compare_exchange_weak`, `fetch_add`, and `fetch_sub` operations. The atomic
+class wrapper supports int, unsigned int, long, unsigned long, long long,
+unsigned long long, float, double and pointer datatypes.
+
+```cpp
+namespace syclcompat {
+
+template <typename T,
+          sycl::memory_scope DefaultScope = sycl::memory_scope::system,
+          sycl::memory_order DefaultOrder = sycl::memory_order::seq_cst,
+          sycl::access::address_space Space =
+              sycl::access::address_space::generic_space>
+class atomic {
+  static constexpr sycl::memory_order default_read_order =
+      sycl::atomic_ref<T, DefaultOrder, DefaultScope,
+                       Space>::default_read_order;
+  static constexpr sycl::memory_order default_write_order =
+      sycl::atomic_ref<T, DefaultOrder, DefaultScope,
+                       Space>::default_write_order;
+  static constexpr sycl::memory_scope default_scope = DefaultScope;
+  static constexpr sycl::memory_order default_read_modify_write_order =
+      DefaultOrder;
+
+  constexpr atomic() noexcept = default;
+
+  constexpr atomic(T d) noexcept;
+
+  void store(T operand, sycl::memory_order memoryOrder = default_write_order,
+             sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  T load(sycl::memory_order memoryOrder = default_read_order,
+         sycl::memory_scope memoryScope = default_scope) const noexcept;
+
+  T exchange(T operand,
+             sycl::memory_order memoryOrder = default_read_modify_write_order,
+             sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  bool compare_exchange_weak(
+      T &expected, T desired, sycl::memory_order success,
+      sycl::memory_order failure,
+      sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  bool compare_exchange_weak(
+      T &expected, T desired,
+      sycl::memory_order memoryOrder = default_read_modify_write_order,
+      sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  bool compare_exchange_strong(
+      T &expected, T desired, sycl::memory_order success,
+      sycl::memory_order failure,
+      sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  bool compare_exchange_strong(
+      T &expected, T desired,
+      sycl::memory_order memoryOrder = default_read_modify_write_order,
+      sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  T fetch_add(arith_t<T> operand,
+              sycl::memory_order memoryOrder = default_read_modify_write_order,
+              sycl::memory_scope memoryScope = default_scope) noexcept;
+
+  T fetch_sub(arith_t<T> operand,
+              sycl::memory_order memoryOrder = default_read_modify_write_order,
+              sycl::memory_scope memoryScope = default_scope) noexcept;
+};
 
 } // namespace syclcompat
 ```

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -68,20 +68,22 @@ inline T atomic_fetch_add(T *addr, arith_t<T> operand) {
 /// \param operand The value to add to the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_add(T *addr, arith_t<T> operand,
                           sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_add<T, addressSpace, sycl::memory_order::relaxed,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -111,20 +113,22 @@ inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
 /// to the data. \param operand The value to subtract from the value at \p
 /// addr \param memoryOrder The memory ordering used. \returns The value at
 /// the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_sub(T *addr, arith_t<T> operand,
                           sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_sub<T, addressSpace, sycl::memory_order::relaxed,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_sub<T, addressSpace, sycl::memory_order::seq_cst,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -154,19 +158,21 @@ inline T atomic_fetch_and(T *addr, T operand) {
 /// addr The pointer to the data. \param operand The value to use in bitwise
 /// AND operation with the value at the \p addr. \param memoryOrder The memory
 /// ordering used. \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_and(T *addr, T operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_and<T, addressSpace, sycl::memory_order::relaxed,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_and<T, addressSpace, sycl::memory_order::seq_cst,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -200,19 +206,21 @@ inline T atomic_fetch_or(T *addr, T operand) {
 /// the \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_or(T *addr, T operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_or<T, addressSpace, sycl::memory_order::relaxed,
-                           sycl::memory_scope::device>(addr, operand);
+                           memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
-                           sycl::memory_scope::device>(addr, operand);
+                           memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_or<T, addressSpace, sycl::memory_order::seq_cst,
-                           sycl::memory_scope::device>(addr, operand);
+                           memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -246,19 +254,21 @@ inline T atomic_fetch_xor(T *addr, T operand) {
 /// the \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_xor(T *addr, T operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_xor<T, addressSpace, sycl::memory_order::relaxed,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_xor<T, addressSpace, sycl::memory_order::seq_cst,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -286,19 +296,21 @@ inline T atomic_fetch_min(T *addr, T operand) {
 /// operand and assign the result to the value at addr. \param [in, out] addr
 /// The pointer to the data. \param operand. \param memoryOrder The memory
 /// ordering used. \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_min(T *addr, T operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_min<T, addressSpace, sycl::memory_order::relaxed,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_min<T, addressSpace, sycl::memory_order::seq_cst,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -326,19 +338,21 @@ inline T atomic_fetch_max(T *addr, T operand) {
 /// operand and assign the result to the value at addr. \param [in, out] addr
 /// The pointer to the data. \param operand. \param memoryOrder The memory
 /// ordering used. \returns The value at the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_fetch_max(T *addr, T operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_max<T, addressSpace, sycl::memory_order::relaxed,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_max<T, addressSpace, sycl::memory_order::seq_cst,
-                            sycl::memory_scope::device>(addr, operand);
+                            memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -381,20 +395,21 @@ inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
 /// \param memoryOrder The memory ordering used.
 /// \returns The old value stored in \p addr.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space>
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
                                              unsigned int operand,
                                              sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::relaxed,
-                                    sycl::memory_scope::device>(addr, operand);
+                                    memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
-                                    sycl::memory_scope::device>(addr, operand);
+                                    memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::seq_cst,
-                                    sycl::memory_scope::device>(addr, operand);
+                                    memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "
@@ -424,19 +439,21 @@ inline T atomic_exchange(T *addr, T operand) {
 /// \param operand The value to be exchanged with the value pointed by \p
 /// addr. \param memoryOrder The memory ordering used. \returns The value at
 /// the \p addr before the call.
-template <typename T, sycl::access::address_space addressSpace =
-                          sycl::access::address_space::global_space>
+template <typename T,
+          sycl::access::address_space addressSpace =
+              sycl::access::address_space::global_space,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline T atomic_exchange(T *addr, T operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_exchange<T, addressSpace, sycl::memory_order::relaxed,
-                           sycl::memory_scope::device>(addr, operand);
+                           memoryScope>(addr, operand);
   case sycl::memory_order::acq_rel:
     return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
-                           sycl::memory_scope::device>(addr, operand);
+                           memoryScope>(addr, operand);
   case sycl::memory_order::seq_cst:
     return atomic_exchange<T, addressSpace, sycl::memory_order::seq_cst,
-                           sycl::memory_scope::device>(addr, operand);
+                           memoryScope>(addr, operand);
   default:
     assert(false &&
            "Invalid memory_order for atomics. Valid memory_order for "

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -93,10 +93,11 @@ inline T atomic_fetch_add(T *addr, arith_t<T> operand,
 }
 
 /// Atomically subtract the value operand from the value at the addr and
-/// assign the result to the value at addr. \param [in, out] addr The pointer
-/// to the data. \param operand The value to subtract from the value at \p
-/// addr \param memoryOrder The memory ordering used. \returns The value at
-/// the \p addr before the call.
+/// assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to subtract from the value at \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -109,10 +110,11 @@ inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
 }
 
 /// Atomically subtract the value operand from the value at the addr and
-/// assign the result to the value at addr. \param [in, out] addr The pointer
-/// to the data. \param operand The value to subtract from the value at \p
-/// addr \param memoryOrder The memory ordering used. \returns The value at
-/// the \p addr before the call.
+/// assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to subtract from the value at \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -138,10 +140,12 @@ inline T atomic_fetch_sub(T *addr, arith_t<T> operand,
 }
 
 /// Atomically perform a bitwise AND between the value operand and the value
-/// at the addr and assign the result to the value at addr. \param [in, out]
-/// addr The pointer to the data. \param operand The value to use in bitwise
-/// AND operation with the value at the \p addr. \param memoryOrder The memory
-/// ordering used. \returns The value at the \p addr before the call.
+/// at the addr and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise AND operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -154,10 +158,12 @@ inline T atomic_fetch_and(T *addr, T operand) {
 }
 
 /// Atomically perform a bitwise AND between the value operand and the value
-/// at the addr and assign the result to the value at addr. \param [in, out]
-/// addr The pointer to the data. \param operand The value to use in bitwise
-/// AND operation with the value at the \p addr. \param memoryOrder The memory
-/// ordering used. \returns The value at the \p addr before the call.
+/// at the addr and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand The value to use in bitwise AND operation with the value at
+/// the \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -278,9 +284,10 @@ inline T atomic_fetch_xor(T *addr, T operand, sycl::memory_order memoryOrder) {
 }
 
 /// Atomically calculate the minimum of the value at addr and the value
-/// operand and assign the result to the value at addr. \param [in, out] addr
-/// The pointer to the data. \param operand. \param memoryOrder The memory
-/// ordering used. \returns The value at the \p addr before the call.
+/// operand and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand. \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -293,9 +300,11 @@ inline T atomic_fetch_min(T *addr, T operand) {
 }
 
 /// Atomically calculate the minimum of the value at addr and the value
-/// operand and assign the result to the value at addr. \param [in, out] addr
-/// The pointer to the data. \param operand. \param memoryOrder The memory
-/// ordering used. \returns The value at the \p addr before the call.
+/// operand and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -320,9 +329,11 @@ inline T atomic_fetch_min(T *addr, T operand, sycl::memory_order memoryOrder) {
 }
 
 /// Atomically calculate the maximum of the value at addr and the value
-/// operand and assign the result to the value at addr. \param [in, out] addr
-/// The pointer to the data. \param operand. \param memoryOrder The memory
-/// ordering used. \returns The value at the \p addr before the call.
+/// operand and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -335,9 +346,11 @@ inline T atomic_fetch_max(T *addr, T operand) {
 }
 
 /// Atomically calculate the maximum of the value at addr and the value
-/// operand and assign the result to the value at addr. \param [in, out] addr
-/// The pointer to the data. \param operand. \param memoryOrder The memory
-/// ordering used. \returns The value at the \p addr before the call.
+/// operand and assign the result to the value at addr.
+/// \param [in, out] addr The pointer to the data.
+/// \param operand.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
@@ -420,9 +433,9 @@ inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
 
 /// Atomically exchange the value at the address addr with the value operand.
 /// \param [in, out] addr The pointer to the data.
-/// \param operand The value to be exchanged with the value pointed by \p
-/// addr. \param memoryOrder The memory ordering used. \returns The value at
-/// the \p addr before the call.
+/// \param operand The value to be exchanged with the value pointed by \p addr.
+/// \param memoryOrder The memory ordering used.
+/// \returns The value at the \p addr before the call.
 template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,


### PR DESCRIPTION
This PR modifies the wrapper to the atomic free functions:
- Extends half of the existing free functions with the `sycl::memory_scope` parameter. This unifies the interface with the rest of the API. 
- To preserve functionality `memoryScope` defaults to `sycl::memory_scope::device`
- README.md has been updated to reflect the new interface.
- README.md has also been updated to include the missing documentation for `class atomic`.