### PR TITLE
[UR] Don't unload UR twice

### DIFF
--- a/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
+++ b/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
@@ -1146,7 +1146,6 @@ __SYCL_EXPORT pi_result piextPeerAccessGetInfo(
 
 __SYCL_EXPORT pi_result piTearDown(void *) {
   releaseAdapters(Adapters.Vec);
-  urTearDown(nullptr);
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
`releaseAdapters` will already call `urTearDown` so we remove this redundant call which was causing segfaults in some cases.