### PR TITLE
[SYCL][Graph] Remove trailing comment whitespace

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1456,7 +1456,7 @@ TEST_F(CommandGraphTest, EnqueueMultipleBarrier) {
   //   (4)|(5)
   //     \|/
   //     (B2)
-  //     /|\ 
+  //     /|\
   //    / | \
   // (6) (7) (8) (those nodes also have B1 as a predecessor)
   ASSERT_EQ(GraphImpl->MRoots.size(), 3lu);


### PR DESCRIPTION
Fixes post commit CI fail https://github.com/intel/llvm/actions/runs/6470268418/job/17566091513
```
/__w/llvm/llvm/src/sycl/unittests/Extensions/CommandGraph.cpp:1459:12: error: backslash and newline separated by space [-Werror,-Wbackslash-newline-escape]
 1459 |   //     /|\
      |            ^
1 error generated.
```

This was occuring due to a trailing whitespace character in the comment that was introduced in https://github.com/intel/llvm/pull/11418#discussion_r1352766009