### PR TITLE
Add operator overloads to device_global class

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
@@ -208,7 +208,7 @@ below for a list of the properties that are allowed.
 [NOTE]
 ====
 
-On a device, `device_global` has similar semantics to a reference wrapper.  The dot operator (`operator.`) cannot be overloaded, so a `get()` member is provided to allow a reference to be extracted directly when needed.  Some operators are declared in `device_global` that must be members (e.g. `operator[]` and `+operator->+`).  Note that other operators can be overloaded by specific `T` as free functions, which will be selected through implicit conversion to `T` in device functions.
+On a device, `device_global` has similar semantics to a reference wrapper.  The dot operator (`operator.`) cannot be overloaded, so a `get()` member is provided to allow a reference to be extracted directly when needed.  Some operators are declared in `device_global` that must be members (e.g. `operator[]` and `+operator->+`).  Note that other operators are overloaded to call the operators for the underlying type `T`. This allows for ease of use when a `device_global` is templated on more complex `T` that may itself be templated. An example of this would be `device_global` templated on a `fpga_mem` which in turn is templated on type `int`.
 
 ====
 

--- a/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
+++ b/sycl/include/sycl/ext/oneapi/device_global/device_global.hpp
@@ -168,6 +168,239 @@ public:
     return *this->get_ptr();
   }
 
