### PR TITLE
[SYCL][Doc] Add kernel compiler extension spec

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -1,0 +1,474 @@
+= sycl_ext_oneapi_kernel_compiler
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+:dpcpp: pass:[DPC++]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== Notice
+
+[%hardbreaks]
+Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.
+OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
+
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+
+== Dependencies
+
+This extension is written against the SYCL 2020 revision 7 specification.
+All references below to the "core SYCL specification" or to section numbers in
+the SYCL specification refer to that revision.
+
+This extension also depends on the following other SYCL extensions:
+
+* link:../experimental/sycl_ext_oneapi_properties.asciidoc[
+  sycl_ext_oneapi_properties]
+
+
+== Status
+
+This is a proposed extension specification, intended to gather community
+feedback.
+Interfaces defined in this specification may not be implemented yet or may be
+in a preliminary state.
+The specification itself may also change in incompatible ways before it is
+finalized.
+*Shipping software products should not rely on APIs defined in this
+specification.*
+
+
+== Overview
+
+This extension adds APIs that allow the application to dynamically generate the
+source code for a kernel, which it can then compile and enqueue to a device.
+The APIs allow a kernel to be written in any of several possible languages,
+where support for each of these languages is defined by a separate extension.
+As a result, this extension provides a framework of APIs for online compilation
+of kernels, but it does not define the details for any specific kernel language.
+These details are provided by other extensions.
+
+The new APIs added by this extension are an expansion of the existing
+`kernel_bundle` capabilities.
+Thus, an application can create a kernel bundle from a source string and then
+build the bundle into "executable" bundle state.
+Once the application obtains a `kernel` object, it can use existing APIs from
+the core SYCL specification to set the value of kernel arguments and enqueue
+the kernel to a device.
+
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.
+An implementation supporting this extension must predefine the macro
+`SYCL_EXT_ONEAPI_KERNEL_COMPILER`
+to one of the values defined in the table below.
+Applications can test for the existence of this macro to determine if
+the implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's features the implementation
+supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|The APIs of this experimental extension are not versioned, so the
+ feature-test macro always has this value.
+|===
+
+=== New kernel bundle state
+
+This extension adds the `ext_oneapi_source` enumerator to `sycl::bundle_state`
+to identify a kernel bundle that is represented as a source code string.
+
+```
+namespace sycl {
+
+enum class bundle_state : /*unspecified*/ {
+  // ...
+  ext_oneapi_source
+};
+
+} // namespace sycl
+```
+
+=== New enumerator of kernel source languages
+
+This extension adds the `source_language` enumeration, which identifies
+possible languages for a kernel bundle that is in `ext_oneapi_source` state:
+
+```
+namespace sycl::ext::oneapi::experimental {
+
+enum class source_language : /*unspecified*/ {
+  // see below
+};
+
+} // namespace sycl::ext::oneapi::experimental
+```
+
+However, there are no enumerators defined by this extension.
+Instead, this enumeration is an extension point for other extensions, which can
+specify the exact semantics of each possible kernel language.
+
+=== New free functions to create and build kernel bundles
+
+This extension adds the following new free functions to create and build a
+kernel bundle in `ext_oneapi_source` state.
+
+|====
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+namespace sycl::ext::oneapi::experimental {
+
+kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
+  const context& ctxt,
+  source_language lang,
+  const std::string& source)
+
+} // namespace sycl::ext::oneapi::experimental {
+----
+!====
+
+_Effects:_ Creates a new kernel bundle that represents a kernel that is defined
+by the source code string `source` using the language `lang`.
+The bundle is associated with the context `ctxt`, and kernels from this bundle
+may only be submitted to a queue that shares the same context.
+
+_Returns:_ The newly created kernel bundle, which has `ext_oneapi_source`
+state.
+
+_Throws:_
+
+* An `exception` with the `errc::invalid` error code if the source language
+  `lang` is not supported by the backend associated with `ctxt`.
+
+_Remarks:_ Calling this function does not attempt to compile the source code.
+As a result, syntactic errors in the source code string are not diagnosed by
+this function.
+
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+namespace sycl::ext::oneapi::experimental {
+
+bool is_source_kernel_bundle_supported(backend be, source_language lang)
+
+} // namespace sycl::ext::oneapi::experimental {
+----
+!====
+
+_Returns:_ The value `true` only if the backend `be` supports kernel bundles
+written in the source language `lang`.
+
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+namespace sycl::ext::oneapi::experimental {
+
+template<typename PropertyListT = properties<>>                       (1)
+kernel_bundle<bundle_state::executable> build(
+  const kernel_bundle<bundle_state::ext_oneapi_source>& sourceBundle,
+  const std::vector<device> &devs,
+  PropertyListT props = {})
+
+template<typename PropertyListT = properties<>>                       (2)
+kernel_bundle<bundle_state::executable> build(
+  const kernel_bundle<bundle_state::ext_oneapi_source>& sourceBundle,
+  PropertyListT props = {})
+
+} // namespace sycl::ext::oneapi::experimental {
+----
+!====
+
+Overload (1):
+
+_Constraints:_ Available only when `PropertyListT` is an instance of
+`sycl::ext::oneapi::experimental::properties` which contains no properties
+other than those listed below in the section "New properties".
+
+_Effects:_ The source code from `sourceBundle` is translated into one or more
+device images of state `bundle_state::executable`, and a new kernel bundle is
+created to contain these device images.
+The new bundle represents all of the kernels in `sourceBundle` that are
+compatible with at least one of the devices in `devs`.
+Any remaining kernels (those that are not compatible with any of the devices in
+`devs`) are not represented in the new kernel bundle.
+
+The new bundle has the same associated context as `sourceBundle`, and the new
+bundle's set of associated devices is `devs` (with duplicate devices removed).
+
+_Returns:_ The newly created kernel bundle, which has `executable` state.
+
+_Throws:_
+
+* An `exception` with the `errc::invalid` error code if any of the devices in
+  `devs` is not contained by the context associated with `sourceBundle`.
+
+* An `exception` with the `errc::invalid` error code if `props` contains an
+  `options` property that specifies an invalid option.
+
+* An `exception` with the `errc::build` error code if the compilation or
+  linking operations fail.
+  In this case, the exception `what` string contains a description of the
+  error.
+  This string is intended for human consumption, and the format may not be
+  stable across implementations of this extension.
+
+Overload (2):
+
+_Constraints:_ Same as overload (1).
+
+_Effects:_ Equivalent to `build(sourceBundle, ctxt.get_devices(), props)`.
+|====
+
+=== New properties
+
+This extension adds the following properties, which can be used in conjunction
+with the `build` function that is defined above:
+
+|====
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+namespace sycl::ext::oneapi::experimental {
+
+struct build_options {
+  std::vector<std::string> opts;
+  build_options(const std::string &name);               (1)
+  build_options(const std::vector<std::string> &opts);  (2)
+};
+using build_options_key = build_options;
+
+template<>
+struct is_property_key<build_options_key> : std::true_type {};
+
+} // namespace sycl::ext::oneapi::experimental {
+----
+!====
+
+This property provides build options that may affect the compilation or linking
+of the kernel, where each build option is a string.
+There are no standard build options that are common across all source
+languages.
+Instead, each source language specification defines its own set of build
+options.
+
+_Effects (1):_ Constructs a `build_options` property with a single build
+option.
+
+_Effects (2):_ Constructs a `build_options` property from a vector of build
+options.
+
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+namespace sycl::ext::oneapi::experimental {
+
+struct build_log {
+  std::string *log;
+  build_log(std::string *log);  (1)
+};
+using build_log_key = build_log;
+
+template<>
+struct is_property_key<build_log_key> : std::true_type {};
+
+} // namespace sycl::ext::oneapi::experimental {
+----
+!====
+
+This property allows the caller to request a log to be created with additional
+information about the compilation and linking operations.
+Use of this property is not required in order to get information about a failed
+build.
+When a build fails, an `exception` is thrown and the exception's `what` string
+provides a description of the error.
+
+Instead, the `log` property provides information about a build operation that
+succeeds.
+This might include warning messages or other diagnostics.i
+Each source language specification can define specific information that is
+provided in the log.
+In general, the log information is intended for human consumption, and the
+format may not be stable across implementations of this extension.
+
+_Effects (1):_ Constructs a `log` property with a pointer to a `std::string`.
+When the `build` function completes successfully, this string will contain the
+log.
+
+|====
+
+=== New constraint for kernel bundle member functions
+
+This extension adds the following constraint to some of the `kernel_bundle`
+member functions from the core SYCL specification:
+
+> _Constraints:_ This function is not available when `State` is
+> `bundle_state::ext_oneapi_source`.
+
+This new constraint applies to the following member functions:
+
+* `empty`;
+* `get_devices`;
+* All overloads and function templates of `has_kernel`;
+* `get_kernel_ids`;
+* `contains_specialization_constants`;
+* `native_specialization_constant`;
+* `has_specialization_constant`;
+* `get_specialization_constant`;
+* `begin`; and
+* `end`.
+
+As a result, the only `kernel_bundle` member functions from the core SYCL
+specification that are available for bundles in `ext_oneapi_source` state are
+`get_backend` and `get_context`.
+
+=== New kernel bundle member functions
+
+This extensions adds the following new `kernel_bundle` member functions:
+
+```
+namespace sycl {
+
+template <bundle_state State>
+class kernel_bundle {
+  // ...
+
+  // Available only if bundle_state is not bundle_state::ext_oneapi_source
+  bool ext_oneapi_has_kernel(const std::string &name);
+
+  // Available only if bundle_state is bundle_state::executable
+  kernel ext_oneapi_get_kernel(const std::string &name);
+};
+
+} // namespace sycl
+```
+
+|====
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+bool ext_oneapi_has_kernel(const std::string &name)
+----
+!====
+
+_Constraint:_ This function is not available when `State` is
+`bundle_state::ext_oneapi_source`.
+
+_Returns:_ The value `true` only if the kernel bundle was created from a bundle
+of state `bundle_state::ext_oneapi_source` and if it defines a kernel whose
+name is `name`.
+The extension specification for each source language tells how the `name`
+string is correlated to kernels defined in that source language.
+
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+kernel ext_oneapi_get_kernel(const std::string &name)
+----
+!====
+
+_Constraint:_ This function is available only when `State` is
+`bundle_state::executable`.
+
+_Returns:_ A `kernel` object representing the kernel in this bundle whose name
+is `name`.
+
+_Throws:_
+
+* An `exception` with the `errc::invalid` error code if
+  `ext_oneapi_has_kernel(name)` returns `false`.
+|====
+
+
+== Example
+
+The following example demonstrates how a SYCL application can define a kernel
+as a string and then compile and launch it.
+
+```
+#include <sycl/sycl.hpp>
+namespace syclex = sycl::ext::oneapi::experimental;
+
+int main() {
+  sycl::queue q;
+
+  // The source code for one or more kernels, defined in one of
+  // the supported source languages.
+  std::string source = R"""(
+    /* language specific kernel source code */
+  )""";
+
+  // Create a kernel bundle in "source" state.  The "some-language" is
+  // a stand-in for the enumerator telling which source language is used.
+  sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source> kb_src =
+    syclex::create_kernel_bundle_from_source(
+      q.get_context(),
+      syclex::source_language::/*some-language*/,
+      source);
+
+  sycl::kernel_bundle<sycl::bundle_state::executable> kb_exe =
+    syclex::build(kb_src);
+
+  // Get the kernel via its name.  The "kernel-name" is a stand-in for the
+  // actual kernel name in the source string.
+  sycl::kernel k = kb_exe.ext_oneapi_get_kernel("kernel-name");
+
+  q.submit([&](sycl::handler &cgh) {
+    // Any arguments for the kernel must be set manually.
+    cgh.set_args(/*...*/);
+
+    // Launch the kernel according to its type.
+    // This assumes a simple "range" kernel.
+    cgh.parallel_for(sycl::range{1024}, k);
+  });
+}
+```

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -163,6 +163,8 @@ _Effects:_ Creates a new kernel bundle that represents a kernel that is defined
 by the source code string `source` using the language `lang`.
 The bundle is associated with the context `ctxt`, and kernels from this bundle
 may only be submitted to a queue that shares the same context.
