### PR TITLE
[SYCL-MLIR][cgeist] Remove `noreturn` attribute in SYCL device code

### DIFF
--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -21,7 +21,7 @@ using namespace mlir;
 
 namespace mlirclang {
 
-constexpr llvm::StringLiteral AttributeList::PassThroughAttrName;
+constexpr StringLiteral AttributeList::PassThroughAttrName;
 
 //===----------------------------------------------------------------------===//
 // Helper functions.

--- a/polygeist/tools/cgeist/Lib/Attributes.cc
+++ b/polygeist/tools/cgeist/Lib/Attributes.cc
@@ -21,7 +21,7 @@ using namespace mlir;
 
 namespace mlirclang {
 
-static constexpr StringLiteral PassThroughAttrName = "passthrough";
+constexpr llvm::StringLiteral AttributeList::PassThroughAttrName;
 
 //===----------------------------------------------------------------------===//
 // Helper functions.
@@ -29,13 +29,13 @@ static constexpr StringLiteral PassThroughAttrName = "passthrough";
 
 static void addToPassThroughAttr(NamedAttribute &PassThroughAttr,
                                  mlir::NamedAttribute Attr, MLIRContext &Ctx) {
-  assert(PassThroughAttr.getName() == PassThroughAttrName &&
+  assert(PassThroughAttr.getName() == AttributeList::PassThroughAttrName &&
          "PassThroughAttr is not valid");
   assert(isa<ArrayAttr>(PassThroughAttr.getValue()) &&
          "PassThroughAttr should have an ArrayAttr as value");
 
   LLVM_DEBUG(llvm::dbgs() << "Adding attribute " << Attr.getName() << " to '"
-                          << PassThroughAttrName << "'.\n";);
+                          << AttributeList::PassThroughAttrName << "'.\n";);
 
   std::vector<mlir::Attribute> Vec =
       cast<ArrayAttr>(PassThroughAttr.getValue()).getValue().vec();
@@ -66,7 +66,7 @@ static void addToPassThroughAttr(NamedAttribute &PassThroughAttr,
   PassThroughAttr.setValue(ArrayAttr::get(&Ctx, Vec));
 
   LLVM_DEBUG({
-    llvm::dbgs().indent(2) << PassThroughAttrName << ": ( ";
+    llvm::dbgs().indent(2) << AttributeList::PassThroughAttrName << ": ( ";
     for (auto Item : Vec)
       llvm::dbgs() << Item << " ";
     llvm::dbgs() << ")\n";
@@ -75,7 +75,7 @@ static void addToPassThroughAttr(NamedAttribute &PassThroughAttr,
 
 static void addToPassThroughAttr(mlir::NamedAttribute &PassThroughAttr,
                                  mlir::ArrayAttr NewAttrs, MLIRContext &Ctx) {
-  assert(PassThroughAttr.getName() == PassThroughAttrName &&
+  assert(PassThroughAttr.getName() == AttributeList::PassThroughAttrName &&
          "PassThroughAttr is not valid");
   assert(isa<ArrayAttr>(PassThroughAttr.getValue()) &&
          "PassThroughAttr should have an ArrayAttr as value");
@@ -212,9 +212,11 @@ AttrBuilder &AttrBuilder::addPassThroughAttribute(StringRef AttrName,
 }
 
 AttrBuilder &AttrBuilder::removeAttribute(llvm::StringRef AttrName) {
-  bool ContainsPassThroughAttr = getAttribute(PassThroughAttrName).has_value();
+  bool ContainsPassThroughAttr =
+      getAttribute(AttributeList::PassThroughAttrName).has_value();
   if (ContainsPassThroughAttr) {
-    NamedAttribute PassThroughAttr = getAttribute(PassThroughAttrName).value();
+    NamedAttribute PassThroughAttr =
+        getAttribute(AttributeList::PassThroughAttrName).value();
     auto ArrAttr = cast<ArrayAttr>(PassThroughAttr.getValue());
     std::vector<mlir::Attribute> Vec = ArrAttr.getValue().vec();
 
@@ -390,21 +392,25 @@ AttrBuilder::addPassThroughRawIntAttr(llvm::Attribute::AttrKind Kind,
 }
 
 NamedAttribute AttrBuilder::getOrCreatePassThroughAttr() const {
-  Optional<NamedAttribute> PassThroughAttr = getAttribute(PassThroughAttrName);
+  Optional<NamedAttribute> PassThroughAttr =
+      getAttribute(AttributeList::PassThroughAttrName);
   if (!PassThroughAttr) {
     LLVM_DEBUG(llvm::dbgs()
-               << "Creating empty '" << PassThroughAttrName << "' attribute\n");
-    PassThroughAttr = NamedAttribute(StringAttr::get(&Ctx, PassThroughAttrName),
-                                     ArrayAttr::get(&Ctx, {}));
+               << "Creating empty '" << AttributeList::PassThroughAttrName
+               << "' attribute\n");
+    PassThroughAttr = NamedAttribute(
+        StringAttr::get(&Ctx, AttributeList::PassThroughAttrName),
+        ArrayAttr::get(&Ctx, {}));
   }
   return *PassThroughAttr;
 }
 
 bool AttrBuilder::containsInPassThrough(StringRef AttrName) const {
-  if (!getAttribute(PassThroughAttrName).has_value())
+  if (!getAttribute(AttributeList::PassThroughAttrName).has_value())
     return false;
 
-  NamedAttribute PassThroughAttr = getAttribute(PassThroughAttrName).value();
+  NamedAttribute PassThroughAttr =
+      getAttribute(AttributeList::PassThroughAttrName).value();
   assert(isa<ArrayAttr>(PassThroughAttr.getValue()) &&
          "passthrough attribute value should be an ArrayAttr");
 

--- a/polygeist/tools/cgeist/Lib/Attributes.h
+++ b/polygeist/tools/cgeist/Lib/Attributes.h
@@ -23,6 +23,8 @@ class AttrBuilder;
 /// its parameters.
 class AttributeList {
 public:
+  static constexpr llvm::StringLiteral PassThroughAttrName = "passthrough";
+
   AttributeList() = default;
   AttributeList(const mlir::NamedAttrList &FnAttrs,
                 const mlir::NamedAttrList &RetAttrs,

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2567,6 +2567,8 @@ void MLIRASTConsumer::setMLIRFunctionAttributes(FunctionOpInterface Function,
 
   // SYCL does not support C++ exceptions or termination in device code, so all
   // functions have to return.
+  //
+  // Adapted from `clang/lib/CodeGen/CGCall.cpp`
   if (getTypes().getCGM().getLangOpts().SYCLIsDevice)
     removePassThroughAttr(Function, llvm::Attribute::NoReturn);
 }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/noreturn.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/noreturn.cpp
@@ -1,0 +1,16 @@
+// RUN: clang++ -O0 -S -fsycl -fsycl-device-only -w -emit-mlir %s -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+// CHECK-NOT: "noreturn"
+
+SYCL_EXTERNAL void noret0() __attribute__((__noreturn__));
+
+SYCL_EXTERNAL void noret1() {
+  noret0();
+}
+
+SYCL_EXTERNAL void foo() {
+  noret0();
+  noret1();
+}


### PR DESCRIPTION
SYCL does not support C++ exceptions or termination in device code, so this attribute cannot appear in device code.