### PR TITLE
[SYCL][E2E] Fix strict aliasing violation in tests

### DIFF
--- a/sycl/test-e2e/ESIMD/api/functional/common.hpp
+++ b/sycl/test-e2e/ESIMD/api/functional/common.hpp
@@ -33,9 +33,10 @@ namespace details {
 template <typename T> bool are_bitwise_equal(T lhs, T rhs) {
   constexpr size_t size{sizeof(T)};
 
-  // Such type-punning is OK from the point of strict aliasing rules
-  const auto &lhs_bytes = reinterpret_cast<const unsigned char(&)[size]>(lhs);
-  const auto &rhs_bytes = reinterpret_cast<const unsigned char(&)[size]>(rhs);
+  std::array<char, size> lhs_bytes;
+  std::array<char, size> rhs_bytes;
+  std::memcpy(lhs_bytes.data(), &lhs, size);
+  std::memcpy(rhs_bytes.data(), &rhs, size);
 
   bool result{true};
   for (size_t i = 0; i < size; ++i) {

--- a/sycl/test-e2e/Regression/half_operators.cpp
+++ b/sycl/test-e2e/Regression/half_operators.cpp
@@ -15,9 +15,10 @@ template <typename T> using shared_vector = std::vector<T, shared_allocator<T>>;
 template <typename T> bool are_bitwise_equal(T lhs, T rhs) {
   constexpr size_t size{sizeof(T)};
 
-  // Such type-punning is OK from the point of strict aliasing rules
-  const auto &lhs_bytes = reinterpret_cast<const unsigned char(&)[size]>(lhs);
-  const auto &rhs_bytes = reinterpret_cast<const unsigned char(&)[size]>(rhs);
+  std::array<char, size> lhs_bytes;
+  std::array<char, size> rhs_bytes;
+  std::memcpy(lhs_bytes.data(), &lhs, size);
+  std::memcpy(rhs_bytes.data(), &rhs, size);
 
   bool result{true};
   for (size_t i = 0; i < size; ++i) {


### PR DESCRIPTION
Turns out this is not valid, just do it in a simpler way.