### PR TITLE
[CG] Re-add code accidentally removed in conflict resolution.

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -2452,7 +2452,8 @@ RValue CodeGenFunction::EmitBuiltinExpr(const GlobalDecl GD, unsigned BuiltinID,
       GenerateIntrinsics =
           ConstWithoutErrnoOrExceptions && ErrnoOverridenToFalseWithOpt;
   }
-  if (GenerateIntrinsics) {
+  if (GenerateIntrinsics &&
+      !(getLangOpts().SYCLIsDevice && getTarget().getTriple().isNVPTX())) {
     switch (BuiltinIDIfNoAsmLabel) {
     case Builtin::BIceil:
     case Builtin::BIceilf:


### PR DESCRIPTION
Commit 28b9e76be1be119745e903e7cb2433c35dad7152 merged 'main' to
'sycl-web'. The conflict resolution for this merge accidentally removed
logic preventing builtins from being emitted for SYCL device code on the
NVPTX target. This patch re-adds that logic.

Fixes the following LIT regressions:

    Clang :: CodeGenSYCL/sycl-libdevice-cmath.cpp
