### PR TITLE
[SYCL-MLIR][polygeist-to-llvm] Revamp alloc-like lowering patterns

### DIFF
--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-grid-ops-to-llvm.mlir
@@ -25,11 +25,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:   llvm.func @test_num_work_items() -> !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_0:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalSize : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_1:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_2:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_3]]] :  (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_5:.*]] = llvm.ptrtoint %[[VAL_4]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_6:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_7:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -49,11 +47,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:     llvm.func @test_global_id() -> !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_32:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalInvocationId : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_33:.*]] = llvm.load %[[VAL_32]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_34:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_34:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_35:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_36:.*]] = llvm.getelementptr %[[VAL_34]]{{\[}}%[[VAL_35]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_37:.*]] = llvm.ptrtoint %[[VAL_36]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_38:.*]] = llvm.alloca %[[VAL_37]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_38:.*]] = llvm.alloca %[[VAL_34]] x !llvm.struct<"class.sycl::_V1::id.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_39:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_40:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_41:.*]] = llvm.mlir.constant(1 : i32) : i32
@@ -79,11 +75,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:     llvm.func @test_local_id() -> !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_69:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_70:.*]] = llvm.load %[[VAL_69]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_71:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_71:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_72:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_73:.*]] = llvm.getelementptr %[[VAL_71]]{{\[}}%[[VAL_72]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_74:.*]] = llvm.ptrtoint %[[VAL_73]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_75:.*]] = llvm.alloca %[[VAL_74]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_75:.*]] = llvm.alloca %[[VAL_71]] x !llvm.struct<"class.sycl::_V1::id.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_76:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_77:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_78:.*]] = llvm.mlir.constant(2 : i32) : i32
@@ -115,11 +109,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:     llvm.func @test_work_group_size() -> !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_111:.*]] = llvm.mlir.addressof @__spirv_BuiltInWorkgroupSize : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_112:.*]] = llvm.load %[[VAL_111]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_113:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_113:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_114:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_115:.*]] = llvm.getelementptr %[[VAL_113]]{{\[}}%[[VAL_114]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.3", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_116:.*]] = llvm.ptrtoint %[[VAL_115]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_117:.*]] = llvm.alloca %[[VAL_116]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_117:.*]] = llvm.alloca %[[VAL_113]] x !llvm.struct<"class.sycl::_V1::range.3", (struct<"class.sycl::_V1::detail::array.3", (array<3 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_118:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_119:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_120:.*]] = llvm.mlir.constant(2 : i32) : i32
@@ -151,11 +143,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:     llvm.func @test_work_group_id() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_153:.*]] = llvm.mlir.addressof @__spirv_BuiltInWorkgroupId : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_154:.*]] = llvm.load %[[VAL_153]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_155:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_155:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_156:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_157:.*]] = llvm.getelementptr %[[VAL_155]]{{\[}}%[[VAL_156]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_158:.*]] = llvm.ptrtoint %[[VAL_157]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_159:.*]] = llvm.alloca %[[VAL_158]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_159:.*]] = llvm.alloca %[[VAL_155]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_160:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_161:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_162:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -205,11 +195,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:     llvm.func @test_global_offset() -> !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_194:.*]] = llvm.mlir.addressof @__spirv_BuiltInGlobalOffset : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_195:.*]] = llvm.load %[[VAL_194]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_196:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_196:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_197:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_198:.*]] = llvm.getelementptr %[[VAL_196]]{{\[}}%[[VAL_197]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_199:.*]] = llvm.ptrtoint %[[VAL_198]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.alloca %[[VAL_199]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_200:.*]] = llvm.alloca %[[VAL_196]] x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_201:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_202:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_203:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -229,11 +217,9 @@ module attributes {gpu.container_module} {
     // CHECK-LABEL:     llvm.func @test_num_work_groups() -> !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> {
     // CHECK-NEXT:        %[[VAL_226:.*]] = llvm.mlir.addressof @__spirv_BuiltInNumWorkgroups : !llvm.ptr<1>
     // CHECK-NEXT:        %[[VAL_227:.*]] = llvm.load %[[VAL_226]] : !llvm.ptr<1> -> vector<3xi64>
-    // CHECK-NEXT:        %[[VAL_228:.*]] = llvm.mlir.null : !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_228:.*]] = llvm.mlir.constant(1 : index) : i64
     // CHECK-NEXT:        %[[VAL_229:.*]] = llvm.mlir.constant(1 : index) : i64
-    // CHECK-NEXT:        %[[VAL_230:.*]] = llvm.getelementptr %[[VAL_228]]{{\[}}%[[VAL_229]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::range.2", {{.*}}>
-    // CHECK-NEXT:        %[[VAL_231:.*]] = llvm.ptrtoint %[[VAL_230]] : !llvm.ptr to i64
-    // CHECK-NEXT:        %[[VAL_232:.*]] = llvm.alloca %[[VAL_231]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
+    // CHECK-NEXT:        %[[VAL_232:.*]] = llvm.alloca %[[VAL_228]] x !llvm.struct<"class.sycl::_V1::range.2", (struct<"class.sycl::_V1::detail::array.2", (array<2 x i64>)>)> : (i64) -> !llvm.ptr
     // CHECK-DAG:         %[[VAL_233:.*]] = llvm.mlir.constant(0 : index) : i64
     // CHECK-DAG:         %[[VAL_234:.*]] = llvm.mlir.constant(0 : i32) : i32
     // CHECK-DAG:         %[[VAL_235:.*]] = llvm.mlir.constant(1 : i32) : i32

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -1349,11 +1349,9 @@ module attributes {gpu.container} {
 // CHECK-SAME:        %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> {
 // CHECK-NEXT:        %[[VAL_1:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
 // CHECK-NEXT:        %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-NEXT:        %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-NEXT:        %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-NEXT:        %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:        %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
-// CHECK-NEXT:        %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr to i64
-// CHECK-NEXT:        %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK-NEXT:        %[[VAL_7:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(2 : i32) : i32
@@ -1399,11 +1397,9 @@ module attributes {gpu.container} {
 // CHECK-SAME:        %[[VAL_1:.*]]: i32) -> i64 {
 // CHECK:             %[[VAL_2:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
 // CHECK:             %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_5:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_6:.*]] = llvm.getelementptr %[[VAL_4]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-// CHECK:             %[[VAL_7:.*]] = llvm.ptrtoint %[[VAL_6]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_8:.*]] = llvm.alloca %[[VAL_7]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_8:.*]] = llvm.alloca %[[VAL_4]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_11:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1413,11 +1409,9 @@ module attributes {gpu.container} {
 // CHECK:             llvm.store %[[VAL_12]], %[[VAL_14]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_15:.*]] = llvm.getelementptr %[[VAL_8]]{{\[}}%[[VAL_9]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK:             %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-// CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_18:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_19:.*]] = llvm.getelementptr %[[VAL_17]]{{\[}}%[[VAL_18]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-// CHECK:             %[[VAL_20:.*]] = llvm.ptrtoint %[[VAL_19]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_21:.*]] = llvm.alloca %[[VAL_20]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_21:.*]] = llvm.alloca %[[VAL_17]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK:             llvm.store %[[VAL_16]], %[[VAL_21]] : !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>, !llvm.ptr
 // CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_21]][0, 0, 0, %[[VAL_1]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK:             %[[VAL_23:.*]] = llvm.load %[[VAL_22]] : !llvm.ptr -> i64
@@ -1564,11 +1558,9 @@ module attributes {gpu.container} {
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr) -> i64 {
 // CHECK:             %[[VAL_1:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
 // CHECK:             %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_3:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_4:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_5:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_4]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-// CHECK:             %[[VAL_6:.*]] = llvm.ptrtoint %[[VAL_5]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_6]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_7:.*]] = llvm.alloca %[[VAL_3]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK-DAG:         %[[VAL_8:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_9:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_10:.*]] = llvm.mlir.constant(0 : i32) : i32
@@ -1578,11 +1570,9 @@ module attributes {gpu.container} {
 // CHECK:             llvm.store %[[VAL_11]], %[[VAL_13]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_14:.*]] = llvm.getelementptr %[[VAL_7]]{{\[}}%[[VAL_8]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
 // CHECK:             %[[VAL_15:.*]] = llvm.load %[[VAL_14]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-// CHECK-DAG:         %[[VAL_16:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_16:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_17:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_18:.*]] = llvm.getelementptr %[[VAL_16]]{{\[}}%[[VAL_17]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
-// CHECK:             %[[VAL_19:.*]] = llvm.ptrtoint %[[VAL_18]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_20:.*]] = llvm.alloca %[[VAL_19]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_20:.*]] = llvm.alloca %[[VAL_16]] x !llvm.struct<"class.sycl::_V1::id.1", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK:             llvm.store %[[VAL_15]], %[[VAL_20]] : !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>, !llvm.ptr
 // CHECK:             %[[VAL_21:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_22:.*]] = llvm.getelementptr inbounds %[[VAL_20]][0, 0, 0, %[[VAL_21]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.1", {{.*}}>
@@ -1597,11 +1587,9 @@ module attributes {gpu.container} {
 // CHECK-NEXT:      llvm.func @test_2(%[[VAL_24:.*]]: !llvm.ptr) -> i64 {
 // CHECK:             %[[VAL_25:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
 // CHECK:             %[[VAL_26:.*]] = llvm.load %[[VAL_25]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_27:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_27:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_28:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_29:.*]] = llvm.getelementptr %[[VAL_27]]{{\[}}%[[VAL_28]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
-// CHECK:             %[[VAL_30:.*]] = llvm.ptrtoint %[[VAL_29]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_31:.*]] = llvm.alloca %[[VAL_30]] x !llvm.struct<"class.sycl::_V1::id.2", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_31:.*]] = llvm.alloca %[[VAL_27]] x !llvm.struct<"class.sycl::_V1::id.2", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK-DAG:         %[[VAL_32:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_33:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_34:.*]] = llvm.mlir.constant(1 : i32) : i32
@@ -1617,11 +1605,9 @@ module attributes {gpu.container} {
 // CHECK:             llvm.store %[[VAL_40]], %[[VAL_42]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_43:.*]] = llvm.getelementptr %[[VAL_31]]{{\[}}%[[VAL_32]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
 // CHECK:             %[[VAL_44:.*]] = llvm.load %[[VAL_43]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
-// CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_45:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_46:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_47:.*]] = llvm.getelementptr %[[VAL_45]]{{\[}}%[[VAL_46]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
-// CHECK:             %[[VAL_48:.*]] = llvm.ptrtoint %[[VAL_47]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_49:.*]] = llvm.alloca %[[VAL_48]] x !llvm.struct<"class.sycl::_V1::id.2", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_49:.*]] = llvm.alloca %[[VAL_45]] x !llvm.struct<"class.sycl::_V1::id.2", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK:             llvm.store %[[VAL_44]], %[[VAL_49]] : !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>, !llvm.ptr
 // CHECK:             %[[VAL_50:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_51:.*]] = llvm.getelementptr inbounds %[[VAL_49]][0, 0, 0, %[[VAL_50]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.2", {{.*}}>
@@ -1643,11 +1629,9 @@ module attributes {gpu.container} {
 // CHECK-NEXT:      llvm.func @test_3(%[[VAL_60:.*]]: !llvm.ptr) -> i64 {
 // CHECK:             %[[VAL_61:.*]] = llvm.mlir.addressof @__spirv_BuiltInLocalInvocationId : !llvm.ptr<1>
 // CHECK:             %[[VAL_62:.*]] = llvm.load %[[VAL_61]] : !llvm.ptr<1> -> vector<3xi64>
-// CHECK-DAG:         %[[VAL_63:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_63:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_64:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_65:.*]] = llvm.getelementptr %[[VAL_63]]{{\[}}%[[VAL_64]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
-// CHECK:             %[[VAL_66:.*]] = llvm.ptrtoint %[[VAL_65]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_67:.*]] = llvm.alloca %[[VAL_66]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_67:.*]] = llvm.alloca %[[VAL_63]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK-DAG:         %[[VAL_68:.*]] = llvm.mlir.constant(0 : index) : i64
 // CHECK-DAG:         %[[VAL_69:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK-DAG:         %[[VAL_70:.*]] = llvm.mlir.constant(2 : i32) : i32
@@ -1669,11 +1653,9 @@ module attributes {gpu.container} {
 // CHECK:             llvm.store %[[VAL_81]], %[[VAL_83]] : i64, !llvm.ptr
 // CHECK:             %[[VAL_84:.*]] = llvm.getelementptr %[[VAL_67]]{{\[}}%[[VAL_68]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
 // CHECK:             %[[VAL_85:.*]] = llvm.load %[[VAL_84]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
-// CHECK-DAG:         %[[VAL_86:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK-DAG:         %[[VAL_86:.*]] = llvm.mlir.constant(1 : index) : i64
 // CHECK-DAG:         %[[VAL_87:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK:             %[[VAL_88:.*]] = llvm.getelementptr %[[VAL_86]]{{\[}}%[[VAL_87]]] : (!llvm.ptr, i64) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>
-// CHECK:             %[[VAL_89:.*]] = llvm.ptrtoint %[[VAL_88]] : !llvm.ptr to i64
-// CHECK:             %[[VAL_90:.*]] = llvm.alloca %[[VAL_89]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
+// CHECK:             %[[VAL_90:.*]] = llvm.alloca %[[VAL_86]] x !llvm.struct<"class.sycl::_V1::id.3", {{.*}}> : (i64) -> !llvm.ptr
 // CHECK:             llvm.store %[[VAL_85]], %[[VAL_90]] : !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>, !llvm.ptr
 // CHECK:             %[[VAL_91:.*]] = llvm.mlir.constant(0 : i32) : i32
 // CHECK:             %[[VAL_92:.*]] = llvm.getelementptr inbounds %[[VAL_90]][0, 0, 0, %[[VAL_91]]] : (!llvm.ptr, i32) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::id.3", {{.*}}>

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -1065,6 +1065,7 @@ public:
     StringRef funcName;
     FunctionType signature;
     bool anyHadConflictingSignature = false;
+    bool anyIsDefinition = false;
     bool found = false;
   };
 
@@ -1089,6 +1090,7 @@ public:
       // an error only if more than one occurrence of the function is found.
       iter->anyHadConflictingSignature |=
           iter->signature != func.getFunctionType();
+      iter->anyIsDefinition |= !func.isDeclaration();
       // If it was already found, the current function should be removed.
       // Otherwise, set the function as already found.
       if (iter->found)
@@ -1100,9 +1102,13 @@ public:
       // If this is a duplicate and a signature difference occurred, signal
       // error.
       if (entry.anyHadConflictingSignature)
-        return func.emitError()
-               << "'" << func.getName()
-               << "' defined with conflicting signature w.r.t. stdlib function";
+        return func.emitError() << "'" << func.getName()
+                                << "' declared with conflicting signature "
+                                   "w.r.t. stdlib function";
+      if (entry.anyIsDefinition)
+        return func.emitError() << "'" << func.getName()
+                                << "' with a definition might not be "
+                                   "compatible with stdlib function";
       func.erase();
     }
     return success();

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -1103,10 +1103,13 @@ public:
     }
     for (LLVM::LLVMFuncOp func : toRemove) {
       auto iter = getEntry(func);
+      assert(iter != entries.end() && "Should always be found");
       // If this is a duplicate and a signature difference occurred, signal
       // error.
-      if (iter != entries.end() && iter->anyHadConflictingSignature)
-        return failure();
+      if (iter->anyHadConflictingSignature)
+        return func.emitError()
+               << "'" << func.getName()
+               << "' defined with conflicting signature w.r.t. stdlib function";
       func.erase();
     }
     return success();

--- a/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
@@ -89,8 +89,8 @@ private:
     SmallVector<Value, 4> strides;
     Value size;
 
-    this->getMemRefDescriptorSizes(loc, memRefType, operands, rewriter, sizes,
-                                   strides, size, !requiresNumElements);
+    getMemRefDescriptorSizes(loc, memRefType, operands, rewriter, sizes,
+                             strides, size, !requiresNumElements);
 
     // Return the final value of the descriptor.
     rewriter.replaceOp(op, allocateBuffer(rewriter, loc, size, op));

--- a/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/CMakeLists.txt
@@ -40,6 +40,7 @@ add_mlir_dialect_library(MLIRPolygeistTransforms
   MLIRLLVMCommonConversion
   MLIRMathDialect
   MLIRMemRefDialect
+  MLIRMemRefToLLVM
   MLIRNVVMDialect
   MLIRPass
   MLIRPolygeistAnalysis  

--- a/polygeist/test/polygeist-opt/polygeist-to-llvm.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-to-llvm.mlir
@@ -135,13 +135,10 @@ func.func private @reshape_dyn(%arg0: memref<4xi32>) -> memref<?xi32> {
 // -----
 
 // CHECK-LABEL:   llvm.func @alloca()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(2 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 : (i64) -> !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x i32 : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
 func.func private @alloca() {
   %0 = memref.alloca() : memref<2xi32>
@@ -151,13 +148,10 @@ func.func private @alloca() {
 // -----
 
 // CHECK-LABEL:   llvm.func @alloca_nd()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(60 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 : (i64) -> !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x i32 : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
 func.func private @alloca_nd() {
   %0 = memref.alloca() : memref<3x10x2xi32>
@@ -167,13 +161,10 @@ func.func private @alloca_nd() {
 // -----
 
 // CHECK-LABEL:   llvm.func @alloca_aligned()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(2 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 {alignment = 8 : i64} : (i64) -> !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_0]] x i32 {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
 func.func private @alloca_aligned() {
   %0 = memref.alloca() {alignment = 8} : memref<2xi32>
@@ -183,13 +174,10 @@ func.func private @alloca_aligned() {
 // -----
 
 // CHECK-LABEL:   llvm.func @alloca_nd_aligned()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(60 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.ptrtoint %[[VAL_2]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x i32 {alignment = 8 : i64} : (i64) -> !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.alloca %[[VAL_5]] x i32 {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
 func.func private @alloca_nd_aligned() {
   %0 = memref.alloca() {alignment = 8} : memref<3x10x2xi32>
@@ -198,17 +186,35 @@ func.func private @alloca_nd_aligned() {
 
 // -----
 
-// CHECK-LABEL:   llvm.func @malloc(i64) -> !llvm.ptr
+// CHECK-LABEL:   llvm.func @mixed_alloca(
+// CHECK-SAME:                            %[[VAL_0:.*]]: i64)
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.constant(42 : index) : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.mul %[[VAL_1]], %[[VAL_0]]  : i64
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_3]] x f32 : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_8:.*]] = llvm.mlir.constant(294 : index) : i64
+// CHECK:           %[[VAL_9:.*]] = llvm.mul %[[VAL_8]], %[[VAL_0]]  : i64
+// CHECK:           %[[VAL_10:.*]] = llvm.alloca %[[VAL_9]] x f32 {alignment = 8 : i64} : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
-// CHECK-LABEL:   llvm.func @alloc()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.call @malloc(%[[VAL_4]]) : (i64) -> !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+func.func private @mixed_alloca(%arg0 : index) {
+  %0 = memref.alloca(%arg0) : memref<?x42xf32>
+  %1 = memref.alloca(%arg0) {alignment = 8} : memref<?x42x7xf32>
+  return
+}
+
+// -----
+
+// CHECK:         llvm.func @malloc(i64) -> !llvm.ptr
+
+// CHECK-LABEL:   llvm.func @alloc() attributes {sym_visibility = "private"} {
+// CHECK:           %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+// CHECK:           %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr to i64
+// CHECK:           %[[VAL_5:.*]] = llvm.call @malloc(%[[VAL_4]]) : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
 func.func private @alloc() {
   %0 = memref.alloc() : memref<2xi32>
@@ -217,19 +223,16 @@ func.func private @alloc() {
 
 // -----
 
-// CHECK-LABEL:   llvm.func @alloc_nd()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(3 : index) : i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(10 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(2 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(20 : index) : i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.call @malloc(%[[VAL_8]]) : (i64) -> !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+// CHECK:         llvm.func @malloc(i64) -> !llvm.ptr
+
+// CHECK-LABEL:   llvm.func @alloc_nd() attributes {sym_visibility = "private"} {
+// CHECK:           %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK:           %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
+// CHECK:           %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr to i64
+// CHECK:           %[[VAL_9:.*]] = llvm.call @malloc(%[[VAL_8]]) : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
 
 func.func private @alloc_nd() {
   %0 = memref.alloc() : memref<3x10x2xi32>
@@ -238,59 +241,24 @@ func.func private @alloc_nd() {
 
 // -----
 
-// CHECK-LABEL:   llvm.func @alloc_aligned()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(2 : index) : i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(8 : index) : i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.add %[[VAL_4]], %[[VAL_5]]  : i64
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.call @malloc(%[[VAL_6]]) : (i64) -> !llvm.ptr
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.sub %[[VAL_5]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.add %[[VAL_8]], %[[VAL_10]]  : i64
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.urem %[[VAL_11]], %[[VAL_5]]  : i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.sub %[[VAL_11]], %[[VAL_12]]  : i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.inttoptr %[[VAL_13]] : i64 to !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
+// CHECK:         llvm.func @malloc(i64) -> !llvm.ptr
 
-func.func private @alloc_aligned() {
-  %0 = memref.alloc() {alignment = 8} : memref<2xi32>
+// CHECK-LABEL:   llvm.func @mixed_alloc(
+// CHECK-SAME:                           %[[VAL_0:.*]]: i64)
+// CHECK:           %[[VAL_4:.*]] = llvm.mlir.constant(294 : index) : i64
+// CHECK:           %[[VAL_5:.*]] = llvm.mul %[[VAL_4]], %[[VAL_0]]  : i64
+// CHECK:           %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK:           %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, f32
+// CHECK:           %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr to i64
+// CHECK:           %[[VAL_9:.*]] = llvm.call @malloc(%[[VAL_8]]) : (i64) -> !llvm.ptr
+// CHECK:           llvm.return
+// CHECK:         }
+
+func.func private @mixed_alloc(%arg0 : index) {
+  %0 = memref.alloc(%arg0) : memref<?x42x7xf32>
   return
 }
 
-// -----
-
-// CHECK-LABEL:   llvm.func @alloc_nd_aligned()
-// CHECK-NEXT:      %[[VAL_0:.*]] = llvm.mlir.constant(3 : index) : i64
-// CHECK-NEXT:      %[[VAL_1:.*]] = llvm.mlir.constant(10 : index) : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.mlir.constant(2 : index) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.mlir.constant(1 : index) : i64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mlir.constant(20 : index) : i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.constant(60 : index) : i64
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.mlir.null : !llvm.ptr
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr %[[VAL_6]]{{\[}}%[[VAL_5]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:      %[[VAL_8:.*]] = llvm.ptrtoint %[[VAL_7]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_9:.*]] = llvm.mlir.constant(8 : index) : i64
-// CHECK-NEXT:      %[[VAL_10:.*]] = llvm.add %[[VAL_8]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_11:.*]] = llvm.call @malloc(%[[VAL_10]]) : (i64) -> !llvm.ptr
-// CHECK-NEXT:      %[[VAL_12:.*]] = llvm.ptrtoint %[[VAL_11]] : !llvm.ptr to i64
-// CHECK-NEXT:      %[[VAL_13:.*]] = llvm.mlir.constant(1 : i64) : i64
-// CHECK-NEXT:      %[[VAL_14:.*]] = llvm.sub %[[VAL_9]], %[[VAL_13]]  : i64
-// CHECK-NEXT:      %[[VAL_15:.*]] = llvm.add %[[VAL_12]], %[[VAL_14]]  : i64
-// CHECK-NEXT:      %[[VAL_16:.*]] = llvm.urem %[[VAL_15]], %[[VAL_9]]  : i64
-// CHECK-NEXT:      %[[VAL_17:.*]] = llvm.sub %[[VAL_15]], %[[VAL_16]]  : i64
-// CHECK-NEXT:      %[[VAL_18:.*]] = llvm.inttoptr %[[VAL_17]] : i64 to !llvm.ptr
-// CHECK-NEXT:      llvm.return
-// CHECK-NEXT:    }
-
-func.func private @alloc_nd_aligned() {
-  %0 = memref.alloc() {alignment = 8} : memref<3x10x2xi32>
-  return
-}
 
 // -----
 
@@ -572,4 +540,57 @@ func.func private @ptr2memref(%arg0: !llvm.ptr) -> memref<?xf32> {
 func.func private @view(%arg0: memref<8xi8, 3>, %arg1: index) -> memref<2xf32, 3> {
   %res = memref.view %arg0[%arg1][] : memref<8xi8, 3> to memref<2xf32, 3>
   return %res : memref<2xf32, 3>
+}
+
+// -----
+
+// CHECK:         llvm.func @malloc(i64) -> !llvm.ptr
+func.func private @malloc(i64) -> !llvm.ptr
+
+// CHECK-LABEL:   llvm.func @f0(
+// CHECK-SAME:                  %[[VAL_0:.*]]: i64) -> !llvm.ptr
+// CHECK:           %[[VAL_2:.*]] = llvm.mlir.null : !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.getelementptr %[[VAL_2]]{{\[}}%[[VAL_0]]] : (!llvm.ptr, i64) -> !llvm.ptr, i8
+// CHECK:           %[[VAL_4:.*]] = llvm.ptrtoint %[[VAL_3]] : !llvm.ptr to i64
+// CHECK:           %[[VAL_5:.*]] = llvm.call @malloc(%[[VAL_4]]) : (i64) -> !llvm.ptr
+// CHECK:           llvm.return %[[VAL_5]] : !llvm.ptr
+// CHECK:         }
+func.func private @f0(%size: index) -> memref<?xi8> {
+  %res = memref.alloc(%size) : memref<?xi8>
+  return %res : memref<?xi8>
+}
+
+// CHECK-LABEL:   llvm.func @f1(
+// CHECK-SAME:                  %[[VAL_0:.*]]: i64) -> !llvm.ptr
+// CHECK:           %[[VAL_1:.*]] = llvm.call @malloc(%[[VAL_0]]) : (i64) -> !llvm.ptr
+// CHECK:           llvm.return %[[VAL_1]] : !llvm.ptr
+// CHECK:         }
+func.func private @f1(%size: i64) -> !llvm.ptr {
+  %res = func.call @malloc(%size) : (i64) -> !llvm.ptr
+  return %res : !llvm.ptr
+}
+
+// -----
+
+// CHECK:         llvm.func @free(!llvm.ptr)
+func.func private @free(!llvm.ptr)
+
+// CHECK-LABEL:   llvm.func @f0(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr)
+// CHECK:           llvm.call @free(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK:           llvm.return
+// CHECK:         }
+func.func private @f0(%ptr: memref<?xi8>) {
+  memref.dealloc %ptr : memref<?xi8>
+  return
+}
+
+// CHECK-LABEL:   llvm.func @f1(
+// CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr)
+// CHECK:           llvm.call @free(%[[VAL_0]]) : (!llvm.ptr) -> ()
+// CHECK:           llvm.return
+// CHECK:         }
+func.func private @f1(%ptr: !llvm.ptr) {
+  func.call @free(%ptr) : (!llvm.ptr) -> ()
+  return
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -181,7 +181,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
-// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
+// CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", i64 1, align 8
 // CHECK-LLVM: [[ACAST:%.*]] = addrspacecast ptr [[ACCESSOR]] to ptr addrspace(4)
 // CHECK-LLVM: call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) [[ACAST]])
 
@@ -274,7 +274,7 @@ extern "C" SYCL_EXTERNAL void cons_10(const sycl::long8 &A,
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_11()
 // CHECK-LLVM-SAME:                                    #[[FUNCATTRS]] {
-// CHECK-LLVM:          %[[VAL1:.*]] = alloca %"class.sycl::_V1::vec.5", align 16
+// CHECK-LLVM:          %[[VAL1:.*]] = alloca %"class.sycl::_V1::vec.5", i64 1, align 16
 // CHECK-LLVM:          call void @llvm.memset.p0.i64(ptr %[[VAL1]], i8 0, i64 16, i1 false)
 
 extern "C" SYCL_EXTERNAL void cons_11() {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -30,10 +30,10 @@
 // CHECK-LLVM-SAME:        ptr noundef byval(%"class.sycl::_V1::range.1") align 8 %0, 
 // CHECK-LLVM-SAME:        ptr noundef byval({ ptr addrspace(1) }) align 8 %1)
 // CHECK-LLVM-NEXT:    call spir_func void @__itt_offload_wi_start_wrapper()
-// CHECK-LLVM-NEXT:    %3 = alloca %"class.sycl::_V1::item.1.true", align 8
+// CHECK-LLVM-NEXT:    %3 = alloca %"class.sycl::_V1::item.1.true", i64 1, align 8
 // CHECK-LLVM-NEXT:    %4 = alloca { ptr addrspace(4) }, i64 1, align 8
-// CHECK-LLVM-NEXT:    %5 = alloca %"class.sycl::_V1::range.1", align 8
-// CHECK-LLVM-NEXT:    %6 = alloca { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, align 8
+// CHECK-LLVM-NEXT:    %5 = alloca %"class.sycl::_V1::range.1", i64 1, align 8
+// CHECK-LLVM-NEXT:    %6 = alloca { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, i64 1, align 8
 // CHECK-LLVM-NEXT:    %7 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 0
 // CHECK-LLVM-NEXT:    %8 = addrspacecast ptr %5 to ptr addrspace(4)
 // CHECK-LLVM-NEXT:    %9 = addrspacecast ptr %0 to ptr addrspace(4)

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -17,7 +17,7 @@
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()
 // CHECK-LLVM-SAME:  #[[FUNCATTRS0:[0-9]+]] {
-// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", align 8
+// CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", i64 1, align 8
 // CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast ptr [[ACCESSOR]] to ptr addrspace(4)
 // CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) [[ACAST]])
 


### PR DESCRIPTION
Patterns lowering `memref.alloc[a]` are now based on the ones in `-finalize-memref-to-llvm`. Changes:

- `memref.alloca`: allow dynamic shapes in lowering;
- `memref.alloc`: enforce no alignment, this would produce invalid code;
- `malloc` and `free` functions are now uniqued after lowering to prevent symbol duplication.

These changes are needed in `cgeist` frontend when we reduce `llvm.func` usage:
- `malloc/free` uniquing is compulsory as `func.func` lowering would lead to two definitions otherwise;
- Lowering changes motivated by `memref.alloc` lowering testing. Will futureproof `cgeist` codegen.