### PR TITLE
[SYCL-MLIR][cgeist] Do not use `SingleBlock::push_back` on `gpu.module`                                                                                                                                             

### DIFF
--- a/mlir/include/mlir/IR/Block.h
+++ b/mlir/include/mlir/IR/Block.h
@@ -211,11 +211,11 @@ public:
   //===--------------------------------------------------------------------===//
 
   /// Get the terminator operation of this block. This function asserts that
-  /// the block has a valid terminator operation.
+  /// the block might have a valid terminator operation.
   Operation *getTerminator();
 
-  /// Check whether this block has a terminator.
-  bool hasTerminator();
+  /// Check whether this block might have a terminator.
+  bool mightHaveTerminator();
 
   //===--------------------------------------------------------------------===//
   // Predecessors and successors.

--- a/mlir/include/mlir/IR/OpDefinition.h
+++ b/mlir/include/mlir/IR/OpDefinition.h
@@ -932,10 +932,6 @@ public:
   }
   template <typename OpT = ConcreteType>
   enable_if_single_region<OpT> insert(Block::iterator insertPt, Operation *op) {
-    Block *body = getBody();
-    // Insert op before the block's terminator if it has one
-    if (insertPt == body->end() && body->hasTerminator())
-      insertPt = Block::iterator(body->getTerminator());
     getBody()->getOperations().insert(insertPt, op);
   }
 };

--- a/mlir/lib/IR/Block.cpp
+++ b/mlir/lib/IR/Block.cpp
@@ -234,14 +234,14 @@ void Block::eraseArguments(function_ref<bool(BlockArgument)> shouldEraseFn) {
 //===----------------------------------------------------------------------===//
 
 /// Get the terminator operation of this block. This function asserts that
-/// the block has a valid terminator operation.
+/// the block might have a valid terminator operation.
 Operation *Block::getTerminator() {
-  assert(hasTerminator());
+  assert(mightHaveTerminator());
   return &back();
 }
 
-/// Check whether this block has a terminator.
-bool Block::hasTerminator() {
+/// Check whether this block might have a terminator.
+bool Block::mightHaveTerminator() {
   return !empty() && back().mightHaveTrait<OpTrait::IsTerminator>();
 }
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -2148,10 +2148,12 @@ MLIRASTConsumer::createMLIRFunction(const FunctionToEmit &FTE,
     Module->push_back(Function);
     Functions[MangledName] = cast<func::FuncOp>(Function);
     break;
-  case InsertionContext::SYCLDevice:
-    mlirclang::getDeviceModule(*Module).push_back(Function);
+  case InsertionContext::SYCLDevice: {
+    gpu::GPUModuleOp deviceModule = mlirclang::getDeviceModule(*Module);
+    deviceModule.insert(deviceModule.getBody()->getTerminator(), Function);
     DeviceFunctions[MangledName] = Function;
     break;
+  }
   }
 
   LLVM_DEBUG(llvm::dbgs() << "Created MLIR function: " << Function << "\n");


### PR DESCRIPTION
DO NOT SQUASH AND MERGE THIS PR

Adapt to upstream `SingleBlock` and `Block` changes after [conversation](https://github.com/llvm/llvm-project/pull/65959)