### PR TITLE
[SYCL][Driver] Add device-link job when compiling with fgpu-rdc for Cuda 

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -4828,7 +4828,16 @@ class OffloadingActionBuilder final {
       if (TT.getOS() != llvm::Triple::NVCL) {
         auto *AA = C.getDriver().ConstructPhaseAction(
             C, Args, phases::Assemble, BA, AssociatedOffloadKind);
-        ActionList DeviceActions = {BA, AA};
+        ActionList DeviceActions;
+        if (Args.hasFlag(options::OPT_fgpu_rdc, options::OPT_fno_gpu_rdc,
+                          /*Default=*/false)) {
+          ActionList AL = {AA};
+          auto *LA = C.MakeAction<LinkJobAction>(AL, types::TY_Object);
+          DeviceActions.push_back(LA);
+        } else {
+          DeviceActions.push_back(AA);
+          DeviceActions.push_back(BA);
+        }
         return C.MakeAction<LinkJobAction>(DeviceActions,
                                            types::TY_CUDA_FATBIN);
       }

--- a/clang/lib/Driver/ToolChains/Cuda.h
+++ b/clang/lib/Driver/ToolChains/Cuda.h
@@ -111,7 +111,7 @@ public:
 // Runs nvlink, which links GPU object files ("cubin" files) into a single file.
 class LLVM_LIBRARY_VISIBILITY Linker : public Tool {
 public:
-  Linker(const ToolChain &TC) : Tool("NVPTX::Linker", "fatbinary", TC) {}
+  Linker(const ToolChain &TC) : Tool("NVPTX::Linker", "nvlink", TC) {}
 
   bool hasIntegratedCPP() const override { return false; }
 


### PR DESCRIPTION
Draft PR with changes for fixing -fgpu-rdc for SYCL->NVPTX targets. This approach requires more work to tie it to an actual non-LTO compilation driver path for Cuda. Will keep it but closed for future reference if this gets brought up.