### PR TITLE
[SYCL] Mark tests that require size 32 subgroups with "REQUIRES: sg-32"

### DIFF
--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 
 // REQUIRES: gpu
+// REQUIRES: sg-32
 
 #include <sycl/sycl.hpp>
 #include <vector>
@@ -11,13 +12,6 @@ template <size_t PartitionSize> class TestKernel;
 
 template <size_t PartitionSize> void test() {
   sycl::queue Q;
-
-  auto SGSizes = Q.get_device().get_info<sycl::info::device::sub_group_sizes>();
-  if (std::find(SGSizes.begin(), SGSizes.end(), 32) == SGSizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
 
   sycl::buffer<bool, 1> MatchBuf{sycl::range{32}};
   sycl::buffer<bool, 1> LeaderBuf{sycl::range{32}};

--- a/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/fixed_size_group_algorithms.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // REQUIRES: gpu
+// REQUIRES: sg-32
 // UNSUPPORTED: hip
 
 #include <sycl/sycl.hpp>
@@ -14,12 +15,6 @@ template <size_t PartitionSize> void test() {
   sycl::queue Q;
 
   constexpr uint32_t SGSize = 32;
-  auto SGSizes = Q.get_device().get_info<sycl::info::device::sub_group_sizes>();
-  if (std::find(SGSizes.begin(), SGSizes.end(), SGSize) == SGSizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
 
   sycl::buffer<size_t, 1> TmpBuf{sycl::range{SGSize}};
   sycl::buffer<bool, 1> BarrierBuf{sycl::range{SGSize}};

--- a/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/tangle_group_algorithms.cpp
@@ -2,6 +2,7 @@
 // RUN: %{run} %t.out
 //
 // REQUIRES: gpu
+// REQUIRES: sg-32
 // UNSUPPORTED: cuda || hip || windows
 // Tangle groups exhibit unpredictable behavior on Windows.
 // The test is disabled while we investigate the root cause.
@@ -16,13 +17,6 @@ constexpr uint32_t SGSize = 32;
 
 int main() {
   sycl::queue Q;
-
-  auto SGSizes = Q.get_device().get_info<sycl::info::device::sub_group_sizes>();
-  if (std::find(SGSizes.begin(), SGSizes.end(), SGSize) == SGSizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return 0;
-  }
 
   sycl::buffer<size_t, 1> TmpBuf{sycl::range{SGSize}};
   sycl::buffer<bool, 1> BarrierBuf{sycl::range{SGSize}};

--- a/sycl/test-e2e/SubGroupMask/Basic.cpp
+++ b/sycl/test-e2e/SubGroupMask/Basic.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -o %t.out
 
 // REQUIRES: gpu
+// REQUIRES: sg-32
 
 // GroupNonUniformBallot capability is supported on Intel GPU only
 // RUN: %{run} %t.out
@@ -23,14 +24,6 @@ constexpr int local_size = 32;
 int main() {
 #ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
   queue Queue;
-
-  auto sgsizes =
-      Queue.get_device().get_info<sycl::info::device::sub_group_sizes>();
-  if (std::find(sgsizes.begin(), sgsizes.end(), 32) == sgsizes.end()) {
-    std::cout << "test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return 0;
-  }
 
   try {
     nd_range<1> NdRange(global_size, local_size);

--- a/sycl/test-e2e/syclcompat/util/util_logical_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_logical_group.cpp
@@ -62,6 +62,14 @@ void test_logical_group() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue q_ct1 = *dev_ct1.default_queue();
+  if (auto sg_sizes =
+          q_ct1.get_device().get_info<sycl::info::device::sub_group_sizes>();
+      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
+    std::cout << "Test skipped due to missing support for sub-group size 32."
+              << std::endl;
+    return;
+  }
+
   unsigned int result_host[4];
   unsigned int *result_device;
   result_device = sycl::malloc_device<unsigned int>(4, q_ct1);

--- a/sycl/test-e2e/syclcompat/util/util_logical_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_logical_group.cpp
@@ -30,6 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// REQUIRES: sg-32
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
@@ -62,14 +63,6 @@ void test_logical_group() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue q_ct1 = *dev_ct1.default_queue();
-  if (auto sg_sizes =
-          q_ct1.get_device().get_info<sycl::info::device::sub_group_sizes>();
-      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
-
   unsigned int result_host[4];
   unsigned int *result_device;
   result_device = sycl::malloc_device<unsigned int>(4, q_ct1);

--- a/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
@@ -84,6 +84,13 @@ void test_permute_sub_group_by_xor() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
+  if (auto sg_sizes =
+          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
+      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
+    std::cout << "Test skipped due to missing support for sub-group size 32."
+              << std::endl;
+    return;
+  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
@@ -30,6 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// REQUIRES: sg-32
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
@@ -84,13 +85,6 @@ void test_permute_sub_group_by_xor() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
-  if (auto sg_sizes =
-          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
-      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
@@ -30,6 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// REQUIRES: sg-32
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
@@ -82,13 +83,6 @@ void test_select_from_sub_group() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
-  if (auto sg_sizes =
-          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
-      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
@@ -82,6 +82,13 @@ void test_select_from_sub_group() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
+  if (auto sg_sizes =
+          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
+      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
+    std::cout << "Test skipped due to missing support for sub-group size 32."
+              << std::endl;
+    return;
+  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
@@ -30,6 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// REQUIRES: sg-32
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
@@ -81,13 +82,6 @@ void test_shift_sub_group_left() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
-  if (auto sg_sizes =
-          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
-      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
@@ -81,6 +81,13 @@ void test_shift_sub_group_left() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
+  if (auto sg_sizes =
+          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
+      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
+    std::cout << "Test skipped due to missing support for sub-group size 32."
+              << std::endl;
+    return;
+  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
@@ -81,6 +81,13 @@ void test_shift_sub_group_right() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
+  if (auto sg_sizes =
+          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
+      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
+    std::cout << "Test skipped due to missing support for sub-group size 32."
+              << std::endl;
+    return;
+  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
@@ -30,6 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// REQUIRES: sg-32
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
@@ -81,13 +82,6 @@ void test_shift_sub_group_right() {
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
-  if (auto sg_sizes =
-          q_ct1->get_device().get_info<sycl::info::device::sub_group_sizes>();
-      std::find(sg_sizes.begin(), sg_sizes.end(), 32) == sg_sizes.end()) {
-    std::cout << "Test skipped due to missing support for sub-group size 32."
-              << std::endl;
-    return;
-  }
   bool Result = true;
   int *dev_data = nullptr;
   unsigned int *dev_data_u = nullptr;


### PR DESCRIPTION
Many AMD devices don't support size 32 subgroups. This patch skips tests for such devices. Same as https://github.com/intel/llvm/pull/11104