### PR TITLE
Allow non-bare pointer convertible `memref` types in non-ABI breaking code

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/Utils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/Utils.h
@@ -155,6 +155,9 @@ inline LLVM::LLVMFuncOp getAllocFn(const LLVMTypeConverter &typeConverter,
                                             /* opaquePointers */ true);
 }
 
+/// Returns whether any public symbol in the module has a non-bare convertible
+/// type.
+LogicalResult verifyABI(ModuleOp module);
 } // namespace mlir
 
 #endif // MLIR_DIALECT_POLYGEIST_UTILS_UTILS_H

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -1332,6 +1332,12 @@ public:
 
   void runOnOperation() override {
     ModuleOp m = getOperation();
+    // Early check we would not be breaking ABI due to LLVM conversion
+    if (failed(verifyABI(m))) {
+      signalPassFailure();
+      return;
+    }
+
     const auto &dataLayoutAnalysis = getAnalysis<DataLayoutAnalysis>();
 
     LowerToLLVMOptions options(&getContext(),

--- a/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
+++ b/polygeist/lib/Conversion/PolygeistToLLVM/PolygeistToLLVM.cpp
@@ -161,7 +161,103 @@ protected:
   }
 };
 
+/// Conversion pattern that transforms a subview op into:
+///   1. An `llvm.mlir.undef` operation to create a memref descriptor
+///   2. Updates to the descriptor to introduce the data ptr, offset, size
+///      and stride.
+/// The subview op is replaced by the descriptor.
 struct SubIndexOpLowering : public BaseSubIndexOpLowering {
+  using BaseSubIndexOpLowering::BaseSubIndexOpLowering;
+
+  LogicalResult
+  matchAndRewrite(SubIndexOp subViewOp, OpAdaptor transformed,
+                  ConversionPatternRewriter &rewriter) const override {
+    assert(isa<MemRefType>(subViewOp.getSource().getType()) &&
+           "Source operand should be a memref type");
+    assert(isa<MemRefType>(subViewOp.getType()) &&
+           "Result should be a memref type");
+
+    auto sourceMemRefType = cast<MemRefType>(subViewOp.getSource().getType());
+    auto viewMemRefType = cast<MemRefType>(subViewOp.getType());
+
+    auto loc = subViewOp.getLoc();
+    MemRefDescriptor targetMemRef(transformed.getSource());
+    Value prev = targetMemRef.alignedPtr(rewriter, loc);
+    Value idxs[] = {transformed.getIndex()};
+
+    SmallVector<Value, 4> sizes, strides;
+    if (sourceMemRefType.getRank() != viewMemRefType.getRank()) {
+      if (sourceMemRefType.getRank() != viewMemRefType.getRank() + 1)
+        return failure();
+
+      size_t sz = 1;
+      for (int64_t i = 1; i < sourceMemRefType.getRank(); i++) {
+        if (sourceMemRefType.getShape()[i] == ShapedType::kDynamic)
+          return failure();
+        sz *= sourceMemRefType.getShape()[i];
+      }
+      Value cop = rewriter.create<LLVM::ConstantOp>(
+          loc, idxs[0].getType(),
+          rewriter.getIntegerAttr(idxs[0].getType(), sz));
+      idxs[0] = rewriter.create<LLVM::MulOp>(loc, idxs[0], cop);
+      for (int64_t i = 1; i < sourceMemRefType.getRank(); i++) {
+        sizes.push_back(targetMemRef.size(rewriter, loc, i));
+        strides.push_back(targetMemRef.stride(rewriter, loc, i));
+      }
+    } else {
+      for (int64_t i = 0; i < sourceMemRefType.getRank(); i++) {
+        sizes.push_back(targetMemRef.size(rewriter, loc, i));
+        strides.push_back(targetMemRef.stride(rewriter, loc, i));
+      }
+    }
+
+    Type sourceElemType = sourceMemRefType.getElementType();
+    Type convSourceElemType = getTypeConverter()->convertType(sourceElemType);
+    Type viewElemType = viewMemRefType.getElementType();
+    Type convViewElemType = getTypeConverter()->convertType(viewElemType);
+
+    // Handle the general (non-SYCL) case first.
+    if (convViewElemType ==
+        cast<MemRefType>(transformed.getSource().getType()).getElementType()) {
+      auto memRefDesc = createMemRefDescriptor(
+          loc, viewMemRefType, targetMemRef.allocatedPtr(rewriter, loc),
+          rewriter.create<LLVM::GEPOp>(loc, prev.getType(), convViewElemType,
+                                       prev, idxs),
+          sizes, strides, rewriter);
+
+      rewriter.replaceOp(subViewOp, {memRefDesc});
+      return success();
+    }
+    assert(isa<LLVM::LLVMStructType>(convSourceElemType) &&
+           "Expecting struct type");
+
+    // SYCL case
+    assert(sourceMemRefType.getRank() == viewMemRefType.getRank() &&
+           "Expecting the input and output MemRef ranks to be the same");
+
+    SmallVector<Value, 4> indices;
+    computeIndices(cast<LLVM::LLVMStructType>(convSourceElemType),
+                   convViewElemType, indices, subViewOp, transformed, rewriter);
+    assert(!indices.empty() && "Expecting a least one index");
+
+    // Note: MLIRScanner::InitializeValueByInitListExpr() in clang-mlir.cc, when
+    // a memref element type is a struct type, the return type of a
+    // polygeist.subindex operation should be a memref of the element type of
+    // the struct.
+    auto elemPtrTy = LLVM::LLVMPointerType::get(
+        convViewElemType.getContext(), viewMemRefType.getMemorySpaceAsInt());
+    auto gep = rewriter.create<LLVM::GEPOp>(loc, elemPtrTy, convViewElemType,
+                                            prev, indices);
+    auto memRefDesc = createMemRefDescriptor(loc, viewMemRefType, gep, gep,
+                                             sizes, strides, rewriter);
+    LLVM_DEBUG(llvm::dbgs() << "SubIndexOpLowering: gep: " << *gep << "\n");
+
+    rewriter.replaceOp(subViewOp, {memRefDesc});
+    return success();
+  }
+};
+
+struct SubIndexBarePtrOpLowering : public BaseSubIndexOpLowering {
   using BaseSubIndexOpLowering::BaseSubIndexOpLowering;
 
   LogicalResult
@@ -235,6 +331,90 @@ struct SubIndexOpLowering : public BaseSubIndexOpLowering {
   }
 };
 
