### PR TITLE
[OpenMP][Doc] Fix OMP documentation link in the root directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ guidelines.
 
 ## Late-outline OpenMP\* and OpenMP\* Offload
 
-See [openmp](/tree/openmp) branch.
+See [openmp](./openmp/README.rst) subproject documentation.
 
 # License
 


### PR DESCRIPTION
Replace the outdated branch link: redirect to the active OpenMP subfolder
instead.

Signed-off-by: Artem Gindinson <artem.gindinson@intel.com>