### PR TITLE
[sycl-post-link] Call cleanup at the very end of sycl-post-link

### DIFF
--- a/llvm/test/tools/sycl-post-link/spec-constants/remove-dead-private-constants.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/remove-dead-private-constants.ll
@@ -1,0 +1,63 @@
+; Test checks the content of simple generated device image.
+; It checks for removal of unused private constants.
+
+; RUN: sycl-post-link -split=auto -spec-const=native -symbols -S -o %t.table %s -generate-device-image-default-spec-consts
+; RUN: FileCheck %s -input-file %t_0.ll -check-prefix=CHECK-IR0
+; RUN: FileCheck %s -input-file %t_1.ll -check-prefix=CHECK-IR1
+
+; CHECK-IR0-NOT: @__usid_str = private
+; CHECK-IR1-NOT: @__usid_str = private
+; CHECK-IR0-NOT: @__usid_str.1 = private
+; CHECK-IR1-NOT: @__usid_str.1 = private
+; CHECK-IR0-NOT: @__usid_str.2 = private
+; CHECK-IR1-NOT: @__usid_str.2 = private
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+%"class.sycl::_V1::specialization_id" = type { %struct.A }
+%"class.sycl::_V1::specialization_id.2" = type { i32 }
+%"class.sycl::_V1::specialization_id.3" = type { %struct.C }
+%struct.A = type { i32, %struct.B }
+%struct.B = type { i32, i32, i32 }
+%struct.C = type { i32 }
+
+@__usid_str = private unnamed_addr constant [28 x i8] c"uida046125e6e1c1f8d____ZL1c\00", align 1
+@__usid_str.1 = private unnamed_addr constant [33 x i8] c"uidcac21ed8fab7d507____ZL6valueS\00", align 1
+@__usid_str.2 = private unnamed_addr constant [28 x i8] c"uida046125e6e1c1f8f____ZL1b\00", align 1
+@_ZL1c = internal addrspace(1) constant %"class.sycl::_V1::specialization_id" { %struct.A { i32 3, %struct.B { i32 3, i32 2, i32 1 } } }, align 4
+@_ZL6valueS = internal addrspace(1) constant %"class.sycl::_V1::specialization_id.2" { i32 123 }, align 4
+@_ZL1b = internal addrspace(1) constant %"class.sycl::_V1::specialization_id.3" { %struct.C { i32 1 } }, align 4
+
+; This constant checks `zeroinitializer` field.
+@_ZL1d = internal addrspace(1) constant %"class.sycl::_V1::specialization_id" { %struct.A { i32 3, %struct.B zeroinitializer } }, align 4
+
+declare spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI1AET_PKcPKvS5_(ptr addrspace(4) sret(%struct.A) align 4, ptr addrspace(4) noundef, ptr addrspace(4) noundef, ptr addrspace(4) noundef)
+
+declare spir_func %struct.C @_Z40__sycl_getComposite2020SpecConstantValueI1CET_PKcPKvS5_(ptr addrspace(4) noundef, ptr addrspace(4) noundef, ptr addrspace(4) noundef)
+
+declare dso_local spir_func noundef i32 @_Z37__sycl_getScalar2020SpecConstantValueIiET_PKcPKvS4_(ptr addrspace(4) noundef, ptr addrspace(4) noundef, ptr addrspace(4) noundef)
+
+; Function for testing symbol generation
+define spir_func void @func() {
+  ret void
+}
+
+define spir_kernel void @kernel() {
+entry:
+  %a.i = alloca %struct.A, align 4
+  %a.ascast.i = addrspacecast ptr %a.i to ptr addrspace(4)
+  call spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI1AET_PKcPKvS5_(ptr addrspace(4) sret(%struct.A) align 4 %a.ascast.i, ptr addrspace(4) noundef addrspacecast (ptr getelementptr inbounds ([28 x i8], [28 x i8]* @__usid_str, i64 0, i64 0) to ptr addrspace(4)), ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @_ZL1c to ptr addrspace(4)), ptr addrspace(4) noundef null)
+  %scalar = call spir_func i32 @_Z37__sycl_getScalar2020SpecConstantValueIiET_PKcPKvS4_(ptr addrspace(4) noundef addrspacecast (ptr getelementptr inbounds ([33 x i8], [33 x i8]* @__usid_str.1, i64 0, i64 0) to ptr addrspace(4)), ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @_ZL6valueS to ptr addrspace(4)), ptr addrspace(4) noundef null)
+  %scalar2 = add i32 %scalar, 1
+
+  %returned_spec_const = call spir_func %struct.C @_Z40__sycl_getComposite2020SpecConstantValueI1CET_PKcPKvS5_(ptr addrspace(4) noundef addrspacecast (ptr getelementptr inbounds ([28 x i8], [28 x i8]* @__usid_str.2, i64 0, i64 0) to ptr addrspace(4)), ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @_ZL1b to ptr addrspace(4)), ptr addrspace(4) noundef null)
+  %sc.e = extractvalue %struct.C %returned_spec_const, 0
+  %scalar3 = add i32 %sc.e, 1
+
+  call spir_func void @_Z40__sycl_getComposite2020SpecConstantValueI1AET_PKcPKvS5_(ptr addrspace(4) sret(%struct.A) align 4 %a.ascast.i, ptr addrspace(4) noundef addrspacecast (ptr getelementptr inbounds ([28 x i8], [28 x i8]* @__usid_str, i64 0, i64 0) to ptr addrspace(4)), ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @_ZL1d  to ptr addrspace(4)), ptr addrspace(4) noundef null)
+
+
+  call void @func()
+  ret void
+}

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -315,7 +315,7 @@ ModuleDesc extractCallGraph(const ModuleDesc &MD,
 
   ModuleDesc SplitM = extractSubModule(MD, GVs, std::move(ModuleEntryPoints));
   // TODO: cleanup pass is now called for each output module at the end of
-  // sycl-post-link. This call is redundant. Hiwever, we subsequently run
+  // sycl-post-link. This call is redundant. However, we subsequently run
   // GenXSPIRVWriterAdaptor pass that relies on this cleanup. This cleanup call
   // can be removed once that pass no longer depends on this cleanup.
   SplitM.cleanup();
@@ -341,7 +341,7 @@ ModuleDesc extractESIMDSubModule(const ModuleDesc &MD,
 
   ModuleDesc SplitM = extractSubModule(MD, GVs, std::move(ModuleEntryPoints));
   // TODO: cleanup pass is now called for each output module at the end of
-  // sycl-post-link. This call is redundant. Hiwever, we subsequently run
+  // sycl-post-link. This call is redundant. However, we subsequently run
   // GenXSPIRVWriterAdaptor pass that relies on this cleanup. This cleanup call
   // can be removed once that pass no longer depends on this cleanup.
   SplitM.cleanup();
@@ -358,7 +358,7 @@ public:
     // Do some basic optimization like unused symbol removal
     // even if there was no split.
     // TODO: cleanup pass is now called for each output module at the end of
-    // sycl-post-link. This call is redundant. Hiwever, we subsequently run
+    // sycl-post-link. This call is redundant. However, we subsequently run
     // GenXSPIRVWriterAdaptor pass that relies on this cleanup. This cleanup
     // call can be removed once that pass no longer depends on this cleanup.
     Desc.cleanup();

--- a/llvm/tools/sycl-post-link/ModuleSplitter.cpp
+++ b/llvm/tools/sycl-post-link/ModuleSplitter.cpp
@@ -314,6 +314,10 @@ ModuleDesc extractCallGraph(const ModuleDesc &MD,
       GVs, MD.getModule(), ModuleEntryPoints, CG, IncludeFunctionPredicate);
 
   ModuleDesc SplitM = extractSubModule(MD, GVs, std::move(ModuleEntryPoints));
+  // TODO: cleanup pass is now called for each output module at the end of
+  // sycl-post-link. This call is redundant. Hiwever, we subsequently run
+  // GenXSPIRVWriterAdaptor pass that relies on this cleanup. This cleanup call
+  // can be removed once that pass no longer depends on this cleanup.
   SplitM.cleanup();
 
   return SplitM;
@@ -336,6 +340,10 @@ ModuleDesc extractESIMDSubModule(const ModuleDesc &MD,
       GVs, MD.getModule(), ModuleEntryPoints, CG, IncludeFunctionPredicate);
 
   ModuleDesc SplitM = extractSubModule(MD, GVs, std::move(ModuleEntryPoints));
+  // TODO: cleanup pass is now called for each output module at the end of
+  // sycl-post-link. This call is redundant. Hiwever, we subsequently run
+  // GenXSPIRVWriterAdaptor pass that relies on this cleanup. This cleanup call
+  // can be removed once that pass no longer depends on this cleanup.
   SplitM.cleanup();
 
   return SplitM;
@@ -349,6 +357,10 @@ public:
     ModuleDesc Desc{releaseInputModule(), nextGroup(), Input.Props};
     // Do some basic optimization like unused symbol removal
     // even if there was no split.
+    // TODO: cleanup pass is now called for each output module at the end of
+    // sycl-post-link. This call is redundant. Hiwever, we subsequently run
+    // GenXSPIRVWriterAdaptor pass that relies on this cleanup. This cleanup
+    // call can be removed once that pass no longer depends on this cleanup.
     Desc.cleanup();
     return Desc;
   }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -1030,6 +1030,7 @@ processInputModule(std::unique_ptr<Module> M) {
         error("some modules had to be split, '-" + IROutputOnly.ArgStr +
               "' can't be used");
       }
+      MMs.front().cleanup();
       saveModuleIR(MMs.front().getModule(), OutputFilename);
       return Table;
     }
