### PR TITLE
[SYCL][UR] Remove unused MaxAllocSize member variable and fix unused parameter 'Alignment' warning

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/hip/device.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/device.hpp
@@ -24,8 +24,6 @@ private:
   ur_platform_handle_t Platform;
   hipCtx_t HIPContext;
 
-  size_t MaxAllocSize{0};
-
 public:
   ur_device_handle_t_(native_type HipDevice, hipCtx_t Context,
                       ur_platform_handle_t Platform)

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/usm.cpp
@@ -99,7 +99,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urUSMFree(ur_context_handle_t hContext,
 
 ur_result_t USMDeviceAllocImpl(void **ResultPtr, ur_context_handle_t Context,
                                ur_device_handle_t, ur_usm_device_mem_flags_t *,
-                               size_t Size, uint32_t Alignment) {
+                               size_t Size,
+                               [[maybe_unused]] uint32_t Alignment) {
   try {
     ScopedContext Active(Context->getDevice());
     UR_CHECK_ERROR(hipMalloc(ResultPtr, Size));
@@ -114,7 +115,7 @@ ur_result_t USMDeviceAllocImpl(void **ResultPtr, ur_context_handle_t Context,
 ur_result_t USMSharedAllocImpl(void **ResultPtr, ur_context_handle_t Context,
                                ur_device_handle_t, ur_usm_host_mem_flags_t *,
                                ur_usm_device_mem_flags_t *, size_t Size,
-                               uint32_t Alignment) {
+                               [[maybe_unused]] uint32_t Alignment) {
   try {
     ScopedContext Active(Context->getDevice());
     UR_CHECK_ERROR(hipMallocManaged(ResultPtr, Size, hipMemAttachGlobal));
@@ -128,7 +129,7 @@ ur_result_t USMSharedAllocImpl(void **ResultPtr, ur_context_handle_t Context,
 
 ur_result_t USMHostAllocImpl(void **ResultPtr, ur_context_handle_t Context,
                              ur_usm_host_mem_flags_t *, size_t Size,
-                             uint32_t Alignment) {
+                             [[maybe_unused]] uint32_t Alignment) {
   try {
     ScopedContext Active(Context->getDevice());
     UR_CHECK_ERROR(hipHostMalloc(ResultPtr, Size));


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/actions/runs/6154418223/job/16699759620