### PR TITLE
[SYCL] Enable profiling info for `host_task`

### DIFF
--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -240,8 +240,21 @@ public:
 
   bool isInteropTask() const { return !!MInteropTask; }
 
-  void call() { MHostTask(); }
-  void call(interop_handle handle) { MInteropTask(handle); }
+  void call(HostProfilingInfo *HPI) {
+    if (HPI)
+      HPI->start();
+    MHostTask();
+    if (HPI)
+      HPI->end();
+  }
+
+  void call(HostProfilingInfo *HPI, interop_handle handle) {
+    if (HPI)
+      HPI->start();
+    MInteropTask(handle);
+    if (HPI)
+      HPI->end();
+  }
 };
 
 // Class which stores specific lambda object.

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -155,7 +155,8 @@ public:
       if (MDevice->has(aspect::queue_profiling)) {
         // When piGetDeviceAndHostTimer is not supported, compute the
         // profiling time OpenCL version < 2.1 case
-        if (!getDeviceImplPtr()->isGetDeviceAndHostTimerSupported())
+        if (!getDeviceImplPtr()->is_host() &&
+            !getDeviceImplPtr()->isGetDeviceAndHostTimerSupported())
           MFallbackProfiling = true;
       } else {
         throw sycl::exception(make_error_code(errc::feature_not_supported),

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -381,9 +381,9 @@ public:
                           HostTask.MQueue->getDeviceImplPtr(),
                           HostTask.MQueue->getContextImplPtr()};
 
-        HostTask.MHostTask->call(IH);
+        HostTask.MHostTask->call(MThisCmd->MEvent->getHostProfilingInfo(), IH);
       } else
-        HostTask.MHostTask->call();
+        HostTask.MHostTask->call(MThisCmd->MEvent->getHostProfilingInfo());
     } catch (...) {
       auto CurrentException = std::current_exception();
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -400,7 +400,7 @@ Scheduler::Scheduler() {
   DefaultHostQueue = QueueImplPtr(
       new queue_impl(detail::getSyclObjImpl(HostDevice),
                      detail::getSyclObjImpl(HostContext), /*AsyncHandler=*/{},
-                     /*PropList=*/{}));
+                     /*PropList=*/{sycl::property::queue::enable_profiling()}));
 }
 
 Scheduler::~Scheduler() { DefaultHostQueue.reset(); }

--- a/sycl/test-e2e/Basic/profile_host_task.cpp
+++ b/sycl/test-e2e/Basic/profile_host_task.cpp
@@ -1,0 +1,37 @@
+// RUN: %{build} -I . -o %t.out
+// RUN: %{run} %t.out
+
+#include <cstdlib>
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q{{sycl::property::queue::enable_profiling()}};
+
+  auto e = q.submit([&](sycl::handler &cgh) { cgh.host_task([=]() {}); });
+  q.wait();
+
+  const uint64_t submitted = e.template get_profiling_info<
+      sycl::info::event_profiling::command_submit>();
+  const uint64_t start = e.template get_profiling_info<
+      sycl::info::event_profiling::command_start>();
+  const uint64_t end =
+      e.template get_profiling_info<sycl::info::event_profiling::command_end>();
+
+  if (submitted == 0) {
+    std::cerr << "Invalid command_submit time" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (start < submitted) {
+    std::cerr << "Invalid command_start time" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (end < start) {
+    std::cerr << "Invalid command_end time" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Use `HostProfilingInfo` to record profiling info for host tasks, and disable calls to `isGetDeviceAndHostTimerSupported` for host device. Fixes #11504.