### PR TITLE
[SYCL][Graph] Fix spec section numbering

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1237,12 +1237,12 @@ code `invalid` if a user tries to add them to a graph.
 Removing this restriction is something we may look at for future revisions of
 `sycl_ext_oneapi_graph`.
 
-=== sycl_ext_oneapi_bindless_images
+==== sycl_ext_oneapi_bindless_images
 
 The new handler methods, and queue shortcuts, defined by
 link:../experimental/sycl_ext_oneapi_bindless_images.asciidoc[sycl_ext_oneapi_bindless_images]
 cannot be used in graph nodes. A synchronous exception will be thrown with error
-code `invalid` if a user tries to add them to a graph
+code `invalid` if a user tries to add them to a graph.
 
 Removing this restriction is something we may look at for future revisions of
 `sycl_ext_oneapi_graph`.


### PR DESCRIPTION
The specification section defining the interaction with `sycl_ext_oneapi_bindless_images` should be one level lower in the heirarchy.