### PR TITLE
[Draft] Use atexit to release the plugins

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -244,8 +244,8 @@ void GlobalHandler::releaseDefaultContexts() {
 }
 
 struct DefaultContextReleaseHandler {
-  ~DefaultContextReleaseHandler() {
-    GlobalHandler::instance().releaseDefaultContexts();
+  DefaultContextReleaseHandler() {
+    atexit([] { GlobalHandler::instance().releaseDefaultContexts(); });
   }
 };
 


### PR DESCRIPTION
AMD CI is incredibly flaky. This may be the case because of static objects being destroyed in some arbitrary and non deterministic order (static objects in the plugins as well as in the native runtimes). This patch is to test whether failures are less likely if using `atexit`, which causes the shutdown of plugin before static destructors are called.