+  void operator++() noexcept {
+    ++(*this->get_ptr());
+  }
+  void operator++(int) noexcept {
+    (*this->get_ptr())++;
+  }
+  void operator--() noexcept {
+    --(*this->get_ptr());
+  }
+  void operator--(int) noexcept {
+    (*this->get_ptr())--;
+  }
+
+  template <typename S>
+  friend S operator+(device_global &dg, S add) {
+      return *dg.get_ptr() + add;
+  }
+
+  template <typename S>
+  friend S operator+(S add, device_global &dg) {
+    return add + *dg.get_ptr();
+  }
+  
+  template <typename S>
+  friend S operator-(S add, device_global &dg) noexcept {
+      return add - *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator-(device_global &dg, S add) noexcept {
+      return *dg.get_ptr() - add;
+  }
+  
+  template <typename S>
+  friend S operator*(S add, device_global &dg) noexcept {
+      return add * *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator*(device_global &dg, S add) noexcept {
+      return *dg.get_ptr() * add;
+  }
+
+  template <typename S>
+  friend S operator/(S add, device_global &dg) noexcept {
+      return add / *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator/(device_global &dg, S add) noexcept {
+      return *dg.get_ptr() / add;
+  }
+
+  template <typename S>
+  friend S operator%(S add, device_global &dg) noexcept {
+      return add % *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator%(device_global &dg, S add) noexcept {
+      return *dg.get_ptr() % add;
+  }
+
+  template <typename S>
+  friend bool operator==(S lhs, device_global &dg) noexcept {
+      return lhs == *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator==(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() == rhs;
+  }
+  
+  template <typename S>
+  friend bool operator>(S lhs, device_global &dg) noexcept {
+      return lhs > *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator>(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() > rhs;
+  }
+
+  template <typename S>
+  friend bool operator>=(S lhs, device_global &dg) noexcept {
+      return lhs >= *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator>=(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() >= rhs;
+  }
+
+  template <typename S>
+  friend bool operator<(S lhs, device_global &dg) noexcept {
+      return lhs < *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator<(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() < rhs;
+  }
+
+  template <typename S>
+  friend bool operator<=(S lhs, device_global &dg) noexcept {
+      return lhs <= *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator<=(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() <= rhs;
+  }
+
+  template <typename S>
+  friend bool operator!=(S lhs, device_global &dg) noexcept {
+      return lhs != *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator!=(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() != rhs;
+  }
+
+  template <typename S>
+  friend bool operator&&(S lhs, device_global &dg) noexcept {
+      return lhs && *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator&&(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() && rhs;
+  }
+
+  template <typename S>
+  friend bool operator||(S lhs, device_global &dg) noexcept {
+      return lhs || *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend bool operator||(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() || rhs;
+  }
+
+  bool operator!() noexcept {
+      return !(*this->get_ptr());
+  }
+
+  template <typename S>
+  friend S operator&(S lhs, device_global &dg) noexcept {
+      return lhs & *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator&(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() & rhs;
+  }
+
+  template <typename S>
+  friend S operator|(S lhs, device_global &dg) noexcept {
+      return lhs | *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator|(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() | rhs;
+  }
+
+  template <typename S>
+  friend S operator^(S lhs, device_global &dg) noexcept {
+
+      return lhs ^ *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator^(device_global &dg, S rhs) noexcept {
+      return *dg.get_ptr() ^ rhs;
+  }
+
+  template <typename S>
+  friend S operator<<(S lhs, device_global &dg) {
+      return lhs << *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator<<(device_global &dg, S rhs) {
+      return *dg.get_ptr() << rhs;
+  }
+
+  template <typename S>
+  friend S operator>>(S lhs, device_global &dg) {
+      return lhs >> *dg.get_ptr();
+  }
+
+  template <typename S>
+  friend S operator>>(device_global &dg, S rhs) {
+      return *dg.get_ptr() >> rhs;
+  }
+
+  T operator~() noexcept {
+      return ~(*this->get_ptr());
+  }
+
+  template <typename S>
+  void operator+=(S add) noexcept {
+      *this->get_ptr() += add;
+  }
+
+  template <typename S>
+  device_global &operator=(const S &newValue) noexcept {
+    *this->get_ptr() = newValue;
+    return *this;
+  }
+
+  template <typename S>
+  void operator-=(S minus) noexcept {
+      *this->get_ptr() -= minus;
+  }
+
+  template <typename S>
+  void operator*=(S mul) noexcept {
+      *this->get_ptr() -= mul;
+  }
+
+  template <typename S>
+  void operator/=(S mul) {
+      *this->get_ptr() /= mul;
+  }
+
+  template <typename S>
+  void operator%=(S mul) {
+      *this->get_ptr() %= mul;
+  }
+
   operator T &() noexcept {
     __SYCL_HOST_NOT_SUPPORTED("Implicit conversion of device_global to T")
     return get();
@@ -176,12 +409,6 @@ public:
   constexpr operator const T &() const noexcept {
     __SYCL_HOST_NOT_SUPPORTED("Implicit conversion of device_global to T")
     return get();
-  }
-
-  device_global &operator=(const T &newValue) noexcept {
-    __SYCL_HOST_NOT_SUPPORTED("Assignment operator")
-    *this->get_ptr() = newValue;
-    return *this;
   }
 
   template <class RelayT = T>

--- a/sycl/test/extensions/device_global/device_global_operators.cpp
+++ b/sycl/test/extensions/device_global/device_global_operators.cpp
@@ -1,0 +1,68 @@
+// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+
+// Tests that device_globals can be templated on arbitrary types but still be
+// able to use the operators of said type
+
+#include <sycl/sycl.hpp>
+#include <iostream>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl::ext::intel::experimental;
+
+using dg_no_host = decltype(properties(device_image_scope, host_access_none));
+device_global<fpga_mem<int>, dg_no_host> dg_int_simple;
+static device_global<fpga_mem<bool>, dg_no_host> dg_bool;
+
+int main() {
+  sycl::queue Q;
+  Q.single_task([]() {
+    // Tests for device_global templated on complex types
+    dg_int_simple = 4;
+    dg_int_simple++;
+    ++dg_int_simple;
+    dg_int_simple--;
+    --dg_int_simple;
+    3 + dg_int_simple;
+    dg_int_simple + 3;
+    5 - dg_int_simple;
+    dg_int_simple- 5;
+    dg_int_simple * 5;
+    5 * dg_int_simple;
+    5 / dg_int_simple;
+    dg_int_simple / 5;
+    5 % dg_int_simple;
+    5 << dg_int_simple;
+    dg_int_simple << 5;
+    5 >> dg_int_simple;
+    dg_int_simple >> 5;
+    int result10 = dg_int_simple % 5;
+    bool result11 = result10 == dg_int_simple;
+    bool result12 = dg_int_simple == result10;
+    bool result13 = result10 < dg_int_simple;
+    bool result14 = dg_int_simple < result10;
+    bool result15 = result10 <= dg_int_simple;
+    bool result16 = dg_int_simple <= result10;
+    bool result17 = result10 > dg_int_simple;
+    bool result18 = dg_int_simple > result10;
+    bool result19 = result10 >= dg_int_simple;
+    bool result20 = dg_int_simple >= result10;
+    bool result21 = dg_int_simple != result10;
+    bool result22 = result10 != dg_int_simple;
+    dg_int_simple & result10;
+    result10 & dg_int_simple;
+    dg_int_simple | result10;
+    result10 | dg_int_simple;
+    result10^dg_int_simple;
+    dg_int_simple^result10;
+    ~dg_int_simple; 
+    true && dg_bool;
+    dg_bool && true;
+    dg_bool || false;
+    false || dg_bool;
+    !dg_bool;
+
+    // The following is one place where we will still need to call .get()
+    int test2 = dg_int_simple.get();
+  });
+}


### PR DESCRIPTION
This PR adds operator overloads to the `device_global` class to enable calling the underlying type's operators.

This allows for ease of use in the following cases:
```c++
device_global<fpga_mem<int>, decltype(properties(device_image_scope))> dg;
...
// Without this change
dg.get()++;
// With this change
dg++;
```