### PR TITLE
[SYCL-MLIR][SYCL] Update get_pointer signature to that of sycl

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1270,7 +1270,10 @@ protected:
       !IsConst || IsAccessReadOnly,
       "A const qualified DataT is only allowed for a read-only accessor");
 
-  using ConcreteASPtrType = typename detail::DecoratedType<DataT, AS>::type *;
+  using ConcreteASPtrType = typename detail::DecoratedType<
+      typename std::conditional_t<IsAccessReadOnly && !IsConstantBuf,
+                                  const DataT, DataT>,
+      AS>::type *;
 
   using RefType = detail::const_if_const_AS<AS, DataT> &;
   using ConstRefType = const DataT &;

--- a/sycl/include/sycl/group_algorithm.hpp
+++ b/sycl/include/sycl/group_algorithm.hpp
@@ -106,7 +106,10 @@ using native_op_list =
 
 template <typename T, typename BinaryOperation> struct is_native_op {
   static constexpr bool value =
-      is_contained<BinaryOperation, native_op_list<T>>::value ||
+      is_contained<BinaryOperation,
+                   native_op_list<std::remove_const_t<T>>>::value ||
+      is_contained<BinaryOperation,
+                   native_op_list<std::add_const_t<T>>>::value ||
       is_contained<BinaryOperation, native_op_list<void>>::value;
 };
 
@@ -131,9 +134,9 @@ struct is_complex : public std::false_type {};
 
 // ---- is_arithmetic_or_complex
 template <typename T>
