### PR TITLE
[SYCL][ESIMD] Support Auto GRF size specification

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -400,8 +400,7 @@ appendCompileOptionsForGRFSizeProperties(std::string &CompileOpts,
     // This option works for both LO AND OCL backends.
     CompileOpts += IsEsimdImage ? "-doubleGRF" : "-ze-opt-large-register-file";
   }
-  // TODO: Support Auto GRF for ESIMD once vc supports it.
-  if (IsAutoGRF && !IsEsimdImage) {
+  if (IsAutoGRF) {
     if (!CompileOpts.empty())
       CompileOpts += " ";
     // This option works for both LO AND OCL backends.


### PR DESCRIPTION
All the pieces were there because it's already supported in normal SYCL, and we just updated the GPU driver which added support for auto GRF in VC.