### PR TITLE
[SYCL][E2E] Disable Annotated_arg_ptr tests on Win

### DIFF
--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -1,6 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// https://github.com/intel/llvm/issues/11224
+// UNSUPPORTED: windows
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
@@ -1,6 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// https://github.com/intel/llvm/issues/11224
+// UNSUPPORTED: windows
 
 #include "common.hpp"
 


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/11224. It seems that whenever those fail (flakily), the entire run time outs and other (hanging) tests aren't killed properly and remain as zombie processes affecting subsequent CI runs. Disable those tests for now.