### PR TITLE
[GHA] Uplift Linux GPU RT version to 23.26.26690.22

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "23.22.26516.18",
-      "version": "23.22.26516.18",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/23.22.26516.18",
+      "github_tag": "23.26.26690.22",
+      "version": "23.26.26690.22",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/23.26.26690.22",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.14062.11",
-      "version": "1.0.14062.11",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.14062.11",
+      "github_tag": "igc-1.0.14508.16",
+      "version": "1.0.14508.16",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.14508.16",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {


### PR DESCRIPTION
Scheduled drivers uplift