### PR TITLE
[SYCL] Mark detail::ReducerElement as device-copyable

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -530,7 +530,18 @@ public:
 private:
   value_type MValue;
 };
+} // namespace detail
 
+// We explicitly claim std::optional as device-copyable in sycl/types.hpp.
+// However, that information isn't propagated to the struct/class types that use
+// it as a member, so we need to provide this partial specialization as well.
+// This is needed to support GNU STL where
+// std::is_trivially_copyable_v<std::optional> is false (e.g., 7.5.* ).
+template <typename T, class BinaryOperation, bool IsOptional>
+struct is_device_copyable<
+    detail::ReducerElement<T, BinaryOperation, IsOptional>> : std::true_type {};
+
+namespace detail {
 template <typename T, class BinaryOperation, int Dims> class reducer_common {
 public:
   using value_type = T;

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -539,7 +539,9 @@ private:
 // std::is_trivially_copyable_v<std::optional> is false (e.g., 7.5.* ).
 template <typename T, class BinaryOperation, bool IsOptional>
 struct is_device_copyable<
-    detail::ReducerElement<T, BinaryOperation, IsOptional>> : std::true_type {};
+    detail::ReducerElement<T, BinaryOperation, IsOptional>>
+    : is_device_copyable<std::conditional_t<IsOptional, std::optional<T>, T>> {
+};
 
 namespace detail {
 template <typename T, class BinaryOperation, int Dims> class reducer_common {


### PR DESCRIPTION
It uses `std::optional` as a member so we need to provide partial specialization for it (no reflection in C++).