### PR TITLE
[SYCL][HIP] Keep track of only shared USM allocations and prefetch only for those

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
@@ -18,7 +18,7 @@
           enum MemorySemanticsMask semantics, TYPE val) {                                                                     \
     int atomic_scope = 0, memory_order = 0;                                                                                   \
     GET_ATOMIC_SCOPE_AND_ORDER(scope, atomic_scope, semantics, memory_order)                                                  \
-    return BUILTIN(p, val, memory_order);                                                                                 \
+    return BUILTIN(p, -val, memory_order);                                                                                    \
   }
 
 #define AMDGPU_ATOMIC_SUB(FUNC_NAME, TYPE, TYPE_MANGLED, BUILTIN)              \
@@ -28,11 +28,11 @@
                          BUILTIN)                                              \
   AMDGPU_ATOMIC_SUB_IMPL(FUNC_NAME, TYPE, TYPE_MANGLED, , , 0, BUILTIN)
 
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_sub)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_add)
 
 #undef AMDGPU_ATOMIC
 #undef AMDGPU_ATOMIC_IMPL

--- a/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
@@ -18,7 +18,7 @@
           enum MemorySemanticsMask semantics, TYPE val) {                                                                     \
     int atomic_scope = 0, memory_order = 0;                                                                                   \
     GET_ATOMIC_SCOPE_AND_ORDER(scope, atomic_scope, semantics, memory_order)                                                  \
-    return BUILTIN(p, -val, memory_order);                                                                                    \
+    return BUILTIN(p, val, memory_order);                                                                                 \
   }
 
 #define AMDGPU_ATOMIC_SUB(FUNC_NAME, TYPE, TYPE_MANGLED, BUILTIN)              \
@@ -28,11 +28,11 @@
                          BUILTIN)                                              \
   AMDGPU_ATOMIC_SUB_IMPL(FUNC_NAME, TYPE, TYPE_MANGLED, , , 0, BUILTIN)
 
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_add)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_add)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_add)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_add)
-AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_sub)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_sub)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_sub)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_sub)
+AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_sub)
 
 #undef AMDGPU_ATOMIC
 #undef AMDGPU_ATOMIC_IMPL

