### PR TITLE
[SYCL] fill() use native functions instead of custom kernels

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -809,32 +809,49 @@ void MemoryManager::copy(SYCLMemObjI *SYCLMemObj, void *SrcMem,
 
 void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
                          size_t PatternSize, const char *Pattern,
-                         unsigned int Dim, sycl::range<3>, sycl::range<3> Range,
-                         sycl::id<3> Offset, unsigned int ElementSize,
+                         unsigned int Dim, sycl::range<3> MemRange,
+                         sycl::range<3> AccRange, sycl::id<3> Offset,
+                         unsigned int ElementSize,
                          std::vector<sycl::detail::pi::PiEvent> DepEvents,
                          sycl::detail::pi::PiEvent &OutEvent,
                          const detail::EventImplPtr &OutEventImpl) {
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const PluginPtr &Plugin = Queue->getPlugin();
+
   if (SYCLMemObj->getType() == detail::SYCLMemObjI::MemObjType::Buffer) {
     if (OutEventImpl != nullptr)
       OutEventImpl->setHostEnqueueTime();
-    if (Dim <= 1) {
+
+    // 2D and 3D buffers accessors can't have custom range or the data will
+    // likely be discontiguous.
+    bool RangesUsable = (Dim <= 1) || (MemRange == AccRange);
+    // For 2D and 3D buffers, the offset must be 0, or the data will be
+    // discontiguous.
+    bool OffsetUsable = (Dim <= 1) || (Offset == sycl::id<3>{0, 0, 0});
+    size_t RangeMultiplier = AccRange[0] * AccRange[1] * AccRange[2];
+
+    if (RangesUsable && OffsetUsable) {
       Plugin->call<PiApiKind::piEnqueueMemBufferFill>(
           Queue->getHandleRef(), pi::cast<sycl::detail::pi::PiMem>(Mem),
-          Pattern, PatternSize, Offset[0] * ElementSize, Range[0] * ElementSize,
-          DepEvents.size(), DepEvents.data(), &OutEvent);
+          Pattern, PatternSize, Offset[0] * ElementSize,
+          RangeMultiplier * ElementSize, DepEvents.size(), DepEvents.data(),
+          &OutEvent);
       return;
     }
+    // The sycl::handler uses a parallel_for kernel in the case of unusable
+    // Range or Offset, not CG:Fill. So we should not be here.
     throw runtime_error("Not supported configuration of fill requested",
                         PI_ERROR_INVALID_OPERATION);
   } else {
     if (OutEventImpl != nullptr)
       OutEventImpl->setHostEnqueueTime();
+    // images don't support offset accessors and thus avoid issues of
+    // discontinguous data
     Plugin->call<PiApiKind::piEnqueueMemImageFill>(
         Queue->getHandleRef(), pi::cast<sycl::detail::pi::PiMem>(Mem), Pattern,
-        &Offset[0], &Range[0], DepEvents.size(), DepEvents.data(), &OutEvent);
+        &Offset[0], &AccRange[0], DepEvents.size(), DepEvents.data(),
+        &OutEvent);
   }
 }
 

--- a/sycl/test-e2e/Basic/fill_accessor_pi.cpp
+++ b/sycl/test-e2e/Basic/fill_accessor_pi.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out | FileCheck %s
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // the fill_accessor.cpp test checks that the .fill() function is working
 // correctly. here we check that it uses the correct PI call.
@@ -18,49 +18,130 @@ void testFill_Buffer1D() {
 
     sycl::queue q;
     std::cout << "start testFill_Buffer1D" << std::endl;
-    auto e1 = q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler &cgh) {
       auto acc1D = buffer_1D.get_access<sycl::access::mode::write>(cgh);
+      // should stage piEnqueueMemBufferFill
       cgh.fill(acc1D, float{1});
     });
     q.wait();
 
     std::cout << "start testFill_Buffer1D -- OFFSET" << std::endl;