+The bundle's set of associated devices is the set of devices contained in
+`ctxt`.
 
 _Returns:_ The newly created kernel bundle, which has `ext_oneapi_source`
 state.
@@ -351,7 +353,6 @@ member functions from the core SYCL specification:
 This new constraint applies to the following member functions:
 
 * `empty`;
-* `get_devices`;
 * All overloads and function templates of `has_kernel`;
 * `get_kernel_ids`;
 * `contains_specialization_constants`;
@@ -363,7 +364,7 @@ This new constraint applies to the following member functions:
 
 As a result, the only `kernel_bundle` member functions from the core SYCL
 specification that are available for bundles in `ext_oneapi_source` state are
-`get_backend` and `get_context`.
+`get_backend`, `get_context`, and `get_devices`.
 
 === Interaction with existing kernel bundle member functions
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -328,7 +328,7 @@ provides a description of the error.
 
 Instead, the `log` property provides information about a build operation that
 succeeds.
-This might include warning messages or other diagnostics.i
+This might include warning messages or other diagnostics.
 Each source language specification can define specific information that is
 provided in the log.
 In general, the log information is intended for human consumption, and the
@@ -365,6 +365,14 @@ As a result, the only `kernel_bundle` member functions from the core SYCL
 specification that are available for bundles in `ext_oneapi_source` state are
 `get_backend` and `get_context`.
 