--- a/llvm/lib/Target/AMDGPU/AMDGPUAddGlobalForAtomicXor.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAddGlobalForAtomicXor.cpp
@@ -1,0 +1,58 @@
+//===- AMDGPUAddGlobalForAtomicXor.cpp ------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Some AMDGPU atomic instructions require a prefetch in order for them to work
+// properly when using hipMallocManaged. This pass scans a module for the
+// problematic atomic instructions and creates a global PrefetchNeeded if the
+// builtin is present. This allows the prefetch to happen at runtime only if the
+// problematic builtin is chosen.
+//
+//===----------------------------------------------------------------------===//
+
+#include "AMDGPUAddGlobalForAtomicXor.h"
+#include "llvm/IR/InstIterator.h"
+#include "llvm/IR/Instructions.h"
+
+using namespace llvm;
+
+#define NEW_GLOBAL_NAME "HipAtomicXorModuleNeedsPrefetch"
+
+namespace {
+
+bool moduleHasAtomicXor(Module &M) {
+  for (auto &F : M) {
+    for (auto &I : instructions(F)) {
+      if (auto *AtomicInst = dyn_cast<AtomicRMWInst>(&I)) {
+        if (AtomicInst->getOperation() == AtomicRMWInst::Xor) {
+          return true;
+        }
+      }
+    }
+  }
+  return false;
+}
+
+bool runImpl(Module &M) {
+  if (moduleHasAtomicXor(M)) {
+    LLVMContext &Ctx = M.getContext();
+    new GlobalVariable(M, Type::getInt1Ty(Ctx), true,
+                       GlobalValue::InternalLinkage,
+                       Constant::getAllOnesValue(Type::getInt1Ty(Ctx)),
+                       NEW_GLOBAL_NAME); // FIXME: this seems wrong and bad, is
+                                         // there a better way to make a new
+                                         // GlobalVariable?
+    return true;
+  }
+  return false;
+}
+} // end anonymous namespace
+
+PreservedAnalyses
+AMDGPUAddGlobalForAtomicXorPass::run(Module &M, ModuleAnalysisManager &AM) {
+  return runImpl(M) ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm/lib/Target/AMDGPU/AMDGPUAddGlobalForAtomicXor.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAddGlobalForAtomicXor.cpp
@@ -37,9 +37,8 @@ bool moduleHasAtomicXor(Module &M) {
 
 PreservedAnalyses
 AMDGPUAddGlobalForAtomicXorPass::run(Module &M, ModuleAnalysisManager &AM) {
-  if (!moduleHasAtomicXor(M)) {
+  if (!moduleHasAtomicXor(M))
     return PreservedAnalyses::all();
-  }
   LLVMContext &Ctx = M.getContext();
   M.getOrInsertGlobal(NEW_GLOBAL_NAME, Type::getInt1Ty(Ctx), [&] {
     return new GlobalVariable(

--- a/llvm/lib/Target/AMDGPU/AMDGPUAddGlobalForAtomicXor.h
+++ b/llvm/lib/Target/AMDGPU/AMDGPUAddGlobalForAtomicXor.h
@@ -1,0 +1,32 @@
+//===- AMDGPUAddGlobalForAtomicXor.h --------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Some AMDGPU atomic instructions require a prefetch in order for them to work
+// properly when using hipMallocManaged. This pass scans a module for the
+// problematic atomic instructions and creates a global PrefetchNeeded if the
+// builtin is present. This allows the prefetch to happen at runtime only if the
+// problematic builtin is chosen.
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef LLVM_LIB_TARGET_AMDGPU_ADDGLOBALFORATOMICXOR_H
+#define LLVM_LIB_TARGET_AMDGPU_ADDGLOBALFORATOMICXOR_H
+
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class AMDGPUAddGlobalForAtomicXorPass
+    : public PassInfoMixin<AMDGPUAddGlobalForAtomicXorPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &AM);
+};
+
+} // namespace llvm
+
+#endif // LLVM_LIB_TARGET_AMDGPU_ADDGLOBALFORATOMICXOR_H

--- a/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUTargetMachine.cpp
@@ -14,6 +14,7 @@
 
 #include "AMDGPUTargetMachine.h"
 #include "AMDGPU.h"
+#include "AMDGPUAddGlobalForAtomicXor.h"
 #include "AMDGPUAliasAnalysis.h"
 #include "AMDGPUCtorDtorLowering.h"
 #include "AMDGPUExportClustering.h"
@@ -616,6 +617,10 @@ void AMDGPUTargetMachine::registerPassBuilderCallbacks(PassBuilder &PB) {
         }
         if (PassName == "amdgpu-always-inline") {
           PM.addPass(AMDGPUAlwaysInlinePass());
+          return true;
+        }
+        if (PassName == "amdgpu-add-global-for-atomic-xor") {
+          PM.addPass(AMDGPUAddGlobalForAtomicXorPass());
           return true;
         }
         if (PassName == "amdgpu-lower-module-lds") {

--- a/llvm/lib/Target/AMDGPU/CMakeLists.txt
+++ b/llvm/lib/Target/AMDGPU/CMakeLists.txt
@@ -41,6 +41,7 @@ tablegen(LLVM InstCombineTables.inc -gen-searchable-tables)
 add_public_tablegen_target(InstCombineTableGen)
 
 add_llvm_target(AMDGPUCodeGen
+  AMDGPUAddGlobalForAtomicXor.cpp
   AMDGPUAliasAnalysis.cpp
   AMDGPUAlwaysInlinePass.cpp
   AMDGPUAnnotateKernelFeatures.cpp

--- a/llvm/test/Analysis/GlobalsModRef/amdgpu-atomic-xor-add-global.ll
+++ b/llvm/test/Analysis/GlobalsModRef/amdgpu-atomic-xor-add-global.ll
@@ -1,15 +1,11 @@
 ; RUN: sed -e s/.T1://g %s | opt -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-add-global-for-atomic-xor -S | FileCheck %s --check-prefix=CHECK1
 ; RUN: sed -e s/.T2://g %s | opt -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-add-global-for-atomic-xor -S | FileCheck %s --check-prefix=CHECK2
 
-;T1: define i32 @test(ptr %p) {
-;T1: ; CHECK1:      @HipAtomicXorModuleNeedsPrefetch
+define i32 @test(ptr %p) {
+; CHECK1:      @HipAtomicXorModuleNeedsPrefetch
+; CHECK2-NOT:  @HipAtomicXorModuleNeedsPrefetch
 ;T1:   %1 = atomicrmw volatile xor ptr %p, i32 1 syncscope("agent-one-as") monotonic, align 4
-;T1:   ret i32 %1
-;T1: }
-
-;T2: define i32 @test(ptr %p) {
-;T2: ; CHECK2-NOT:  @HipAtomicXorModuleNeedsPrefetch
 ;T2:   %1 = atomicrmw volatile add ptr %p, i32 1 syncscope("agent-one-as") monotonic, align 4
-;T2:   ret i32 %1
-;T2: }
+  ret i32 %1
+}
 

--- a/llvm/test/Analysis/GlobalsModRef/amdgpu-atomic-xor-add-global.ll
+++ b/llvm/test/Analysis/GlobalsModRef/amdgpu-atomic-xor-add-global.ll
@@ -1,0 +1,15 @@
+; RUN: sed -e s/.T1://g %s | opt -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-add-global-for-atomic-xor -S | FileCheck %s --check-prefix=CHECK1
+; RUN: sed -e s/.T2://g %s | opt -mtriple=amdgcn-amd-amdhsa -passes=amdgpu-add-global-for-atomic-xor -S | FileCheck %s --check-prefix=CHECK2
+
+;T1: define i32 @test(ptr %p) {
+;T1: ; CHECK1:      @HipAtomicXorModuleNeedsPrefetch
+;T1:   %1 = atomicrmw volatile xor ptr %p, i32 1 syncscope("agent-one-as") monotonic, align 4
+;T1:   ret i32 %1
+;T1: }
+
+;T2: define i32 @test(ptr %p) {
+;T2: ; CHECK2-NOT:  @HipAtomicXorModuleNeedsPrefetch
+;T2:   %1 = atomicrmw volatile add ptr %p, i32 1 syncscope("agent-one-as") monotonic, align 4
+;T2:   ret i32 %1
+;T2: }
+


### PR DESCRIPTION
https://github.com/intel/llvm/pull/10430 caused a perf regression. This does the same prefetching but only for shared USM allocations, not for all USM allocations. This should revert some of the perf regression for non shared USM. Patch to follow to minimize perf hit unless using problematic instructions.