+struct Memref2PointerOpLowering
+    : public ConvertOpToLLVMPattern<Memref2PointerOp> {
+  using ConvertOpToLLVMPattern<Memref2PointerOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Memref2PointerOp op, OpAdaptor transformed,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (LogicalResult verifyResult = verifyPtrMemrefConversion(
+            *getTypeConverter(), op, op.getType(), op.getSource().getType());
+        failed(verifyResult))
+      return verifyResult;
+
+    auto loc = op.getLoc();
+
+    // MemRefDescriptor sourceMemRef(operands.front());
+    MemRefDescriptor targetMemRef(
+        transformed.getSource()); // MemRefDescriptor::undef(rewriter, loc,
+                                  // targetDescTy);
+
+    // Offset.
+    Value baseOffset = targetMemRef.offset(rewriter, loc);
+    Value ptr = targetMemRef.alignedPtr(rewriter, loc);
+    Value idxs[] = {baseOffset};
+    auto elemType = getTypeConverter()->convertType(
+        op.getSource().getType().getElementType());
+    ptr = rewriter.create<LLVM::GEPOp>(loc, ptr.getType(), elemType, ptr, idxs);
+
+    rewriter.replaceOp(op, {ptr});
+    return success();
+  }
+};
+
+struct Pointer2MemrefOpLowering
+    : public ConvertOpToLLVMPattern<Pointer2MemrefOp> {
+  using ConvertOpToLLVMPattern<Pointer2MemrefOp>::ConvertOpToLLVMPattern;
+
+  LogicalResult
+  matchAndRewrite(Pointer2MemrefOp op, OpAdaptor adaptor,
+                  ConversionPatternRewriter &rewriter) const override {
+    if (LogicalResult verifyResult = verifyPtrMemrefConversion(
+            *getTypeConverter(), op, op.getSource().getType(), op.getType());
+        failed(verifyResult))
+      return verifyResult;
+
+    auto loc = op.getLoc();
+
+    // MemRefDescriptor sourceMemRef(operands.front());
+    auto convertedType = getTypeConverter()->convertType(op.getType());
+    assert(convertedType && "unexpected failure in memref type conversion");
+    auto descr = MemRefDescriptor::undef(rewriter, loc, convertedType);
+    auto ptr = adaptor.getSource();
+
+    // Extract all strides and offsets and verify they are static.
+    int64_t offset;
+    SmallVector<int64_t, 4> strides;
+    auto result = getStridesAndOffset(op.getType(), strides, offset);
+    (void)result;
+    assert(succeeded(result) && "unexpected failure in stride computation");
+    assert(offset != ShapedType::kDynamic && "expected static offset");
+
+    bool first = true;
+    assert(!llvm::any_of(strides, [&](int64_t stride) {
+      if (first) {
+        first = false;
+        return false;
+      }
+      return stride == ShapedType::kDynamic;
+    }) && "expected static strides except first element");
+
+    descr.setAllocatedPtr(rewriter, loc, ptr);
+    descr.setAlignedPtr(rewriter, loc, ptr);
+    descr.setConstantOffset(rewriter, loc, offset);
+
+    // Fill in sizes and strides
+    for (unsigned i = 0, e = op.getType().getRank(); i != e; ++i) {
+      descr.setConstantSize(rewriter, loc, i, op.getType().getDimSize(i));
+      descr.setConstantStride(rewriter, loc, i, strides[i]);
+    }
+
+    rewriter.replaceOp(op, {descr});
+    return success();
+  }
+};
+
 struct StreamToTokenOpLowering
     : public ConvertOpToLLVMPattern<StreamToTokenOp> {
   using ConvertOpToLLVMPattern<StreamToTokenOp>::ConvertOpToLLVMPattern;
@@ -250,7 +430,7 @@ struct StreamToTokenOpLowering
 };
 
 /// Lowers to a bitcast operation
