### PR TITLE
[Driver][SYCL][clang-linker-wrapper] Add support for additional linker wrapper options

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5203,77 +5203,6 @@ class OffloadingActionBuilder final {
       }
     }
 
-    // Return whether to use native bfloat16 library.
-    bool selectBfloatLibs(const ToolChain *TC, bool &useNative) {
-      const char *TargetOpt = nullptr;
-      const char *DeviceOpt = nullptr;
-      bool needLibs = false;
-      for (auto *A : Args) {
-        llvm::Triple *TargetBE = nullptr;
-
-        auto GetTripleIt = [&, this](llvm::StringRef Triple) {
-          llvm::Triple TargetTriple{Triple};
-          auto TripleIt = llvm::find_if(SYCLTripleList, [&](auto &SYCLTriple) {
-            return SYCLTriple == TargetTriple;
-          });
-          return TripleIt != SYCLTripleList.end() ? &*TripleIt : nullptr;
-        };
-
-        if (A->getOption().matches(options::OPT_fsycl_targets_EQ)) {
-          // spir64 target is actually JIT compilation, so we defer selection of
-          // bfloat16 libraries to runtime. For AOT we need libraries, but skip
-          // for Nvidia.
-          needLibs = TC->getTriple().getSubArch() != llvm::Triple::NoSubArch &&
-                     !TC->getTriple().isNVPTX();
-          TargetBE = GetTripleIt(A->getValue(0));
-          if (TargetBE)
-            TargetOpt = A->getValue(0);
-          else
-            continue;
-        } else if (A->getOption().matches(options::OPT_Xsycl_backend_EQ)) {
-          // Passing device args: -Xsycl-target-backend=<triple> <opt>
-          TargetBE = GetTripleIt(A->getValue(0));
-          if (TargetBE)
-            DeviceOpt = A->getValue(1);
-          else
-            continue;
-        } else if (A->getOption().matches(options::OPT_Xsycl_backend)) {
-          // Passing device args: -Xsycl-target-backend <opt>
-          TargetBE = &SYCLTripleList.front();
-          DeviceOpt = A->getValue(0);
-        } else if (A->getOption().matches(options::OPT_Xs_separate)) {
-          // Passing device args: -Xs <opt>
-          DeviceOpt = A->getValue(0);
-        } else {
-          continue;
-        };
-      }
-      useNative = false;
-      if (needLibs)
-        if (TC->getTriple().getSubArch() == llvm::Triple::SPIRSubArch_gen &&
-            TargetOpt && DeviceOpt) {
-
-          auto checkBF = [=](std::string &Dev) {
-            static const std::regex BFFs("pvc.*|ats.*");
-            return std::regex_match(Dev, BFFs);
-          };
-
-          needLibs = true;
-          std::string Params{DeviceOpt};
-          size_t DevicesPos = Params.find("-device ");
-          useNative = false;
-          if (DevicesPos != std::string::npos) {
-            useNative = true;
-            std::istringstream Devices(Params.substr(DevicesPos + 8));
-            for (std::string S; std::getline(Devices, S, ',');) {
-              useNative &= checkBF(S);
-            }
-          }
-        }
-
-      return needLibs;
-    }
-
     bool addSYCLNativeCPULibs(const ToolChain *TC,
                               ActionList &DeviceLinkObjects) {
       std::string LibSpirvFile;
@@ -5323,146 +5252,48 @@ class OffloadingActionBuilder final {
 
     bool addSYCLDeviceLibs(const ToolChain *TC, ActionList &DeviceLinkObjects,
                            bool isSpirvAOT, bool isMSVCEnv) {
-      struct DeviceLibOptInfo {
-        StringRef devicelib_name;
-        StringRef devicelib_option;
-      };
-
-      bool NoDeviceLibs = false;
       int NumOfDeviceLibLinked = 0;
-      // Currently, all SYCL device libraries will be linked by default. Linkage
-      // of "internal" libraries cannot be affected via -fno-sycl-device-lib.
-      llvm::StringMap<bool> devicelib_link_info = {
-          {"libc", true},          {"libm-fp32", true},   {"libm-fp64", true},
-          {"libimf-fp32", true},   {"libimf-fp64", true}, {"libimf-bf16", true},
-          {"libm-bfloat16", true}, {"internal", true}};
-      if (Arg *A = Args.getLastArg(options::OPT_fsycl_device_lib_EQ,
-                                   options::OPT_fno_sycl_device_lib_EQ)) {
-        if (A->getValues().size() == 0)
-          C.getDriver().Diag(diag::warn_drv_empty_joined_argument)
-              << A->getAsString(Args);
-        else {
-          if (A->getOption().matches(options::OPT_fno_sycl_device_lib_EQ))
-            NoDeviceLibs = true;
-
-          for (StringRef Val : A->getValues()) {
-            if (Val == "all") {
-              for (const auto &K : devicelib_link_info.keys())
-                devicelib_link_info[K] =
-                    true && (!NoDeviceLibs || K.equals("internal"));
-              break;
-            }
-            auto LinkInfoIter = devicelib_link_info.find(Val);
-            if (LinkInfoIter == devicelib_link_info.end() ||
-                Val.equals("internal")) {
-              // TODO: Move the diagnostic to the SYCL section of
-              // Driver::CreateOffloadingDeviceToolChains() to minimize code
-              // duplication.
-              C.getDriver().Diag(diag::err_drv_unsupported_option_argument)
-                  << A->getSpelling() << Val;
-            }
-            devicelib_link_info[Val] = true && !NoDeviceLibs;
-          }
-        }
-      }
-
       SmallVector<SmallString<128>, 4> LibLocCandidates;
       SYCLInstallation.getSYCLDeviceLibPath(LibLocCandidates);
-      StringRef LibSuffix = isMSVCEnv ? ".obj" : ".o";
-      using SYCLDeviceLibsList = SmallVector<DeviceLibOptInfo, 5>;
 
-      const SYCLDeviceLibsList sycl_device_wrapper_libs = {
-        {"libsycl-crt", "libc"},
-        {"libsycl-complex", "libm-fp32"},
-        {"libsycl-complex-fp64", "libm-fp64"},
-        {"libsycl-cmath", "libm-fp32"},
-        {"libsycl-cmath-fp64", "libm-fp64"},
-#if defined(_WIN32)
-        {"libsycl-msvc-math", "libm-fp32"},
-#endif
-        {"libsycl-imf", "libimf-fp32"},
-        {"libsycl-imf-fp64", "libimf-fp64"},
-        {"libsycl-imf-bf16", "libimf-bf16"},
-      };
-      // For AOT compilation, we need to link sycl_device_fallback_libs as
-      // default too.
-      const SYCLDeviceLibsList sycl_device_fallback_libs = {
-          {"libsycl-fallback-cassert", "libc"},
-          {"libsycl-fallback-cstring", "libc"},
-          {"libsycl-fallback-complex", "libm-fp32"},
-          {"libsycl-fallback-complex-fp64", "libm-fp64"},
-          {"libsycl-fallback-cmath", "libm-fp32"},
-          {"libsycl-fallback-cmath-fp64", "libm-fp64"},
-          {"libsycl-fallback-imf", "libimf-fp32"},
-          {"libsycl-fallback-imf-fp64", "libimf-fp64"},
-          {"libsycl-fallback-imf-bf16", "libimf-bf16"}};
-      const SYCLDeviceLibsList sycl_device_bfloat16_fallback_lib = {
-          {"libsycl-fallback-bfloat16", "libm-bfloat16"}};
-      const SYCLDeviceLibsList sycl_device_bfloat16_native_lib = {
-          {"libsycl-native-bfloat16", "libm-bfloat16"}};
-      // ITT annotation libraries are linked in separately whenever the device
-      // code instrumentation is enabled.
-      const SYCLDeviceLibsList sycl_device_annotation_libs = {
-          {"libsycl-itt-user-wrappers", "internal"},
-          {"libsycl-itt-compiler-wrappers", "internal"},
-          {"libsycl-itt-stubs", "internal"}};
-      auto addInputs = [&](const SYCLDeviceLibsList &LibsList) {
+      SmallVector<std::string, 8> DeviceLibraries;
+      DeviceLibraries =
+          tools::SYCL::getDeviceLibraries(C, TC->getTriple(), isSpirvAOT);
+
+      for (const auto &DeviceLib : DeviceLibraries) {
         bool LibLocSelected = false;
         for (const auto &LLCandidate : LibLocCandidates) {
           if (LibLocSelected)
             break;
-          for (const DeviceLibOptInfo &Lib : LibsList) {
-            if (!devicelib_link_info[Lib.devicelib_option])
-              continue;
-            SmallString<128> LibName(LLCandidate);
-            llvm::sys::path::append(LibName, Lib.devicelib_name);
-            llvm::sys::path::replace_extension(LibName, LibSuffix);
-            if (llvm::sys::fs::exists(LibName)) {
-              ++NumOfDeviceLibLinked;
-              Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
-                                           Args.MakeArgString(LibName));
-              auto *SYCLDeviceLibsInputAction =
-                  C.MakeAction<InputAction>(*InputArg, types::TY_Object);
-              auto *SYCLDeviceLibsUnbundleAction =
-                  C.MakeAction<OffloadUnbundlingJobAction>(
-                      SYCLDeviceLibsInputAction);
+          SmallString<128> LibName(LLCandidate);
+          llvm::sys::path::append(LibName, DeviceLib);
+          if (llvm::sys::fs::exists(LibName)) {
+            ++NumOfDeviceLibLinked;
+            Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
+                                         Args.MakeArgString(LibName));
+            auto *SYCLDeviceLibsInputAction =
+                C.MakeAction<InputAction>(*InputArg, types::TY_Object);
+            auto *SYCLDeviceLibsUnbundleAction =
+                C.MakeAction<OffloadUnbundlingJobAction>(
+                    SYCLDeviceLibsInputAction);
 
-              // We are using BoundArch="" here since the NVPTX bundles in
-              // the devicelib .o files do not contain any arch information
-              SYCLDeviceLibsUnbundleAction->registerDependentActionInfo(
-                  TC, /*BoundArch=*/"", Action::OFK_SYCL);
-              OffloadAction::DeviceDependences Dep;
-              Dep.add(*SYCLDeviceLibsUnbundleAction, *TC, /*BoundArch=*/"",
-                      Action::OFK_SYCL);
-              auto *SYCLDeviceLibsDependenciesAction =
-                  C.MakeAction<OffloadAction>(
-                      Dep, SYCLDeviceLibsUnbundleAction->getType());
+            // We are using BoundArch="" here since the NVPTX bundles in
+            // the devicelib .o files do not contain any arch information
+            SYCLDeviceLibsUnbundleAction->registerDependentActionInfo(
+                TC, /*BoundArch=*/"", Action::OFK_SYCL);
+            OffloadAction::DeviceDependences Dep;
+            Dep.add(*SYCLDeviceLibsUnbundleAction, *TC, /*BoundArch=*/"",
+                    Action::OFK_SYCL);
+            auto *SYCLDeviceLibsDependenciesAction =
+                C.MakeAction<OffloadAction>(
+                    Dep, SYCLDeviceLibsUnbundleAction->getType());
 
-              DeviceLinkObjects.push_back(SYCLDeviceLibsDependenciesAction);
-              if (!LibLocSelected)
-                LibLocSelected = !LibLocSelected;
-            }
+            DeviceLinkObjects.push_back(SYCLDeviceLibsDependenciesAction);
+            if (!LibLocSelected)
+              LibLocSelected = !LibLocSelected;
           }
         }
-      };
-
-      addInputs(sycl_device_wrapper_libs);
-      if (isSpirvAOT || TC->getTriple().isNVPTX())
-        addInputs(sycl_device_fallback_libs);
-
-      bool nativeBfloatLibs;
-      bool needBfloatLibs = selectBfloatLibs(TC, nativeBfloatLibs);
-      if (needBfloatLibs) {
-        // Add native or fallback bfloat16 library.
-        if (nativeBfloatLibs)
-          addInputs(sycl_device_bfloat16_native_lib);
-        else
-          addInputs(sycl_device_bfloat16_fallback_lib);
       }
-
-      if (Args.hasFlag(options::OPT_fsycl_instrument_device_code,
-                       options::OPT_fno_sycl_instrument_device_code, true))
-        addInputs(sycl_device_annotation_libs);
 
       // For NVPTX backend we need to also link libclc and CUDA libdevice
       // at the same stage that we link all of the unbundled SYCL libdevice

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10397,6 +10397,92 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   if (Args.getLastArg(options::OPT_save_temps_EQ))
     CmdArgs.push_back("--save-temps");
 
+  // Add any SYCL offloading specific options to the clang-linker-wrapper
+  if (C.hasOffloadToolChain<Action::OFK_SYCL>()) {
+    // --sycl-device-libraries=<comma separated list> contains all of the SYCL
+    // device specific libraries that are needed.  This provides the list of
+    // files file only.
+    // TODO: This generic list will be populated with only device binaries
+    // for spir64.  Other targets (AOT and others) can represent a different
+    // set of device libraries.  We will cross that bridge when we begin to
+    // enable the other possible targets.
+    llvm::Triple TargetTriple;
+    auto ToolChainRange = C.getOffloadToolChains<Action::OFK_SYCL>();
+    for (auto &I :
+         llvm::make_range(ToolChainRange.first, ToolChainRange.second)) {
+      const ToolChain *TC = I.second;
+      if (TC->getTriple().isSPIR() &&
+          TC->getTriple().getSubArch() == llvm::Triple::NoSubArch) {
+        TargetTriple = TC->getTriple();
+        break;
+      }
+    }
+    SmallVector<std::string, 8> SYCLDeviceLibs;
+    SYCLDeviceLibs = SYCL::getDeviceLibraries(C, TargetTriple,
+                                              /*IsSpirvAOT=*/false);
+    // Create a comma separated list to pass along to the linker wrapper.
+    SmallString<256> LibList;
+    for (const auto &AddLib : SYCLDeviceLibs) {
+      if (LibList.size() > 0)
+        LibList += ",";
+      LibList += AddLib;
+    }
+    // --sycl-device-libraries=<libs> provides a comma separate list of
+    // libraries to add to the device linking step.
+    // SYCL device libraries can be found.
+    if (LibList.size())
+      CmdArgs.push_back(
+          Args.MakeArgString(Twine("--sycl-device-libraries=") + LibList));
+
+    // --sycl-device-library-location=<dir> provides the location in which the
+    // SYCL device libraries can be found.
+    SmallString<128> DeviceLibDir(D.Dir);
+    llvm::sys::path::append(DeviceLibDir, "..", "lib");
+    // Check the library location candidates for the the libsycl-crt library
+    // and use that location.  Base the location on relative to driver if this
+    // is not resolved.
+    SmallVector<SmallString<128>, 4> LibLocCandidates;
+    SYCLInstallationDetector SYCLInstallation(D);
+    SYCLInstallation.getSYCLDeviceLibPath(LibLocCandidates);
+    SmallString<128> LibName("libsycl-crt");
+    StringRef LibSuffix = TheTriple.isWindowsMSVCEnvironment() ? ".obj" : ".o";
+    llvm::sys::path::replace_extension(LibName, LibSuffix);
+    for (const auto &LibLoc : LibLocCandidates) {
+      SmallString<128> FullLibName(LibLoc);
+      llvm::sys::path::append(FullLibName, LibName);
+      if (llvm::sys::fs::exists(FullLibName)) {
+        DeviceLibDir = LibLoc;
+        break;
+      }
+    }
+    CmdArgs.push_back(Args.MakeArgString(
+        Twine("--sycl-device-library-location=") + DeviceLibDir));
+  }
+
+  auto appendOption = [](SmallString<128> &OptString, StringRef AddOpt) {
+    if (!OptString.empty())
+      OptString += " ";
+    OptString += AddOpt.str();
+  };
+  // --sycl-post-link-options="options" provides a string of options to be
+  // passed along to the sycl-post-link tool during device link.
+  if (Args.hasArg(options::OPT_Xdevice_post_link)) {
+    SmallString<128> OptString;
+    for (const auto &A : Args.getAllArgValues(options::OPT_Xdevice_post_link))
+      appendOption(OptString, A);
+    CmdArgs.push_back(
+        Args.MakeArgString("--sycl-post-link-options=" + OptString));
+  }
+
+  // --llvm-spirv-options="options" provides a string of options to be passed
+  // along to the llvm-spirv (translation) step during device link.
+  if (Args.hasArg(options::OPT_Xspirv_translator)) {
+    SmallString<128> OptString;
+    for (const auto &A : Args.getAllArgValues(options::OPT_Xspirv_translator))
+      appendOption(OptString, A);
+    CmdArgs.push_back(Args.MakeArgString("--llvm-spirv-options=" + OptString));
+  }
+
   // Construct the link job so we can wrap around it.
   Linker->ConstructJob(C, JA, Output, Inputs, Args, LinkingOutput);
   const auto &LinkCommand = C.getJobs().getJobs().back();

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -17,7 +17,6 @@
 #include "llvm/Support/CommandLine.h"
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
-#include <regex>
 #include <sstream>
 
 using namespace clang::driver;
@@ -164,9 +163,8 @@ static bool selectBfloatLibs(const llvm::Triple &Triple, const Compilation &C,
       }
     }
 
-    auto checkBF = [=](std::string &Dev) {
-      static const std::regex BFFs("pvc.*|ats.*");
-      return std::regex_match(Dev, BFFs);
+    auto checkBF = [](StringRef Device) {
+      return Device.starts_with("pvc") || Device.starts_with("ats");
     };
 
     std::string Params;

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -18,6 +18,7 @@
 #include "llvm/Support/FileSystem.h"
 #include "llvm/Support/Path.h"
 #include <regex>
+#include <sstream>
 
 using namespace clang::driver;
 using namespace clang::driver::toolchains;

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -39,6 +39,13 @@ void constructLLVMForeachCommand(Compilation &C, const JobAction &JA,
                                  const InputInfo &Output, const Tool *T,
                                  StringRef Increment, StringRef Ext = "out",
                                  StringRef ParallelJobs = "");
+
+// Provides a vector of device library names that are associated with the
+// given triple and AOT information.
+SmallVector<std::string, 8> getDeviceLibraries(const Compilation &C,
+                                               const llvm::Triple &TargetTriple,
+                                               bool IsSpirvAOT);
+
 bool shouldDoPerObjectFileLinking(const Compilation &C);
 // Runs llvm-spirv to convert spirv to bc, llvm-link, which links multiple LLVM
 // bitcode. Converts generated bc back to spirv using llvm-spirv, wraps with


### PR DESCRIPTION
Adds support for a handful of linker wrapper options that are part of the new offload model support.
  --sycl-device-libraries=libs provides a comma separated list of
    libraries that are used during the device link
  --sycl-device-library-location=dir the location in which the device
    libraries reside.
  --sycl-post-link-options=opts all options as specified by the user
    via the -Xdevice-post-link option.
  --llvm-spirv-options=opts all options as specified by the user via
    the -Xspirv-translator option.

Does some refactoring for what libraries are added, moving the functionality to the SYCL based toolchain.
These options are documented in the following design document: sycl/doc/design/OffloadDesign.md