### PR TITLE
[SYCL-MLIR][cgeist] Omit clang ignored arguments

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -130,7 +130,11 @@ void MLIRScanner::init(FunctionOpInterface Func, const FunctionToEmit &FTE) {
   auto FIArgs = FI.arguments();
 
   for (clang::ParmVarDecl *Parm : FD->parameters()) {
-    assert(I != Function.getNumArguments());
+    // No IR argument corresponding to clang argument
+    if (FIArgs[I].info.getKind() == clang::CodeGen::ABIArgInfo::Ignore) {
+      ++I;
+      continue;
+    }
 
     clang::QualType ParmType = Parm->getType();
 

--- a/polygeist/tools/cgeist/Test/Verification/omitarg.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/omitarg.cpp
@@ -1,0 +1,15 @@
+// RUN: cgeist %s --function=* -S | FileCheck %s
+
+struct x {};
+
+int foo(x arg);
+
+// CHECK-LABEL:   func.func @_Z3barv() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK:           %[[VAL_0:.*]] = call @_Z3foo1x() : () -> i32
+// CHECK:           return %[[VAL_0]] : i32
+// CHECK:         }
+int bar() {
+  return foo(x{});
+}
+
+// CHECK:         func.func private @_Z3foo1x() -> i32 attributes {llvm.linkage = #llvm.linkage<external>}


### PR DESCRIPTION
Omit clang arguments with no MLIR/LLVM IR counterpart, e.g., empty
structs.