### PR TITLE
[SYCL][COMPAT] Updated devices to support memory queries. Extended definitions for windows.

### DIFF
--- a/sycl/include/syclcompat/kernel.hpp
+++ b/sycl/include/syclcompat/kernel.hpp
@@ -35,6 +35,25 @@
 #include <sycl/nd_range.hpp>
 #include <sycl/queue.hpp>
 
+#ifdef _WIN32
+#include <unordered_set>
+#include <windows.h>
+#else
+#include <dlfcn.h>
+#endif
+
+#if defined(__has_include) && __has_include(<filesystem>)
+#include <filesystem>
+#elif defined(__has_include) && __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+#else
+#error "SYCLomatic runtime requires C++ filesystem support"
+#endif
+
+#include <fstream>
+#include <image.hpp>
+#include <random>
+
 namespace syclcompat {
 
 typedef void (*kernel_functor)(sycl::queue &, const sycl::nd_range<3> &,
@@ -44,20 +63,406 @@ struct kernel_function_info {
   int max_work_group_size = 0;
 };
 
-static void get_kernel_function_info(kernel_function_info *kernel_info,
-                                     const void *function) {
+static inline void get_kernel_function_info(kernel_function_info *kernel_info,
+                                            const void *function) {
   kernel_info->max_work_group_size =
       detail::dev_mgr::instance()
           .current_device()
           .get_info<sycl::info::device::max_work_group_size>();
 }
-static kernel_function_info get_kernel_function_info(const void *function) {
+static inline kernel_function_info
+get_kernel_function_info(const void *function) {
   kernel_function_info kernel_info;
   kernel_info.max_work_group_size =
       detail::dev_mgr::instance()
           .current_device()
           .get_info<sycl::info::device::max_work_group_size>();
   return kernel_info;
+}
+
+namespace detail {
+
+#if defined(__has_include) && __has_include(<filesystem>)
+namespace fs = std::filesystem;
+#else
+namespace fs = std::experimental::filesystem;
+#endif
+
+/// Write data to temporary file and return absolute path to temporary file.
+/// Temporary file is created in a temporary directory both of which have random
+/// names with only the user having access permissions.  Only one temporary file
+/// will be created in the temporary directory.
+static inline fs::path write_data_to_file(char const *const data, size_t size) {
+  std::error_code ec;
+
+  if (sizeof(size_t) >= sizeof(std::streamsize) &&
+      size > (std::numeric_limits<std::streamsize>::max)())
+    throw std::runtime_error("[SYCLcompat] data file too large");
+
+  // random number generator
+  std::random_device dev;
+  std::mt19937 prng(dev());
+  std::uniform_int_distribution<uint64_t> rand(0);
+
+  // find temporary directory
+  auto tmp_dir = fs::temp_directory_path(ec);
+  if (ec)
+    throw std::runtime_error("[SYCLcompat] could not find temporary directory");
+
+  // create private directory
+  std::stringstream directory;
+  fs::path directory_path;
+  constexpr int max_attempts = 5;
+  int i;
+
+  for (i = 0; i < max_attempts; i++) {
+    directory << std::hex << rand(prng);
+    directory_path = tmp_dir / directory.str();
+    if (fs::create_directory(directory_path)) {
+      break;
+    }
+  }
+  if (i == max_attempts)
+    throw std::runtime_error("[SYCLcompat] could not create directory");
+
+  // only allow owner permissions to private directory
+  fs::permissions(directory_path, fs::perms::owner_all, ec);
+  if (ec)
+    throw std::runtime_error(
+        "[SYCLcompat] could not set directory permissions");
+
+  // random filename in private directory
+  std::stringstream filename;
+  filename << std::hex << rand(prng);
+#ifdef _WIN32
+  auto filepath = directory_path / (filename.str() + ".dll");
+#else
+  auto filepath = directory_path / filename.str();
+#endif
+
+  // write data to temporary file
+  auto outfile = std::ofstream(filepath, std::ios::out | std::ios::binary);
+  if (outfile) {
+    // only allow program to write file
+    fs::permissions(filepath, fs::perms::owner_write, ec);
+    if (ec)
+      throw std::runtime_error("[SYCLcompat] could not set permissions");
+
+    outfile.write(data, size);
+    if (!outfile.good())
+      throw std::runtime_error("[SYCLcompat] could not write data");
+    outfile.close();
+
+    // only allow program to read/execute file
+    fs::permissions(filepath, fs::perms::owner_read | fs::perms::owner_exec,
+                    ec);
+    if (ec)
+      throw std::runtime_error("[SYCLcompat] could not set permissions");
+  } else
+    throw std::runtime_error("[SYCLcompat] could not write data");
+
+  // check temporary file contents
+  auto infile = std::ifstream(filepath, std::ios::in | std::ios::binary);
+  if (infile) {
+    bool mismatch = false;
+    size_t cnt = 0;
+
+    while (1) {
+      char c;
+      infile.get(c);
+      if (infile.eof())
+        break;
+      if (c != data[cnt++])
+        mismatch = true;
+    }
+    if (cnt != size || mismatch)
+      throw std::runtime_error(
+          "[SYCLcompat] file contents not written correctly");
+  } else
+    throw std::runtime_error("[SYCLcompat] could not validate file");
+
+  if (!filepath.is_absolute())
+    throw std::runtime_error("[SYCLcompat] temporary filepath is not absolute");
+
+  return filepath;
+}
+
+static inline uint16_t extract16(unsigned char const *const ptr) {
+  uint16_t ret = 0;
+
+  ret |= static_cast<uint16_t>(ptr[0]) << 0;
+  ret |= static_cast<uint16_t>(ptr[1]) << 8;
+
+  return (ret);
+}
+
+static inline uint32_t extract32(unsigned char const *const ptr) {
+  uint32_t ret = 0;
+
+  ret |= static_cast<uint32_t>(ptr[0]) << 0;
+  ret |= static_cast<uint32_t>(ptr[1]) << 8;
+  ret |= static_cast<uint32_t>(ptr[2]) << 16;
+  ret |= static_cast<uint32_t>(ptr[3]) << 24;
+
+  return (ret);
+}
+
+static inline uint64_t extract64(unsigned char const *const ptr) {
+  uint64_t ret = 0;
+
+  ret |= static_cast<uint64_t>(ptr[0]) << 0;
+  ret |= static_cast<uint64_t>(ptr[1]) << 8;
+  ret |= static_cast<uint64_t>(ptr[2]) << 16;
+  ret |= static_cast<uint64_t>(ptr[3]) << 24;
+  ret |= static_cast<uint64_t>(ptr[4]) << 32;
+  ret |= static_cast<uint64_t>(ptr[5]) << 40;
+  ret |= static_cast<uint64_t>(ptr[6]) << 48;
+  ret |= static_cast<uint64_t>(ptr[7]) << 56;
+
+  return (ret);
+}
+
+static inline uint64_t get_lib_size(char const *const blob) {
+#ifdef _WIN32
+  ///////////////////////////////////////////////////////////////////////
+  // Analyze DOS stub
+  unsigned char const *const ublob =
+      reinterpret_cast<unsigned char const *const>(blob);
+  if (ublob[0] != 0x4d || ublob[1] != 0x5a) {
+    throw std::runtime_error("[SYCLcompat] blob is not a Windows DLL.");
+  }
+  uint32_t pe_header_offset = extract32(ublob + 0x3c);
+
+  ///////////////////////////////////////////////////////////////////////
+  // Ananlyze PE-header
+  unsigned char const *const pe_header = ublob + pe_header_offset;
+
+  // signature
+  uint32_t pe_signature = extract32(pe_header + 0);
+  if (pe_signature != 0x00004550) {
+    throw std::runtime_error(
+        "[SYCLcompat] PE-header signature is not 0x00004550");
+  }
+
+  // machine
+  uint16_t machine = extract16(pe_header + 4);
+  if (machine != 0x8664) {
+    throw std::runtime_error("[SYCLcompat] only DLLs for x64 supported");
+  }
+
+  // number of sections
+  uint16_t number_of_sections = extract16(pe_header + 6);
+
+  // sizeof optional header
+  uint16_t sizeof_optional_header = extract16(pe_header + 20);
+
+  // magic
+  uint16_t magic = extract16(pe_header + 24);
+  if (magic != 0x10b && magic != 0x20b) {
+    throw std::runtime_error("[SYCLcompat] MAGIC is not 0x010b or 0x020b");
+  }
+
+  ///////////////////////////////////////////////////////////////////////
+  // Analyze tail of optional header
+  constexpr int coff_header_size = 24;
+
+  unsigned char const *const tail_of_optional_header =
+      pe_header + coff_header_size + sizeof_optional_header;
+  if (extract64(tail_of_optional_header - 8) != 0) {
+    throw std::runtime_error("Optional header not zero-padded");
+  }
+
+  ///////////////////////////////////////////////////////////////////////
+  // Analyze last section header
+  constexpr int section_header_size = 40;
+  unsigned char const *const last_section_header =
+      tail_of_optional_header + section_header_size * (number_of_sections - 1);
+
+  uint32_t sizeof_raw_data = extract32(last_section_header + 16);
+  uint32_t pointer_to_raw_data = extract32(last_section_header + 20);
+
+  return sizeof_raw_data + pointer_to_raw_data;
+#else
+  if (blob[0] != 0x7F || blob[1] != 'E' || blob[2] != 'L' || blob[3] != 'F')
+    throw std::runtime_error("[SYCLcompat] blob is not in ELF format");
+
+  if (blob[4] != 0x02)
+    throw std::runtime_error("[SYCLcompat] only 64-bit headers are supported");
+
+  if (blob[5] != 0x01)
+    throw std::runtime_error(
+        "[SYCLcompat] only little-endian headers are supported");
+
+  unsigned char const *const ublob =
+      reinterpret_cast<unsigned char const *const>(blob);
+  uint64_t e_shoff = extract64(ublob + 0x28);
+  uint16_t e_shentsize = extract16(ublob + 0x3A);
+  uint16_t e_shnum = extract16(ublob + 0x3C);
+
+  return e_shoff + (e_shentsize * e_shnum);
+#endif
+}
+
+#ifdef _WIN32
+class path_lib_record {
+public:
+  void operator=(const path_lib_record &) = delete;
+  ~path_lib_record() {
+    for (auto entry : lib_to_path) {
+      FreeLibrary(static_cast<HMODULE>(entry.first));
+      fs::permissions(entry.second, fs::perms::owner_all);
+      fs::remove_all(entry.second.remove_filename());
+    }
+  }
+  static void record_lib_path(fs::path path, void *library) {
+    lib_to_path[library] = path;
+  }
+  static void remove_lib(void *library) {
+    auto path = lib_to_path[library];
+    std::error_code ec;
+
+    FreeLibrary(static_cast<HMODULE>(library));
+    fs::permissions(path, fs::perms::owner_all);
+    if (fs::remove_all(path.remove_filename(), ec) != 2 || ec)
+      // one directory and one temporary file should have been deleted
+      throw std::runtime_error("[SYCLcompat] directory delete failed");
+
+    lib_to_path.erase(library);
+  }
+
+private:
+  static inline std::unordered_map<void *, fs::path> lib_to_path;
+};
+#endif
+
+} // namespace detail
+
+class kernel_library {
+public:
+  kernel_library() : ptr{nullptr} {}
+  kernel_library(void *ptr) : ptr{ptr} {}
+
+  operator void *() const { return ptr; }
+
+private:
+  void *ptr;
+#ifdef _WIN32
+  static inline detail::path_lib_record single_instance_to_trigger_destructor;
+#endif
+};
+
+namespace detail {
+
+static inline kernel_library load_dl_from_data(char const *const data,
+                                               size_t size) {
+  fs::path filename = write_data_to_file(data, size);
+#ifdef _WIN32
+  void *so = LoadLibraryW(filename.wstring().c_str());
+#else
+  void *so = dlopen(filename.c_str(), RTLD_LAZY);
+#endif
+  if (so == nullptr)
+    throw std::runtime_error("[SYCLcompat] failed to load kernel library");
+
+#ifdef _WIN32
+  detail::path_lib_record::record_lib_path(filename, so);
+#else
+  std::error_code ec;
+
+  // Windows DLL cannot be deleted while in use
+  if (fs::remove_all(filename.remove_filename(), ec) != 2 || ec)
+    // one directory and one temporary file should have been deleted
+    throw std::runtime_error("[SYCLcompat] directory delete failed");
+#endif
+
+  return so;
+}
+
+} // namespace detail
+
+/// Load kernel library and return a handle to use the library.
+/// \param [in] name The name of the library.
+static inline kernel_library load_kernel_library(const std::string &name) {
+  std::ifstream ifs;
+  ifs.open(name, std::ios::in | std::ios::binary);
+
+  std::stringstream buffer;
+  buffer << ifs.rdbuf();
+
+  const std::string buffer_string = buffer.str();
+  return detail::load_dl_from_data(buffer_string.c_str(), buffer_string.size());
+}
+
+/// Load kernel library whose image is alreay in memory and return a handle to
+/// use the library.
+/// \param [in] image A pointer to the image in memory.
+static inline kernel_library load_kernel_library_mem(char const *const image) {
+  const size_t size = detail::get_lib_size(image);
+
+  return detail::load_dl_from_data(image, size);
+}
+
+/// Unload kernel library.
+/// \param [in,out] library Handle to the library to be closed.
+static inline void unload_kernel_library(const kernel_library &library) {
+#ifdef _WIN32
+  detail::path_lib_record::remove_lib(library);
+#else
+  dlclose(library);
+#endif
+}
+
+class kernel_function {
+public:
+  kernel_function() : ptr{nullptr} {}
+  kernel_function(kernel_functor ptr) : ptr{ptr} {}
+
+  operator void *() const { return ((void *)ptr); }
+
+  void operator()(sycl::queue &q, const sycl::nd_range<3> &range,
+                  unsigned int a, void **args, void **extra) {
+    ptr(q, range, a, args, extra);
+  }
+
+private:
+  kernel_functor ptr;
+};
+
+/// Find kernel function in a kernel library and return its address.
+/// \param [in] library Handle to the kernel library.
+/// \param [in] name Name of the kernel function.
+static inline kernel_function get_kernel_function(kernel_library &library,
+                                                  const std::string &name) {
+#ifdef _WIN32
+  kernel_functor fn = reinterpret_cast<kernel_functor>(
+      GetProcAddress(static_cast<HMODULE>(static_cast<void *>(library)),
+                     (name + std::string("_wrapper")).c_str()));
+#else
+  kernel_functor fn = reinterpret_cast<kernel_functor>(
+      dlsym(library, (name + std::string("_wrapper")).c_str()));
+#endif
+  if (fn == nullptr)
+    throw std::runtime_error("[SYCLcompat] failed to get function");
+  return fn;
+}
+
+/// Invoke a kernel function.
+/// \param [in] function kernel function.
+/// \param [in] queue SYCL queue used to execute kernel
+/// \param [in] groupRange SYCL group range
+/// \param [in] localRange SYCL local range
+/// \param [in] localMemSize The size of local memory required by the kernel
+///             function.
+/// \param [in] kernelParams Array of pointers to kernel arguments.
+/// \param [in] extra Extra arguments.
+static inline void invoke_kernel_function(kernel_function &function,
+                                          sycl::queue &queue,
+                                          sycl::range<3> groupRange,
+                                          sycl::range<3> localRange,
+                                          unsigned int localMemSize,
+                                          void **kernelParams, void **extra) {
+  function(queue, sycl::nd_range<3>(groupRange * localRange, localRange),
+           localMemSize, kernelParams, extra);
 }
 
 } // namespace syclcompat

--- a/sycl/test-e2e/syclcompat/defs.cpp
+++ b/sycl/test-e2e/syclcompat/defs.cpp
@@ -17,22 +17,40 @@
  *  Defs.cpp
  *
  *  Description:
- *     __sycl_compat_align__ tests
+ *     __syclcompat_align__ tests
  **************************************************************************/
 
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <cassert>
+#include <iostream>
 #include <syclcompat/defs.hpp>
 
-int main() {
-  struct __sycl_compat_align__(16) {
+void test_align() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr std::size_t expected_size = 16;
+  struct __syclcompat_align__(expected_size) {
     int a;
     char c;
   }
   s;
-  assert(sizeof(s) == 16);
+  assert(sizeof(s) == expected_size);
+}
+
+void test_check_error() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  assert(syclcompat::error_code::SUCCESS == SYCLCOMPAT_CHECK_ERROR(0));
+  assert(syclcompat::error_code::DEFAULT_ERROR ==
+         SYCLCOMPAT_CHECK_ERROR(throw std::runtime_error(
+             "Expected exception in test_check_error")));
+}
+
+int main() {
+  test_align();
+  test_check_error();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -36,156 +36,200 @@
 
 #include "device_fixt.hpp"
 
+/*
+  Device Tests
+*/
+void test_at_least_one_device() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  assert(dtf.get_n_devices() > 0);
+}
+
+// Check the device returned matches the device ID
+void test_matches_id() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  assert(syclcompat::get_device(syclcompat::get_current_device_id()) ==
+         syclcompat::get_current_device());
+}
+
+// Check error on insufficient devices
+void test_not_enough_devices() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  try {
+    syclcompat::select_device(dtf.get_n_devices());
+  } catch (std::runtime_error const &e) {
+    std::cout << "Expected SYCL exception caught: " << e.what();
+  }
+}
+
+// Check the default context matches default queue's context
+void test_default_context() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  assert(dtf.get_queue().get_context() == syclcompat::get_default_context());
+}
+
+/*
+  Queue Tests
+*/
+void test_make_in_order_queue() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  sycl::queue q = syclcompat::get_default_queue();
+  assert(q.is_in_order());
+}
+
+void test_check_default_device() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  sycl::queue q = syclcompat::get_default_queue();
+  assert(q.get_device() == sycl::device{sycl::default_selector_v});
+}
+
+// Check behaviour of in order & out of order queue construction
+void test_create_queue_arguments() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  sycl::queue q_create_def{syclcompat::create_queue()};
+  assert(q_create_def.is_in_order());
+  sycl::queue q_in_order{syclcompat::create_queue(false, true)};
+  assert(q_in_order.is_in_order());
+  sycl::queue q_out_order{syclcompat::create_queue(false, false)};
+  assert(!q_out_order.is_in_order());
+}
+
+/*
+  Device Extension Tests
+*/
+void test_device_ext_api() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  dev_.is_native_host_atomic_supported();
+  dev_.get_major_version();
+  dev_.get_minor_version();
+  dev_.get_max_compute_units();
+  dev_.get_max_clock_frequency();
+  dev_.get_integrated();
+  syclcompat::device_info Info;
+  dev_.get_device_info(Info);
+  Info = dev_.get_device_info();
+  dev_.reset();
+  auto QueuePtr = dev_.default_queue();
+  dev_.queues_wait_and_throw();
+  QueuePtr = dev_.create_queue();
+  dev_.destroy_queue(QueuePtr);
+  QueuePtr = dev_.create_queue();
+  dev_.set_saved_queue(QueuePtr);
+  QueuePtr = dev_.get_saved_queue();
+  auto Context = dev_.get_context();
+}
+
+void test_default_saved_queue() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  assert(*dev_.default_queue() == *dev_.get_saved_queue());
+}
+
+void test_saved_queue() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  auto q = *dev_.create_queue();
+  dev_.set_saved_queue(&q);
+  assert(q == *dev_.get_saved_queue());
+}
+
+// Check reset() resets the queues etc
+void test_reset() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  auto q = *dev_.create_queue();
+  dev_.set_saved_queue(&q);
+  dev_.reset();
+  assert(q != *dev_.get_saved_queue());
+}
+
+void test_reset_arguments() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+
+  dev_.reset(false, false);
+  assert(!dev_.get_saved_queue()->is_in_order());
+
+  dev_.reset(false, true);
+  assert(dev_.get_saved_queue()->is_in_order());
+}
+
+void test_device_info_api() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  syclcompat::device_info Info;
+  const char *Name = "DEVNAME";
+  std::array<unsigned char, 16> uuid;
+  uuid.fill('0');
+  sycl::range<3> max_work_item_sizes;
+
+  Info.set_name(Name);
+  Info.set_max_work_item_sizes(max_work_item_sizes);
+  Info.set_major_version(1);
+  Info.set_minor_version(1);
+  Info.set_integrated(1);
+  Info.set_max_clock_frequency(1000);
+  Info.set_max_compute_units(32);
+  Info.set_global_mem_size(1000);
+  Info.set_local_mem_size(1000);
+  Info.set_max_work_group_size(32);
+  Info.set_max_sub_group_size(16);
+  Info.set_max_work_items_per_compute_unit(16);
+  int SizeArray[3] = {1, 2, 3};
+  Info.set_max_nd_range_size(SizeArray);
+
+  Info.set_host_unified_memory(true);
+  Info.set_memory_clock_rate(1000);
+  Info.set_max_register_size_per_work_group(1000);
+  Info.set_device_id(0);
+  Info.set_uuid(uuid);
+  Info.set_global_mem_cache_size(1000);
+
+  assert(!strcmp(Info.get_name(), Name));
+  assert(Info.get_max_work_item_sizes() == max_work_item_sizes);
+  assert(Info.get_minor_version() == 1);
+  assert(Info.get_integrated() == 1);
+  assert(Info.get_max_clock_frequency() == 1000);
+  assert(Info.get_max_compute_units() == 32);
+  assert(Info.get_max_work_group_size() == 32);
+  assert(Info.get_max_sub_group_size() == 16);
+  assert(Info.get_max_work_items_per_compute_unit() == 16);
+  assert(Info.get_max_nd_range_size()[0] == SizeArray[0]);
+  assert(Info.get_max_nd_range_size()[1] == SizeArray[1]);
+  assert(Info.get_max_nd_range_size()[2] == SizeArray[2]);
+  assert(Info.get_global_mem_size() == 1000);
+  assert(Info.get_local_mem_size() == 1000);
+
+  uuid.fill('0'); // set_uuid uses std::move
+  assert(Info.get_host_unified_memory());
+  assert(Info.get_memory_clock_rate() == 1000);
+  assert(Info.get_max_register_size_per_work_group() == 1000);
+  assert(Info.get_device_id() == 0);
+  assert(Info.get_uuid() == uuid);
+  assert(Info.get_global_mem_cache_size() == 1000);
+}
+
 int main() {
-  /*
-    Device Tests
-  */
-  std::cout << "Testing AtLeastOneDevice" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    assert(dtf.get_n_devices() > 0);
-  }
-
-  // Check the device returned matches the device ID
-  std::cout << "Testing MatchesID" << std::endl;
-  {
-    assert(syclcompat::get_device(syclcompat::get_current_device_id()) ==
-           syclcompat::get_current_device());
-  }
-
-  // Check error on insufficient devices
-  std::cout << "Testing NotEnoughDevices" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    try {
-      syclcompat::select_device(dtf.get_n_devices());
-    } catch (std::runtime_error const &e) {
-      std::cout << "Expected SYCL exception caught: " << e.what();
-    }
-  }
-
-  // Check the default context matches default queue's context
-  std::cout << "Testing DefaultContext" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    assert(dtf.get_queue().get_context() == syclcompat::get_default_context());
-  }
-
-  /*
-    Queue Tests
-  */
-  std::cout << "Testing MakeInOrderQueue" << std::endl;
-  {
-    sycl::queue q = syclcompat::get_default_queue();
-    assert(q.is_in_order());
-  }
-
-  std::cout << "Testing CheckDefaultDevice" << std::endl;
-  {
-    sycl::queue q = syclcompat::get_default_queue();
-    assert(q.get_device() == sycl::device{sycl::default_selector_v});
-  }
-
-  // Check behaviour of in order & out of order queue construction
-  std::cout << "Testing QueuePropOrder" << std::endl;
-  {
-    sycl::queue q_create_def{syclcompat::create_queue()};
-    assert(q_create_def.is_in_order());
-    sycl::queue q_in_order{syclcompat::create_queue(false, true)};
-    assert(q_in_order.is_in_order());
-    sycl::queue q_out_order{syclcompat::create_queue(false, false)};
-    assert(!q_out_order.is_in_order());
-  }
-
-  /*
-    Device Extension Tests
-  */
-  std::cout << "Testing DeviceExtAPI" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    dev_.is_native_host_atomic_supported();
-    dev_.get_major_version();
-    dev_.get_minor_version();
-    dev_.get_max_compute_units();
-    dev_.get_max_clock_frequency();
-    dev_.get_integrated();
-    syclcompat::device_info Info;
-    dev_.get_device_info(Info);
-    Info = dev_.get_device_info();
-    dev_.reset();
-    auto QueuePtr = dev_.default_queue();
-    dev_.queues_wait_and_throw();
-    QueuePtr = dev_.create_queue();
-    dev_.destroy_queue(QueuePtr);
-    QueuePtr = dev_.create_queue();
-    dev_.set_saved_queue(QueuePtr);
-    QueuePtr = dev_.get_saved_queue();
-    auto Context = dev_.get_context();
-  }
-
-  std::cout << "Testing DefaultSavedQueue" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    assert(*dev_.default_queue() == *dev_.get_saved_queue());
-  }
-
-  std::cout << "Testing SavedQueue" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    auto q = *dev_.create_queue();
-    dev_.set_saved_queue(&q);
-    assert(q == *dev_.get_saved_queue());
-  }
-
-  // Check reset() resets the queues etc
-  std::cout << "Testing Reset" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    auto q = *dev_.create_queue();
-    dev_.set_saved_queue(&q);
-    dev_.reset();
-    assert(q != *dev_.get_saved_queue());
-  }
-
-  std::cout << "Testing DeviceInfoAPI" << std::endl;
-  {
-    syclcompat::device_info Info;
-    const char *Name = "DEVNAME";
-    Info.set_name(Name);
-    sycl::id<3> max_work_item_sizes;
-    Info.set_max_work_item_sizes(max_work_item_sizes);
-    Info.set_major_version(1);
-    Info.set_minor_version(1);
-    Info.set_integrated(1);
-    Info.set_max_clock_frequency(1000);
-    Info.set_max_compute_units(32);
-    Info.set_global_mem_size(1000);
-    Info.set_local_mem_size(1000);
-    Info.set_max_work_group_size(32);
-    Info.set_max_sub_group_size(16);
-    Info.set_max_work_items_per_compute_unit(16);
-    int SizeArray[3] = {1, 2, 3};
-    Info.set_max_nd_range_size(SizeArray);
-
-    assert(!strcmp(Info.get_name(), Name));
-    assert(Info.get_max_work_item_sizes() == max_work_item_sizes);
-    assert(Info.get_minor_version() == 1);
-    assert(Info.get_integrated() == 1);
-    assert(Info.get_max_clock_frequency() == 1000);
-    assert(Info.get_max_compute_units() == 32);
-    assert(Info.get_max_work_group_size() == 32);
-    assert(Info.get_max_sub_group_size() == 16);
-    assert(Info.get_max_work_items_per_compute_unit() == 16);
-    assert(Info.get_max_nd_range_size()[0] == SizeArray[0]);
-    assert(Info.get_max_nd_range_size()[1] == SizeArray[1]);
-    assert(Info.get_max_nd_range_size()[2] == SizeArray[2]);
-    assert(Info.get_global_mem_size() == 1000);
-    assert(Info.get_local_mem_size() == 1000);
-  }
+  test_at_least_one_device();
+  test_matches_id();
+  test_not_enough_devices();
+  test_default_context();
+  test_make_in_order_queue();
+  test_check_default_device();
+  test_create_queue_arguments();
+  test_device_ext_api();
+  test_default_saved_queue();
+  test_saved_queue();
+  test_reset();
+  test_device_info_api();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/device/device_threaded.cpp
+++ b/sycl/test-e2e/syclcompat/device/device_threaded.cpp
@@ -38,34 +38,39 @@
 
 #include "device_fixt.hpp"
 