-using is_arithmetic_or_complex =
-    std::integral_constant<bool, sycl::detail::is_complex<T>::value ||
-                                     sycl::detail::is_arithmetic<T>::value>;
+using is_arithmetic_or_complex = std::integral_constant<
+    bool, sycl::detail::is_complex<typename std::remove_cv_t<T>>::value ||
+              sycl::detail::is_arithmetic<T>::value>;
 
 template <typename T>
 struct is_vector_arithmetic_or_complex

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -127,8 +127,9 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(
-            detail::cast_AS<decorated_type *>(Accessor.get_pointer().get())) {}
+      : multi_ptr(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space || generic_space
   template <int Dimensions, access::mode Mode,
@@ -153,7 +154,8 @@ public:
                 (Space == access::address_space::generic_space ||
                  Space == access::address_space::local_space)>>
   multi_ptr(local_accessor<ElementType, Dimensions> Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Only if Space == constant_space
   template <
@@ -167,7 +169,8 @@ public:
   multi_ptr(accessor<ElementType, dimensions, access_mode::read,
                      target::constant_buffer, isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // The following constructors are necessary to create multi_ptr<const
   // ElementType, Space, DecorateAddress> from accessor<ElementType, ...>.
@@ -195,8 +198,9 @@ public:
   multi_ptr(accessor<typename std::remove_const_t<RelayElementType>, Dimensions,
                      Mode, target::device, isPlaceholder, PropertyListT>
                 Accessor)
-      : m_Pointer(
-            detail::cast_AS<decorated_type *>(Accessor.get_pointer().get())) {}
+      : m_Pointer(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space || generic_space and element type is const
   template <int Dimensions, access::mode Mode,
@@ -232,7 +236,8 @@ public:
       // Not having get_decorated() results in facing issue represented in
       // https://github.com/intel/llvm/issues/9745.
       // TODO: would be good to simplify it in future without facing above issue
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Only if Space == constant_space and element type is const
   template <
@@ -250,7 +255,8 @@ public:
                      access_mode::read, target::constant_buffer, isPlaceholder,
                      PropertyListT>
                 Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Assignment and access operators
   multi_ptr &operator=(const multi_ptr &) = default;
@@ -481,8 +487,9 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(
-            detail::cast_AS<decorated_type *>(Accessor.get_pointer().get())) {}
+      : multi_ptr(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space
   template <
@@ -507,7 +514,8 @@ public:
                 (Space == access::address_space::local_space ||
                  Space == access::address_space::generic_space)>>
   multi_ptr(local_accessor<ElementType, Dimensions> Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Only if Space == constant_space
   template <
@@ -522,7 +530,8 @@ public:
                      target::constant_buffer, access::placeholder::false_t,
                      PropertyListT>
                 Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Assignment operators
   multi_ptr &operator=(const multi_ptr &) = default;
@@ -629,8 +638,9 @@ public:
   multi_ptr(accessor<ElementType, Dimensions, Mode, target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(
-            detail::cast_AS<decorated_type *>(Accessor.get_pointer().get())) {}
+      : multi_ptr(detail::cast_AS<decorated_type *>(
+            Accessor.template get_multi_ptr<DecorateAddress>()
+                .get_decorated())) {}
 
   // Only if Space == local_space
   template <
@@ -655,7 +665,8 @@ public:
                 (Space == access::address_space::local_space ||
                  Space == access::address_space::generic_space)>>
   multi_ptr(local_accessor<ElementType, Dimensions> Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Only if Space == constant_space
   template <
@@ -670,7 +681,8 @@ public:
                      target::constant_buffer, access::placeholder::false_t,
                      PropertyListT>
                 Accessor)
-      : multi_ptr(detail::cast_AS<decorated_type *>(Accessor.get_pointer())) {}
+      : multi_ptr(Accessor.template get_multi_ptr<DecorateAddress>()
+                      .get_decorated()) {}
 
   // Assignment operators
   multi_ptr &operator=(const multi_ptr &) = default;

--- a/sycl/test-e2e/Basic/multi_ptr.hpp
+++ b/sycl/test-e2e/Basic/multi_ptr.hpp
@@ -31,7 +31,7 @@ template <typename T> struct point {
 };
 
 template <typename T, access::decorated IsDecorated>
-void innerFunc(id<1> wiID, global_ptr<T, IsDecorated> ptr_1,
+void innerFunc(id<1> wiID, global_ptr<const T, IsDecorated> ptr_1,
                global_ptr<T, IsDecorated> ptr_2,
                global_ptr<T, IsDecorated> ptr_3,
                global_ptr<T, IsDecorated> ptr_4,
@@ -110,9 +110,8 @@ template <typename T, access::decorated IsDecorated> void testMultPtr() {
           private_data[i] = 0;
         localAccessor[wiID.get_local_id()] = 0;
 
-        auto ptr_1 =
-            multi_ptr<T, access::address_space::global_space, IsDecorated>(
-                accessorData_1);
+        auto ptr_1 = multi_ptr<const T, access::address_space::global_space,
+                               IsDecorated>(accessorData_1);
         auto ptr_2 =
             multi_ptr<T, access::address_space::global_space, IsDecorated>(
                 accessorData_2);
@@ -136,11 +135,13 @@ template <typename T, access::decorated IsDecorated> void testMultPtr() {
 
         // Construct extension pointer from accessors.
         auto dev_ptr =
-            multi_ptr<T, access::address_space::ext_intel_global_device_space,
+            multi_ptr<const T,
+                      access::address_space::ext_intel_global_device_space,
                       IsDecorated>(accessorData_1);
-        static_assert(std::is_same_v<ext::intel::device_ptr<T, IsDecorated>,
-                                     decltype(dev_ptr)>,
-                      "Incorrect type for dev_ptr.");
+        static_assert(
+            std::is_same_v<ext::intel::device_ptr<const T, IsDecorated>,
+                           decltype(dev_ptr)>,
+            "Incorrect type for dev_ptr.");
 
         // General conversions in multi_ptr class
         T *RawPtr = nullptr;
@@ -148,7 +149,7 @@ template <typename T, access::decorated IsDecorated> void testMultPtr() {
             address_space_cast<access::address_space::global_space,
                                IsDecorated>(RawPtr);
 
-        global_ptr<T, IsDecorated> ptr_7(accessorData_1);
+        global_ptr<const T, IsDecorated> ptr_7(accessorData_1);
 
         global_ptr<void, IsDecorated> ptr_8 =
             address_space_cast<access::address_space::global_space,
@@ -206,12 +207,12 @@ void testMultPtrArrowOperator() {
             point<T> private_val = 0;
 
             auto ptr_1 =
-                multi_ptr<point<T>, access::address_space::global_space,
+                multi_ptr<const point<T>, access::address_space::global_space,
                           IsDecorated>(accessorData_1);
             auto ptr_2 = multi_ptr<point<T>, access::address_space::local_space,
                                    IsDecorated>(accessorData_2);
             auto ptr_3 =
-                multi_ptr<point<T>,
+                multi_ptr<const point<T>,
                           access::address_space::ext_intel_global_device_space,
                           IsDecorated>(accessorData_3);
             auto ptr_4 =

--- a/sycl/test-e2e/Basic/multi_ptr_legacy.hpp
+++ b/sycl/test-e2e/Basic/multi_ptr_legacy.hpp
@@ -8,7 +8,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <sycl/sycl.hpp>
+#include <sycl.hpp>
 #include <type_traits>
 
 using namespace sycl;
@@ -30,7 +30,7 @@ template <typename T> struct point {
 };
 
 template <typename T>
-void innerFunc(id<1> wiID, global_ptr<T> ptr_1, global_ptr<T> ptr_2,
+void innerFunc(id<1> wiID, global_ptr<const T> ptr_1, global_ptr<T> ptr_2,
                local_ptr<T> local_ptr) {
   T t = ptr_1[wiID.get(0)];
   local_ptr[wiID.get(0)] = t;
@@ -64,12 +64,14 @@ template <typename T> void testMultPtr() {
 
       cgh.parallel_for<class testMultPtrKernel<T>>(
           nd_range<1>{10, 10}, [=](nd_item<1> wiID) {
-            auto ptr_1 = make_ptr<T, access::address_space::global_space,
+            auto ptr_1 = make_ptr<const T, access::address_space::global_space,
                                   access::decorated::legacy>(
-                accessorData_1.get_pointer());
+                accessorData_1
+                    .template get_multi_ptr<sycl::access::decorated::legacy>());
             auto ptr_2 = make_ptr<T, access::address_space::global_space,
                                   access::decorated::legacy>(
-                accessorData_2.get_pointer());
+                accessorData_2
+                    .template get_multi_ptr<sycl::access::decorated::legacy>());
             auto local_ptr = make_ptr<T, access::address_space::local_space,
                                       access::decorated::legacy>(
                 localAccessor.get_pointer());
@@ -100,19 +102,19 @@ template <typename T> void testMultPtr() {
 
             // Construct extension pointer from accessors.
             auto dev_ptr =
-                multi_ptr<T,
+                multi_ptr<const T,
                           access::address_space::ext_intel_global_device_space>(
                     accessorData_1);
-            static_assert(
-                std::is_same_v<ext::intel::device_ptr<T>, decltype(dev_ptr)>,
-                "Incorrect type for dev_ptr.");
+            static_assert(std::is_same_v<ext::intel::device_ptr<const T>,
+                                         decltype(dev_ptr)>,
+                          "Incorrect type for dev_ptr.");
 
             // General conversions in multi_ptr class
             T *RawPtr = nullptr;
             global_ptr<T> ptr_4(RawPtr);
             ptr_4 = RawPtr;
 
-            global_ptr<T> ptr_5(accessorData_1);
+            global_ptr<const T> ptr_5(accessorData_1);
 
             global_ptr<void> ptr_6((void *)RawPtr);
 
@@ -168,9 +170,11 @@ template <typename T> void testMultPtrArrowOperator() {
 
       cgh.parallel_for<class testMultPtrArrowOperatorKernel<T>>(
           sycl::nd_range<1>{1, 1}, [=](sycl::nd_item<1>) {
-            auto ptr_1 = make_ptr<point<T>, access::address_space::global_space,
-                                  access::decorated::legacy>(
-                accessorData_1.get_pointer());
+            auto ptr_1 =
+                make_ptr<const point<T>, access::address_space::global_space,
+                         access::decorated::legacy>(
+                    accessorData_1.template get_multi_ptr<
+                        sycl::access::decorated::legacy>());
             auto ptr_2 =
                 make_ptr<point<T>, access::address_space::constant_space,
                          access::decorated::legacy>(
@@ -179,7 +183,7 @@ template <typename T> void testMultPtrArrowOperator() {
                                   access::decorated::legacy>(
                 accessorData_3.get_pointer());
             auto ptr_4 =
-                make_ptr<point<T>,
+                make_ptr<const point<T>,
                          access::address_space::ext_intel_global_device_space,
                          access::decorated::legacy>(
                     accessorData_4.get_pointer());

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/all_of.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/all_of.cpp
@@ -36,7 +36,9 @@ void test(queue q, InputContainer input, OutputContainer output,
         int lid = it.get_local_id(0);
         out[0] = all_of_group(g, pred(in[lid]));
         out[1] = all_of_group(g, in[lid], pred);
-        out[2] = joint_all_of(g, in.get_pointer(), in.get_pointer() + N, pred);
+        out[2] = joint_all_of(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N, pred);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/any_of.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/any_of.cpp
@@ -44,7 +44,9 @@ void test(queue q, InputContainer input, OutputContainer output,
         int lid = it.get_local_id(0);
         out[0] = any_of_group(g, pred(in[lid]));
         out[1] = any_of_group(g, in[lid], pred);
-        out[2] = joint_any_of(g, in.get_pointer(), in.get_pointer() + N, pred);
+        out[2] = joint_any_of(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N, pred);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
@@ -88,8 +88,10 @@ void test(queue q, InputContainer input, OutputContainer output,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name2>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_exclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), binary_op);
+        joint_exclusive_scan(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N,
+            out.template get_multi_ptr<access::decorated::no>(), binary_op);
       });
     });
   }
@@ -105,8 +107,11 @@ void test(queue q, InputContainer input, OutputContainer output,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name3>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_exclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), init, binary_op);
+        joint_exclusive_scan(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N,
+            out.template get_multi_ptr<access::decorated::no>(), init,
+            binary_op);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
@@ -88,8 +88,10 @@ void test(queue q, InputContainer input, OutputContainer output,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name2>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_inclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), binary_op);
+        joint_inclusive_scan(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N,
+            out.template get_multi_ptr<access::decorated::no>(), binary_op);
       });
     });
   }
@@ -105,8 +107,11 @@ void test(queue q, InputContainer input, OutputContainer output,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name3>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_inclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), binary_op, init);
+        joint_inclusive_scan(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N,
+            out.template get_multi_ptr<access::decorated::no>(), binary_op,
+            init);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/none_of.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/none_of.cpp
@@ -42,7 +42,9 @@ void test(queue q, InputContainer input, OutputContainer output,
         int lid = it.get_local_id(0);
         out[0] = none_of_group(g, pred(in[lid]));
         out[1] = none_of_group(g, in[lid], pred);
-        out[2] = joint_none_of(g, in.get_pointer(), in.get_pointer() + N, pred);
+        out[2] = joint_none_of(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N, pred);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce.cpp
@@ -36,10 +36,14 @@ void test(queue q, InputContainer input, OutputContainer output,
             int lid = it.get_local_id(0);
             out[0] = reduce_over_group(g, in[lid], binary_op);
             out[1] = reduce_over_group(g, in[lid], init, binary_op);
-            out[2] = joint_reduce(g, in.get_pointer(), in.get_pointer() + N,
-                                  binary_op);
-            out[3] = joint_reduce(g, in.get_pointer(), in.get_pointer() + N,
-                                  init, binary_op);
+            out[2] = joint_reduce(
+                g, in.template get_multi_ptr<access::decorated::no>(),
+                in.template get_multi_ptr<access::decorated::no>() + N,
+                binary_op);
+            out[3] = joint_reduce(
+                g, in.template get_multi_ptr<access::decorated::no>(),
+                in.template get_multi_ptr<access::decorated::no>() + N, init,
+                binary_op);
           });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/exclusive_scan_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/exclusive_scan_sycl2020.cpp
@@ -111,8 +111,10 @@ void test(const InputContainer &input, BinaryOperation binary_op,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name2>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_exclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), binary_op);
+        joint_exclusive_scan(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N,
+            out.template get_multi_ptr<access::decorated::no>(), binary_op);
       });
     });
   }
@@ -136,8 +138,11 @@ void test(const InputContainer &input, BinaryOperation binary_op,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name3>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_exclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), init, binary_op);
+        joint_exclusive_scan(
+            g, in.template get_multi_ptr<access::decorated::no>(),
+            in.template get_multi_ptr<access::decorated::no>() + N,
+            out.template get_multi_ptr<access::decorated::no>(), init,
+            binary_op);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/inclusive_scan_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/inclusive_scan_sycl2020.cpp
@@ -111,8 +111,9 @@ void test(const InputContainer &input, BinaryOperation binary_op,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name2>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_inclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), binary_op);
+        joint_inclusive_scan(
+            g, global_ptr<const InputT>(in), global_ptr<const InputT>(in) + N,
+            out.template get_multi_ptr<access::decorated::no>(), binary_op);
       });
     });
   }
