### PR TITLE
[SYCL] Include <complex>/<cmath> from sycl.hpp, unless SYCL2020_CONFORMANT_APIS

### DIFF
--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -91,3 +91,9 @@
 #include <sycl/ext/oneapi/sub_group.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 #include <sycl/ext/oneapi/weak_object.hpp>
+
+#ifndef SYCL2020_CONFORMANT_APIS
+// We used to include those and some code might be reliant on that.
+#include <cmath>
+#include <complex>
+#endif

--- a/sycl/test/basic_tests/no_math_in_global_ns.cpp
+++ b/sycl/test/basic_tests/no_math_in_global_ns.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=warning,note
+// RUN: %clangxx -DSYCL2020_CONFORMANT_APIS=1 -fsycl -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=warning,note
 // expected-no-diagnostics
 
 // MSVC has the following includes:


### PR DESCRIPTION
https://github.com/intel/llvm/pull/11274 and
https://github.com/intel/llvm/pull/11196 could break customers code that relied on implicit inclusion of those headers. Don't break it before the next ABI breaking window.