-    auto e1 = q.submit([&](sycl::handler &cgh) {
+    q.submit([&](sycl::handler &cgh) {
       auto acc1DOffset =
-          buffer_1D.get_access<sycl::access::mode::write>(cgh, {2}, {4});
+          buffer_1D.get_access<sycl::access::mode::write>(cgh, {4}, {2});
+      // despite being offset, should stage piEnqueueMemBufferFill
       cgh.fill(acc1DOffset, float{2});
     });
     q.wait();
   } // ~buffer
+
+  // quick check.  fill_accessor.cpp is more thorough.
   assert(data_1D[1] == 1);
   assert(data_1D[2] == 2);
 }
 
 void testFill_Buffer2D() {
-  std::cout << "start testFill_Buffer2D" << std::endl;
   std::vector<float> data_2D(total_2D, 0);
   {
     sycl::buffer<float, 2> buffer_2D(data_2D.data(),
                                      sycl::range<2>(height, width));
 
     sycl::queue q;
+    std::cout << "start testFill_Buffer2D" << std::endl;
     q.submit([&](sycl::handler &cgh) {
-      // cgh.depends_on(e1);
-      // auto acc2D = buffer_2D.get_access<sycl::access::mode::write>(cgh); //
-      // working now.
-
-      // should go to parall_for, not MemoryManager::fill()
-      auto acc2D =
-          buffer_2D.get_access<sycl::access::mode::write>(cgh, {12, 8}, {4, 2});
-      sycl::range<2> r = acc2D.get_range();
-      std::cout << r[0] << "/" << r[1] << std::endl; // 32/64
-      sycl::id<2> id = acc2D.get_offset();           // 0/0
-      std::cout << "offset: " << id[0] << "/" << id[1] << std::endl;
-
-      cgh.fill(acc2D, float{2});
+      auto acc2D = buffer_2D.get_access<sycl::access::mode::write>(cgh);
+      // should stage piEnqueueMemBufferFill
+      cgh.fill(acc2D, float{3});
     });
+    q.wait();
 
+    std::cout << "start testFill_Buffer2D -- OFFSET" << std::endl;
+    q.submit([&](sycl::handler &cgh) {
+      auto acc2D =
+          buffer_2D.get_access<sycl::access::mode::write>(cgh, {8, 12}, {2, 2});
+      // "ranged accessor" will have to be handled by custom kernel:
+      // piEnqueueKernelLaunch
+      cgh.fill(acc2D, float{4});
+    });
+    q.wait();
   } // ~buffer
-  printData("Buffer2d", data_2D.data(), height * num);
-  std::cout << "end testFill Buffer2d" << std::endl;
+
+  // quick check.  fill_accessor.cpp is more thorough.
+  assert(data_2D[(1 * width) + 1] == 3); // [1][1] sb 3
+  assert(data_2D[(2 * width) + 2] == 4); // [2][2] sb 4
 }
+
+void testFill_Buffer3D() {
+  std::vector<float> data_3D(total_3D, 0);
+  {
+    sycl::buffer<float, 3> buffer_3D(data_3D.data(),
+                                     sycl::range<3>(depth, height, width));
+
+    sycl::queue q;
+    std::cout << "start testFill_Buffer3D" << std::endl;
+    q.submit([&](sycl::handler &cgh) {
+      auto acc3D = buffer_3D.get_access<sycl::access::mode::write>(cgh);
+      // should stage piEnqueueMemBufferFill
+      cgh.fill(acc3D, float{5});
+    });
+    q.wait();
+
+    std::cout << "start testFill_Buffer3D -- OFFSET" << std::endl;
+    q.submit([&](sycl::handler &cgh) {
+      auto acc3D = buffer_3D.get_access<sycl::access::mode::write>(
+          cgh, {4, 8, 12}, {3, 3, 3});
+      // "ranged accessor" will have to be handled by custom kernel:
+      // piEnqueueKernelLaunch
+      cgh.fill(acc3D, float{6});
+    });
+    q.wait();
+  } // ~buffer
+
+  // quick check.  fill_accessor.cpp is more thorough.
+  assert(data_3D[(1 * height * width) + (1 * width) + 1] ==
+         5); // [1][1][1] sb 5
+  assert(data_3D[(3 * height * width) + (3 * width) + 3] ==
+         6); // [3][3][3] sb 6
+}
+
+void testFill_ZeroDim() {
+  sycl::range<1> r{1};
+  std::vector<float> data_0D(1, 0);
+  {
+    sycl::buffer<float, 1> Buffer(data_0D.data(), r);
+    sycl::queue q;
+    std::cout << "start testFill_ZeroDim" << std::endl;
+    q.submit([&](sycl::handler &cgh) {
+      sycl::accessor<float, 0, sycl::access::mode::write> Acc0(Buffer, cgh);
+      cgh.fill(Acc0, float{1});
+    });
+    q.wait();
+  }
+  assert(data_0D[0] == 1);
+}
+
+int main() {
+  testFill_Buffer1D();
+  testFill_Buffer2D();
+  testFill_Buffer3D();
+  testFill_ZeroDim();
+  return 0;
+}
+
+// CHECK: start testFill_Buffer1D
+// CHECK: piEnqueueMemBufferFill
+// CHECK: start testFill_Buffer1D -- OFFSET
+// CHECK: piEnqueueMemBufferFill
+
+// CHECK: start testFill_Buffer2D
+// CHECK: piEnqueueMemBufferFill
+// CHECK: start testFill_Buffer2D -- OFFSET
+// CHECK: piEnqueueKernelLaunch
+
+// CHECK: start testFill_Buffer3D
+// CHECK: piEnqueueMemBufferFill
+// CHECK: start testFill_Buffer3D -- OFFSET
+// CHECK: piEnqueueKernelLaunch
+
+// CHECK: start testFill_ZeroDim
+// CHECK: piEnqueueMemBufferFill