@@ -136,8 +137,10 @@ void test(const InputContainer &input, BinaryOperation binary_op,
       accessor out{out_buf, cgh, sycl::write_only, sycl::no_init};
       cgh.parallel_for<kernel_name3>(nd_range<1>(G, G), [=](nd_item<1> it) {
         group<1> g = it.get_group();
-        joint_inclusive_scan(g, in.get_pointer(), in.get_pointer() + N,
-                             out.get_pointer(), binary_op, init);
+        joint_inclusive_scan(
+            g, global_ptr<const InputT>(in), global_ptr<const InputT>(in) + N,
+            out.template get_multi_ptr<access::decorated::no>(), binary_op,
+            init);
       });
     });
   }

--- a/sycl/test-e2e/GroupAlgorithm/reduce_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/reduce_sycl2020.cpp
@@ -39,14 +39,16 @@ void test(const InputContainer &input, BinaryOperation binary_op,
             int lid = it.get_local_id(0);
             out[0] = reduce_over_group(g, in[lid], binary_op);
             out[1] = reduce_over_group(g, in[lid], init, binary_op);
-            out[2] = joint_reduce(g, in.get_pointer(), in.get_pointer() + N,
-                                  binary_op);
-            out[3] = joint_reduce(g, in.get_pointer(), in.get_pointer() + N,
-                                  init, binary_op);
-            out[4] = joint_reduce(sg, in.get_pointer(), in.get_pointer() + N,
-                                  binary_op);
-            out[5] = joint_reduce(sg, in.get_pointer(), in.get_pointer() + N,
-                                  init, binary_op);
+            out[2] = joint_reduce(g, global_ptr<const InputT>(in),
+                                  global_ptr<const InputT>(in) + N, binary_op);
+            out[3] =
+                joint_reduce(g, global_ptr<const InputT>(in),
+                             global_ptr<const InputT>(in) + N, init, binary_op);
+            out[4] = joint_reduce(sg, global_ptr<const InputT>(in),
+                                  global_ptr<const InputT>(in) + N, binary_op);
+            out[5] =
+                joint_reduce(sg, global_ptr<const InputT>(in),
+                             global_ptr<const InputT>(in) + N, init, binary_op);
           });
     });
   }

--- a/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
@@ -46,11 +46,14 @@ int main() {
       cgh.parallel_for<class KernelOne>(numVec, [=](id<1> i) {
         size_t offset = i;
         vec<int, VEC> in1;
-        in1.load(offset, accIn1.get_pointer());
+        in1.load(offset,
+                 accIn1.template get_multi_ptr<access::decorated::no>());
         vec<int, VEC> in2;
-        in2.load(offset, accIn2.get_pointer());
+        in2.load(offset,
+                 accIn2.template get_multi_ptr<access::decorated::no>());
         auto tmp = in1 + in2;
-        tmp.store(offset, accTmp.get_pointer());
+        tmp.store(offset,
+                  accTmp.template get_multi_ptr<sycl::access::decorated::no>());
       });
     });
 
@@ -62,11 +65,14 @@ int main() {
       cgh.parallel_for<class KernelTwo>(numVec, [=](id<1> i) {
         size_t offset = i;
         vec<int, VEC> tmp;
-        tmp.load(offset, accTmp.get_pointer());
+        tmp.load(offset,
+                 accTmp.template get_multi_ptr<sycl::access::decorated::no>());
         vec<int, VEC> in3;
-        in3.load(offset, accIn3.get_pointer());
+        in3.load(offset,
+                 accIn3.template get_multi_ptr<access::decorated::no>());
         auto out = tmp * in3;
-        out.store(offset, accOut.get_pointer());
+        out.store(offset,
+                  accOut.template get_multi_ptr<access::decorated::no>());
       });
     });
 

--- a/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_bf16_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_bf16_impl.hpp
@@ -60,10 +60,11 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] + make_bf16(2);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -93,10 +94,11 @@ void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] - make_bf16(2);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -126,10 +128,11 @@ void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] * make_bf16(3.0);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -159,10 +162,11 @@ void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] / make_bf16(2.0);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -210,10 +214,11 @@ void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
                }
              }
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);

--- a/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_half_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_half_impl.hpp
@@ -46,10 +46,11 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] + static_cast<half>(2);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -79,10 +80,11 @@ void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] - static_cast<half>(2);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -112,10 +114,11 @@ void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] * static_cast<half>(3.0);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -145,10 +148,11 @@ void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] / static_cast<half>(2.0);
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -197,10 +201,11 @@ void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
                }
              }
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);

--- a/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_int8_impl.hpp
@@ -45,10 +45,11 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] + 2;
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -78,10 +79,11 @@ void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] - 2;
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -111,10 +113,11 @@ void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] * 3;
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -144,10 +147,11 @@ void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_a.length(); i++) {
              wi_slice_a[i] = wi_slice_a[i] / 2;
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
@@ -192,10 +196,11 @@ void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
                }
              }
            }
-           joint_matrix_store(sg, sub_a,
-                              accA.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);

--- a/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_int8_packed_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/element_wise_all_ops_int8_packed_impl.hpp
@@ -45,10 +45,11 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_b.length(); i++) {
              wi_slice_b[i] = wi_slice_b[i] + 2;
            }
-           joint_matrix_store(sg, sub_b,
-                              accA.get_pointer() + (sg_startx * TM) * N * 4 +
-                                  sg_starty / SG_SZ * TN * 4,
-                              N * 4, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_b,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
+               N * 4, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
@@ -78,10 +79,11 @@ void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_b.length(); i++) {
              wi_slice_b[i] = wi_slice_b[i] - 2;
            }
-           joint_matrix_store(sg, sub_b,
-                              accA.get_pointer() + (sg_startx * TM) * N * 4 +
-                                  sg_starty / SG_SZ * TN * 4,
-                              N * 4, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_b,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
+               N * 4, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
@@ -111,10 +113,11 @@ void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_b.length(); i++) {
              wi_slice_b[i] = wi_slice_b[i] * 3;
            }
-           joint_matrix_store(sg, sub_b,
-                              accA.get_pointer() + (sg_startx * TM) * N * 4 +
-                                  sg_starty / SG_SZ * TN * 4,
-                              N * 4, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_b,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
+               N * 4, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
@@ -144,10 +147,11 @@ void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            for (int i = 0; i < wi_slice_b.length(); i++) {
              wi_slice_b[i] = wi_slice_b[i] / 2;
            }
-           joint_matrix_store(sg, sub_b,
-                              accA.get_pointer() + (sg_startx * TM) * N * 4 +
-                                  sg_starty / SG_SZ * TN * 4,
-                              N * 4, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_b,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
+               N * 4, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
@@ -192,10 +196,11 @@ void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
                }
              }
            }
