### PR TITLE
[SYCL] Fix test/check_device_cod/fpga_*_local.cpp for asserts disabled in compiler

### DIFF
--- a/sycl/test/check_device_code/fpga_datapath_local.cpp
+++ b/sycl/test/check_device_code/fpga_datapath_local.cpp
@@ -16,7 +16,7 @@ int main() {
 
   Q.single_task([=]() {
     intel::fpga_datapath<int[10]> empty;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %empty{{.*}}, ptr addrspace(1) [[RegisterINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[RegisterINTEL]]
     volatile int ReadVal = empty[f];
   });
   return 0;

--- a/sycl/test/check_device_code/fpga_mem_local.cpp
+++ b/sycl/test/check_device_code/fpga_mem_local.cpp
@@ -30,55 +30,55 @@ int main() {
 
   Q.single_task([=]() {
     intel::fpga_mem<int[10]> empty;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %empty{{.*}}, ptr addrspace(1) [[MemoryINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[MemoryINTEL]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::ram_stitching_min_ram))>
         min_ram;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %min_ram{{.*}}, ptr addrspace(1) [[ForcePow2DepthINTEL_FALSE]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[ForcePow2DepthINTEL_FALSE]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::ram_stitching_max_fmax))>
         max_fmax;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %max_fmax{{.*}}, ptr addrspace(1) [[ForcePow2DepthINTEL_TRUE]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[ForcePow2DepthINTEL_TRUE]]
     intel::fpga_mem<int[10], decltype(oneapi::properties(intel::clock_2x_true))>
         double_pumped;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %double_pumped{{.*}}, ptr addrspace(1) [[DoublepumpINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[DoublepumpINTEL]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::clock_2x_false))>
         single_pumped;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %single_pumped{{.*}}, ptr addrspace(1) [[SinglepumpINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[SinglepumpINTEL]]
     intel::fpga_mem<int[10], decltype(oneapi::properties(intel::resource_mlab))>
         mlab;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %mlab{{.*}}, ptr addrspace(1) [[MemoryINTEL_mlab]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[MemoryINTEL_mlab]]
     intel::fpga_mem<int[10], decltype(oneapi::properties(
                                  intel::bi_directional_ports_false))>
         simple_dual_port;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %simple_dual_port{{.*}}, ptr addrspace(1) [[SimpleDualPortINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[SimpleDualPortINTEL]]
     intel::fpga_mem<int[10], decltype(oneapi::properties(
                                  intel::bi_directional_ports_true))>
         true_dual_port;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %true_dual_port{{.*}}, ptr addrspace(1) [[TrueDualPortINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[TrueDualPortINTEL]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::resource_block_ram))>
         block_ram;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %block_ram{{.*}}, ptr addrspace(1) [[MemoryINTEL_block_ram]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[MemoryINTEL_block_ram]]
     intel::fpga_mem<int[10], decltype(oneapi::properties(intel::num_banks<4>))>
         banks;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %banks{{.*}}, ptr addrspace(1) [[NumbanksINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[NumbanksINTEL]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::stride_size<2>))>
         stride;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %stride{{.*}}, ptr addrspace(1) [[StridesizeINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[StridesizeINTEL]]
     intel::fpga_mem<int[10], decltype(oneapi::properties(intel::word_size<8>))>
         word;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %word{{.*}}, ptr addrspace(1) [[WordsizeINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[WordsizeINTEL]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::max_private_copies<3>))>
         copies;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %copies{{.*}}, ptr addrspace(1) [[MaxPrivateCopiesINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[MaxPrivateCopiesINTEL]]
     intel::fpga_mem<int[10],
                     decltype(oneapi::properties(intel::num_replicates<5>))>
         replicates;
-    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) %replicates{{.*}}, ptr addrspace(1) [[MaxReplicatesINTEL]]
+    // CHECK: @llvm.ptr.annotation{{.*}}(ptr addrspace(4) {{.*}}, ptr addrspace(1) [[MaxReplicatesINTEL]]
 
     volatile int ReadVal = word[f];
   });


### PR DESCRIPTION
Caused by https://github.com/intel/llvm/pull/10849 

Due to the fact that if the test are run on a compiler that was compiled with `--hip --cuda`. This causes the LLVM IR variable names to be obfuscated from `%empty` to `%0`. The failing LIT tests relied on that names being intact. 