### PR TITLE
[SYCL-MLIR][polygeist] Verify `pointer2memref` and `memref2pointer`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistOps.td
+++ b/polygeist/include/mlir/Dialect/Polygeist/IR/PolygeistOps.td
@@ -92,6 +92,7 @@ def Memref2PointerOp : Polygeist_Op<"memref2pointer", [
 
   let hasFolder = 1;
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
   
   let extraClassDeclaration = [{
     ::mlir::Value getViewSource() { return getSource(); }
@@ -108,6 +109,7 @@ def Pointer2MemrefOp : Polygeist_Op<"pointer2memref", [
 
   let hasFolder = 1;
   let hasCanonicalizer = 1;
+  let hasVerifier = 1;
   
   let extraClassDeclaration = [{
     ::mlir::Value getViewSource() { return getSource(); }

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -338,10 +338,10 @@ struct Memref2PointerOpLowering
   LogicalResult
   matchAndRewrite(Memref2PointerOp op, OpAdaptor transformed,
                   ConversionPatternRewriter &rewriter) const override {
-    if (LogicalResult verifResult = verifyPtrMemrefConversion(
+    if (LogicalResult verifyResult = verifyPtrMemrefConversion(
             *getTypeConverter(), op, op.getType(), op.getSource().getType());
-        failed(verifResult))
-      return verifResult;
+        failed(verifyResult))
+      return verifyResult;
 
     auto loc = op.getLoc();
 
@@ -370,10 +370,10 @@ struct Pointer2MemrefOpLowering
   LogicalResult
   matchAndRewrite(Pointer2MemrefOp op, OpAdaptor adaptor,
                   ConversionPatternRewriter &rewriter) const override {
-    if (LogicalResult verifResult = verifyPtrMemrefConversion(
+    if (LogicalResult verifyResult = verifyPtrMemrefConversion(
             *getTypeConverter(), op, op.getSource().getType(), op.getType());
-        failed(verifResult))
-      return verifResult;
+        failed(verifyResult))
+      return verifyResult;
 
     auto loc = op.getLoc();
 
@@ -440,10 +440,10 @@ struct BareMemref2PointerOpLowering
     if (!canBeLoweredToBarePtr(op.getSource().getType()))
       return failure();
 
-    if (LogicalResult verifResult = verifyPtrMemrefConversion(
+    if (LogicalResult verifyResult = verifyPtrMemrefConversion(
             *getTypeConverter(), op, op.getType(), op.getSource().getType());
-        failed(verifResult))
-      return verifResult;
+        failed(verifyResult))
+      return verifyResult;
 
     const auto target = transformed.getSource();
     // In an opaque pointer world, a bitcast is a no-op, so no need to insert
@@ -465,10 +465,10 @@ struct BarePointer2MemrefOpLowering
     if (!canBeLoweredToBarePtr(op.getType()))
       return failure();
 
-    if (LogicalResult verifResult = verifyPtrMemrefConversion(
+    if (LogicalResult verifyResult = verifyPtrMemrefConversion(
             *getTypeConverter(), op, op.getSource().getType(), op.getType());
-        failed(verifResult))
-      return verifResult;
+        failed(verifyResult))
+      return verifyResult;
 
     const auto convertedType = getTypeConverter()->convertType(op.getType());
     if (!convertedType)


### PR DESCRIPTION
Verify `llvm.ptr`'s address space and `memref` memory space are compatible:

- At verification time, we can check whether both use their defaults, which are compatible, or the memory space is expressed as an integer attribute with the same value as the address space.
- At conversion time, we can extend this by checking the converted memory space attribute is compatible with the address space.