### PR TITLE
[SYCL][Graph] Bugfix test e2e Graph/submission_while_executing.cpp

### DIFF
--- a/sycl/test-e2e/Graph/submission_while_executing.cpp
+++ b/sycl/test-e2e/Graph/submission_while_executing.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
-
-// https://github.com/intel/llvm/issues/11277:
-// UNSUPPORTED: windows
 //
 // CHECK-NOT: LEAK
 
@@ -14,13 +11,19 @@
 
 #include "graph_common.hpp"
 
+inline bool
+isSubmittedOrRunningCommand(sycl::info::event_command_status Status) {
+  return ((Status == sycl::info::event_command_status::submitted) ||
+          (Status == sycl::info::event_command_status::running));
+}
+
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 
   size_t LargeSize =
-      1000000; // we use large Size to increase the kernel execution time
+      10000; // we use large Size to increase the kernel execution time
   size_t NumIterations = 10;
   size_t SuccessfulSubmissions = 0;
 
@@ -57,25 +60,47 @@ int main() {
 
   // Concurrent Submissions
   sycl::event Event;
-  sycl::info::event_command_status PreEventInfo =
+  sycl::event PreEvent;
+  sycl::info::event_command_status PreEventInfoStateBefore =
       sycl::info::event_command_status::ext_oneapi_unknown;
-  std::error_code ErrorCode = make_error_code(sycl::errc::success);
+  sycl::info::event_command_status PreEventInfoStateAfter =
+      sycl::info::event_command_status::ext_oneapi_unknown;
+  std::error_code ErrorCode;
   for (unsigned i = 0; i < NumIterations; ++i) {
+    ErrorCode = make_error_code(sycl::errc::success);
+    PreEventInfoStateBefore =
+        PreEvent.get_info<sycl::info::event::command_execution_status>();
+
+    // Submit the kernel
     try {
       Event =
           Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
     } catch (const sycl::exception &e) {
       ErrorCode = e.code();
     }
-    if ((PreEventInfo == sycl::info::event_command_status::submitted) ||
-        (PreEventInfo == sycl::info::event_command_status::running)) {
+    PreEventInfoStateAfter =
+        PreEvent.get_info<sycl::info::event::command_execution_status>();
+
+    // Check submission status
+    if (isSubmittedOrRunningCommand(PreEventInfoStateBefore) &&
+        isSubmittedOrRunningCommand(PreEventInfoStateAfter)) {
       assert(ErrorCode == sycl::errc::invalid);
-    } else {
+    } else if (PreEventInfoStateBefore ==
+               sycl::info::event_command_status::complete) {
       // Submission has succeeded
       SuccessfulSubmissions++;
+      PreEvent = Event;
+    } else {
+      // We cannot be sure of the state of the previous task when the current
+      // submission occurred because `PreEventInfoStateBefore` and
+      // `PreEventInfoStateAfter` indicate different status We therefore only
+      // read the submission status and increment the number of successful
+      // submissions if the submission was successful
+      if (ErrorCode == sycl::errc::success) {
+        SuccessfulSubmissions++;
+        PreEvent = Event;
+      }
     }
-    PreEventInfo =
-        Event.get_info<sycl::info::event::command_execution_status>();
   }
   Queue.wait_and_throw();
 
@@ -91,6 +116,7 @@ int main() {
   // Compute the reference based on the total number of successful executions
   calculate_reference_data(NumIterations + SuccessfulSubmissions, LargeSize,
                            ReferenceA, ReferenceB, ReferenceC);
+
   assert(ReferenceA == DataA);
   assert(ReferenceB == DataB);
   assert(ReferenceC == DataC);

--- a/sycl/test-e2e/Graph/submission_while_executing.cpp
+++ b/sycl/test-e2e/Graph/submission_while_executing.cpp
@@ -59,15 +59,13 @@ int main() {
   }
 
   // Concurrent Submissions
-  sycl::event Event;
-  sycl::event PreEvent;
+  sycl::event PreEvent, Event;
   sycl::info::event_command_status PreEventInfoStateBefore =
       sycl::info::event_command_status::ext_oneapi_unknown;
   sycl::info::event_command_status PreEventInfoStateAfter =
       sycl::info::event_command_status::ext_oneapi_unknown;
-  std::error_code ErrorCode;
   for (unsigned i = 0; i < NumIterations; ++i) {
-    ErrorCode = make_error_code(sycl::errc::success);
+    std::error_code ErrorCode = make_error_code(sycl::errc::success);
     PreEventInfoStateBefore =
         PreEvent.get_info<sycl::info::event::command_execution_status>();
 


### PR DESCRIPTION
The test behaviour was indeterministic.
This PR improves the test to make it deterministic. 
The data size has also been reduced to avoid risk of an "out of memory" exception.

Addresses Issue: #11277
https://github.com/intel/llvm/issues/11277