### PR TITLE
[SYCL][COMPAT] Memset API updated to support 2-byte and 4-byte memsets

### DIFF
--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -149,12 +149,19 @@ static inline void *malloc(size_t size, sycl::queue q) {
 
 /// Calculate pitch (padded length of major dimension \p x) by rounding up to
 /// multiple of 32.
-/// \param x The dimension to be padded
-/// \returns size_t representing pitched length of dimension x.
+/// \param x The dimension to be padded (in bytes)
+/// \returns size_t representing pitched length of dimension x (in bytes).
 static inline constexpr size_t get_pitch(size_t x) {
   return ((x) + 31) & ~(0x1F);
 }
 
+/// @brief Malloc pitched 3D data
+/// @param [out] pitch returns the calculated pitch (in bytes)
+/// @param [in] x width of the allocation (in bytes)
+/// @param [in] y height of the allocation
+/// @param [in] z depth of the allocation
+/// @param [in] q The queue in which the operation is done.
+/// \returns A pointer to the allocated memory
 static inline void *malloc(size_t &pitch, size_t x, size_t y, size_t z,
                            sycl::queue q) {
   pitch = get_pitch(x);

--- a/sycl/test-e2e/syclcompat/id_query/id_query_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query_fixt.hpp
@@ -40,7 +40,7 @@ public:
       : grid_{grid}, threads_{threads}, size_{grid_.size() * threads_.size()},
         host_data_(size_) {
     data_ = (int *)syclcompat::malloc(size_ * sizeof(int));
-    syclcompat::memset(data_, 0, size_ * sizeof(int));
+    syclcompat::memset<int>(data_, 0, size_);
   };
   ~QueryLauncher() { syclcompat::free(data_); }
   template <typename... Args>

--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -23,11 +23,12 @@
 // RUN: %clangxx -std=c++20 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
+#include <type_traits>
+
 #include <sycl/sycl.hpp>
 #include <syclcompat/device.hpp>
 #include <syclcompat/launch.hpp>
-
-#include <type_traits>
+#include <syclcompat/memory.hpp>
 
 #include "../common.hpp"
 #include "launch_fixt.hpp"

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
@@ -87,7 +87,8 @@ void test_memcpy3D_memset() {
 
   check(h_data, h_ref, width * height * depth);
   // memset device data.
-  syclcompat::memset(d_data, 0x1, extent);
+  auto extent_elements = sycl::range<3>(width, height, depth);
+  syclcompat::memset_d32(d_data, 0x1, extent_elements);
 
   // copy back to host
   cpyParm_from_data_ct1 = d_data;
@@ -153,7 +154,8 @@ void test_memcpy3D_memset_q() {
 
   check(h_data, h_ref, width * height * depth);
   // memset device data.
-  syclcompat::memset(d_data, 0x1, extent, q);
+  auto extent_elements = sycl::range<3>(width, height, depth);
+  syclcompat::memset_d32(d_data, 0x1, extent_elements, q);
 
   // copy back to host
   cpyParm_from_data_ct1 = d_data;

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
@@ -55,11 +55,13 @@ void test_memcpy3D_memset() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -102,8 +104,8 @@ void test_memcpy3D_memset() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data);
+  syclcompat::free(h_ref);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -122,11 +124,13 @@ void test_memcpy3D_memset_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -169,8 +173,8 @@ void test_memcpy3D_memset_q() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data, q);
+  syclcompat::free(h_ref, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -187,7 +191,8 @@ void test_memcpy3D_offset() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -262,7 +267,7 @@ void test_memcpy3D_offset() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -281,7 +286,8 @@ void test_memcpy3D_offset_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -355,7 +361,7 @@ void test_memcpy3D_offset_q() {
                      cpyParm_size_ct1, q);
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -372,7 +378,8 @@ void test_memcpy3D_offsetZ() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -447,7 +454,7 @@ void test_memcpy3D_offsetZ() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -465,7 +472,8 @@ void test_memcpy3D_offsetZ_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -540,7 +548,7 @@ void test_memcpy3D_offsetZ_q() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -560,7 +568,8 @@ void test_memcpy3D_plane() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -637,7 +646,7 @@ void test_memcpy3D_plane() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -657,7 +666,8 @@ void test_memcpy3D_row() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -728,7 +738,7 @@ void test_memcpy3D_row() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
@@ -125,7 +125,8 @@ void test_memcpy3D_async_pitchedAPI() {
   check(h_data, h_ref, width * height * depth);
   // memset device data.
   // test_feature:memset_async
-  syclcompat::memset_async(d_data, 0x1, extent);
+  auto extent_elements = sycl::range<3>(width, height, depth);
+  syclcompat::memset_d32_async(d_data, 0x1, extent_elements);
   syclcompat::get_default_queue().wait_and_throw();
   // copy back to host
   cpyParm_from_data_ct1 = d_data;
@@ -199,7 +200,8 @@ void test_memcpy3D_async_pitchedAPI_q() {
   check(h_data, h_ref, width * height * depth);
   // memset device data.
   // test_feature:memset_async
-  syclcompat::memset_async(d_data, 0x1, extent, q);
+  auto extent_elements = sycl::range<3>(width, height, depth);
+  syclcompat::memset_d32_async(d_data, 0x1, extent_elements, q);
   q.wait_and_throw();
   // copy back to host
   cpyParm_from_data_ct1 = d_data;

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
@@ -58,11 +58,13 @@ void test_memcpy3D_async_pitchedAPI() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -142,8 +144,8 @@ void test_memcpy3D_async_pitchedAPI() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data);
+  syclcompat::free(h_ref);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 void test_memcpy3D_async_pitchedAPI_q() {
@@ -162,11 +164,13 @@ void test_memcpy3D_async_pitchedAPI_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -218,8 +222,8 @@ void test_memcpy3D_async_pitchedAPI_q() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data, q);
+  syclcompat::free(h_ref, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -237,7 +241,8 @@ void test_memcpy3D_async_offset() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -314,7 +319,7 @@ void test_memcpy3D_async_offset() {
   syclcompat::get_default_queue().wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -332,7 +337,8 @@ void test_memcpy3D_async_offset_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -409,7 +415,7 @@ void test_memcpy3D_async_offset_q() {
   q.wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -427,7 +433,8 @@ void test_memcpy3D_async_offsetZ() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -504,7 +511,7 @@ void test_memcpy3D_async_offsetZ() {
   syclcompat::get_default_queue().wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -522,7 +529,8 @@ void test_memcpy3D_async_offsetZ_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -599,7 +607,7 @@ void test_memcpy3D_async_offsetZ_q() {
   q.wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 

--- a/sycl/test-e2e/syclcompat/memory/memory_async.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_async.cpp
@@ -108,7 +108,7 @@ void test_memset_async1() {
   AsyncTest atest;
 
   sycl::event memset_ev =
-      syclcompat::memset_async(atest.d_C_, 1, sizeof(int) * atest.size_);
+      syclcompat::memset_async<float>(atest.d_C_, 1, atest.size_);
   sycl::event host_ev = atest.launch_host_task({memset_ev});
 
   atest.check_events(memset_ev, host_ev);
@@ -119,7 +119,7 @@ void test_memset_async2() {
   AsyncTest atest;
 
   sycl::event memset_ev =
-      syclcompat::memset_async(atest.d_C_, 32, 1, sizeof(int) * 32, 4);
+      syclcompat::memset_async<float>(atest.d_C_, 32, 1, 32, 4);
   sycl::event host_ev = atest.launch_host_task({memset_ev});
 
   atest.check_events(memset_ev, host_ev);
@@ -134,23 +134,12 @@ void test_memset_async3() {
   size_t depth = 4;
   assert(width * height * depth <= atest.size_);
 
-  syclcompat::pitched_data d_A_pitched{atest.d_A_, sizeof(int) * width, width,
-                                       height};
+  syclcompat::pitched_data d_A_pitched{atest.d_A_, width, width, height};
   sycl::event memset_ev =
-      syclcompat::memset_async(d_A_pitched, 1, {sizeof(int) * 2, 2, 2});
+      syclcompat::memset_async<float>(d_A_pitched, 1, {2, 2, 2});
   sycl::event host_ev = atest.launch_host_task({memset_ev});
 
   atest.check_events(memset_ev, host_ev);
-}
-
-void test_fill_event() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  AsyncTest atest;
-
-  sycl::event fill_ev = syclcompat::fill_async(atest.d_A_, 1.0f, atest.size_);
-  sycl::event host_ev = atest.launch_host_task({fill_ev});
-
-  atest.check_events(fill_ev, host_ev);
 }
 
 void test_combine_events() {
@@ -200,7 +189,6 @@ int main() {
   test_memset_async2();
   test_memset_async3();
 
-  test_fill_event();
   test_combine_events();
 
   return 0;

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
@@ -145,7 +145,7 @@ void test_memset() {
   syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(int));
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset((void *)d_A, 0, (Num - 3) * sizeof(int));
+  syclcompat::memset<int>((void *)d_A, 0, Num - 3);
 
   // deviceA -> hostA
   syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(int));
@@ -183,7 +183,7 @@ void test_memset_q() {
   syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(int), q);
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset((void *)d_A, 0, (Num - 3) * sizeof(int), q);
+  syclcompat::memset<int>((void *)d_A, 0, Num - 3, q);
 
   // deviceA -> hostA
   syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(int), q);
@@ -286,86 +286,6 @@ template <typename T> void test_memcpy_t_q() {
   free(h_A);
   free(h_B);
   free(h_C);
-}
-
-template <typename T> void test_fill() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  bool skip = should_skip<T>(syclcompat::get_current_device());
-  if (skip) // Unsupported aspect
-    return;
-
-  constexpr int Num = 10;
-  T *h_A = (T *)malloc(Num * sizeof(T));
-
-  for (int i = 0; i < Num; i++) {
-    h_A[i] = static_cast<T>(4);
-  }
-
-  T *d_A = nullptr;
-
-  d_A = syclcompat::malloc<T>(Num);
-  // hostA -> deviceA
-  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(T));
-
-  // set d_A[0,..., 6] = 0
-  syclcompat::fill((void *)d_A, static_cast<T>(0), (Num - 3));
-
-  // deviceA -> hostA
-  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(T));
-
-  syclcompat::free((void *)d_A);
-
-  // check d_A[0,..., 6] = 0
-  for (int i = 0; i < Num - 3; i++) {
-    assert(h_A[i] == static_cast<T>(0));
-  }
-
-  // check d_A[7,..., 9] = 4
-  for (int i = Num - 3; i < Num; i++) {
-    assert(h_A[i] == static_cast<T>(4));
-  }
-
-  free(h_A);
-}
-
-template <typename T> void test_fill_q() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  bool skip = should_skip<T>(syclcompat::get_current_device());
-  if (skip) // Unsupported aspect
-    return;
-  sycl::queue q{{sycl::property::queue::in_order()}};
-  constexpr int Num = 10;
-  T *h_A = (T *)malloc(Num * sizeof(T));
-
-  for (int i = 0; i < Num; i++) {
-    h_A[i] = static_cast<T>(4);
-  }
-
-  T *d_A = nullptr;
-
-  d_A = syclcompat::malloc<T>(Num, q);
-  // hostA -> deviceA
-  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(T), q);
-
-  // set d_A[0,..., 6] = 0
-  syclcompat::fill((void *)d_A, static_cast<T>(0), (Num - 3), q);
-
-  // deviceA -> hostA
-  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(T), q);
-
-  syclcompat::free((void *)d_A, q);
-
-  // check d_A[0,..., 6] = 0
-  for (int i = 0; i < Num - 3; i++) {
-    assert(h_A[i] == static_cast<T>(0));
-  }
-
-  // check d_A[7,..., 9] = 4
-  for (int i = Num - 3; i < Num; i++) {
-    assert(h_A[i] == static_cast<T>(4));
-  }
-
-  free(h_A);
 }
 
 void test_constant_memcpy() {
@@ -485,8 +405,6 @@ int main() {
 
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_t);
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_t_q);
-  INSTANTIATE_ALL_TYPES(value_type_list, test_fill);
-  INSTANTIATE_ALL_TYPES(value_type_list, test_fill_q);
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test2.cpp
@@ -74,7 +74,7 @@ void test_memcpy_pitched() {
   check(h_data, h_ref, width * height);
 
   // memset device data.
-  syclcompat::memset(d_data, d_pitch, 0x1, sizeof(float) * width, height);
+  syclcompat::memset_d32(d_data, d_pitch, 0x1, width, height);
 
   // copy back to host
   syclcompat::memcpy(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,
@@ -344,7 +344,7 @@ void test_memcpy_pitched_q() {
   check(h_data, h_ref, width * height);
 
   // memset device data.
-  syclcompat::memset(d_data, d_pitch, 0x1, sizeof(float) * width, height, q);
+  syclcompat::memset_d32(d_data, d_pitch, 0x1, width, height, q);
 
   // copy back to host
   syclcompat::memcpy(h_data, h_pitch, d_data, d_pitch, sizeof(float) * width,

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -180,7 +180,7 @@ void test_memcpy_async_pitched() {
   check(h_data, h_ref, width * height);
 
   // memset device data.
-  syclcompat::memset_async(d_data, d_pitch, 0x1, sizeof(float) * width, height);
+  syclcompat::memset_d32_async(d_data, d_pitch, 0x1, width, height);
 
   // copy back to host
   syclcompat::memcpy_async(h_data, h_pitch, d_data, d_pitch,
@@ -228,8 +228,7 @@ void test_memcpy_async_pitched_q() {
   check(h_data, h_ref, width * height);
 
   // memset device data.
-  syclcompat::memset_async(d_data, d_pitch, 0x1, sizeof(float) * width, height,
-                           q);
+  syclcompat::memset_d32_async(d_data, d_pitch, 0x1, width, height, q);
 
   // copy back to host
   syclcompat::memcpy_async(h_data, h_pitch, d_data, d_pitch,
@@ -259,7 +258,7 @@ void test_memset_async() {
   syclcompat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(int));
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(int));
+  syclcompat::memset_async<int>((void *)d_A, 0, (Num - 3));
 
   // deviceA -> hostA
   syclcompat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(int));
@@ -297,7 +296,7 @@ void test_memset_async_q() {
   syclcompat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(int), q);
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(int), q);
+  syclcompat::memset_async<int>((void *)d_A, 0, Num - 3, q);
 
   // deviceA -> hostA
   syclcompat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(int), q);
@@ -395,91 +394,6 @@ template <typename T> void test_memcpy_async_t() {
   free(h_A);
   free(h_B);
   free(h_C);
-}
-
-template <typename T> void test_fill_async() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  bool skip = should_skip<T>(syclcompat::get_current_device());
-  if (skip) // Unsupported aspect
-    return;
-
-  constexpr int Num = 10;
-  T *h_A = (T *)malloc(Num * sizeof(T));
-
-  for (int i = 0; i < Num; i++) {
-    h_A[i] = static_cast<T>(4);
-  }
-
-  T *d_A = nullptr;
-
-  d_A = syclcompat::malloc<T>(Num);
-  // hostA -> deviceA
-  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(T));
-
-  // set d_A[0,..., 6] = 0
-  syclcompat::fill_async((void *)d_A, static_cast<T>(0), (Num - 3));
-
-  // deviceA -> hostA
-  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(T));
-
-  syclcompat::get_default_queue().wait_and_throw();
-
-  syclcompat::free((void *)d_A);
-
-  // check d_A[0,..., 6] = 0
-  for (int i = 0; i < Num - 3; i++) {
-    assert(h_A[i] == static_cast<T>(0));
-  }
-
-  // check d_A[7,..., 9] = 4
-  for (int i = Num - 3; i < Num; i++) {
-    assert(h_A[i] == static_cast<T>(4));
-  }
-
-  free(h_A);
-}
-
-template <typename T> void test_fill_async_q() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  bool skip = should_skip<T>(syclcompat::get_current_device());
-  if (skip) // Unsupported aspect
-    return;
-
-  sycl::queue q{{sycl::property::queue::in_order()}};
-  constexpr int Num = 10;
-  T *h_A = (T *)malloc(Num * sizeof(T));
-
-  for (int i = 0; i < Num; i++) {
-    h_A[i] = static_cast<T>(4);
-  }
-
-  T *d_A = nullptr;
-
-  d_A = syclcompat::malloc<T>(Num, q);
-  // hostA -> deviceA
-  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(T), q);
-
-  // set d_A[0,..., 6] = 0
-  syclcompat::fill_async((void *)d_A, static_cast<T>(0), (Num - 3), q);
-
-  // deviceA -> hostA
-  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(T), q);
-
-  q.wait_and_throw();
-
-  syclcompat::free((void *)d_A, q);
-
-  // check d_A[0,..., 6] = 0
-  for (int i = 0; i < Num - 3; i++) {
-    assert(h_A[i] == static_cast<T>(0));
-  }
-
-  // check d_A[7,..., 9] = 4
-  for (int i = Num - 3; i < Num; i++) {
-    assert(h_A[i] == static_cast<T>(4));
-  }
-
-  free(h_A);
 }
 
 void test_constant_memcpy_async() {
@@ -615,8 +529,6 @@ int main() {
 
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_async_t);
   INSTANTIATE_ALL_TYPES(value_type_list, test_memcpy_async_t_q);
-  INSTANTIATE_ALL_TYPES(value_type_list, test_fill_async);
-  INSTANTIATE_ALL_TYPES(value_type_list, test_fill_async_q);
 
   return 0;
 }


### PR DESCRIPTION
- The memory interface has changed:
    - fill has been removed
    - memset now offers a templated version (which works as fill did)
    - memset_d8, memset_d16, and memset_d32 were added to allow memsetting 1, 2 and 4 byte-sized values.