-           joint_matrix_store(sg, sub_b,
-                              accA.get_pointer() + (sg_startx * TM) * N * 4 +
-                                  sg_starty / SG_SZ * TN * 4,
-                              N * 4, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_b,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
+               N * 4, matrix_layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);

--- a/sycl/test-e2e/Matrix/Legacy/element_wise_irreg_sum_rows_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/element_wise_irreg_sum_rows_impl.hpp
@@ -47,10 +47,11 @@ void matrix_sum_rows(queue q, big_matrix<T, M, N> &B, nd_range<2> &r) {
 
            joint_matrix<T, TK, TN, matrix_layout::packed_b> sub_b(sg);
 
-           joint_matrix_load(sg, sub_b,
-                             accB.get_pointer() + (global_idx * (TK / 4) * N) +
-                                 sg_starty / SG_SZ * TN * 4,
-                             N, matrix_layout::packed_b);
+           joint_matrix_load(
+               sg, sub_b,
+               accB.template get_multi_ptr<access::decorated::no>() +
+                   (global_idx * (TK / 4) * N) + sg_starty / SG_SZ * TN * 4,
+               N, matrix_layout::packed_b);
            // calculate sum of rows in sum_rows_v[8], there are 8 rows in sub_b
            // (tK/4)
            int32_t sum_local_rows[M] = {0}; // 8 local rows, M total

--- a/sycl/test-e2e/Matrix/Legacy/element_wise_ops_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/element_wise_ops_impl.hpp
@@ -59,29 +59,34 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
            auto wi_slice_c = sub_c.get_wi_data();
            for (int i = 0; i < wi_slice_c.length(); i++) {
              wi_slice_c[i] *= 2;
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/elemwise_irreg_size_ops_bf16.cpp
+++ b/sycl/test-e2e/Matrix/Legacy/elemwise_irreg_size_ops_bf16.cpp
@@ -83,29 +83,34 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix<unsigned short, TK, TN, matrix_layout::packed_b> sub_b(
                sg);
            joint_matrix<float, TM, TN> sub_c(sg);
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K; k += TK) {
-             joint_matrix_load(sg, sub_a,
-                               accA.get_pointer() + (sg_startx * TM) * K + k, K,
-                               matrix_layout::row_major);
+             joint_matrix_load(
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k,
+                 K, matrix_layout::row_major);
              // Assume we alreay in vnni format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k) * (N) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k) * (N) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
            auto wi_slice_c = sub_c.get_wi_data();
            for (int i = 0; i < wi_slice_c.length(); i++) {
              wi_slice_c[i] += 5.0;
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_bf16_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_bf16_impl.hpp
@@ -59,25 +59,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix<unsigned short, TK, TN, matrix_layout::packed_b> sub_b(
                sg);
            joint_matrix<float, TM, TN> sub_c(sg);
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K; k += TK) {
-             joint_matrix_load(sg, sub_a,
-                               accA.get_pointer() + (sg_startx * TM) * K + k, K,
-                               matrix_layout::row_major);
+             joint_matrix_load(
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k,
+                 K, matrix_layout::row_major);
              // Assume we alreay in vnni format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k) * (N) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k) * (N) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_32x64_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_32x64_impl.hpp
@@ -51,25 +51,30 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix<bfloat16, TK, TN, matrix_layout::packed_b> sub_b(sg);
            joint_matrix<float, TM, TN> sub_c(sg);
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp
@@ -46,24 +46,29 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix<bfloat16, TK, TN, matrix_layout::packed_b> sub_b(sg);
            joint_matrix<float, TM, TN> sub_c(sg);
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (k * TK) * M + sg_startx * TM,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * M + sg_startx * TM,
                  M, matrix_layout::col_major);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() +
-                                   (sg_starty / SG_SZ * TN) * K + k * TK,
-                               K, matrix_layout::col_major);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (sg_starty / SG_SZ * TN) * K + k * TK,
+                 K, matrix_layout::col_major);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_impl.hpp
@@ -51,25 +51,30 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix<bfloat16, TK, TN, matrix_layout::packed_b> sub_b(sg);
            joint_matrix<float, TM, TN> sub_c(sg);
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp
@@ -46,24 +46,29 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix<bfloat16, TK, TN, matrix_layout::packed_b> sub_b(sg);
            joint_matrix<float, TM, TN> sub_c(sg);
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK) * (N) +
-                                   sg_starty / SG_SZ * TN,
-                               N, matrix_layout::row_major);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * (N) + sg_starty / SG_SZ * TN,
+                 N, matrix_layout::row_major);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_half_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_half_impl.hpp
@@ -56,25 +56,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix<half, TK, TN, matrix_layout::packed_b> sub_b(sg);
            joint_matrix<float, TM, TN> sub_c(sg);
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_int8_colmajorA_colmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_int8_colmajorA_colmajorB_impl.hpp
@@ -63,18 +63,22 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (k * TK) * M + sg_startx * TM,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * M + sg_startx * TM,
                  M, matrix_layout::col_major);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() +
-                                   (sg_starty / SG_SZ * TN) * K + k * TK,
-                               K, matrix_layout::col_major);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (sg_starty / SG_SZ * TN) * K + k * TK,
+                 K, matrix_layout::col_major);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_int8_vnni_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_int8_vnni_impl.hpp
@@ -54,19 +54,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                joint_matrix_fill(sg, sub_c, 0);
                for (int k = 0; k < K / TK; k += 1) {
                  joint_matrix_load(
-                     sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                     sg, sub_a,
+                     accA.template get_multi_ptr<access::decorated::no>() +
+                         (sg_startx * TM) * K + k * TK,
                      K, matrix_layout::row_major);
                  // VNNI transform is done automatically at this level
-                 joint_matrix_load(sg, sub_b,
-                                   accB.get_pointer() + (k * TK) * N +
-                                       sg_starty / SG_SZ * TN,
-                                   N, matrix_layout::row_major);
+                 joint_matrix_load(
+                     sg, sub_b,
+                     accB.template get_multi_ptr<access::decorated::no>() +
+                         (k * TK) * N + sg_starty / SG_SZ * TN,
+                     N, matrix_layout::row_major);
                  sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
                }
-               joint_matrix_store(sg, sub_c,
-                                  accC.get_pointer() + (sg_startx * TM) * N +
-                                      sg_starty / SG_SZ * TN,
-                                  N, matrix_layout::row_major);
+               joint_matrix_store(
+                   sg, sub_c,
+                   accC.template get_multi_ptr<access::decorated::no>() +
+                       (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   N, matrix_layout::row_major);
              }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_query_default.cpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_query_default.cpp
@@ -80,25 +80,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            myparams2::joint_matrix_b<sub_group> sub_b(sg);
            myparams2::joint_matrix_c<sub_group> sub_c(sg);
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_ss_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_ss_int8_impl.hpp
@@ -60,19 +60,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_su_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_su_int8_impl.hpp
@@ -59,25 +59,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_us_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_us_int8_impl.hpp
@@ -61,25 +61,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/Legacy/joint_matrix_uu_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/Legacy/joint_matrix_uu_int8_impl.hpp
@@ -59,25 +59,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_half_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_half_impl.hpp
@@ -48,8 +48,8 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * N +
-                   sg_starty / SG_SZ * TN,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
                N);
          }); // parallel for
    }).wait();
@@ -83,8 +83,8 @@ void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * N +
-                   sg_starty / SG_SZ * TN,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
                N);
          }); // parallel for
    }).wait();
@@ -118,8 +118,8 @@ void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * N +
-                   sg_starty / SG_SZ * TN,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
                N);
          }); // parallel for
    }).wait();
@@ -153,8 +153,8 @@ void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * N +
-                   sg_starty / SG_SZ * TN,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
                N);
          }); // parallel for
    }).wait();
@@ -207,8 +207,8 @@ void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * N +
-                   sg_starty / SG_SZ * TN,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
                N);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_impl.hpp
