### PR TITLE
[CI] Add Level Zero E2E on Intel Arc A-Series Graphics in post-commit

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -33,18 +33,32 @@ jobs:
       cxx: clang++
       merge_ref: ''
 
-  test:
+  e2e-lin:
     needs: [build]
     if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Intel GEN12 Graphics with Level Zero
+            runner: '["Linux", "gen12"]'
+          - name: Intel Arc A-Series Graphics with Level Zero
+            runner: '["Linux", "arc"]'
+            extra_lit_opts: --param matrix-xmx8=True --param gpu-intel-dg2=True
     uses: ./.github/workflows/sycl_linux_run_tests.yml
     with:
-      name: SYCL E2E on Intel Linux L0
-      runner: '["Linux", "gen12"]'
+      name: ${{ matrix.name }}
+      runner: ${{ matrix. runner }}
       image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
       image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
       target_devices: ext_oneapi_level_zero:gpu
+      reset_gpu: true
+
+      extra_lit_opts: ${{ matrix.extra_lit_opts }}
+
       ref: ${{ github.sha }}
       merge_ref: ''
+
       sycl_toolchain_artifact: sycl_linux_sprod_shared
       sycl_toolchain_archive: ${{ needs.build.outputs.artifact_archive_name }}
       sycl_toolchain_decompress_command: ${{ needs.build.outputs.artifact_decompress_command }}

--- a/sycl/test-e2e/Basic/accessor/empty_zero_dim_accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/empty_zero_dim_accessor.cpp
@@ -5,6 +5,9 @@
 // (https://github.com/intel/llvm/issues/10360)
 // UNSUPPORTED: cuda || hip
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 // Tests the size and iterator members of an empty zero-dimensional accessor.
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -8,6 +8,9 @@
 // FIXME: enable opaque pointers support on CPU.
 // UNSUPPORTED: cpu
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #include <cassert>
 #include <cstdint>
 #include <cstring>

--- a/sycl/test-e2e/ESIMD/slm_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/slm_block_load_store.cpp
@@ -9,11 +9,9 @@
 // RUN: %{run} %t.out
 //
 // UNSUPPORTED: esimd_emulator
-// Even though the driver we use in CI is now new enough so this test doesn't
-// skip itself, it still fails. Temporary XFAIL-ing it while it is being
-// investigated.
-// FIXME: enable it back after investigation, see intel/llvm#11358
-// XFAIL: linux
+//
+// https://github.com/intel/llvm/issues/11358
+// UNSUPPORTED: linux
 
 // This test verifies usage of slm_block_load() and slm_block_store().
 
@@ -102,15 +100,6 @@ int main() {
   auto Dev = Q.get_device();
   auto DeviceSLMSize = Dev.get_info<sycl::info::device::local_mem_size>();
   esimd_test::printTestLabel(Q, "Local memory size available", DeviceSLMSize);
-
-  // GPU driver had an error in handling of SLM aligned block_loads/stores,
-  // which has been fixed only in "1.3.26816", and in win/opencl version going
-  // _after_ 101.4575.
-  if (!esimd_test::isGPUDriverGE(Q, esimd_test::GPUDriverOS::LinuxAndWindows,
-                                 "26816", "101.4576")) {
-    std::cout << "Skipped. The test requires GPU driver 1.3.26816 or newer.\n";
-    return 0;
-  }
 
   constexpr size_t Align4 = 4;
   constexpr size_t Align8 = 8;

--- a/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/basic_buffer.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_2d.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target_2d.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target_offset.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_offsets.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_offsets.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
@@ -4,6 +4,9 @@
 //
 // CHECK: complete
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/event_status_querying.cpp"

--- a/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/temp_buffer_reinterpret.cpp"

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/usm_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/basic_buffer.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_2d.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_2d.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target_2d.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target_offset.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_offsets.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_offsets.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
@@ -1,3 +1,6 @@
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
@@ -4,6 +4,9 @@
 //
 // CHECK: complete
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/event_status_querying.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/temp_buffer_reinterpret.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/usm_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 // Tests memcpy operation using device USM and an in-order queue.
 
 #include "../graph_common.hpp"

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
@@ -3,6 +3,9 @@
 // RUN: %{run} %t.out
 // UNSUPPORTED: accelerator
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 // The test verifies sort API extension.
 // Currently it checks the following combinations:
 // For number of elements {18, 64}

--- a/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
@@ -4,6 +4,9 @@
 // spir-v gen for legacy images at O0 not working
 // UNSUPPORTED: O0
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // RUN: %{build} -o %t.out
 // Native images are created with host pointers only with host unified memory
 // support, enforce it for this test.

--- a/sycl/test-e2e/Plugin/level_zero_usm_residency.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_usm_residency.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: gpu, level_zero
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=DEVICE %s
 // RUN: env SYCL_PI_LEVEL_ZERO_USM_RESIDENT=0x001 SYCL_PI_TRACE=-1 ZE_DEBUG=-1 %{run} %t.out 2>&1 | FileCheck --check-prefixes=DEVICE %s

--- a/sycl/test-e2e/USM/usm_leak_check.cpp
+++ b/sycl/test-e2e/USM/usm_leak_check.cpp
@@ -1,5 +1,8 @@
 // REQUIRES: level_zero
 
+// https://github.com/intel/llvm/issues/11434
+// XFAIL: gpu-intel-dg2
+
 // RUN: %{build} -o %t.out
 
 // RUN: env ZE_DEBUG=4 %{run} %t.out u 2>&1 | FileCheck %s --check-prefix CHECK-USM


### PR DESCRIPTION
Some tests had to be disabled. They are tracked in #11434 and also contain an inline comment with the link to the same.