### PR TITLE
[SYCL][Graph] Support for sycl_ext_oneapi_enqueue_barrier extension

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2757,9 +2757,6 @@ public:
   /// until all commands previously submitted to this queue have entered the
   /// complete state.
   void ext_oneapi_barrier() {
-    throwIfGraphAssociated<
-        ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
-            sycl_ext_oneapi_enqueue_barrier>();
     throwIfActionIsCreated();
     setType(detail::CG::Barrier);
   }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -441,7 +441,7 @@ std::vector<sycl::detail::EventImplPtr> graph_impl::getExitNodesEvents() {
   std::vector<sycl::detail::EventImplPtr> Events;
   auto EnqueueExitNodesEvents = [&](std::shared_ptr<node_impl> &Node,
                                     std::deque<std::shared_ptr<node_impl>> &) {
-    if (Node->MSuccessors.size() == 0) {
+    if (Node->MSuccessors.empty()) {
       Events.push_back(getEventForNode(Node));
     }
     return false;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -370,7 +370,7 @@ event handler::finalize() {
   case detail::CG::Barrier:
   case detail::CG::BarrierWaitlist: {
     if (auto GraphImpl = getCommandGraph(); GraphImpl != nullptr) {
-      // if no event to wait for was specified, we add all the previous
+      // if no event to wait for was specified, we add all exit
       // nodes/events of the graph
       if (MEventsWaitWithBarrier.size() == 0) {
         MEventsWaitWithBarrier = GraphImpl->getExitNodesEvents();

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -1,0 +1,121 @@
+// REQUIRES: level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using ZE_DEBUG
+// RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
+//
+// CHECK-NOT: LEAK
+
+#include "../graph_common.hpp"
+
+//// Test Explicit API graph construction with USM.
+///
+/// @param Q Command-queue to make kernel submissions to.
+/// @param Size Number of elements in the buffers.
+/// @param DataA Pointer to first USM allocation to use in kernels.
+/// @param DataB Pointer to second USM allocation to use in kernels.
+/// @param DataC Pointer to third USM allocation to use in kernels.
+///
+/// @return Event corresponding to the exit node of the submission sequence.
+template <typename T>
+event run_kernels_usm_with_barrier(queue Q, const size_t Size, T *DataA,
+                                   T *DataB, T *DataC) {
+  // Read & write Buffer A
+  auto EventA = Q.submit([&](handler &CGH) {
+    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+      auto LinID = Id.get_linear_id();
+      DataA[LinID]++;
+    });
+  });
+
+  Q.ext_oneapi_submit_barrier();
+
+  // Reads Buffer A
+  // Read & Write Buffer B
+  auto EventB = Q.submit([&](handler &CGH) {
+    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+      auto LinID = Id.get_linear_id();
+      DataB[LinID] += DataA[LinID];
+    });
+  });
+
+  // Reads Buffer A
+  // Read & writes Buffer C
+  auto EventC = Q.submit([&](handler &CGH) {
+    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+      auto LinID = Id.get_linear_id();
+      DataC[LinID] -= DataA[LinID];
+    });
+  });
+
+  Q.ext_oneapi_submit_barrier();
+
+  // Read & write Buffers B and C
+  auto ExitEvent = Q.submit([&](handler &CGH) {
+    CGH.parallel_for(range<1>(Size), [=](item<1> Id) {
+      auto LinID = Id.get_linear_id();
+      DataB[LinID]--;
+      DataC[LinID]--;
+    });
+  });
+  return ExitEvent;
+}
+
+int main() {
+  queue Queue;
+
+  using T = int;
+
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
+
+  std::iota(DataA.begin(), DataA.end(), 1);
+  std::iota(DataB.begin(), DataB.end(), 10);
+  std::iota(DataC.begin(), DataC.end(), 1000);
+
+  std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
+  calculate_reference_data(Iterations, Size, ReferenceA, ReferenceB,
+                           ReferenceC);
+
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
+
+  T *PtrA = malloc_device<T>(Size, Queue);
+  T *PtrB = malloc_device<T>(Size, Queue);
+  T *PtrC = malloc_device<T>(Size, Queue);
+
+  Queue.copy(DataA.data(), PtrA, Size);
+  Queue.copy(DataB.data(), PtrB, Size);
+  Queue.copy(DataC.data(), PtrC, Size);
+  Queue.wait_and_throw();
+
+  // Add commands to graph
+  Graph.begin_recording(Queue);
+  auto ev = run_kernels_usm_with_barrier(Queue, Size, PtrA, PtrB, PtrC);
+  Graph.end_recording(Queue);
+
+  auto GraphExec = Graph.finalize();
+
+  event Event;
+  for (unsigned n = 0; n < Iterations; n++) {
+    Event = Queue.submit([&](handler &CGH) {
+      CGH.depends_on(Event);
+      CGH.ext_oneapi_graph(GraphExec);
+    });
+    Event.wait();
+  }
+  Queue.wait_and_throw();
+
+  Queue.copy(PtrA, DataA.data(), Size);
+  Queue.copy(PtrB, DataB.data(), Size);
+  Queue.copy(PtrC, DataC.data(), Size);
+  Queue.wait_and_throw();
+
+  free(PtrA, Queue);
+  free(PtrB, Queue);
+  free(PtrC, Queue);
+
+  assert(ReferenceA == DataA);
+  assert(ReferenceB == DataB);
+  assert(ReferenceC == DataC);
+
+  return 0;
+}

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -270,93 +270,6 @@ void testParallelForProperties(
                           Is...>(G, Q, Props, KernelFunctor);
 }
 
-/// Tries to enqueue oneapi barrier to the graph G
-/// It tests that an invalid exception has been thrown
-/// Since sycl_ext_oneapi_enqueue_barrier extension can not be used
-/// along with SYCL Graph.
-template <OperationPath PathKind> void testEnqueueBarrier() {
-  sycl::context Context;
-  sycl::queue Q1(Context, sycl::default_selector_v);
-
-  experimental::command_graph<experimental::graph_state::modifiable> Graph1{
-      Q1.get_context(), Q1.get_device()};
-
-  Graph1.add([&](sycl::handler &cgh) {});
-  Graph1.add([&](sycl::handler &cgh) {});
-
-  if constexpr (PathKind != OperationPath::Explicit) {
-    Graph1.begin_recording(Q1);
-  }
-
-  // call queue::ext_oneapi_submit_barrier()
-  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
-  try {
-    if constexpr (PathKind == OperationPath::Shortcut) {
-      Q1.ext_oneapi_submit_barrier();
-    }
-    if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q1.submit([&](sycl::handler &CGH) { CGH.ext_oneapi_barrier(); });
-    }
-    if constexpr (PathKind == OperationPath::Explicit) {
-      Graph1.add([&](handler &CGH) { CGH.ext_oneapi_barrier(); });
-    }
-
-  } catch (exception &Exception) {
-    ExceptionCode = Exception.code();
-  }
-  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
-
-  if constexpr (PathKind != OperationPath::Explicit) {
-    Graph1.end_recording();
-  }
-
-  sycl::queue Q2(Context, sycl::default_selector_v);
-  sycl::queue Q3(Context, sycl::default_selector_v);
-
-  experimental::command_graph<experimental::graph_state::modifiable> Graph2{
-      Q2.get_context(), Q2.get_device()};
-  experimental::command_graph<experimental::graph_state::modifiable> Graph3{
-      Q3.get_context(), Q3.get_device()};
-
-  Graph2.begin_recording(Q2);
-  Graph3.begin_recording(Q3);
-
-  auto Event1 = Q2.submit([&](sycl::handler &cgh) {});
-  auto Event2 = Q3.submit([&](sycl::handler &cgh) {});
-
-  if constexpr (PathKind == OperationPath::Explicit) {
-    Graph2.end_recording();
-    Graph3.end_recording();
-  }
-
-  // call handler::barrier(const std::vector<event> &WaitList)
-  ExceptionCode = make_error_code(sycl::errc::success);
-  try {
-    if constexpr (PathKind == OperationPath::Shortcut) {
-      Q3.ext_oneapi_submit_barrier({Event1, Event2});
-    }
-    if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q3.submit([&](sycl::handler &CGH) {
-        CGH.ext_oneapi_barrier({Event1, Event2});
-      });
-    }
-    if constexpr (PathKind == OperationPath::Explicit) {
-      Graph3.add([&](handler &CGH) {
-        CGH.ext_oneapi_barrier({Event1, Event2});
-      });
-    }
-
-  } catch (exception &Exception) {
-    ExceptionCode = Exception.code();
-  }
-  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
-
-  if constexpr (PathKind != OperationPath::Explicit) {
-    Graph2.end_recording();
-    Graph3.end_recording();
-  }
-}
-
 /// Tries to add a memcpy2D node to the graph G
 /// It tests that an invalid exception has been thrown
 /// Since sycl_ext_oneapi_memcpy2d extension can not be used
