### PR TITLE
[SYCL][DOC] Fix syntax errors in auto_range spec

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_auto_local_range.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_auto_local_range.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
@@ -78,7 +78,7 @@ if (N % multiple == 0) {
 else {
   local = /* find largest work-group size smaller than max that divides N */;
 }
-q.parallel_for<class KernelName>(sycl::nd_range<1>{N, local}, [=](sycl::nd_item<1>) {
+q.parallel_for<class KernelName>(sycl::nd_range<1>{{N}, local}, [=](sycl::nd_item<1>) {
   /* kernel body */
 });
 ----
@@ -91,7 +91,7 @@ example simplifies to:
 
 [source, c++]
 ----
-q.parallel_for(sycl::nd_range<1>{N, sycl::ext::oneapi::experimental::auto_range<1>}, [=](sycl::nd_item<1>) {
+q.parallel_for(sycl::nd_range<1>{{N}, sycl::ext::oneapi::experimental::auto_range<1>()}, [=](sycl::nd_item<1>) {
   /* kernel body */
 });
 ----


### PR DESCRIPTION
Fix some syntax errors in the extension specification for `auto_range`. Since `auto_range` is a function, we need to add parens to call it.  We also need braces around the integral `N` when it is used to construct an anonymous `range`.