### PR TITLE
[SYCL][Graph] Re-enable buffer_ordering tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
@@ -1,5 +1,4 @@
-// FIXME: re-enabled the test once intel/llvm#11374 is resolved
-// REQUIRES: level_zero, gpu, TEMPORARILY_DISABLED
+// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_ordering.cpp
@@ -1,5 +1,4 @@
-// FIXME: re-enabled the test once intel/llvm#11374 is resolved
-// REQUIRES: level_zero, gpu, TEMPORARILY_DISABLED
+// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG


### PR DESCRIPTION
PR #11380 fixed the reported issue with buffer_ordering tests. 
This PR re-enables these tests.