### PR TITLE
[SYCL-MLIR][cgeist] Early drop host code by default when raising

### DIFF
--- a/polygeist/tools/cgeist/Options.h
+++ b/polygeist/tools/cgeist/Options.h
@@ -250,4 +250,10 @@ static llvm::cl::opt<bool>
                   llvm::cl::desc("Print the pass pipelines in textual format"),
                   llvm::cl::Hidden);
 
+static llvm::cl::opt<bool> NoEarlyDropHostCode(
+    "no-early-drop-host-code", llvm::cl::init(false),
+    llvm::cl::desc(
+        "Do not drop host code after early host-device optimizations"),
+    llvm::cl::Hidden);
+
 #endif /* CGEIST_OPTIONS_H_ */

--- a/polygeist/tools/cgeist/Test/Verification/sycl/nop_kernel.hpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/nop_kernel.hpp
@@ -1,0 +1,8 @@
+// This is an auxiliary file to be used when testing raising.
+// It provides a NOP kernel launch in host code that will trigger raising.
+
+void do_nothing(sycl::queue q) {
+  q.submit([&](sycl::handler &cgh) {
+    cgh.single_task<class K>([=]() {});
+  });
+}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_captures.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_captures.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_id_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_id_constructors.cpp
@@ -177,3 +177,6 @@ template void id<2>(sycl::id<2> &&);
 // CHECK-NEXT:      llvm.return
 // CHECK-NEXT:    }
 template void id<3>(sycl::id<3> &&);
+
+// Keep at the end of the file to not affect test results
+#include "../nop_kernel.hpp"

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_id_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_id_constructors.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_index.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range_constructors.cpp
@@ -211,3 +211,6 @@ template void nd_range_move(sycl::nd_range<2> &&);
 // CHECK-NEXT:      llvm.return
 // CHECK-NEXT:    }
 template void nd_range_move(sycl::nd_range<3> &&);
+
+// Keep at the end of the file to not affect test results
+#include "../nop_kernel.hpp"

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_nd_range_constructors.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_pipeline.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_pipeline.cpp
@@ -6,11 +6,15 @@
 // CHECK-SAME:    gpu.module(any({{.*}})),
 // CHECK-SAME:    gpu.module(any({{.*}})))
 
-// CHECK-LABEL: Optimization pipeline:
-// CHECK:       Pass Manager with 8 passes:
+// CHECK-LABEL: Early Host-Device Optimization pipeline:
+// CHECK:       Pass Manager with 2 passes:
 // CHECK:       any(
 // CHECK-SAME:    sycl-raise-host{ }
 // CHECK-SAME:    sycl-constant-propagation{relaxed-aliasing=false}
+
+// CHECK-LABEL: Optimization pipeline:
+// CHECK:       Pass Manager with 6 passes:
+// CHECK:       any(
 // CHECK-SAME:    arg-promotion
 // CHECK-SAME:    kernel-disjoint-specialization{relaxed-aliasing=false}
 // CHECK-SAME:    gpu.module(any({{.*}})),loop-internalization{relaxed-aliasing=false shared-memory-size=32000 unroll-factor=4}

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_pipeline.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_pipeline.cpp
@@ -1,4 +1,4 @@
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -print-pipeline 2>&1 | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -Xcgeist -print-pipeline 2>&1 | FileCheck %s
 
 // CHECK-LABEL: Canonicalization pipeline:
 // CHECK:       Pass Manager with 2 passes:

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_constructors.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -w | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code -w | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_constructors.cpp
@@ -138,3 +138,6 @@ template void range<2>(sycl::range<2> &&);
 // CHECK-NEXT:      llvm.return
 // CHECK-NEXT:    }
 template void range<3>(sycl::range<3> &&);
+
+// Keep at the end of the file to not affect test results
+#include "../nop_kernel.hpp"

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_range_offset.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_schedule_kernel.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/raising/host_raising_schedule_kernel.cpp
@@ -1,6 +1,6 @@
-// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
-// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host | FileCheck %s
+// RUN: clang++ -O1 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O2 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
+// RUN: clang++ -O3 %s -S -emit-mlir -o - -fsycl -fsycl-raise-host -Xcgeist -no-early-drop-host-code | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_use_host_module.cpp
@@ -13,6 +13,8 @@
 
 #include <sycl/sycl.hpp>
 
