### PR TITLE
[SYCL] Don't include <cmath>/<complex> by default

### DIFF
--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -105,12 +105,6 @@
 #include <sycl/ext/oneapi/sub_group.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 #include <sycl/ext/oneapi/weak_object.hpp>
-#if !defined(SYCL2020_CONFORMANT_APIS) &&                                      \
-    !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
-// We used to include those and some code might be reliant on that.
-#include <cmath>
-#include <complex>
-#endif
 
 #if !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 namespace sycl {

--- a/sycl/test-e2e/ESIMD/api/functional/value.hpp
+++ b/sycl/test-e2e/ESIMD/api/functional/value.hpp
@@ -20,6 +20,7 @@
 #include <sycl/sycl.hpp>
 
 #include <climits>
+#include <cmath>
 #include <limits>
 #include <type_traits>
 

--- a/sycl/test-e2e/ESIMD/kmeans/kmeans.cpp
+++ b/sycl/test-e2e/ESIMD/kmeans/kmeans.cpp
@@ -11,6 +11,7 @@
 #include "kmeans.h"
 #include "esimd_test_utils.hpp"
 
+#include <cmath>
 #include <fstream>
 #include <iostream>
 #include <string.h>

--- a/sycl/test/basic_tests/fp-accuracy.cpp
+++ b/sycl/test/basic_tests/fp-accuracy.cpp
@@ -1,6 +1,9 @@
 // RUN: %clangxx -%fsycl-host-only -c -ffp-accuracy=high -faltmathlib=SVMLAltMathLibrary -fno-math-errno %s
 
 #include <sycl/sycl.hpp>
+
+#include <cmath>
+
 using namespace sycl;
 
 int main() {

--- a/sycl/test/basic_tests/no_math_in_global_ns.cpp
+++ b/sycl/test/basic_tests/no_math_in_global_ns.cpp
@@ -1,4 +1,5 @@
-// RUN: %clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=warning,note
+// RUN: %clangxx -fsycl  -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=warning,note
+// RUN: %clangxx -fsycl  -fsyntax-only -Xclang -verify %s -Xclang -verify-ignore-unexpected=warning,note -fpreview-breaking-changes
 // expected-no-diagnostics
 
 // MSVC has the following includes:

--- a/sycl/test/check_device_code/fp-accuracy.cpp
+++ b/sycl/test/check_device_code/fp-accuracy.cpp
@@ -8,6 +8,8 @@
 
 #include <sycl/sycl.hpp>
 
+#include <cmath>
+
 SYCL_EXTERNAL auto foo(double x) {
   using namespace sycl;
   return cos(exp(log(x)));


### PR DESCRIPTION
Any user code relying on those included implicitly is wrong and we don't consider it a breaking change, just a bug fix.

Reverts https://github.com/intel/llvm/pull/11326.

We agreed that this isn't an ABI break as the code relying on this wasn't standard conforming. However, ABI break is next week, so I'll be merging it then. Meanwhile, adding `abi-break` label to ease documentation update later.