### PR TITLE
[UR][Adapters] Add support for passing device list to urProgramBuild/Link/Compile

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -3,8 +3,8 @@
 if (NOT DEFINED UNIFIED_RUNTIME_LIBRARY OR NOT DEFINED UNIFIED_RUNTIME_INCLUDE_DIR)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  set(UNIFIED_RUNTIME_TAG b38855ed815ffd076bfde5e5e06170ca4f723dc1)
+  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
+  set(UNIFIED_RUNTIME_TAG 6e8d89474358831c748c07c40e0047f1f242b432)
 
   set(UR_BUILD_ADAPTER_L0 ON)
 


### PR DESCRIPTION
pre-commit check of https://github.com/oneapi-src/unified-runtime/pull/934

piProgramBuild receives a list of devices, while urProgramBuild does not. This produces a series of issues when a UR program needs to be created for a specific device.

So define a new API, called urProgramBuildExp to pass this list.