### PR TITLE
[SYCL][NFC] Do not use std::exclusive_scan/inclusive_scan/reduce in tests

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -I . -o %t.out
 // RUN: %{run} %t.out
 
+#include "../../helpers.hpp"
 #include "support.h"
 #include <algorithm>
 #include <cassert>

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/exclusive_scan.cpp
@@ -14,23 +14,6 @@ using namespace sycl;
 template <class SpecializationKernelName, int TestNumber>
 class exclusive_scan_kernel;
 
-// std::exclusive_scan isn't implemented yet, so use serial implementation
-// instead
-namespace emu {
-template <typename InputIterator, typename OutputIterator,
-          class BinaryOperation, typename T>
-OutputIterator exclusive_scan(InputIterator first, InputIterator last,
-                              OutputIterator result, T init,
-                              BinaryOperation binary_op) {
-  T partial = init;
-  for (InputIterator it = first; it != last; ++it) {
-    *(result++) = partial;
-    partial = binary_op(partial, *it);
-  }
-  return result;
-}
-} // namespace emu
-
 template <typename SpecializationKernelName, typename InputContainer,
           typename OutputContainer, class BinaryOperation>
 void test(queue q, InputContainer input, OutputContainer output,

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -I . -o %t.out
 // RUN: %{run} %t.out
 
+#include "../../helpers.hpp"
 #include "support.h"
 #include <algorithm>
 #include <cassert>

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/inclusive_scan.cpp
@@ -14,23 +14,6 @@ using namespace sycl;
 template <class SpecializationKernelName, int TestNumber>
 class inclusive_scan_kernel;
 
-// std::inclusive_scan isn't implemented yet, so use serial implementation
-// instead
-namespace emu {
-template <typename InputIterator, typename OutputIterator,
-          class BinaryOperation, typename T>
-OutputIterator inclusive_scan(InputIterator first, InputIterator last,
-                              OutputIterator result, BinaryOperation binary_op,
-                              T init) {
-  T partial = init;
-  for (InputIterator it = first; it != last; ++it) {
-    partial = binary_op(partial, *it);
-    *(result++) = partial;
-  }
-  return result;
-}
-} // namespace emu
-
 template <typename SpecializationKernelName, typename InputContainer,
           typename OutputContainer, class BinaryOperation>
 void test(queue q, InputContainer input, OutputContainer output,

--- a/sycl/test-e2e/GroupAlgorithm/different_types.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/different_types.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -I . -o %t.out
 // RUN: %{run} %t.out
 
+#include "../helpers.hpp"
 #include <complex>
 #include <cstdint>
 #include <limits>
@@ -46,7 +47,7 @@ void test(queue &q, const InputContainer &input, InitT init,
   host_accessor a_reduce_out(b_reduce_out);
   host_accessor a_scan_out(b_scan_out);
 
-  const auto r = std::reduce(input.begin(), input.end(), init, binary_op);
+  const auto r = std::accumulate(input.begin(), input.end(), init, binary_op);
   assert(r == a_reduce_out[0]);
   assert(r == a_reduce_out[1]);
   assert(r == a_reduce_out[2]);
@@ -55,14 +56,14 @@ void test(queue &q, const InputContainer &input, InitT init,
     return std::equal(C1.begin(), C1.end(), C2.begin());
   };
   std::vector<OutT> escan_ref(N);
-  std::exclusive_scan(input.begin(), input.end(), escan_ref.begin(), init,
+  emu::exclusive_scan(input.begin(), input.end(), escan_ref.begin(), init,
                       binary_op);
   assert(equal(escan_ref, span(&a_scan_out[0][0], N)));
   assert(equal(escan_ref, span(&a_scan_out[1][0], N)));
   assert(equal(escan_ref, span(&a_scan_out[2][0], N)));
 
   std::vector<OutT> iscan_ref(N);
-  std::inclusive_scan(input.begin(), input.end(), iscan_ref.begin(), binary_op,
+  emu::inclusive_scan(input.begin(), input.end(), iscan_ref.begin(), binary_op,
                       init);
   assert(equal(iscan_ref, span(&a_scan_out[3][0], N)));
   assert(equal(iscan_ref, span(&a_scan_out[4][0], N)));

--- a/sycl/test-e2e/GroupAlgorithm/exclusive_scan_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/exclusive_scan_sycl2020.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -I . -o %t.out
 // RUN: %{run} %t.out
 
+#include "../helpers.hpp"
 #include "support.h"
 #include <algorithm>
 #include <cassert>
@@ -15,24 +16,6 @@ using namespace sycl;
 
 template <class SpecializationKernelName, int TestNumber>
 class exclusive_scan_kernel;
-
-// std::exclusive_scan isn't implemented yet, so use serial implementation
-// instead
-// TODO: use std::exclusive_scan when it will be supported
-namespace emu {
-template <typename InputIterator, typename OutputIterator,
-          class BinaryOperation, typename T>
-OutputIterator exclusive_scan(InputIterator first, InputIterator last,
-                              OutputIterator result, T init,
-                              BinaryOperation binary_op) {
-  T partial = init;
-  for (InputIterator it = first; it != last; ++it) {
-    *(result++) = partial;
-    partial = binary_op(partial, *it);
-  }
-  return result;
-}
-} // namespace emu
 
 queue q;
 

--- a/sycl/test-e2e/GroupAlgorithm/inclusive_scan_sycl2020.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/inclusive_scan_sycl2020.cpp
@@ -2,6 +2,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -I . -o %t.out
 // RUN: %{run} %t.out
 
+#include "../helpers.hpp"
 #include "support.h"
 #include <algorithm>
 #include <cassert>
@@ -17,24 +18,6 @@ queue q;
 
 template <class SpecializationKernelName, int TestNumber>
 class inclusive_scan_kernel;
-
-// std::inclusive_scan isn't implemented yet, so use serial implementation
-// instead
-// TODO: use std::inclusive_scan when it will be supported
-namespace emu {
-template <typename InputIterator, typename OutputIterator,
-          class BinaryOperation, typename T>
-OutputIterator inclusive_scan(InputIterator first, InputIterator last,
-                              OutputIterator result, BinaryOperation binary_op,
-                              T init) {
-  T partial = init;
-  for (InputIterator it = first; it != last; ++it) {
-    partial = binary_op(partial, *it);
-    *(result++) = partial;
-  }
-  return result;
-}
-} // namespace emu
 
 template <typename SpecializationKernelName, typename InputContainer,
           class BinaryOperation>

--- a/sycl/test-e2e/Regression/exclusive-scan-char-short.cpp
+++ b/sycl/test-e2e/Regression/exclusive-scan-char-short.cpp
@@ -4,6 +4,7 @@
 // This test ensures the result computed by exclusive_scan_over_group
 // for the first work item when given a short or char argument with
 // the maximum or minimum operator is computed correctly.
+#include "../helpers.hpp"
 #include <numeric>
 #include <sycl/sycl.hpp>
 
@@ -18,7 +19,7 @@ template <typename T, typename OpT> void test() {
   auto *p = malloc_shared<T>(1, q);
   *p = 0;
   T ref;
-  std::exclusive_scan(p, p + 1, &ref, init, op);
+  emu::exclusive_scan(p, p + 1, &ref, init, op);
   range r(1);
   q.parallel_for(nd_range(r, r), [=](nd_item<1> it) {
      auto g = it.get_group();

--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
@@ -145,13 +145,16 @@ void test(queue q, InputContainer input, OutputContainer output,
     });
     q.wait();
   }
-  assert(output[0] == std::reduce(input.begin(), input.begin() + workgroup_size,
-                                  identity, binary_op));
-  assert(output[1] == std::reduce(input.begin(), input.begin() + workgroup_size,
-                                  init, binary_op));
+  assert(output[0] == std::accumulate(input.begin(),
+                                      input.begin() + workgroup_size, identity,
+                                      binary_op));
+  assert(output[1] == std::accumulate(input.begin(),
+                                      input.begin() + workgroup_size, init,
+                                      binary_op));
   assert(output[2] ==
-         std::reduce(input.begin(), input.end(), identity, binary_op));
-  assert(output[3] == std::reduce(input.begin(), input.end(), init, binary_op));
+         std::accumulate(input.begin(), input.end(), identity, binary_op));
+  assert(output[3] ==
+         std::accumulate(input.begin(), input.end(), init, binary_op));
 }
 
 int main() {

--- a/sycl/test-e2e/helpers.hpp
+++ b/sycl/test-e2e/helpers.hpp
@@ -71,3 +71,34 @@ public:
 
   ~TestQueue() { wait_and_throw(); }
 };
+
+namespace emu {
+
+// std::exclusive_scan/inclusive_scan are not supported GCC 7.4,
+// so use our own implementations
+template <typename InputIterator, typename OutputIterator,
+          class BinaryOperation, typename T>
+OutputIterator exclusive_scan(InputIterator first, InputIterator last,
+                              OutputIterator result, T init,
+                              BinaryOperation binary_op) {
+  T partial = init;
+  for (InputIterator it = first; it != last; ++it) {
+    *(result++) = partial;
+    partial = binary_op(partial, *it);
+  }
+  return result;
+}
+
+template <typename InputIterator, typename OutputIterator,
+          class BinaryOperation, typename T>
+OutputIterator inclusive_scan(InputIterator first, InputIterator last,
+                              OutputIterator result, BinaryOperation binary_op,
+                              T init) {
+  T partial = init;
+  for (InputIterator it = first; it != last; ++it) {
+    partial = binary_op(partial, *it);
+    *(result++) = partial;
+  }
+  return result;
+}
+} // namespace emu


### PR DESCRIPTION
To adhere to [LLVM host compiler requirements](https://github.com/intel/llvm/blob/sycl/llvm/docs/GettingStarted.rst#host-c-toolchain-both-compiler-and-standard-library), this PR removes uses of std::exclusive_scan/inclusive_scan/reduce in some end to end tests, as they are not supported in GCC 7.4