### PR TITLE
[SYCL-MLIR][sycl] Add SYCL 2020 `sycl.target` values

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.h
@@ -26,7 +26,7 @@ namespace sycl {
 inline unsigned targetToAddressSpace(Target target) {
   switch (target) {
   case Target::ConstantBuffer:
-  case Target::GlobalBuffer:
+  case Target::Device:
     return 1;
   case Target::Local:
     return 3;

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLAttributes.td
@@ -52,8 +52,8 @@ def MemoryAccessModeAttr
 // Target
 ////////////////////////////////////////////////////////////////////////////////
 
-def GlobalBufferTarget
-    : I32EnumAttrCase<"GlobalBuffer", 2014, "global_buffer">;
+def DeviceTarget
+    : I32EnumAttrCase<"Device", 2014, "device">;
 def ConstantBufferTarget
     : I32EnumAttrCase<"ConstantBuffer", 2015, "constant_buffer">;
 def LocalTarget
@@ -66,12 +66,14 @@ def HostImageTarget
     : I32EnumAttrCase<"HostImage", 2019, "host_image">;
 def ImageArrayTarget
     : I32EnumAttrCase<"ImageArray", 2020, "image_array">;
+def HostTaskTarget
+    : I32EnumAttrCase<"HostTask", 2021, "host_task">;
 
 def TargetAttr
     : SYCL_I32EnumAttr<"Target", "valid SYCL Target", "target",
-                       [GlobalBufferTarget, ConstantBufferTarget, LocalTarget,
+                       [DeviceTarget, ConstantBufferTarget, LocalTarget,
 		       ImageTarget, HostBufferTarget, HostImageTarget,
-		       ImageArrayTarget]>;
+		       ImageArrayTarget, HostTaskTarget]>;
 
 ////////////////////////////////////////////////////////////////////////////////
 // AccessAddrSpace

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLDialect.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLDialect.cpp
@@ -100,8 +100,8 @@ private:
 
   static llvm::StringRef getAlias(mlir::sycl::Target Target) {
     switch (Target) {
-    case mlir::sycl::Target::GlobalBuffer:
-      return "gb";
+    case mlir::sycl::Target::Device:
+      return "dev";
     case mlir::sycl::Target::ConstantBuffer:
       return "cb";
     case mlir::sycl::Target::Local:

--- a/mlir-sycl/test/Analysis/accessor-analysis.mlir
+++ b/mlir-sycl/test/Analysis/accessor-analysis.mlir
@@ -4,8 +4,8 @@ llvm.func @__gxx_personality_v0(...) -> i32
 
 !sycl_id_1_ = !sycl.id<[1], (i64)>
 !sycl_range_1_ = !sycl.range<[1], (i64)>
-!sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
-!sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
+!sycl_accessor_1_21llvm2Evoid_w_dev = !sycl.accessor<[1, !llvm.void, write, device], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_accessor_1_21llvm2Evoid_rw_dev = !sycl.accessor<[1, !llvm.void, read_write, device], (!llvm.void)>
 
 // CHECK-LABEL: test_tag: full_information:
 // CHECK:        operand #0
@@ -29,7 +29,7 @@ llvm.func @full_information() -> !llvm.ptr attributes {personality = @__gxx_pers
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-   sycl.host.constructor(%acc, %0, %range, %offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+   sycl.host.constructor(%acc, %0, %range, %offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   %4 = llvm.load %acc {tag = "full_information"} : !llvm.ptr -> i32
@@ -56,7 +56,7 @@ llvm.func @no_information() -> !llvm.ptr attributes {personality = @__gxx_person
   %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %4 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  sycl.host.constructor(%acc, %0, %1, %2, %3, %4) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %0, %1, %2, %3, %4) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   %5 = llvm.load %acc {tag = "no_information"} : !llvm.ptr -> i32
@@ -92,13 +92,13 @@ llvm.func @join_accessor(%arg0 : i1) -> !llvm.ptr attributes {personality = @__g
   sycl.host.constructor(%buf1, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   sycl.host.constructor(%acc_range, %c128_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%acc_offset, %c64_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
-  sycl.host.constructor(%acc, %buf1, %acc_range, %acc_offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %buf1, %acc_range, %acc_offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb3
 ^bb2:
   sycl.host.constructor(%buf2, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   sycl.host.constructor(%acc_range, %c64_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%acc_offset, %c128_i64) {type = !sycl_id_1_} : (!llvm.ptr, i64) -> ()
-  sycl.host.constructor(%acc, %buf2, %acc_range, %acc_offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %buf2, %acc_range, %acc_offset, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb3
 ^bb3:
   %4 = llvm.load %acc {tag = "join_accessor"} : !llvm.ptr -> i32
@@ -124,8 +124,8 @@ llvm.func @alias_same_buffer_no_range_info() -> !llvm.ptr attributes {personalit
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_no_range_info"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
@@ -146,8 +146,8 @@ llvm.func @alias_same_buffer_no_range_required() -> !llvm.ptr attributes {person
   %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_no_range_required"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
@@ -175,8 +175,8 @@ llvm.func @alias_same_buffer_no_overlap() -> !llvm.ptr attributes {personality =
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_no_overlap"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
@@ -204,8 +204,8 @@ llvm.func @alias_same_buffer_full_overlap() -> !llvm.ptr attributes {personality
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%0, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %0, %range1, %offset1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %0, %range2, %offset2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_same_buffer_full_overlap"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
@@ -231,8 +231,8 @@ llvm.func @alias_two_buffers_with_info() -> !llvm.ptr attributes {personality = 
   sycl.host.constructor(%1, %c256_i64) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
   sycl.host.constructor(%buf1, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   sycl.host.constructor(%buf2, %1, %2, %3) {type = !sycl.buffer<[1, !llvm.void]>} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %buf2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %buf2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_two_buffers_with_info"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
@@ -254,8 +254,8 @@ llvm.func @alias_two_buffers_no_info() -> !llvm.ptr attributes {personality = @_
   %1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array", (array<1 x i64>)>)> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %buf2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %buf1, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %buf2, %2, %3) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%1, %acc1, %acc2) {type = !sycl_range_1_, tag = "alias_two_buffers_no_info"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()

--- a/mlir-sycl/test/Analysis/local-accessor-analysis.mlir
+++ b/mlir-sycl/test/Analysis/local-accessor-analysis.mlir
@@ -4,9 +4,9 @@ llvm.func @__gxx_personality_v0(...) -> i32
 
 !sycl_id_1_ = !sycl.id<[1], (i64)>
 !sycl_range_1_ = !sycl.range<[1], (i64)>
-!sycl_local_accessor_1_21llvm2Evoid_w_gb = !sycl.local_accessor<[1, !llvm.void], (!sycl_range_1_)>
-!sycl_local_accessor_1_21llvm2Evoid_rw_gb = !sycl.local_accessor<[1, !llvm.void], (!llvm.void)>
-!sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!llvm.void)>
+!sycl_local_accessor_1_21llvm2Evoid_w_dev = !sycl.local_accessor<[1, !llvm.void], (!sycl_range_1_)>
+!sycl_local_accessor_1_21llvm2Evoid_rw_dev = !sycl.local_accessor<[1, !llvm.void], (!llvm.void)>
+!sycl_accessor_1_21llvm2Evoid_w_dev = !sycl.accessor<[1, !llvm.void, write, device], (!llvm.void)>
 
 // CHECK-LABEL: test_tag: full_information:
 // CHECK:        operand #0
@@ -22,7 +22,7 @@ llvm.func @full_information(%handler: !llvm.ptr) -> !llvm.ptr attributes {person
   %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   sycl.host.constructor(%1, %range) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-  sycl.host.constructor(%acc, %1, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %1, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   %4 = llvm.load %acc {tag = "full_information"} : !llvm.ptr -> i32
@@ -40,7 +40,7 @@ llvm.func @no_information(%handler: !llvm.ptr, %range: !llvm.ptr) -> !llvm.ptr a
   %acc = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::local_accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %3 = llvm.alloca %c1_i32 x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  sycl.host.constructor(%acc, %range, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %range, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   %5 = llvm.load %acc {tag = "no_information"} : !llvm.ptr -> i32
@@ -63,11 +63,11 @@ llvm.func @join_accessor(%handler: !llvm.ptr, %arg0 : i1) -> !llvm.ptr attribute
   llvm.cond_br %arg0, ^bb1, ^bb2
 ^bb1:
   sycl.host.constructor(%1, %range) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-  sycl.host.constructor(%acc, %1, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %1, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb3
 ^bb2:
   sycl.host.constructor(%1, %range) {type = !sycl_range_1_} : (!llvm.ptr, i64) -> ()
-  sycl.host.constructor(%acc, %1, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %1, %handler, %2, %3) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb3
 ^bb3:
   %4 = llvm.load %acc {tag = "join_accessor"} : !llvm.ptr -> i32
@@ -82,8 +82,8 @@ llvm.func @no_alias(%handler: !llvm.ptr, %range: !llvm.ptr, %props: !llvm.ptr, %
   %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %acc1 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::local_accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %acc2 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::local_accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  sycl.host.constructor(%acc1, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%acc2, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc1, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc2, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb1
 ^bb1:
   sycl.host.constructor(%0, %acc2, %acc2) {type = !sycl_range_1_, tag = "no_alias"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
@@ -98,11 +98,11 @@ llvm.func @join_top(%arg0: i1, %acc: !llvm.ptr, %handler: !llvm.ptr, %range: !ll
   llvm.cond_br %arg0, ^bb1, ^bb2
 ^bb1:
   // Device accessor
-  sycl.host.constructor(%acc, %buf, %range, %props, %codeloc) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %buf, %range, %props, %codeloc) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb3
 ^bb2:
   // Local accessor
-  sycl.host.constructor(%acc, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%acc, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.br ^bb3
 ^bb3:
   %4 = llvm.load %acc {tag = "join_top"} : !llvm.ptr -> i32
@@ -117,8 +117,8 @@ llvm.func @no_alias_device(%arg0: i1, %handler: !llvm.ptr, %range: !llvm.ptr, %b
   %dev_acc = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %local_acc = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::local_accessor", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
   %0 = llvm.alloca %c1_i32 x !llvm.struct<"class.sycl::_V1::range", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-  sycl.host.constructor(%dev_acc, %buf, %range, %props, %codeloc) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-  sycl.host.constructor(%local_acc, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%dev_acc, %buf, %range, %props, %codeloc) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%local_acc, %range, %handler, %props, %codeloc) {type = !sycl_local_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   sycl.host.constructor(%0, %dev_acc, %local_acc) {type = !sycl_range_1_, tag = "no_alias_device"} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   llvm.return %0 : !llvm.ptr
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-call-to-llvm.mlir
@@ -24,14 +24,14 @@ func.func @test() -> (i32) {
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<1>)>)>
 
 // CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE([[ARG_TYPES:!llvm.ptr,.*]])
-func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE(memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)
+func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE(memref<?x!sycl_accessor_1_i32_rw_dev>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_)
 
-func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>, %arg1: memref<?xi32>, %arg2: !sycl_range_1_, %arg3: !sycl_range_1_, %arg4: !sycl_id_1_) {
+func.func @accessorInit1(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev>, %arg1: memref<?xi32>, %arg2: !sycl_range_1_, %arg3: !sycl_range_1_, %arg4: !sycl_id_1_) {
   // CHECK: llvm.call @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE({{.*}}) : ([[ARG_TYPES]]) -> ()
-  sycl.call @__init(%arg0, %arg1, %arg2, %arg3, %arg4) {MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_) -> ()
+  sycl.call @__init(%arg0, %arg1, %arg2, %arg3, %arg4) {MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEE6__initEPU3AS1iNS0_5rangeILi1EEESE_NS0_2idILi1EEE, TypeName = @accessor} : (memref<?x!sycl_accessor_1_i32_rw_dev>, memref<?xi32>, !sycl_range_1_, !sycl_range_1_, !sycl_id_1_) -> ()
   return
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-cast-to-llvm.mlir
@@ -27,33 +27,33 @@ func.func @cast_sycl_id_to_array(%arg0: memref<?x!sycl_id_1_>) -> memref<?x!sycl
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<1>)>)>
-func.func @cast_sycl_accessor_to_accessor_common(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl.accessor_common> {
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<1>)>)>
+func.func @cast_sycl_accessor_to_accessor_common(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?x!sycl.accessor_common> {
   // CHECK-LABEL: llvm.func @cast_sycl_accessor_to_accessor_common(
   // CHECK-SAME:                                                   [[SRC:%.*]]: !llvm.ptr) -> !llvm.ptr
   // CHECK-NEXT: llvm.return [[SRC]] : !llvm.ptr
 
-  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl.accessor_common>
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?x!sycl.accessor_common>
   func.return %0: memref<?x!sycl.accessor_common>
 }
 
 !sycl_LocalAccessorBaseDevice_1_ = !sycl.LocalAccessorBaseDevice<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 !sycl_local_accessor_base_1_i32_rw = !sycl.local_accessor_base<[1, i32, read_write], (!sycl_LocalAccessorBaseDevice_1_, memref<?xi32, 3>)>
-func.func @cast_sycl_accessor_to_local_accessor_base(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl_local_accessor_base_1_i32_rw> {
+func.func @cast_sycl_accessor_to_local_accessor_base(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?x!sycl_local_accessor_base_1_i32_rw> {
   // CHECK-LABEL: llvm.func @cast_sycl_accessor_to_local_accessor_base(
   // CHECK-SAME:                                                       [[SRC:%.*]]: !llvm.ptr) -> !llvm.ptr
   // CHECK-NEXT: llvm.return [[SRC]] : !llvm.ptr
 
-  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl_local_accessor_base_1_i32_rw>
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?x!sycl_local_accessor_base_1_i32_rw>
   func.return %0: memref<?x!sycl_local_accessor_base_1_i32_rw>
 }
 
-func.func @cast_sycl_accessor_to_owner_less_base(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl.owner_less_base> {
+func.func @cast_sycl_accessor_to_owner_less_base(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?x!sycl.owner_less_base> {
   // CHECK-LABEL: llvm.func @cast_sycl_accessor_to_owner_less_base(
   // CHECK-SAME:                                                   [[SRC:%.*]]: !llvm.ptr) -> !llvm.ptr
   // CHECK-NEXT: llvm.return [[SRC]] : !llvm.ptr
   
-  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?x!sycl.owner_less_base>
+  %0 = "sycl.cast"(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?x!sycl.owner_less_base>
   func.return %0: memref<?x!sycl.owner_less_base>
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-constructor-to-llvm.mlir
@@ -6,14 +6,14 @@
 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<1>)>)>
 
 // CHECK: llvm.func @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev([[THIS_PTR_TYPE:!llvm.ptr]])
-func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev(memref<?x!sycl_accessor_1_i32_rw_gb>)
+func.func private @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev(memref<?x!sycl_accessor_1_i32_rw_dev>)
 
-func.func @accessorInt1ReadWriteGlobalBufferFalseCtor(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb>) {
+func.func @accessorInt1ReadWriteGlobalBufferFalseCtor(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev>) {
   // CHECK: llvm.call @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev({{.*}}) : ([[THIS_PTR_TYPE]]) -> ()
-  sycl.constructor @accessor(%arg0) {MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev} : (memref<?x!sycl_accessor_1_i32_rw_gb>)
+  sycl.constructor @accessor(%arg0) {MangledFunctionName = @_ZN2cl4sycl8accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC2Ev} : (memref<?x!sycl_accessor_1_i32_rw_dev>)
   return
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-flat-to-llvm.mlir
@@ -47,7 +47,7 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
@@ -58,8 +58,8 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64, 4> {
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.addrspacecast %[[VAL_4]] : !llvm.ptr<1> to !llvm.ptr<4>
 // CHECK-NEXT:      llvm.return %[[VAL_5]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 4>
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>, %idx: i64) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_dev>, i64) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -72,15 +72,15 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2_i32_rw_dev = !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 !sycl_accessor_impl_device_3_ = !sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>
-!sycl_accessor_3_i32_rw_gb = !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_3_i32_rw_dev = !sycl.accessor<[3, i32, read_write, device], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test_1(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
@@ -98,8 +98,8 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.addrspacecast %[[VAL_11]] : !llvm.ptr<1> to !llvm.ptr<4>
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
-func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_dev>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -125,8 +125,8 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_18:.*]] = llvm.addrspacecast %[[VAL_17]] : !llvm.ptr<1> to !llvm.ptr<4>
 // CHECK-NEXT:      llvm.return %[[VAL_18]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
-func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_dev>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_dev>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }
 
@@ -158,7 +158,7 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_24:.*]] = llvm.addrspacecast %[[VAL_23]] : !llvm.ptr<1> to !llvm.ptr<4>
 // CHECK-NEXT:      llvm.return %[[VAL_24]] : !llvm.ptr<4>
 // CHECK-NEXT:    }
-func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 4> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 4>
+func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_dev>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 4> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_dev>, memref<?x!sycl_id_3_>) -> memref<?xi32, 4>
   return %0 : memref<?xi32, 4>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-m32.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm-m32.mlir
@@ -7,15 +7,15 @@
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi32>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi32>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr<1> {
 // CHECK-NEXT:      %0 = llvm.mlir.constant(0 : i32) : i32
 // CHECK-NEXT:      %1 = llvm.mlir.constant(0 : i32) : i32
-// CHECK-NEXT:      %2 = llvm.getelementptr inbounds %arg0[0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %2 = llvm.getelementptr inbounds %arg0[0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_dev
 // CHECK-NEXT:      %3 = llvm.load %2 : !llvm.ptr -> i32
-// CHECK-NEXT:      %4 = llvm.getelementptr inbounds %arg0[0, 0, 0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %4 = llvm.getelementptr inbounds %arg0[0, 0, 0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_dev
 // CHECK-NEXT:      %5 = llvm.load %4 : !llvm.ptr -> i32
 // CHECK-NEXT:      %6 = llvm.mul %3, %1  : i32
 // CHECK-NEXT:      %7 = llvm.add %6, %5  : i32
@@ -25,7 +25,7 @@
 // CHECK-NEXT:      %11 = llvm.getelementptr inbounds %10[%8] : (!llvm.ptr<1>, i32) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %11 : !llvm.ptr<1>
 // CHECK-NEXT:    }
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-methods-to-llvm.mlir
@@ -155,15 +155,15 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.ptr<1> {
 // CHECK-DAG:       %[[VAL_1:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-DAG:       %[[VAL_2:.*]] = llvm.mlir.constant(0 : i64) : i64
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 2, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_dev
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> i64
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_gb
+// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 0, 0, 0, 0] : (!llvm.ptr) -> !llvm.ptr, !sycl_accessor_1_i32_rw_dev
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.mul %[[VAL_4]], %[[VAL_2]]  : i64
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.add %[[VAL_7]], %[[VAL_6]]  : i64
@@ -172,8 +172,8 @@ func.func @test(%id: memref<?x!sycl_id_3_>, %idx: i32) -> memref<?xi64> {
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.load %[[VAL_10]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]]{{\[}}%[[VAL_9]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_12]] : !llvm.ptr<1>
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1>
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -186,15 +186,15 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi32, 1> 
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.struct<"class.sycl::_V1::range.1", {{.*}}> {
 // CHECK-NEXT:      %[[VAL_1:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.sycl::_V1::accessor.1", {{.*}}>
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.load %[[VAL_1]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_2]] : !llvm.struct<"class.sycl::_V1::range.1", {{.*}}>
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
-  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>) -> !sycl_range_1_ {
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
@@ -207,7 +207,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr) -> i64 {
@@ -217,8 +217,8 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_1_ {
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.mul %[[VAL_3]], %[[VAL_1]]  : i64
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : i64
 // CHECK-NEXT:    }
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
-  %0 = sycl.accessor.size(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>) -> i64 {
+  %0 = sycl.accessor.size(%acc) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> i64
   return %0 : i64
 }
 
@@ -231,7 +231,7 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr,
@@ -240,8 +240,8 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> i64 {
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_3]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_4]] : !llvm.ptr<1>
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, i64) -> memref<?xi32, 1>
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>, %idx: i64) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_dev>, i64) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -256,12 +256,12 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 !sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2_i32_rw_dev = !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 !sycl_accessor_impl_device_3_ = !sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>
-!sycl_accessor_3_i32_rw_gb = !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>
-!sycl_accessor_subscript_2_ = !sycl.accessor_subscript<[2], (!sycl_id_2_, !sycl_accessor_2_i32_rw_gb)>
-!sycl_accessor_subscript_3_ = !sycl.accessor_subscript<[3], (!sycl_id_3_, !sycl_accessor_3_i32_rw_gb)>
+!sycl_accessor_3_i32_rw_dev = !sycl.accessor<[3, i32, read_write, device], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_subscript_2_ = !sycl.accessor_subscript<[2], (!sycl_id_2_, !sycl_accessor_2_i32_rw_dev)>
+!sycl_accessor_subscript_3_ = !sycl.accessor_subscript<[3], (!sycl_id_3_, !sycl_accessor_3_i32_rw_dev)>
 
 // CHECK-LABEL:   llvm.func @test_2(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
@@ -272,8 +272,8 @@ func.func @test(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: i64) -> memref
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::accessor.2", {{.*}}>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_5]], %[[VAL_3]][1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_6]] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.2", {{.*}}>
-func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: i64) -> !sycl_accessor_subscript_2_ {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> !sycl_accessor_subscript_2_
+func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_dev>, %idx: i64) -> !sycl_accessor_subscript_2_ {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_dev>, i64) -> !sycl_accessor_subscript_2_
   return %0 : !sycl_accessor_subscript_2_
 }
 
@@ -287,8 +287,8 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_0]] : !llvm.ptr -> !llvm.struct<"class.sycl::_V1::accessor.3", {{.*}}>
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.insertvalue %[[VAL_6]], %[[VAL_5]][1] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.3", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_7]] : !llvm.struct<"class.sycl::_V1::detail::accessor_common.AccessorSubscript.3", {{.*}}>
-func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !sycl_accessor_subscript_3_ {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, i64) -> !sycl_accessor_subscript_3_
+func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_dev>, %idx: i64) -> !sycl_accessor_subscript_3_ {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_dev>, i64) -> !sycl_accessor_subscript_3_
   return %0 : !sycl_accessor_subscript_3_
 }
 
@@ -301,17 +301,17 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !syc
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2_i32_rw_dev = !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_id_3_ = !sycl.id<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64>)>)>
 !sycl_accessor_impl_device_3_ = !sycl.accessor_impl_device<[3], (!sycl_id_3_, !sycl_range_3_, !sycl_range_3_)>
-!sycl_accessor_3_i32_rw_gb = !sycl.accessor<[3, i32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_3_i32_rw_dev = !sycl.accessor<[3, i32, read_write, device], (!sycl_accessor_impl_device_3_, !llvm.struct<(ptr<i32, 1>)>)>
 !my_struct = !llvm.struct<(i32, f32)>
-!sycl_accessor_1_struct_rw_gb = !sycl.accessor<[1, !my_struct, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<!my_struct, 1>)>)>
+!sycl_accessor_1_struct_rw_dev = !sycl.accessor<[1, !my_struct, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<!my_struct, 1>)>)>
 
 // CHECK-LABEL:   llvm.func @test_1(
 // CHECK-SAME:                      %[[VAL_0:.*]]: !llvm.ptr,
@@ -327,8 +327,8 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: i64) -> !syc
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<1>
-func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
+func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>, %idx: memref<?x!sycl_id_1_>) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_rw_dev>, memref<?x!sycl_id_1_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -352,8 +352,8 @@ func.func @test_1(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_16:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_17:.*]] = llvm.getelementptr inbounds %[[VAL_16]]{{\[}}%[[VAL_14]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_17]] : !llvm.ptr<1>
-func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
+func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_dev>, %idx: memref<?x!sycl_id_2_>) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_2_i32_rw_dev>, memref<?x!sycl_id_2_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -383,8 +383,8 @@ func.func @test_2(%acc: memref<?x!sycl_accessor_2_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_22:.*]] = llvm.load %[[VAL_21]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_23:.*]] = llvm.getelementptr inbounds %[[VAL_22]]{{\[}}%[[VAL_20]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      llvm.return %[[VAL_23]] : !llvm.ptr<1>
-func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_gb>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
+func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_dev>, %idx: memref<?x!sycl_id_3_>) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_3_i32_rw_dev>, memref<?x!sycl_id_3_>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
@@ -402,8 +402,8 @@ func.func @test_3(%acc: memref<?x!sycl_accessor_3_i32_rw_gb>, %idx: memref<?x!sy
 // CHECK-NEXT:      %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> !llvm.ptr<1>
 // CHECK-NEXT:      %[[VAL_11:.*]] = llvm.getelementptr inbounds %[[VAL_10]]{{\[}}%[[VAL_8]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, !llvm.struct<(i32, f32)>
 // CHECK-NEXT:      llvm.return %[[VAL_11]] : !llvm.ptr<1>
-func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memref<?x!sycl_id_1_>) -> !llvm.ptr<1> {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_struct_rw_gb>, memref<?x!sycl_id_1_>) -> !llvm.ptr<1>
+func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_dev>, %idx: memref<?x!sycl_id_1_>) -> !llvm.ptr<1> {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_struct_rw_dev>, memref<?x!sycl_id_1_>) -> !llvm.ptr<1>
   return %0 : !llvm.ptr<1>
 }
 
@@ -417,7 +417,7 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_ato_dev = !sycl.accessor<[1, i32, atomic, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_atomic_i32_glo = !sycl.atomic<[i32, global], (memref<?xi32, 1>)>
 
 // CHECK-LABEL:   llvm.func @test(
@@ -436,8 +436,8 @@ func.func @test_struct(%acc: memref<?x!sycl_accessor_1_struct_rw_gb>, %idx: memr
 // CHECK-NEXT:      %[[VAL_12:.*]] = llvm.getelementptr inbounds %[[VAL_11]]{{\[}}%[[VAL_9]]] : (!llvm.ptr<1>, i64) -> !llvm.ptr<1>, i32
 // CHECK-NEXT:      %[[VAL_13:.*]] = llvm.insertvalue %[[VAL_12]], %[[VAL_2]][0] : !llvm.struct<"class.sycl::_V1::atomic", {{.*}}>
 // CHECK-NEXT:      llvm.return %[[VAL_13]] : !llvm.struct<"class.sycl::_V1::atomic", {{.*}}>
-func.func @test(%acc: memref<?x!sycl_accessor_1_i32_ato_gb>, %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo {
-  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
+func.func @test(%acc: memref<?x!sycl_accessor_1_i32_ato_dev>, %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo {
+  %0 = sycl.accessor.subscript %acc[%idx] : (memref<?x!sycl_accessor_1_i32_ato_dev>, memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo
   return %0 : !sycl_atomic_i32_glo
 }
 

--- a/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToLLVM/sycl-types-to-llvm.mlir
@@ -49,14 +49,14 @@ func.func @test_range.2(%arg0: !sycl_range_2_) {
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
-!sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<1>)>)>
-!sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
-!sycl_accessor_2_f32_rw_gb = !sycl.accessor<[2, f32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_2_i32_rw_dev = !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_f32_rw_dev = !sycl.accessor<[1, f32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_2_f32_rw_dev = !sycl.accessor<[2, f32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<1>)>)>
 !sycl_LocalAccessorBaseDevice_1_ = !sycl.LocalAccessorBaseDevice<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 !sycl_local_accessor_base_1_i32_rw = !sycl.local_accessor_base<[1, i32, read_write], (!sycl_LocalAccessorBaseDevice_1_, memref<?xi32, 3>)>
 !sycl_accessor_1_i32_rw_1 = !sycl.accessor<[1, i32, read_write, local], (!sycl_local_accessor_base_1_i32_rw)>
-!sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<1>)>)>)>
+!sycl_accessor_subscript_1_ = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(ptr<1>)>)>)>
 // CHECK: llvm.func @test_accessor_common(%arg0: !llvm.struct<"class.sycl::_V1::detail::accessor_common", (i8)>)
 func.func @test_accessor_common(%arg0: !sycl.accessor_common) {
   return
@@ -66,19 +66,19 @@ func.func @test_accessorImplDevice(%arg0: !sycl_accessor_impl_device_1_) {
   return
 }
 // CHECK: llvm.func @test_accessor.1(%arg0: !llvm.struct<"class.sycl::_V1::accessor{{.*}}", ([[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<1>)>[[SUFFIX]])
-func.func @test_accessor.1(%arg0: !sycl_accessor_1_i32_rw_gb) {
+func.func @test_accessor.1(%arg0: !sycl_accessor_1_i32_rw_dev) {
   return
 }
 // CHECK: llvm.func @test_accessor.2(%arg0: !llvm.[[ACCESSOR_2:struct<"class.sycl::_V1::accessor.*", \(]][[ACCESSORIMPLDEVICE_2:struct<"class.sycl::_V1::detail::AccessorImplDevice.*", \(]][[ID_2:struct<"class.sycl::_V1::id.*", \(]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<1>)>[[SUFFIX]])
-func.func @test_accessor.2(%arg0: !sycl_accessor_2_i32_rw_gb) {
+func.func @test_accessor.2(%arg0: !sycl_accessor_2_i32_rw_dev) {
   return
 }
 // CHECK: llvm.func @test_accessor.3(%arg0: !llvm.struct<"class.sycl::_V1::accessor{{.*}}", ([[ACCESSORIMPLDEVICE_1]][[ID_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], struct<(ptr<1>)>[[SUFFIX]])
-func.func @test_accessor.3(%arg0: !sycl_accessor_1_f32_rw_gb) {
+func.func @test_accessor.3(%arg0: !sycl_accessor_1_f32_rw_dev) {
   return
 }
 // CHECK: llvm.func @test_accessor.4(%arg0: !llvm.struct<"class.sycl::_V1::accessor{{.*}}", ([[ACCESSORIMPLDEVICE_2]][[ID_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]], [[RANGE_2]][[ARRAY_2]][[SUFFIX]][[SUFFIX]], struct<(ptr<1>)>[[SUFFIX]])
-func.func @test_accessor.4(%arg0: !sycl_accessor_2_f32_rw_gb) {
+func.func @test_accessor.4(%arg0: !sycl_accessor_2_f32_rw_dev) {
   return
 }
 // CHECK: llvm.func @test_accessor.5(%arg0: !llvm.struct<"class.sycl::_V1::accessor{{.*}}", (struct<"class.sycl::_V1::local_accessor_base{{.*}}", ([[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[RANGE_1]][[ARRAY_1]][[SUFFIX]], [[ID_1]][[ARRAY_1]][[SUFFIX]][[SUFFIX]], ptr<3>
@@ -218,9 +218,9 @@ func.func @test_sub_group(%arg0: !sycl.sub_group) {
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
-!sycl_accessor_1_i8_rw_gb = !sycl.accessor<[1, i8, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
-!sycl_stream = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_gb, !sycl_accessor_1_i32_ato_gb, !sycl_accessor_1_i8_rw_gb, i32, i64, i32, i32, i32, i32)>
+!sycl_accessor_1_i32_ato_dev = !sycl.accessor<[1, i32, atomic, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_i8_rw_dev = !sycl.accessor<[1, i8, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+!sycl_stream = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_dev, !sycl_accessor_1_i32_ato_dev, !sycl_accessor_1_i8_rw_dev, i32, i64, i32, i32, i32, i32)>
 // CHECK: llvm.func @test_stream(%arg0: !llvm.struct<"class.sycl::_V1::stream", (array<16 x i8>, struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<1>)>)>, struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<1>)>)>, struct<"class.sycl::_V1::accessor.1", (struct<"class.sycl::_V1::detail::AccessorImplDevice.1", (struct<"class.sycl::_V1::id.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>, struct<"class.sycl::_V1::range.1", (struct<"class.sycl::_V1::detail::array.1", (array<1 x i64>)>)>)>, struct<(ptr<1>)>)>, i32, i64, i32, i32, i32, i32)>) {
 func.func @test_stream(%arg0: !sycl_stream) {
     return

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -6,7 +6,7 @@
 !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
-!sycl_accessor_2_i32_r_gb = !sycl.accessor<[2, i32, read, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2_i32_r_dev = !sycl.accessor<[2, i32, read, device], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 // CHECK-LABEL: test_host_constructor
 // CHECK:  %1 = llvm.alloca %0 x !sycl_id_1_ : (i32) -> !llvm.ptr
@@ -19,12 +19,12 @@ func.func @test_host_constructor() -> !llvm.ptr {
 }
 
 // CHECK-LABEL: test_host_constructor_args
-// CHECK:  %1 = llvm.alloca %0 x !sycl_accessor_2_i32_r_gb : (i32) -> !llvm.ptr
-// CHECK:  sycl.host.constructor(%[[#PTR:]], %arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:  %1 = llvm.alloca %0 x !sycl_accessor_2_i32_r_dev : (i32) -> !llvm.ptr
+// CHECK:  sycl.host.constructor(%[[#PTR:]], %arg0, %arg1) {type = !sycl_accessor_2_i32_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 func.func @test_host_constructor_args(%arg0: !llvm.ptr, %arg1: !llvm.ptr) -> !llvm.ptr {
   %0 = llvm.mlir.constant(1 : i32) : i32
-  %1 = llvm.alloca %0 x !sycl_accessor_2_i32_r_gb : (i32) -> !llvm.ptr
-  sycl.host.constructor(%1, %arg0, %arg1) {type = !sycl_accessor_2_i32_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  %1 = llvm.alloca %0 x !sycl_accessor_2_i32_r_dev : (i32) -> !llvm.ptr
+  sycl.host.constructor(%1, %arg0, %arg1) {type = !sycl_accessor_2_i32_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   return %1 : !llvm.ptr
 }
 
@@ -82,11 +82,11 @@ func.func @set_nd_range_range_with_offset(%handler: !llvm.ptr, %range: !llvm.ptr
 // CHECK-SAME:                            %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: i16, %[[VAL_2:.*]]: !llvm.ptr, %[[VAL_3:.*]]: !llvm.ptr) {
 // CHECK:           sycl.host.set_captured %[[VAL_0]][0] = %[[VAL_1]] : !llvm.ptr, i16
 // CHECK:           sycl.host.set_captured %[[VAL_0]][1] = %[[VAL_2]] : !llvm.ptr, !llvm.ptr
-// CHECK:           sycl.host.set_captured %[[VAL_0]][2] = %[[VAL_3]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_2_i32_r_gb)
+// CHECK:           sycl.host.set_captured %[[VAL_0]][2] = %[[VAL_3]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_2_i32_r_dev)
 func.func @set_captured(%lambda: !llvm.ptr, %scalar_arg: i16, %struct_arg: !llvm.ptr, %accessor_arg: !llvm.ptr) {
   sycl.host.set_captured %lambda[0] = %scalar_arg : !llvm.ptr, i16
   sycl.host.set_captured %lambda[1] = %struct_arg : !llvm.ptr, !llvm.ptr
-  sycl.host.set_captured %lambda[2] = %accessor_arg : !llvm.ptr,  !llvm.ptr (!sycl_accessor_2_i32_r_gb)
+  sycl.host.set_captured %lambda[2] = %accessor_arg : !llvm.ptr,  !llvm.ptr (!sycl_accessor_2_i32_r_dev)
   func.return
 }
 
@@ -95,14 +95,14 @@ func.func @set_captured(%lambda: !llvm.ptr, %scalar_arg: i16, %struct_arg: !llvm
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0 : (!llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]]) : (!llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]], %[[VAL_2]]) : (!llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0(%[[VAL_1]], %[[VAL_2]], %[[VAL_3]]: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_single_task(%handler: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel %handler -> @kernels::@k0 : (!llvm.ptr) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0) : (!llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0, %arg1) : (!llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
@@ -111,14 +111,14 @@ func.func @schedule_kernel_single_task(%handler: !llvm.ptr, %arg0: i32, %arg1: i
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[nd_range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_nd_range(%handler: !llvm.ptr, %nd_range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range] : (!llvm.ptr, !llvm.ptr) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[nd_range %nd_range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
@@ -127,14 +127,14 @@ func.func @schedule_kernel_nd_range(%handler: !llvm.ptr, %nd_range: !llvm.ptr, %
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]] : (!llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]]) : (!llvm.ptr, !llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]]](%[[VAL_2]], %[[VAL_3]], %[[VAL_4]]: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_range(%handler: !llvm.ptr, %range: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range] : (!llvm.ptr, !llvm.ptr) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0) : (!llvm.ptr, !llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 
@@ -143,14 +143,14 @@ func.func @schedule_kernel_range(%handler: !llvm.ptr, %range: !llvm.ptr, %arg0: 
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]] : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
-// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]], %[[VAL_4]], %[[VAL_5]]: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @kernels::@k0[range %[[VAL_1]], offset %[[VAL_2]]](%[[VAL_3]], %[[VAL_4]], %[[VAL_5]]: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 func.func @schedule_kernel_range_with_offset(%handler: !llvm.ptr, %range: !llvm.ptr, %offset: !llvm.ptr, %arg0: i32, %arg1: i32, %arg2: !llvm.ptr) {
   sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset] : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32) -> ()
   sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0, %arg1) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32) -> ()
-  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_gb) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
+  sycl.host.schedule_kernel %handler -> @kernels::@k0[range %range, offset %offset](%arg0, %arg1, %arg2: !sycl_accessor_2_i32_r_dev) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, i32, !llvm.ptr) -> ()
   func.return
 }
 

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -88,11 +88,11 @@ func.func @test_non_sycl_arg_constructor(%i: memref<1xi32>) {
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 
-func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi64, 1> {
+func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?xi64, 1> {
   // expected-error @+1 {{'sycl.accessor.get_pointer' op Expecting a reference to this accessor's value type}}
-  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> memref<?xi64, 1>
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> memref<?xi64, 1>
   return %0 : memref<?xi64, 1>
 }
 
@@ -101,12 +101,12 @@ func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>)
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64>)>)>
 
-func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_ {
+func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_dev>) -> !sycl_range_2_ {
   // expected-error @+1 {{'sycl.accessor.get_range' op Both the result and the accessor must have the same number of dimensions, but the accessor has 1 dimension(s) and the result has 2 dimension(s)}}
-  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_gb>) -> !sycl_range_2_
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_rw_dev>) -> !sycl_range_2_
   return %0 : !sycl_range_2_
 }
 
@@ -115,15 +115,15 @@ func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_rw_gb>) -
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 3>)>)>
+!sycl_accessor_1_i32_ato_dev = !sycl.accessor<[1, i32, atomic, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 3>)>)>
 !sycl_atomic_i64_glo = !sycl.atomic<[i64, global], (memref<?xi64, 1>)>
 
 func.func @test_accessor_subscript_atomic(
-  %acc: memref<?x!sycl_accessor_1_i32_ato_gb>,
+  %acc: memref<?x!sycl_accessor_1_i32_ato_dev>,
   %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i64_glo {
   // expected-error @+1 {{'sycl.accessor.subscript' op Expecting a reference to this accessor's value type}}
   %0 = sycl.accessor.subscript %acc[%idx]
-      : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>)
+      : (memref<?x!sycl_accessor_1_i32_ato_dev>, memref<?x!sycl_id_1_>)
       -> !sycl_atomic_i64_glo
   return %0 : !sycl_atomic_i64_glo
 }

--- a/mlir-sycl/test/Dialect/SYCL/ops.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/ops.mlir
@@ -10,9 +10,9 @@
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 !sycl_range_3_ = !sycl.range<[3], (!sycl_array_3_)>
-!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_w_dev = !sycl.accessor<[1, i32, write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 3>)>)>
+!sycl_accessor_1_i32_ato_dev = !sycl.accessor<[1, i32, atomic, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 3>)>)>
 !sycl_atomic_i32_glo = !sycl.atomic<[i32, global], (memref<?xi32, 1>)>
 
 // CHECK-LABEL: test_addrspacecast_to_generic
@@ -48,8 +48,8 @@ func.func @test_cast_range(%arg: memref<1x!sycl_range_2_>) -> memref<1x!sycl_arr
 }
 
 // CHECK-LABEL: test_cast_accessor
-func.func @test_cast_accessor(%arg: memref<1x!sycl_accessor_1_i32_w_gb>) -> memref<1x!sycl.accessor_common> {
-  %0 = sycl.cast %arg : memref<1x!sycl_accessor_1_i32_w_gb> to memref<1x!sycl.accessor_common>
+func.func @test_cast_accessor(%arg: memref<1x!sycl_accessor_1_i32_w_dev>) -> memref<1x!sycl.accessor_common> {
+  %0 = sycl.cast %arg : memref<1x!sycl_accessor_1_i32_w_dev> to memref<1x!sycl.accessor_common>
   return %0 : memref<1x!sycl.accessor_common>
 }
 
@@ -178,23 +178,23 @@ func.func @test_sub_group_local_id() -> i32 {
 }
 
 // CHECK-LABEL: test_accessor_get_pointer
-func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1> {
-  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_w_gb>) -> memref<?xi32, 1>
+func.func @test_accessor_get_pointer(%acc: memref<?x!sycl_accessor_1_i32_w_dev>) -> memref<?xi32, 1> {
+  %0 = sycl.accessor.get_pointer(%acc) : (memref<?x!sycl_accessor_1_i32_w_dev>) -> memref<?xi32, 1>
   return %0 : memref<?xi32, 1>
 }
 
 // CHECK-LABEL: test_accessor_get_range
-func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_ {
-  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_w_gb>) -> !sycl_range_1_
+func.func @test_accessor_get_range(%acc: memref<?x!sycl_accessor_1_i32_w_dev>) -> !sycl_range_1_ {
+  %0 = sycl.accessor.get_range(%acc) : (memref<?x!sycl_accessor_1_i32_w_dev>) -> !sycl_range_1_
   return %0 : !sycl_range_1_
 }
 
 // CHECK-LABEL: test_accessor_subscript_atomic
 func.func @test_accessor_subscript_atomic(
-  %acc: memref<?x!sycl_accessor_1_i32_ato_gb>, 
+  %acc: memref<?x!sycl_accessor_1_i32_ato_dev>, 
   %idx: memref<?x!sycl_id_1_>) -> !sycl_atomic_i32_glo {
   %0 = sycl.accessor.subscript %acc[%idx]
-      : (memref<?x!sycl_accessor_1_i32_ato_gb>, memref<?x!sycl_id_1_>)
+      : (memref<?x!sycl_accessor_1_i32_ato_dev>, memref<?x!sycl_id_1_>)
       -> !sycl_atomic_i32_glo
   return %0 : !sycl_atomic_i32_glo
 }

--- a/mlir-sycl/test/Dialect/SYCL/types.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/types.mlir
@@ -29,15 +29,15 @@ func.func @_Z4id_2N2cl4sycl2idILi2EEE(%arg0: !sycl_id_2_) attributes {llvm.linka
 !sycl_id_2_ = !sycl.id<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
-!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
-!sycl_accessor_2_i32_r_gb = !sycl.accessor<[2, i32, read, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i32_w_dev = !sycl.accessor<[1, i32, write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_2_i32_r_dev = !sycl.accessor<[2, i32, read, device], (!sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
-// CHECK: func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_w_gb)
-func.func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_w_gb) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_w_dev)
+func.func @_Z5acc_1N2cl4sycl8accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_1_i32_w_dev) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
-// CHECK: func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_r_gb)
-func.func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_r_gb) attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK: func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_r_dev)
+func.func @_Z5acc_2N2cl4sycl8accessorIiLi2ELNS0_6access4modeE1024ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(%arg0: !sycl_accessor_2_i32_r_dev) attributes {llvm.linkage = #llvm.linkage<external>} {
   return
 }
 
@@ -250,9 +250,9 @@ func.func @_Z9multi_ptrN4sycl3_V19multi_ptrIiLNS0_6access13address_spaceE1ELNS2_
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_ato_gb = !sycl.accessor<[1, i32, atomic, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
-!sycl_accessor_1_i8_rw_gb = !sycl.accessor<[1, i8, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i8, 1>)>)>
-!sycl_stream = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_gb, !sycl_accessor_1_i32_ato_gb, !sycl_accessor_1_i8_rw_gb, i32, i64, i32, i32, i32, i32)>
+!sycl_accessor_1_i32_ato_dev = !sycl.accessor<[1, i32, atomic, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i8_rw_dev = !sycl.accessor<[1, i8, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<i8, 1>)>)>
+!sycl_stream = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_dev, !sycl_accessor_1_i32_ato_dev, !sycl_accessor_1_i8_rw_dev, i32, i64, i32, i32, i32, i32)>
 
 // CHECK: func @_Z6streamN4sycl3_V16streamE(%arg0: !sycl_stream)
 func.func @_Z6streamN4sycl3_V16streamE(%arg0: !sycl_stream) attributes {llvm.linkage = #llvm.linkage<external>} {

--- a/mlir-sycl/test/Transforms/constant-propagation.mlir
+++ b/mlir-sycl/test/Transforms/constant-propagation.mlir
@@ -73,12 +73,12 @@ llvm.func internal @foo.1(%handler: !llvm.ptr, %ptr: !llvm.ptr) {
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
-!sycl_accessor_1_i64_w_gb = !sycl.accessor<[1, i64, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_i64_w_dev = !sycl.accessor<[1, i64, write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 // COM: Check we can detect kernel argument %c is constant
 
 gpu.module @kernels {
-  func.func private @init(%acc: memref<1x!sycl_accessor_1_i64_w_gb>,
+  func.func private @init(%acc: memref<1x!sycl_accessor_1_i64_w_dev>,
                           %ptr: memref<?xi64, 1>,
                           %accRange: memref<?x!sycl_range_1_>,
                           %memRange: memref<?x!sycl_range_1_>,
@@ -89,9 +89,9 @@ gpu.module @kernels {
 // CHECK-NEXT:        %[[VAL_5:.*]] = llvm.mlir.constant(0 : i64) : i64
 // CHECK-NEXT:        %[[VAL_6:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[VAL_7:.*]] = arith.constant 0 : i64
-// CHECK-NEXT:        %[[VAL_8:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i64_w_gb>
-// CHECK-NEXT:        func.call @init(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]]) : (memref<1x!sycl_accessor_1_i64_w_gb>, memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
-// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.accessor.subscript %[[VAL_8]]{{\[}}%[[VAL_7]]] : (memref<1x!sycl_accessor_1_i64_w_gb>, i64) -> memref<?xi64>
+// CHECK-NEXT:        %[[VAL_8:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i64_w_dev>
+// CHECK-NEXT:        func.call @init(%[[VAL_8]], %[[VAL_0]], %[[VAL_1]], %[[VAL_2]], %[[VAL_3]]) : (memref<1x!sycl_accessor_1_i64_w_dev>, memref<?xi64, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        %[[VAL_9:.*]] = sycl.accessor.subscript %[[VAL_8]]{{\[}}%[[VAL_7]]] : (memref<1x!sycl_accessor_1_i64_w_dev>, i64) -> memref<?xi64>
 // CHECK-NEXT:        memref.store %[[VAL_5]], %[[VAL_9]]{{\[}}%[[VAL_6]]] : memref<?xi64>
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
@@ -102,13 +102,13 @@ gpu.module @kernels {
                %c: i64) kernel {
     %c0 = arith.constant 0 : index
     %c0_i64 = arith.constant 0 : i64
-    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i64_w_gb>
+    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i64_w_dev>
     func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
-        : (memref<1x!sycl_accessor_1_i64_w_gb>, memref<?xi64, 1>,
+        : (memref<1x!sycl_accessor_1_i64_w_dev>, memref<?xi64, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
     %res = sycl.accessor.subscript %acc[%c0_i64]
-        : (memref<1x!sycl_accessor_1_i64_w_gb>, i64) -> memref<?xi64>
+        : (memref<1x!sycl_accessor_1_i64_w_dev>, i64) -> memref<?xi64>
     memref.store %c, %res[%c0] : memref<?xi64>
     gpu.return
   }
@@ -116,7 +116,7 @@ gpu.module @kernels {
 
 llvm.func internal @foo(%handler: !llvm.ptr, %acc: !llvm.ptr) {
   %c = llvm.mlir.constant(0 : i64) : i64
-  sycl.host.schedule_kernel %handler -> @kernels::@k0(%acc: !sycl_accessor_1_i64_w_gb, %c)
+  sycl.host.schedule_kernel %handler -> @kernels::@k0(%acc: !sycl_accessor_1_i64_w_dev, %c)
       : (!llvm.ptr, !llvm.ptr, i64) -> ()
   llvm.return
 }
@@ -1270,13 +1270,13 @@ llvm.func internal @foo_constant_constant_global_local_size(
 !sycl_array_1_ = !sycl.array<[1], (memref<1xi64>)>
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
-!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
-!sycl_accessor_host = !sycl.accessor<[1, i32, write, global_buffer], (!llvm.void)>
-!sycl_accessor_host_range = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_range_1_)>
-!sycl_accessor_host_offset = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
+!sycl_accessor_1_i32_w_dev = !sycl.accessor<[1, i32, write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_host = !sycl.accessor<[1, i32, write, device], (!llvm.void)>
+!sycl_accessor_host_range = !sycl.accessor<[1, i32, write, device], (!sycl_range_1_)>
+!sycl_accessor_host_offset = !sycl.accessor<[1, i32, write, device], (!sycl_range_1_, !sycl_id_1_)>
 
 gpu.module @kernels0 {
-  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_gb>,
+  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_dev>,
                           %ptr: memref<?xi32, 1>,
                           %accRange: memref<?x!sycl_range_1_>,
                           %memRange: memref<?x!sycl_range_1_>,
@@ -1292,17 +1292,17 @@ gpu.module @kernels0 {
 // CHECK-NEXT:        %[[VAL_7:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[VAL_8:.*]] = sycl.id.constructor(%[[VAL_7]]) : (index) -> memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_9:.*]] = memref.cast %[[VAL_8]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
-// CHECK-NEXT:        %[[VAL_10:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb2>
-// CHECK-NEXT:        func.call @init(%[[VAL_10]], %[[VAL_0]], %[[VAL_6]], %[[VAL_2]], %[[VAL_9]]) : (memref<1x!sycl_accessor_1_i32_w_gb2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        %[[VAL_10:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev2>
+// CHECK-NEXT:        func.call @init(%[[VAL_10]], %[[VAL_0]], %[[VAL_6]], %[[VAL_2]], %[[VAL_9]]) : (memref<1x!sycl_accessor_1_i32_w_dev2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k0(%ptr: memref<?xi32, 1>,
                %accRange: memref<?x!sycl_range_1_>,
                %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
-    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
+    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev>
     func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
-        : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
+        : (memref<1x!sycl_accessor_1_i32_w_dev>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
     gpu.return
@@ -1336,7 +1336,7 @@ llvm.func internal @constant_offset_and_range(
 // COM: No access range needed, unknown memory range and default offset.
 
 gpu.module @kernels1 {
-  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_gb>,
+  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_dev>,
                           %ptr: memref<?xi32, 1>,
                           %accRange: memref<?x!sycl_range_1_>,
                           %memRange: memref<?x!sycl_range_1_>,
@@ -1346,17 +1346,17 @@ gpu.module @kernels1 {
 // CHECK-SAME:                   %[[VAL_11:.*]]: memref<?xi32, 1>, %[[VAL_12:.*]]: memref<?x!sycl_range_1_>, %[[VAL_13:.*]]: memref<?x!sycl_range_1_>, %[[VAL_14:.*]]: memref<?x!sycl_id_1_>) kernel {
 // CHECK-NEXT:        %[[VAL_15:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_16:.*]] = memref.cast %[[VAL_15]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
-// CHECK-NEXT:        %[[VAL_17:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb2>
-// CHECK-NEXT:        func.call @init(%[[VAL_17]], %[[VAL_11]], %[[VAL_13]], %[[VAL_13]], %[[VAL_16]]) : (memref<1x!sycl_accessor_1_i32_w_gb2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        %[[VAL_17:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev2>
+// CHECK-NEXT:        func.call @init(%[[VAL_17]], %[[VAL_11]], %[[VAL_13]], %[[VAL_13]], %[[VAL_16]]) : (memref<1x!sycl_accessor_1_i32_w_dev2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k1(%ptr: memref<?xi32, 1>,
                %accRange: memref<?x!sycl_range_1_>,
                %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
-    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
+    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev>
     func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
-        : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
+        : (memref<1x!sycl_accessor_1_i32_w_dev>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
     gpu.return
@@ -1385,7 +1385,7 @@ llvm.func internal @unknown_buffer_range_default_offset(
 // COM: No access range needed, constant memory range and default offset.
 
 gpu.module @kernels2 {
-  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_gb>,
+  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_dev>,
                           %ptr: memref<?xi32, 1>,
                           %accRange: memref<?x!sycl_range_1_>,
                           %memRange: memref<?x!sycl_range_1_>,
@@ -1398,17 +1398,17 @@ gpu.module @kernels2 {
 // CHECK-NEXT:        %[[VAL_24:.*]] = memref.cast %[[VAL_23]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
 // CHECK-NEXT:        %[[VAL_25:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_26:.*]] = memref.cast %[[VAL_25]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
-// CHECK-NEXT:        %[[VAL_27:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb2>
-// CHECK-NEXT:        func.call @init(%[[VAL_27]], %[[VAL_18]], %[[VAL_24]], %[[VAL_24]], %[[VAL_26]]) : (memref<1x!sycl_accessor_1_i32_w_gb2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        %[[VAL_27:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev2>
+// CHECK-NEXT:        func.call @init(%[[VAL_27]], %[[VAL_18]], %[[VAL_24]], %[[VAL_24]], %[[VAL_26]]) : (memref<1x!sycl_accessor_1_i32_w_dev2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k2(%ptr: memref<?xi32, 1>,
                %accRange: memref<?x!sycl_range_1_>,
                %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
-    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
+    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev>
     func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
-        : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
+        : (memref<1x!sycl_accessor_1_i32_w_dev>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
     gpu.return
@@ -1442,7 +1442,7 @@ llvm.func internal @known_buffer_range_default_offset(
 // COM: Not enough info
 
 gpu.module @kernels3 {
-  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_gb>,
+  func.func private @init(%acc: memref<1x!sycl_accessor_1_i32_w_dev>,
                           %ptr: memref<?xi32, 1>,
                           %accRange: memref<?x!sycl_range_1_>,
                           %memRange: memref<?x!sycl_range_1_>,
@@ -1450,17 +1450,17 @@ gpu.module @kernels3 {
 
 // CHECK-LABEL:     gpu.func @k3(
 // CHECK-SAME:                   %[[VAL_28:.*]]: memref<?xi32, 1>, %[[VAL_29:.*]]: memref<?x!sycl_range_1_>, %[[VAL_30:.*]]: memref<?x!sycl_range_1_>, %[[VAL_31:.*]]: memref<?x!sycl_id_1_>) kernel {
-// CHECK-NEXT:        %[[VAL_32:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb2>
-// CHECK-NEXT:        func.call @init(%[[VAL_32]], %[[VAL_28]], %[[VAL_29]], %[[VAL_30]], %[[VAL_31]]) : (memref<1x!sycl_accessor_1_i32_w_gb2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        %[[VAL_32:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev2>
+// CHECK-NEXT:        func.call @init(%[[VAL_32]], %[[VAL_28]], %[[VAL_29]], %[[VAL_30]], %[[VAL_31]]) : (memref<1x!sycl_accessor_1_i32_w_dev2>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
   gpu.func @k3(%ptr: memref<?xi32, 1>,
                %accRange: memref<?x!sycl_range_1_>,
                %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
-    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
+    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev>
     func.call @init(%acc, %ptr, %accRange, %memRange, %offset)
-        : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
+        : (memref<1x!sycl_accessor_1_i32_w_dev>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
     gpu.return
@@ -1539,8 +1539,8 @@ llvm.func internal @propagate_array(%ptr: !llvm.ptr, %handler: !llvm.ptr) {
 !sycl_range_1_ = !sycl.range<[1], (memref<1xi64>)>
 !sycl_id_1_ = !sycl.id<[1], (memref<1xi64>)>
 !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
-!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
-!sycl_accessor_host = !sycl.accessor<[1, i32, write, global_buffer], (!llvm.void)>
+!sycl_accessor_1_i32_w_dev = !sycl.accessor<[1, i32, write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_host = !sycl.accessor<[1, i32, write, device], (!llvm.void)>
 
 gpu.module @kernels {
 
@@ -1623,7 +1623,7 @@ gpu.module @kernels {
   }
 
   func.func private @__init(
-      memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
+      memref<1x!sycl_accessor_1_i32_w_dev>, memref<?xi32, 1>,
       memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
       memref<?x!sycl_id_1_>)
 
@@ -1633,8 +1633,8 @@ gpu.module @kernels {
 // CHECK-SAME:                   %[[VAL_30:.*]]: memref<?xi32, 1>, %[[VAL_31:.*]]: memref<?x!sycl_range_1_>, %[[VAL_32:.*]]: memref<?x!sycl_range_1_>, %[[VAL_33:.*]]: memref<?x!sycl_id_1_>) kernel {
 // CHECK-NEXT:        %[[VAL_34:.*]] = sycl.id.constructor() : () -> memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_35:.*]] = memref.cast %[[VAL_34]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
-// CHECK-NEXT:        %[[VAL_36:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb1>
-// CHECK-NEXT:        func.call @__init(%[[VAL_36]], %[[VAL_30]], %[[VAL_32]], %[[VAL_32]], %[[VAL_35]]) : (memref<1x!sycl_accessor_1_i32_w_gb1>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
+// CHECK-NEXT:        %[[VAL_36:.*]] = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev1>
+// CHECK-NEXT:        func.call @__init(%[[VAL_36]], %[[VAL_30]], %[[VAL_32]], %[[VAL_32]], %[[VAL_35]]) : (memref<1x!sycl_accessor_1_i32_w_dev1>, memref<?xi32, 1>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_id_1_>) -> ()
 // CHECK-NEXT:        gpu.return
 // CHECK-NEXT:      }
 
@@ -1642,9 +1642,9 @@ gpu.module @kernels {
                %accRange: memref<?x!sycl_range_1_>,
                %memRange: memref<?x!sycl_range_1_>,
                %offset: memref<?x!sycl_id_1_>) kernel {
-    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_gb>
+    %acc = memref.alloca() : memref<1x!sycl_accessor_1_i32_w_dev>
     func.call @__init(%acc, %ptr, %accRange, %memRange, %offset)
-        : (memref<1x!sycl_accessor_1_i32_w_gb>, memref<?xi32, 1>,
+        : (memref<1x!sycl_accessor_1_i32_w_dev>, memref<?xi32, 1>,
            memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>,
            memref<?x!sycl_id_1_>) -> ()
     gpu.return

--- a/polygeist/test/polygeist-opt/cudalower.mlir
+++ b/polygeist/test/polygeist-opt/cudalower.mlir
@@ -79,13 +79,13 @@ module {
 
 module {
   func.func private @somethingA() -> () 
-  func.func private @somethingB() -> ()
+  func.func private @somethindev() -> ()
   func.func private @S(%arg0: i1) {
     func.call @somethingA() : () -> ()
     scf.if %arg0 {
         nvvm.barrier0
     }
-    func.call @somethingB() : () -> ()
+    func.call @somethindev() : () -> ()
     return 
   }
   func.func @meta(%arg: i1) {
@@ -112,7 +112,7 @@ module {
 // CHECK-NEXT:           scf.if %arg0 {
 // CHECK-NEXT:             "polygeist.barrier"(%arg4, %arg5, %arg6) : (index, index, index) -> ()
 // CHECK-NEXT:           }
-// CHECK-NEXT:           func.call @somethingB() : () -> ()
+// CHECK-NEXT:           func.call @somethindev() : () -> ()
 // CHECK-NEXT:           scf.yield
 // CHECK-NEXT:         }
 // CHECK-NEXT:         }

--- a/polygeist/test/polygeist-opt/licm.mlir
+++ b/polygeist/test/polygeist-opt/licm.mlir
@@ -179,7 +179,7 @@ func.func @scf_parallel_nohoist1(%arg0: memref<?xf32>, %arg1: index, %arg2: inde
 // COM: Test LICM on affine.for loops.
 !sycl_id_1 = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1 = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
-!sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1, !sycl_range_1, !sycl_range_1)>, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_1_f32_rw_dev = !sycl.accessor<[1, f32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1, !sycl_range_1, !sycl_range_1)>, !llvm.struct<(memref<?xf32, 1>)>)>
 
 module {
 
@@ -295,14 +295,14 @@ func.func @affine_for_hoist4(%arg0: memref<?xi32>) {
 
 // COM: Ensure accessor.subscript operation is hoisted and the load + store instructions before the 
 // COM: accessor.subscript operation are also hoisted (because %4 is not aliased with %alloca).
-func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
-  // CHECK:        func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_dev, 4>) {
+  // CHECK:        func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_dev, 4>) {
   // CHECK-DAG:      %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   // CHECK-DAG:      %alloca_0 = memref.alloca() : memref<1x!sycl_id_1_>  
   // CHECK:          affine.if #set1() {
   // CHECK-NEXT:       %0 = affine.load %alloca[0] : memref<1x!sycl_id_1_>
   // CHECK-NEXT:       affine.store %0, %alloca_0[0] : memref<1x!sycl_id_1_>
-  // CHECK-NEXT:       %1 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
+  // CHECK-NEXT:       %1 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
   // CHECK-NEXT:       affine.for %arg1 = 0 to 10 {
   // CHECK-NEXT:         %2 = affine.load %1[0] : memref<?xf32, 4>
   // CHECK-NEXT:         %3 = arith.addf %2, {{.*}} : f32
@@ -310,14 +310,14 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   // CHECK-NEXT:       }
   // CHECK-NEXT:     }    
 
-  // CHECK-RELAXED-ALIASING:         func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+  // CHECK-RELAXED-ALIASING:         func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_dev, 4>) {
   // CHECK-RELAXED-ALIASING-DAG:      %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   // CHECK-RELAXED-ALIASING-DAG:      %alloca_0 = memref.alloca() : memref<1x!sycl_id_1_>  
   // CHECK-RELAXED-ALIASING:          sycl.constructor @id(%memspacecast, %c64_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
   // CHECK-RELAXED-ALIASING-NEXT:     affine.for %arg1 = 0 to 10 {
   // CHECK-RELAXED-ALIASING-NEXT:      %0 = affine.load %alloca[0] : memref<1x!sycl_id_1_>
   // CHECK-RELAXED-ALIASING-NEXT:      affine.store %0, %alloca_0[0] : memref<1x!sycl_id_1_>
-  // CHECK-RELAXED-ALIASING-NEXT:      %1 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
+  // CHECK-RELAXED-ALIASING-NEXT:      %1 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<1x!sycl_id_1_>) -> memref<?xf32, 4>
   // CHECK-RELAXED-ALIASING-NEXT:      %2 = affine.load %1[0] : memref<?xf32, 4>
   // CHECK-RELAXED-ALIASING-NEXT:      %3 = arith.addf %2, %cst : f32
   // CHECK-RELAXED-ALIASING-NEXT:      affine.store %3, %1[0] : memref<?xf32, 4>
@@ -335,7 +335,7 @@ func.func @affine_for_hoist5(%arg0: memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
   affine.for %arg1 = 0 to 10 {    
     %2 = affine.load %alloca[0] : memref<1x!sycl_id_1>
     affine.store %2, %alloca_0[0] : memref<1x!sycl_id_1>
-    %3 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<1x!sycl_id_1>) -> memref<?xf32, 4>
+    %3 = sycl.accessor.subscript %arg0[%alloca_0] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<1x!sycl_id_1>) -> memref<?xf32, 4>
     %4 = affine.load %3[0] : memref<?xf32, 4>
     %5 = arith.addf %4, %cst : f32
     affine.store %5, %3[0] : memref<?xf32, 4>

--- a/polygeist/test/polygeist-opt/memoryAccess.mlir
+++ b/polygeist/test/polygeist-opt/memoryAccess.mlir
@@ -6,9 +6,9 @@
 !sycl_range_1 = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_2 = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
 !sycl_range_3 = !sycl.range<[3], (!sycl.array<[3], (memref<3xi64, 4>)>)>
-!sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1, !sycl_range_1, !sycl_range_1)>, !llvm.struct<(memref<?xf32, 1>)>)>
-!sycl_accessor_2_f32_rw_gb = !sycl.accessor<[2, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>, !llvm.struct<(memref<?xf32, 1>)>)>
-!sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[3], (!sycl_id_3, !sycl_range_3, !sycl_range_3)>, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_1_f32_rw_dev = !sycl.accessor<[1, f32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1, !sycl_range_1, !sycl_range_1)>, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_2_f32_rw_dev = !sycl.accessor<[2, f32, read_write, device], (!sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_3_f32_rw_dev = !sycl.accessor<[3, f32, read_write, device], (!sycl.accessor_impl_device<[3], (!sycl_id_3, !sycl_range_3, !sycl_range_3)>, !llvm.struct<(memref<?xf32, 1>)>)>
 !sycl_nditem_2 = !sycl.nd_item<[2], (!sycl.item<[2, true], (!sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>)>, !sycl.item<[2, false], (!sycl.item_base<[2, false], (!sycl_range_2, !sycl_id_2)>)>, !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>)>
 !sycl_item_base_2 = !sycl.item_base<[2, false], (!sycl_range_2, !sycl_id_2)>
 !sycl_item_2 = !sycl.item<[2, false], (!sycl_item_base_2)>
@@ -20,7 +20,7 @@
 // CHECK-NEXT: 1
 // CHECK-NEXT: offsets:
 // CHECK-NEXT: 0
-func.func @test1(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+func.func @test1(%acc : memref<?x!sycl_accessor_1_f32_rw_dev, 4>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1>
   %alloca_0 = memref.alloca() : memref<1x!sycl_id_1>
   %cast = memref.cast %alloca : memref<1x!sycl_id_1> to memref<?x!sycl_id_1>
@@ -32,7 +32,7 @@ func.func @test1(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     sycl.constructor @id(%id, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
     %val = affine.load %alloca[0] : memref<1x!sycl_id_1>
     affine.store %val, %alloca_0[0] : memref<1x!sycl_id_1>
-    %subscr = sycl.accessor.subscript %acc[%cast_0] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr = sycl.accessor.subscript %acc[%cast_0] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load = affine.load %subscr[0] {tag = "test1_load1"} : memref<?xf32, 4>
   }
   return
@@ -40,7 +40,7 @@ func.func @test1(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
 
 // COM: Test 1-dim accessor memory access.
 //      The underlying values of the accessor subscript operations are affine expression.
-func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_dev, 4>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1>
   %cast = memref.cast %alloca : memref<1x!sycl_id_1> to memref<?x!sycl_id_1>
   %id = memref.memory_space_cast %cast : memref<?x!sycl_id_1> to  memref<?x!sycl_id_1, 4>
@@ -67,7 +67,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     // CHECK-NEXT: 0
     %mul1 = arith.muli %index_cast, %c2_i64 : i64
     sycl.constructor @id1(%id, %mul1) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load1 = affine.load %subscr1[0] {tag = "test1a_load1"} : memref<?xf32, 4>
 
     // (i*3)+1
@@ -79,7 +79,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     %mul2 = arith.muli %index_cast, %c3_i64 : i64
     %add2 = arith.addi %mul2, %c1_i64 : i64
     sycl.constructor @id1(%id, %add2) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr2 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr2 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load2 = affine.load %subscr2[0] {tag = "test1a_load2"} : memref<?xf32, 4>
 
     // (i*4)*1
@@ -91,7 +91,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     %mul3a = arith.muli %index_cast, %c4_i64 : i64
     %mul3b = arith.muli %mul3a, %c1_i64 : i64
     sycl.constructor @id1(%id, %mul3b) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr3 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr3 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load3 = affine.load %subscr3[0] {tag = "test1a_load3"} : memref<?xf32, 4>
 
     // (i+2)
@@ -102,7 +102,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     // CHECK-NEXT: 2
     %add4 = arith.addi %index_cast, %c2_i64 : i64
     sycl.constructor @id2(%id, %add4) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr4 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr4 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load4 = affine.load %subscr4[0] {tag = "test1a_load4"} : memref<?xf32, 4>
 
     // (i+3)*1
@@ -114,7 +114,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     %add5 = arith.addi %index_cast, %c3_i64 : i64
     %mul5 = arith.muli %add5, %c1_i64 : i64
     sycl.constructor @id(%id, %mul5) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr5 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr5 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load5 = affine.load %subscr5[0] {tag = "test1a_load5"} : memref<?xf32, 4>
 
     // (i+4)+1
@@ -126,7 +126,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     %add6a = arith.addi %index_cast, %c4_i64 : i64
     %add6b = arith.addi %add6a, %c1_i64 : i64
     sycl.constructor @id(%id, %add6b) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr6 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr6 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load6 = affine.load %subscr6[0] {tag = "test1a_load6"} : memref<?xf32, 4>
 
     // i*(-1)
@@ -137,7 +137,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     // CHECK-NEXT: 0
     %mul7 = arith.muli %index_cast, %negc1_i64 : i64
     sycl.constructor @id1(%id, %mul7) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr7 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr7 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load7 = affine.load %subscr7[0] {tag = "test1a_load7"} : memref<?xf32, 4>
 
     // (i*2)*3
@@ -149,7 +149,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     %mul8a = arith.muli %index_cast, %c2_i64 : i64
     %mul8b = arith.muli %mul8a, %c3_i64 : i64
     sycl.constructor @id1(%id, %mul8b) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr8 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr8 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load8 = affine.load %subscr8[0] {tag = "test1a_load8"} : memref<?xf32, 4>
 
     // i/2
@@ -157,7 +157,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     // CHECK-NEXT: memoryAccess: <none>
     %div9 = arith.divsi %index_cast, %c2_i64 : i64
     sycl.constructor @id1(%id, %div9) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr9 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr9 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load9 = affine.load %subscr9[0] {tag = "test1a_load9"} : memref<?xf32, 4>
 
     // 2
@@ -167,7 +167,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     // CHECK-NEXT: offsets:
     // CHECK-NEXT: 2
     sycl.constructor @id1(%id, %c2_i64) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr10 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr10 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load10 = affine.load %subscr10[0] {tag = "test1a_load10"} : memref<?xf32, 4>
 
     // (3*2)+i
@@ -179,7 +179,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
     %mul11 = arith.muli  %c3_i64, %c2_i64 : i64
     %add11 = arith.addi %index_cast, %mul11 : i64
     sycl.constructor @id1(%id, %add11) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1, 4>, i64)
-    %subscr11 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+    %subscr11 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
     %load11 = affine.load %subscr11[0] {tag = "test1a_load11"} : memref<?xf32, 4>
   }
   return
@@ -192,7 +192,7 @@ func.func @test1a(%acc : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
 // CHECK-NEXT: 0 1
 // CHECK-NEXT: offsets:
 // CHECK-NEXT: 0 0
-func.func @test2(%acc : memref<?x!sycl_accessor_2_f32_rw_gb, 4>) {
+func.func @test2(%acc : memref<?x!sycl_accessor_2_f32_rw_dev, 4>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %cst = arith.constant 1.000000e+00 : f32
@@ -202,7 +202,7 @@ func.func @test2(%acc : memref<?x!sycl_accessor_2_f32_rw_gb, 4>) {
     affine.for %jj = 0 to 64 {
       %j = arith.index_cast %jj : index to i64
       sycl.constructor @id(%id, %i, %j) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-      %subscr = sycl.accessor.subscript %acc[%id] : (memref<?x!sycl_accessor_2_f32_rw_gb, 4>, memref<?x!sycl_id_2>) -> memref<?xf32, 4>
+      %subscr = sycl.accessor.subscript %acc[%id] : (memref<?x!sycl_accessor_2_f32_rw_dev, 4>, memref<?x!sycl_id_2>) -> memref<?xf32, 4>
       affine.store %cst, %subscr[0] {tag = "test2_store1"} : memref<?xf32, 4>
     }
   }
@@ -217,7 +217,7 @@ func.func @test2(%acc : memref<?x!sycl_accessor_2_f32_rw_gb, 4>) {
 // CHECK-NEXT: 0 0 1
 // CHECK-NEXT: offsets:
 // CHECK-NEXT: 0 0 0
-func.func @test3a(%acc : memref<?x!sycl_accessor_3_f32_rw_gb, 4>, %nditem : memref<?x!sycl_nditem_2>) {
+func.func @test3a(%acc : memref<?x!sycl_accessor_3_f32_rw_dev, 4>, %nditem : memref<?x!sycl_nditem_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_3>
   %cast = memref.cast %alloca : memref<1x!sycl_id_3> to memref<?x!sycl_id_3>
   %id = memref.memory_space_cast %cast : memref<?x!sycl_id_3> to  memref<?x!sycl_id_3, 4>
@@ -232,7 +232,7 @@ func.func @test3a(%acc : memref<?x!sycl_accessor_3_f32_rw_gb, 4>, %nditem : memr
 
     // [tx,ty,i] 
     sycl.constructor @id(%id, %tx, %ty, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3, 4>, i64, i64, i64)
-    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_3_f32_rw_gb, 4>, memref<?x!sycl_id_3>) -> memref<?xf32, 4>
+    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_3_f32_rw_dev, 4>, memref<?x!sycl_id_3>) -> memref<?xf32, 4>
     %load1 = affine.load %subscr1[0] {tag = "test3a_load1"} : memref<?xf32, 4>
   }
   return
@@ -246,7 +246,7 @@ func.func @test3a(%acc : memref<?x!sycl_accessor_3_f32_rw_gb, 4>, %nditem : memr
 // CHECK-NEXT: 0 1 2
 // CHECK-NEXT: offsets:
 // CHECK-NEXT: 1 0 2
-func.func @test3b(%acc : memref<?x!sycl_accessor_3_f32_rw_gb, 4>, %item : memref<?x!sycl_item_2>) {
+func.func @test3b(%acc : memref<?x!sycl_accessor_3_f32_rw_dev, 4>, %item : memref<?x!sycl_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_3>
   %cast = memref.cast %alloca : memref<1x!sycl_id_3> to memref<?x!sycl_id_3>
   %id = memref.memory_space_cast %cast : memref<?x!sycl_id_3> to  memref<?x!sycl_id_3, 4>
@@ -267,7 +267,7 @@ func.func @test3b(%acc : memref<?x!sycl_accessor_3_f32_rw_gb, 4>, %item : memref
     %add1a = arith.addi %mul1, %c2_i64 : i64
     %add1b = arith.addi %add1a, %ty : i64
     sycl.constructor @id(%id, %add1, %mul1, %add1b) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3, 4>, i64, i64, i64)
-    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_3_f32_rw_gb, 4>, memref<?x!sycl_id_3>) -> memref<?xf32, 4>
+    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_3_f32_rw_dev, 4>, memref<?x!sycl_id_3>) -> memref<?xf32, 4>
     %load1 = affine.load %subscr1[0] {tag = "test3b_load1"} : memref<?xf32, 4>
   }
   return
@@ -281,7 +281,7 @@ func.func @test3b(%acc : memref<?x!sycl_accessor_3_f32_rw_gb, 4>, %item : memref
 // CHECK-NEXT: 0 0 1
 // CHECK-NEXT: offsets:
 // CHECK-NEXT: 0 0 
-func.func @test4(%acc : memref<?x!sycl_accessor_2_f32_rw_gb, 4>, %item : memref<?x!sycl_item_2>) {
+func.func @test4(%acc : memref<?x!sycl_accessor_2_f32_rw_dev, 4>, %item : memref<?x!sycl_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %cast = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %id = memref.memory_space_cast %cast : memref<?x!sycl_id_2> to  memref<?x!sycl_id_2, 4>
@@ -294,7 +294,7 @@ func.func @test4(%acc : memref<?x!sycl_accessor_2_f32_rw_gb, 4>, %item : memref<
 
     // [ty, i]
     sycl.constructor @id(%id, %ty, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2, 4>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_2_f32_rw_gb, 4>, memref<?x!sycl_id_2>) -> memref<?xf32, 4>
+    %subscr1 = sycl.accessor.subscript %acc[%cast] : (memref<?x!sycl_accessor_2_f32_rw_dev, 4>, memref<?x!sycl_id_2>) -> memref<?xf32, 4>
     %load1 = affine.load %subscr1[0] {tag = "test4_load1"} : memref<?xf32, 4>
   }
   return

--- a/polygeist/test/polygeist-opt/reachingDefinitions.mlir
+++ b/polygeist/test/polygeist-opt/reachingDefinitions.mlir
@@ -3,7 +3,7 @@
 !sycl_id_1 = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1 = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_2 = !sycl.range<[2], (!sycl.array<[2], (memref<2xi64, 4>)>)>
-!sycl_accessor_1_f32_rw_gb = !sycl.accessor<[1, f32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1, !sycl_range_1, !sycl_range_1)>, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_1_f32_rw_dev = !sycl.accessor<[1, f32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1, !sycl_range_1, !sycl_range_1)>, !llvm.struct<(memref<?xf32, 1>)>)>
 
 // COM: Test that the correct definition reaches a load.
 // CHECK-LABEL: test_tag: test1_load1
@@ -267,11 +267,11 @@ func.func @test14(%val: i64) {
 // CHECK: operand #1
 // CHECK-NEXT: - mods: test15_store1
 // CHECK-NEXT: - pMods: <none>
-func.func @test15(%val: !sycl_id_1, %arg0 : memref<?x!sycl_accessor_1_f32_rw_gb, 4>) {
+func.func @test15(%val: !sycl_id_1, %arg0 : memref<?x!sycl_accessor_1_f32_rw_dev, 4>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1>
   %cast = memref.cast %alloca : memref<1x!sycl_id_1> to memref<?x!sycl_id_1>  
   affine.store %val, %alloca[0] {tag_name = "test15_store1"}: memref<1x!sycl_id_1>
-  %1 = sycl.accessor.subscript %arg0[%cast] {tag = "test15_sub1", ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>], FunctionName = @"operator[]", MangledFunctionName = @subscript, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
+  %1 = sycl.accessor.subscript %arg0[%cast] {tag = "test15_sub1", ArgumentTypes = [memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>], FunctionName = @"operator[]", MangledFunctionName = @subscript, TypeName = @accessor} : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1>) -> memref<?xf32, 4>
   return
 }
 

--- a/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/detect-reduction-accessor-versioning.mlir
@@ -17,19 +17,19 @@
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
-!sycl_accessor_1_i32_r_gb = !sycl.accessor<[1, i32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_r_dev = !sycl.accessor<[1, i32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 
 
 // CHECK-LABEL: func.func private @test(
-// CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_gb, 4>) {
+// CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_rw_dev, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_dev, 4>) {
 
 // COM: Obtain a pointer to the beginning of the accessor %arg0.
 // CHECK:         %[[VAL_19:.*]] = sycl.id.constructor(%c0{{.*}}) : (index) -> memref<1x!sycl_id_1_>
-// CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%2] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.subscript %arg0[%2] : (memref<?x!sycl_accessor_1_i32_rw_dev, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
 
 // COM: Obtain a pointer to the end of the accessor %arg0.
-// CHECK-NEXT:    %[[VAL_21:.*]] = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>) -> !sycl_range_1_
+// CHECK-NEXT:    %[[VAL_21:.*]] = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_i32_rw_dev, 4>) -> !sycl_range_1_
 // CHECK-NEXT:    %[[VAL_22:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
 // CHECK-NEXT:    %[[VAL_23:.*]] = arith.constant 0 : index
 // CHECK-NEXT:    memref.store %[[VAL_21]], %[[VAL_22]]{{\[}}%[[VAL_23]]] : memref<1x!sycl_range_1_>
@@ -37,7 +37,7 @@
 // CHECK-NEXT:    %[[VAL_25:.*]] = arith.constant 0 : i32
 // CHECK-NEXT:    %[[VAL_26:.*]] = sycl.range.get %[[VAL_22]]{{\[}}%[[VAL_25]]] : (memref<1x!sycl_range_1_>, i32) -> index
 // CHECK-NEXT:    %[[VAL_27:.*]] = sycl.id.constructor(%[[VAL_26]]) : (index) -> memref<1x!sycl_id_1_>
-// CHECK-NEXT:    [[ARG0_END:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_27]]] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
+// CHECK-NEXT:    [[ARG0_END:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_27]]] : (memref<?x!sycl_accessor_1_i32_rw_dev, 4>, memref<1x!sycl_id_1_>) -> memref<?xi32, 1>
 
 // CHECK:         [[ARG1_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%{{.*}}]
 // CHECK:         [[ARG1_END:%.*]] = sycl.accessor.subscript %arg1[%{{.*}}]
@@ -67,7 +67,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 
-func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_gb, 4>) {
+func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_dev, 4>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
@@ -85,13 +85,13 @@ func.func private @test(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: m
   sycl.constructor @id(%memspacecast_6, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
   %0 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
   affine.store %0, %alloca[0] : memref<1x!sycl_id_1_>
-  %1 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+  %1 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
   scf.for %i = %c0 to %c8 step %c1 {
     %2 = arith.index_cast %i : index to i64
     sycl.constructor @id(%memspacecast, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %5 = affine.load %4[0] : memref<?xi32, 4>
     %6 = affine.load %1[0] : memref<?xi32, 4>
     %7 = arith.addi %6, %5 : i32

--- a/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
@@ -4,37 +4,37 @@
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_f32_w_gb = !sycl.accessor<[1, f32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
-!sycl_accessor_1_f32_r_gb = !sycl.accessor<[1, f32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
-!sycl_accessor_1_i32_r_gb = !sycl.accessor<[1, i32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_f32_w_dev = !sycl.accessor<[1, f32, write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+!sycl_accessor_1_f32_r_dev = !sycl.accessor<[1, f32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_1_i32_r_dev = !sycl.accessor<[1, i32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 
 !sycl_array_2_ = !sycl.array<[2], (memref<1xi64, 4>)>
 !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 !sycl_id_2_ = !sycl.id<[2], (!sycl_array_2_)>
 !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-!sycl_accessor_2_f32_w_gb = !sycl.accessor<[2, f32, write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xf32, 1>)>)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_2_f32_w_dev = !sycl.accessor<[2, f32, write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xf32, 1>)>)>
 
-!sycl_accessor_0_f32_w_gb = !sycl.accessor<[0, f32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
-!sycl_accessor_0_f32_r_gb = !sycl.accessor<[0, f32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_0_f32_w_dev = !sycl.accessor<[0, f32, write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_0_f32_r_dev = !sycl.accessor<[0, f32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
 
 gpu.module @device_func {
   // COM: This function is a candidate, check that it is transformed correctly.
   // CHECK-LABEL: func.func private @callee1.specialized(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_gb> {sycl.inner.disjoint},
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_gb> {sycl.inner.disjoint})
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev> {sycl.inner.disjoint},
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint})
   // CHECK-LABEL: func.func private @callee1(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_gb>,
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_gb>)
-  // CHECK-LABEL: gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) kernel {
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev>,
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>)
+  // CHECK-LABEL: gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
 
   // COM: Obtain a pointer to the beginning of the first accessor.
   // CHECK-NEXT:    %[[VAL_6:.*]] = arith.constant 0 : index
   // CHECK-NEXT:    %[[VAL_7:.*]] = sycl.id.constructor(%[[VAL_6]]) : (index) -> memref<1x!sycl_id_1_>
-  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_7]]] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_7]]] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Obtain a pointer to the end of the first accessor.
-  // CHECK-NEXT:    %[[VAL_9:.*]] = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_f32_r_gb>) -> !sycl_range_1_
+  // CHECK-NEXT:    %[[VAL_9:.*]] = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_1_f32_r_dev>) -> !sycl_range_1_
   // CHECK-NEXT:    %[[VAL_10:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
   // CHECK-NEXT:    %[[VAL_11:.*]] = arith.constant 0 : index
   // CHECK-NEXT:    memref.store %[[VAL_9]], %[[VAL_10]]{{\[}}%[[VAL_11]]] : memref<1x!sycl_range_1_>
@@ -42,11 +42,11 @@ gpu.module @device_func {
   // CHECK-NEXT:    %[[VAL_13:.*]] = arith.constant 0 : i32
   // CHECK-NEXT:    %[[VAL_14:.*]] = sycl.range.get %[[VAL_10]]{{\[}}%[[VAL_13]]] : (memref<1x!sycl_range_1_>, i32) -> index
   // CHECK-NEXT:    %[[VAL_15:.*]] = sycl.id.constructor(%[[VAL_14]]) : (index) -> memref<1x!sycl_id_1_>
-  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_15]]] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_15]]] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
-  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}]  : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
-  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_f32_w_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[{{.*}}]  : (memref<?x!sycl_accessor_1_f32_w_dev>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_f32_w_dev>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
   // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
   // CHECK-NEXT:    %14 = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<1>
@@ -55,53 +55,53 @@ gpu.module @device_func {
   // CHECK-NEXT:    %17 = llvm.icmp "uge" [[ACC1_BEGIN_PTR]], [[ACC2_END_PTR]] : !llvm.ptr<1>
   // CHECK-NEXT:    %18 = arith.ori %14, %17 : i1
   // CHECK-NEXT:    scf.if %18 {
-  // CHECK-NEXT:      func.call @callee1.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee1.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    } else {
-  // CHECK-NEXT:      func.call @callee1(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee1(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  func.func private @callee1(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) {
+  func.func private @callee1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
     return
   }
-  gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) kernel {
-    func.call @callee1(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
+    func.call @callee1(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
     gpu.return
   }
 
   // COM: No need to version as the accessor types are different.
   // CHECK-LABEL: func.func private @callee2.specialized(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_r_gb> {sycl.inner.disjoint}, 
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_gb> {sycl.inner.disjoint}) attributes {llvm.linkage = #llvm.linkage<private>} {
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_r_dev> {sycl.inner.disjoint}, 
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint}) attributes {llvm.linkage = #llvm.linkage<private>} {
   // CHECK-LABEL: func.func private @callee2(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_r_gb>, 
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) {
-  // CHECK-LABEL: gpu.func @caller2(%arg0: memref<?x!sycl_accessor_1_i32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) kernel {
-  // CHECK-NEXT:    func.call @callee2.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_1_i32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_r_dev>, 
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
+  // CHECK-LABEL: gpu.func @caller2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
+  // CHECK-NEXT:    func.call @callee2.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_1_i32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    gpu.return
   // CHECK-NEXT:  }
-  func.func private @callee2(%arg0: memref<?x!sycl_accessor_1_i32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) {
+  func.func private @callee2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
     return
   }
-  gpu.func @caller2(%arg0: memref<?x!sycl_accessor_1_i32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) kernel {
-    func.call @callee2(%arg0, %arg1) : (memref<?x!sycl_accessor_1_i32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  gpu.func @caller2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
+    func.call @callee2(%arg0, %arg1) : (memref<?x!sycl_accessor_1_i32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
     gpu.return
   }
 
   /// COM: Check 2D accessors.
   // CHECK-LABEL: func.func private @callee3.specialized(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_2_f32_r_gb> {sycl.inner.disjoint}, 
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_2_f32_w_gb> {sycl.inner.disjoint})
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_2_f32_r_dev> {sycl.inner.disjoint}, 
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_2_f32_w_dev> {sycl.inner.disjoint})
   // CHECK-LABEL: func.func private @callee3(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_2_f32_r_gb>, 
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_2_f32_w_gb>)
-  // CHECK-LABEL: gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_accessor_2_f32_w_gb>) kernel {
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_2_f32_r_dev>, 
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_2_f32_w_dev>)
+  // CHECK-LABEL: gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) kernel {
 
   // COM: Obtain a pointer to the beginning of the first accessor.
   // CHECK-NEXT:    %[[VAL_47:.*]] = arith.constant 0 : index
   // CHECK-NEXT:    %[[VAL_48:.*]] = sycl.id.constructor(%[[VAL_47]], %[[VAL_47]]) : (index, index) -> memref<1x!sycl_id_2_>
-  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_48]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_BEGIN:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_48]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 
   // COM: Obtain a pointer to the end of the first accessor.
-  // CHECK-NEXT:    %[[VAL_50:.*]] = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_f32_r_gb>) -> !sycl_range_2_
+  // CHECK-NEXT:    %[[VAL_50:.*]] = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_f32_r_dev>) -> !sycl_range_2_
   // CHECK-NEXT:    %[[VAL_51:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
   // CHECK-NEXT:    %[[VAL_52:.*]] = arith.constant 0 : index
   // CHECK-NEXT:    memref.store %[[VAL_50]], %[[VAL_51]]{{\[}}%[[VAL_52]]] : memref<1x!sycl_range_2_>
@@ -112,11 +112,11 @@ gpu.module @device_func {
   // CHECK-NEXT:    %[[VAL_57:.*]] = arith.constant 1 : i32
   // CHECK-NEXT:    %[[VAL_58:.*]] = sycl.range.get %[[VAL_51]]{{\[}}%[[VAL_57]]] : (memref<1x!sycl_range_2_>, i32) -> index
   // CHECK-NEXT:    %[[VAL_59:.*]] = sycl.id.constructor(%[[VAL_56]], %[[VAL_58]]) : (index, index) -> memref<1x!sycl_id_2_>
-  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_59]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ACC1_END:%.*]] = sycl.accessor.subscript %arg0{{\[}}%[[VAL_59]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 
   // COM: Version with condition: [[ACC1_END]] <= [[ACC2_BEGIN]] || [[ACC1_BEGIN]] >= [[ACC2_END]].
-  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%{{.*}}] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
-  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%{{.*}}] : (memref<?x!sycl_accessor_2_f32_w_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_BEGIN:%.*]] = sycl.accessor.subscript %arg1[%{{.*}}] : (memref<?x!sycl_accessor_2_f32_w_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+  // CHECK:         [[ACC2_END:%.*]] = sycl.accessor.subscript %arg1[%{{.*}}] : (memref<?x!sycl_accessor_2_f32_w_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ACC1_END_PTR:%.*]] = "polygeist.memref2pointer"([[ACC1_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
   // CHECK-DAG:     [[ACC2_BEGIN_PTR:%.*]]  = "polygeist.memref2pointer"([[ACC2_BEGIN]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
   // CHECK-NEXT:    %[[VAL_77:.*]] = llvm.icmp "ule" [[ACC1_END_PTR]], [[ACC2_BEGIN_PTR]] : !llvm.ptr<1>
@@ -125,63 +125,63 @@ gpu.module @device_func {
   // CHECK-NEXT:    %[[VAL_80:.*]] = llvm.icmp "uge" [[ACC1_BEGIN_PTR]], [[ACC2_END_PTR]] : !llvm.ptr<1>
   // CHECK-NEXT:    %[[VAL_81:.*]] = arith.ori %[[VAL_77]], %[[VAL_80]] : i1
   // CHECK-NEXT:    scf.if %[[VAL_81]] {
-  // CHECK-NEXT:      func.call @callee3.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_accessor_2_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee3.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_accessor_2_f32_w_dev>) -> ()
   // CHECK-NEXT:    } else {
-  // CHECK-NEXT:      func.call @callee3(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_accessor_2_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee3(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_accessor_2_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  func.func private @callee3(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_accessor_2_f32_w_gb>) {
+  func.func private @callee3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) {
     return
   }
-  gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_accessor_2_f32_w_gb>) kernel {
-    func.call @callee3(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_accessor_2_f32_w_gb>) -> ()
+  gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) kernel {
+    func.call @callee3(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_accessor_2_f32_w_dev>) -> ()
     gpu.return
   }
 
   // COM: Check callee (@callee4) called indirectly from GPU kernel (@wrapper4).
   // CHECK-LABEL: func.func private @callee4.specialized(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_gb> {sycl.inner.disjoint},
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_gb> {sycl.inner.disjoint})
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev> {sycl.inner.disjoint},
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint})
   // CHECK-LABEL: func.func private @callee4(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_gb>,
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_gb>)
-  // CHECK-LABEL: func.func @caller4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>) {
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev>,
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>)
+  // CHECK-LABEL: func.func @caller4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) {
   // CHECK:         scf.if %{{.*}} {
-  // CHECK-NEXT:      func.call @callee4.specialized(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee4.specialized(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    } else {
-  // CHECK-NEXT:      func.call @callee4(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee4(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  // CHECK-LABEL: gpu.func @wrapper4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>) kernel {
+  // CHECK-LABEL: gpu.func @wrapper4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) kernel {
   // CHECK-NEXT:    sycl.call @caller4(%arg0)
-  func.func private @callee4(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_accessor_1_f32_w_gb>) {
+  func.func private @callee4(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
     return
   }
-  func.func @caller4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>) {
+  func.func @caller4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
-    %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>, index) -> memref<?x!sycl_accessor_1_f32_r_gb>
-    %1 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>, index) -> memref<?x!sycl_accessor_1_f32_w_gb>
-    func.call @callee4(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_accessor_1_f32_w_gb>) -> ()
+    %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>, index) -> memref<?x!sycl_accessor_1_f32_r_dev>
+    %1 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>, index) -> memref<?x!sycl_accessor_1_f32_w_dev>
+    func.call @callee4(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
     return
   }
-  gpu.func @wrapper4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>) kernel {
-    sycl.call @caller4(%arg0) {MangledFunctionName = @caller4, TypeName = @RoundedRangeKernel}: (memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_gb, !sycl_accessor_1_f32_w_gb)>>) -> ()
+  gpu.func @wrapper4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) kernel {
+    sycl.call @caller4(%arg0) {MangledFunctionName = @caller4, TypeName = @RoundedRangeKernel}: (memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) -> ()
     gpu.return
   }
 
   // COM: Check accessors with dimension 0.
   // CHECK-LABEL: func.func private @callee5.specialized(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_gb> {sycl.inner.disjoint},
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_gb> {sycl.inner.disjoint})
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_dev> {sycl.inner.disjoint},
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_dev> {sycl.inner.disjoint})
   // CHECK-LABEL: func.func private @callee5(
-  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_gb>,
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_gb>)
-  // CHECK-LABEL: gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_gb>, %arg1: memref<?x!sycl_accessor_0_f32_w_gb>) kernel {
-  // CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_gb>) -> memref<?xf32, 1>
-  // CHECK-NEXT:    %1 = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_gb>) -> memref<?xf32, 1>
+  // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_dev>,
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_dev>)
+  // CHECK-LABEL: gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) kernel {
+  // CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_dev>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    %1 = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_dev>) -> memref<?xf32, 1>
   // CHECK-NEXT:    %c1 = arith.constant 1 : index
   // CHECK-NEXT:    [[ARG0_END:%.*]] = "polygeist.subindex"(%1, %c1) : (memref<?xf32, 1>, index) -> memref<?xf32, 1>
-  // CHECK-NEXT:    [[ARG1_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
-  // CHECK-NEXT:    %4 = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_gb>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    [[ARG1_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_dev>) -> memref<?xf32, 1>
+  // CHECK-NEXT:    %4 = sycl.accessor.get_pointer(%arg1) : (memref<?x!sycl_accessor_0_f32_w_dev>) -> memref<?xf32, 1>
   // CHECK-NEXT:    %c1_0 = arith.constant 1 : index
   // CHECK-NEXT:    [[ARG1_END:%.*]] = "polygeist.subindex"(%4, %c1_0) : (memref<?xf32, 1>, index) -> memref<?xf32, 1>
   // CHECK-DAG:     [[ARG0_END_PTR:%.*]] = "polygeist.memref2pointer"([[ARG0_END]]) : (memref<?xf32, 1>) -> !llvm.ptr<1>
@@ -192,15 +192,15 @@ gpu.module @device_func {
   // CHECK-NEXT:    %11 = llvm.icmp "uge" [[ARG0_BEGIN_PTR]], [[ARG1_END_PTR]] : !llvm.ptr<1>
   // CHECK-NEXT:    %12 = arith.ori %8, %11 : i1
   // CHECK-NEXT:    scf.if %12 {
-  // CHECK-NEXT:      func.call @callee5.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_gb>, memref<?x!sycl_accessor_0_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee5.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_dev>, memref<?x!sycl_accessor_0_f32_w_dev>) -> ()
   // CHECK-NEXT:    } else {
-  // CHECK-NEXT:      func.call @callee5(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_gb>, memref<?x!sycl_accessor_0_f32_w_gb>) -> ()
+  // CHECK-NEXT:      func.call @callee5(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_dev>, memref<?x!sycl_accessor_0_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  func.func private @callee5(%arg0: memref<?x!sycl_accessor_0_f32_r_gb>, %arg1: memref<?x!sycl_accessor_0_f32_w_gb>) {
+  func.func private @callee5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) {
     return
   }
-  gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_gb>, %arg1: memref<?x!sycl_accessor_0_f32_w_gb>) kernel {
-    func.call @callee5(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_gb>, memref<?x!sycl_accessor_0_f32_w_gb>) -> ()
+  gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) kernel {
+    func.call @callee5(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_dev>, memref<?x!sycl_accessor_0_f32_w_dev>) -> ()
     gpu.return
   }
 }

--- a/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
+++ b/polygeist/test/polygeist-opt/sycl/licm-accessor-versioning.mlir
@@ -19,17 +19,17 @@
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
-!sycl_accessor_1_i32_r_gb = !sycl.accessor<[1, i32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_r_dev = !sycl.accessor<[1, i32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 
 // CHECK-LABEL: testSCFLoopVersioning
-// CHECK-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_RW:!sycl_accessor_1_i32_rw_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_R:!sycl_accessor_1_i32_r_gb]], 4>) 
+// CHECK-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_RW:!sycl_accessor_1_i32_rw_dev]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_R:!sycl_accessor_1_i32_r_dev]], 4>) 
 
 // CHECK-DAG:  [[C0:%.*]] = arith.constant 0 : index
 // CHECK-DAG:  [[C8:%.*]] = arith.constant 8 : index
 // CHECK:      [[GUARD_COND:%.*]] = arith.cmpi slt, [[C0]], [[C8]] : index
 // CHECK-NEXT: scf.if [[GUARD_COND]] {
-// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Obtain a pointer to the beginning of the accessor %arg1.
 // CHECK-DAG:  [[C0_index:%.*]] = arith.constant 0 : index
@@ -66,7 +66,7 @@
 // CHECK: } else {
 // CHECK-NEXT: scf.for
 
-func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_gb, 4>) {
+func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_dev, 4>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
@@ -86,12 +86,12 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw
     sycl.constructor @id(%memspacecast, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %5 = affine.load %4[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_6, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %6 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
     affine.store %6, %alloca[0] : memref<1x!sycl_id_1_>
-    %7 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %7 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %8 = affine.load %7[0] : memref<?xi32, 4>
     %9 = arith.addi %8, %5 : i32
     affine.store %9, %7[0] : memref<?xi32, 4>
@@ -104,16 +104,16 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
-!sycl_accessor_1_i32_r_gb = !sycl.accessor<[1, i32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_r_dev = !sycl.accessor<[1, i32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 
 // CHECK: [[GUARD_COND:#.*]] = affine_set<() : (7 >= 0)>
 
 // CHECK-LABEL: testAffineLoopVersioning
-// CHECK-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_RW:!sycl_accessor_1_i32_rw_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_R:!sycl_accessor_1_i32_r_gb]], 4>)
+// CHECK-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_RW:!sycl_accessor_1_i32_rw_dev]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_R:!sycl_accessor_1_i32_r_dev]], 4>)
 
 // CHECK: affine.if [[GUARD_COND]]() {
-// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK: [[ARG1_ACC:%.*]] = sycl.accessor.subscript %arg1[{{.*}}] : (memref<?x!sycl_accessor_1_i32_r_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Version with condition: [[ARG1_END]] <= [[ARG0_BEGIN]] || [[ARG1_BEGIN]] >= [[ARG0_END]].
 // CHECK:      [[BEFORE_COND:%.*]] = llvm.icmp "ule" {{.*}}, {{.*}} : !llvm.ptr<1>
@@ -127,7 +127,7 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw
 // CHECK: } else {
 // CHECK-NEXT: affine.for
 
-func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw_gb, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_gb, 4>) {
+func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_rw_dev, 4>, %arg1: memref<?x!sycl_accessor_1_i32_r_dev, 4>) {
   %c0_i64 = arith.constant 0 : i64
   %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   %cast = memref.cast %alloca : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
@@ -144,12 +144,12 @@ func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32
     sycl.constructor @id(%memspacecast, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_r_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %5 = affine.load %4[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_6, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %6 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
     affine.store %6, %alloca[0] : memref<1x!sycl_id_1_>
-    %7 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %7 = sycl.accessor.subscript %arg0[%cast] : (memref<?x!sycl_accessor_1_i32_rw_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     %8 = affine.load %7[0] : memref<?xi32, 4>
     %9 = arith.addi %8, %5 : i32
     affine.store %9, %7[0] : memref<?xi32, 4>
@@ -187,23 +187,23 @@ func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+!sycl_accessor_1_i32_w_dev = !sycl.accessor<[1, i32, write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 
 // COM: There is only one loop, i.e., the loop is not versioned.
 // 1PAIR-LABEL: testSCFLoopVersioning
-// 1PAIR-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
+// 1PAIR-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_dev]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
 // 1PAIR: [[C1_i32:%.*]] = arith.constant 1 : i32
-// 1PAIR: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// 1PAIR: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 // 1PAIR: scf.for
 // 1PAIR: affine.store [[C1_i32]], [[ARG0_ACC]][0] : memref<?xi32, 4>
 // 1PAIR-NOT: } else {
 // 1PAIR-NOT: scf.for
 
 // 2PAIRS-LABEL: testSCFLoopVersioning
-// 2PAIRS-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_gb]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
+// 2PAIRS-SAME:  ([[ARG0:%.*]]: memref<?x[[ACC_W:!sycl_accessor_1_i32_w_dev]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>, [[ARG1:%.*]]: memref<?x[[ACC_W]], 4>) 
 
 // 2PAIRS: [[C1_i32:%.*]] = arith.constant 1 : i32
-// 2PAIRS: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// 2PAIRS: [[ARG0_ACC:%.*]] = sycl.accessor.subscript %arg0[{{.*}}] : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 // COM: Version with condition: ([[ARG0_END]] <= [[ARG1_BEGIN]] || [[ARG0_BEGIN]] >= [[ARG1_END]])
 // COM:                          && ([[ARG0_END]] <= [[ARG2_BEGIN]] || [[ARG0_BEGIN]] >= [[ARG2_END]]).
@@ -222,7 +222,7 @@ func.func private @testAffineLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32
 // 2PAIRS: } else {
 // 2PAIRS-NEXT: scf.for
 
-func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_w_gb, 4>, %arg1: memref<?x!sycl_accessor_1_i32_w_gb, 4>, %arg2: memref<?x!sycl_accessor_1_i32_w_gb, 4>) {
+func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_w_dev, 4>, %arg1: memref<?x!sycl_accessor_1_i32_w_dev, 4>, %arg2: memref<?x!sycl_accessor_1_i32_w_dev, 4>) {
   %c0 = arith.constant 0 : index
   %c1 = arith.constant 1 : index
   %c8 = arith.constant 8 : index
@@ -250,17 +250,17 @@ func.func private @testSCFLoopVersioning(%arg0: memref<?x!sycl_accessor_1_i32_w_
     sycl.constructor @id(%memspacecast, %c0_i64) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %3 = affine.load %alloca_8[0] : memref<1x!sycl_id_1_>
     affine.store %3, %alloca_6[0] : memref<1x!sycl_id_1_>
-    %4 = sycl.accessor.subscript %arg0[%cast_7] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %4 = sycl.accessor.subscript %arg0[%cast_7] : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     affine.store %c1_i32, %4[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_10, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %5 = affine.load %alloca_4[0] : memref<1x!sycl_id_1_>
     affine.store %5, %alloca_2[0] : memref<1x!sycl_id_1_>
-    %6 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %6 = sycl.accessor.subscript %arg1[%cast_3] : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     affine.store %c2_i32, %6[0] : memref<?xi32, 4>
     sycl.constructor @id(%memspacecast_11, %2) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ILi1EEENSt9enable_ifIXeqT_Li1EEmE4typeE} : (memref<?x!sycl_id_1_, 4>, i64)
     %7 = affine.load %alloca_0[0] : memref<1x!sycl_id_1_>
     affine.store %7, %alloca[0] : memref<1x!sycl_id_1_>
-    %8 = sycl.accessor.subscript %arg2[%cast] : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+    %8 = sycl.accessor.subscript %arg2[%cast] : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
     affine.store %c3_i32, %8[0] : memref<?xi32, 4>
   }
   return

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -6,7 +6,7 @@
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
@@ -15,7 +15,7 @@
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<64xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine_2d(
-// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_item_2_>) {
+// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_item_2_>) {
 
 // COM: Get local ids:
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.local_id : !sycl_id_2_1
@@ -58,7 +58,7 @@
 // COM: Copy to shared local memory for 1st memref:
 // CHECK-NEXT:      %[[VAL_27:.*]] = sycl.id.constructor(%[[VAL_16]], %[[VAL_25]]) : (index, index) -> memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[VAL_28:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_29:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_27]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+// CHECK-NEXT:      %[[VAL_29:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_27]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 // CHECK-NEXT:      %[[VAL_30:.*]] = memref.load %[[VAL_29]]{{\[}}%[[VAL_28]]] : memref<?xf32, 1>
 // CHECK-NEXT:      memref.store %[[VAL_30]], %[[VAL_21]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<2x4xf32, #sycl.access.address_space<local>>
 
@@ -69,7 +69,7 @@
 // COM: Copy to shared local memory for 2nd memref:
 // CHECK-NEXT:      %[[VAL_31:.*]] = sycl.id.constructor(%[[VAL_16]], %[[VAL_23]]) : (index, index) -> memref<1x!sycl_id_2_>
 // CHECK-NEXT:      %[[VAL_32:.*]] = arith.constant 0 : index
-// CHECK-NEXT:      %[[VAL_33:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_31]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+// CHECK-NEXT:      %[[VAL_33:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_31]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 // CHECK-NEXT:      %[[VAL_34:.*]] = memref.load %[[VAL_33]]{{\[}}%[[VAL_32]]] : memref<?xf32, 1>
 // CHECK-NEXT:      memref.store %[[VAL_34]], %[[VAL_37]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<2x4xf32, #sycl.access.address_space<local>>
 
@@ -89,7 +89,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -99,15 +99,15 @@ func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: 
   affine.for %ii = 0 to 256 {
     %i = arith.index_cast %ii : index to i64
     sycl.constructor @id(%id, %tx, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
-    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load2 = affine.load %subscr2[0] : memref<?xf32>
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
-  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_item_2>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
+  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_item_2>) -> ()
   gpu.return
 }
 }
@@ -119,7 +119,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 !sycl_accessor_impl_device_3 = !sycl.accessor_impl_device<[3], (!sycl_id_3, !sycl_range_3, !sycl_range_3)>
 !sycl_group_3 = !sycl.group<[3], (!sycl_range_3, !sycl_range_3, !sycl_range_3, !sycl_id_3)>
 !sycl_item_base_3 = !sycl.item_base<[3, true], (!sycl_range_3, !sycl_id_3, !sycl_id_3)>
-!sycl_accessor_3_f32_r_gb = !sycl.accessor<[3, f32, read, global_buffer], (!sycl_accessor_impl_device_3, !llvm.struct<(memref<?xf32, 3>)>)>
+!sycl_accessor_3_f32_r_dev = !sycl.accessor<[3, f32, read, device], (!sycl_accessor_impl_device_3, !llvm.struct<(memref<?xf32, 3>)>)>
 !sycl_item_3 = !sycl.item<[3, true], (!sycl_item_base_3)>
 !sycl_nd_item_3 = !sycl.nd_item<[3], (!sycl_item_3, !sycl_item_3, !sycl_group_3)>
 
@@ -128,7 +128,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + s0 + 1, 512)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL:  func.func private @affine_3d(
-// CHECK-SAME:       %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
+// CHECK-SAME:       %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
 
 // COM: Get work group sizes:
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_3_1
@@ -203,7 +203,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // COM: Copy to shared local memory for 1st memref:
 // CHECK-NEXT:        %[[VAL_52:.*]] = sycl.id.constructor(%[[VAL_40]], %[[VAL_43]], %[[VAL_50]]) : (index, index, index) -> memref<1x!sycl_id_3_>
 // CHECK-NEXT:        %[[VAL_53:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_54:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_52]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
+// CHECK-NEXT:        %[[VAL_54:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_52]]] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
 // CHECK-NEXT:        %[[VAL_55:.*]] = memref.load %[[VAL_54]]{{\[}}%[[VAL_53]]] : memref<?xf32, 1>
 // CHECK-NEXT:        memref.store %[[VAL_55]], %[[VAL_47]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[LOCALID2]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
 
@@ -215,7 +215,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:          sycl.constructor @id(%[[VAL_35]], %[[VAL_39]], %[[VAL_48]], %[[VAL_65]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
 // CHECK-NEXT:          %[[VAL_67:.*]] = memref.load %[[VAL_47]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[VAL_64]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:          sycl.constructor @id(%[[VAL_35]], %[[VAL_39]], %[[VAL_41]], %[[VAL_42]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:          %[[VAL_68:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3_>) -> memref<?xf32>
+// CHECK-NEXT:          %[[VAL_68:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3_>) -> memref<?xf32>
 // CHECK-NEXT:          %[[VAL_69:.*]] = affine.load %[[VAL_68]][0] : memref<?xf32>
 // CHECK-NEXT:        }
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
@@ -225,17 +225,17 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:        %[[VAL_73:.*]] = arith.index_cast %[[VAL_43]] : index to i64
 // CHECK-NEXT:        %[[VAL_74:.*]] = arith.index_cast %[[VAL_72]] : index to i64
 // CHECK-NEXT:        sycl.constructor @id(%[[VAL_35]], %[[VAL_39]], %[[VAL_73]], %[[VAL_74]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:        %[[VAL_75:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3_>) -> memref<?xf32>
+// CHECK-NEXT:        %[[VAL_75:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3_>) -> memref<?xf32>
 // CHECK-NEXT:        %[[VAL_76:.*]] = affine.load %[[VAL_75]][0] : memref<?xf32>
 // CHECK-NEXT:        sycl.constructor @id(%[[VAL_35]], %[[VAL_39]], %[[VAL_41]], %[[VAL_42]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:        %[[VAL_77:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3_>) -> memref<?xf32>
+// CHECK-NEXT:        %[[VAL_77:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3_>) -> memref<?xf32>
 // CHECK-NEXT:        %[[VAL_78:.*]] = affine.load %[[VAL_77]][0] : memref<?xf32>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:  }
 // CHECK-NEXT:  return
 gpu.module @device_func {
-func.func private @affine_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_3>) {
+func.func private @affine_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_3>
   %id = memref.cast %alloca : memref<1x!sycl_id_3> to memref<?x!sycl_id_3>
   %c0_i32 = arith.constant 0 : i32
@@ -252,19 +252,19 @@ func.func private @affine_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: 
 
       // Should use shared memory (access exhibits temporal locality).
       sycl.constructor @id(%id, %tx, %i, %j) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3>, i64, i64, i64)
-      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3>) -> memref<?xf32>
+      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3>) -> memref<?xf32>
       %load1 = affine.load %subscr1[0] : memref<?xf32>
 
       // Should use global memory (access is coalesced).
       sycl.constructor @id(%id, %tx, %ty, %tz) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3>, i64, i64, i64)
-      %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3>) -> memref<?xf32>      
+      %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3>) -> memref<?xf32>      
       %load2 = affine.load %subscr2[0] : memref<?xf32>      
     }
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_3>) kernel {
-  func.call @affine_3d(%arg0, %arg1) : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_nd_item_3>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) kernel {
+  func.call @affine_3d(%arg0, %arg1) : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_nd_item_3>) -> ()
   gpu.return
 }
 }
@@ -276,13 +276,13 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 // CHECK:           memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL:     func.func private @scf_2d(
-// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_2_>) {
+// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_2_>) {
 
 // COM: Get work group sizes:
 // CHECK-NEXT:        %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_2_1
@@ -362,7 +362,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // COM: Copy to shared local memory for 1st memref:
 // CHECK-NEXT:            %[[VAL_54:.*]] = sycl.id.constructor(%[[VAL_35]], %[[VAL_47]]) : (index, index) -> memref<1x!sycl_id_2_>
 // CHECK-NEXT:            %[[VAL_55:.*]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_56:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_54]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+// CHECK-NEXT:            %[[VAL_56:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_54]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 // CHECK-NEXT:            %[[VAL_57:.*]] = memref.load %[[VAL_56]]{{\[}}%[[VAL_55]]] : memref<?xf32, 1>
 // CHECK-NEXT:            memref.store %[[VAL_57]], %[[VAL_50]]{{\[}}%[[LOCALID0]], %[[LOCALID1]]] : memref<?x?xf32, #sycl.access.address_space<local>>
 
@@ -378,7 +378,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // COM: Copy to local memory for 2nd memref:
 // CHECK:                 %[[VAL_68:.*]] = sycl.id.constructor(%[[GLOBALID1]], %[[VAL_45]]) : (index, index) -> memref<1x!sycl_id_2_>
 // CHECK:                 %[[VAL_69:.*]] = arith.constant 0 : index
-// CHECK:                 %[[VAL_70:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_68]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
+// CHECK:                 %[[VAL_70:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_68]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<1x!sycl_id_2_>) -> memref<?xf32, 1>
 // CHECK:                 %[[VAL_71:.*]] = memref.load %[[VAL_70]]{{\[}}%[[VAL_69]]] : memref<?xf32, 1>
 // CHECK:                 memref.store %[[VAL_71]], %[[VAL_67]]{{\[}}%[[LOCALID1]], %[[LOCALID0]]] : memref<?x?xf32, #sycl.access.address_space<local>>
 
@@ -399,17 +399,17 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:          scf.for %[[VAL_84:.*]] = %[[VAL_29]] to %[[VAL_31]] step %[[VAL_30]] {
 // CHECK-NEXT:            %[[VAL_85:.*]] = arith.index_cast %[[VAL_84]] : index to i64
 // CHECK-NEXT:            sycl.constructor @id(%[[VAL_28]], %[[VAL_34]], %[[VAL_85]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:            %[[VAL_86:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_28]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
+// CHECK-NEXT:            %[[VAL_86:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_28]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2_>) -> memref<?xf32>
 // CHECK-NEXT:            %[[VAL_87:.*]] = affine.load %[[VAL_86]][0] : memref<?xf32>
 // CHECK-NEXT:            sycl.constructor @id(%[[VAL_28]], %[[VAL_36]], %[[VAL_85]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2_>, i64, i64)
-// CHECK-NEXT:            %[[VAL_88:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_28]]] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2_>) -> memref<?xf32>
+// CHECK-NEXT:            %[[VAL_88:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_28]]] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2_>) -> memref<?xf32>
 // CHECK-NEXT:            %[[VAL_89:.*]] = affine.load %[[VAL_88]][0] : memref<?xf32>
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }
 // CHECK-NEXT:        return
 // CHECK-NEXT:      }
 gpu.module @device_func {
-func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0 = arith.constant 0 : index
@@ -423,17 +423,17 @@ func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: mem
   scf.for %ii = %c0 to %c256 step %c1 {
     %i = arith.index_cast %ii : index to i64    
     sycl.constructor @id(%id, %tx, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
 
     sycl.constructor @id(%id, %ty, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)    
-    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load2 = affine.load %subscr2[0] : memref<?xf32>
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) kernel {
-  func.call @scf_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) kernel {
+  func.call @scf_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_nd_item_2>) -> ()
   gpu.return
 }
 }
@@ -445,13 +445,13 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 !sycl_accessor_impl_device_3 = !sycl.accessor_impl_device<[3], (!sycl_id_3, !sycl_range_3, !sycl_range_3)>
 !sycl_group_3 = !sycl.group<[3], (!sycl_range_3, !sycl_range_3, !sycl_range_3, !sycl_id_3)>
 !sycl_item_base_3 = !sycl.item_base<[3, true], (!sycl_range_3, !sycl_id_3, !sycl_id_3)>
-!sycl_accessor_3_f32_r_gb = !sycl.accessor<[3, f32, read, global_buffer], (!sycl_accessor_impl_device_3, !llvm.struct<(memref<?xf32, 3>)>)>
+!sycl_accessor_3_f32_r_dev = !sycl.accessor<[3, f32, read, device], (!sycl_accessor_impl_device_3, !llvm.struct<(memref<?xf32, 3>)>)>
 !sycl_item_3 = !sycl.item<[3, true], (!sycl_item_base_3)>
 !sycl_nd_item_3 = !sycl.nd_item<[3], (!sycl_item_3, !sycl_item_3, !sycl_group_3)>
 
 // CHECK:           memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL:     func.func private @scf_3d(
-// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
+// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
 
 // COM: Get work group sizes:
 // CHECK-NEXT:        %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_3_1
@@ -530,7 +530,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:            %[[VAL_56:.*]] = arith.index_cast %[[VAL_45]] : index to i64
 // CHECK-NEXT:            %[[VAL_57:.*]] = sycl.id.constructor(%[[VAL_44]], %[[VAL_45]], %[[VAL_49]]) : (index, index, index) -> memref<1x!sycl_id_3_>
 // CHECK-NEXT:            %[[VAL_58:.*]] = arith.constant 0 : index
-// CHECK-NEXT:            %[[VAL_59:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_57]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
+// CHECK-NEXT:            %[[VAL_59:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_57]]] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<1x!sycl_id_3_>) -> memref<?xf32, 1>
 // CHECK-NEXT:            %[[VAL_60:.*]] = memref.load %[[VAL_59]]{{\[}}%[[VAL_58]]] : memref<?xf32, 1>
 // CHECK-NEXT:            memref.store %[[VAL_60]], %[[VAL_52]]{{\[}}%[[LOCALID0]], %[[LOCALID1]], %[[LOCALID2]]] : memref<?x?x?xf32, #sycl.access.address_space<local>>
 
@@ -549,14 +549,14 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 // CHECK-NEXT:            %[[VAL_76:.*]] = arith.index_cast %[[VAL_45]] : index to i64
 // CHECK-NEXT:            %[[VAL_77:.*]] = arith.index_cast %[[VAL_75]] : index to i64
 // CHECK-NEXT:            sycl.constructor @id(%[[VAL_35]], %[[VAL_43]], %[[VAL_76]], %[[VAL_77]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3_>, i64, i64, i64)
-// CHECK-NEXT:            %[[VAL_78:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3_>) -> memref<?xf32>
+// CHECK-NEXT:            %[[VAL_78:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_35]]] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3_>) -> memref<?xf32>
 // CHECK-NEXT:            %[[VAL_79:.*]] = affine.load %[[VAL_78]][0] : memref<?xf32>
 // CHECK-NEXT:          }
 // CHECK-NEXT:        }
 // CHECK-NEXT:      }
 // CHECK-NEXT:      return
 gpu.module @device_func {
-func.func private @scf_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_3>) {
+func.func private @scf_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_3>
   %id = memref.cast %alloca : memref<1x!sycl_id_3> to memref<?x!sycl_id_3>
   %c0 = arith.constant 0 : index
@@ -573,14 +573,14 @@ func.func private @scf_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: mem
       %i = arith.index_cast %ii : index to i64
       %j = arith.index_cast %jj : index to i64
       sycl.constructor @id(%id, %tx, %i, %j) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_3>, i64, i64, i64)
-      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_id_3>) -> memref<?xf32>
+      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_id_3>) -> memref<?xf32>
       %load1 = affine.load %subscr1[0] : memref<?xf32>
     }
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_3>) kernel {
-  func.call @scf_3d(%arg0, %arg1) : (memref<?x!sycl_accessor_3_f32_r_gb>, memref<?x!sycl_nd_item_3>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) kernel {
+  func.call @scf_3d(%arg0, %arg1) : (memref<?x!sycl_accessor_3_f32_r_dev>, memref<?x!sycl_nd_item_3>) -> ()
   gpu.return
 }
 }

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
@@ -11,12 +11,12 @@
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 gpu.module @device_func {
-func.func private @callee1(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @callee1(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -25,17 +25,17 @@ func.func private @callee1(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: me
   affine.for %ii = 0 to 256 {
     %i = arith.index_cast %ii : index to i64
     sycl.constructor @id(%id, %tx, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
   }
   return
 }
-gpu.func @caller1(%arg0: memref<?xi32, #sycl.access.address_space<local>>, %arg1: memref<?x!sycl_accessor_2_f32_r_gb>, %arg2: memref<?x!sycl_nd_item_2>) kernel {
-  func.call @callee1(%arg1, %arg2) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+gpu.func @caller1(%arg0: memref<?xi32, #sycl.access.address_space<local>>, %arg1: memref<?x!sycl_accessor_2_f32_r_dev>, %arg2: memref<?x!sycl_nd_item_2>) kernel {
+  func.call @callee1(%arg1, %arg2) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_nd_item_2>) -> ()
   gpu.return
 }
 
-func.func private @callee2(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @callee2(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -44,14 +44,14 @@ func.func private @callee2(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: me
   affine.for %ii = 0 to 256 {
     %i = arith.index_cast %ii : index to i64
     sycl.constructor @id(%id, %tx, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
   }
   return
 }
 // COM: Not candidate: kernel uses local_accessor
-gpu.func @caller2(%arg0: memref<?xi32, 3>, %arg1: memref<?x!sycl_accessor_2_f32_r_gb>, %arg2: memref<?x!sycl_nd_item_2>) kernel {
-  func.call @callee2(%arg1, %arg2) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+gpu.func @caller2(%arg0: memref<?xi32, 3>, %arg1: memref<?x!sycl_accessor_2_f32_r_dev>, %arg2: memref<?x!sycl_nd_item_2>) kernel {
+  func.call @callee2(%arg1, %arg2) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_nd_item_2>) -> ()
   gpu.return
 }
 }
@@ -69,12 +69,12 @@ gpu.func @caller2(%arg0: memref<?xi32, 3>, %arg1: memref<?x!sycl_accessor_2_f32_
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -85,17 +85,17 @@ func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: 
   affine.for %ii = 0 to 256 {
     %i = arith.index_cast %ii : index to i64
     sycl.constructor @id(%id, %tx, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
 
     sycl.constructor @id(%id, %i, %ty) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)    
-    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load2 = affine.load %subscr2[0] : memref<?xf32>
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
-  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
+  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_nd_item_2>) -> ()
   gpu.return
 }
 }
@@ -113,12 +113,12 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -130,18 +130,18 @@ func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: 
     %i = arith.index_cast %ii : index to i64
     %add1 = arith.addi %i, %ty : i64
     sycl.constructor @id(%id, %tx, %add1) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
 
     %add2 = arith.addi %tx, %ty : i64
     sycl.constructor @id(%id, %add2, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_2>, i64, i64)    
-    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_id_2>) -> memref<?xf32>
+    %subscr2 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_id_2>) -> memref<?xf32>
     %load2 = affine.load %subscr2[0] : memref<?xf32>
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
-  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_gb>, memref<?x!sycl_nd_item_2>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) kernel attributes {reqd_work_group_size = [4, 2]} {
+  func.call @affine_2d(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_nd_item_2>) -> ()
   gpu.return
 }
 }
@@ -158,11 +158,11 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sy
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 !sycl_item_base_1_ = !sycl.item_base<[2, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
-!sycl_accessor_1_f32_r_gb = !sycl.accessor<[1, f32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_1_f32_r_dev = !sycl.accessor<[1, f32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 
 gpu.module @device_func {
-func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_item_1_>) {
+func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   %id = memref.cast %alloca : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
   %c0_i32 = arith.constant 0 : i32
@@ -175,7 +175,7 @@ func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_acce
     affine.for %ii = 0 to 256 {
       %i = arith.index_cast %ii : index to i64
       sycl.constructor @id(%id, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1_>, i64)
-      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_id_1_>) -> memref<?xf32>
+      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_id_1_>) -> memref<?xf32>
       %load1 = affine.load %subscr1[0] : memref<?xf32>
     }
   }
@@ -187,7 +187,7 @@ func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_acce
     affine.for %ii = 0 to 256 {
       %i = arith.index_cast %ii : index to i64
       sycl.constructor @id(%id, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1_>, i64)
-      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_id_1_>) -> memref<?xf32>
+      %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_id_1_>) -> memref<?xf32>
       %load1 = affine.load %subscr1[0] : memref<?xf32>
     }
   }
@@ -195,7 +195,7 @@ func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_acce
   return
 }
 
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_item_1_>) kernel {
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) kernel {
   %alloca = memref.alloca() : memref<1xi1>
   %c0 = arith.constant 0 : index
   %c0_i32 = arith.constant 0 : i32
@@ -206,7 +206,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sy
   // COM: Store the condition (non-uniform) into memory.
   memref.store %cond, %alloca[%c0] : memref<1xi1>
 
-  func.call @affine(%alloca, %arg0, %arg1) : (memref<1xi1>, memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_item_1_>) -> ()
+  func.call @affine(%alloca, %arg0, %arg1) : (memref<1xi1>, memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_item_1_>) -> ()
   gpu.return
 }
 }

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization_unroll.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization_unroll.mlir
@@ -8,14 +8,14 @@
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 !sycl_item_base_1_ = !sycl.item_base<[2, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)>
-!sycl_accessor_1_f32_r_gb = !sycl.accessor<[1, f32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_1_f32_r_dev = !sycl.accessor<[1, f32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 
 // CHECK-DAG:   [[MAP1:#map.*]] = affine_map<()[s0] -> (256 ceildiv s0)>
 // CHECK-DAG:   [[MAP2:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine(
-// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_1_f32_r_gb>, %[[VAL_1:.*]]: memref<?x!sycl_item_1_>) {
+// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_1_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_item_1_>) {
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_1_1
 // CHECK-NEXT:    %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_range_1_1>
 // CHECK-NEXT:    %[[VAL_4:.*]] = arith.constant 0 : index
@@ -50,7 +50,7 @@
 // CHECK-NEXT:        %[[VAL_30:.*]] = arith.index_cast %[[VAL_29]] : index to i64
 // CHECK-NEXT:        %[[VAL_31:.*]] = sycl.id.constructor(%[[VAL_29]]) : (index) -> memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_32:.*]] = arith.constant 0 : index
-// CHECK-NEXT:        %[[VAL_33:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_31]]] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
+// CHECK-NEXT:        %[[VAL_33:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_31]]] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<1x!sycl_id_1_>) -> memref<?xf32, 1>
 // CHECK-NEXT:        %[[VAL_34:.*]] = memref.load %[[VAL_33]]{{\[}}%[[VAL_32]]] : memref<?xf32, 1>
 // CHECK-NEXT:        memref.store %[[VAL_34]], %[[VAL_27]]{{\[}}%[[VAL_17]]] : memref<?xf32, #sycl.access.address_space<local>>
 // CHECK-NEXT:        spirv.ControlBarrier <Workgroup>, <Workgroup>, <SequentiallyConsistent|WorkgroupMemory>
@@ -107,14 +107,14 @@
 // CHECK-NEXT:      affine.for %[[VAL_70:.*]] = 0 to 256 {
 // CHECK-NEXT:        %[[VAL_71:.*]] = arith.index_cast %[[VAL_70]] : index to i64
 // CHECK-NEXT:        sycl.constructor @id(%[[VAL_19]], %[[VAL_71]]) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1_>, i64)
-// CHECK-NEXT:        %[[VAL_72:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_19]]] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_id_1_>) -> memref<?xf32>
+// CHECK-NEXT:        %[[VAL_72:.*]] = sycl.accessor.subscript %[[VAL_0]]{{\[}}%[[VAL_19]]] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_id_1_>) -> memref<?xf32>
 // CHECK-NEXT:        %[[VAL_73:.*]] = affine.load %[[VAL_72]][0] : memref<?xf32>
 // CHECK-NEXT:      }
 // CHECK-NEXT:    }
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 gpu.module @device_func {
-func.func private @affine(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_item_1_>) {
+func.func private @affine(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) {
   %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   %id = memref.cast %alloca : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
   %c0_i32 = arith.constant 0 : i32
@@ -123,13 +123,13 @@ func.func private @affine(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: mem
   affine.for %ii = 0 to 256 {
     %i = arith.index_cast %ii : index to i64
     sycl.constructor @id(%id, %i) {MangledFunctionName = @dummy} : (memref<?x!sycl_id_1_>, i64)
-    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_id_1_>) -> memref<?xf32>
+    %subscr1 = sycl.accessor.subscript %arg0[%id] : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_id_1_>) -> memref<?xf32>
     %load1 = affine.load %subscr1[0] : memref<?xf32>
   }
   return
 }
-gpu.func @kernel(%arg0: memref<?x!sycl_accessor_1_f32_r_gb>, %arg1: memref<?x!sycl_item_1_>) kernel {
-  func.call @affine(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_gb>, memref<?x!sycl_item_1_>) -> ()
+gpu.func @kernel(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) kernel {
+  func.call @affine(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_item_1_>) -> ()
   gpu.return
 }
 }

--- a/polygeist/test/polygeist-opt/sycl/matrix_multiply_reduction.mlir
+++ b/polygeist/test/polygeist-opt/sycl/matrix_multiply_reduction.mlir
@@ -1,9 +1,9 @@
 // RUN: polygeist-opt -arg-promotion -kernel-disjoint-specialization -licm -raise-scf-to-affine -detect-reduction %s | FileCheck %s
 
 // CHECK-LABEL: func.func private @matrix_multiply_reduction
-// CHECK-SAME:    (%arg0: memref<?x!sycl_accessor_1_f32_w_gb, 4> {llvm.noalias, sycl.inner.disjoint},
-// CHECK-SAME:     %arg1: memref<?x!sycl_accessor_1_f32_r_gb, 4> {llvm.noalias, sycl.inner.disjoint},
-// CHECK-SAME:     %arg2: memref<?x!sycl_accessor_1_f32_r_gb, 4> {llvm.noalias, sycl.inner.disjoint},
+// CHECK-SAME:    (%arg0: memref<?x!sycl_accessor_1_f32_w_dev, 4> {llvm.noalias, sycl.inner.disjoint},
+// CHECK-SAME:     %arg1: memref<?x!sycl_accessor_1_f32_r_dev, 4> {llvm.noalias, sycl.inner.disjoint},
+// CHECK-SAME:     %arg2: memref<?x!sycl_accessor_1_f32_r_dev, 4> {llvm.noalias, sycl.inner.disjoint},
 // CHECK-SAME:     %arg3: i32) attributes {llvm.linkage = #llvm.linkage<private>} {
 // CHECK-DAG: [[ALLOCA:%.*]] = memref.alloca()
 // CHECK-DAG: [[CAST:%.*]] = memref.cast [[ALLOCA]]
@@ -27,8 +27,8 @@
 !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 !sycl_id_1_ = !sycl.id<[1], (!sycl_array_1_)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_write_1_ = !sycl.accessor<[1, f32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
-!sycl_accessor_read_1_ = !sycl.accessor<[1, f32, read, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_write_1_ = !sycl.accessor<[1, f32, write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
+!sycl_accessor_read_1_ = !sycl.accessor<[1, f32, read, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xf32, 1>)>)>
 
 gpu.module @device_func {
   gpu.func @caller() kernel {

--- a/polygeist/test/polygeist-opt/sycl/subindex.mlir
+++ b/polygeist/test/polygeist-opt/sycl/subindex.mlir
@@ -21,7 +21,7 @@ func.func @test_1(%arg0: memref<?x!llvm.struct<(!sycl_id_1_)>>) -> memref<?x!syc
 !sycl_id_1_ = !sycl.id<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-!sycl_accessor_1_ = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
+!sycl_accessor_1_ = !sycl.accessor<[1, i32, read_write, device], (!sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>, !llvm.struct<(ptr<i32, 1>)>)>
 
 func.func @test_2(%arg0: memref<?x!sycl_accessor_1_>) -> memref<?x!sycl_accessor_impl_device_1_> {
   %c0 = arith.constant 0 : index

--- a/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
+++ b/polygeist/test/polygeist-opt/sycl/sycl-raise-host.mlir
@@ -104,10 +104,10 @@ llvm.func @raise_sub_buffer() -> !llvm.ptr attributes {personality = @__gxx_pers
 
 llvm.func @__gxx_personality_v0(...) -> i32
 
-// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
+// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_rw_dev = !sycl.accessor<[1, !llvm.void, read_write, device], (!llvm.void)>
 // CHECK:       !sycl_id_1_ = !sycl.id<[1], (!llvm.void)>
 // CHECK:       !sycl_range_1_ = !sycl.range<[1], (!llvm.void)>
-// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
+// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_dev = !sycl.accessor<[1, !llvm.void, write, device], (!sycl_range_1_, !sycl_id_1_)>
 
 // CHECK-LABEL:   llvm.func @raise_accessor() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
@@ -118,10 +118,10 @@ llvm.func @__gxx_personality_v0(...) -> i32
 // CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_6:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_7:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::accessor.5", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
-// CHECK:           sycl.host.constructor(%[[VAL_4]], %[[VAL_3]], %[[VAL_5]], %[[VAL_6]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_4]], %[[VAL_3]], %[[VAL_5]], %[[VAL_6]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_3]], %[[VAL_1]], %[[VAL_2]], %[[VAL_5]], %[[VAL_6]]) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_3]], %[[VAL_1]], %[[VAL_2]], %[[VAL_5]], %[[VAL_6]]) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb2
 // CHECK:         ^bb2:
 // CHECK:           llvm.return %[[VAL_3]] : !llvm.ptr
@@ -188,11 +188,11 @@ llvm.func @raise_local_accessor(%handler: !llvm.ptr) -> !llvm.ptr attributes {pe
 llvm.func @__gxx_personality_v0(...) -> i32
 llvm.func @_ZN4sycl3_V16bufferIfLi1ENS0_6detail17aligned_allocatorIfEEvE10get_accessILNS0_6access4modeE1024ELNS7_6targetE2014EEENS0_8accessorIfLi1EXT_EXT0_ELNS7_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEERNS0_7handlerENS2_13code_locationE(!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
-// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_r_gb = !sycl.accessor<[1, !llvm.void, read, global_buffer], (!llvm.void)>
-// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_gb = !sycl.accessor<[1, !llvm.void, write, global_buffer], (!llvm.void)>
+// CHECK-LABEL: !sycl_accessor_1_21llvm2Evoid_r_dev = !sycl.accessor<[1, !llvm.void, read, device], (!llvm.void)>
+// CHECK:       !sycl_accessor_1_21llvm2Evoid_w_dev = !sycl.accessor<[1, !llvm.void, write, device], (!llvm.void)>
 // CHECK:       !sycl_id_1_ = !sycl.id<[1], (!llvm.void)>
 // CHECK:       !sycl_range_1_ = !sycl.range<[1], (!llvm.void)>
-// CHECK:       !sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!sycl_range_1_, !sycl_id_1_)>
+// CHECK:       !sycl_accessor_1_21llvm2Evoid_rw_dev = !sycl.accessor<[1, !llvm.void, read_write, device], (!sycl_range_1_, !sycl_id_1_)>
 
 // CHECK-LABEL:   llvm.func @raise_get_access() -> !llvm.ptr attributes {personality = @__gxx_personality_v0} {
 // CHECK:           %[[VAL_0:.*]] = arith.constant 1 : i32
@@ -207,13 +207,13 @@ llvm.func @_ZN4sycl3_V16bufferIfLi1ENS0_6detail17aligned_allocatorIfEEvE10get_ac
 // CHECK:           %[[VAL_9:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"class.sycl::_V1::property_list", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_10:.*]] = llvm.alloca %[[VAL_0]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", ()> {alignment = 8 : i64} : (i32) -> !llvm.ptr
 // COM: Read-only
-// CHECK:           sycl.host.constructor(%[[VAL_6]], %[[VAL_3]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_6]], %[[VAL_3]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // COM: Read-write with range and offset
-// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_4]], %[[VAL_1]], %[[VAL_2]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_4]], %[[VAL_1]], %[[VAL_2]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, i64, i64, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb1
 // CHECK:         ^bb1:
 // COM: Write-only
-// CHECK:           sycl.host.constructor(%[[VAL_8]], %[[VAL_5]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_8]], %[[VAL_5]], %[[VAL_9]], %[[VAL_10]]) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb2
 // CHECK:         ^bb2:
 // CHECK:           llvm.return %[[VAL_3]] : !llvm.ptr
@@ -775,7 +775,7 @@ gpu.module @device_functions {
 llvm.mlir.global private unnamed_addr constant @kernel_str("kernel\00") {addr_space = 0 : i32, alignment = 1 : i64, dso_local}
 
 !lambda_class = !llvm.struct<"class.lambda", (i16, i32, !llvm.struct<"class.sycl::_V1::accessor", (ptr)>, !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32, array<5 x f32>, array<5 x f32>, !llvm.struct<"class.sycl::_V1::accessor", (ptr)>)>
-!sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
+!sycl_accessor_1_21llvm2Evoid_rw_dev = !sycl.accessor<[1, !llvm.void, read_write, device], (!llvm.void)>
 !sycl_range_1_ = !sycl.range<[1], (!sycl.array<[1], (memref<1xi64, 4>)>)>
 !sycl_local_accessor_1_21llvm2Evoid = !sycl.local_accessor<[1, !llvm.void], (!sycl_range_1_)>
 
@@ -807,7 +807,7 @@ llvm.func @_ZN4sycl3_V17handler6unpackEv(%arg0: !llvm.ptr)
 // CHECK:           %[[VAL_15:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<"class.sycl::_V1::accessor", (ptr)> : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_16:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<"class.sycl::_V1::accessor", (ptr)> : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_17:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)> : (i32) -> !llvm.ptr
-// CHECK:           sycl.host.constructor(%[[VAL_15]], %[[VAL_14]], %[[VAL_14]], %[[VAL_14]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_15]], %[[VAL_14]], %[[VAL_14]], %[[VAL_14]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           sycl.host.constructor(%[[VAL_16]], %[[VAL_14]], %[[VAL_14]], %[[VAL_14]]) {type = !sycl_local_accessor_1_21llvm2Evoid} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           %[[VAL_18:.*]] = llvm.alloca %[[VAL_11]] x !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32, array<5 x f32>, array<5 x f32>, struct<"class.sycl::_V1::accessor", (ptr)>)> : (i32) -> !llvm.ptr
 // CHECK:           llvm.store %[[VAL_9]], %[[VAL_18]] : i16, !llvm.ptr
@@ -818,7 +818,7 @@ llvm.func @_ZN4sycl3_V17handler6unpackEv(%arg0: !llvm.ptr)
 // CHECK:           %[[VAL_20:.*]] = llvm.getelementptr %[[VAL_18]][0, 2] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32, array<5 x f32>, array<5 x f32>, struct<"class.sycl::_V1::accessor", (ptr)>)>
 // CHECK:           %[[VAL_21:.*]] = llvm.load %[[VAL_15]] : !llvm.ptr -> !llvm.ptr
 // CHECK:           llvm.store %[[VAL_21]], %[[VAL_20]] : !llvm.ptr, !llvm.ptr
-// CHECK:           sycl.host.set_captured %[[VAL_18]][2] = %[[VAL_15]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
+// CHECK:           sycl.host.set_captured %[[VAL_18]][2] = %[[VAL_15]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_dev)
 // CHECK:           %[[VAL_22:.*]] = llvm.getelementptr %[[VAL_18]][0, 3] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<"class.lambda", (i16, i32, struct<"class.sycl::_V1::accessor", (ptr)>, struct<"class.sycl::_V1::vec", (array<16 x i16>)>, f32, f32, array<5 x f32>, array<5 x f32>, struct<"class.sycl::_V1::accessor", (ptr)>)>
 // CHECK:           "llvm.intr.memcpy"(%[[VAL_22]], %[[VAL_17]], %[[VAL_10]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i32) -> ()
 // CHECK:           sycl.host.set_captured %[[VAL_18]][3] = %[[VAL_17]] : !llvm.ptr, !llvm.ptr
@@ -878,7 +878,7 @@ llvm.func @raise_set_captured(%handler: !llvm.ptr) {
   %vector = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::vec", (array<16 x i16>)> : (i32) -> !llvm.ptr
   
   // COM: ensure the accessors are actually detected as such
-  sycl.host.constructor(%accessor, %nullptr, %nullptr, %nullptr) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+  sycl.host.constructor(%accessor, %nullptr, %nullptr, %nullptr) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
   sycl.host.constructor(%local_accessor, %nullptr, %nullptr, %nullptr) {type = !sycl_local_accessor_1_21llvm2Evoid} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
   // COM: struct containing the captured values
@@ -1073,7 +1073,7 @@ gpu.module @device_functions {
 }
 
 !lambda_class = !llvm.struct<"class.lambda", opaque>
-!sycl_accessor_1_21llvm2Evoid_rw_gb = !sycl.accessor<[1, !llvm.void, read_write, global_buffer], (!llvm.void)>
+!sycl_accessor_1_21llvm2Evoid_rw_dev = !sycl.accessor<[1, !llvm.void, read_write, device], (!llvm.void)>
 !kernel_signatures_type = !llvm.array<7 x struct<"struct.sycl::_V1::detail::kernel_param_desc_t", (i32, i32, i32)>>
 
 llvm.mlir.global internal constant @_ZN4sycl3_V16detailL17kernel_signaturesE() : !kernel_signatures_type {
@@ -1130,8 +1130,8 @@ llvm.mlir.global private unnamed_addr constant @kernel_param_desc_str("kernel_pa
 // CHECK:           %[[VAL_7:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"class.sycl::_V1::accessor", opaque> : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_8:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"class.sycl::_V1::property_list", opaque> : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_9:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", opaque> : (i32) -> !llvm.ptr
-// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_6]], %[[VAL_8]], %[[VAL_9]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:           sycl.host.set_captured %[[VAL_5]][0] = %[[VAL_7]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
+// CHECK:           sycl.host.constructor(%[[VAL_7]], %[[VAL_6]], %[[VAL_8]], %[[VAL_9]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.set_captured %[[VAL_5]][0] = %[[VAL_7]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_dev)
 // CHECK:           %[[VAL_10:.*]] = llvm.mlir.addressof @_ZN4sycl3_V16detailL17kernel_signaturesE : !llvm.ptr
 // CHECK:           %[[VAL_11:.*]] = llvm.mlir.addressof @kernel_num_params_str : !llvm.ptr
 // CHECK:           %[[VAL_12:.*]] = llvm.mlir.addressof @kernel_param_desc_str : !llvm.ptr
@@ -1143,7 +1143,7 @@ llvm.mlir.global private unnamed_addr constant @kernel_param_desc_str("kernel_pa
 // CHECK:           "llvm.intr.var.annotation"(%[[VAL_14]], %[[VAL_12]], %[[VAL_3]], %[[VAL_1]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @device_functions::@foo[range %[[VAL_4]]](%[[VAL_7]]: !sycl_accessor_1_21llvm2Evoid_rw_gb) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @device_functions::@foo[range %[[VAL_4]]](%[[VAL_7]]: !sycl_accessor_1_21llvm2Evoid_rw_dev) : (!llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           llvm.return
 // CHECK:         }
 llvm.func @raise_schedule_parallel_for_range_accessor(%handler: !llvm.ptr) {
@@ -1159,8 +1159,8 @@ llvm.func @raise_schedule_parallel_for_range_accessor(%handler: !llvm.ptr) {
   %accessor = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::accessor", opaque> : (i32) -> !llvm.ptr
   %pl = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::property_list", opaque> : (i32) -> !llvm.ptr
   %cl = llvm.alloca %c1 x !llvm.struct<"struct.sycl::_V1::detail::code_location", opaque> : (i32) -> !llvm.ptr
-  sycl.host.constructor(%accessor, %buffer, %pl, %cl) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> () 
-  sycl.host.set_captured %lambda[0] = %accessor : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
+  sycl.host.constructor(%accessor, %buffer, %pl, %cl) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> () 
+  sycl.host.set_captured %lambda[0] = %accessor : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_dev)
 
   %kernel_signatures = llvm.mlir.addressof @_ZN4sycl3_V16detailL17kernel_signaturesE : !llvm.ptr
   %kernel_num_params_str = llvm.mlir.addressof @kernel_num_params_str : !llvm.ptr
@@ -1193,9 +1193,9 @@ llvm.func @raise_schedule_parallel_for_range_accessor(%handler: !llvm.ptr) {
 // CHECK:           %[[VAL_9:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"class.sycl::_V1::accessor", opaque> : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_10:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"class.sycl::_V1::property_list", opaque> : (i32) -> !llvm.ptr
 // CHECK:           %[[VAL_11:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<"struct.sycl::_V1::detail::code_location", opaque> : (i32) -> !llvm.ptr
-// CHECK:           sycl.host.constructor(%[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_11]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           sycl.host.constructor(%[[VAL_9]], %[[VAL_8]], %[[VAL_10]], %[[VAL_11]]) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 // CHECK:           sycl.host.set_captured %[[VAL_7]][0] = %[[VAL_1]] : !llvm.ptr, i32
-// CHECK:           sycl.host.set_captured %[[VAL_7]][1] = %[[VAL_9]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
+// CHECK:           sycl.host.set_captured %[[VAL_7]][1] = %[[VAL_9]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_dev)
 // CHECK:           %[[VAL_12:.*]] = llvm.mlir.addressof @_ZN4sycl3_V16detailL17kernel_signaturesE : !llvm.ptr
 // CHECK:           %[[VAL_13:.*]] = llvm.getelementptr %[[VAL_12]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<7 x struct<"struct.sycl::_V1::detail::kernel_param_desc_t", (i32, i32, i32)>>
 // CHECK:           %[[VAL_14:.*]] = llvm.mlir.addressof @kernel_num_params_str : !llvm.ptr
@@ -1208,7 +1208,7 @@ llvm.func @raise_schedule_parallel_for_range_accessor(%handler: !llvm.ptr) {
 // CHECK:           "llvm.intr.var.annotation"(%[[VAL_17]], %[[VAL_15]], %[[VAL_4]], %[[VAL_1]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
 // CHECK:           llvm.br ^bb1
 // CHECK:         ^bb1:
-// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @device_functions::@foo[range %[[VAL_5]], offset %[[VAL_6]]](%[[VAL_1]], %[[VAL_9]]: !sycl_accessor_1_21llvm2Evoid_rw_gb) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
+// CHECK:           sycl.host.schedule_kernel %[[VAL_0]] -> @device_functions::@foo[range %[[VAL_5]], offset %[[VAL_6]]](%[[VAL_1]], %[[VAL_9]]: !sycl_accessor_1_21llvm2Evoid_rw_dev) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, i32, !llvm.ptr) -> ()
 // CHECK:           llvm.return
 // CHECK:         }
 llvm.func @raise_schedule_parallel_for_range_offset_std_layout_accessor(%handler: !llvm.ptr) {
@@ -1226,9 +1226,9 @@ llvm.func @raise_schedule_parallel_for_range_offset_std_layout_accessor(%handler
   %accessor = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::accessor", opaque> : (i32) -> !llvm.ptr
   %pl = llvm.alloca %c1 x !llvm.struct<"class.sycl::_V1::property_list", opaque> : (i32) -> !llvm.ptr
   %cl = llvm.alloca %c1 x !llvm.struct<"struct.sycl::_V1::detail::code_location", opaque> : (i32) -> !llvm.ptr
-  sycl.host.constructor(%accessor, %buffer, %pl, %cl) {type = !sycl_accessor_1_21llvm2Evoid_rw_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> () 
+  sycl.host.constructor(%accessor, %buffer, %pl, %cl) {type = !sycl_accessor_1_21llvm2Evoid_rw_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> () 
   sycl.host.set_captured %lambda[0] = %c0 : !llvm.ptr, i32
-  sycl.host.set_captured %lambda[1] = %accessor : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_gb)
+  sycl.host.set_captured %lambda[1] = %accessor : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_rw_dev)
 
   %kernel_signatures = llvm.mlir.addressof @_ZN4sycl3_V16detailL17kernel_signaturesE : !llvm.ptr
   %sig_offset = llvm.getelementptr %kernel_signatures[0, 1] : (!llvm.ptr) -> !llvm.ptr, !kernel_signatures_type

--- a/polygeist/test/polygeist-opt/uniformity.mlir
+++ b/polygeist/test/polygeist-opt/uniformity.mlir
@@ -6,7 +6,7 @@
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
@@ -153,7 +153,7 @@ func.func @test1b(%arg0 : index, %arg1: memref<?x!sycl_nd_item_2>)  {
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
@@ -229,7 +229,7 @@ func.func @test2(%cond: i1, %val: i64, %arg1: memref<?x!sycl_nd_item_2>)  {
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
@@ -271,7 +271,7 @@ func.func private @test3(%cond: i1, %uniform_val: i64, %non_uniform_val : i64)  
   return
 }
 
-gpu.func @kernel(%cond: i1, %arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: memref<?x!sycl_nd_item_2>) kernel {
+gpu.func @kernel(%cond: i1, %arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) kernel {
   %c0_i32 = arith.constant 0 : i32
   %tx = sycl.nd_item.get_global_id(%arg1, %c0_i32) : (memref<?x!sycl_nd_item_2>, i32) -> i64
 
@@ -290,7 +290,7 @@ gpu.func @kernel(%cond: i1, %arg0: memref<?x!sycl_accessor_2_f32_r_gb>, %arg1: m
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
@@ -338,7 +338,7 @@ gpu.func @kernel(%cond: i1, %arg1: memref<?x!sycl_nd_item_2>) kernel {
 !sycl_accessor_impl_device_2 = !sycl.accessor_impl_device<[2], (!sycl_id_2, !sycl_range_2, !sycl_range_2)>
 !sycl_group_2 = !sycl.group<[2], (!sycl_range_2, !sycl_range_2, !sycl_range_2, !sycl_id_2)>
 !sycl_item_base_2 = !sycl.item_base<[2, true], (!sycl_range_2, !sycl_id_2, !sycl_id_2)>
-!sycl_accessor_2_f32_r_gb = !sycl.accessor<[2, f32, read, global_buffer], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
+!sycl_accessor_2_f32_r_dev = !sycl.accessor<[2, f32, read, device], (!sycl_accessor_impl_device_2, !llvm.struct<(memref<?xf32, 2>)>)>
 !sycl_item_2 = !sycl.item<[2, true], (!sycl_item_base_2)>
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-capture.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-capture.cpp
@@ -23,9 +23,9 @@ int main(){
 // CHECK-SAME:                            %{{.*}}: memref<?x!sycl_id_1_>
 // CHECK-SAME:                            %[[VAL_303:.*]]: !llvm.ptr
 // CHECK:             %[[VAL_305:.*]] = arith.constant 1 : index
-// CHECK:             %[[VAL_326:.*]] = memref.alloca() : memref<1x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>>
-// CHECK-NEXT:        %[[VAL_327:.*]] = memref.cast %[[VAL_326]] : memref<1x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>> to memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>>
-// CHECK:             %[[VAL_331:.*]] = "polygeist.subindex"(%[[VAL_327]], %[[VAL_305]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>>, index) -> memref<?x!llvm.array<8 x f32>>
+// CHECK:             %[[VAL_326:.*]] = memref.alloca() : memref<1x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>>
+// CHECK-NEXT:        %[[VAL_327:.*]] = memref.cast %[[VAL_326]] : memref<1x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>> to memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>>
+// CHECK:             %[[VAL_331:.*]] = "polygeist.subindex"(%[[VAL_327]], %[[VAL_305]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>>, index) -> memref<?x!llvm.array<8 x f32>>
 // CHECK-NEXT:        %[[VAL_332:.*]] = "polygeist.memref2pointer"(%[[VAL_331]]) : (memref<?x!llvm.array<8 x f32>>) -> !llvm.ptr
 // CHECK-NEXT:        %[[VAL_333:.*]] = llvm.getelementptr inbounds %[[VAL_303]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<8 x f32>)>
 // CHECK-NEXT:        %[[VAL_334:.*]] = llvm.getelementptr inbounds %[[VAL_333]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<8 x f32>
@@ -40,7 +40,7 @@ int main(){
 
 // COM: Check the *= operation is performed:
 // CHECK-LABEL:     func.func private @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlNS0_2idILi1EEEE_clES5_(
-// CHECK-SAME:                                                                                               %[[VAL_358:.*]]: memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>, 4>
+// CHECK-SAME:                                                                                               %[[VAL_358:.*]]: memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>, 4>
 // CHECK-SAME:                                                                                               %[[VAL_359:.*]]: memref<?x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_360:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[VAL_361:.*]] = arith.constant 0 : index
@@ -48,19 +48,19 @@ int main(){
 // CHECK-NEXT:        %[[VAL_363:.*]] = memref.cast %[[VAL_362]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_364:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_365:.*]] = memref.cast %[[VAL_364]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
-// CHECK-NEXT:        %[[VAL_366:.*]] = "polygeist.subindex"(%[[VAL_358]], %[[VAL_360]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>, 4>, index) -> memref<?x!llvm.array<8 x f32>, 4>
+// CHECK-NEXT:        %[[VAL_366:.*]] = "polygeist.subindex"(%[[VAL_358]], %[[VAL_360]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>, 4>, index) -> memref<?x!llvm.array<8 x f32>, 4>
 // CHECK-NEXT:        %[[VAL_367:.*]] = "polygeist.memref2pointer"(%[[VAL_366]]) : (memref<?x!llvm.array<8 x f32>, 4>) -> !llvm.ptr<4>
 // CHECK-NEXT:        %[[VAL_368:.*]] = sycl.id.get %[[VAL_359]][] : (memref<?x!sycl_id_1_>) -> i64
 // CHECK-NEXT:        %[[VAL_369:.*]] = arith.trunci %[[VAL_368]] : i64 to i32
 // CHECK-NEXT:        %[[VAL_370:.*]] = llvm.getelementptr %[[VAL_367]]{{\[}}%[[VAL_369]]] : (!llvm.ptr<4>, i32) -> !llvm.ptr<4>, f32
 // CHECK-NEXT:        %[[VAL_371:.*]] = llvm.load %[[VAL_370]] : !llvm.ptr<4> -> f32
-// CHECK-NEXT:        %[[VAL_372:.*]] = "polygeist.subindex"(%[[VAL_358]], %[[VAL_361]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_gb, array<8 x f32>)>, 4>, index) -> memref<?x!sycl_accessor_1_f32_rw_gb, 4>
+// CHECK-NEXT:        %[[VAL_372:.*]] = "polygeist.subindex"(%[[VAL_358]], %[[VAL_361]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>, 4>, index) -> memref<?x!sycl_accessor_1_f32_rw_dev, 4>
 // CHECK-NEXT:        %[[VAL_373:.*]] = memref.memory_space_cast %[[VAL_365]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
 // CHECK-NEXT:        %[[VAL_374:.*]] = memref.memory_space_cast %[[VAL_359]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
 // CHECK-NEXT:        sycl.constructor @id(%[[VAL_373]], %[[VAL_374]]) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ERKS2_} : (memref<?x!sycl_id_1_, 4>, memref<?x!sycl_id_1_, 4>)
 // CHECK-NEXT:        %[[VAL_375:.*]] = affine.load %[[VAL_364]][0] : memref<1x!sycl_id_1_>
 // CHECK-NEXT:        affine.store %[[VAL_375]], %[[VAL_362]][0] : memref<1x!sycl_id_1_>
-// CHECK-NEXT:        %[[VAL_376:.*]] = sycl.accessor.subscript %[[VAL_372]]{{\[}}%[[VAL_363]]] : (memref<?x!sycl_accessor_1_f32_rw_gb, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
+// CHECK-NEXT:        %[[VAL_376:.*]] = sycl.accessor.subscript %[[VAL_372]]{{\[}}%[[VAL_363]]] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>
 // CHECK-NEXT:        %[[VAL_377:.*]] = affine.load %[[VAL_376]][0] : memref<?xf32, 4>
 // CHECK-NEXT:        %[[VAL_378:.*]] = arith.mulf %[[VAL_377]], %[[VAL_371]] : f32
 // CHECK-NEXT:        affine.store %[[VAL_378]], %[[VAL_376]][0] : memref<?xf32, 4>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -11,7 +11,7 @@
 // CHECK-DAG: !sycl_range_1_ = !sycl.range<[1], (!sycl_array_1_)>
 // CHECK-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 // CHECK-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
-// CHECK-DAG: !sycl_accessor_1_i32_w_gb = !sycl.accessor<[1, i32, write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_i32_w_dev = !sycl.accessor<[1, i32, write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
 // CHECK-DAG: ![[ITEM_BASE:.*]] = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
 // CHECK-DAG: ![[ITEM:.*]] = !sycl.item<[2, true], (![[ITEM_BASE]])>
 
@@ -176,7 +176,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 
 // CHECK-LABEL: func.func @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(
 // CHECK-SAME: {{.*}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
-// CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_w_gb, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
+// CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
 // CHECK: sycl.constructor @AccessorImplDevice([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl_id_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>)
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_5()

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -11,10 +11,10 @@
 // CHECK-MLIR-DAG: !sycl_range_2_ = !sycl.range<[2], (!sycl_array_2_)>
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_1_ = !sycl.accessor_impl_device<[1], (!sycl_id_1_, !sycl_range_1_, !sycl_range_1_)>
 // CHECK-MLIR-DAG: !sycl_accessor_impl_device_2_ = !sycl.accessor_impl_device<[2], (!sycl_id_2_, !sycl_range_2_, !sycl_range_2_)>
-// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
-// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
-// CHECK-MLIR-DAG: ![[ACC_STRUCT:.*]] = !sycl.accessor<[1, !llvm.struct<(i32)>, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
-// CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl_accessor_2_i32_rw_gb)>
+// CHECK-MLIR-DAG: !sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-MLIR-DAG: !sycl_accessor_2_i32_rw_dev = !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-MLIR-DAG: ![[ACC_STRUCT:.*]] = !sycl.accessor<[1, !llvm.struct<(i32)>, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(ptr<1>)>)>
+// CHECK-MLIR-DAG: ![[ACC_SUBSCRIPT:.*]] = !sycl.accessor_subscript<[1], (!sycl_id_2_, !sycl_accessor_2_i32_rw_dev)>
 // CHECK-MLIR-DAG: ![[ITEM_BASE1:.*]] = !sycl.item_base<[1, true], (!sycl_range_1_, !sycl_id_1_, !sycl_id_1_)
 // CHECK-MLIR-DAG: ![[ITEM_BASE2:.*]] = !sycl.item_base<[2, true], (!sycl_range_2_, !sycl_id_2_, !sycl_id_2_)>
 // CHECK-MLIR-DAG: ![[ITEM1:.*]] = !sycl.item<[1, true], (![[ITEM_BASE1]])>
@@ -28,50 +28,50 @@ template <typename T> SYCL_EXTERNAL void keep(T);
 // enable the checks below.
 
 // COM-MLIR-LABEL: func.func @_Z20accessor_get_pointerN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// COM-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> memref<?xi32, 1>
+// COM-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_dev, llvm.noundef})
+// COM-MLIR: %{{.*}} = sycl.accessor.get_pointer(%{{.*}}) : (memref<?x!sycl_accessor_2_i32_rw_dev>) -> memref<?xi32, 1>
 
 SYCL_EXTERNAL void accessor_get_pointer(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_pointer());
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z18accessor_get_rangeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> !sycl_range_2_
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_dev, llvm.noundef})
+// CHECK-MLIR: %{{.*}} = sycl.accessor.get_range(%arg0) : (memref<?x!sycl_accessor_2_i32_rw_dev>) -> !sycl_range_2_
 
 SYCL_EXTERNAL void accessor_get_range(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.get_range());
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z13accessor_sizeN4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) : (memref<?x!sycl_accessor_2_i32_rw_gb>) -> i64
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_dev, llvm.noundef})
+// CHECK-MLIR: %{{.*}} = sycl.accessor.size(%arg0) : (memref<?x!sycl_accessor_2_i32_rw_dev>) -> i64
 
 SYCL_EXTERNAL void accessor_size(sycl::accessor<sycl::cl_int, 2> acc) {
   keep(acc.size());
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_0N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEENS0_2idILi2EEE(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef}, 
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_dev, llvm.noundef}, 
 // CHECK_MLIR_SAME:      %{{.*}}: memref<?x!sycl_id_2_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_2_, llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_2_i32_rw_gb>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_2_i32_rw_dev>, memref<?x!sycl_id_2_>) -> memref<?xi32, 4>
 
 SYCL_EXTERNAL void accessor_subscript_operator_0(sycl::accessor<sycl::cl_int, 2> acc, sycl::id<2> index) {
   keep(acc[index]);
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_1N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_gb>, %{{.*}}: i64)
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_2_i32_rw_gb>, i64) -> ![[ACC_SUBSCRIPT]]
+// CHECK_MLIR:           %{{.*}}: memref<?x!sycl_accessor_2_i32_rw_dev>, %{{.*}}: i64)
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_2_i32_rw_dev>, i64) -> ![[ACC_SUBSCRIPT]]
 
 SYCL_EXTERNAL void accessor_subscript_operator_1(sycl::accessor<sycl::cl_int, 2> acc, size_t index) {
   keep(acc[index]);
 }
 
 // CHECK-MLIR-LABEL: func.func @_Z29accessor_subscript_operator_2N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEEm(
-// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef}, 
+// CHECK-MLIR:           %{{.*}}: memref<?x!sycl_accessor_1_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_dev, llvm.noundef}, 
 // CHECK-MLIR-SAME:      %{{.*}}: i64 {llvm.noundef})
-// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_1_i32_rw_gb>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
+// CHECK-MLIR: %{{.*}} = sycl.accessor.subscript %{{.*}}[%{{.*}}] : (memref<?x!sycl_accessor_1_i32_rw_dev>, memref<?x!sycl_id_1_>) -> memref<?xi32, 4>
 
 SYCL_EXTERNAL void accessor_subscript_operator_2(sycl::accessor<sycl::cl_int, 1> acc, size_t index) {
   keep(acc[index]);

--- a/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/image.cpp
@@ -27,7 +27,7 @@ static constexpr unsigned N = 8;
 // CHECK-NEXT:  }
 
 void testImage() {
-  const image_channel_order ChanOrder = image_channel_order::rgba;
+  const image_channel_order ChanOrder = image_channel_order::rgb;
   const image_channel_type ChanType = image_channel_type::fp32;
   const range<1> ImgSize_1D(N);
   std::vector<float4> data_from_1D(ImgSize_1D.size(), {1, 2, 3, 4});

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_captures.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_captures.cpp
@@ -16,8 +16,8 @@ class KernelName;
 // CHECK:         %[[cgf:.*]] = llvm.load %arg0 {{.*}} : !llvm.ptr -> !llvm.ptr
 
 // COM: check that we correctly identified the accessors.
-// CHECK:         sycl.host.set_captured %[[lambda]][0] = %[[accessor_1]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_w_gb)
-// CHECK:         sycl.host.set_captured %[[lambda]][1] = %[[accessor_2]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_r_gb)
+// CHECK:         sycl.host.set_captured %[[lambda]][0] = %[[accessor_1]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_w_dev)
+// CHECK:         sycl.host.set_captured %[[lambda]][1] = %[[accessor_2]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_r_dev)
 
 // COM: can't match the constant here because we don't propagate constants through the command group function object yet;
 // COM: just ensure that the value corresponds to the CGF's second capture.

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
@@ -25,9 +25,9 @@ class KernelName;
 
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
 // CHECK:          %[[N:.*]] = llvm.mlir.constant(1024 : i64) : i64
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect nd-range assignment with a scalar argument
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
@@ -27,9 +27,9 @@ class KernelName;
 // CHECK-DAG:      %[[ZERO:.*]] = llvm.mlir.constant(0 : i64) : i64
 
 // COM: These three lines are needed to match the right GS, LS and OFF.
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect nd-range assignment with an nd_range argument
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
@@ -24,9 +24,9 @@ class KernelName;
 // COM: Check we can detect accessors construction
 
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect nd-range assignment with a range argument
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
@@ -24,9 +24,9 @@ class KernelName;
 // CHECK-LABEL: llvm.func internal @_ZNSt17_Function_handlerIFvRN4sycl3_V17handlerEEZ4mainEUlS3_E_E9_M_invokeERKSt9_Any_dataS3_
 // CHECK-DAG:      %[[N:.*]] = llvm.mlir.constant(1024 : i64) : i64
 // CHECK-DAG:      %[[OFFSET:.*]] = llvm.mlir.constant(2 : i64) : i64
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
-// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_gb} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_r_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
+// CHECK:          sycl.host.constructor({{.*}}) {type = !sycl_accessor_1_21llvm2Evoid_w_dev} : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr) -> ()
 
 // COM: Check we can detect nd-range assignment with range and offset arguments
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_schedule_kernel.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_schedule_kernel.cpp
@@ -15,8 +15,8 @@ class KernelName;
 // CHECK:         %[[cgf:.*]] = llvm.load %arg0 {{.*}} : !llvm.ptr -> !llvm.ptr
 
 // COM: check that we correctly identified the accessors.
-// CHECK:         sycl.host.set_captured %[[lambda]][0] = %[[accessor_1]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_w_gb)
-// CHECK:         sycl.host.set_captured %[[lambda]][1] = %[[accessor_2]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_r_gb)
+// CHECK:         sycl.host.set_captured %[[lambda]][0] = %[[accessor_1]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_w_dev)
+// CHECK:         sycl.host.set_captured %[[lambda]][1] = %[[accessor_2]] : !llvm.ptr, !llvm.ptr (!sycl_accessor_1_21llvm2Evoid_r_dev)
 
 // COM: can't match the constant here because we don't propagate constants through the command group function object yet;
 // COM: just ensure that the value corresponds to the CGF's second capture.
@@ -29,7 +29,7 @@ class KernelName;
 // CHECK:         sycl.host.handler.set_nd_range %[[handler:.*]] -> range %[[range:.*]] : !llvm.ptr, !llvm.ptr
 
 // COM: finally, check that the `schedule_kernel` op has been raised
-// CHECK:         sycl.host.schedule_kernel %[[handler]] -> @device_functions::@_ZTS10KernelName[range %[[range]]](%[[accessor_1]]: !sycl_accessor_1_21llvm2Evoid_w_gb, %[[accessor_2]]: !sycl_accessor_1_21llvm2Evoid_r_gb, %[[cgf_capture_2_load]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i16) -> ()
+// CHECK:         sycl.host.schedule_kernel %[[handler]] -> @device_functions::@_ZTS10KernelName[range %[[range]]](%[[accessor_1]]: !sycl_accessor_1_21llvm2Evoid_w_dev, %[[accessor_2]]: !sycl_accessor_1_21llvm2Evoid_r_dev, %[[cgf_capture_2_load]]) : (!llvm.ptr, !llvm.ptr, !llvm.ptr, !llvm.ptr, i16) -> ()
 
 int main() {
   constexpr std::size_t N = 1024;

--- a/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp
@@ -3,10 +3,10 @@
 
 #include <sycl/sycl.hpp>
 
-// CHECK-DAG: !sycl_accessor_1_i32_rw_gb = !sycl.accessor<[1, i32, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_2_i32_rw_gb = !sycl.accessor<[2, i32, read_write, global_buffer], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_3_f32_rw_gb = !sycl.accessor<[3, f32, read_write, global_buffer], (!sycl_accessor_impl_device_3_, !llvm.struct<(memref<?xf32, 1>)>)>
-// CHECK-DAG: !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb = !sycl.accessor<[1, !sycl_vec_i32_4_, read_write, global_buffer], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?x!sycl_vec_i32_4_, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_i32_rw_dev = !sycl.accessor<[1, i32, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_2_i32_rw_dev = !sycl.accessor<[2, i32, read_write, device], (!sycl_accessor_impl_device_2_, !llvm.struct<(memref<?xi32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_3_f32_rw_dev = !sycl.accessor<[3, f32, read_write, device], (!sycl_accessor_impl_device_3_, !llvm.struct<(memref<?xf32, 1>)>)>
+// CHECK-DAG: !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_dev = !sycl.accessor<[1, !sycl_vec_i32_4_, read_write, device], (!sycl_accessor_impl_device_1_, !llvm.struct<(memref<?x!sycl_vec_i32_4_, 1>)>)>
 // CHECK-DAG: !sycl_array_1_ = !sycl.array<[1], (memref<1xi64, 4>)>
 // CHECK-DAG: !sycl_array_2_ = !sycl.array<[2], (memref<2xi64, 4>)>
 // CHECK-DAG: !sycl_atomic_f32_loc = !sycl.atomic<[f32, local], (memref<?xf32, 3>)>
@@ -34,26 +34,26 @@
 // CHECK-DAG: !sycl_nd_item_2_ = !sycl.nd_item<[2], (![[ITEM_2_T]], ![[ITEM_2_F]], !sycl_group_2_)>
 // CHECK-DAG: !sycl_nd_range_1_ = !sycl.nd_range<[1], (!sycl_range_1_, !sycl_range_1_, !sycl_id_1_)>
 // CHECK-DAG: !sycl_nd_range_2_ = !sycl.nd_range<[2], (!sycl_range_2_, !sycl_range_2_, !sycl_id_2_)>
-// CHECK-DAG: !sycl_stream = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_gb, !sycl_accessor_1_i32_ato_gb, !sycl_accessor_1_i8_rw_gb, i32, i64, i32, i32, i32, i32)>
+// CHECK-DAG: !sycl_stream = !sycl.stream<(!llvm.array<16 x i8>, !sycl_accessor_1_i8_rw_dev, !sycl_accessor_1_i32_ato_dev, !sycl_accessor_1_i8_rw_dev, i32, i64, i32, i32, i32, i32)>
 // CHECK-DAG: !sycl_swizzled_vec_f32_8_ = !sycl.swizzled_vec<[!sycl_vec_f32_8_, 0, 1, 2], (memref<?x!sycl_vec_f32_8_, 4>, !llvm.struct<(i8)>, !llvm.struct<(i8)>)>
 // CHECK-DAG: !sycl_vec_f32_8_ = !sycl.vec<[f32, 8], (vector<8xf32>)>
 // CHECK-DAG: !sycl_vec_i32_4_ = !sycl.vec<[i32, 4], (vector<4xi32>)>
 
 // CHECK-LABEL: func.func @_Z10accessor_1N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_gb, llvm.noundef})
+// CHECK:          %arg0: memref<?x!sycl_accessor_1_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_i32_rw_dev, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKEXT:llvm.linkage = #llvm.linkage<external>]],
 // CHECK-SAME: [[PASSTHROUGH:passthrough = \["convergent", "mustprogress", "noinline", "norecurse", "nounwind", "optnone", \["frame-pointer", "all"\], \["no-trapping-math", "true"\], \["stack-protector-buffer-size", "8"\], \["sycl-module-id", ".*/polygeist/tools/cgeist/Test/Verification/sycl/types.cpp"\]\]]]} {
-SYCL_EXTERNAL void accessor_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
+SYCL_EXTERNAL void accessor_1(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::device>) {}
 
 // CHECK-LABEL: func.func @_Z10accessor_2N4sycl3_V18accessorIiLi2ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK:          %arg0: memref<?x!sycl_accessor_2_i32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_gb, llvm.noundef})
+// CHECK:          %arg0: memref<?x!sycl_accessor_2_i32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_2_i32_rw_dev, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void accessor_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
+SYCL_EXTERNAL void accessor_2(sycl::accessor<sycl::cl_int, 2, sycl::access::mode::read_write, sycl::access::target::device>) {}
 
 // CHECK-LABEL: func.func @_Z10accessor_3N4sycl3_V18accessorIfLi3ELNS0_6access4modeE1026ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK:          %arg0: memref<?x!sycl_accessor_3_f32_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_3_f32_rw_gb, llvm.noundef})
+// CHECK:          %arg0: memref<?x!sycl_accessor_3_f32_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_3_f32_rw_dev, llvm.noundef})
 // CHECK-SAME: attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void accessor_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
+SYCL_EXTERNAL void accessor_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mode::read_write, sycl::access::target::device>) {}
 
 // COM: Local Accessor Test
 // CHECK-LABEL: func.func @_Z10accessor_4N4sycl3_V18accessorIiLi1ELNS0_6access4modeE1026ELNS2_6targetE2016ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
@@ -62,9 +62,9 @@ SYCL_EXTERNAL void accessor_3(sycl::accessor<sycl::cl_float, 3, sycl::access::mo
 SYCL_EXTERNAL void accessor_4(sycl::accessor<sycl::cl_int, 1, sycl::access::mode::read_write, sycl::access::target::local>) {}
 
 // CHECK-LABEL: func.func @_Z10accessor_5N4sycl3_V18accessorINS0_3vecIiLi4EEELi1ELNS0_6access4modeE1026ELNS4_6targetE2014ELNS4_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEE(
-// CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_gb, llvm.noundef})
+// CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_dev> {llvm.align = 8 : i64, llvm.byval = !sycl_accessor_1_21sycl2Evec3C5Bi322C_45D2C_28vector3C4xi323E293E_rw_dev, llvm.noundef})
 // CHECK-SAME:  attributes {[[SPIR_FUNCCC]], [[LINKEXT]], [[PASSTHROUGH]]
-SYCL_EXTERNAL void accessor_5(sycl::accessor<sycl::vec<int, 4>, 1, sycl::access::mode::read_write, sycl::access::target::global_buffer>) {}
+SYCL_EXTERNAL void accessor_5(sycl::accessor<sycl::vec<int, 4>, 1, sycl::access::mode::read_write, sycl::access::target::device>) {}
 
 // CHECK-LABEL: func.func @_Z5arr_1N4sycl3_V16detail5arrayILi1EEE(
 // CHECK:          %arg0: memref<?x!sycl_array_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_array_1_, llvm.noundef})


### PR DESCRIPTION
- Add `device` and use instead of the deprecated `global_buffer`;
- Add `host_task`.