+=== Interaction with existing kernel bundle member functions
+
+Kernels created from online compilation of source code do not have any
+associated `kernel_id`.
+Therefore, the function `kernel_bundle::get_kernel_ids` returns an empty vector
+of `kernel_id` objects if the kernel bundle was created from a bundle of state
+`bundle_state::ext_oneapi_source`.
+
 === New kernel bundle member functions
 
 This extensions adds the following new `kernel_bundle` member functions:
@@ -397,7 +405,7 @@ bool ext_oneapi_has_kernel(const std::string &name)
 ----
 !====
 
-_Constraint:_ This function is not available when `State` is
+_Constraints:_ This function is not available when `State` is
 `bundle_state::ext_oneapi_source`.
 
 _Returns:_ The value `true` only if the kernel bundle was created from a bundle
@@ -416,7 +424,7 @@ kernel ext_oneapi_get_kernel(const std::string &name)
 ----
 !====
 
-_Constraint:_ This function is available only when `State` is
+_Constraints:_ This function is available only when `State` is
 `bundle_state::executable`.
 
 _Returns:_ A `kernel` object representing the kernel in this bundle whose name

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -373,6 +373,24 @@ Therefore, the function `kernel_bundle::get_kernel_ids` returns an empty vector
 of `kernel_id` objects if the kernel bundle was created from a bundle of state
 `bundle_state::ext_oneapi_source`.
 
