### PR TITLE
[SYCL] Disable VectorCombine load insert vectorization for SPIR targets 

### DIFF
--- a/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
+++ b/llvm/lib/Transforms/Vectorize/VectorCombine.cpp
@@ -26,6 +26,7 @@
 #include "llvm/IR/IRBuilder.h"
 #include "llvm/IR/PatternMatch.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/TargetParser/Triple.h"
 #include "llvm/Transforms/Utils/Local.h"
 #include <numeric>
 
@@ -150,6 +151,11 @@ static bool canWidenLoad(LoadInst *Load, const TargetTransformInfo &TTI) {
 }
 
 bool VectorCombine::vectorizeLoadInsert(Instruction &I) {
+  // SPIR targets use the default TTI which may give
+  // a misleading view into the target (minimum vector size, etc).
+  // Skip load insert vectorization for SPIR targets.
+  if (Triple(I.getModule()->getTargetTriple()).isSPIR())
+    return false;
   // Match insert into fixed vector of scalar value.
   // TODO: Handle non-zero insert index.
   Value *Scalar;

--- a/llvm/test/Transforms/VectorCombine/SPIR/skip-vector-load-vectorize.ll
+++ b/llvm/test/Transforms/VectorCombine/SPIR/skip-vector-load-vectorize.ll
@@ -1,0 +1,22 @@
+; RUN: opt < %s -passes=vector-combine -S | FileCheck --implicit-check-not=shufflevector --implicit-check-not="load <4 x i32>" %s
+
+; Verify we don't replace the insertelement with a shufflevector and a vector load for SPIR targets.
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"twoInt" = type { i32, i32 }
+%"myS" = type { <1 x i32> }
+; Function Attrs: convergent inlinehint norecurse nounwind
+define linkonce_odr dso_local spir_func void @foo(ptr addrspace(4) dereferenceable(32) %arg) {
+entry:
+  %0 = alloca %"myS", align 4
+  %1 = getelementptr inbounds %"twoInt", ptr addrspace(4) %arg, i64 0, i32 1
+  %2 = load i32, ptr addrspace(4) %1, align 4
+; CHECK: %3 = insertelement <1 x i32> poison, i32 %[[#Op:]], i64 0
+  %3 = insertelement <1 x i32> poison, i32 %2, i64 0
+  %4 = addrspacecast ptr %0 to ptr addrspace(4)
+  %5 = getelementptr inbounds %"myS", ptr addrspace(4) %4, i64 0, i32 0
+  store <1 x i32> %3, ptr addrspace(4) %5, align 4
+  ret void
+ }


### PR DESCRIPTION
One of the operations VectorCombine does is to change scalar loads + insertelement into vector loads + shufflevector.

It heavily uses the TTI to determine if it is beneficial to do this. However, for SPIR targets, we don't know what the final hardware is and the TTI uses default values. This gives a misleading view into the target. 

The pass aggressively performs the above transformation even if the new cost is equal to the old cost (which it is here, both are 1) because it claims the backend can undo it if it wants, however other passes such as SROA transform the IR significantly based on the changes to liveness from instructions introduced here, so it becomes unrealistic to undo this in a later pass.

I did not disable the pass overall because it still does beneficial transformations in other functions.

This fixes a performance regression in ESIMD caused by me enabling this pass for SYCL [here](https://github.com/intel/llvm/commit/f439f089f40584f15dfc8ac2608bcfce18c866f1), previously it was disabled.