### PR TITLE
[UR][L0] Pick up improve fix for windows build and localcopy feature

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -5,7 +5,7 @@ if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_D
 
   # The UR tag should be from the 'adapters' branch
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  set(UNIFIED_RUNTIME_TAG 9265d33b3b1e538bb1d27aea29d30f2ed47859be)
+  set(UNIFIED_RUNTIME_TAG b38855ed815ffd076bfde5e5e06170ca4f723dc1)
 
   set(UR_BUILD_ADAPTER_L0 ON)
   set(UMF_ENABLE_POOL_TRACKING ON)


### PR DESCRIPTION
    Piotor has refactor the cmake for windows build to improve the fix,
    we also enabled local copy to avoid leaking path.
    we should pick them up .
