### PR TITLE
[SYCL][Fusion] Short-circuit the cyclic dependency check in common case

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1533,6 +1533,11 @@ Scheduler::GraphBuilder::completeFusion(QueueImplPtr Queue,
   // dependency is created through a third command not part of the fusion, on
   // which this kernel depends and which in turn depends on another kernel in
   // fusion list.
+  //
+  // Note that we only have to consider dependencies via fusion queues here:
+  // Let K1 be a kernel submitted to a queue Q1 in fusion mode. If a kernel K2
+  // is submitted to a non-fusion queue Q2 and K2 depends on K1, fusion on Q1 is
+  // cancelled automatically.
   bool CreatesCircularDep =
       MFusionMap.size() > 1 &&
       std::any_of(CmdList.begin(), CmdList.end(), [&](ExecCGCommand *Cmd) {

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1526,13 +1526,15 @@ Scheduler::GraphBuilder::completeFusion(QueueImplPtr Queue,
   auto *PlaceholderCmd = FusionList->second.get();
   auto &CmdList = PlaceholderCmd->getFusionList();
 
-  // We need to check if fusing the kernel would create a circular dependency. A
-  // circular dependency would arise, if a kernel in the fusion list
-  // *indirectly* depends on another kernel in the fusion list. Here, indirectly
-  // means, that the dependency is created through a third command not part of
-  // the fusion, on which this kernel depends and which in turn depends on
-  // another kernel in fusion list.
+  // If there is more than one queue currently in fusion mode, we need to check
+  // if fusing the kernel would create a circular dependency. A circular
+  // dependency would arise, if a kernel in the fusion list *indirectly* depends
+  // on another kernel in the fusion list. Here, indirectly means, that the
+  // dependency is created through a third command not part of the fusion, on
+  // which this kernel depends and which in turn depends on another kernel in
+  // fusion list.
   bool CreatesCircularDep =
+      MFusionMap.size() > 1 &&
       std::any_of(CmdList.begin(), CmdList.end(), [&](ExecCGCommand *Cmd) {
         return checkForCircularDependency(Cmd, true, PlaceholderCmd);
       });


### PR DESCRIPTION
Skip the (potentially expensive) cyclic dependency check if there's only one queue in fusion mode.