### PR TITLE
[SYCL][FPGA] Drop duplicate attributes

### DIFF
--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7537,7 +7537,7 @@ static void handleIntelSimpleDualPortAttr(Sema &S, Decl *D,
   // 'simple_dual_port' Attribute does not take any argument. Give a warning for
   // duplicate attributes but not if it's one we've implicitly added and drop
   // any duplicates.
-  if (const auto *ExistingAttr = D->getAttr<SYCLIntelDoublePumpAttr>()) {
+  if (const auto *ExistingAttr = D->getAttr<SYCLIntelSimpleDualPortAttr>()) {
     if (ExistingAttr && !ExistingAttr->isImplicit()) {
       S.Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact) << &AL;
       S.Diag(ExistingAttr->getLoc(), diag::note_previous_attribute);

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7251,7 +7251,16 @@ static void handleSYCLIntelNoGlobalWorkOffsetAttr(Sema &S, Decl *D,
 /// Handle the [[intel::singlepump]] attribute.
 static void handleSYCLIntelSinglePumpAttr(Sema &S, Decl *D,
                                           const ParsedAttr &AL) {
-  checkForDuplicateAttribute<SYCLIntelSinglePumpAttr>(S, D, AL);
+  // 'singlepump' Attribute does not take any argument. Give a warning for
+  // duplicate attributes but not if it's one we've implicitly added and drop
+  // any duplicates.
+  if (const auto *ExistingAttr = D->getAttr<SYCLIntelSinglePumpAttr>()) {
+    if (ExistingAttr && !ExistingAttr->isImplicit()) {
+      S.Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact) << &AL;
+      S.Diag(ExistingAttr->getLoc(), diag::note_previous_attribute);
+      return;
+    }
+  }
 
   // If the declaration does not have an [[intel::fpga_memory]]
   // attribute, this creates one as an implicit attribute.
@@ -7265,7 +7274,16 @@ static void handleSYCLIntelSinglePumpAttr(Sema &S, Decl *D,
 /// Handle the [[intel::doublepump]] attribute.
 static void handleSYCLIntelDoublePumpAttr(Sema &S, Decl *D,
                                           const ParsedAttr &AL) {
-  checkForDuplicateAttribute<SYCLIntelDoublePumpAttr>(S, D, AL);
+  // 'doublepump' Attribute does not take any argument. Give a warning for
+  // duplicate attributes but not if it's one we've implicitly added and drop
+  // any duplicates.
+  if (const auto *ExistingAttr = D->getAttr<SYCLIntelDoublePumpAttr>()) {
+    if (ExistingAttr && !ExistingAttr->isImplicit()) {
+      S.Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact) << &AL;
+      S.Diag(ExistingAttr->getLoc(), diag::note_previous_attribute);
+      return;
+    }
+  }
 
   // If the declaration does not have an [[intel::fpga_memory]]
   // attribute, this creates one as an implicit attribute.
@@ -7326,7 +7344,18 @@ static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
 /// This is incompatible with most of the other memory attributes.
 static void handleSYCLIntelRegisterAttr(Sema &S, Decl *D,
 		                        const ParsedAttr &A) {
-  checkForDuplicateAttribute<SYCLIntelRegisterAttr>(S, D, A);
+
+  // 'fpga_register' Attribute does not take any argument. Give a warning for
+  // duplicate attributes but not if it's one we've implicitly added and drop
+  // any duplicates.
+  if (const auto *ExistingAttr = D->getAttr<SYCLIntelRegisterAttr>()) {
+    if (ExistingAttr && !ExistingAttr->isImplicit()) {
+      S.Diag(A.getLoc(), diag::warn_duplicate_attribute_exact) << &A;
+      S.Diag(ExistingAttr->getLoc(), diag::note_previous_attribute);
+      return;
+    }
+  }
+
   if (checkIntelFPGARegisterAttrCompatibility(S, D, A))
     return;
 
@@ -7505,7 +7534,16 @@ static void handleSYCLIntelNumBanksAttr(Sema &S, Decl *D, const ParsedAttr &A) {
 
 static void handleIntelSimpleDualPortAttr(Sema &S, Decl *D,
                                           const ParsedAttr &AL) {
-  checkForDuplicateAttribute<SYCLIntelSimpleDualPortAttr>(S, D, AL);
+  // 'simple_dual_port' Attribute does not take any argument. Give a warning for
+  // duplicate attributes but not if it's one we've implicitly added and drop
+  // any duplicates.
+  if (const auto *ExistingAttr = D->getAttr<SYCLIntelDoublePumpAttr>()) {
+    if (ExistingAttr && !ExistingAttr->isImplicit()) {
+      S.Diag(AL.getLoc(), diag::warn_duplicate_attribute_exact) << &AL;
+      S.Diag(ExistingAttr->getLoc(), diag::note_previous_attribute);
+      return;
+    }
+  }
 
   if (!D->hasAttr<SYCLIntelMemoryAttr>())
     D->addAttr(SYCLIntelMemoryAttr::CreateImplicit(

--- a/clang/test/SemaSYCL/intel-fpga-local-ast.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local-ast.cpp
@@ -278,6 +278,37 @@ void check_ast()
   //CHECK-NEXT: IntegerLiteral{{.*}}1{{$}}
   //CHECK-NOT: SYCLIntelForcePow2DepthAttr
   [[intel::force_pow2_depth(1), intel::force_pow2_depth(0)]] unsigned int force_p2d_dup[64];
+
+  // Checking of duplicate attributes.
+  //CHECK: VarDecl{{.*}}dual_port1
+  //CHECK: SYCLIntelMemoryAttr{{.*}}Implicit
+  //CHECK: SYCLIntelSimpleDualPortAttr
+  //CHECK-NOT: SYCLIntelSimpleDualPortAttr
+  [[intel::simple_dual_port]]
+  [[intel::simple_dual_port]] unsigned int dual_port1[64];
+
+  // Checking of duplicate attributes.
+  //CHECK: VarDecl{{.*}}doublepump1
+  //CHECK: SYCLIntelMemoryAttr{{.*}}Implicit
+  //CHECK: SYCLIntelDoublePumpAttr
+  //CHECK-NOT: SYCLIntelDoublePumpAttr
+  [[intel::doublepump]]
+  [[intel::doublepump]] unsigned int doublepump1[64];
+
+  // Checking of duplicate attributes.
+  //CHECK: VarDecl{{.*}}singlepump1
+  //CHECK: SYCLIntelMemoryAttr{{.*}}Implicit
+  //CHECK: SYCLIntelSinglePumpAttr
+  //CHECK-NOT: SYCLIntelSinglePumpAttr
+  [[intel::singlepump]]
+  [[intel::singlepump]] unsigned int singlepump1[64];
+
+  // Checking of duplicate attributes.
+  //CHECK: VarDecl{{.*}}reg1
+  //CHECK: SYCLIntelRegisterAttr
+  //CHECK-NOT: SYCLIntelRegisterAttr
+  [[intel::fpga_register]]
+  [[intel::fpga_register]] unsigned int reg1[64];
 }
 
 struct foo {

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -19,7 +19,7 @@ void diagnostics()
   unsigned int dpump_spump[64];
 
   //expected-warning@+2{{attribute 'doublepump' is already applied}}
-  [[intel::doublepump]]
+  [[intel::doublepump]] //expected-note{{previous attribute is here}}
   [[intel::doublepump]] unsigned int dpump[64];
 
   //expected-error@+2{{attributes are not compatible}}
@@ -38,7 +38,7 @@ void diagnostics()
   unsigned int spump_dpump[64];
 
   //expected-warning@+2{{attribute 'singlepump' is already applied}}
-  [[intel::singlepump]]
+  [[intel::singlepump]] //expected-note{{previous attribute is here}}
   [[intel::singlepump]] unsigned int spump[64];
 
   //expected-error@+2{{attributes are not compatible}}
@@ -51,8 +51,9 @@ void diagnostics()
   //expected-warning@+1 {{unknown attribute 'register' ignored}}
   [[intelfpga::register]] unsigned int reg_var[64];
 
-  //expected-warning@+1{{attribute 'fpga_register' is already applied}}
-  [[intel::fpga_register]] [[intel::fpga_register]] unsigned int reg_reg[64];
+  //expected-warning@+2{{attribute 'fpga_register' is already applied}}
+  [[intel::fpga_register]] //expected-note{{previous attribute is here}}
+  [[intel::fpga_register]] unsigned int reg_reg[64];
 
   //expected-error@+2{{attributes are not compatible}}
   [[intel::fpga_register]]
@@ -190,6 +191,10 @@ void diagnostics()
   [[intel::fpga_register]]
   //expected-error@+1{{'simple_dual_port' and 'fpga_register' attributes are not compatible}}
   [[intel::simple_dual_port]] unsigned int sdp_reg[64];
+
+  //expected-warning@+2{{attribute 'simple_dual_port' is already applied}}
+  [[intel::simple_dual_port]] //expected-note{{previous attribute is here}}
+  [[intel::simple_dual_port]] unsigned int dual_port_var_dup[64];
 
   // Checking of different argument values.
   //expected-warning@+2{{attribute 'bankwidth' is already applied}}


### PR DESCRIPTION
This patch adds a warning for duplicate attributes but not if it's one we've implicitly added and drop any duplicates for FPGA attributes below:

1. [[intel::simple_dual_port]]
2. [[intel::fpga_register]]
3. [[intel::singlepump]]
4. [[intel::doublepump]]