### PR TITLE
[SYCL][UR][L0] Add support for multi-device kernel compilation (1/N)

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.cpp
@@ -39,6 +39,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
         *OutEvent ///< [in,out][optional] return an event object that identifies
                   ///< this particular kernel execution instance.
 ) {
+  auto ZeDevice = Queue->Device->ZeDevice;
+
+  ze_kernel_handle_t ZeKernel{};
+  if (Kernel->ZeKernelMap.empty()) {
+    ZeKernel = Kernel->ZeKernel;
+  } else {
+    auto It = Kernel->ZeKernelMap.find(ZeDevice);
+    ZeKernel = It->second;
+  }
+
   // Lock automatically releases when this goes out of scope.
   std::scoped_lock<ur_shared_mutex, ur_shared_mutex, ur_shared_mutex> Lock(
       Queue->Mutex, Kernel->Mutex, Kernel->Program->Mutex);
@@ -63,7 +73,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
                                         Queue->Device));
     }
     ZE2UR_CALL(zeKernelSetArgumentValue,
-               (Kernel->ZeKernel, Arg.Index, Arg.Size, ZeHandlePtr));
+               (ZeKernel, Arg.Index, Arg.Size, ZeHandlePtr));
   }
   Kernel->PendingArguments.clear();
 
@@ -97,7 +107,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     }
     if (SuggestGroupSize) {
       ZE2UR_CALL(zeKernelSuggestGroupSize,
-                 (Kernel->ZeKernel, GlobalWorkSize[0], GlobalWorkSize[1],
+                 (ZeKernel, GlobalWorkSize[0], GlobalWorkSize[1],
                   GlobalWorkSize[2], &WG[0], &WG[1], &WG[2]));
     } else {
       for (int I : {0, 1, 2}) {
@@ -173,7 +183,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     return UR_RESULT_ERROR_INVALID_WORK_GROUP_SIZE;
   }
 
-  ZE2UR_CALL(zeKernelSetGroupSize, (Kernel->ZeKernel, WG[0], WG[1], WG[2]));
+  ZE2UR_CALL(zeKernelSetGroupSize, (ZeKernel, WG[0], WG[1], WG[2]));
 
   bool UseCopyEngine = false;
   _ur_ze_event_list_t TmpWaitList;
@@ -225,18 +235,16 @@ UR_APIEXPORT ur_result_t UR_APICALL urEnqueueKernelLaunch(
     Queue->CaptureIndirectAccesses();
     // Add the command to the command list, which implies submission.
     ZE2UR_CALL(zeCommandListAppendLaunchKernel,
-               (CommandList->first, Kernel->ZeKernel, &ZeThreadGroupDimensions,
-                ZeEvent, (*Event)->WaitList.Length,
-                (*Event)->WaitList.ZeEventList));
+               (CommandList->first, ZeKernel, &ZeThreadGroupDimensions, ZeEvent,
+                (*Event)->WaitList.Length, (*Event)->WaitList.ZeEventList));
   } else {
     // Add the command to the command list for later submission.
     // No lock is needed here, unlike the immediate commandlist case above,
     // because the kernels are not actually submitted yet. Kernels will be
     // submitted only when the comamndlist is closed. Then, a lock is held.
     ZE2UR_CALL(zeCommandListAppendLaunchKernel,
-               (CommandList->first, Kernel->ZeKernel, &ZeThreadGroupDimensions,
-                ZeEvent, (*Event)->WaitList.Length,
-                (*Event)->WaitList.ZeEventList));
+               (CommandList->first, ZeKernel, &ZeThreadGroupDimensions, ZeEvent,
+                (*Event)->WaitList.Length, (*Event)->WaitList.ZeEventList));
   }
 
   urPrint("calling zeCommandListAppendLaunchKernel() with"
@@ -359,22 +367,45 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelCreate(
     return UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE;
   }
 
-  ZeStruct<ze_kernel_desc_t> ZeKernelDesc;
-  ZeKernelDesc.flags = 0;
-  ZeKernelDesc.pKernelName = KernelName;
-
-  ze_kernel_handle_t ZeKernel;
-  ZE2UR_CALL(zeKernelCreate, (Program->ZeModule, &ZeKernelDesc, &ZeKernel));
-
   try {
-    ur_kernel_handle_t_ *UrKernel =
-        new ur_kernel_handle_t_(ZeKernel, true, Program);
+    ur_kernel_handle_t_ *UrKernel = new ur_kernel_handle_t_(true, Program);
     *RetKernel = reinterpret_cast<ur_kernel_handle_t>(UrKernel);
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
     return UR_RESULT_ERROR_UNKNOWN;
   }
+
+  for (auto It : Program->ZeModuleMap) {
+    auto ZeModule = It.second;
+    ZeStruct<ze_kernel_desc_t> ZeKernelDesc;
+    ZeKernelDesc.flags = 0;
+    ZeKernelDesc.pKernelName = KernelName;
+
+    ze_kernel_handle_t ZeKernel;
+    ZE2UR_CALL(zeKernelCreate, (ZeModule, &ZeKernelDesc, &ZeKernel));
+
+    auto ZeDevice = It.first;
+
+    // Store the kernel in the ZeKernelMap so the correct
+    // kernel can be retrieved later for a specific device
+    // where a queue is being submitted.
+    (*RetKernel)->ZeKernelMap[ZeDevice] = ZeKernel;
+    (*RetKernel)->ZeKernels.push_back(ZeKernel);
+
+    // If the device used to create the module's kernel is a root-device
+    // then store the kernel also using the sub-devices, since application
+    // could submit the root-device's kernel to a sub-device's queue.
+    uint32_t SubDevicesCount = 0;
+    zeDeviceGetSubDevices(ZeDevice, &SubDevicesCount, nullptr);
+    std::vector<ze_device_handle_t> ZeSubDevices(SubDevicesCount);
+    zeDeviceGetSubDevices(ZeDevice, &SubDevicesCount, ZeSubDevices.data());
+    for (auto ZeSubDevice : ZeSubDevices) {
+      (*RetKernel)->ZeKernelMap[ZeSubDevice] = ZeKernel;
+    }
+  }
+
+  (*RetKernel)->ZeKernel = (*RetKernel)->ZeKernelMap.begin()->second;
 
   UR_CALL((*RetKernel)->initialize());
 
@@ -405,8 +436,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetArgValue(
   }
 
   std::scoped_lock<ur_shared_mutex> Guard(Kernel->Mutex);
-  ZE2UR_CALL(zeKernelSetArgumentValue,
-             (Kernel->ZeKernel, ArgIndex, ArgSize, PArgValue));
+  for (auto It : Kernel->ZeKernelMap) {
+    auto ZeKernel = It.second;
+    ZE2UR_CALL(zeKernelSetArgumentValue,
+               (ZeKernel, ArgIndex, ArgSize, PArgValue));
+  }
 
   return UR_RESULT_SUCCESS;
 }
