### PR TITLE
[SYCL][CUDA] Add missing nearbyint

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -153,4 +153,11 @@ float asinhf(float x) { return __devicelib_asinhf(x); }
 
 DEVICE_EXTERN_C_INLINE
 float atanhf(float x) { return __devicelib_atanhf(x); }
+
+#ifdef __NVPTX__
+extern "C" SYCL_EXTERNAL float __nv_nearbyintf(float);
+DEVICE_EXTERN_C_INLINE
+float nearbyintf(float x) { return __nv_nearbyintf(x); }
+#endif // __NVPTX__
+
 #endif // __SPIR__ || __NVPTX__

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -143,6 +143,12 @@ double atanh(double x) { return __devicelib_atanh(x); }
 DEVICE_EXTERN_C_INLINE
 double scalbn(double x, int exp) { return __devicelib_scalbn(x, exp); }
 
+#ifdef __NVPTX__
+extern "C" SYCL_EXTERNAL double __nv_nearbyint(double);
+DEVICE_EXTERN_C_INLINE
+double nearbyint(double x) { return __nv_nearbyint(x); }
+#endif // __NVPTX__
+
 #if defined(_MSC_VER)
 #include <math.h>
 // FLOAT PROPERTIES


### PR DESCRIPTION
`nearbyint` was missing for NVPTX. `nearbyint` is not found in `libclc`, so instead of the usual `libdevice->libclc->native_bc_lib` it was necessary to just skip libclc and go straight to the `__nv` symbols which are found in nvvm libdevice.