### PR TITLE
[Pulldown] Always use ours when merging from other branches for CODEOWNERS

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.github/CODEOWNERS merge=ours


### PR DESCRIPTION
This is to tell git merge.ours driver to always use sycl version.
It should be a nop op for default merge strategy.

To use merge.ours driver, you can set it in config once.

git config --global merge.ours.driver true

This is to avoid trivial conflict in CODEOWNERS break pulldown
automation.