--- a/sycl/test-e2e/Basic/fill_accessor_pi.cpp
+++ b/sycl/test-e2e/Basic/fill_accessor_pi.cpp
@@ -1,0 +1,66 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out | FileCheck %s
+
+// the fill_accessor.cpp test checks that the .fill() function is working
+// correctly. here we check that it uses the correct PI call.
+
+#include <sycl/sycl.hpp>
+constexpr int width = 32;
+constexpr int height = 16;
+constexpr int depth = 8;
+constexpr int total_2D = width * height;
+constexpr int total_3D = width * height * depth;
+
+void testFill_Buffer1D() {
+  std::vector<float> data_1D(width, 0);
+  {
+    sycl::buffer<float, 1> buffer_1D(data_1D.data(), sycl::range<1>(width));
+
+    sycl::queue q;
+    std::cout << "start testFill_Buffer1D" << std::endl;
+    auto e1 = q.submit([&](sycl::handler &cgh) {
+      auto acc1D = buffer_1D.get_access<sycl::access::mode::write>(cgh);
+      cgh.fill(acc1D, float{1});
+    });
+    q.wait();
+
+    std::cout << "start testFill_Buffer1D -- OFFSET" << std::endl;
+    auto e1 = q.submit([&](sycl::handler &cgh) {
+      auto acc1DOffset =
+          buffer_1D.get_access<sycl::access::mode::write>(cgh, {2}, {4});
+      cgh.fill(acc1DOffset, float{2});
+    });
+    q.wait();
+  } // ~buffer
+  assert(data_1D[1] == 1);
+  assert(data_1D[2] == 2);
+}
+
+void testFill_Buffer2D() {
+  std::cout << "start testFill_Buffer2D" << std::endl;
+  std::vector<float> data_2D(total_2D, 0);
+  {
+    sycl::buffer<float, 2> buffer_2D(data_2D.data(),
+                                     sycl::range<2>(height, width));
+
+    sycl::queue q;
+    q.submit([&](sycl::handler &cgh) {
+      // cgh.depends_on(e1);
+      // auto acc2D = buffer_2D.get_access<sycl::access::mode::write>(cgh); //
+      // working now.
+
+      // should go to parall_for, not MemoryManager::fill()
+      auto acc2D =
+          buffer_2D.get_access<sycl::access::mode::write>(cgh, {12, 8}, {4, 2});
+      sycl::range<2> r = acc2D.get_range();
+      std::cout << r[0] << "/" << r[1] << std::endl; // 32/64
+      sycl::id<2> id = acc2D.get_offset();           // 0/0
+      std::cout << "offset: " << id[0] << "/" << id[1] << std::endl;
+
+      cgh.fill(acc2D, float{2});
+    });
+
+  } // ~buffer
+  printData("Buffer2d", data_2D.data(), height * num);
+  std::cout << "end testFill Buffer2d" << std::endl;
+}


### PR DESCRIPTION
`handler::fill()` is only staging `piEnqueueMemBufferFill` in the case of 1D buffer accessors. This PR changes this to include 2D and 3D buffers ( when not using ranged accessors ). 