-int main() {
-  // Check a thread is able to select a non-default device
-  std::cout << "Testing DeviceSelect" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    if (dtf.get_n_devices() > 1) {
-      constexpr unsigned int TARGET_DEV = 1;
-      unsigned int thread_dev_id{};
-      std::thread other_thread{[&]() {
-        syclcompat::select_device(TARGET_DEV);
-        thread_dev_id = syclcompat::get_current_device_id();
-      }};
-      other_thread.join();
-      assert(thread_dev_id == TARGET_DEV);
-    } else {
-      std::cout << "  Skipping, only doable with multiple devices" << std::endl;
-    }
-  }
+// Check a thread is able to select a non-default device
+void test_device_select() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  // Check multiple threads get same device by default
-  std::cout << "Testing Threads" << std::endl;
-  {
+  DeviceTestsFixt dtf;
+  if (dtf.get_n_devices() > 1) {
+    constexpr unsigned int TARGET_DEV = 1;
     unsigned int thread_dev_id{};
-    std::thread other_thread{
-        [&]() { thread_dev_id = syclcompat::get_current_device_id(); }};
+    std::thread other_thread{[&]() {
+      syclcompat::select_device(TARGET_DEV);
+      thread_dev_id = syclcompat::get_current_device_id();
+    }};
     other_thread.join();
-    assert(thread_dev_id == syclcompat::get_current_device_id());
+    assert(thread_dev_id == TARGET_DEV);
+  } else {
+    std::cout << "  Skipping, only doable with multiple devices" << std::endl;
   }
+}
+
+// Check multiple threads get same device by default
+void test_threads() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  unsigned int thread_dev_id{};
+  std::thread other_thread{
+      [&]() { thread_dev_id = syclcompat::get_current_device_id(); }};
+  other_thread.join();
+  assert(thread_dev_id == syclcompat::get_current_device_id());
+}
+
+int main() {
+  test_device_select();
+  test_threads();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/id_query/id_query_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query_fixt.hpp
@@ -23,7 +23,9 @@
 #pragma once
 
 #include <sycl/sycl.hpp>
-#include <syclcompat.hpp>
+#include <syclcompat/id_query.hpp>
+#include <syclcompat/launch.hpp>
+#include <syclcompat/memory.hpp>
 
 // Class to launch a kernel and run a lambda on output data
 template <auto F> class QueryLauncher {
@@ -40,7 +42,7 @@ public:
       : grid_{grid}, threads_{threads}, size_{grid_.size() * threads_.size()},
         host_data_(size_) {
     data_ = (int *)syclcompat::malloc(size_ * sizeof(int));
-    syclcompat::memset(data_, 0, size_ * sizeof(int));
+    syclcompat::memset(data_, 0, size_);
   };
   ~QueryLauncher() { syclcompat::free(data_); }
   template <typename... Args>

--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -23,11 +23,12 @@
 // RUN: %clangxx -std=c++20 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
+#include <type_traits>
+
 #include <sycl/sycl.hpp>
 #include <syclcompat/device.hpp>
 #include <syclcompat/launch.hpp>
-
-#include <type_traits>
+#include <syclcompat/memory.hpp>
 
 #include "../common.hpp"
 #include "launch_fixt.hpp"

--- a/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_fixt.hpp
@@ -23,7 +23,9 @@
 #pragma once
 
 #include <sycl/sycl.hpp>
-#include <syclcompat.hpp>
+
+#include <syclcompat/device.hpp>
+#include <syclcompat/dims.hpp>
 
 // Struct containing test case data (local & global ranges)
 template <int Dim> struct RangeParams {


### PR DESCRIPTION
- The Defs header now has definitions that work on Windows as well.
- Device_info wrapper has been extended to query groups, memory clock.