### PR TITLE
[CI] Lock Windows CI

### DIFF
--- a/.github/workflows/sycl_windows_build_and_test.yml
+++ b/.github/workflows/sycl_windows_build_and_test.yml
@@ -27,6 +27,7 @@ jobs:
   build:
     name: Build + LIT
     runs-on: [Windows, build]
+    environment: WindowsCILock
     # TODO use cached checkout
     outputs:
       build_conclusion: ${{ steps.build.conclusion }}
@@ -126,6 +127,7 @@ jobs:
     if: ${{ always() && needs.build.outputs.build_conclusion == 'success' }}
     name: SYCL E2E on Windows
     runs-on: [Windows, gen12]
+    environment: WindowsCILock
     steps:
     - uses: ilammy/msvc-dev-cmd@7315a94840631165970262a99c72cfb48a65d25d
       with:


### PR DESCRIPTION
I've created `WindowsCILock` environment and put
@intel/dpcpp-devops-reviewers into *workflow* reviewers list. Tasks using this environment will need to be approved by a member of this team before they run.

Once CI is stabilized I'm going to clear the box to require those reviews but keep the workflow files change so that we can lock the CI in future. I'm also planning in implementing the same for Linux pre-commit later.