### PR TITLE
[SYCL-MLIR][cgeist] Add sub-group size metadata to kernels

### DIFF
--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1079,8 +1079,7 @@ LogicalResult ModuleTranslation::convertFunctionSignatures() {
     }
 
     // Convert sycl_explicit_simd attribute to metadata.
-    if (UnitAttr sgSize = dyn_cast_or_null<UnitAttr>(
-            function->getAttr("sycl_explicit_simd"))) {
+    if (isa<UnitAttr>(function->getAttr("sycl_explicit_simd"))) {
       llvmFunc->setMetadata("sycl_explicit_simd",
                             llvm::MDNode::get(llvmModule->getContext(), {}));
     }

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1056,6 +1056,35 @@ LogicalResult ModuleTranslation::convertFunctionSignatures() {
                             llvm::MDNode::get(ctx, AttrMDArgs));
     }
 
+    // Convert intel_reqd_sub_group_size attribute to metadata.
+    if (Attribute sgSize = function->getAttr("intel_reqd_sub_group_size")) {
+      TypeSwitch<Attribute>(sgSize).Case<IntegerAttr, StringAttr>(
+          [&](auto sgSize) {
+            llvm::LLVMContext &ctx = llvmModule->getContext();
+            llvmFunc->setMetadata(
+                "intel_reqd_sub_group_size",
+                llvm::MDNode::get(
+                    ctx,
+                    {TypeSwitch<Attribute, llvm::Metadata *>(sgSize)
+                         .template Case<IntegerAttr>([&](auto intAttr) {
+                           llvm::IntegerType *i32Ty =
+                               llvm::IntegerType::get(ctx, 32);
+                           return llvm::ConstantAsMetadata::get(
+                               llvm::ConstantInt::get(i32Ty, intAttr.getInt()));
+                         })
+                         .template Case<StringAttr>([&](auto strAttr) {
+                           return llvm::MDString::get(ctx, strAttr.getValue());
+                         })}));
+          });
+    }
+
+    // Convert sycl_explicit_simd attribute to metadata.
+    if (UnitAttr sgSize = dyn_cast_or_null<UnitAttr>(
+            function->getAttr("sycl_explicit_simd"))) {
+      llvmFunc->setMetadata("sycl_explicit_simd",
+                            llvm::MDNode::get(llvmModule->getContext(), {}));
+    }
+
     // Convert result attributes.
     if (ArrayAttr allResultAttrs = function.getAllResultAttrs()) {
       DictionaryAttr resultAttrs = cast<DictionaryAttr>(allResultAttrs[0]);

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1057,25 +1057,22 @@ LogicalResult ModuleTranslation::convertFunctionSignatures() {
     }
 
     // Convert intel_reqd_sub_group_size attribute to metadata.
-    if (Attribute sgSize = function->getAttr("intel_reqd_sub_group_size")) {
-      TypeSwitch<Attribute>(sgSize).Case<IntegerAttr, StringAttr>(
-          [&](auto sgSize) {
-            llvm::LLVMContext &ctx = llvmModule->getContext();
-            llvmFunc->setMetadata(
-                "intel_reqd_sub_group_size",
-                llvm::MDNode::get(
-                    ctx,
-                    {TypeSwitch<Attribute, llvm::Metadata *>(sgSize)
-                         .template Case<IntegerAttr>([&](auto intAttr) {
-                           llvm::IntegerType *i32Ty =
-                               llvm::IntegerType::get(ctx, 32);
-                           return llvm::ConstantAsMetadata::get(
-                               llvm::ConstantInt::get(i32Ty, intAttr.getInt()));
-                         })
-                         .template Case<StringAttr>([&](auto strAttr) {
-                           return llvm::MDString::get(ctx, strAttr.getValue());
-                         })}));
-          });
+    if (Attribute sgSize = function->getAttr("intel_reqd_sub_group_size");
+        isa_and_nonnull<IntegerAttr, StringAttr>(sgSize)) {
+      llvm::LLVMContext &ctx = llvmModule->getContext();
+      llvmFunc->setMetadata(
+          "intel_reqd_sub_group_size",
+          llvm::MDNode::get(
+              ctx, {TypeSwitch<Attribute, llvm::Metadata *>(sgSize)
+                        .template Case<IntegerAttr>([&](auto intAttr) {
+                          llvm::IntegerType *i32Ty =
+                              llvm::IntegerType::get(ctx, 32);
+                          return llvm::ConstantAsMetadata::get(
+                              llvm::ConstantInt::get(i32Ty, intAttr.getInt()));
+                        })
+                        .template Case<StringAttr>([&](auto strAttr) {
+                          return llvm::MDString::get(ctx, strAttr.getValue());
+                        })}));
     }
 
     // Convert sycl_explicit_simd attribute to metadata.

--- a/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleTranslation.cpp
@@ -1079,7 +1079,7 @@ LogicalResult ModuleTranslation::convertFunctionSignatures() {
     }
 
     // Convert sycl_explicit_simd attribute to metadata.
-    if (isa<UnitAttr>(function->getAttr("sycl_explicit_simd"))) {
+    if (isa_and_nonnull<UnitAttr>(function->getAttr("sycl_explicit_simd"))) {
       llvmFunc->setMetadata("sycl_explicit_simd",
                             llvm::MDNode::get(llvmModule->getContext(), {}));
     }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/default_sub_group_size.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/default_sub_group_size.cpp
@@ -1,0 +1,20 @@
+// RUN: clang++  -fsycl -fsycl-device-only -O0 -w -S -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-NONE
+// RUN: clang++  -fsycl -fsycl-device-only -fsycl-default-sub-group-size=8 -O0 -w -S -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-8
+// RUN: clang++  -fsycl -fsycl-device-only -fsycl-default-sub-group-size=automatic -O0 -w -S -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO
+// RUN: clang++  -fsycl -fsycl-device-only -fsycl-default-sub-group-size=primary -O0 -w -S -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK,CHECK-PRIM
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  queue q;
+  q.submit([&](handler &h) { h.single_task<class kernel_name>([]() {}); });
+  return 0;
+}
+
+// CHECK: kernel_name
+// CHECK-NONE-NOT:    intel_reqd_sub_group_size
+// CHECK-8:           intel_reqd_sub_group_size = 8
+// CHECK-AUTO:        intel_reqd_sub_group_size = "automatic"
+// CHECK-PRIM:        intel_reqd_sub_group_size = "primary"

--- a/polygeist/tools/cgeist/Test/Verification/sycl/esimd_metadata.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/esimd_metadata.cpp
@@ -3,7 +3,7 @@
 
 // The test checks that:
 // 1. !sycl_explicit_simd metadata is generated for functions
-// 2. !intel_reqd_sub_group_size !1 is added to explicit SIMD
+// 2. !intel_reqd_sub_group_size 1 is added to explicit SIMD
 //    kernel
 
 template <typename name, typename Func>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/esimd_metadata.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/esimd_metadata.cpp
@@ -1,0 +1,35 @@
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -emit-mlir %s -o - | FileCheck %s --check-prefixes=CHECK
+// RUN: clang++ -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefixes=CHECK-LLVM
+
+// The test checks that:
+// 1. !sycl_explicit_simd metadata is generated for functions
+// 2. !intel_reqd_sub_group_size !1 is added to explicit SIMD
+//    kernel
+
+template <typename name, typename Func>
+void kernel(const Func &f) __attribute__((sycl_kernel)) {
+  f();
+}
+
+void bar() {
+  kernel<class MyKernel>([=]() __attribute__((sycl_explicit_simd)){});
+  // CHECK-LABEL: @_ZTSZ3barvE8MyKernel()
+  // CHECK-SAME:                          intel_reqd_sub_group_size = 1 : i32
+  // CHECK-SAME:                          sycl_explicit_simd
+
+  // CHECK-LLVM: @_ZTSZ3barvE8MyKernel()
+  // CHECK-LLVM-SAME:                     !intel_reqd_sub_group_size ![[REQD_SIZE:[0-9]+]]
+  // CHECK-LLVM-SAME:                     !sycl_explicit_simd ![[EMPTY:[0-9]+]]
+
+  kernel<class MyEsimdKernel>([=]() [[intel::sycl_explicit_simd]]{});
+  // CHECK-LABEL: @_ZTSZ3barvE13MyEsimdKernel()
+  // CHECK-SAME:                          intel_reqd_sub_group_size = 1 : i32
+  // CHECK-SAME:                          sycl_explicit_simd
+
+  // CHECK-LLVM: @_ZTSZ3barvE13MyEsimdKernel()
+  // CHECK-LLVM-SAME:                     !intel_reqd_sub_group_size ![[REQD_SIZE:[0-9]+]]
+  // CHECK-LLVM-SAME:                     !sycl_explicit_simd ![[EMPTY:[0-9]+]]
+}
+
+// CHECK-LLVM: ![[REQD_SIZE]] = !{i32 1}
+// CHECK-LLVM: ![[EMPTY]] = !{}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/named_sub_group_size.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/named_sub_group_size.cpp
@@ -1,0 +1,40 @@
+// RUN: clang++  -fsycl -fsycl-device-only -O0 -w -S -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++  -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+class FunctorAuto {
+public:
+  [[intel::named_sub_group_size(automatic)]] void operator()() const {}
+};
+
+class FunctorPrim {
+public:
+  [[intel::named_sub_group_size(primary)]] void operator()() const {}
+};
+
+int main() {
+  queue q;
+  q.submit([&](handler &h) {
+    FunctorAuto fauto;
+    h.single_task<class kernel_name1>(fauto);
+
+    FunctorPrim fprim;
+    h.single_task<class kernel_name2>(fprim);
+  });
+  return 0;
+}
+
+// CHECK-MLIR: kernel_name1
+// CHECK-MLIR-SAME:         intel_reqd_sub_group_size = "automatic"
+// CHECK-MLIR: kernel_name2
+// CHECK-MLIR-SAME:         intel_reqd_sub_group_size = "primary"
+
+// CHECK-LLVM: define {{.*}}kernel_name1()
+// CHECK-LLVM-SAME:                        !intel_reqd_sub_group_size ![[SGAUTO:[0-9]+]]
+// CHECK-LLVM: define {{.*}}kernel_name2()
+// CHECK-LLVM-SAME:                        !intel_reqd_sub_group_size ![[SGPRIM:[0-9]+]]
+// CHECK-LLVM: ![[SGAUTO]] = !{!"automatic"}
+// CHECK-LLVM: ![[SGPRIM]] = !{!"primary"}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/reqd_sub_group_size.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/reqd_sub_group_size.cpp
@@ -1,0 +1,49 @@
+// RUN: clang++  -fsycl -fsycl-device-only -O0 -w -S -emit-mlir %s -o - | FileCheck %s --check-prefix=CHECK-MLIR
+// RUN: clang++  -fsycl -fsycl-device-only -O0 -w -S -emit-llvm -fsycl-targets=spir64-unknown-unknown-syclmlir %s -o - | FileCheck %s --check-prefix=CHECK-LLVM
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+class Functor16 {
+public:
+  [[intel::reqd_sub_group_size(16)]] void operator()() const {}
+};
+
+template <int SIZE>
+class Functor2 {
+public:
+  [[intel::reqd_sub_group_size(SIZE)]] void operator()() const {}
+};
+
+int main() {
+  queue q;
+  q.submit([&](handler &h) {
+    Functor16 f16;
+    h.single_task<class kernel_name1>(f16);
+
+    h.single_task<class kernel_name2>(
+        []() [[intel::reqd_sub_group_size(4)]]{});
+
+    Functor2<2> f2;
+    h.single_task<class kernel_name3>(f2);
+  });
+  return 0;
+}
+
+// CHECK-MLIR: kernel_name1
+// CHECK-MLIR-SAME:         intel_reqd_sub_group_size = 16
+// CHECK-MLIR: kernel_name2
+// CHECK-MLIR-SAME:         intel_reqd_sub_group_size = 4
+// CHECK-MLIR: kernel_name3
+// CHECK-MLIR-SAME:         intel_reqd_sub_group_size = 2
+
+// CHECK-LLVM: define {{.*}}kernel_name1()
+// CHECK-LLVM-SAME:                        !intel_reqd_sub_group_size ![[SGSIZE16:[0-9]+]]
+// CHECK-LLVM: define {{.*}}kernel_name2()
+// CHECK-LLVM-SAME:                        !intel_reqd_sub_group_size ![[SGSIZE4:[0-9]+]]
+// CHECK-LLVM: define {{.*}}kernel_name3()
+// CHECK-LLVM-SAME:                        !intel_reqd_sub_group_size ![[SGSIZE2:[0-9]+]]
+// CHECK-LLVM: ![[SGSIZE16]] = !{i32 16}
+// CHECK-LLVM: ![[SGSIZE4]] = !{i32 4}
+// CHECK-LLVM: ![[SGSIZE2]] = !{i32 2}


### PR DESCRIPTION
Add sub-group size metadata following these rules:

- Follow SYCL 2020 rules, i.e., no propagation of these attributes when functions are called from a kernel;
- Use `reqd_sub_group_size()` value if available, this can be numeric or a named value `("automatic"` or `"primary"`);
- Get `fsycl-default-sub-group-size` value if available;
- For `sycl_explicit_simd` kernels, set `intel_reqd_sub_group_size` to `1`.