### PR TITLE
[SYCL-MLIR][sycl] Add `SYCLInheritanceTypeTrait<OwnerLessBaseType>` trait to `LocalAccessor`

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
@@ -157,7 +157,8 @@ def SYCL_LocalAccessorBaseType
 
 def SYCL_LocalAccessorType
     : SYCL_Type<"LocalAccessor", "local_accessor",
-        [SYCLInheritanceTypeTrait<"LocalAccessorBaseType">]> {
+        [SYCLInheritanceTypeTrait<"LocalAccessorBaseType">,
+         SYCLInheritanceTypeTrait<"OwnerLessBaseType">]> {
   let summary = "Local Accessor";
   let description = [{ Accessor to a local buffer.}];
   let parameters = (ins "::mlir::Type":$type,


### PR DESCRIPTION
Add trait expressing `sycl::local_accessor<DataT, Dimensions>` derives from `sycl::detail::OwnerLessBase<local_accessor<DataT, Dimensions>>`.

This is needed so that we can `sycl.cast` from `local_accessor` to `OwnerLessBase`,
making our dialect more DPC++-specific, but also making it work with current's
approach.