### PR TITLE
[SYCL][Driver] Remove -fsycl-esimd-build-host-code

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3641,12 +3641,7 @@ defm sycl_esimd_force_stateless_mem : BoolFOption<"sycl-esimd-force-stateless-me
     BothFlags<[], [ClangOption, CLOption, DXCOption, CC1Option], "">>;
 // TODO: Remove this option once ESIMD headers are updated to
 // guard vectors to be device only.
-defm sycl_esimd_build_host_code : BoolFOption<"sycl-esimd-build-host-code",
-    LangOpts<"SYCLESIMDBuildHostCode">, DefaultTrue,
-    PosFlag<SetTrue, [], [ClangOption], "Build the host implementation of ESIMD functions."
-            "Enabled by default.">,
-    NegFlag<SetFalse, [], [ClangOption], "Don't build the host implementation of ESIMD functions.">,
-    BothFlags<[HelpHidden], [ClangOption, CLOption, DXCOption, CC1Option], "">>;    
+def fno_sycl_esimd_build_host_code :  Flag<["-"], "fno-sycl-esimd-build-host-code">, Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>, Flags<[HelpHidden]>, HelpText<"Don't build the host implementation of ESIMD functions.">;
 def fsycl_targets_EQ : CommaJoined<["-"], "fsycl-targets=">, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>,
   HelpText<"Specify comma-separated list of triples SYCL offloading targets to be supported">;

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3641,7 +3641,9 @@ defm sycl_esimd_force_stateless_mem : BoolFOption<"sycl-esimd-force-stateless-me
     BothFlags<[], [ClangOption, CLOption, DXCOption, CC1Option], "">>;
 // TODO: Remove this option once ESIMD headers are updated to
 // guard vectors to be device only.
-def fno_sycl_esimd_build_host_code :  Flag<["-"], "fno-sycl-esimd-build-host-code">, Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>, Flags<[HelpHidden]>, HelpText<"Don't build the host implementation of ESIMD functions.">;
+def fno_sycl_esimd_build_host_code :  Flag<["-"], "fno-sycl-esimd-build-host-code">,
+  Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>, Flags<[HelpHidden]>,
+  HelpText<"Don't build the host implementation of ESIMD functions.">;
 def fsycl_targets_EQ : CommaJoined<["-"], "fsycl-targets=">, Flags<[NoXarchOption]>,
   Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>,
   HelpText<"Specify comma-separated list of triples SYCL offloading targets to be supported">;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5429,8 +5429,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     else {
       for (auto &Macro : D.getSYCLTargetMacroArgs())
         CmdArgs.push_back(Args.MakeArgString(Macro));
-      if (!Args.hasFlag(options::OPT_fsycl_esimd_build_host_code,
-                        options::OPT_fno_sycl_esimd_build_host_code, true))
+      if (Args.hasArg(options::OPT_fno_sycl_esimd_build_host_code))
         CmdArgs.push_back("-fno-sycl-esimd-build-host-code");
     }
     if (Args.hasFlag(options::OPT_fsycl_esimd_force_stateless_mem,


### PR DESCRIPTION
Remove the positive option and keep only the negative option. The option was added only a couple of days ago and nobody should be using it. It is a hidden option as well.

Based on feedback from https://github.com/intel/llvm/pull/11037#discussion_r1328955361