@@ -71,7 +71,8 @@ void verify_op_a(const T l, const T r, const float ref, OP op) {
 
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_mat,
-               accessMat.get_pointer() + (sg_startx * SUB_ROWS) * NUM_COLS +
+               accessMat.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * SUB_ROWS) * NUM_COLS +
                    sg_starty / SG_SZ * SUB_COLS,
                NUM_COLS);
          }); // parallel for
@@ -109,11 +110,12 @@ void verify_op_c(const T l, const T r, const float ref, OP op) {
              wi_slice[i] = op(wi_slice[i], r);
            }
 
-           joint_matrix_store(sg, sub_mat,
-                              accessMat.get_pointer() +
-                                  (sg_startx * SUB_ROWS) * NUM_COLS +
-                                  sg_starty / SG_SZ * SUB_COLS,
-                              NUM_COLS, layout::row_major);
+           joint_matrix_store(
+               sg, sub_mat,
+               accessMat.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * SUB_ROWS) * NUM_COLS +
+                   sg_starty / SG_SZ * SUB_COLS,
+               NUM_COLS, layout::row_major);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, NUM_ROWS, NUM_COLS>(bufMat.get_host_access(read_only), ref);

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_tf32_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_tf32_impl.hpp
@@ -49,8 +49,8 @@ void matrix_verify_add(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
 
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * K +
-                   sg_starty / SG_SZ * TK,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
                K);
          }); // parallel for
    }).wait();
@@ -84,8 +84,8 @@ void matrix_verify_sub(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * K +
-                   sg_starty / SG_SZ * TK,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
                K);
          }); // parallel for
    }).wait();
@@ -118,8 +118,8 @@ void matrix_verify_mul(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * K +
-                   sg_starty / SG_SZ * TK,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
                K);
          }); // parallel for
    }).wait();
@@ -153,8 +153,8 @@ void matrix_verify_div(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * K +
-                   sg_starty / SG_SZ * TK,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
                K);
          }); // parallel for
    }).wait();
@@ -203,8 +203,8 @@ void matrix_verify_logic(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
            }
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
-               accA.get_pointer() + (sg_startx * TM) * K +
-                   sg_starty / SG_SZ * TK,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
                K);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/element_wise_irreg_sum_rows_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_irreg_sum_rows_impl.hpp
@@ -48,10 +48,11 @@ void matrix_sum_rows(queue q, big_matrix<T, M, N> &B, nd_range<2> &r) {
                         ext::intel::experimental::matrix::layout::packed>
                sub_b;
 
-           joint_matrix_load(sg, sub_b,
-                             accB.get_pointer() + (global_idx * (TK / 4) * N) +
-                                 sg_starty / SG_SZ * TN * 4,
-                             N);
+           joint_matrix_load(
+               sg, sub_b,
+               accB.template get_multi_ptr<access::decorated::no>() +
+                   (global_idx * (TK / 4) * N) + sg_starty / SG_SZ * TN * 4,
+               N);
            // calculate sum of rows in sum_rows_v[8], there are 8 rows in sub_b
            // (tK/4)
            int32_t sum_local_rows[M] = {0}; // 8 local rows, M total

--- a/sycl/test-e2e/Matrix/element_wise_ops_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_ops_impl.hpp
@@ -56,18 +56,22 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                sub_b;
            joint_matrix<sub_group, int32_t, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
            auto wi_slice_c =
@@ -75,10 +79,11 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            for (int i = 0; i < wi_slice_c.length(); i++) {
              wi_slice_c[i] *= 2;
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/elemwise_irreg_size_ops_bf16.cpp
+++ b/sycl/test-e2e/Matrix/elemwise_irreg_size_ops_bf16.cpp
@@ -84,18 +84,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                         ext::intel::experimental::matrix::layout::packed>
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K; k += TK) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k, K);
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k,
+                 K);
              // Assume we alreay in vnni format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k) * (N) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k) * (N) + sg_starty / SG_SZ * TN * 2,
+                 N * 2);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
            auto wi_slice_c =
@@ -103,10 +108,11 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            for (int i = 0; i < wi_slice_c.length(); i++) {
              wi_slice_c[i] += 5.0;
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/get_coord_int8_matB_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matB_impl.hpp
@@ -116,10 +116,11 @@ void matrix_sum_cols(queue q, big_matrix<T, K, N> &B, nd_range<2> &r) {
                         ext::intel::experimental::matrix::layout::packed>
                sub_b;
 
-           joint_matrix_load(sg, sub_b,
-                             accB.get_pointer() + (sg_startx * (TK / VF) * N) +
-                                 sg_starty / SG_SZ * TN * VF,
-                             N);
+           joint_matrix_load(
+               sg, sub_b,
+               accB.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * (TK / VF) * N) + sg_starty / SG_SZ * TN * VF,
+               N);
 
            int32_t sum_local_cols[N] = {0};
            auto wiData =

--- a/sycl/test-e2e/Matrix/joint_matrix_all_sizes_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_all_sizes_impl.hpp
@@ -61,25 +61,30 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                sub_b;
            joint_matrix<sub_group, T1, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() +
-                                   (k * TK / vnniFactor) * (N * vnniFactor) +
-                                   sg_starty / SG_SZ * TN * vnniFactor,
-                               N * vnniFactor);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / vnniFactor) * (N * vnniFactor) +
+                     sg_starty / SG_SZ * TN * vnniFactor,
+                 N * vnniFactor);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_bf16_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_bf16_impl.hpp
@@ -48,7 +48,8 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
 
        ext::intel::experimental::matrix::joint_matrix_store(
            sg, sub_a,
-           accA.get_pointer() + (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+           accA.template get_multi_ptr<access::decorated::no>() +
+               (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
            N);
      }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_cuda.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_cuda.hpp
@@ -75,11 +75,11 @@ void matrix_verify_lambda(queue q,
 
         sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
 
-        joint_matrix_store(sg, sub_c,
-                           accC.get_pointer() +
-                               (sg_startx * M) * (N * nWGperDim) +
-                               sg_starty / SG_SZ * N,
-                           (N * nWGperDim), layout::row_major);
+        joint_matrix_store(
+            sg, sub_c,
+            accC.template get_multi_ptr<access::decorated::no>() +
+                (sg_startx * M) * (N * nWGperDim) + sg_starty / SG_SZ * N,
+            (N * nWGperDim), layout::row_major);
       }); // parallel for
     });
   }
@@ -158,11 +158,11 @@ void matrix_verify_op(queue q, big_matrix<T2, M * nWGperDim, N * nWGperDim> &C,
 
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
 
-             joint_matrix_store(sg, sub_c,
-                                accC.get_pointer() +
-                                    (sg_startx * M) * (N * nWGperDim) +
-                                    sg_starty / SG_SZ * N,
-                                (N * nWGperDim), layout::row_major);
+             joint_matrix_store(
+                 sg, sub_c,
+                 accC.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * M) * (N * nWGperDim) + sg_starty / SG_SZ * N,
+                 (N * nWGperDim), layout::row_major);
            }); // parallel for
      })
         .wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_32x64_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_32x64_impl.hpp
