### PR TITLE
[SYCL][Doc] Fix formatting in sycl_ext_oneapi_properties

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -195,6 +195,7 @@ template<typename... Ts>
 inline constexpr boo_key::value_t<Ts...> boo;
 
 } // namespace experimental::oneapi::ext::sycl
+```
 
 === Property traits
 


### PR DESCRIPTION
Code block was missing closing ` ``` `.