### PR TITLE
[SYCL] Simplify sycl::is_device_copyable implementation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -23,9 +23,7 @@ namespace sycl {
 // device_copyable trait
 template <typename T, typename PropertyList>
 struct is_device_copyable<
-    ext::oneapi::experimental::annotated_arg<T, PropertyList>,
-    std::enable_if_t<!std::is_trivially_copyable_v<
-        ext::oneapi::experimental::annotated_arg<T, PropertyList>>>>
+    ext::oneapi::experimental::annotated_arg<T, PropertyList>>
     : is_device_copyable<T> {};
 
 inline namespace _V1 {

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -242,13 +242,8 @@ struct ValueOrDefault<
 } // namespace detail
 } // namespace ext::oneapi::experimental
 
-// If property_list is not trivially copyable, allow properties to propagate
-// is_device_copyable
 template <typename PropertiesT>
-struct is_device_copyable<
-    ext::oneapi::experimental::properties<PropertiesT>,
-    std::enable_if_t<!std::is_trivially_copyable_v<
-        ext::oneapi::experimental::properties<PropertiesT>>>>
+struct is_device_copyable<ext::oneapi::experimental::properties<PropertiesT>>
     : is_device_copyable<PropertiesT> {};
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -2335,92 +2335,64 @@ __SYCL_DEFINE_HALF_VECSTORAGE(16)
 /// Specializing is_device_copyable such a way that
 /// is_device_copyable_v<T> == true on a T that does not satisfy all
 /// the requirements of a device copyable type is undefined behavior.
+template <typename T> struct is_device_copyable;
+
+namespace detail {
 template <typename T, typename = void>
-struct is_device_copyable : std::false_type {};
-
-// NOTE: this specialization is a candidate for all T such that T is trivially
-// copyable, including std::array<T, N>, std::optional<T>, std::variant<T>,
-// sycl::marray<T> and T[N]. Thus, specializations for all these mentioned
-// types are guarded by `std::enable_if_t<!std::is_trivially_copyable<...>>`
-// so that they are candidates only for non-trivially-copyable types.
-// Otherwise, there are several candidates and the compiler can't decide.
-template <typename T>
-struct is_device_copyable<T, std::enable_if_t<std::is_trivially_copyable_v<T>>>
-    : std::true_type {};
+struct is_device_copyable_impl : std::is_trivially_copyable<T> {};
 
 template <typename T>
-inline constexpr bool is_device_copyable_v = is_device_copyable<T>::value;
+struct is_device_copyable_impl<
+    T, std::enable_if_t<!std::is_same_v<T, std::remove_cv_t<T>>>>
+    // Cannot express this "recursion" (to take user's partial non-cv
+    // specializations into account) without this helper struct.
+    : is_device_copyable<std::remove_cv_t<T>> {};
+} // namespace detail
+
+template <typename T>
+struct is_device_copyable : detail::is_device_copyable_impl<T> {};
 
 // std::array<T, 0> is implicitly device copyable type.
 template <typename T>
 struct is_device_copyable<std::array<T, 0>> : std::true_type {};
 
-// std::array<T, N> is implicitly device copyable type if T is device copyable
+// std::array<T, N> is implicitly device copyable type if T is device copyable.
 template <typename T, std::size_t N>
-struct is_device_copyable<
-    std::array<T, N>,
-    std::enable_if_t<!std::is_trivially_copyable_v<std::array<T, N>>>>
-    : is_device_copyable<T> {};
+struct is_device_copyable<std::array<T, N>> : is_device_copyable<T> {};
 
-// std::optional<T> is implicitly device copyable type if T is device copyable
+// std::optional<T> is implicitly device copyable type if T is device copyable.
 template <typename T>
-struct is_device_copyable<
-    std::optional<T>,
-    std::enable_if_t<!std::is_trivially_copyable_v<std::optional<T>>>>
-    : is_device_copyable<T> {};
+struct is_device_copyable<std::optional<T>> : is_device_copyable<T> {};
 
 // std::pair<T1, T2> is implicitly device copyable type if T1 and T2 are device
-// copyable
+// copyable.
 template <typename T1, typename T2>
-struct is_device_copyable<
-    std::pair<T1, T2>,
-    std::enable_if_t<!std::is_trivially_copyable_v<std::pair<T1, T2>>>>
+struct is_device_copyable<std::pair<T1, T2>>
     : std::bool_constant<is_device_copyable<T1>::value &&
                          is_device_copyable<T2>::value> {};
 