@@ -1044,6 +1045,7 @@ processInputModule(std::unique_ptr<Module> M) {
                 "have been made\n";
     }
     for (module_split::ModuleDesc &IrMD : MMs) {
+      IrMD.cleanup();
       IrPropSymFilenameTriple T = saveModule(IrMD, ID, OutIRFileName);
       addTableRow(*Table, T);
     }

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -668,6 +668,7 @@ IrPropSymFilenameTriple saveModule(module_split::ModuleDesc &MD, int I,
     // don't save IR, just record the filename
     Res.Ir = IRFilename.str();
   } else {
+    MD.cleanup();
     Res.Ir = saveModuleIR(MD.getModule(), I, Suffix);
   }
   GlobalBinImageProps Props = {EmitKernelParamInfo, EmitProgramMetadata,
@@ -1045,7 +1046,6 @@ processInputModule(std::unique_ptr<Module> M) {
                 "have been made\n";
     }
     for (module_split::ModuleDesc &IrMD : MMs) {
-      IrMD.cleanup();
       IrPropSymFilenameTriple T = saveModule(IrMD, ID, OutIRFileName);
       addTableRow(*Table, T);
     }

--- a/sycl/test/esimd/genx_func_attr.cpp
+++ b/sycl/test/esimd/genx_func_attr.cpp
@@ -24,7 +24,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL ESIMD_NOINLINE void callee(int x) {
 // inherits SLMSize and NBarrierCount from callee
 void caller_abc(int x) {
   kernel<class kernel_abc>([=]() SYCL_ESIMD_KERNEL { callee(x); });
-  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abciE10kernel_abc() local_unnamed_addr #2
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_abciE10kernel_abc() local_unnamed_addr #[[ATTR:[0-9]+]]
 }
 
 // inherits only NBarrierCount from callee
@@ -33,7 +33,7 @@ void caller_xyz(int x) {
     slm_init(1235); // also works in non-O0
     callee(x);
   });
-  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz() local_unnamed_addr #2
+  // CHECK: define dso_local spir_kernel void @_ZTSZ10caller_xyziE10kernel_xyz() local_unnamed_addr #[[ATTR]]
 }
 
-// CHECK: attributes #2 = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="2469"
+// CHECK: attributes #[[ATTR]] = { {{.*}} "VCNamedBarrierCount"="13" "VCSLMSize"="2469"


### PR DESCRIPTION
This PR resolves https://github.com/intel/llvm/issues/9962

This change calls cleanup as the final step in sycl-post-link before writing the module into file. This helps to remove several dead variables. Some of these 'dead' variables seem to get translated to erroneous SPIR-V code resulting in spirv-val failures.
In addition to improving code size, this change help to resolve such errors as a side-effect.

Thanks
Sincerely