### PR TITLE
[SYCL-MLIR][sycl] Define `isBaseClass` function

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.h
@@ -72,6 +72,9 @@ public:
 };
 using AccessorPtrPair = std::pair<AccessorPtrValue, AccessorPtrValue>;
 
+/// Return whether \p baseType is a base type of \p derivedType
+bool isBaseClass(Type baseType, Type derivedType);
+
 } // namespace sycl
 } // namespace mlir
 

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
@@ -33,6 +33,8 @@ class SYCL_Type<string name, string typeMnemonic, list<Trait> traits = []>
   let mnemonic = typeMnemonic;
 }
 
+// NOTE: Handle new `SYCLInheritanceTypeTrait` not present in
+// `mlir::sycl::isBaseType`.
 class SYCLInheritanceTypeTrait<string ParentClass>
     : NativeTypeTrait<"SYCLInheritanceTypeTrait<" # ParentClass # ">::Trait"> {
   let cppNamespace = "::mlir::sycl";

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -136,24 +136,7 @@ bool SYCLCastOp::areCastCompatible(TypeRange Inputs, TypeRange Outputs) {
   Type InputElemType = Input.getElementType();
   Type OutputElemType = Output.getElementType();
 
-  return TypeSwitch<Type, bool>(OutputElemType)
-      .template Case<ArrayType>([&](auto) {
-        return InputElemType
-            .hasTrait<SYCLInheritanceTypeTrait<ArrayType>::Trait>();
-      })
-      .template Case<AccessorCommonType>([&](auto) {
-        return InputElemType
-            .hasTrait<SYCLInheritanceTypeTrait<AccessorCommonType>::Trait>();
-      })
-      .template Case<LocalAccessorBaseType>([&](auto) {
-        return InputElemType
-            .hasTrait<SYCLInheritanceTypeTrait<LocalAccessorBaseType>::Trait>();
-      })
-      .template Case<OwnerLessBaseType>([&](auto) {
-        return InputElemType
-            .hasTrait<SYCLInheritanceTypeTrait<OwnerLessBaseType>::Trait>();
-      })
-      .Default(false);
+  return isBaseClass(OutputElemType, InputElemType);
 }
 
 bool SYCLAddrSpaceCastOp::areCastCompatible(TypeRange inputs,

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -91,5 +91,15 @@ bool AccessorPtrValue::classof(Value v) {
   return isPtrOf<sycl::AccessorType>(v.getType());
 }
 
+bool isBaseClass(Type baseType, Type derivedType) {
+  return TypeSwitch<Type, bool>(baseType)
+      .Case<ArrayType, AccessorCommonType, LocalAccessorBaseType,
+            OwnerLessBaseType>([&](auto bt) {
+        return derivedType
+            .hasTrait<SYCLInheritanceTypeTrait<decltype(bt)>::template Trait>();
+      })
+      .Default(false);
+}
+
 } // namespace sycl
 } // namespace mlir

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1272,14 +1272,8 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
   return ValueCategory(Result, /*isReference*/ true, InnerTy);
 }
 
-static bool isSYCLInheritType(Type &Ty, Value &Val) {
-  assert(isa<MemRefType>(Val.getType()));
-  if (!isa<MemRefType>(Ty))
-    return false;
-
-  Type OutputTy = cast<MemRefType>(Ty).getElementType();
-  Type InputTy = cast<MemRefType>(Val.getType()).getElementType();
-  return sycl::isBaseClass(OutputTy, InputTy);
+static bool isSYCLInheritType(Type Ty, Value Val) {
+  return sycl::SYCLCastOp::areCastCompatible(Val.getType(), Ty);
 }
 
 Value MLIRScanner::GetAddressOfDerivedClass(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1277,21 +1277,9 @@ static bool isSYCLInheritType(Type &Ty, Value &Val) {
   if (!isa<MemRefType>(Ty))
     return false;
 
-  Type ElemTy = cast<MemRefType>(Ty).getElementType();
-  return TypeSwitch<Type, bool>(
-             cast<MemRefType>(Val.getType()).getElementType())
-      .Case<sycl::AccessorType>([&](auto) {
-        return isa<sycl::AccessorCommonType>(ElemTy) ||
-               isa<sycl::LocalAccessorBaseType>(ElemTy) ||
-               isa<sycl::OwnerLessBaseType>(ElemTy);
-      })
-      .Case<sycl::LocalAccessorBaseType>(
-          [&](auto) { return isa<sycl::AccessorCommonType>(ElemTy); })
-      .Case<sycl::LocalAccessorType>(
-          [&](auto) { return isa<sycl::LocalAccessorBaseType>(ElemTy); })
-      .Case<sycl::IDType, sycl::RangeType>(
-          [&](auto) { return isa<sycl::ArrayType>(ElemTy); })
-      .Default(false);
+  Type OutputTy = cast<MemRefType>(Ty).getElementType();
+  Type InputTy = cast<MemRefType>(Val.getType()).getElementType();
+  return sycl::isBaseClass(OutputTy, InputTy);
 }
 
 Value MLIRScanner::GetAddressOfDerivedClass(


### PR DESCRIPTION
Define `isBaseClass` checking DPC++'s class hierarchy.