-// std::tuple<> is implicitly device copyable type.
-template <> struct is_device_copyable<std::tuple<>> : std::true_type {};
-
 // std::tuple<Ts...> is implicitly device copyable type if each type T of Ts...
 // is device copyable.
-template <typename T, typename... Ts>
-struct is_device_copyable<
-    std::tuple<T, Ts...>,
-    std::enable_if_t<!std::is_trivially_copyable_v<std::tuple<T, Ts...>>>>
-    : std::bool_constant<is_device_copyable<T>::value &&
-                         is_device_copyable<std::tuple<Ts...>>::value> {};
-
-// std::variant<> is implicitly device copyable type
-template <> struct is_device_copyable<std::variant<>> : std::true_type {};
+template <typename... Ts>
+struct is_device_copyable<std::tuple<Ts...>>
+    : std::bool_constant<(... && is_device_copyable<Ts>::value)> {};
 
 // std::variant<Ts...> is implicitly device copyable type if each type T of
-// Ts... is device copyable
+// Ts... is device copyable.
 template <typename... Ts>
-struct is_device_copyable<
-    std::variant<Ts...>,
-    std::enable_if_t<!std::is_trivially_copyable_v<std::variant<Ts...>>>>
-    : std::bool_constant<(is_device_copyable<Ts>::value && ...)> {};
+struct is_device_copyable<std::variant<Ts...>>
+    : std::bool_constant<(... && is_device_copyable<Ts>::value)> {};
 
-// marray is device copyable if element type is device copyable and it is also
-// not trivially copyable (if the element type is trivially copyable, the marray
-// is device copyable by default).
+// marray is device copyable if element type is device copyable.
 template <typename T, std::size_t N>
-struct is_device_copyable<sycl::marray<T, N>,
-                          std::enable_if_t<is_device_copyable<T>::value &&
-                                           !std::is_trivially_copyable_v<T>>>
-    : std::true_type {};
+struct is_device_copyable<sycl::marray<T, N>> : is_device_copyable<T> {};
 
-// array is device copyable if element type is device copyable
+// array is device copyable if element type is device copyable.
 template <typename T, std::size_t N>
-struct is_device_copyable<T[N],
-                          std::enable_if_t<!std::is_trivially_copyable_v<T>>>
-    : is_device_copyable<T> {};
+struct is_device_copyable<T[N]> : is_device_copyable<T> {};
 
 template <typename T>
-struct is_device_copyable<
-    T, std::enable_if_t<!std::is_trivially_copyable_v<T> &&
-                        (std::is_const_v<T> || std::is_volatile_v<T>)>>
-    : is_device_copyable<std::remove_cv_t<T>> {};
+inline constexpr bool is_device_copyable_v = is_device_copyable<T>::value;
 
 namespace detail {
 template <typename T, typename = void>

--- a/sycl/test/basic_tests/is_device_copyable_neg.cpp
+++ b/sycl/test/basic_tests/is_device_copyable_neg.cpp
@@ -70,17 +70,17 @@ void test() {
   Q.single_task<class TestC>(FB);
 }
 
-// CHECK: static assertion failed due to requirement 'is_device_copyable<A, void>
+// CHECK: static assertion failed due to requirement 'is_device_copyable<A>
 // CHECK: is_device_copyable_neg.cpp:60:5: note: in instantiation of function
 
-// CHECK: static assertion failed due to requirement 'is_device_copyable<B, void>
+// CHECK: static assertion failed due to requirement 'is_device_copyable<B>
 // CHECK: is_device_copyable_neg.cpp:60:5: note: in instantiation of function
 
-// CHECK: static assertion failed due to requirement 'is_device_copyable<sycl::marray<B, 2>, void>
+// CHECK: static assertion failed due to requirement 'is_device_copyable<sycl::marray<B, 2>>
 // CHECK: is_device_copyable_neg.cpp:60:5: note: in instantiation of function
 
-// CHECK: static assertion failed due to requirement 'is_device_copyable<C, void>
+// CHECK: static assertion failed due to requirement 'is_device_copyable<C>
 // CHECK: is_device_copyable_neg.cpp:67:5: note: in instantiation of function
 
-// CHECK: static assertion failed due to requirement 'is_device_copyable<D, void>
+// CHECK: static assertion failed due to requirement 'is_device_copyable<D>
 // CHECK: is_device_copyable_neg.cpp:70:5: note: in instantiation of function


### PR DESCRIPTION
Two benefits:
1) Errors are cleaner now
2) User-provided partial specialization cannot cause "ambiguous partial
   specialization" error anymore. We use those internally as well, so
   that has been simplified too.