### PR TITLE
[SYCL] Re-allow auto& parameter in range parallel_for

### DIFF
--- a/sycl/test/basic_tests/handler/parallel_for_arg_restrictions.cpp
+++ b/sycl/test/basic_tests/handler/parallel_for_arg_restrictions.cpp
@@ -71,6 +71,18 @@ int main() {
     CGH.parallel_for(sycl::nd_range{sycl::range{1, 1, 1}, sycl::range{1, 1, 1}},
                      [=](ConvertibleFromItem<3>) {});
   });
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error@sycl/handler.hpp:* {{Kernel should be invocable with a sycl::item}}
+    CGH.parallel_for(sycl::range{1}, [=](auto &) {});
+  });
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error@sycl/handler.hpp:* {{Kernel should be invocable with a sycl::item}}
+    CGH.parallel_for(sycl::range{1, 1}, [=](auto &) {});
+  });
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error@sycl/handler.hpp:* {{Kernel should be invocable with a sycl::item}}
+    CGH.parallel_for(sycl::range{1, 1, 1}, [=](auto &) {});
+  });
 #endif // SYCL2020_CONFORMANT_APIS
 
   // Range parallel_for with nd_item.

--- a/sycl/test/basic_tests/handler/parallel_for_arg_restrictions.cpp
+++ b/sycl/test/basic_tests/handler/parallel_for_arg_restrictions.cpp
@@ -84,6 +84,15 @@ int main() {
     CGH.parallel_for(sycl::range{1, 1, 1}, [=](auto &) {});
   });
 #endif // SYCL2020_CONFORMANT_APIS
+  Q.submit([&](sycl::handler &CGH) {
+    CGH.parallel_for(sycl::range{1}, [=](auto &) {});
+  });
+  Q.submit([&](sycl::handler &CGH) {
+    CGH.parallel_for(sycl::range{1, 1}, [=](auto &) {});
+  });
+  Q.submit([&](sycl::handler &CGH) {
+    CGH.parallel_for(sycl::range{1, 1, 1}, [=](auto &) {});
+  });
 
   // Range parallel_for with nd_item.
   Q.submit([&](sycl::handler &CGH) {


### PR DESCRIPTION
Before #10864, our header implementation allowed kernels with an auto& parameter, e.g. `q.parallel_for(1, [=](auto &id) {})` , but strictly speaking, this would not follow the criteria in [4.9.4.2.2. parallel_for invoke](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_parallel_for_invoke). After that PR, this behavior unintentionally became disallowed. This PR restores the old behavior while disallowing it under `-DSYCL2020_CONFORMANT_APIS`.