+#include "nop_kernel.hpp"
+
 // CHECK:        gpu.module @device_functions
 // CHECK:        memref.global constant @c : memref<i32, 1> {alignment = 4 : i64}
 // CHECK-NEXT:   func.func @host_foo() -> memref<i32, 1> {
@@ -28,4 +30,3 @@
 // CHECK-DROP-NOT: func.func @host_foo() -> memref<i32, 1> {
 
 // CHECK-LLVM-NOT: host_foo
-SYCL_EXTERNAL void do_nothing() {}

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -409,13 +409,13 @@ static LogicalResult canonicalize(mlir::MLIRContext &Ctx,
   return success();
 }
 
+static bool emitMLIR() { return EmitAssembly && !EmitLLVM; }
+
 static bool shouldEarlyDropHostCode() {
   // We can drop host code early if both conditions apply:
   // 1. -no-early-drop-host-code is not passed;
   // 2. Host code isn't explicitly asked for when we emit MLIR.
-  return !NoEarlyDropHostCode && (SYCLDeviceOnly ||
-                                  // We do not emit MLIR
-                                  EmitLLVM || EmitOpenMPIR || EmitAssembly);
+  return !NoEarlyDropHostCode && (SYCLDeviceOnly || !emitMLIR());
 }
 
 // Optimize the MLIR.
@@ -943,7 +943,7 @@ static LogicalResult compileModule(mlir::OwningOpRef<mlir::ModuleOp> &Module,
   }
 
   bool EmitBC = EmitLLVM && !EmitAssembly;
-  bool EmitMLIR = EmitAssembly && !EmitLLVM;
+  bool EmitMLIR = emitMLIR();
   std::error_code EC;
   SmallString<128> TmpResultPath;
   llvm::StringRef IRFileName = Output;

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -1446,13 +1446,13 @@ int main(int argc, char **argv) {
     Module->dump();
   });
 
-  if (shouldRaiseHost(Module.get())) {
+  if (!SYCLUseHostModule.empty()) {
     if (!SYCLIsDevice) {
       llvm::errs() << "\"-sycl-use-host-module\" can only be used during SYCL "
                       "device compilation\n";
       return -1;
     }
-    if (!readHostModule(Ctx, *Module, SYCLUseHostModule)) {
+    if (shouldRaiseHost(Module.get()) && !readHostModule(Ctx, *Module, SYCLUseHostModule)) {
       llvm::errs() << "Failed to read SYCL host module\n";
       return -1;
     }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -445,9 +445,13 @@ static LogicalResult optimize(mlir::MLIRContext &Ctx,
       if (EnableSYCLConstantPropagation)
         PM.addPass(sycl::createConstantPropagationPass(
             {options.getCgeistOpts().getRelaxedAliasing()}));
+      if (PrintPipeline) {
+        llvm::errs() << "Early Host-Device Optimization pipeline:\n";
+        PM.dump();
+      }
       if (mlir::failed(PM.run(Module.get()))) {
         llvm::errs()
-            << "*** Early Host-Device Optimizations Failed. Module: ***\n";
+            << "*** Early Host-Device Optimization Failed. Module: ***\n";
         Module->dump();
         return failure();
       }

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -1452,7 +1452,8 @@ int main(int argc, char **argv) {
                       "device compilation\n";
       return -1;
     }
-    if (shouldRaiseHost(Module.get()) && !readHostModule(Ctx, *Module, SYCLUseHostModule)) {
+    if (shouldRaiseHost(Module.get()) &&
+        !readHostModule(Ctx, *Module, SYCLUseHostModule)) {
       llvm::errs() << "Failed to read SYCL host module\n";
       return -1;
     }


### PR DESCRIPTION
Add `-no-early-drop-host-code` cgeist hidden option to revert this behaviour.