### PR TITLE
[SYCL][E2E] Remove reliance on library loading ordering from test 

### DIFF
--- a/sycl/test-e2e/Basic/library_loading.cpp
+++ b/sycl/test-e2e/Basic/library_loading.cpp
@@ -1,7 +1,9 @@
 // REQUIRES: linux
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 %{run-unfiltered-devices} %t.out &> %t_trace_no_filter.txt || true
+// RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER-CUDA %s
 // RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER %s
+// RUN: FileCheck --input-file=%t_trace_no_filter.txt --check-prefix=CHECK-NO-FILTER-HIP %s
 // RUN: env SYCL_PI_TRACE=-1 ONEAPI_DEVICE_SELECTOR='esimd_emulator:*' %{run-unfiltered-devices} %t.out &> %t_trace_esimd_filter.txt || true
 // RUN: FileCheck --input-file=%t_trace_esimd_filter.txt --check-prefix=CHECK-ESIMD-FILTER %s
 // Checks pi traces on library loading
@@ -11,9 +13,9 @@
 using namespace sycl;
 
 int main() {
-  // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
+  // CHECK-NO-FILTER-CUDA: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_cuda.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_cuda.so)}}
   // CHECK-NO-FILTER-NOT: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
-  // CHECK-NO-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
+  // CHECK-NO-FILTER-HIP: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_hip.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_hip.so)}}
   // CHECK-ESIMD-FILTER: {{(SYCL_PI_TRACE\[-1\]: dlopen\(.*/libpi_esimd_emulator.so\) failed with)|(SYCL_PI_TRACE\[basic\]: Plugin found and successfully loaded: libpi_esimd_emulator.so)}}
   queue q;
   q.submit([&](handler &cgh) {});


### PR DESCRIPTION
library_loading.cpp test is dependent on the ordering in which libraries are loaded, causing failures in some builds. This commit addresses that dependency by running FileCheck on each loaded library separately.