### PR TITLE
[SYCL][DOC] Modify behavior of empty waitList for enqueued barrier

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_enqueue_barrier.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_enqueue_barrier.asciidoc
@@ -40,7 +40,7 @@ Because the interfaces defined by this specification are not final and are subje
 == Version
 
 Built On: {docdate} +
-Revision: 2
+Revision: 3
 
 == Contact
 Please open an issue in the https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions/[extensions repository]
@@ -91,7 +91,7 @@ two new members to the `queue` class:
 |`void ext_oneapi_barrier( const std::vector<event> &waitList )` | `event ext_oneapi_submit_barrier( const std::vector<event> &waitList )`
 |========================================
 
-The first variant of the barrier takes no parameters, and waits for all previously submitted commands to the queue to enter the `info::event_command_status::complete` state before any command later submitted to the same queue is allowed to execute. A second variant of the barrier accepts a list of events, with the behavior that no commands submitted to the same queue after barrier submission may execute until all events in the `waitList` have entered the `info::event_command_status::complete` state.  Both variants are non-blocking from the host program perspective, in that they do not wait for the barrier conditions to have been met before returning.
+The first variant of the barrier takes no parameters, and waits for all previously submitted commands to the queue to enter the `info::event_command_status::complete` state before any command later submitted to the same queue is allowed to execute. A second variant of the barrier accepts a list of events, with the behavior that no commands submitted to the same queue after barrier submission may execute until all events in the `waitList` have entered the `info::event_command_status::complete` state. If the waitList is empty, the call behaves as in the case with no parameters. Both variants are non-blocking from the host program perspective, in that they do not wait for the barrier conditions to have been met before returning.
 
 The new barrier operations implicitly add dependence edges to the SYCL task execution graph, and do not have other side effects.
 
@@ -237,7 +237,7 @@ void wait();
 |========================================
 |*Member functions*|*Description*
 |`event ext_oneapi_submit_barrier()` | Same effect as submitting a `handler::ext_oneapi_barrier()` within a command group to this `queue`.  The returned event enters the `info::event_command_status::complete` state when all events that the barrier is dependent on (implicitly from all previously submitted commands to the same queue) have entered the `info::event_command_status::complete` state.
-|`event ext_oneapi_submit_barrier( const std::vector<event> &waitList )` | Same effect as submitting a `handler:ext_oneapi_barrier( const std::vector<event> &waitList )` within a command group to this `queue`.  The returned event enters the `info::event_command_status::complete` state when all events that the barrier is dependent on (explicitly from `waitList`) have entered the `info::event_command_status::complete` state.
+|`event ext_oneapi_submit_barrier( const std::vector<event> &waitList )` | Same effect as submitting a `handler:ext_oneapi_barrier( const std::vector<event> &waitList )` within a command group to this `queue`.  The returned event enters the `info::event_command_status::complete` state when all events that the barrier is dependent on (explicitly from `waitList`) have entered the `info::event_command_status::complete` state. If the `waitList` is empty, the call behaves as in the case with no parameters.
 |========================================
 
 
@@ -287,7 +287,7 @@ void ext_oneapi_barrier( const std::vector<event> &waitList );
 
 Barriers may be submitted to a queue, with the effect that they prevent later operations submitted to the same queue from executing until the barrier wait conditions have been satisfied. The wait conditions can be explicitly described by `waitList` or implicitly from all previously submitted commands to the same queue. There are no constraints on the context from which queues may participate in the `waitList`. Enqueued barriers do not block host program execution, but instead form additional dependence edges with the execution task graph. 
 
-Barriers can be created by two members of the `handler` class that force synchronization on the SYCL command queue. The first variant of the `handler` barrier (`handler::barrier()`) takes no parameters, and waits for all previously submitted commands to the queue to enter the `info::event_command_status::complete` state before any command later submitted to the same queue is allowed to execute. The second variant of the `handler` barrier (`handler::barrier( const std::vector<event> &waitList )`) accepts a list of events, with the behavior that no commands submitted to the same queue after barrier submission may execute until all events in the waitList have entered the `info::event_command_status::complete` state. 
+Barriers can be created by two members of the `handler` class that force synchronization on the SYCL command queue. The first variant of the `handler` barrier (`handler::barrier()`) takes no parameters, and waits for all previously submitted commands to the queue to enter the `info::event_command_status::complete` state before any command later submitted to the same queue is allowed to execute. The second variant of the `handler` barrier (`handler::barrier( const std::vector<event> &waitList )`) accepts a list of events, with the behavior that no commands submitted to the same queue after barrier submission may execute until all events in the waitList have entered the `info::event_command_status::complete` state. If the waitList is empty, the call behaves as in the case with no parameters.
 
 === Add a new table in the new section between 4.9.4 and 4.9.5: Member functions of the handler class.
 
@@ -297,7 +297,7 @@ Barriers can be created by two members of the `handler` class that force synchro
 |========================================
 |*Member functions*|*Description*
 |`void ext_oneapi_barrier()` | Prevents any commands submitted afterward to this queue from executing until all commands previously submitted to this queue have entered the `info::event_command_status::complete` state.
-|`void ext_oneapi_barrier( const std::vector<event> &waitList` ) | Prevents any commands submitted afterward to this queue from executing until all events in `waitList` have entered the `info::event_command_status::complete` state.  If `waitList` is empty, then the barrier has no effect.
+|`void ext_oneapi_barrier( const std::vector<event> &waitList` ) | Prevents any commands submitted afterward to this queue from executing until all events in `waitList` have entered the `info::event_command_status::complete` state.  If `waitList` is empty, then the barrier behaves as if called with no arguments.
 |========================================
 
 == Issues


### PR DESCRIPTION
The previously described behavior was not expected. Align behavior with the default.