### PR TITLE
[SYCL][E2E] Add REQUIRES-INTEL-DRIVER to a test

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp
@@ -1,3 +1,8 @@
+// GPU driver had an error in handling of SLM aligned block_loads/stores,
+// which has been fixed only in "1.3.26816", and in win/opencl version going
+// _after_ 101.4575.
+// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+//
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../slm_load_store.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
 //


### PR DESCRIPTION
`test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp` wasn't updated together with
`test-e2e/InvokeSimd/Regression/slm_load_store.cpp` that it includes in https://github.com/intel/llvm/pull/11427. Do it now.