+Depending on the source language, the following kernel bundle functions may be
+used to query for a kernel when the kernel bundle was created from a bundle of
+state `bundle_state::ext_oneapi_source`.
+
+```
+template <typename KernelName>
+bool has_kernel() const noexcept;
+
+template <typename KernelName>
+bool has_kernel(const device& dev) const noexcept;
+
+template <typename KernelName>
+kernel get_kernel() const;
+```
+
+The specification for each source language tells how these functions behave and
+how the `KernelName` is interpreted.
+
 === New kernel bundle member functions
 
 This extensions adds the following new `kernel_bundle` member functions:

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -266,10 +266,19 @@ _Throws:_
 
 * An `exception` with the `errc::build` error code if the compilation or
   linking operations fail.
-  In this case, the exception `what` string contains a description of the
-  error.
+  In this case, the exception `what` string provides a full build log,
+  including descriptions of any errors, warning messages, and other
+  diagnostics.
   This string is intended for human consumption, and the format may not be
   stable across implementations of this extension.
+
+[NOTE]
+====
+An uncaught `errc::build` exception may result in some or all of the source
+code used to create the kernel bundle being printed to the terminal.
+In situations where this is undesirable, developers must ensure that the
+exception is caught and handled appropriately.
+====
 
 Overload (2):
 
@@ -327,14 +336,14 @@ a!
 ----
 namespace sycl::ext::oneapi::experimental {
 
-struct build_log {
+struct save_log {
   std::string *log;
-  build_log(std::string *log);  (1)
+  save_log(std::string *to);  (1)
 };
-using build_log_key = build_log;
+using save_log_key = save_log;
 
 template<>
-struct is_property_key<build_log_key> : std::true_type {};
+struct is_property_key<save_log_key> : std::true_type {};
 
 } // namespace sycl::ext::oneapi::experimental {
 ----
@@ -347,7 +356,7 @@ build.
 When a build fails, an `exception` is thrown and the exception's `what` string
 provides a description of the error.
 
-Instead, the `build_log` property provides information about a build operation
+Instead, the `save_log` property provides information about a build operation
 that succeeds.
 This might include warning messages or other diagnostics.
 Each source language specification can define specific information that is
@@ -355,7 +364,7 @@ provided in the log.
 In general, the log information is intended for human consumption, and the
 format may not be stable across implementations of this extension.
 
-_Effects (1):_ Constructs a `build_log` property with a pointer to a
+_Effects (1):_ Constructs a `save_log` property with a pointer to a
 `std::string`.
 When the `build` function completes successfully, this string will contain the
 log.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -155,7 +155,7 @@ kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
   source_language lang,
   const std::string& source)
 
-} // namespace sycl::ext::oneapi::experimental {
+} // namespace sycl::ext::oneapi::experimental
 ----
 !====
 
@@ -328,15 +328,16 @@ build.
 When a build fails, an `exception` is thrown and the exception's `what` string
 provides a description of the error.
 
-Instead, the `build_log` property provides information about a build operation that
-succeeds.
+Instead, the `build_log` property provides information about a build operation
+that succeeds.
 This might include warning messages or other diagnostics.
 Each source language specification can define specific information that is
 provided in the log.
 In general, the log information is intended for human consumption, and the
 format may not be stable across implementations of this extension.
 
-_Effects (1):_ Constructs a `build_log` property with a pointer to a `std::string`.
+_Effects (1):_ Constructs a `build_log` property with a pointer to a
+`std::string`.
 When the `build` function completes successfully, this string will contain the
 log.
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -328,7 +328,7 @@ build.
 When a build fails, an `exception` is thrown and the exception's `what` string
 provides a description of the error.
 
-Instead, the `log` property provides information about a build operation that
+Instead, the `build_log` property provides information about a build operation that
 succeeds.
 This might include warning messages or other diagnostics.
 Each source language specification can define specific information that is
