### PR TITLE
[ESIMD] Fix performance regression after switching to LLVM IR for block load/stores

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -964,6 +964,9 @@ static void translateBlockLoad(CallInst &CI, bool IsSLM) {
     // Convert 'uint32_t' to 'addrspace(3)*' pointer.
     auto PtrType = PointerType::get(DataType, 3);
     Op0 = Builder.CreateIntToPtr(Op0, PtrType);
+  } else {
+    auto PtrType = PointerType::get(DataType, 1);
+    Op0 = Builder.CreateAddrSpaceCast(Op0, PtrType);
   }
 
   auto LI = Builder.CreateAlignedLoad(DataType, Op0, Align, CI.getName());
@@ -981,11 +984,14 @@ static void translateBlockStore(CallInst &CI, bool IsSLM) {
 
   auto Op0 = CI.getArgOperand(0);
   auto Op1 = CI.getArgOperand(1);
+  auto DataType = Op1->getType();
   if (IsSLM) {
     // Convert 'uint32_t' to 'addrspace(3)*' pointer.
-    auto DataType = Op1->getType();
     auto PtrType = PointerType::get(DataType, 3);
     Op0 = Builder.CreateIntToPtr(Op0, PtrType);
+  } else {
+    auto PtrType = PointerType::get(DataType, 1);
+    Op0 = Builder.CreateAddrSpaceCast(Op0, PtrType);
   }
 
   auto SI = Builder.CreateAlignedStore(Op1, Op0, Align);

--- a/sycl/test/esimd/intrins_trans.cpp
+++ b/sycl/test/esimd/intrins_trans.cpp
@@ -81,21 +81,21 @@ test_mem_intrins(int *addr, const vec<float, 8> &xf,
     using VecT = typename simd<int, 8>::raw_vector_type;
     VecT *vec_addr = reinterpret_cast<VecT *>(addr);
     vec<int, 8> x = __esimd_svm_block_ld<int, 8, 4>(vec_addr);
-    // CHECK-LABEL: load <8 x i32>, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
+    // CHECK-LABEL: load <8 x i32>, ptr addrspace(1) %{{[a-zA-Z0-9.]+}}, align 4
     use(x);
   }
   {
     using VecT = typename simd<int, 8>::raw_vector_type;
     VecT *vec_addr = reinterpret_cast<VecT *>(addr);
     vec<int, 8> x = __esimd_svm_block_ld<int, 8, 32>(vec_addr);
-    // CHECK-LABEL: load <8 x i32>, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 32
+    // CHECK-LABEL: load <8 x i32>, ptr addrspace(1) %{{[a-zA-Z0-9.]+}}, align 32
     use(x);
   }
   {
     using VecT = typename simd<int, 8>::raw_vector_type;
     VecT *vec_addr = reinterpret_cast<VecT *>(addr);
     __esimd_svm_block_st<int, 8, 32>(vec_addr, get8i());
-    // CHECK-LABEL: store <8 x i32> %{{[a-zA-Z0-9.]+}}, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 32
+    // CHECK-LABEL: store <8 x i32> %{{[a-zA-Z0-9.]+}}, ptr addrspace(1) %{{[a-zA-Z0-9.]+}}, align 32
   }
   {
     uint32_t offset = 128;
@@ -219,9 +219,9 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL simd<float, 16> foo() {
   // CHECK: %{{[0-9a-zA-Z_.]+}} = call <32 x i32> @llvm.genx.svm.atomic.cmpxchg.v32i32.v32i1.v32i64(<32 x i1> %{{[0-9a-zA-Z_.]+}}, <32 x i64> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> %{{[0-9a-zA-Z_.]+}}, <32 x i32> undef)
 
   simd<uint32_t, VL> v00 = __esimd_svm_block_ld<uint32_t, VL, 4>(vec_ptr);
-  // CHECK: %[[VAR1:[0-9a-zA-Z_.]+]] = load <32 x i32>, ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 4
+  // CHECK: load <32 x i32>, ptr addrspace(1) %{{[a-zA-Z0-9.]+}}, align 4
   __esimd_svm_block_st<uint32_t, VL, 128>(vec_ptr, v00.data());
-  // CHECK-NEXT: store <32 x i32> %[[VAR1]], ptr addrspace(4) %{{[a-zA-Z0-9.]+}}, align 128
+  // CHECK: store <32 x i32> %{{[a-zA-Z0-9.]+}}, ptr addrspace(1) %{{[a-zA-Z0-9.]+}}, align 128
 
   simd<uint32_t, VL> v01 =
       __esimd_svm_gather<uint32_t, VL>(v_addr.data(), pred.data());


### PR DESCRIPTION
The regression is seen when block_load/block_store() and copy_to()/copy_from() are used in ESIMD functions called through invoke_simd.

invoke_simd() passes pointers as generic address-space pointers, and thus IGC BE has to generate runtime checks and conditional jumps depending on which address space that pointer is (local vs global).

For a trivial esimd function called with uniform pointer for 1 block_load() the code is 80 instructions instead of 69. Regression comes not only from increase of number of instructions, but from conditions/jumps.

The fix is trivial. Because ESIMD works only with USM memory or with SLM, when the block_load is not from SLM it must be the load from global memory (address-space = 1). That address-space is forced in the fix in sycl-post-link where the esimd intrinsics are lowered to vector load operations now.