### PR TITLE
[SYCL][Driver] Fix -fgpu-rdc option for CUDA

### DIFF
--- a/clang/lib/Driver/ToolChains/Cuda.cpp
+++ b/clang/lib/Driver/ToolChains/Cuda.cpp
@@ -476,11 +476,15 @@ void NVPTX::Assembler::ConstructJob(Compilation &C, const JobAction &JA,
     Relocatable = Args.hasFlag(options::OPT_fopenmp_relocatable_target,
                                options::OPT_fnoopenmp_relocatable_target,
                                /*Default=*/true);
-  else if (JA.isOffloading(Action::OFK_Cuda) ||
-           JA.isOffloading(Action::OFK_SYCL))
+  else if (JA.isOffloading(Action::OFK_Cuda))
     // In CUDA we generate relocatable code by default.
     Relocatable = Args.hasFlag(options::OPT_fgpu_rdc, options::OPT_fno_gpu_rdc,
                                /*Default=*/false);
+  else if (JA.isOffloading(Action::OFK_SYCL))
+    // In SYCL we control [no-]rdc linking at bitcode stage with 'llvm-link'.
+    // This allows for link-time optimisations and for now we do no support a
+    // non-LTO path, which means we cannot generate relocatable device code.
+    Relocatable = false;
   else
     // Otherwise, we are compiling directly and should create linkable output.
     Relocatable = true;

--- a/clang/test/Driver/sycl-cuda-rdc.cpp
+++ b/clang/test/Driver/sycl-cuda-rdc.cpp
@@ -1,0 +1,10 @@
+// Tests for -fgpu-rdc with CUDA
+
+// REQUIRES: nvptx-registered-target
+
+// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_61 -fgpu-rdc %s 2>&1 \
+// RUN: | FileCheck %s -check-prefix=CHECK-SYCL_RDC_NVPTX
+
+// Verify that ptxas does not pass "-c"
+// CHECK-SYCL_RDC_NVPTX: {{.*}} "-cc1" "-triple" "nvptx64-nvidia-cuda" {{.*}} "-target-cpu" "sm_61" "-target-feature" "+ptx{{[0-9]+}}" {{.*}} "-fgpu-rdc" {{.*}} "-o" "[[PTX:.+]].s"
+// CHECK-SYCL_RDC_NVPTX-NOT: ptxas{{.*}}"-m64" "-O3" "--gpu-name" "sm_61" "--output-file" "[[CUBIN:.+]].cubin" "[[PTX]].s" "-c"

--- a/clang/test/Driver/sycl-cuda-rdc.cpp
+++ b/clang/test/Driver/sycl-cuda-rdc.cpp
@@ -2,6 +2,8 @@
 
 // REQUIRES: nvptx-registered-target
 
+// UNSUPPORTED: system-windows
+
 // RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_61 -fgpu-rdc %s 2>&1 \
 // RUN: | FileCheck %s -check-prefix=CHECK-SYCL_RDC_NVPTX
 


### PR DESCRIPTION
This commit fixes an issue with -fgpu-rdc for NVPTX targets in the SYCL driver. When the driver calls the `ptxas` assembling job in relocatable device code compilation mode, we pass `-c` to the command-line to get a relocatable code ELF instead of a statically fully linked object. This is the correct behaviour for the purpose of CUDA separate compilation flow with RDC, but in SYCL it does not make sense for us to do so because we do RDC at a bitcode level rather than PTX. We link the IR modules with llvm-link way earlier and the linking method based on `-fgpu[no]-rdc` is determined there. Hence, we always want a fully linked object from `ptxas` in SYCL. This simplifies the need for adding a `nvlink` job in the pipeline.

Related github issue: https://github.com/intel/llvm/issues/8690