@@ -592,10 +626,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelRelease(
 
   auto KernelProgram = Kernel->Program;
   if (Kernel->OwnNativeHandle) {
-    auto ZeResult = ZE_CALL_NOCHECK(zeKernelDestroy, (Kernel->ZeKernel));
-    // Gracefully handle the case that L0 was already unloaded.
-    if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
-      return ze2urResult(ZeResult);
+    for (auto &ZeKernel : Kernel->ZeKernels) {
+      auto ZeResult = ZE_CALL_NOCHECK(zeKernelDestroy, (ZeKernel));
+      // Gracefully handle the case that L0 was already unloaded.
+      if (ZeResult && ZeResult != ZE_RESULT_ERROR_UNINITIALIZED)
+        return ze2urResult(ZeResult);
+    }
   }
   if (IndirectAccessTrackingEnabled) {
     UR_CALL(urContextRelease(KernelProgram->Context));
@@ -635,6 +671,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
   std::ignore = PropSize;
   std::ignore = Properties;
 
+  auto ZeKernel = Kernel->ZeKernel;
   std::scoped_lock<ur_shared_mutex> Guard(Kernel->Mutex);
   if (PropName == UR_KERNEL_EXEC_INFO_USM_INDIRECT_ACCESS &&
       *(static_cast<const ur_bool_t *>(PropValue)) == true) {
@@ -645,7 +682,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
         ZE_KERNEL_INDIRECT_ACCESS_FLAG_HOST |
         ZE_KERNEL_INDIRECT_ACCESS_FLAG_DEVICE |
         ZE_KERNEL_INDIRECT_ACCESS_FLAG_SHARED;
-    ZE2UR_CALL(zeKernelSetIndirectAccess, (Kernel->ZeKernel, IndirectFlags));
+    ZE2UR_CALL(zeKernelSetIndirectAccess, (ZeKernel, IndirectFlags));
   } else if (PropName == UR_KERNEL_EXEC_INFO_CACHE_CONFIG) {
     ze_cache_config_flag_t ZeCacheConfig{};
     auto CacheConfig =
@@ -659,7 +696,7 @@ UR_APIEXPORT ur_result_t UR_APICALL urKernelSetExecInfo(
     else
       // Unexpected cache configuration value.
       return UR_RESULT_ERROR_INVALID_VALUE;
-    ZE2UR_CALL(zeKernelSetCacheConfig, (Kernel->ZeKernel, ZeCacheConfig););
+    ZE2UR_CALL(zeKernelSetCacheConfig, (ZeKernel, ZeCacheConfig););
   } else {
     urPrint("urKernelSetExecInfo: unsupported ParamName\n");
     return UR_RESULT_ERROR_INVALID_VALUE;

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/kernel.hpp
@@ -12,6 +12,11 @@
 #include <unordered_set>
 
 struct ur_kernel_handle_t_ : _ur_object {
+  ur_kernel_handle_t_(bool OwnZeHandle, ur_program_handle_t Program)
+      : Program{Program}, SubmissionsCount{0}, MemAllocs{} {
+    OwnNativeHandle = OwnZeHandle;
+  }
+
   ur_kernel_handle_t_(ze_kernel_handle_t Kernel, bool OwnZeHandle,
                       ur_program_handle_t Program)
       : Program{Program}, ZeKernel{Kernel}, SubmissionsCount{0}, MemAllocs{} {
@@ -30,8 +35,18 @@ struct ur_kernel_handle_t_ : _ur_object {
   // Keep the program of the kernel.
   ur_program_handle_t Program;
 
-  // Level Zero function handle.
+  // Level Zero kernel handle.
+  // TODO: Left for now, but to be removed in favor of ZeKernelMap
   ze_kernel_handle_t ZeKernel;
+
+  // Map of L0 kernels created for all the devices for which a UR Program
+  // has been built. It may contain duplicated kernel entries for a root
+  // device and its sub-devices.
+  std::unordered_map<ze_device_handle_t, ze_kernel_handle_t> ZeKernelMap;
+
+  // Vector of L0 kernels. Each entry is unique, so this is used for
+  // destroying the kernels instead of ZeKernelMap
+  std::vector<ze_kernel_handle_t> ZeKernels;
 
   // Counter to track the number of submissions of the kernel.
   // When this value is zero, it means that kernel is not submitted for an

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.cpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.cpp
@@ -8,6 +8,7 @@
 
 #include "program.hpp"
 #include "ur_level_zero.hpp"
+#include <utility>
 
 extern "C" {
 // Check to see if a Level Zero module has any unresolved symbols.
@@ -140,46 +141,55 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramBuild(
   ZeModuleDesc.pBuildFlags = Options;
   ZeModuleDesc.pConstants = Shim.ze();
 
-  ze_device_handle_t ZeDevice = Context->Devices[0]->ZeDevice;
-  ze_context_handle_t ZeContext = Program->Context->ZeContext;
-  ze_module_handle_t ZeModule = nullptr;
-
   ur_result_t Result = UR_RESULT_SUCCESS;
-  Program->State = ur_program_handle_t_::Exe;
-  ze_result_t ZeResult =
-      ZE_CALL_NOCHECK(zeModuleCreate, (ZeContext, ZeDevice, &ZeModuleDesc,
-                                       &ZeModule, &Program->ZeBuildLog));
-  if (ZeResult != ZE_RESULT_SUCCESS) {
-    // We adjust ur_program below to avoid attempting to release zeModule when
-    // RT calls urProgramRelease().
-    Program->State = ur_program_handle_t_::Invalid;
-    Result = ze2urResult(ZeResult);
-    if (ZeModule) {
-      ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
-      ZeModule = nullptr;
-    }
-  } else {
-    // The call to zeModuleCreate does not report an error if there are
-    // unresolved symbols because it thinks these could be resolved later via a
-    // call to zeModuleDynamicLink.  However, modules created with
-    // urProgramBuild are supposed to be fully linked and ready to use.
-    // Therefore, do an extra check now for unresolved symbols.
-    ZeResult = checkUnresolvedSymbols(ZeModule, &Program->ZeBuildLog);
+  for (auto Device : Context->Devices) {
+    ze_device_handle_t ZeDevice = Device->ZeDevice;
+    ze_context_handle_t ZeContext = Program->Context->ZeContext;
+    ze_module_handle_t ZeModule = nullptr;
+    ze_module_build_log_handle_t ZeBuildLog{};
+
+    Program->State = ur_program_handle_t_::Exe;
+    ze_result_t ZeResult =
+        ZE_CALL_NOCHECK(zeModuleCreate, (ZeContext, ZeDevice, &ZeModuleDesc,
+                                         &ZeModule, &ZeBuildLog));
+
     if (ZeResult != ZE_RESULT_SUCCESS) {
+      // We adjust ur_program below to avoid attempting to release zeModule when
+      // RT calls urProgramRelease().
       Program->State = ur_program_handle_t_::Invalid;
-      Result = (ZeResult == ZE_RESULT_ERROR_MODULE_LINK_FAILURE)
-                   ? UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE
-                   : ze2urResult(ZeResult);
+      Result = ze2urResult(ZeResult);
       if (ZeModule) {
         ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
         ZeModule = nullptr;
       }
+      break;
+    } else {
+      // The call to zeModuleCreate does not report an error if there are
+      // unresolved symbols because it thinks these could be resolved later via
+      // a call to zeModuleDynamicLink.  However, modules created with
+      // urProgramBuild are supposed to be fully linked and ready to use.
+      // Therefore, do an extra check now for unresolved symbols.
+      ZeResult = checkUnresolvedSymbols(ZeModule, &ZeBuildLog);
+      if (ZeResult != ZE_RESULT_SUCCESS) {
+        Program->State = ur_program_handle_t_::Invalid;
+        Result = (ZeResult == ZE_RESULT_ERROR_MODULE_LINK_FAILURE)
+                     ? UR_RESULT_ERROR_PROGRAM_BUILD_FAILURE
+                     : ze2urResult(ZeResult);
+        if (ZeModule) {
+          ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
+          ZeModule = nullptr;
+        }
+      }
+      Program->ZeModuleMap.insert(std::make_pair(ZeDevice, ZeModule));
+      Program->ZeBuildLogMap.insert(std::make_pair(ZeDevice, ZeBuildLog));
     }
   }
 
   // We no longer need the IL / native code.
   Program->Code.reset();
-  Program->ZeModule = ZeModule;
+  if (!Program->ZeModuleMap.empty())
+    Program->ZeModule = Program->ZeModuleMap.begin()->second;
+
   return Result;
 }
 
@@ -196,8 +206,8 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramCompile(
   // It's only valid to compile a program created from IL (we don't support
   // programs created from source code).
   //
-  // The OpenCL spec says that the header parameters are ignored when compiling
-  // IL programs, so we don't validate them.
+  // The OpenCL spec says that the header parameters are ignored when
+  // compiling IL programs, so we don't validate them.
   if (Program->State != ur_program_handle_t_::IL)
     return UR_RESULT_ERROR_INVALID_OPERATION;
 
@@ -241,17 +251,17 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
 
   ur_result_t UrResult = UR_RESULT_SUCCESS;
   try {
-    // Acquire a "shared" lock on each of the input programs, and also validate
-    // that they are all in Object state.
+    // Acquire a "shared" lock on each of the input programs, and also
+    // validate that they are all in Object state.
     //
     // There is no danger of deadlock here even if two threads call
-    // urProgramLink simultaneously with the same input programs in a different
-    // order.  If we were acquiring these with "exclusive" access, this could
-    // lead to a classic lock ordering deadlock.  However, there is no such
-    // deadlock potential with "shared" access.  There could also be a deadlock
-    // potential if there was some other code that holds more than one of these
-    // locks simultaneously with "exclusive" access.  However, there is no such
-    // code like that, so this is also not a danger.
+    // urProgramLink simultaneously with the same input programs in a
+    // different order.  If we were acquiring these with "exclusive" access,
+    // this could lead to a classic lock ordering deadlock.  However, there is
+    // no such deadlock potential with "shared" access.  There could also be a
+    // deadlock potential if there was some other code that holds more than
+    // one of these locks simultaneously with "exclusive" access.  However,
+    // there is no such code like that, so this is also not a danger.
     std::vector<std::shared_lock<ur_shared_mutex>> Guards(Count);
     for (uint32_t I = 0; I < Count; I++) {
       std::shared_lock<ur_shared_mutex> Guard(Programs[I]->Mutex);
@@ -263,11 +273,11 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
 
     // Previous calls to urProgramCompile did not actually compile the SPIR-V.
     // Instead, we postpone compilation until this point, when all the modules
-    // are linked together.  By doing compilation and linking together, the JIT
-    // compiler is able see all modules and do cross-module optimizations.
+    // are linked together.  By doing compilation and linking together, the
+    // JIT compiler is able see all modules and do cross-module optimizations.
     //
-    // Construct a ze_module_program_exp_desc_t which contains information about
-    // all of the modules that will be linked together.
+    // Construct a ze_module_program_exp_desc_t which contains information
+    // about all of the modules that will be linked together.
     ZeStruct<ze_module_program_exp_desc_t> ZeExtModuleDesc;
     std::vector<size_t> CodeSizes(Count);
     std::vector<const uint8_t *> CodeBufs(Count);
@@ -306,15 +316,15 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
     ZeModuleDesc.pInputModule = reinterpret_cast<const uint8_t *>(1);
     ZeModuleDesc.inputSize = 1;
 
-    // We need a Level Zero extension to compile multiple programs together into
-    // a single Level Zero module.  However, we don't need that extension if
-    // there happens to be only one input program.
+    // We need a Level Zero extension to compile multiple programs together
+    // into a single Level Zero module.  However, we don't need that extension
+    // if there happens to be only one input program.
     //
     // The "|| (NumInputPrograms == 1)" term is a workaround for a bug in the
     // Level Zero driver.  The driver's "ze_module_program_exp_desc_t"
     // extension should work even in the case when there is just one input
-    // module.  However, there is currently a bug in the driver that leads to a
-    // crash.  As a workaround, do not use the extension when there is one
+    // module.  However, there is currently a bug in the driver that leads to
+    // a crash.  As a workaround, do not use the extension when there is one
     // input module.
     //
     // TODO: Remove this workaround when the driver is fixed.
@@ -333,48 +343,60 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramLink(
       }
     }
 
-    // Call the Level Zero API to compile, link, and create the module.
-    ze_device_handle_t ZeDevice = Context->Devices[0]->ZeDevice;
-    ze_context_handle_t ZeContext = Context->ZeContext;
-    ze_module_handle_t ZeModule = nullptr;
-    ze_module_build_log_handle_t ZeBuildLog = nullptr;
-    ze_result_t ZeResult =
-        ZE_CALL_NOCHECK(zeModuleCreate, (ZeContext, ZeDevice, &ZeModuleDesc,
-                                         &ZeModule, &ZeBuildLog));
+    std::unordered_map<ze_device_handle_t, ze_module_handle_t> ZeModuleMap;
+    std::unordered_map<ze_device_handle_t, ze_module_build_log_handle_t>
+        ZeBuildLogMap;
 
-    // We still create a ur_program_handle_t_ object even if there is a
-    // BUILD_FAILURE because we need the object to hold the ZeBuildLog.  There
-    // is no build log created for other errors, so we don't create an object.
-    UrResult = ze2urResult(ZeResult);
-    if (ZeResult != ZE_RESULT_SUCCESS &&
-        ZeResult != ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
-      return ze2urResult(ZeResult);
-    }
+    for (auto Device : Context->Devices) {
+      // Call the Level Zero API to compile, link, and create the module.
+      ze_device_handle_t ZeDevice = Device->ZeDevice;
+      ze_context_handle_t ZeContext = Context->ZeContext;
+      ze_module_handle_t ZeModule = nullptr;
+      ze_module_build_log_handle_t ZeBuildLog = nullptr;
+      ze_result_t ZeResult =
+          ZE_CALL_NOCHECK(zeModuleCreate, (ZeContext, ZeDevice, &ZeModuleDesc,
+                                           &ZeModule, &ZeBuildLog));
 
-    // The call to zeModuleCreate does not report an error if there are
-    // unresolved symbols because it thinks these could be resolved later via a
-    // call to zeModuleDynamicLink.  However, modules created with piProgramLink
-    // are supposed to be fully linked and ready to use.  Therefore, do an extra
-    // check now for unresolved symbols.  Note that we still create a
-    // ur_program_handle_t_ if there are unresolved symbols because the
-    // ZeBuildLog tells which symbols are unresolved.
-    if (ZeResult == ZE_RESULT_SUCCESS) {
-      ZeResult = checkUnresolvedSymbols(ZeModule, &ZeBuildLog);
-      if (ZeResult == ZE_RESULT_ERROR_MODULE_LINK_FAILURE) {
-        UrResult =
-            UR_RESULT_ERROR_UNKNOWN; // TODO:
-                                     // UR_RESULT_ERROR_PROGRAM_LINK_FAILURE;
-      } else if (ZeResult != ZE_RESULT_SUCCESS) {
+      // We still create a ur_program_handle_t_ object even if there is a
+      // BUILD_FAILURE because we need the object to hold the ZeBuildLog.  There
+      // is no build log created for other errors, so we don't create an object.
+      UrResult = ze2urResult(ZeResult);
+      if (ZeResult != ZE_RESULT_SUCCESS &&
+          ZeResult != ZE_RESULT_ERROR_MODULE_BUILD_FAILURE) {
         return ze2urResult(ZeResult);
       }
+
+      // The call to zeModuleCreate does not report an error if there are
+      // unresolved symbols because it thinks these could be resolved later via
+      // a call to zeModuleDynamicLink.  However, modules created with
+      // piProgramLink are supposed to be fully linked and ready to use.
+      // Therefore, do an extra check now for unresolved symbols.  Note that we
+      // still create a ur_program_handle_t_ if there are unresolved symbols
+      // because the ZeBuildLog tells which symbols are unresolved.
+      if (ZeResult == ZE_RESULT_SUCCESS) {
+        ZeResult = checkUnresolvedSymbols(ZeModule, &ZeBuildLog);
+        if (ZeResult == ZE_RESULT_ERROR_MODULE_LINK_FAILURE) {
+          UrResult =
+              UR_RESULT_ERROR_UNKNOWN; // TODO:
+                                       // UR_RESULT_ERROR_PROGRAM_LINK_FAILURE;
+        } else if (ZeResult != ZE_RESULT_SUCCESS) {
+          return ze2urResult(ZeResult);
+        }
+      }
+
+      ZeModuleMap.insert(std::make_pair(ZeDevice, ZeModule));
+      ZeBuildLogMap.insert(std::make_pair(ZeDevice, ZeBuildLog));
     }
 
     ur_program_handle_t_::state State = (UrResult == UR_RESULT_SUCCESS)
                                             ? ur_program_handle_t_::Exe
                                             : ur_program_handle_t_::Invalid;
     ur_program_handle_t_ *UrProgram =
-        new ur_program_handle_t_(State, Context, ZeModule, ZeBuildLog);
+        new ur_program_handle_t_(State, Context, ZeModuleMap.begin()->second,
+                                 ZeBuildLogMap.begin()->second);
     *Program = reinterpret_cast<ur_program_handle_t>(UrProgram);
+    (*Program)->ZeModuleMap = ZeModuleMap;
+    (*Program)->ZeBuildLogMap = ZeBuildLogMap;
   } catch (const std::bad_alloc &) {
     return UR_RESULT_ERROR_OUT_OF_HOST_MEMORY;
   } catch (...) {
@@ -434,11 +456,12 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetFunctionPointer(
         Program, ///< [in] handle of the program to search for function in.
                  ///< The program must already be built to the specified
                  ///< device, or otherwise
-                 ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is returned.
+                 ///< ::UR_RESULT_ERROR_INVALID_PROGRAM_EXECUTABLE is
+                 ///< returned.
     const char *FunctionName, ///< [in] A null-terminates string denoting the
                               ///< mangled function name.
-    void **FunctionPointerRet ///< [out] Returns the pointer to the function if
-                              ///< it is found in the program.
+    void **FunctionPointerRet ///< [out] Returns the pointer to the function
+                              ///< if it is found in the program.
 ) {
   std::ignore = Device;
 
@@ -608,13 +631,13 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetBuildInfo(
     ur_program_handle_t Program, ///< [in] handle of the Program object
     ur_device_handle_t Device,   ///< [in] handle of the Device object
     ur_program_build_info_t
-        PropName,    ///< [in] name of the Program build info to query
-    size_t PropSize, ///< [in] size of the Program build info property.
-    void *PropValue, ///< [in,out][optional] value of the Program build
-                     ///< property. If propSize is not equal to or greater than
-                     ///< the real number of bytes needed to return the info
-                     ///< then the ::UR_RESULT_ERROR_INVALID_SIZE error is
-                     ///< returned and pKernelInfo is not used.
+        PropName,       ///< [in] name of the Program build info to query
+    size_t PropSize,    ///< [in] size of the Program build info property.
+    void *PropValue,    ///< [in,out][optional] value of the Program build
+                        ///< property. If propSize is not equal to or greater
+                        ///< than the real number of bytes needed to return the
+                        ///< info then the ::UR_RESULT_ERROR_INVALID_SIZE error
+                        ///< is returned and pKernelInfo is not used.
     size_t *PropSizeRet ///< [out][optional] pointer to the actual size in
                         ///< bytes of data being queried by propName.
 ) {
@@ -645,23 +668,26 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramGetBuildInfo(
     }
 
     // Next check if there is a Level Zero build log.
-    if (Program->ZeBuildLog) {
+    if (Program->ZeBuildLogMap.find(Device->ZeDevice) !=
+        Program->ZeBuildLogMap.end()) {
+      ze_module_build_log_handle_t ZeBuildLog =
+          Program->ZeBuildLogMap.begin()->second;
       size_t LogSize = PropSize;
       ZE2UR_CALL(zeModuleBuildLogGetString,
-                 (Program->ZeBuildLog, &LogSize, ur_cast<char *>(PropValue)));
+                 (ZeBuildLog, &LogSize, ur_cast<char *>(PropValue)));
       if (PropSizeRet) {
         *PropSizeRet = LogSize;
       }
       if (PropValue) {
-        // When the program build fails in urProgramBuild(), we delayed cleaning
-        // up the build log because RT later calls this routine to get the
-        // failed build log.
-        // To avoid memory leaks, we should clean up the failed build log here
-        // because RT does not create sycl::program when urProgramBuild() fails,
-        // thus it won't call urProgramRelease() to clean up the build log.
+        // When the program build fails in urProgramBuild(), we delayed
+        // cleaning up the build log because RT later calls this routine to
+        // get the failed build log. To avoid memory leaks, we should clean up
+        // the failed build log here because RT does not create sycl::program
+        // when urProgramBuild() fails, thus it won't call urProgramRelease()
+        // to clean up the build log.
         if (Program->State == ur_program_handle_t_::Invalid) {
-          ZE_CALL_NOCHECK(zeModuleBuildLogDestroy, (Program->ZeBuildLog));
-          Program->ZeBuildLog = nullptr;
+          ZE_CALL_NOCHECK(zeModuleBuildLogDestroy, (ZeBuildLog));
+          Program->ZeBuildLogMap.erase(Device->ZeDevice);
         }
       }
       return UR_RESULT_SUCCESS;
@@ -747,12 +773,14 @@ ur_program_handle_t_::~ur_program_handle_t_() {
   // According to Level Zero Specification, all kernels and build logs
   // must be destroyed before the Module can be destroyed.  So, be sure
   // to destroy build log before destroying the module.
-  if (ZeBuildLog) {
-    ZE_CALL_NOCHECK(zeModuleBuildLogDestroy, (ZeBuildLog));
+  for (auto &ZeBuildLogPair : this->ZeBuildLogMap) {
+    ZE_CALL_NOCHECK(zeModuleBuildLogDestroy, (ZeBuildLogPair.second));
   }
 
   if (ZeModule && OwnZeModule) {
-    ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModule));
+    for (auto &ZeModulePair : this->ZeModuleMap) {
+      ZE_CALL_NOCHECK(zeModuleDestroy, (ZeModulePair.second));
+    }
   }
 }
 
@@ -766,8 +794,9 @@ UR_APIEXPORT ur_result_t UR_APICALL urProgramSetSpecializationConstants(
   std::scoped_lock<ur_shared_mutex> Guard(Program->Mutex);
 
   // Remember the value of this specialization constant until the program is
-  // built.  Note that we only save the pointer to the buffer that contains the
-  // value.  The caller is responsible for maintaining storage for this buffer.
+  // built.  Note that we only save the pointer to the buffer that contains
+  // the value.  The caller is responsible for maintaining storage for this
+  // buffer.
   //
   // NOTE: SpecSize is unused in Level Zero, the size is known from SPIR-V by
   // SpecID.

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.hpp
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/program.hpp
@@ -127,8 +127,19 @@ struct ur_program_handle_t_ : _ur_object {
   std::string BuildFlags;
 
   // The Level Zero module handle.  Used primarily in Exe state.
+  // TODO: Left for now, but to be removed in favor of ZeModuleMap
   ze_module_handle_t ZeModule{};
 
+  // Map of L0 Modules created for all the devices for which a UR Program
+  // has been built.
+  std::unordered_map<ze_device_handle_t, ze_module_handle_t> ZeModuleMap;
+
   // The Level Zero build log from the last call to zeModuleCreate().
+  // TODO: Left for now, but to be removed in favor of ZeBuildLogMap
   ze_module_build_log_handle_t ZeBuildLog{};
+
+  // Map of L0 Module Build logs created for all the devices for which a UR
+  // Program has been built.
+  std::unordered_map<ze_device_handle_t, ze_module_build_log_handle_t>
+      ZeBuildLogMap;
 };


### PR DESCRIPTION
urProgramBuild and alike dont accept device as parameters, so it is expected the programs and kernels are built for all devices in the context.

With this patch, the L0 modules and L0 kernels are created for all L0 devices in the context, and then on enqueue operations, the correct kernel is used matching the device in the queue.

(1): Handle the case for root-device's kernels used on sub-device's queues.