### PR TITLE
Fix shared library build

### DIFF
--- a/llvm/lib/Transforms/Vectorize/CMakeLists.txt
+++ b/llvm/lib/Transforms/Vectorize/CMakeLists.txt
@@ -23,5 +23,6 @@ add_llvm_component_library(LLVMVectorize
   Analysis
   Core
   Support
+  TargetParser
   TransformUtils
   )


### PR DESCRIPTION
We need to explicitly link against TargetParser for shared library builds because we are using `Triple` in this shared library now.