@@ -51,25 +51,30 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp
@@ -48,23 +48,29 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (k * TK) * M + sg_startx * TM,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * M + sg_startx * TM,
                  M);
              joint_matrix_load(
                  sg, sub_b,
-                 accB.get_pointer() + (sg_starty / SG_SZ * TN) * K + k * TK, K);
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (sg_starty / SG_SZ * TN) * K + k * TK,
+                 K);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_impl.hpp
@@ -50,24 +50,29 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp
@@ -48,24 +48,29 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK) * (N) +
-                                   sg_starty / SG_SZ * TN,
-                               N);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * (N) + sg_starty / SG_SZ * TN,
+                 N);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_gemm_cuda.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_gemm_cuda.hpp
@@ -147,18 +147,24 @@ void test(queue &q) {
                          use::accumulator, M, N>
                 sub_c;
 
-            joint_matrix_load(sg, sub_c,
-                              accC.get_pointer() + (m * M) * Big_N + n * N,
-                              Big_N, layout::row_major);
+            joint_matrix_load(
+                sg, sub_c,
+                accC.template get_multi_ptr<access::decorated::no>() +
+                    (m * M) * Big_N + n * N,
+                Big_N, layout::row_major);
             // k = row/col id of current submatrix of BIG A/B matrices
             for (int k = 0; k < Sub_Tiles_K; k++) {
-              joint_matrix_load(sg, sub_a,
-                                accA.get_pointer() + (k * K) + (m * M * Big_K),
-                                Big_K);
+              joint_matrix_load(
+                  sg, sub_a,
+                  accA.template get_multi_ptr<access::decorated::no>() +
+                      (k * K) + (m * M * Big_K),
+                  Big_K);
 
-              joint_matrix_load(sg, sub_b,
-                                accB.get_pointer() + (k * K * Big_N) + (n * N),
-                                Big_N);
+              joint_matrix_load(
+                  sg, sub_b,
+                  accB.template get_multi_ptr<access::decorated::no>() +
+                      (k * K * Big_N) + (n * N),
+                  Big_N);
 
               // round values to correct precision if using tf32
               if constexpr (std::is_same<T3, precision::tf32>::value) {
@@ -174,9 +180,11 @@ void test(queue &q) {
 
               sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
             }
-            joint_matrix_store(sg, sub_c,
-                               accD.get_pointer() + (m * M) * Big_N + n * N,
-                               Big_N, layout::row_major);
+            joint_matrix_store(
+                sg, sub_c,
+                accD.template get_multi_ptr<access::decorated::no>() +
+                    (m * M) * Big_N + n * N,
+                Big_N, layout::row_major);
           });
     });
     q.wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_half_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_half_impl.hpp
@@ -55,24 +55,29 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                    sub_b;
                joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
 
-               joint_matrix_load(sg, sub_c,
-                                 accC.get_pointer() + (sg_startx * TM) * N +
-                                     sg_starty / SG_SZ * TN,
-                                 N, layout::row_major);
+               joint_matrix_load(
+                   sg, sub_c,
+                   accC.template get_multi_ptr<access::decorated::no>() +
+                       (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   N, layout::row_major);
                for (int k = 0; k < K / TK; k += 1) {
                  joint_matrix_load(
                      sg, sub_a,
-                     accA.get_pointer() + (sg_startx * TM) * K + k * TK, K);
-                 joint_matrix_load(sg, sub_b,
-                                   accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                       sg_starty / SG_SZ * TN * 2,
-                                   N * 2);
+                     accA.template get_multi_ptr<access::decorated::no>() +
+                         (sg_startx * TM) * K + k * TK,
+                     K);
+                 joint_matrix_load(
+                     sg, sub_b,
+                     accB.template get_multi_ptr<access::decorated::no>() +
+                         (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                     N * 2);
                  sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
                }
-               joint_matrix_store(sg, sub_c,
-                                  accC.get_pointer() + (sg_startx * TM) * N +
-                                      sg_starty / SG_SZ * TN,
-                                  N, layout::row_major);
+               joint_matrix_store(
+                   sg, sub_c,
+                   accC.template get_multi_ptr<access::decorated::no>() +
+                       (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   N, layout::row_major);
              }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB_impl.hpp
@@ -55,17 +55,22 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (k * TK) * M + sg_startx * TM,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * M + sg_startx * TM,
                  M);
              joint_matrix_load(
                  sg, sub_b,
-                 accB.get_pointer() + (sg_starty / SG_SZ * TN) * K + k * TK, K);
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (sg_starty / SG_SZ * TN) * K + k * TK,
+                 K);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_vnni_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_vnni_impl.hpp
@@ -55,18 +55,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // VNNI transform is done automatically at this level
              joint_matrix_load(
                  sg, sub_b,
-                 accB.get_pointer() + (k * TK) * N + sg_starty / SG_SZ * TN, N);
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK) * N + sg_starty / SG_SZ * TN,
+                 N);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_query_default.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_query_default.cpp
@@ -84,25 +84,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                sub_b;
            myparams2::joint_matrix_c<sub_group> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_ss_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_ss_int8_impl.hpp
@@ -59,18 +59,22 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_su_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_su_int8_impl.hpp
@@ -56,24 +56,29 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                sub_b;
            joint_matrix<sub_group, int32_t, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_tf32_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tf32_impl.hpp