-struct Memref2PointerOpLowering
+struct BareMemref2PointerOpLowering
     : public ConvertOpToLLVMPattern<Memref2PointerOp> {
   using ConvertOpToLLVMPattern<Memref2PointerOp>::ConvertOpToLLVMPattern;
 
@@ -275,7 +455,7 @@ struct Memref2PointerOpLowering
 };
 
 /// Lowers to a bitcast operation
-struct Pointer2MemrefOpLowering
+struct BarePointer2MemrefOpLowering
     : public ConvertOpToLLVMPattern<Pointer2MemrefOp> {
   using ConvertOpToLLVMPattern<Pointer2MemrefOp>::ConvertOpToLLVMPattern;
 
@@ -396,9 +576,16 @@ void populatePolygeistToLLVMConversionPatterns(LLVMTypeConverter &converter,
          "These patterns only work with bare pointer calling convention");
   populatePolygeistToLLVMTypeConversion(converter);
 
-  patterns.add<TypeSizeOpLowering, TypeAlignOpLowering>(converter);
-  patterns.add<SubIndexOpLowering, Memref2PointerOpLowering,
-               Pointer2MemrefOpLowering>(converter);
+  patterns.add<TypeSizeOpLowering, TypeAlignOpLowering, SubIndexOpLowering,
+               Memref2PointerOpLowering, Pointer2MemrefOpLowering>(converter);
+  // When adding these patterns (and other patterns changing the
+  // default conversion of operations on MemRef values), a higher
+  // benefit is passed (2), so that these patterns have a higher
+  // priority than the ones performing the default conversion, which
+  // should only run if the "bare pointer" ones fail.
+  patterns.add<SubIndexBarePtrOpLowering, BareMemref2PointerOpLowering,
+               BarePointer2MemrefOpLowering>(converter,
+                                             /*benefit*/ 2);
 }
 
 namespace {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/BareMemRefToLLVM.cpp
@@ -501,11 +501,8 @@ void mlir::polygeist::populateBareMemRefToLLVMConversionPatterns(
   // Patterns are tried in reverse add order, so this is tried before the
   // one added by default.
   converter.addConversion([&](MemRefType type) -> Optional<Type> {
-    if (!canBeLoweredToBarePtr(type)) {
-      emitError(UnknownLoc::get(type.getContext()))
-          << "'" << type << "' cannot be converted to a bare pointer";
-      return Type{};
-    }
+    if (!canBeLoweredToBarePtr(type))
+      return std::nullopt;
 
     FailureOr<unsigned> addrSpace = converter.getMemRefAddressSpace(type);
     if (failed(addrSpace)) {

--- a/polygeist/lib/Dialect/Polygeist/Utils/CMakeLists.txt
+++ b/polygeist/lib/Dialect/Polygeist/Utils/CMakeLists.txt
@@ -1,6 +1,7 @@
 add_mlir_dialect_library(MLIRPolygeistUtils
   AliasUtils.cpp
   TransformUtils.cpp
+  Utils.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Dialect/Polygeist/Utils

--- a/polygeist/lib/Dialect/Polygeist/Utils/Utils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/Utils.cpp
@@ -1,0 +1,73 @@
+//===- Utils.cpp - Polygeist Dialect Utilities  ---------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "mlir/Dialect/Polygeist/Utils/Utils.h"
+
+#include "mlir/Dialect/GPU/IR/GPUDialect.h"
+#include "mlir/Dialect/LLVMIR/LLVMAttrs.h"
+#include "mlir/Dialect/LLVMIR/LLVMDialect.h"
+#include "mlir/Dialect/MemRef/IR/MemRef.h"
+#include "mlir/Support/LLVM.h"
+#include "llvm/ADT/TypeSwitch.h"
+
+namespace mlir {
+static bool isNonBareConvertibleMemref(Type type) {
+  return TypeSwitch<Type, bool>(type)
+      .Case<MemRefType>(std::not_fn(canBeLoweredToBarePtr))
+      .Default(false);
+}
+
+static constexpr bool linkageCouldBreakABI(LLVM::Linkage linkage) {
+  return linkage != LLVM::Linkage::Private &&
+         linkage != LLVM::Linkage::Internal;
+}
+
+static bool couldBreakABI(SymbolOpInterface symbol) {
+  return TypeSwitch<Operation *, bool>(symbol)
+      .Case<FunctionOpInterface>([](auto func) {
+        // We use llvm.linkage to specify linkage.
+        static constexpr StringLiteral linkageAttrName = "llvm.linkage";
+        // Default "external" value for linkage;
+        LLVM::Linkage linkage = LLVM::Linkage::External;
+        if (auto linkageAttr = dyn_cast_or_null<LLVM::LinkageAttr>(
+                func->getAttr(linkageAttrName)))
+          linkage = linkageAttr.getLinkage();
+        if (!linkageCouldBreakABI(linkage))
+          return false;
+        return llvm::any_of(func.getArgumentTypes(),
+                            isNonBareConvertibleMemref) ||
+               llvm::any_of(func.getResultTypes(), isNonBareConvertibleMemref);
+      })
+      .Case<memref::GlobalOp>([](auto globalOp) {
+        if (static_cast<SymbolOpInterface>(globalOp).isPrivate())
+          return false;
+        return isNonBareConvertibleMemref(globalOp.getType());
+      })
+      .Case<LLVM::GlobalOp>([](auto globalOp) {
+        if (!linkageCouldBreakABI(globalOp.getLinkage()))
+          return false;
+        return isNonBareConvertibleMemref(globalOp.getGlobalType());
+      })
+      // Safe operations, no types involved
+      .Case<gpu::GPUModuleOp, LLVM::ComdatSelectorOp, LLVM::ComdatOp>(
+          [](auto) { return false; })
+      // Safely assume operations can break ABI by default.
+      .Default(true);
+}
+
+LogicalResult verifyABI(ModuleOp module) {
+  return failure(module
+                     .walk([](SymbolOpInterface symbol) -> WalkResult {
+                       if (couldBreakABI(symbol))
+                         return symbol->emitOpError()
+                                << "could break ABI when converting to LLVM";
+                       return WalkResult::advance();
+                     })
+                     .wasInterrupted());
+}
+} // namespace mlir

--- a/polygeist/test/polygeist-opt/polygeist-to-llvm-abi-break.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-to-llvm-abi-break.mlir
@@ -1,0 +1,13 @@
+// RUN: polygeist-opt %s --convert-polygeist-to-llvm --split-input-file --verify-diagnostics 2>&1
+
+// expected-error @below {{'func.func' op could break ABI when converting to LLVM}}
+func.func @bare_abi_break(%arg: memref<?x?xf32>) {
+  return
+}
+
+// -----
+
+// expected-error @below {{'func.func' op could break ABI when converting to LLVM}}
+func.func @bare_abi_break(%arg: memref<?x?xf32>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+  return
+}

--- a/polygeist/test/polygeist-opt/polygeist-to-llvm.mlir
+++ b/polygeist/test/polygeist-opt/polygeist-to-llvm.mlir
@@ -532,7 +532,7 @@ func.func private @ptr2memref(%arg0: !llvm.ptr) -> memref<?xf32> {
 
 #layout = affine_map<(s0) -> (s0 - 1)>
 
-// CHECK-LABEL:   llvm.func @non_bare_due_to_layout(
+// CHECK-LABEL:   llvm.func private @non_bare_due_to_layout(
 // CHECK-SAME:                                      %[[VAL_0:.*]]: !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)>,
 // CHECK-SAME:                                      %[[VAL_1:.*]]: i64) -> i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.extractvalue %[[VAL_0]][1] : !llvm.struct<(ptr, ptr, i64, array<1 x i64>, array<1 x i64>)> 
@@ -543,7 +543,7 @@ func.func private @ptr2memref(%arg0: !llvm.ptr) -> memref<?xf32> {
 // CHECK-NEXT:      llvm.return %[[VAL_6]] : i64
 // CHECK-NEXT:    }
 
-func.func private @non_bare_due_to_layout(%arg0: memref<100xi64, #layout>, %arg1: index) -> i64 {
+func.func private @non_bare_due_to_layout(%arg0: memref<100xi64, #layout>, %arg1: index) -> i64 attributes {llvm.linkage = #llvm.linkage<private>} {
   %res = memref.load %arg0[%arg1] : memref<100xi64, #layout>
   return %res : i64
 }
@@ -617,9 +617,9 @@ func.func private @f1(%ptr: !llvm.ptr) {
 
 // -----
 
-// CHECK-LABEL:   llvm.func @view(
+// CHECK-LABEL:   llvm.func private @view(
 // CHECK-SAME:                    %[[VAL_0:.*]]: !llvm.ptr<3>,
-// CHECK-SAME:                    %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64) -> !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)> attributes {sym_visibility = "private"} {
+// CHECK-SAME:                    %[[VAL_1:.*]]: i64, %[[VAL_2:.*]]: i64, %[[VAL_3:.*]]: i64) -> !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr %[[VAL_0]]{{\[}}%[[VAL_1]]] : (!llvm.ptr<3>, i64) -> !llvm.ptr<3>, i8
 // CHECK-NEXT:      %[[VAL_5:.*]] = llvm.mlir.undef : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.insertvalue %[[VAL_0]], %[[VAL_5]][0] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
@@ -635,7 +635,7 @@ func.func private @f1(%ptr: !llvm.ptr) {
 // CHECK-NEXT:      llvm.return %[[VAL_15]] : !llvm.struct<(ptr<3>, ptr<3>, i64, array<2 x i64>, array<2 x i64>)>
 // CHECK-NEXT:    }
 
-func.func private @view(%arg0: memref<8xi8, 3>, %arg1: index, %arg2: index, %arg3: index) -> memref<?x?xf32, 3> {
+func.func private @view(%arg0: memref<8xi8, 3>, %arg1: index, %arg2: index, %arg3: index) -> memref<?x?xf32, 3> attributes {llvm.linkage = #llvm.linkage<private>} {
   %res = memref.view %arg0[%arg1][%arg2, %arg3] : memref<8xi8, 3> to memref<?x?xf32, 3>
   return %res : memref<?x?xf32, 3>
 }


### PR DESCRIPTION
DO NOT SQUASH AND MERGE THIS PR

Review just 77c5a7bbdced2361fe46ec1d529c0b703119805a.

cec61ea9e397e4dc26c7188e0b40398726036f6c caused errors if `-loop-internalization` introduced non-bare pointer convertible code. This PR reverts that commit and verifies we are not breaking ABI before conversion to `llvm` dialect.