### PR TITLE
[SYCL][KernelFusion] Prevent unnecessary scheduler creation

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -168,6 +168,8 @@ Scheduler &GlobalHandler::getScheduler() {
   return *MScheduler.Inst;
 }
 
+bool GlobalHandler::isSchedulerAlive() const { return MScheduler.Inst.get(); }
+
 void GlobalHandler::registerSchedulerUsage(bool ModifyCounter) {
   thread_local ObjectUsageCounter SchedulerCounter(ModifyCounter);
 }

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -58,6 +58,7 @@ public:
 
   void registerSchedulerUsage(bool ModifyCounter = true);
   Scheduler &getScheduler();
+  bool isSchedulerAlive() const;
   ProgramManager &getProgramManager();
   Sync &getSync();
   std::vector<PlatformImplPtr> &getPlatformCache();

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -559,7 +559,9 @@ pi_native_handle queue_impl::getNative(int32_t &NativeHandleDesc) const {
 }
 
 void queue_impl::cleanup_fusion_cmd() {
-  detail::Scheduler::getInstance().cleanUpCmdFusion(this);
+  // Clean up only if a scheduler instance exits.
+  if (detail::Scheduler::isInstanceAlive())
+    detail::Scheduler::getInstance().cleanUpCmdFusion(this);
 }
 
 bool queue_impl::ext_oneapi_empty() const {

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -261,6 +261,10 @@ Scheduler &Scheduler::getInstance() {
   return GlobalHandler::instance().getScheduler();
 }
 
+bool Scheduler::isInstanceAlive() {
+  return GlobalHandler::instance().isSchedulerAlive();
+}
+
 void Scheduler::waitForEvent(const EventImplPtr &Event) {
   ReadLockT Lock = acquireReadLock();
   // It's fine to leave the lock unlocked upon return from waitForEvent as

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -438,6 +438,8 @@ public:
 
   /// \return an instance of the scheduler object.
   static Scheduler &getInstance();
+  /// \return true if an instance of the scheduler object exists.
+  static bool isInstanceAlive();
 
   QueueImplPtr getDefaultHostQueue() { return DefaultHostQueue; }
 


### PR DESCRIPTION
Test is a scheduler instance is alive before before attempting to cleanup fusion commands.

Hopefully addresses https://github.com/intel/llvm/pull/10948#issuecomment-1732066144 (I cannot locally reproduce the issue)