@@ -55,17 +55,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                         layout::row_major>
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            joint_matrix_fill(sg, sub_a, 42);
            for (int k = 0; k < K; k += TK) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k, K);
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k,
+                 K);
              joint_matrix_load(
                  sg, sub_b,
-                 accB.get_pointer() + (k) * (N) + sg_starty / SG_SZ * TN, N);
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k) * (N) + sg_starty / SG_SZ * TN,
+                 N);
              // If no rounding to tf32 function is called, joint_matrix_mad
              // function will work on truncated floats.
              joint_matrix_apply(sg, sub_a,
@@ -80,10 +86,11 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            auto wi_slice_a =
                sycl::ext::intel::experimental::matrix::get_wi_data(sg, sub_a);
            joint_matrix_apply(sg, sub_a, [=](float x) { x *= 2; });
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_us_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_us_int8_impl.hpp
@@ -58,25 +58,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                sub_b;
            joint_matrix<sub_group, int32_t, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_uu_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_uu_int8_impl.hpp
@@ -56,25 +56,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                sub_b;
            joint_matrix<sub_group, int32_t, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
@@ -123,8 +123,9 @@ void test(queue q, InputContainer input, OutputContainer output,
                 sycl::ext::oneapi::experimental::group_with_scratchpad(
                     it.get_group(), sycl::span(&scratch[0], temp_memory_size));
 
-            InputT *first = in.get_pointer();
-            InputT *last = first + N;
+            const InputT *first =
+                in.template get_multi_ptr<access::decorated::no>();
+            const InputT *last = first + N;
             // check reduce_over_group w/o init
             out[0] = sycl::ext::oneapi::experimental::reduce_over_group(
                 handle, in[it.get_global_id(0)], binary_op);

--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
@@ -45,8 +45,11 @@ void test(queue q, InputContainer input, OutputContainer output,
       auto scratch = sycl::local_accessor<std::byte, 1>(temp_memory_size, cgh);
       cgh.parallel_for(
           nd_range<1>(workgroup_size, workgroup_size), [=](nd_item<1> it) {
-            InputT *segment_begin = in.get_pointer();
-            InputT *segment_end = in.get_pointer() + segment_size;
+            const InputT *segment_begin =
+                in.template get_multi_ptr<access::decorated::no>();
+            const InputT *segment_end =
+                in.template get_multi_ptr<access::decorated::no>() +
+                segment_size;
             auto handle =
                 sycl::ext::oneapi::experimental::group_with_scratchpad(
                     it.get_group(), sycl::span(&scratch[0], temp_memory_size));

--- a/sycl/test-e2e/XPTI/kernel/content.cpp
+++ b/sycl/test-e2e/XPTI/kernel/content.cpp
@@ -51,9 +51,12 @@ int main() {
       cgh.parallel_for<class test2>(
           nd_range<3>({128, 4, 2}, {32, 2, 1}, {16, 1, 0}), [=](nd_item<3> it) {
             auto sg = it.get_sub_group();
-            joint_exclusive_scan(sg, in.get_pointer(),
-                                 in.get_pointer() + sg.get_local_id(),
-                                 out.get_pointer(), std::plus<>{});
+            joint_exclusive_scan(
+                sg, in.template get_multi_ptr<access::decorated::no>(),
+                in.template get_multi_ptr<access::decorated::no>() +
+                    sg.get_local_id(),
+                out.template get_multi_ptr<access::decorated::no>(),
+                std::plus<>{});
           });
     });
   }

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-bfloat16-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-bfloat16-test.cpp
@@ -45,17 +45,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.a.row.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.b.row.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.mma.row.row.bf16(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m16n16k16>(
@@ -70,17 +76,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.load.c.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.a.col.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.b.col.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.mma.col.col.bf16(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m32n8k16>(
@@ -95,17 +107,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.a.row.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.b.row.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.mma.row.row.bf16(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m32n8k16>(
@@ -120,17 +138,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.load.c.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.a.col.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.b.col.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.mma.col.col.bf16(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m8n32k16>(
@@ -145,17 +169,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.a.row.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.b.row.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.mma.row.row.bf16(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m8n32k16>(
@@ -170,17 +200,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.load.c.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.a.col.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.b.col.stride.bf16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.mma.col.col.bf16(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
   });
 

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-double-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-double-test.cpp
@@ -55,17 +55,23 @@ int main() {
               sub_b{};
 
           //CHECK-OPAQUE: tail call { double, double } @llvm.nvvm.wmma.m8n8k4.load.c.row.stride.f64.p1(ptr addrspace(1) %{{.*}}, i32 8)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), N,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              N, layout::row_major);
           //CHECK-OPAQUE: tail call double @llvm.nvvm.wmma.m8n8k4.load.a.row.stride.f64.p1(ptr addrspace(1) %{{.*}}, i32 4)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), K);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              K);
           //CHECK-OPAQUE: tail call double @llvm.nvvm.wmma.m8n8k4.load.b.row.stride.f64.p1(ptr addrspace(1) %{{.*}}, i32 8)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), N);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              N);
           //CHECK-OPAQUE: tail call { double, double } @llvm.nvvm.wmma.m8n8k4.mma.row.row.f64(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           //CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n8k4.store.d.row.stride.f64.p1(ptr addrspace(1) %{{.*}}, double {{.*}}, double {{.*}}, i32 8)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), N,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              N, layout::row_major);
         });
 
     cgh.parallel_for<class col_col>(
@@ -80,17 +86,23 @@ int main() {
               sub_b{};
 
           //CHECK-OPAQUE: tail call { double, double } @llvm.nvvm.wmma.m8n8k4.load.c.col.stride.f64.p1(ptr addrspace(1) %{{.*}}, i32 8)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), M,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              M, layout::col_major);
           //CHECK-OPAQUE: tail call double @llvm.nvvm.wmma.m8n8k4.load.a.col.stride.f64.p1(ptr addrspace(1) %{{.*}}, i32 8)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), M);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              M);
           //CHECK-OPAQUE: tail call double @llvm.nvvm.wmma.m8n8k4.load.b.col.stride.f64.p1(ptr addrspace(1) %{{.*}}, i32 4)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), K);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              K);
           //CHECK-OPAQUE: tail call { double, double } @llvm.nvvm.wmma.m8n8k4.mma.col.col.f64(double {{.*}}, double {{.*}}, double {{.*}}, double {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           //CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n8k4.store.d.col.stride.f64.p1(ptr addrspace(1) %{{.*}}, double {{.*}}, double {{.*}}, i32 8)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), M,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              M, layout::col_major);
         });
   });
 

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-float-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-float-test.cpp
@@ -44,17 +44,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.a.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.b.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.mma.row.row.f32.f32(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m16n16k16>(
@@ -69,17 +75,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.load.c.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.a.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.b.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.mma.col.col.f32.f32(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m32n8k16>(
@@ -94,17 +106,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.a.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.b.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.mma.row.row.f32.f32(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m32n8k16>(
@@ -119,17 +137,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.load.c.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.a.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.b.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m32n8k16.mma.col.col.f32.f32(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m8n32k16>(
@@ -144,17 +168,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.a.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.b.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.mma.row.row.f32.f32(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m8n32k16>(
@@ -169,17 +199,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.load.c.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.a.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.b.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m8n32k16.mma.col.col.f32.f32(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.col.stride.f32.p1(ptr addrspace(1) %{{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
   });
 

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-half-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-half-half-test.cpp
@@ -44,17 +44,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.c.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.a.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.b.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.mma.row.row.f16.f16(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.row.stride.f16.p0(ptr %{{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m16n16k16>(
@@ -69,17 +75,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.c.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.a.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.load.b.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m16n16k16.mma.col.col.f16.f16(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.col.stride.f16.p0(ptr %{{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m32n8k16>(
@@ -94,17 +106,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.c.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.a.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.b.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.mma.row.row.f16.f16(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.row.stride.f16.p0(ptr %{{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m32n8k16>(
@@ -119,17 +137,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.c.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.a.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.load.b.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m32n8k16.mma.col.col.f16.f16(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.col.stride.f16.p0(ptr %{{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m8n32k16>(
@@ -144,17 +168,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.c.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.a.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.b.row.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.mma.row.row.f16.f16(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.row.stride.f16.p0(ptr %{{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m8n32k16>(
@@ -169,17 +199,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.c.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.a.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.load.b.col.stride.f16.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { <2 x half>, <2 x half>, <2 x half>, <2 x half> } @llvm.nvvm.wmma.m8n32k16.mma.col.col.f16.f16(<2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.col.stride.f16.p0(ptr %{{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, <2 x half> {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
   });
 

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-int8-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-int8-test.cpp
@@ -44,17 +44,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.c.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.a.row.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.b.row.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.mma.row.row.s8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m16n16k16>(
@@ -69,17 +75,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.c.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.a.col.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.b.col.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.mma.col.col.s8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m32n8k16>(
@@ -94,17 +106,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.c.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.a.row.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m32n8k16.load.b.row.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.mma.row.row.s8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m32n8k16>(
@@ -119,17 +137,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.c.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.a.col.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m32n8k16.load.b.col.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.mma.col.col.s8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m8n32k16>(
@@ -144,17 +168,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.c.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m8n32k16.load.a.row.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.b.row.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.mma.row.row.s8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m8n32k16>(
@@ -169,17 +199,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.c.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m8n32k16.load.a.col.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.b.col.stride.s8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.mma.col.col.s8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
   });
 

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-tf32-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-tf32-test.cpp
@@ -67,12 +67,17 @@ int main() {
           joint_matrix<sub_group, float, use::accumulator, M, N> sub_c{};
 
           //CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k8.load.a.row.stride.tf32.p0(ptr %{{.*}}, i32 8)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), K);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              K);
           //CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k8.load.b.row.stride.tf32.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), N);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              N);
           //CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.load.c.row.stride.f32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), N,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              N, layout::row_major);
 
           // Round a, b to tf32
           for (auto i = 0; i < 4; ++i)
@@ -85,8 +90,9 @@ int main() {
 
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           //CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.row.stride.f32.p1(ptr addrspace(1) {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 {{.*}}
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), N,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              N, layout::row_major);
         });
   });
 
@@ -110,12 +116,17 @@ int main() {
           joint_matrix<sub_group, float, use::accumulator, M, N> sub_c{};
 
           //CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k8.load.a.col.stride.tf32.p0(ptr %{{.*}}, i32 8)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), K);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              K);
           //CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k8.load.b.col.stride.tf32.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), N);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              N);
           //CHECK-OPAQUE: tail call { float, float, float, float, float, float, float, float } @llvm.nvvm.wmma.m16n16k16.load.c.col.stride.f32.p1(ptr addrspace(1) {{.*}}, i32 {{.*}})
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), N,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              N, layout::col_major);
 
           // Round a, b to tf32
           for (auto i = 0; i < 4; ++i)
@@ -128,8 +139,9 @@ int main() {
 
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           //CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.col.stride.f32.p1(ptr addrspace(1) {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, float {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), N,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              N, layout::col_major);
         });
   });
 

--- a/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-uint8-test.cpp
+++ b/sycl/test/check_device_code/cuda/matrix/matrix-nvptx-uint8-test.cpp
@@ -44,17 +44,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.c.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.a.row.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.b.row.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.mma.row.row.u8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m16n16k16>(
@@ -69,17 +75,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.c.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.a.col.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32 } @llvm.nvvm.wmma.m16n16k16.load.b.col.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m16n16k16.mma.col.col.u8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m16n16k16.store.d.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m32n8k16>(
@@ -94,17 +106,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.c.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.a.row.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m32n8k16.load.b.row.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.mma.row.row.u8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m32n8k16>(
@@ -119,17 +137,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.c.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.load.a.col.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m32n8k16.load.b.col.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m32n8k16.mma.col.col.u8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m32n8k16.store.d.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
 
     cgh.parallel_for<class row_row_m8n32k16>(
@@ -144,17 +168,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.c.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::row_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m8n32k16.load.a.row.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.b.row.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.mma.row.row.u8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.row.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::row_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::row_major);
         });
 
     cgh.parallel_for<class col_col_m8n32k16>(
@@ -169,17 +199,23 @@ int main() {
               sub_b{};
 
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.c.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_c, accC.get_pointer(), stride,
-                            layout::col_major);
+          joint_matrix_load(
+              sg, sub_c, accC.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
           // CHECK-OPAQUE: tail call i32 @llvm.nvvm.wmma.m8n32k16.load.a.col.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_a, accA.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_a, accA.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.load.b.col.stride.u8.p0(ptr %{{.*}}, i32 16)
-          joint_matrix_load(sg, sub_b, accB.get_pointer(), stride);
+          joint_matrix_load(
+              sg, sub_b, accB.template get_multi_ptr<access::decorated::yes>(),
+              stride);
           // CHECK-OPAQUE: tail call { i32, i32, i32, i32, i32, i32, i32, i32 } @llvm.nvvm.wmma.m8n32k16.mma.col.col.u8(i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}})
           sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
           // CHECK-OPAQUE: tail call void @llvm.nvvm.wmma.m8n32k16.store.d.col.stride.s32.p1(ptr addrspace(1) %{{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 {{.*}}, i32 16)
-          joint_matrix_store(sg, sub_c, accD.get_pointer(), stride,
-                             layout::col_major);
+          joint_matrix_store(
+              sg, sub_c, accD.template get_multi_ptr<access::decorated::yes>(),
+              stride, layout::col_major);
         });
   });
 

--- a/sycl/test/matrix/legacy/matrix-bf16-test-SG-16.cpp
+++ b/sycl/test/matrix/legacy/matrix-bf16-test-SG-16.cpp
@@ -72,25 +72,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/legacy/matrix-bf16-test.cpp
+++ b/sycl/test/matrix/legacy/matrix-bf16-test.cpp
@@ -71,25 +71,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/legacy/matrix-bfloat16-test.cpp
+++ b/sycl/test/matrix/legacy/matrix-bfloat16-test.cpp
@@ -70,25 +70,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/legacy/matrix-elemwise-ops.cpp
+++ b/sycl/test/matrix/legacy/matrix-elemwise-ops.cpp
@@ -71,29 +71,34 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
            auto wi_data_c = sub_c.get_wi_data();
            for (int i = 0; i < wi_data_c.length(); i++) {
              wi_data_c[i] *= 2;
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/legacy/matrix-int8-test-SG-16.cpp
+++ b/sycl/test/matrix/legacy/matrix-int8-test-SG-16.cpp
@@ -71,25 +71,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, matrix_layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/legacy/matrix-int8-test.cpp
+++ b/sycl/test/matrix/legacy/matrix-int8-test.cpp
@@ -78,19 +78,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K, matrix_layout::row_major);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4, matrix_layout::packed_b);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4, matrix_layout::packed_b);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, matrix_layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, matrix_layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/matrix-bfloat16-test-coord-basicB.cpp
+++ b/sycl/test/matrix/matrix-bfloat16-test-coord-basicB.cpp
@@ -160,10 +160,11 @@ void matrix_sum_cols(queue q, big_matrix<T, M, N> &B, nd_range<2> &r) {
                         ext::intel::experimental::matrix::layout::packed>
                sub_b;
 
-           joint_matrix_load(sg, sub_b,
-                             accB.get_pointer() + (global_idx * (TK / 4) * N) +
-                                 sg_starty / SG_SZ * TN * 4,
-                             N);
+           joint_matrix_load(
+               sg, sub_b,
+               accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (global_idx * (TK / 4) * N) + sg_starty / SG_SZ * TN * 4,
+               N);
 
            int32_t sum_local_cols[N] = {0}; // 4 local cols, N total
            // sub_b has 32x16 elements, 32 elements per WI, 4 per WI per row

--- a/sycl/test/matrix/matrix-bfloat16-test.cpp
+++ b/sycl/test/matrix/matrix-bfloat16-test.cpp
@@ -72,25 +72,30 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                sub_b;
            joint_matrix<sycl::sub_group, float, use::accumulator, TM, TN> sub_c;
 
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 2) * (N * 2) +
-                                   sg_starty / SG_SZ * TN * 2,
-                               N * 2);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                 N * 2);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/matrix-elemwise-ops.cpp
+++ b/sycl/test/matrix/matrix-elemwise-ops.cpp
@@ -76,19 +76,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
 
            // AMX: 8 register tiles : 1k byte size, SMmaxxSKmax =16x64
            // strideX = X's cols, so strideC = N, strideA = K, strideB = N*4
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
            auto wi_data_c =
@@ -96,10 +100,11 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            for (int i = 0; i < wi_data_c.length(); i++) {
              wi_data_c[i] *= 2;
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/matrix-int8-test.cpp
+++ b/sycl/test/matrix/matrix-int8-test.cpp
@@ -84,19 +84,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_fill(sg, sub_c, 0);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k * TK,
+                 sg, sub_a,
+                 accA.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
                  K);
              // Assuming B data is already in VNNI format.
-             joint_matrix_load(sg, sub_b,
-                               accB.get_pointer() + (k * TK / 4) * (N * 4) +
-                                   sg_starty / SG_SZ * TN * 4,
-                               N * 4);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<sycl::access::decorated::no>() +
+                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                 N * 4);
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<sycl::access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test/matrix/matrix-tf32-test.cpp
+++ b/sycl/test/matrix/matrix-tf32-test.cpp
@@ -66,17 +66,23 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
                         layout::row_major>
                sub_b;
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
-           joint_matrix_load(sg, sub_c,
-                             accC.get_pointer() + (sg_startx * TM) * N +
-                                 sg_starty / SG_SZ * TN,
-                             N, layout::row_major);
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
            joint_matrix_fill(sg, sub_a, 42);
            for (int k = 0; k < K; k += TK) {
              joint_matrix_load(
-                 sg, sub_a, accA.get_pointer() + (sg_startx * TM) * K + k, K);
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k,
+                 K);
              joint_matrix_load(
                  sg, sub_b,
-                 accB.get_pointer() + (k) * (N) + sg_starty / SG_SZ * TN, N);
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k) * (N) + sg_starty / SG_SZ * TN,
+                 N);
              // If no rounding to tf32 function is called, joint_matrix_mad
              // function will work on truncated floats.
              joint_matrix_apply(sg, sub_a,
@@ -88,10 +94,11 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              }
              sub_c = joint_matrix_mad(sg, sub_a, sub_b, sub_c);
            }
-           joint_matrix_store(sg, sub_c,
-                              accC.get_pointer() + (sg_startx * TM) * N +
-                                  sg_starty / SG_SZ * TN,
-                              N, layout::row_major);
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+               N, layout::row_major);
          }); // parallel for
    }).wait();
 }


### PR DESCRIPTION
Apply changes from 712cb4e4f75e4d2c5d9f1967e87ffe17d0b7fa60, fd4598035b7e21a642681f4e5c85850f7982fd7f and a69e5152874e5c3805d6ec9b46c71331da3a277d, as asked in #9535.

This commit gets `sycl-mlir` branch closer to `sycl`, only missing
`detail::loop`-related changes, not possible with current C++
front-end.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>