### PR TITLE
[SYCL][ESIMD] Use correct execSize in LSC functions

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2873,7 +2873,7 @@ ESIMD_INLINE SYCL_ESIMD_FUNCTION __ESIMD_NS::simd<T, N> lsc_load_2d(
   constexpr uint32_t exDesc = 0x0;
   constexpr uint32_t desc =
       base_desc | cache_mask | transformMask | transposeMask;
-  constexpr uint8_t execSize = N;
+  constexpr uint8_t execSize = 1;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numDst = (N * sizeof(T)) / 64;
@@ -2938,7 +2938,7 @@ ESIMD_INLINE SYCL_ESIMD_FUNCTION void lsc_prefetch_2d(
   constexpr uint32_t exDesc = 0x0;
   constexpr uint32_t desc =
       base_desc | cache_mask | transformMask | transposeMask;
-  constexpr uint8_t execSize = N;
+  constexpr uint8_t execSize = 1;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numDst = (N * sizeof(T)) / 64;
   raw_send<execSize, sfid, numDst>(payload.get_raw_data(), exDesc, desc);
@@ -2976,7 +2976,7 @@ lsc_store_2d(config_2d_mem_access<T, BlockWidth, BlockHeight, NBlocks> &payload,
 
   constexpr uint32_t exDesc = 0x0;
   constexpr uint32_t desc = base_desc | cache_mask;
-  constexpr uint8_t execSize = N;
+  constexpr uint8_t execSize = 1;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numSrc1 = (N * sizeof(T)) / 64;

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2873,7 +2873,7 @@ ESIMD_INLINE SYCL_ESIMD_FUNCTION __ESIMD_NS::simd<T, N> lsc_load_2d(
   constexpr uint32_t exDesc = 0x0;
   constexpr uint32_t desc =
       base_desc | cache_mask | transformMask | transposeMask;
-  constexpr uint8_t execSize = 0x0;
+  constexpr uint8_t execSize = N;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numDst = (N * sizeof(T)) / 64;
@@ -2938,7 +2938,7 @@ ESIMD_INLINE SYCL_ESIMD_FUNCTION void lsc_prefetch_2d(
   constexpr uint32_t exDesc = 0x0;
   constexpr uint32_t desc =
       base_desc | cache_mask | transformMask | transposeMask;
-  constexpr uint8_t execSize = 0x0;
+  constexpr uint8_t execSize = N;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numDst = (N * sizeof(T)) / 64;
   raw_send<execSize, sfid, numDst>(payload.get_raw_data(), exDesc, desc);
@@ -2976,7 +2976,7 @@ lsc_store_2d(config_2d_mem_access<T, BlockWidth, BlockHeight, NBlocks> &payload,
 
   constexpr uint32_t exDesc = 0x0;
   constexpr uint32_t desc = base_desc | cache_mask;
-  constexpr uint8_t execSize = 0x0;
+  constexpr uint8_t execSize = N;
   constexpr uint8_t sfid = 0xF;
   constexpr uint8_t numSrc0 = 0x1;
   constexpr uint8_t numSrc1 = (N * sizeof(T)) / 64;


### PR DESCRIPTION
It seemed to work before, but after https://github.com/intel/llvm/commit/cc3fd43996456b397117ea33bf8c0fef5b16959e where we started to use execSize for the mask size, we hit a compile time assert because we try to make a 0-length mask.

This is locked down with existing tests, but they run on PVC only. I manually confirmed this fixes it.