### PR TITLE
[SYCL] Use SFINAE to reject wrong signature of CGF object parameter

### DIFF
--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -339,8 +339,10 @@ public:
   /// \param CodeLoc is the code location of the submit call (default argument)
   /// \return a SYCL event object for the submitted command group.
   template <typename T>
-  event submit(T CGF, const detail::code_location &CodeLoc =
-                          detail::code_location::current()) {
+  std::enable_if_t<std::is_convertible_v<T, std::function<void(handler &)>>,
+                   event>
+  submit(T CGF, const detail::code_location &CodeLoc =
+                    detail::code_location::current()) {
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);
 #if __SYCL_USE_FALLBACK_ASSERT
     auto PostProcess = [this, &CodeLoc](bool IsKernel, bool KernelUsesAssert,
@@ -375,7 +377,9 @@ public:
   /// \return a SYCL event object, which corresponds to the queue the command
   /// group is being enqueued on.
   template <typename T>
-  event submit(
+  std::enable_if_t<std::is_convertible_v<T, std::function<void(handler &)>>,
+                   event>
+  submit(
       T CGF, queue &SecondaryQueue,
       const detail::code_location &CodeLoc = detail::code_location::current()) {
     detail::tls_code_loc_t TlsCodeLocCapture(CodeLoc);


### PR DESCRIPTION
For a mistake like this:

```
  q.submit([&](sycl::handler cgh) { // Missing "&"
    cgh.single_task([=]() {});
  }).wait_and_throw();
```

changes errors from

```
In file included from <...>/build/bin/../include/sycl/sycl.hpp:16:
In file included from <...>/build/bin/../include/sycl/backend.hpp:34:
<...>/build/bin/../include/sycl/queue.hpp:361:18: error:
      no matching member function for call to 'submit_impl'
  361 |     auto Event = submit_impl(CGF, CodeLoc);
      |                  ^~~~~~~~~~~
a.cpp:5:5: note: in instantiation of function template
      specialization 'sycl::queue::submit<(lambda at a.cpp:5:12)>' requested here
    5 |   q.submit([&](sycl::handler cgh) {
      |     ^
<...>/build/bin/../include/sycl/queue.hpp:2811:9: note:
      candidate function not viable: no known conversion from '(lambda at a.cpp:5:12)'
      to 'std::function<void (handler &)>' for 1st argument
 2811 |   event submit_impl(std::function<void(handler &)> CGH,
      |         ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
<...>/build/bin/../include/sycl/queue.hpp:2814:9: note:
      candidate function not viable: requires 3 arguments, but 2 were provided
 2814 |   event submit_impl(std::function<void(handler &)> CGH, queue secondQueue,
      |         ^           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 2815 |                     const detail::code_location &CodeLoc);
      |                     ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```

to

```
a.cpp:5:5: error: no matching member function for call to 'submit'
    5 |   q.submit([&](sycl::handler cgh) {
      |   ~~^~~~~~
<...>/build/bin/../include/sycl/queue.hpp:344:3: note: candidate template ignored: requirement 'std::is_convertible_v<(lambda at
      a.cpp:5:12), std::function<void (sycl::handler &)>>' was not satisfied [with T = (lambda at a.cpp:5:12)]
  344 |   submit(T CGF, const detail::code_location &CodeLoc =
      |   ^
<...>/build/bin/../include/sycl/queue.hpp:382:3: note: candidate function template not viable: requires at least 2 arguments, but 1 was
      provided
  382 |   submit(
      |   ^
  383 |       T CGF, queue &SecondaryQueue,
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  384 |       const detail::code_location &CodeLoc = detail::code_location::current()) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
1 error generated.
```