@@ -336,7 +336,7 @@ provided in the log.
 In general, the log information is intended for human consumption, and the
 format may not be stable across implementations of this extension.
 
-_Effects (1):_ Constructs a `log` property with a pointer to a `std::string`.
+_Effects (1):_ Constructs a `build_log` property with a pointer to a `std::string`.
 When the `build` function completes successfully, this string will contain the
 log.
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -275,7 +275,7 @@ namespace sycl::ext::oneapi::experimental {
 
 struct build_options {
   std::vector<std::string> opts;
-  build_options(const std::string &name);               (1)
+  build_options(const std::string &opt);               (1)
   build_options(const std::vector<std::string> &opts);  (2)
 };
 using build_options_key = build_options;

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -136,6 +136,29 @@ However, there are no enumerators defined by this extension.
 Instead, this enumeration is an extension point for other extensions, which can
 specify the exact semantics of each possible kernel language.
 
+=== New member functions for the device class
+
+This extension adds the following new member functions to the `device` class:
+
+|====
+a|
+[frame=all,grid=none]
+!====
+a!
+[source]
+----
+class device {
+
+bool ext_oneapi_can_compile(ext::oneapi::experimental::source_language lang);
+
+};
+----
+!====
+
+_Returns:_ The value `true` only if the device supports kernel bundles written
+in the source language `lang`.
+|====
+
 === New free functions to create and build kernel bundles
 
 This extension adds the following new free functions to create and build a
@@ -172,28 +195,20 @@ state.
 _Throws:_
 
 * An `exception` with the `errc::invalid` error code if the source language
-  `lang` is not supported by the backend associated with `ctxt`.
+  `lang` is not supported by any device contained by the context `ctxt`.
 
-_Remarks:_ Calling this function does not attempt to compile the source code.
+[NOTE]
+====
+Calling this function does not attempt to compile the source code.
 As a result, syntactic errors in the source code string are not diagnosed by
 this function.
 
-a|
-[frame=all,grid=none]
-!====
-a!
-[source]
-----
-namespace sycl::ext::oneapi::experimental {
-
-bool is_source_kernel_bundle_supported(backend be, source_language lang)
-
-} // namespace sycl::ext::oneapi::experimental {
-----
-!====
-
-_Returns:_ The value `true` only if the backend `be` supports kernel bundles
-written in the source language `lang`.
+This function succeeds even if some devices in `ctxt` do not support the source
+language `lang`.
+However, the `build` function fails unless _all_ of its devices support `lang`.
+Therefore, applications should take care to omit devices that do not support
+`lang` when calling `build`.
+====
 
 a|
 [frame=all,grid=none]
@@ -241,6 +256,10 @@ _Throws:_
 
 * An `exception` with the `errc::invalid` error code if any of the devices in
   `devs` is not contained by the context associated with `sourceBundle`.
+
+* An `exception` with the `errc::invalid` error code if any of the devices in
+  `devs` does not support compilation of kernels in the source language of
+  `sourceBundle`.
 
 * An `exception` with the `errc::invalid` error code if `props` contains an
   `options` property that specifies an invalid option.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -228,7 +228,7 @@ kernel_bundle<bundle_state::executable> build(
   const kernel_bundle<bundle_state::ext_oneapi_source>& sourceBundle,
   PropertyListT props = {})
 
-} // namespace sycl::ext::oneapi::experimental {
+} // namespace sycl::ext::oneapi::experimental
 ----
 !====
 
@@ -300,7 +300,7 @@ namespace sycl::ext::oneapi::experimental {
 
 struct build_options {
   std::vector<std::string> opts;
-  build_options(const std::string &opt);               (1)
+  build_options(const std::string &opt);                (1)
   build_options(const std::vector<std::string> &opts);  (2)
 };
 using build_options_key = build_options;
@@ -308,7 +308,7 @@ using build_options_key = build_options;
 template<>
 struct is_property_key<build_options_key> : std::true_type {};
 
-} // namespace sycl::ext::oneapi::experimental {
+} // namespace sycl::ext::oneapi::experimental
 ----
 !====
 
@@ -335,14 +335,14 @@ namespace sycl::ext::oneapi::experimental {
 
 struct save_log {
   std::string *log;
-  save_log(std::string *to);  (1)
+  save_log(std::string *to);
 };
 using save_log_key = save_log;
 
 template<>
 struct is_property_key<save_log_key> : std::true_type {};
 
-} // namespace sycl::ext::oneapi::experimental {
+} // namespace sycl::ext::oneapi::experimental
 ----
 !====
 
@@ -361,8 +361,7 @@ provided in the log.
 In general, the log information is intended for human consumption, and the
 format may not be stable across implementations of this extension.
 
