### PR TITLE
[SYCL] Try interop e2e test on L0 and opencl CI.

### DIFF
--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: CUDA || HIP
 // RUN: %{build} %if hip %{ -DSYCL_EXT_ONEAPI_BACKEND_HIP %} %else %{ %if cuda %{ -DSYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL %} %else %{ %if level_zero %{ -DSYCL_EXT_ONEAPI_BACKEND_L0 %} %} %} -o %t.out
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
I had meant to make this patch in https://github.com/intel/llvm/pull/11292. This test should also work on L0 and opencl backends.