### PR TITLE
[SYCL] [FPGA] Leverage `add_ir_annotations_member` in latency controls

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -57,10 +57,9 @@ public:
     check_load();
 #if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
     _T *P = Ptr;
-    if constexpr (!std::is_same_v<
-                      _propertiesT,
-                      oneapi::experimental::detail::empty_properties_t>) {
-      detail::annotated<_T *, _propertiesT> annotated_wrapper(Ptr);
+    if constexpr (!std::is_same_v<_propertiesT,
+                                  oneapi::experimental::empty_properties_t>) {
+      detail::AnnotatedMemberValue<_T *, _propertiesT> annotated_wrapper(Ptr);
       P = annotated_wrapper.MValue;
     }
     return *__builtin_intel_fpga_mem(
@@ -86,10 +85,9 @@ public:
     check_store();
 #if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
     _T *P = Ptr;
-    if constexpr (!std::is_same_v<
-                      _propertiesT,
-                      oneapi::experimental::detail::empty_properties_t>) {
-      detail::annotated<_T *, _propertiesT> annotated_wrapper(Ptr);
+    if constexpr (!std::is_same_v<_propertiesT,
+                                  oneapi::experimental::empty_properties_t>) {
+      detail::AnnotatedMemberValue<_T *, _propertiesT> annotated_wrapper(Ptr);
       P = annotated_wrapper.MValue;
     }
     *__builtin_intel_fpga_mem(

--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -101,6 +101,7 @@ public:
                                 _burst_coalesce | _cache |
                                     _dont_statically_coalesce | _prefetch,
                                 _cache_val) = Val;
+    }
 #else
     (void)Properties;
     *Ptr = Val;

--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -56,19 +56,16 @@ public:
     check_space<_space>();
     check_load();
 #if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
-    if constexpr (std::is_same_v<
+    _T *P = Ptr;
+    if constexpr (!std::is_same_v<
                       _propertiesT,
                       oneapi::experimental::detail::empty_properties_t>) {
-      return *__builtin_intel_fpga_mem(
-          (_T *)Ptr,
-          _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
-          _cache_val);
+      detail::annotated<_T *, _propertiesT> annotated_wrapper(Ptr);
+      P = annotated_wrapper.MValue;
     }
-    detail::annotated<_T *, _propertiesT> annotated_ptr(Ptr);
-    return *__builtin_intel_fpga_mem((_T *)annotated_ptr.MValue,
-                                     _burst_coalesce | _cache |
-                                         _dont_statically_coalesce | _prefetch,
-                                     _cache_val);
+    return *__builtin_intel_fpga_mem(
+        P, _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
+        _cache_val);
 #else
     (void)Properties;
     return *Ptr;
@@ -88,20 +85,16 @@ public:
     check_space<_space>();
     check_store();
 #if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
-    if constexpr (std::is_same_v<
+    _T *P = Ptr;
+    if constexpr (!std::is_same_v<
                       _propertiesT,
                       oneapi::experimental::detail::empty_properties_t>) {
-      *__builtin_intel_fpga_mem((_T *)Ptr,
-                                _burst_coalesce | _cache |
-                                    _dont_statically_coalesce | _prefetch,
-                                _cache_val) = Val;
-    } else {
-      detail::annotated<_T *, _propertiesT> annotated_ptr(Ptr);
-      *__builtin_intel_fpga_mem((_T *)annotated_ptr.MValue,
-                                _burst_coalesce | _cache |
-                                    _dont_statically_coalesce | _prefetch,
-                                _cache_val) = Val;
+      detail::annotated<_T *, _propertiesT> annotated_wrapper(Ptr);
+      P = annotated_wrapper.MValue;
     }
+    *__builtin_intel_fpga_mem(
+        P, _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
+        _cache_val) = Val;
 #else
     (void)Properties;
     *Ptr = Val;

--- a/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sycl/ext/oneapi/latency_control/properties.hpp> // for latency_co...
+#include <sycl/ext/oneapi/properties/properties.hpp> // for empty_properties_t
 
 #include <stdint.h>    // for int32_t
 #include <type_traits> // for conditional_t

--- a/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
@@ -33,17 +33,18 @@ struct _GetValue<_Type, _T1, _T...> {
 };
 
 template <typename T, typename PropertyListT =
-                          ext::oneapi::experimental::detail::empty_properties_t>
-class annotated {
+                          ext::oneapi::experimental::empty_properties_t>
+class AnnotatedMemberValue {
   static_assert(oneapi::experimental::is_property_list<PropertyListT>::value,
                 "Property list is invalid.");
 };
 
 template <typename T, typename... Props>
-class annotated<T, oneapi::experimental::detail::properties_t<Props...>> {
+class AnnotatedMemberValue<
+    T, oneapi::experimental::detail::properties_t<Props...>> {
 public:
-  annotated() {}
-  annotated(T Value) : MValue(Value) {}
+  AnnotatedMemberValue() {}
+  AnnotatedMemberValue(T Value) : MValue(Value) {}
   T MValue [[__sycl_detail__::add_ir_annotations_member(
       ext::oneapi::experimental::detail::PropertyMetaInfo<Props>::name...,
       ext::oneapi::experimental::detail::PropertyMetaInfo<Props>::value...)]];

--- a/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
@@ -31,28 +31,22 @@ struct _GetValue<_Type, _T1, _T...> {
                          _GetValue<_Type, _T...>>::value;
 };
 
-// Get the specified property from the given compile-time property list. If
-// the property is not provided in the property list, get the default version of
-// this property.
-template <typename PropListT, typename PropKeyT, typename DefaultPropValT,
-          typename = void>
-struct GetOrDefaultValT {
-  using type = DefaultPropValT;
-};
-template <typename PropListT, typename PropKeyT, typename DefaultPropValT>
-struct GetOrDefaultValT<
-    PropListT, PropKeyT, DefaultPropValT,
-    std::enable_if_t<PropListT::template has_property<PropKeyT>()>> {
-  using type = decltype(PropListT::template get_property<PropKeyT>());
+template <typename T, typename PropertyListT =
+                          ext::oneapi::experimental::detail::empty_properties_t>
+class annotated {
+  static_assert(oneapi::experimental::is_property_list<PropertyListT>::value,
+                "Property list is invalid.");
 };
 
-// Default latency_anchor_id property for latency control, indicating the
-// applied operation is not an anchor.
-using defaultLatencyAnchorIdProperty = latency_anchor_id_key::value_t<-1>;
-// Default latency_constraint property for latency control, indicating the
-// applied operation is not a non-anchor.
-using defaultLatencyConstraintProperty =
-    latency_constraint_key::value_t<0, latency_control_type::none, 0>;
+template <typename T, typename... Props>
+class annotated<T, oneapi::experimental::detail::properties_t<Props...>> {
+public:
+  annotated() {}
+  annotated(T Value) : MValue(Value) {}
+  T MValue [[__sycl_detail__::add_ir_annotations_member(
+      ext::oneapi::experimental::detail::PropertyMetaInfo<Props>::name...,
+      ext::oneapi::experimental::detail::PropertyMetaInfo<Props>::value...)]];
+};
 
 } // namespace ext::intel::experimental::detail
 } // namespace _V1

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -136,36 +136,20 @@ public:
   template <typename _functionPropertiesT>
   static _dataT read(bool &Success, _functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
-    // Get latency control properties
-    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
-        detail::defaultLatencyAnchorIdProperty>::type;
-    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
-        detail::defaultLatencyConstraintProperty>::type;
-
-    // Get latency control property values
-    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
-    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
-    static constexpr latency_control_type _control_type =
-        _latency_constraint_prop::type;
-    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
-
-    int32_t _control_type_code = 0; // latency_control_type::none is default
-    if constexpr (_control_type == latency_control_type::exact) {
-      _control_type_code = 1;
-    } else if constexpr (_control_type == latency_control_type::max) {
-      _control_type_code = 2;
-    } else if constexpr (_control_type == latency_control_type::min) {
-      _control_type_code = 3;
-    }
-
     __ocl_RPipeTy<_dataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
     _dataT TempData;
-    Success = !static_cast<bool>(__latency_control_nb_read_wrapper(
-        _RPipe, &TempData, _anchor_id, _target_anchor, _control_type_code,
-        _relative_cycle));
+    if constexpr (std::is_same_v<
+                      _functionPropertiesT,
+                      oneapi::experimental::detail::empty_properties_t>) {
+      Success = !static_cast<bool>(
+          __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
+    } else {
+      detail::annotated<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
+          annotated_ptr(_RPipe);
+      Success = !static_cast<bool>(__spirv_ReadPipe(
+          annotated_ptr.MValue, &TempData, m_Size, m_Alignment));
+    }
     return TempData;
 #else
     (void)Success;
@@ -185,35 +169,19 @@ public:
   template <typename _functionPropertiesT>
   static void write(const _dataT &Data, bool &Success, _functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
-    // Get latency control properties
-    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
-        detail::defaultLatencyAnchorIdProperty>::type;
-    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
-        detail::defaultLatencyConstraintProperty>::type;
-
-    // Get latency control property values
-    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
-    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
-    static constexpr latency_control_type _control_type =
-        _latency_constraint_prop::type;
-    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
-
-    int32_t _control_type_code = 0; // latency_control_type::none is default
-    if constexpr (_control_type == latency_control_type::exact) {
-      _control_type_code = 1;
-    } else if constexpr (_control_type == latency_control_type::max) {
-      _control_type_code = 2;
-    } else if constexpr (_control_type == latency_control_type::min) {
-      _control_type_code = 3;
-    }
-
     __ocl_WPipeTy<_dataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
-    Success = !static_cast<bool>(__latency_control_nb_write_wrapper(
-        _WPipe, &Data, _anchor_id, _target_anchor, _control_type_code,
-        _relative_cycle));
+    if constexpr (std::is_same_v<
+                      _functionPropertiesT,
+                      oneapi::experimental::detail::empty_properties_t>) {
+      Success = !static_cast<bool>(
+          __spirv_WritePipe(_WPipe, &Data, m_Size, m_Alignment));
+    } else {
+      detail::annotated<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
+          annotated_ptr(_WPipe);
+      Success = !static_cast<bool>(
+          __spirv_WritePipe(annotated_ptr.MValue, &Data, m_Size, m_Alignment));
+    }
 #else
     (void)Success;
     (void)Data;
@@ -281,36 +249,19 @@ public:
   template <typename _functionPropertiesT>
   static _dataT read(_functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
-    // Get latency control properties
-    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
-        detail::defaultLatencyAnchorIdProperty>::type;
-    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
-        detail::defaultLatencyConstraintProperty>::type;
-
-    // Get latency control property values
-    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
-    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
-    static constexpr latency_control_type _control_type =
-        _latency_constraint_prop::type;
-    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
-
-    int32_t _control_type_code = 0; // latency_control_type::none is default
-    if constexpr (_control_type == latency_control_type::exact) {
-      _control_type_code = 1;
-    } else if constexpr (_control_type == latency_control_type::max) {
-      _control_type_code = 2;
-    } else if constexpr (_control_type == latency_control_type::min) {
-      _control_type_code = 3;
-    }
-
     __ocl_RPipeTy<_dataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
     _dataT TempData;
-    __latency_control_bl_read_wrapper(_RPipe, &TempData, _anchor_id,
-                                      _target_anchor, _control_type_code,
-                                      _relative_cycle);
+    if constexpr (std::is_same_v<
+                      _functionPropertiesT,
+                      oneapi::experimental::detail::empty_properties_t>) {
+      __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
+    } else {
+      detail::annotated<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
+          annotated_ptr(_RPipe);
+      __spirv_ReadPipeBlockingINTEL(annotated_ptr.MValue, &TempData, m_Size,
+                                    m_Alignment);
+    }
     return TempData;
 #else
     throw sycl::exception(
@@ -327,35 +278,18 @@ public:
   template <typename _functionPropertiesT>
   static void write(const _dataT &Data, _functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
-    // Get latency control properties
-    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_anchor_id_key,
-        detail::defaultLatencyAnchorIdProperty>::type;
-    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
-        _functionPropertiesT, latency_constraint_key,
-        detail::defaultLatencyConstraintProperty>::type;
-
-    // Get latency control property values
-    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
-    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
-    static constexpr latency_control_type _control_type =
-        _latency_constraint_prop::type;
-    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
-
-    int32_t _control_type_code = 0; // latency_control_type::none is default
-    if constexpr (_control_type == latency_control_type::exact) {
-      _control_type_code = 1;
-    } else if constexpr (_control_type == latency_control_type::max) {
-      _control_type_code = 2;
-    } else if constexpr (_control_type == latency_control_type::min) {
-      _control_type_code = 3;
-    }
-
     __ocl_WPipeTy<_dataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
-    __latency_control_bl_write_wrapper(_WPipe, &Data, _anchor_id,
-                                       _target_anchor, _control_type_code,
-                                       _relative_cycle);
+    if constexpr (std::is_same_v<
+                      _functionPropertiesT,
+                      oneapi::experimental::detail::empty_properties_t>) {
+      __spirv_WritePipeBlockingINTEL(_WPipe, &Data, m_Size, m_Alignment);
+    } else {
+      detail::annotated<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
+          annotated_ptr(_WPipe);
+      __spirv_WritePipeBlockingINTEL(annotated_ptr.MValue, &Data, m_Size,
+                                     m_Alignment);
+    }
 #else
     (void)Data;
     throw sycl::exception(
@@ -401,45 +335,6 @@ public:
       m_uses_valid,
       m_first_symbol_in_high_order_bits,
       m_protocol};
-
-#ifdef __SYCL_DEVICE_ONLY__
-private:
-  // FPGA BE will recognize this function and extract its arguments.
-  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
-  static int32_t __latency_control_nb_read_wrapper(
-      __ocl_RPipeTy<_T> Pipe, _T *Data, int32_t /* AnchorID */,
-      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
-    return __spirv_ReadPipe(Pipe, Data, m_Size, m_Alignment);
-  }
-
-  // FPGA BE will recognize this function and extract its arguments.
-  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
-  static int32_t __latency_control_nb_write_wrapper(
-      __ocl_WPipeTy<_T> Pipe, const _T *Data, int32_t /* AnchorID */,
-      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
-    return __spirv_WritePipe(Pipe, Data, m_Size, m_Alignment);
-  }
-
-  // FPGA BE will recognize this function and extract its arguments.
-  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
-  static void __latency_control_bl_read_wrapper(
-      __ocl_RPipeTy<_T> Pipe, _T *Data, int32_t /* AnchorID */,
-      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
-    return __spirv_ReadPipeBlockingINTEL(Pipe, Data, m_Size, m_Alignment);
-  }
-
-  // FPGA BE will recognize this function and extract its arguments.
-  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
-  template <typename _T>
-  static void __latency_control_bl_write_wrapper(
-      __ocl_WPipeTy<_T> Pipe, const _T *Data, int32_t /* AnchorID*/,
-      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
-    return __spirv_WritePipeBlockingINTEL(Pipe, Data, m_Size, m_Alignment);
-  }
-#endif // __SYCL_DEVICE_ONLY__
 };
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -146,9 +146,9 @@ public:
           __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
     } else {
       detail::annotated<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
-          annotated_ptr(_RPipe);
+          annotated_wrapper(_RPipe);
       Success = !static_cast<bool>(__spirv_ReadPipe(
-          annotated_ptr.MValue, &TempData, m_Size, m_Alignment));
+          annotated_wrapper.MValue, &TempData, m_Size, m_Alignment));
     }
     return TempData;
 #else
@@ -178,9 +178,9 @@ public:
           __spirv_WritePipe(_WPipe, &Data, m_Size, m_Alignment));
     } else {
       detail::annotated<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
-          annotated_ptr(_WPipe);
-      Success = !static_cast<bool>(
-          __spirv_WritePipe(annotated_ptr.MValue, &Data, m_Size, m_Alignment));
+          annotated_wrapper(_WPipe);
+      Success = !static_cast<bool>(__spirv_WritePipe(
+          annotated_wrapper.MValue, &Data, m_Size, m_Alignment));
     }
 #else
     (void)Success;
@@ -258,8 +258,8 @@ public:
       __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
     } else {
       detail::annotated<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
-          annotated_ptr(_RPipe);
-      __spirv_ReadPipeBlockingINTEL(annotated_ptr.MValue, &TempData, m_Size,
+          annotated_wrapper(_RPipe);
+      __spirv_ReadPipeBlockingINTEL(annotated_wrapper.MValue, &TempData, m_Size,
                                     m_Alignment);
     }
     return TempData;
@@ -286,8 +286,8 @@ public:
       __spirv_WritePipeBlockingINTEL(_WPipe, &Data, m_Size, m_Alignment);
     } else {
       detail::annotated<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
-          annotated_ptr(_WPipe);
-      __spirv_WritePipeBlockingINTEL(annotated_ptr.MValue, &Data, m_Size,
+          annotated_wrapper(_WPipe);
+      __spirv_WritePipeBlockingINTEL(annotated_wrapper.MValue, &Data, m_Size,
                                      m_Alignment);
     }
 #else

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -139,13 +139,12 @@ public:
     __ocl_RPipeTy<_dataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
     _dataT TempData;
-    if constexpr (std::is_same_v<
-                      _functionPropertiesT,
-                      oneapi::experimental::detail::empty_properties_t>) {
+    if constexpr (std::is_same_v<_functionPropertiesT,
+                                 oneapi::experimental::empty_properties_t>) {
       Success = !static_cast<bool>(
           __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
     } else {
-      detail::annotated<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
+      detail::AnnotatedMemberValue<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
           annotated_wrapper(_RPipe);
       Success = !static_cast<bool>(__spirv_ReadPipe(
           annotated_wrapper.MValue, &TempData, m_Size, m_Alignment));
@@ -171,13 +170,12 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_WPipeTy<_dataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
-    if constexpr (std::is_same_v<
-                      _functionPropertiesT,
-                      oneapi::experimental::detail::empty_properties_t>) {
+    if constexpr (std::is_same_v<_functionPropertiesT,
+                                 oneapi::experimental::empty_properties_t>) {
       Success = !static_cast<bool>(
           __spirv_WritePipe(_WPipe, &Data, m_Size, m_Alignment));
     } else {
-      detail::annotated<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
+      detail::AnnotatedMemberValue<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
           annotated_wrapper(_WPipe);
       Success = !static_cast<bool>(__spirv_WritePipe(
           annotated_wrapper.MValue, &Data, m_Size, m_Alignment));
@@ -252,12 +250,11 @@ public:
     __ocl_RPipeTy<_dataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
     _dataT TempData;
-    if constexpr (std::is_same_v<
-                      _functionPropertiesT,
-                      oneapi::experimental::detail::empty_properties_t>) {
+    if constexpr (std::is_same_v<_functionPropertiesT,
+                                 oneapi::experimental::empty_properties_t>) {
       __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
     } else {
-      detail::annotated<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
+      detail::AnnotatedMemberValue<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
           annotated_wrapper(_RPipe);
       __spirv_ReadPipeBlockingINTEL(annotated_wrapper.MValue, &TempData, m_Size,
                                     m_Alignment);
@@ -280,12 +277,11 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     __ocl_WPipeTy<_dataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
-    if constexpr (std::is_same_v<
-                      _functionPropertiesT,
-                      oneapi::experimental::detail::empty_properties_t>) {
+    if constexpr (std::is_same_v<_functionPropertiesT,
+                                 oneapi::experimental::empty_properties_t>) {
       __spirv_WritePipeBlockingINTEL(_WPipe, &Data, m_Size, m_Alignment);
     } else {
-      detail::annotated<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
+      detail::AnnotatedMemberValue<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
           annotated_wrapper(_WPipe);
       __spirv_WritePipeBlockingINTEL(annotated_wrapper.MValue, &Data, m_Size,
                                      m_Alignment);

--- a/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
@@ -17,11 +17,11 @@ namespace sycl {
 inline namespace _V1 {
 namespace ext::intel::experimental {
 
-enum class latency_control_type {
-  none, // default
-  exact,
-  max,
-  min
+enum class latency_control_type : int {
+  none = 0, // default
+  exact = 1,
+  max = 2,
+  min = 3
 };
 
 struct latency_anchor_id_key {
@@ -83,6 +83,22 @@ struct IsCompileTimeProperty<intel::experimental::latency_anchor_id_key>
 template <>
 struct IsCompileTimeProperty<intel::experimental::latency_constraint_key>
     : std::true_type {};
+
+template <int Anchor>
+struct PropertyMetaInfo<
+    intel::experimental::latency_anchor_id_key::value_t<Anchor>> {
+  static constexpr const char *name = "sycl-latency-anchor-id";
+  static constexpr int value = Anchor;
+};
+
+template <int Target, intel::experimental::latency_control_type Type, int Cycle>
+struct PropertyMetaInfo<
+    intel::experimental::latency_constraint_key::value_t<Target, Type, Cycle>> {
+  static constexpr const char *name = "sycl-latency-constraint";
+  static constexpr const char *value =
+      SizeListToStr<static_cast<size_t>(Target), static_cast<size_t>(Type),
+                    static_cast<size_t>(Cycle)>::value;
+};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental


### PR DESCRIPTION
Clean up the experimental latency control headers by leveraging `add_ir_annotations_member`.
No change to the user APIs.

FPGA BE support: https://github.com/intel-innersource/applications.fpga.oneapi.products.acl-source/pull/1609

Local E2E tests combining this change and the FPGA BE change:
- On LSUs: https://psg-sc-arc.sc.intel.com/p/psg/swip/w/shuoniu/git/shuoniu.latency-control-prototype/add_ir_annotations_member/build/lsu.prj/reports/report.html
- On blocking pipes: https://psg-sc-arc.sc.intel.com/p/psg/swip/w/shuoniu/git/shuoniu.latency-control-prototype/add_ir_annotations_member/build/blocking_pipe.prj/reports/report.html
- On non-blocking pipes: https://psg-sc-arc.sc.intel.com/p/psg/swip/w/shuoniu/git/shuoniu.latency-control-prototype/add_ir_annotations_member/build/non_blocking_pipe.prj/reports/report.html