### PR TITLE
[Bindless][NFC] Move common utility functions into vulkan_common.hpp

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_common.hpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/vulkan_common.hpp
@@ -404,4 +404,120 @@ int getSemaphoreOpaqueFD(VkSemaphore semaphore) {
   return fd;
 }
 
+auto createImageMemoryBarrier(VkImage &img) {
+  VkImageMemoryBarrier barrierInput = {};
+  barrierInput.sType = VK_STRUCTURE_TYPE_IMAGE_MEMORY_BARRIER;
+  barrierInput.oldLayout = VK_IMAGE_LAYOUT_UNDEFINED;
+  barrierInput.newLayout = VK_IMAGE_LAYOUT_GENERAL;
+  barrierInput.srcQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrierInput.dstQueueFamilyIndex = VK_QUEUE_FAMILY_IGNORED;
+  barrierInput.image = img;
+  barrierInput.subresourceRange.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+  barrierInput.subresourceRange.levelCount = 1;
+  barrierInput.subresourceRange.layerCount = 1;
+  barrierInput.srcAccessMask = 0;
+  barrierInput.dstAccessMask = VK_ACCESS_TRANSFER_WRITE_BIT;
+  return barrierInput;
+}
+
+struct vulkan_image_test_resources_t {
+  VkImage vkImage;
+  VkDeviceMemory imageMemory;
+  VkBuffer stagingBuffer;
+  VkDeviceMemory stagingMemory;
+
+  vulkan_image_test_resources_t(VkImageType imgType, VkFormat format,
+                                VkExtent3D ext, const size_t imageSizeBytes) {
+    vkImage = vkutil::createImage(imgType, format, ext,
+                                  VK_IMAGE_USAGE_TRANSFER_SRC_BIT |
+                                      VK_IMAGE_USAGE_TRANSFER_DST_BIT |
+                                      VK_IMAGE_USAGE_STORAGE_BIT);
+    auto inputImageMemoryTypeIndex = vkutil::getImageMemoryTypeIndex(
+        vkImage, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
+    imageMemory =
+        vkutil::allocateDeviceMemory(imageSizeBytes, inputImageMemoryTypeIndex);
+    VK_CHECK_CALL(
+        vkBindImageMemory(vk_device, vkImage, imageMemory, 0 /*memoryOffset*/));
+
+    stagingBuffer = vkutil::createBuffer(imageSizeBytes,
+                                         VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                                             VK_BUFFER_USAGE_TRANSFER_DST_BIT);
+    auto inputStagingMemoryTypeIndex = vkutil::getBufferMemoryTypeIndex(
+        stagingBuffer, VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT |
+                           VK_MEMORY_PROPERTY_HOST_COHERENT_BIT);
+    stagingMemory = vkutil::allocateDeviceMemory(
+        imageSizeBytes, inputStagingMemoryTypeIndex, false /*exportable*/);
+    VK_CHECK_CALL(vkBindBufferMemory(vk_device, stagingBuffer, stagingMemory,
+                                     0 /*memoryOffset*/));
+  }
+
+  ~vulkan_image_test_resources_t() {
+    vkDestroyBuffer(vk_device, stagingBuffer, nullptr);
+    vkDestroyImage(vk_device, vkImage, nullptr);
+    vkFreeMemory(vk_device, stagingMemory, nullptr);
+    vkFreeMemory(vk_device, imageMemory, nullptr);
+  }
+};
+
+VkFormat to_vulkan_format(sycl::image_channel_order order,
+                          sycl::image_channel_type channel_type) {
+  if (channel_type == sycl::image_channel_type::unsigned_int32) {
+    switch (order) {
+    case sycl::image_channel_order::r:
+      return VK_FORMAT_R32_UINT;
+    case sycl::image_channel_order::rg:
+      return VK_FORMAT_R32G32_UINT;
+    case sycl::image_channel_order::rgba:
+      return VK_FORMAT_R32G32B32A32_UINT;
+    default: {
+      std::cerr << "error in converting to vulkan format\n";
+      exit(-1);
+    }
+    }
+  } else if (channel_type == sycl::image_channel_type::signed_int32) {
+    switch (order) {
+    case sycl::image_channel_order::r:
+      return VK_FORMAT_R32_SINT;
+    case sycl::image_channel_order::rg:
+      return VK_FORMAT_R32G32_SINT;
+    case sycl::image_channel_order::rgba:
+      return VK_FORMAT_R32G32B32A32_SINT;
+    default: {
+      std::cerr << "error in converting to vulkan format\n";
+      exit(-1);
+    }
+    }
+  } else if (channel_type == sycl::image_channel_type::fp32) {
+    switch (order) {
+    case sycl::image_channel_order::r:
+      return VK_FORMAT_R32_SFLOAT;
+    case sycl::image_channel_order::rg:
+      return VK_FORMAT_R32G32_SFLOAT;
+    case sycl::image_channel_order::rgba:
+      return VK_FORMAT_R32G32B32A32_SFLOAT;
+    default: {
+      std::cerr << "error in converting to vulkan format\n";
+      exit(-1);
+    }
+    }
+  } else {
+    std::cerr
+        << "error in converting to vulkan format - channel type not included\n";
+    exit(-1);
+  }
+}
+
 } // namespace vkutil
+
+namespace util {
+
+template <typename DType>
+bool is_equal(DType lhs, DType rhs, float epsilon = 0.0001f) {
+  if constexpr (std::is_floating_point_v<DType>) {
+    return (std::abs(lhs - rhs) < epsilon);
+  } else {
+    return lhs == rhs;
+  }
+}
+
+} // namespace util


### PR DESCRIPTION
move utilities that can be used by sampled and unsampled images tests under namespace (vk)util to header vulkan_common.hpp.