-_Effects (1):_ Constructs a `save_log` property with a pointer to a
-`std::string`.
+_Effects:_ Constructs a `save_log` property with a pointer to a `std::string`.
 When the `build` function completes successfully, this string will contain the
 log.
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -10,6 +10,7 @@
 :encoding: utf-8
 :lang: en
 :dpcpp: pass:[DPC++]
+:endnote: &#8212;{nbsp}end{nbsp}note
 
 // Set the default source code type in this document to C++,
 // for syntax highlighting purposes.  This is needed because
@@ -197,9 +198,7 @@ _Throws:_
 * An `exception` with the `errc::invalid` error code if the source language
   `lang` is not supported by any device contained by the context `ctxt`.
 
-[NOTE]
-====
-Calling this function does not attempt to compile the source code.
+[_Note:_ Calling this function does not attempt to compile the source code.
 As a result, syntactic errors in the source code string are not diagnosed by
 this function.
 
@@ -208,7 +207,7 @@ language `lang`.
 However, the `build` function fails unless _all_ of its devices support `lang`.
 Therefore, applications should take care to omit devices that do not support
 `lang` when calling `build`.
-====
+_{endnote}_]
 
 a|
 [frame=all,grid=none]
@@ -272,13 +271,11 @@ _Throws:_
   This string is intended for human consumption, and the format may not be
   stable across implementations of this extension.
 
-[NOTE]
-====
-An uncaught `errc::build` exception may result in some or all of the source
-code used to create the kernel bundle being printed to the terminal.
+[_Note:_ An uncaught `errc::build` exception may result in some or all of the
+source code used to create the kernel bundle being printed to the terminal.
 In situations where this is undesirable, developers must ensure that the
 exception is caught and handled appropriately.
-====
+_{endnote}_]
 
 Overload (2):
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
@@ -116,7 +116,7 @@ creating an OpenCL library.
 The kernel compiler can be used to create an OpenCL program, but not an OpenCL
 library.
 
-=== Obtaining a kernel from its name
+=== Obtaining a kernel
 
 OpenCL C kernel functions do not support {cpp} features like overloads or
 templates.
