### PR TITLE
[SYCL] Added test-e2e for queue, device, and event interop.

### DIFF
--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,0 +1,62 @@
+// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %elif ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %elif ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} -o test.out RUN:
+// %{run} test.out
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+#ifdef SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL
+#include <sycl/ext/oneapi/experimental/backend/cuda.hpp>
+constexpr auto BACKEND = backend::ext_oneapi_cuda;
+#elif defined(SYCL_EXT_ONEAPI_BACKEND_HIP)
+#include <sycl/ext/oneapi/backend/hip.hpp>
+constexpr auto BACKEND = backend::ext_oneapi_hip;
+#elif defined(SYCL_EXT_ONEAPI_BACKEND_L0)
+constexpr auto BACKEND = backend::ext_oneapi_level_zero;
+#else
+constexpr auto BACKEND = backend::opencl;
+#endif
+
+constexpr int N = 100;
+constexpr int VAL = 3;
+
+int main() {
+
+  device Device;
+  auto NativeDevice = get_native<BACKEND>(Device);
+  auto IDevice = make_device<BACKEND>(NativeDevice);
+
+  context Context(IDevice);
+
+  // Create queue with device created from a native device.
+  queue Queue(IDevice, {sycl::property::queue::in_order()});
+  auto NativeQueue = get_native<BACKEND>(Queue);
+  auto IQueue = make_queue<BACKEND>(NativeQueue, Context);
+
+  auto A = (int *)malloc_device(N * sizeof(int), IQueue);
+  std::vector<int> vec(N, 0);
+
+  auto Event = Queue.submit([&](handler &h) {
+    h.parallel_for<class kern1>(range<1>(N),
+                                [=](id<1> item) { A[item] = VAL; });
+  });
+
+  auto NativeEvent = get_native<BACKEND>(Event);
+  event IEvent = make_event<BACKEND>(NativeEvent, Context);
+
+  // depends_on event created from a native event.
+  auto Event2 = IQueue.submit([&](handler &h) {
+    h.depends_on(IEvent);
+    h.parallel_for<class kern2>(range<1>(N), [=](id<1> item) { A[item]++; });
+  });
+
+  auto Event3 = IQueue.memcpy(&vec[0], A, N * sizeof(int), Event2);
+  Event3.wait();
+
+  free(A, IQueue);
+
+  for (const auto &val : vec) {
+    assert(val == VAL + 1);
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %if ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %if ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} -o test.out
+// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ %if ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %{ %if ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} %} %} -o test.out
 // RUN: %{run} test.out
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -33,12 +33,19 @@ constexpr int VAL = 3;
 
 int main() {
 
-  assert(static_cast<bool>(std::is_same_v<backend_traits<BACKEND>::return_type<device>, nativeDevice>));
-  assert(static_cast<bool>(std::is_same_v<backend_traits<BACKEND>::return_type<queue>, nativeQueue>));
-  assert(static_cast<bool>(std::is_same_v<backend_traits<BACKEND>::return_type<event>, nativeEvent>));
+  assert(static_cast<bool>(
+      std::is_same_v<backend_traits<BACKEND>::return_type<device>,
+                     nativeDevice>));
+  assert(static_cast<bool>(
+      std::is_same_v<backend_traits<BACKEND>::return_type<queue>,
+                     nativeQueue>));
+  assert(static_cast<bool>(
+      std::is_same_v<backend_traits<BACKEND>::return_type<event>,
+                     nativeEvent>));
 
   device Device;
-  backend_traits<BACKEND>::return_type<device> NativeDevice = get_native<BACKEND>(Device);
+  backend_traits<BACKEND>::return_type<device> NativeDevice =
+      get_native<BACKEND>(Device);
   // Create sycl device with a native device.
   auto InteropDevice = make_device<BACKEND>(NativeDevice);
 
@@ -46,7 +53,8 @@ int main() {
 
   // Create sycl queue with device created from a native device.
   queue Queue(InteropDevice, {sycl::property::queue::in_order()});
-  backend_traits<BACKEND>::return_type<queue> NativeQueue = get_native<BACKEND>(Queue);
+  backend_traits<BACKEND>::return_type<queue> NativeQueue =
+      get_native<BACKEND>(Queue);
   auto InteropQueue = make_queue<BACKEND>(NativeQueue, Context);
 
   auto A = (int *)malloc_device(N * sizeof(int), InteropQueue);
@@ -57,7 +65,8 @@ int main() {
                                 [=](id<1> item) { A[item] = VAL; });
   });
 
-  backend_traits<BACKEND>::return_type<event> NativeEvent = get_native<BACKEND>(Event);
+  backend_traits<BACKEND>::return_type<event> NativeEvent =
+      get_native<BACKEND>(Event);
   // Create sycl event with a native event.
   event InteropEvent = make_event<BACKEND>(NativeEvent, Context);
 

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,5 +1,5 @@
-// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %elif ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %elif ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} -o test.out RUN:
-// %{run} test.out
+// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %elif ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %elif ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} -o test.out
+// RUN: %{run} test.out
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,5 +1,5 @@
-// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ %if ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %{ %if ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} %} %} -o test.out
-// RUN: %{run} test.out
+// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ %if ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %{ %if ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} %} %} -o %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: CUDA || HIP
-// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} -o %t.out
-// RUN: %{run} %t.out
+// RUN: %{build} %if hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ %if cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %{ %if level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} %} %} -o %t.out
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
@@ -8,9 +7,13 @@ using namespace sycl;
 #ifdef SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL
 #include <sycl/ext/oneapi/experimental/backend/cuda.hpp>
 constexpr auto BACKEND = backend::ext_oneapi_cuda;
-#else // defined(SYCL_EXT_ONEAPI_BACKEND_HIP)
+#elif defined(SYCL_EXT_ONEAPI_BACKEND_HIP)
 #include <sycl/ext/oneapi/backend/hip.hpp>
 constexpr auto BACKEND = backend::ext_oneapi_hip;
+#elif defined(SYCL_EXT_ONEAPI_BACKEND_L0)
+constexpr auto BACKEND = backend::ext_oneapi_level_zero;
+#else
+constexpr auto BACKEND = backend::opencl;
 #endif
 
 constexpr int N = 100;

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,4 +1,5 @@
-// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ %if ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %{ %if ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} %} %} -o %t.out
+// REQUIRES: CUDA || HIP
+// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/sycl.hpp>
@@ -7,13 +8,9 @@ using namespace sycl;
 #ifdef SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL
 #include <sycl/ext/oneapi/experimental/backend/cuda.hpp>
 constexpr auto BACKEND = backend::ext_oneapi_cuda;
-#elif defined(SYCL_EXT_ONEAPI_BACKEND_HIP)
+#else // defined(SYCL_EXT_ONEAPI_BACKEND_HIP)
 #include <sycl/ext/oneapi/backend/hip.hpp>
 constexpr auto BACKEND = backend::ext_oneapi_hip;
-#elif defined(SYCL_EXT_ONEAPI_BACKEND_L0)
-constexpr auto BACKEND = backend::ext_oneapi_level_zero;
-#else
-constexpr auto BACKEND = backend::opencl;
 #endif
 
 constexpr int N = 100;

--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %elif ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %elif ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} -o test.out
+// RUN: %{build} %if ext_oneapi_hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %if ext_oneapi_cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %if ext_oneapi_level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} -o test.out
 // RUN: %{run} test.out
 
 #include <sycl/sycl.hpp>
