### PR TITLE
[SYCL][Graph] Improve multithread e2e tests

### DIFF
--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -5,9 +5,14 @@
 //
 // CHECK-NOT: LEAK
 
-// Test finalizing and submitting a graph in a threaded situation.
+// Test submitting a graph in a threaded situation.
 // The second run is to check that there are no leaks reported with the embedded
 // ZE_DEBUG=4 testing capability.
+
+// Note that we do not check the outputs becuse multiple concurrent executions
+// is indeterministic (and depends on the backend command management).
+// However, this test verifies that concurrent graph submissions do not trigger
+// errors nor memory leaks.
 
 #include "../graph_common.hpp"
 
@@ -44,19 +49,26 @@ int main() {
   run_kernels_usm(Queue, Size, PtrA, PtrB, PtrC);
   Graph.end_recording();
 
+  std::vector<exp_ext::command_graph<exp_ext::graph_state::executable>>
+      GraphExecs;
+  for (unsigned i = 0; i < NumThreads; ++i) {
+    GraphExecs.push_back(Graph.finalize());
+  }
+
   Barrier SyncPoint{NumThreads};
 
-  auto FinalizeGraph = [&](int ThreadNum) {
+  auto SubmitGraph = [&](int ThreadNum) {
     SyncPoint.wait();
-    auto GraphExec = Graph.finalize();
-    Queue.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](sycl::handler &CGH) {
+      CGH.ext_oneapi_graph(GraphExecs[ThreadNum]);
+    });
   };
 
   std::vector<std::thread> Threads;
   Threads.reserve(NumThreads);
 
   for (unsigned i = 0; i < NumThreads; ++i) {
-    Threads.emplace_back(FinalizeGraph, i);
+    Threads.emplace_back(SubmitGraph, i);
   }
 
   for (unsigned i = 0; i < NumThreads; ++i) {
@@ -65,18 +77,9 @@ int main() {
 
   Queue.wait_and_throw();
 
-  Queue.copy(PtrA, DataA.data(), Size);
-  Queue.copy(PtrB, DataB.data(), Size);
-  Queue.copy(PtrC, DataC.data(), Size);
-  Queue.wait_and_throw();
-
   free(PtrA, Queue);
   free(PtrB, Queue);
   free(PtrC, Queue);
-
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
 
   return 0;
 }


### PR DESCRIPTION
Multihtread `finalize.cpp` e2e was written to test both finalize and submit processes. 
This test was based on strong assumptions about backend's kernel ordering, and was unstable. 
Since the behaviour of the finalize process in multi-threaded environment is already tested by a unitest, we (re)focused this test to verify concurrent submissions only. 
The test is therefore renamed submit.cpp