### PR TITLE
[SYCL] Remove unused NativeCPUGlobalAS

### DIFF
--- a/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLLowerIR/PrepareSYCLNativeCPU.cpp
@@ -261,7 +261,6 @@ static Value *getStateArg(Function *F, llvm::Constant *StateTLS) {
   return F->getArg(FT->getNumParams() - 1);
 }
 
-static constexpr unsigned int NativeCPUGlobalAS = 1;
 static inline bool IsNativeCPUKernel(const Function *F) {
   return F->getCallingConv() == llvm::CallingConv::SPIR_KERNEL;
 }


### PR DESCRIPTION
This will causing warning and become error when building with -Werror.