@@ -23,16 +23,17 @@ int main() {
 
   device Device;
   auto NativeDevice = get_native<BACKEND>(Device);
-  auto IDevice = make_device<BACKEND>(NativeDevice);
+  // Create sycl device with a native device.
+  auto InteropDevice = make_device<BACKEND>(NativeDevice);
 
-  context Context(IDevice);
+  context Context(InteropDevice);
 
-  // Create queue with device created from a native device.
-  queue Queue(IDevice, {sycl::property::queue::in_order()});
+  // Create sycl queue with device created from a native device.
+  queue Queue(InteropDevice, {sycl::property::queue::in_order()});
   auto NativeQueue = get_native<BACKEND>(Queue);
-  auto IQueue = make_queue<BACKEND>(NativeQueue, Context);
+  auto InteropQueue = make_queue<BACKEND>(NativeQueue, Context);
 
-  auto A = (int *)malloc_device(N * sizeof(int), IQueue);
+  auto A = (int *)malloc_device(N * sizeof(int), InteropQueue);
   std::vector<int> vec(N, 0);
 
   auto Event = Queue.submit([&](handler &h) {
@@ -41,18 +42,19 @@ int main() {
   });
 
   auto NativeEvent = get_native<BACKEND>(Event);
-  event IEvent = make_event<BACKEND>(NativeEvent, Context);
+  // Create sycl event with a native event.
+  event InteropEvent = make_event<BACKEND>(NativeEvent, Context);
 
-  // depends_on event created from a native event.
-  auto Event2 = IQueue.submit([&](handler &h) {
-    h.depends_on(IEvent);
+  // depends_on sycl event created from a native event.
+  auto Event2 = InteropQueue.submit([&](handler &h) {
+    h.depends_on(InteropEvent);
     h.parallel_for<class kern2>(range<1>(N), [=](id<1> item) { A[item]++; });
   });
 
-  auto Event3 = IQueue.memcpy(&vec[0], A, N * sizeof(int), Event2);
+  auto Event3 = InteropQueue.memcpy(&vec[0], A, N * sizeof(int), Event2);
   Event3.wait();
 
-  free(A, IQueue);
+  free(A, InteropQueue);
 
   for (const auto &val : vec) {
     assert(val == VAL + 1);


### PR DESCRIPTION
All CI backends (cuda, hip, l0, opencl) currently support these three types of interop, that are probably the most important cases, but a complete e2e test did not previously exist. opencl is also the only backend with an existing test-e2e that calls make_* for these three sycl objects.

This adds a short test-e2e corresponding to e.g. https://github.com/intel/llvm/pull/10526.