### PR TITLE
[SYCL-MLIR][NFC] Migrate SYCL analyses tests

### DIFF
--- a/mlir-sycl/CMakeLists.txt
+++ b/mlir-sycl/CMakeLists.txt
@@ -74,7 +74,10 @@ include(AddMLIRSYCL)
 
 add_subdirectory(include/mlir)
 add_subdirectory(lib)
-add_subdirectory(test)
+if (MLIR_INCLUDE_TESTS)
+  add_definitions(-DMLIR_INCLUDE_TESTS)
+  add_subdirectory(test)
+endif()
 add_subdirectory(tools)
 
 install(DIRECTORY include/

--- a/mlir-sycl/test/Analysis/accessor-analysis.mlir
+++ b/mlir-sycl/test/Analysis/accessor-analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt -split-input-file -test-accessor-analysis %s 2>&1 | FileCheck %s
+// RUN: sycl-mlir-opt -split-input-file -test-accessor-analysis %s 2>&1 | FileCheck %s
 
 llvm.func @__gxx_personality_v0(...) -> i32
 

--- a/mlir-sycl/test/Analysis/buffer-analysis.mlir
+++ b/mlir-sycl/test/Analysis/buffer-analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt -split-input-file -test-buffer-analysis %s 2>&1 | FileCheck %s
+// RUN: sycl-mlir-opt -split-input-file -test-buffer-analysis %s 2>&1 | FileCheck %s
 
 !sycl_id_1_ = !sycl.id<[1], (i64)>
 !sycl_range_1_ = !sycl.range<[1], (i64)>

--- a/mlir-sycl/test/Analysis/id-range-analysis.mlir
+++ b/mlir-sycl/test/Analysis/id-range-analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt -split-input-file -test-id-range-analysis %s 2>&1 | FileCheck %s
+// RUN: sycl-mlir-opt -split-input-file -test-id-range-analysis %s 2>&1 | FileCheck %s
 
 !sycl_id_1_ = !sycl.id<[1], (i64)>
 !sycl_id_2_ = !sycl.id<[2], (i64)>

--- a/mlir-sycl/test/Analysis/local-accessor-analysis.mlir
+++ b/mlir-sycl/test/Analysis/local-accessor-analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt -split-input-file -test-accessor-analysis %s 2>&1 | FileCheck %s
+// RUN: sycl-mlir-opt -split-input-file -test-accessor-analysis %s 2>&1 | FileCheck %s
 
 llvm.func @__gxx_personality_v0(...) -> i32
 

--- a/mlir-sycl/test/Analysis/nd-range-analysis.mlir
+++ b/mlir-sycl/test/Analysis/nd-range-analysis.mlir
@@ -1,4 +1,4 @@
-// RUN: polygeist-opt -test-nd-range-analysis %s 2>&1 | FileCheck %s
+// RUN: sycl-mlir-opt -test-nd-range-analysis %s 2>&1 | FileCheck %s
 
 !sycl_id_1_ = !sycl.id<[1], (i64)>
 !sycl_id_2_ = !sycl.id<[2], (i64)>

--- a/mlir-sycl/tools/sycl-mlir-opt/CMakeLists.txt
+++ b/mlir-sycl/tools/sycl-mlir-opt/CMakeLists.txt
@@ -8,11 +8,18 @@ set(LIBS
   MLIRSYCLTransforms
 )
 
+if(MLIR_INCLUDE_TESTS)
+  set(TEST_LIBS
+    MLIRSYCLTestAnalysis
+  )
+endif()
+
 add_mlir_tool(sycl-mlir-opt
   sycl-mlir-opt.cpp
 
   DEPENDS
   ${LIBS}
+  ${TEST_LIBS}
   )
-target_link_libraries(sycl-mlir-opt PRIVATE ${LIBS})
+target_link_libraries(sycl-mlir-opt PRIVATE ${LIBS} ${TEST_LIBS})
 mlir_check_all_link_libraries(sycl-mlir-opt)

--- a/mlir-sycl/tools/sycl-mlir-opt/sycl-mlir-opt.cpp
+++ b/mlir-sycl/tools/sycl-mlir-opt/sycl-mlir-opt.cpp
@@ -30,6 +30,24 @@
 using namespace llvm;
 using namespace mlir;
 
+namespace mlir {
+namespace test {
+void registerTestAccessorAnalysisPass();
+void registerTestBufferAnalysisPass();
+void registerTestIDAndRangeAnalysisPass();
+void registerTestNDRangeAnalysisPass();
+} // namespace test
+} // namespace mlir
+
+#ifdef MLIR_INCLUDE_TESTS
+void registerTestPasses() {
+  mlir::test::registerTestAccessorAnalysisPass();
+  mlir::test::registerTestBufferAnalysisPass();
+  mlir::test::registerTestIDAndRangeAnalysisPass();
+  mlir::test::registerTestNDRangeAnalysisPass();
+}
+#endif
+
 int main(int argc, char **argv) {
   InitLLVM y(argc, argv);
 
@@ -42,6 +60,9 @@ int main(int argc, char **argv) {
   registerAllPasses();
   sycl::registerSYCLPasses();
   sycl::registerConversionPasses();
+#ifdef MLIR_INCLUDE_TESTS
+  registerTestPasses();
+#endif
 
   return mlir::asMainReturnCode(
       mlir::MlirOptMain(argc, argv, "SYCL MLIR optimizer driver\n", registry));

--- a/polygeist/tools/polygeist-opt/CMakeLists.txt
+++ b/polygeist/tools/polygeist-opt/CMakeLists.txt
@@ -5,7 +5,6 @@ get_property(extension_libs GLOBAL PROPERTY MLIR_EXTENSION_LIBS)
 if(MLIR_INCLUDE_TESTS)
   set(test_libs
     MLIRPolygeistTestAnalysis
-    MLIRSYCLTestAnalysis
   )
 endif()
 

--- a/polygeist/tools/polygeist-opt/polygeist-opt.cpp
+++ b/polygeist/tools/polygeist-opt/polygeist-opt.cpp
@@ -50,11 +50,7 @@ struct PtrElementModel
 
 namespace mlir {
 namespace test {
-void registerTestAccessorAnalysisPass();
-void registerTestBufferAnalysisPass();
-void registerTestIDAndRangeAnalysisPass();
 void registerTestMemoryAccessAnalysisPass();
-void registerTestNDRangeAnalysisPass();
 void registerTestReachingDefinitionAnalysisPass();
 void registerTestUniformityAnalysisPass();
 } // namespace test
@@ -62,11 +58,7 @@ void registerTestUniformityAnalysisPass();
 
 #ifdef MLIR_INCLUDE_TESTS
 void registerTestPasses() {
-  mlir::test::registerTestAccessorAnalysisPass();
-  mlir::test::registerTestBufferAnalysisPass();
-  mlir::test::registerTestIDAndRangeAnalysisPass();
   mlir::test::registerTestMemoryAccessAnalysisPass();
-  mlir::test::registerTestNDRangeAnalysisPass();
   mlir::test::registerTestReachingDefinitionAnalysisPass();
   mlir::test::registerTestUniformityAnalysisPass();
 }


### PR DESCRIPTION
Migrate the tests for the SYCL constructor-based analyses to the
mlir-sycl directory.

To that end, migrate the test passes from polygeist-opt to
sycl-mlir-opt.

Signed-off-by: Lukas Sommer <lukas.sommer@codeplay.com>