@@ -1306,10 +1219,185 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl->getContext());
 }
 
-TEST_F(CommandGraphTest, EnqueueBarrierExceptionCheck) {
-  testEnqueueBarrier<OperationPath::Explicit>();
-  testEnqueueBarrier<OperationPath::RecordReplay>();
-  testEnqueueBarrier<OperationPath::Shortcut>();
+TEST_F(CommandGraphTest, ExplicitBarrierException) {
+
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    auto Barrier =
+        Graph.add([&](sycl::handler &cgh) { cgh.ext_oneapi_barrier(); });
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+}
+
+TEST_F(CommandGraphTest, EnqueueBarrier) {
+  Graph.begin_recording(Queue);
+  auto Node1Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node2Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node3Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto Barrier =
+      Queue.submit([&](sycl::handler &cgh) { cgh.ext_oneapi_barrier(); });
+
+  auto Node4Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node5Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  Graph.end_recording(Queue);
+
+  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+
+  // Check the graph structure
+  // (1) (2) (3)
+  //   \  |  /
+  //    \ | /
+  //     (B)
+  //     / \
+  //   (4) (5)
+  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
+  for (auto Node : GraphImpl->MRoots) {
+    ASSERT_EQ(Node->MSuccessors.size(), 1lu);
+    auto BarrierNode = Node->MSuccessors.front();
+    ASSERT_EQ(BarrierNode->MCGType, sycl::detail::CG::Barrier);
+    ASSERT_EQ(GraphImpl->getEventForNode(BarrierNode),
+              sycl::detail::getSyclObjImpl(Barrier));
+    ASSERT_EQ(BarrierNode->MPredecessors.size(), 3lu);
+    ASSERT_EQ(BarrierNode->MSuccessors.size(), 2lu);
+  }
+}
+
+TEST_F(CommandGraphTest, EnqueueBarrierWaitList) {
+  Graph.begin_recording(Queue);
+  auto Node1Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node2Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node3Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto Barrier = Queue.submit([&](sycl::handler &cgh) {
+    cgh.ext_oneapi_barrier({Node1Graph, Node2Graph});
+  });
+
+  auto Node4Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node5Graph = Queue.submit([&](sycl::handler &cgh) {
+    cgh.depends_on(Node3Graph);
+    cgh.single_task<TestKernel<>>([]() {});
+  });
+  Graph.end_recording(Queue);
+
+  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+
+  // Check the graph structure
+  // (1) (2) (3)
+  //   \  |   |
+  //    \ |   |
+  //     (B)  |
+  //     / \ /
+  //   (4) (5)
+  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
+  for (auto Node : GraphImpl->MRoots) {
+    ASSERT_EQ(Node->MSuccessors.size(), 1lu);
+    auto SuccNode = Node->MSuccessors.front();
+    if (SuccNode->MCGType == sycl::detail::CG::Barrier) {
+      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
+                sycl::detail::getSyclObjImpl(Barrier));
+      ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
+      ASSERT_EQ(SuccNode->MSuccessors.size(), 2lu);
+    } else {
+      // Node 5
+      ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
+    }
+  }
+}
+
+TEST_F(CommandGraphTest, EnqueueMultipleBarrier) {
+  Graph.begin_recording(Queue);
+  auto Node1Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node2Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node3Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto Barrier1 = Queue.submit([&](sycl::handler &cgh) {
+    cgh.ext_oneapi_barrier({Node1Graph, Node2Graph});
+  });
+
+  auto Node4Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node5Graph = Queue.submit([&](sycl::handler &cgh) {
+    cgh.depends_on(Node3Graph);
+    cgh.single_task<TestKernel<>>([]() {});
+  });
+
+  auto Barrier2 =
+      Queue.submit([&](sycl::handler &cgh) { cgh.ext_oneapi_barrier(); });
+
+  auto Node6Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node7Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Node8Graph = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  Graph.end_recording(Queue);
+
+  auto GraphImpl = sycl::detail::getSyclObjImpl(Graph);
+
+  // Check the graph structure
+  // (1) (2) (3)
+  //   \  |   |
+  //    \ |   |
+  //    (B1)  |
+  //     /|\ /
+  //   (4)|(5)
+  //     \|/
+  //     (B2)
+  //     /|\ 
+  //    / | \
+  // (6) (7) (8) (those nodes also have as a precedessor)
+  ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
+  for (auto Node : GraphImpl->MRoots) {
+    ASSERT_EQ(Node->MSuccessors.size(), 1lu);
+    auto SuccNode = Node->MSuccessors.front();
+    if (SuccNode->MCGType == sycl::detail::CG::Barrier) {
+      ASSERT_EQ(GraphImpl->getEventForNode(SuccNode),
+                sycl::detail::getSyclObjImpl(Barrier1));
+      ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
+      ASSERT_EQ(SuccNode->MSuccessors.size(), 6lu);
+      for (auto SuccBarrier1 : SuccNode->MSuccessors) {
+        if (SuccBarrier1->MCGType == sycl::detail::CG::Barrier) {
+          ASSERT_EQ(GraphImpl->getEventForNode(SuccBarrier1),
+                    sycl::detail::getSyclObjImpl(Barrier2));
+          ASSERT_EQ(SuccBarrier1->MPredecessors.size(), 3lu);
+          ASSERT_EQ(SuccBarrier1->MSuccessors.size(), 3lu);
+          for (auto SuccBarrier2 : SuccBarrier1->MSuccessors) {
+            // Nodes 6, 7, 8
+            ASSERT_EQ(SuccBarrier2->MPredecessors.size(), 2lu);
+            ASSERT_EQ(SuccBarrier2->MSuccessors.size(), 0lu);
+          }
+        } else {
+          // Node 4 or Node 5
+          if (GraphImpl->getEventForNode(SuccBarrier1) ==
+              sycl::detail::getSyclObjImpl(Node4Graph)) {
+            // Node 4
+            ASSERT_EQ(SuccBarrier1->MPredecessors.size(), 1lu);
+            ASSERT_EQ(SuccBarrier1->MSuccessors.size(), 1lu);
+          }
+        }
+      }
+    } else {
+      // Node 5
+      ASSERT_EQ(SuccNode->MPredecessors.size(), 2lu);
+      ASSERT_EQ(SuccNode->MSuccessors.size(), 1lu);
+    }
+  }
 }
 
 TEST_F(CommandGraphTest, FusionExtensionExceptionCheck) {

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1361,7 +1361,7 @@ TEST_F(CommandGraphTest, EnqueueMultipleBarrier) {
   //     (B2)
   //     /|\ 
   //    / | \
-  // (6) (7) (8) (those nodes also have as a precedessor)
+  // (6) (7) (8) (those nodes also have B1 as a predecessor)
   ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);
   for (auto Node : GraphImpl->MRoots) {
     ASSERT_EQ(Node->MSuccessors.size(), 1lu);


### PR DESCRIPTION
Adds support to handle barrier enqueuing with Record&Replay API. Barriers are implemented as empty nodes enforcing the required dependencies.

Adds tests that check:
1) correctness of graph structure when barriers have been enqueued, 
2) processing behavior, 
3) exception throwing if barriers are used within explicit API.

Notes:
1) Barriers can only be used with Record&Replay API, since barriers rely on events to enforce dependencies.
2) The scope of a barrier is limited to the Graph in which the barrier was added. As a result, if a barrier with no explicit events to wait for is part of a graph, when the graph is executed this barrier waits for all the kernels/operations in the graph that were previously submitted. However, the barrier does not wait for kernels/operations outside the graph that might have been submitted to the same execution queue.



---------