@@ -137,6 +137,10 @@ Then the application's host code can query for the kernel like so:
 sycl::kernel_bundle<sycl::bundle_state::executable> kb = /*...*/;
 sycl::kernel k = kb.ext_oneapi_get_kernel("foo");
 ```
+
+There is no mechanism to decorate an OpenCL C kernel with a type-name, so the
+forms of `kernel_bundle::has_kernel` or `kernel_bundle::get_kernel` that take a
+type-name are not useful for kernels defined in OpenCL C.
 
 
 == Example

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
@@ -1,0 +1,249 @@
+= sycl_ext_oneapi_kernel_compiler_opencl
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+:dpcpp: pass:[DPC++]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== Notice
+
+[%hardbreaks]
+Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.
+OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
+
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+
+== Dependencies
+
+This extension is written against the SYCL 2020 revision 7 specification.
+All references below to the "core SYCL specification" or to section numbers in
+the SYCL specification refer to that revision.
+
+This extension also depends on the following other SYCL extensions:
+
+* link:../proposed/sycl_ext_oneapi_kernel_compiler.asciidoc[
+  sycl_ext_oneapi_kernel_compiler]
+
+
+== Status
+
+This is a proposed extension specification, intended to gather community
+feedback.
+Interfaces defined in this specification may not be implemented yet or may be
+in a preliminary state.
+The specification itself may also change in incompatible ways before it is
+finalized.
+*Shipping software products should not rely on APIs defined in this
+specification.*
+
+
+== Overview
+
+This is an extension to
+link:../proposed/sycl_ext_oneapi_kernel_compiler.asciidoc[
+sycl_ext_oneapi_kernel_compiler], which allows an application to define a
+kernel in the OpenCL C language when dynamically compiling a kernel from
+source.
+
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.
+An implementation supporting this extension must predefine the macro
+`SYCL_EXT_ONEAPI_KERNEL_COMPILER_OPENCL`
+to one of the values defined in the table below.
+Applications can test for the existence of this macro to determine if the
+implementation supports this feature, or applications can test the macro's
+value to determine which of the extension's features the implementation
+supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|The APIs of this experimental extension are not versioned, so the
+ feature-test macro always has this value.
+|===
+
+=== New source language enumerator
+
+This extension adds the `opencl` enumerator to the `source_language`
+enumeration, which indicates that a kernel bundle defines kernels in the
+OpenCL C language.
+
+```
+namespace sycl::ext::oneapi::experimental {
+
+enum class source_language : /*unspecified*/ {
+  // ...
+  opencl
+};
+
+} // namespace sycl::ext::oneapi::experimental
+```
+
+=== Build options
+
+The `build_options` property accepts any of the compiler or linker options
+defined by the OpenCL specification, except for those that are specific to
+creating an OpenCL library.
+The kernel compiler can be used to create an OpenCL program, but not an OpenCL
+library.
+
+=== Obtaining a kernel from its name
+
+OpenCL C kernel functions do not support {cpp} features like overloads or
+templates.
+As a result, the function name itself uniquely identifies the kernel function.
+Therefore, the `ext_oneapi_has_kernel` and `ext_oneapi_get_kernel` member
+functions identify a kernel using the function name, exactly as it appears in
+the OpenCL C source code.
+For example, if the kernel is defined this way in OpenCL C:
+
+```
+__kernel
+void foo(__global int *in, __global int *out) {/*...*/}
+```
+
+Then the application's host code can query for the kernel like so:
+
+```
+sycl::kernel_bundle<sycl::bundle_state::executable> kb = /*...*/;
+sycl::kernel k = kb.ext_oneapi_get_kernel("foo");
+```
+
+
+== Example
+
+The following example shows a simple SYCL program that defines an OpenCL C
+kernel as a string and then compiles and launches it.
+
+```
+#include <sycl/sycl.hpp>
+namespace syclex = sycl::ext::oneapi::experimental;
+
+int main() {
+  sycl::queue q;
+
+  // Kernel defined as an OpenCL C string.  This could be dynamically
+  // generated instead of a literal.
+  std::string source = R"""(
+    __kernel void my_kernel(__global int *in, __global int *out) {
+      size_t i = get_global_id(0);
+      out[i] = in[i]*2 + 100;
+    }
+  )""";
+
+  sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source> kb_src =
+    syclex::create_kernel_bundle_from_source(
+      q.get_context(),
+      syclex::source_language::opencl,
+      source);
+
+  // Compile and link the kernel from the source definition.
+  sycl::kernel_bundle<sycl::bundle_state::executable> kb_exe =
+    syclex::build(kb_src);
+
+  // Get a "kernel" object representing the kernel defined in the
+  // source string.
+  sycl::kernel k = kb_exe.ext_oneapi_get_kernel("my_kernel");
+
+  constexpr int N = 4;
+  int input[N] = {0, 1, 2, 3};
+  int output[N] = {};
+
+  sycl::buffer inputbuf(input, sycl::range{N});
+  sycl::buffer outputbuf(output, sycl::range{N});
+
+  q.submit([&](sycl::handler &cgh) {
+    sycl::accessor in{inputbuf, cgh, sycl::read_only};
+    sycl::accessor out{outputbuf, cgh, sycl::read_write};
+
+    // Each argument to the kernel is a SYCL accessor.
+    cgh.set_args(in, out);
+
+    // Invoke the kernel over a range.
+    cgh.parallel_for(sycl::range{N}, k);
+  });
+}
+```
+
+
+== Issues
+
+* How should we expose the difference between OpenCL C versions?
+  It seems like there are two aspects to the problem.
+  Applications need some way to query which versions the backend (or device)
+  supports.
+  Applications also need some way to tell the runtime which version the kernel
+  is written in.
++
+--
+One option is to define separate enumerators in `source_language` for each
+version like this:
+
+```
+enum class source_language : /*unspecified*/ {
+  opencl_1_0,
+  opencl_1_1,
+  opencl_2_0,
+  opencl_3_0,
+};
+```
+
+Applications could then query the supported versions via
+`is_source_kernel_bundle_supported`, and applications would identify the
+version of their kernel string via the `lang` parameter to
+`create_kernel_bundle_from_source`.
+
+Alternatively, this extension could define just a single language enumerator
+(`opencl`), but also provide as separate query to get the supported OpenCL C
+versions.
+When building a kernel bundle, applications would be required to pass "-cl-std"
+via the `build_options` property in order to identify the OpenCL C version of
+their source string.
+--
+
+* How can an application determine the OpenCL C optional features that are
+  supported and the extensions that are supported?
+  One option is to require the application to use OpenCL APIs for these
+  queries.
+  This seems better than duplicating these queries into this extension.
+  However, this assumes the application is running with an OpenCL backend.
+  Do we want to support the use of OpenCL C kernels also with the Level Zero
+  backend?
+  Currently, the online_compiler does support this case (but it provides no way
+  to query about optional features or extensions).
+
+* There should be a more formal definition of the kernel arguments that can be
+  passed.
+  For example, can the application pass a `local_accessor` as an argument to an
+  OpenCL C kernel?
+  We should have a complete list of allowed arguments and describe how each is
+  passed from the SYCL host code.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
@@ -10,6 +10,7 @@
 :encoding: utf-8
 :lang: en
 :dpcpp: pass:[DPC++]
+:endnote: &#8212;{nbsp}end{nbsp}note
 
 // Set the default source code type in this document to C++,
 // for syntax highlighting purposes.  This is needed because
@@ -142,6 +143,48 @@ There is no mechanism to decorate an OpenCL C kernel with a type-name, so the
 forms of `kernel_bundle::has_kernel` or `kernel_bundle::get_kernel` that take a
 type-name are not useful for kernels defined in OpenCL C.
 
+=== Kernel argument restrictions
+
+When a kernel is defined in OpenCL C and invoked from SYCL via a `kernel`
+object, the arguments to the kernel are restricted to certain types.
+In general, the host application passes an argument value via
+`handler::set_arg` using one type and the kernel receives the argument value
+as a corresponding OpenCL C type.
+The following table lists the set of valid types for these kernel arguments:
+
+
+[%header,cols="1,1"]
+|===
+|Type in SYCL host code
+|Type in OpenCL C kernel
+
+|One of the OpenCL scalar types (e.g. `cl_int`, `cl_float`, etc.)
+|The corresponding OpenCL C type (e.g. `int`, `float`, etc.)
+
+|A USM pointer.
+|A `+__global+` pointer of the corresponding type.
+
+|A class (or struct) that is device copyable in SYCL whose elements are
+ composed of OpenCL scalar types or USM pointers.
+|A class (or struct) passed by value whose elements have the corresponding
+ OpenCL C types.
+
+|An `accessor` with `target::device` whose `DataT` is an OpenCL scalar type,
+ a USM pointer, or a device copyable class (or struct) whose elements are
+ composed of these types.
+|A `+__global+` pointer to the first element of the accessor's buffer.
+ The pointer has the corresponding OpenCL C type.
+
+[_Note:_ The accessor's size is not passed as a kernel argument, so the host
+code must pass a separate argument with the size if this is desired.
+_{endnote}_]
+
+|A `local_accessor` whose `DataT` is an OpenCL scalar type, a USM pointer, or a
+ device copyable class (or struct) whose elements are composed of these types.
+|A `+__local+` pointer to the first element of the accessor's local memory.
+ The pointer has the corresponding OpenCL C type.
+|===
+
 
 == Example
 
@@ -150,6 +193,7 @@ kernel as a string and then compiles and launches it.
 
 ```
 #include <sycl/sycl.hpp>
