### PR TITLE
[SYCL-MLIR][NFC] Remove unused `sycl.host.kernel_name` op.

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLHostOps.td
@@ -72,17 +72,6 @@ def SYCLHostConstructorOp : SYCL_HostOp<"constructor",
   let hasVerifier = true;
 }
 
-def SYCLHostKernelNameOp
-    : SYCL_HostOp<"kernel_name",
-        [Symbol, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {
-  let summary = "Represents a constant holding the name of a SYCL kernel, " #
-                "i.e., a `gpu.func` with the `kernel` attribute.";
-  let arguments = (ins SymbolNameAttr:$sym_name, SymbolRefAttr:$kernel_name);
-  let assemblyFormat = [{
-    $sym_name `->` $kernel_name attr-dict
-  }];
-}
-
 def SYCLHostGetKernelOp
     : SYCL_HostOp<"get_kernel",
         [Pure, DeclareOpInterfaceMethods<SymbolUserOpInterface>]> {

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -527,11 +527,6 @@ void SYCLHostConstructorOp::getEffects(
 }
 
 LogicalResult
-SYCLHostKernelNameOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
-  return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
-}
-
-LogicalResult
 SYCLHostGetKernelOp::verifySymbolUses(SymbolTableCollection &symbolTable) {
   return verifyReferencesKernel(*this, symbolTable, getKernelNameAttr());
 }

--- a/mlir-sycl/test/Dialect/SYCL/host.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/host.mlir
@@ -34,9 +34,6 @@ gpu.module @kernels {
   }
 }
 
-// CHECK-LABEL:  sycl.host.kernel_name @kernel_ref -> @kernels::@k0
-sycl.host.kernel_name @kernel_ref -> @kernels::@k0
-
 // CHECK-LABEL:  func.func @f() -> !llvm.ptr {
 // CHECK-NEXT:     %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
 func.func @f() -> !llvm.ptr {

--- a/mlir-sycl/test/Dialect/SYCL/invalid.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/invalid.mlir
@@ -441,28 +441,10 @@ func.func @math_op_invalid_vector_type(%arg0 : !sycl_vec_i32_4_) {
 
 // COM: Check inexistent symbol.
 
-// expected-error @below {{'sycl.host.kernel_name' op '@kernels::@k0' does not reference a valid kernel}}
-sycl.host.kernel_name @kernel_ref -> @kernels::@k0
-
-// -----
-
-// COM: Check inexistent symbol.
-
 func.func @f() -> !llvm.ptr {
   // expected-error @below {{'sycl.host.get_kernel' op '@kernels::@k0' does not reference a valid kernel}}
   %0 = sycl.host.get_kernel @kernels::@k0 : !llvm.ptr
   func.return %0 : !llvm.ptr
-}
-
-// -----
-
-// COM: Check function is not a gpu.func
-
-// expected-error @below {{'sycl.host.kernel_name' op '@f0' does not reference a valid kernel}}
-sycl.host.kernel_name @kernel_ref -> @f0
-
-func.func @f0() {
-  func.return
 }
 
 // -----
@@ -478,19 +460,6 @@ func.func @f() -> !llvm.ptr {
 func.func @f0() {
   func.return
 }
-
-// -----
-
-// COM: Check function is not a kernel
-
-gpu.module @kernels {
-  gpu.func @k0() {
-    gpu.return
-  }
-}
-
-// expected-error @below {{'sycl.host.kernel_name' op '@kernels::@k0' does not reference a valid kernel}}
-sycl.host.kernel_name @kernel_ref -> @kernels::@k0
 
 // -----
 


### PR DESCRIPTION
This PR removes the definition and IR tests for the `sycl.host.kernel_name` op which is no longer used by our host raising pass.