### PR TITLE
[SYCL][E2E] Enable sort test on DG2

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
@@ -3,9 +3,6 @@
 // RUN: %{run} %t.out
 // UNSUPPORTED: accelerator
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 // The test verifies sort API extension.
 // Currently it checks the following combinations:
 // For number of elements {18, 64}


### PR DESCRIPTION
https://github.com/intel/llvm/pull/11442 fixed an issue with UB causing failures in group sorting implementations on certain hardware. This fixed the sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp on DG2 and so this commit enables this test.