+#include <OpenCL/opencl.h>
 namespace syclex = sycl::ext::oneapi::experimental;
 
 int main() {
@@ -179,8 +223,8 @@ int main() {
   sycl::kernel k = kb_exe.ext_oneapi_get_kernel("my_kernel");
 
   constexpr int N = 4;
-  int input[N] = {0, 1, 2, 3};
-  int output[N] = {};
+  cl_int input[N] = {0, 1, 2, 3};
+  cl_int output[N] = {};
 
   sycl::buffer inputbuf(input, sycl::range{N});
   sycl::buffer outputbuf(output, sycl::range{N});
@@ -244,13 +288,6 @@ their source string.
   backend?
   Currently, the online_compiler does support this case (but it provides no way
   to query about optional features or extensions).
-
-* There should be a more formal definition of the kernel arguments that can be
-  passed.
-  For example, can the application pass a `local_accessor` as an argument to an
-  OpenCL C kernel?
-  We should have a complete list of allowed arguments and describe how each is
-  passed from the SYCL host code.
 
 * Do we need to document some restrictions on the OpenCL C
   https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#work-item-functions[

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
@@ -251,3 +251,20 @@ their source string.
   OpenCL C kernel?
   We should have a complete list of allowed arguments and describe how each is
   passed from the SYCL host code.
+
+* Do we need to document some restrictions on the OpenCL C
+  https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_C.html#work-item-functions[
+  work-item functions] that the kernel can call, which depends on how the
+  kernel was launched?
+  For example, can a kernel launched with the simple `range` form of
+  `parallel_for` call `get_local_size`?
+  In OpenCL, there is only one way to launch kernels
+  (`clEnqueueNDRangeKernel`), so it is always legal to call any of the
+  work-item functions.
+  If an OpenCL kernel is launched with a NULL `local_work_size` (which is
+  roughly equivalent to SYCL's `range` form of `parallel_for`), the
+  `get_local_size` function returns the local work-group size that is chosen by
+  the implementation.
+  Level Zero, similarly, has only one way to launch kernels.
+  Therefore, maybe it is OK to let kernels in this extension call any of the
+  work-item functions, regardless of how they are launched?


### PR DESCRIPTION
Add a proposed extension specification for the "kernel compiler", a replacement for the existing "online_compiler" extension.  There are two related extensions specifications:

* sycl_ext_oneapi_kernel_compiler: Defines the API framework for online compilation of kernels from a source string.  This framework allows for kernels to be written in different possible languages.

* sycl_ext_oneapi_kernel_compiler_opencl: Defines the support for online compiled kernels that are written in OpenCL C.