### PR TITLE
[SYCL][HIP] Change atomic sub to atomic add (-val)

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
@@ -32,7 +32,6 @@ AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_add)
 AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_add)
 AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_add)
 AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_add)
-AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_add)
 
 #undef AMDGPU_ATOMIC
 #undef AMDGPU_ATOMIC_IMPL

--- a/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_sub.cl
@@ -18,7 +18,7 @@
           enum MemorySemanticsMask semantics, TYPE val) {                                                                     \
     int atomic_scope = 0, memory_order = 0;                                                                                   \
     GET_ATOMIC_SCOPE_AND_ORDER(scope, atomic_scope, semantics, memory_order)                                                  \
-    return BUILTIN(p, val, memory_order);                                                                                 \
+    return BUILTIN(p, -val, memory_order);                                                                                    \
   }
 
 #define AMDGPU_ATOMIC_SUB(FUNC_NAME, TYPE, TYPE_MANGLED, BUILTIN)              \
@@ -28,11 +28,11 @@
                          BUILTIN)                                              \
   AMDGPU_ATOMIC_SUB_IMPL(FUNC_NAME, TYPE, TYPE_MANGLED, , , 0, BUILTIN)
 
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_sub)
-AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_sub)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, int, i, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned int, j, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, long, l, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z18__spirv_AtomicISub, unsigned long, m, __atomic_fetch_add)
+AMDGPU_ATOMIC_SUB(_Z21__spirv_AtomicFSubEXT, float, f, __atomic_fetch_add)
 
 #undef AMDGPU_ATOMIC
 #undef AMDGPU_ATOMIC_IMPL


### PR DESCRIPTION
This PR changes the use of `atomic_sub` to `atomic_add` with a negated `val`. Doing so extends the number of cases in which the atomic operation will work, since support for `atomic_add` is more common than `atomic_sub`, especially at the PCIe level. 