### PR TITLE
[do not review][Driver] Adjust integration footer inclusion

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7821,23 +7821,6 @@ Action *Driver::ConstructPhaseAction(
              "Cannot preprocess this input type!");
     }
     types::ID HostPPType = types::getPreprocessedType(Input->getType());
-    if (Args.hasArg(options::OPT_fsycl) && HostPPType != types::TY_INVALID &&
-        !Args.hasArg(options::OPT_fno_sycl_use_footer) &&
-        TargetDeviceOffloadKind == Action::OFK_None &&
-        Input->getType() != types::TY_CUDA_DEVICE) {
-      // Performing a host compilation with -fsycl.  Append the integration
-      // footer to the source file.
-      auto *AppendFooter =
-          C.MakeAction<AppendFooterJobAction>(Input, Input->getType());
-      // FIXME: There are 2 issues with dependency generation in regards to
-      // the integration footer that need to be addressed.
-      // 1) Input file referenced on the RHS of a dependency is based on the
-      //    input src, which is a temporary.  We want this to be the true
-      //    user input src file.
-      // 2) When generating dependencies against a preprocessed file, header
-      //    file information (using -MD or-MMD) is not provided.
-      return C.MakeAction<PreprocessJobAction>(AppendFooter, OutputTy);
-    }
     return C.MakeAction<PreprocessJobAction>(Input, OutputTy);
   }
   case phases::Precompile: {

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8321,8 +8321,22 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
     FrontendInputs = {};
 
   for (const InputInfo &Input : FrontendInputs) {
-    if (Input.isFilename())
-      CmdArgs.push_back(Input.getFilename());
+    if (Input.isFilename()) {
+      if (IsSYCL && !IsSYCLOffloadDevice) {
+        StringRef Footer(
+            C.getDriver().getIntegrationFooter(Input.getBaseInput()));
+        // Add the footer mtoguchi
+        if (!Footer.empty()) {
+          CmdArgs.push_back("-include");
+          CmdArgs.push_back(Input.getFilename());
+          CmdArgs.push_back(Args.MakeArgString(Footer));
+        } else {
+          CmdArgs.push_back(Input.getFilename());
+        }
+      } else {
+        CmdArgs.push_back(Input.getFilename());
+      }
+    }
     else
       Input.getInputArg().renderAsInput(Args, CmdArgs);
   }

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -8336,8 +8336,7 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       } else {
         CmdArgs.push_back(Input.getFilename());
       }
-    }
-    else
+    } else
       Input.getInputArg().renderAsInput(Args, CmdArgs);
   }
 


### PR DESCRIPTION
This is an experimental change right now - just testing.

Remove usage of the 'append-file' tool which creates a temporary file that is used when building the host source file in a SYCL offloading compilation environment.

Instead, pull in the main source file as an '-include' and the footer is then used as the main source file.