### PR TITLE
[SYCL-MLIR][sycl] Define `SYCLType` base class for `sycl` dialect types

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.h
@@ -25,16 +25,18 @@
 
 namespace mlir {
 namespace sycl {
+class SYCLType : public Type {
+public:
+  using Type::Type;
+
+  static bool classof(Type type);
+};
+
 template <typename Parameter> class SYCLInheritanceTypeTrait {
 public:
   template <typename ConcreteType>
   class Trait : public mlir::TypeTrait::TraitBase<ConcreteType, Trait> {};
 };
-
-/// Return true if the given \p type is a SYCL type.
-inline bool isSYCLType(Type type) {
-  return isa<SYCLDialect>(type.getDialect());
-}
 
 /// Return the number of dimensions of type \p type.
 unsigned getDimensions(Type type);

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLTypes.td
@@ -25,11 +25,12 @@ include "mlir/IR/BuiltinTypes.td"
 // TYPES DECLARATIONS
 ////////////////////////////////////////////////////////////////////////////////
 
-class SYCL_Type<string name, string typeMnemonic, list<Trait> traits = []>
+class SYCL_Type<string name, string typeMnemonic, list<Trait> traits = [],
+    string baseCppClass = "::mlir::sycl::SYCLType">
     : TypeDef<SYCL_Dialect, name,
               !listconcat([MemRefElementTypeInterface,
                            LLVM_PointerElementTypeInterface],
-                               traits)> {
+                               traits), baseCppClass> {
   let mnemonic = typeMnemonic;
 }
 

--- a/mlir-sycl/lib/Dialect/SYCL/Analysis/AliasAnalysis.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/Analysis/AliasAnalysis.cpp
@@ -63,7 +63,7 @@ static bool isSYCLInnerDisjointArgument(Value val) {
 // type.
 static bool isMemRefOfSYCLType(Type ty) {
   if (auto mt = dyn_cast<MemRefType>(ty))
-    return sycl::isSYCLType(mt.getElementType());
+    return isa<sycl::SYCLType>(mt.getElementType());
   return false;
 }
 

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLOps.cpp
@@ -504,7 +504,7 @@ static LogicalResult verifyReferencesKernel(SymbolUserOpInterface user,
 
 LogicalResult SYCLHostConstructorOp::verify() {
   Type type = getType().getValue();
-  if (!isSYCLType(type))
+  if (!isa<SYCLType>(type))
     return emitOpError("expecting a sycl type as constructed type. Got ")
            << type;
   return success();
@@ -552,7 +552,7 @@ static LogicalResult verifySYCLTypeAttribute(Operation *op, Value value,
   if (!isa<LLVM::LLVMPointerType>(value.getType()))
     return op->emitOpError(
         "does not expect a type attribute for a non-pointer value");
-  if (!isSYCLType(type))
+  if (!isa<SYCLType>(type))
     return op->emitOpError(
         "expects the type attribute to reference a SYCL type");
 

--- a/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
+++ b/mlir-sycl/lib/Dialect/SYCL/IR/SYCLTypes.cpp
@@ -18,6 +18,10 @@ static bool isMemRefWithExpectedShape(MemRefType mt) {
           mt.getLayout().isIdentity());
 }
 
+bool SYCLType::classof(Type type) {
+  return llvm::isa<SYCLDialect>(type.getDialect());
+}
+
 llvm::SmallVector<TypeID> getDerivedTypes(TypeID typeID) {
   if (typeID == AccessorCommonType::getTypeID())
     return {AccessorType::getTypeID()};

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -275,7 +275,7 @@ mlir::Attribute MLIRScanner::InitializeValueByInitListExpr(mlir::Value ToInit,
             ET = mlir::MemRefType::get(Shape, StoreTy,
                                        MemRefLayoutAttrInterface(),
                                        MT.getMemorySpace());
-          } else if (sycl::isSYCLType(ElemTy)) {
+          } else if (isa<sycl::SYCLType>(ElemTy)) {
             std::pair<mlir::MemRefType, mlir::Type> Types =
                 TypeSwitch<mlir::Type, std::pair<mlir::MemRefType, mlir::Type>>(
                     MRET)

--- a/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
+++ b/polygeist/tools/cgeist/Lib/CodeGenTypes.cc
@@ -1568,7 +1568,7 @@ mlir::Type CodeGenTypes::getMLIRType(clang::QualType QT, bool *ImplicitRef,
       // a sycl::Functor type, that will help us get rid of those conditions.
       bool InnerSYCL = false;
       if (auto ST = dyn_cast<mlir::LLVM::LLVMStructType>(SubType))
-        InnerSYCL |= any_of(ST.getBody(), mlir::sycl::isSYCLType);
+        InnerSYCL |= any_of(ST.getBody(), sycl::SYCLType::classof);
 
       if (!InnerSYCL)
         return getPointerType(SubType, CGM.getContext().getTargetAddressSpace(
@@ -1816,9 +1816,9 @@ mlir::Type CodeGenTypes::getPointerOrMemRefType(mlir::Type Ty,
                                                 bool IsAlloc) const {
   auto ST = dyn_cast<mlir::LLVM::LLVMStructType>(Ty);
 
-  bool IsSYCLType = mlir::sycl::isSYCLType(Ty);
+  bool IsSYCLType = isa<sycl::SYCLType>(Ty);
   if (ST)
-    IsSYCLType |= any_of(ST.getBody(), mlir::sycl::isSYCLType);
+    IsSYCLType |= any_of(ST.getBody(), sycl::SYCLType::classof);
 
   if (!ST || IsSYCLType)
     return mlir::MemRefType::get(IsAlloc ? 1 : ShapedType::kDynamic, Ty, {},

--- a/polygeist/tools/cgeist/Lib/TypeUtils.cc
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.cc
@@ -502,7 +502,7 @@ bool areSYCLMemberFunctionOrConstructorArgs(mlir::TypeRange Types) {
   return !Types.empty() &&
          TypeSwitch<mlir::Type, bool>(Types[0])
              .Case<mlir::MemRefType>([](auto Ty) {
-               return mlir::sycl::isSYCLType(Ty.getElementType());
+               return isa<mlir::sycl::SYCLType>(Ty.getElementType());
              })
              .Default(false);
 }

--- a/polygeist/tools/cgeist/Lib/TypeUtils.h
+++ b/polygeist/tools/cgeist/Lib/TypeUtils.h
@@ -75,14 +75,12 @@ inline bool isPointerOrMemRefTy(mlir::Type Ty) {
 inline bool isFirstClassType(mlir::Type Ty) {
   return llvm::isa<mlir::IntegerType, mlir::IndexType, mlir::FloatType,
                    mlir::VectorType, mlir::MemRefType,
-                   mlir::LLVM::LLVMPointerType, mlir::LLVM::LLVMStructType>(
-             Ty) ||
-         mlir::sycl::isSYCLType(Ty);
+                   mlir::LLVM::LLVMPointerType, mlir::LLVM::LLVMStructType,
+                   mlir::sycl::SYCLType>(Ty);
 }
 
 inline bool isAggregateType(mlir::Type Ty) {
-  return llvm::isa<mlir::LLVM::LLVMStructType>(Ty) ||
-         mlir::sycl::isSYCLType(Ty);
+  return llvm::isa<mlir::LLVM::LLVMStructType, mlir::sycl::SYCLType>(Ty);
 }
 
 unsigned getPrimitiveSizeInBits(mlir::Type Ty);

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1109,7 +1109,7 @@ Value MLIRScanner::SYCLCommonFieldLookup(Value V, size_t FNum,
   auto MT = cast<MemRefType>(V.getType());
   Type ElemTy = MT.getElementType();
   assert(isa<T>(ElemTy) && "Expecting element type to be the templated type");
-  assert(sycl::isSYCLType(ElemTy) && "Expecting SYCL element type");
+  assert(isa<sycl::SYCLType>(ElemTy) && "Expecting SYCL element type");
   auto SYCLElemTy = cast<T>(ElemTy);
   assert(FNum < SYCLElemTy.getBody().size() && "ERROR");
 
@@ -1213,7 +1213,7 @@ ValueCategory MLIRScanner::CommonFieldLookup(clang::QualType CT,
 
     Result = Builder.create<polygeist::SubIndexOp>(Loc, ResultType, Val,
                                                    getConstantIndex(FNum));
-  } else if (sycl::isSYCLType(MT.getElementType())) {
+  } else if (isa<sycl::SYCLType>(MT.getElementType())) {
     Type ElemTy = MT.getElementType();
     std::pair<Value, Type> ResultAndType =
         TypeSwitch<Type, std::pair<Value, Type>>(ElemTy)


### PR DESCRIPTION
`SYCLType` is the base class of all `sycl` dialect types. Replace `isSYCLType` instances with `llvm::isa<mlir::sycl::SYCLType>` or `mlir::sycl::SYCLType::classof`.