### PR TITLE
[SYCL][NATIVECPU] Fix for mismatching debug format between host and device 

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -185,6 +185,11 @@ public:
       return this->HostTC.isPICDefault();
     return false;
   }
+  llvm::codegenoptions::DebugInfoFormat getDefaultDebugFormat() const override {
+    if (this->IsSYCLNativeCPU)
+      return this->HostTC.getDefaultDebugFormat();
+    return ToolChain::getDefaultDebugFormat();
+  }
   bool isPIEDefault(const llvm::opt::ArgList &Args) const override {
     return false;
   }

--- a/clang/test/Driver/sycl-native-cpu.cpp
+++ b/clang/test/Driver/sycl-native-cpu.cpp
@@ -1,9 +1,18 @@
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=native_cpu %s -### 2>&1 | FileCheck %s
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=native_cpu -target aarch64-unknown-linux-gnu %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-AARCH64
 
-
 // checks that the host and device triple are the same, and that the sycl-native-cpu LLVM option is set
 // CHECK: clang{{.*}}"-triple" "[[TRIPLE:.*]]"{{.*}}"-aux-triple" "[[TRIPLE]]"{{.*}}"-fsycl-is-native-cpu"{{.*}}"-D" "__SYCL_NATIVE_CPU__"
 
 // checks that the target triples are set correctly when the target is set explicitly
 // CHECK-AARCH64: clang{{.*}}"-triple" "aarch64-unknown-linux-gnu"{{.*}}"-aux-triple" "aarch64-unknown-linux-gnu"{{.*}}"-fsycl-is-native-cpu"{{.*}}"-D" "__SYCL_NATIVE_CPU__"
+
+// RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=native_cpu -g %s 2>&1 | FileCheck -check-prefix=CHECK-LINUX %s
+// CHECK-LINUX: {{.*}}"-fsycl-is-device"{{.*}}"-dwarf-version=[[DVERSION:.*]]" "-debugger-tuning=gdb"
+// CHECK-LINUX-DAG: {{.*}}"-fsycl-is-host"{{.*}}"-dwarf-version=[[DVERSION]]" "-debugger-tuning=gdb"
+// CHECK-LINUX-NOT: codeview
+
+// RUN:   %clang -### -target x86_64-windows-msvc -fsycl -fsycl-targets=native_cpu -g %s 2>&1 | FileCheck -check-prefix=CHECK-WIN %s
+// CHECK-WIN: {{.*}}"-fsycl-is-device"{{.*}}"-gcodeview"
+// CHECK-WIN-DAG: {{.*}}"-fsycl-is-host"{{.*}}"-gcodeview"
+// CHECK-WIN-NOT: dwarf

--- a/clang/test/Driver/sycl-native-cpu.cpp
+++ b/clang/test/Driver/sycl-native-cpu.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=native_cpu %s -### 2>&1 | FileCheck %s
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=native_cpu -target aarch64-unknown-linux-gnu %s -### 2>&1 | FileCheck %s --check-prefix=CHECK-AARCH64
 
+
 // checks that the host and device triple are the same, and that the sycl-native-cpu LLVM option is set
 // CHECK: clang{{.*}}"-triple" "[[TRIPLE:.*]]"{{.*}}"-aux-triple" "[[TRIPLE]]"{{.*}}"-fsycl-is-native-cpu"{{.*}}"-D" "__SYCL_NATIVE_CPU__"
 


### PR DESCRIPTION
This PR fixes the SYCL toolchain to pass the debug format used for the host compilation to the device compilation.   
Without this patch mismatching debug formats could lead to corrupt debug information and link errors.