### PR TITLE
[SYCL][COMPAT] Updated pitched_memory tests to use malloc_host

### DIFF
--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
@@ -55,11 +55,13 @@ void test_memcpy3D_memset() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -101,8 +103,8 @@ void test_memcpy3D_memset() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data);
+  syclcompat::free(h_ref);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -121,11 +123,13 @@ void test_memcpy3D_memset_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -167,8 +171,8 @@ void test_memcpy3D_memset_q() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data, q);
+  syclcompat::free(h_ref, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -185,7 +189,8 @@ void test_memcpy3D_offset() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -260,7 +265,7 @@ void test_memcpy3D_offset() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -279,7 +284,8 @@ void test_memcpy3D_offset_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -353,7 +359,7 @@ void test_memcpy3D_offset_q() {
                      cpyParm_size_ct1, q);
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -370,7 +376,8 @@ void test_memcpy3D_offsetZ() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -445,7 +452,7 @@ void test_memcpy3D_offsetZ() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -463,7 +470,8 @@ void test_memcpy3D_offsetZ_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -538,7 +546,7 @@ void test_memcpy3D_offsetZ_q() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -558,7 +566,8 @@ void test_memcpy3D_plane() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -635,7 +644,7 @@ void test_memcpy3D_plane() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -655,7 +664,8 @@ void test_memcpy3D_row() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -726,7 +736,7 @@ void test_memcpy3D_row() {
 
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
@@ -58,11 +58,13 @@ void test_memcpy3D_async_pitchedAPI() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -141,8 +143,8 @@ void test_memcpy3D_async_pitchedAPI() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data);
+  syclcompat::free(h_ref);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 void test_memcpy3D_async_pitchedAPI_q() {
@@ -161,11 +163,13 @@ void test_memcpy3D_async_pitchedAPI_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_data[i] = (float)i;
 
-  h_ref = (float *)malloc(sizeof(float) * width * height * depth);
+  h_ref = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   for (int i = 0; i < width * height * depth; i++)
     h_ref[i] = (float)i;
 
@@ -216,8 +220,8 @@ void test_memcpy3D_async_pitchedAPI_q() {
   memset(h_ref, 0x1, width * height * depth * sizeof(float));
   check(h_data, h_ref, width * height * depth);
 
-  free(h_data);
-  free(h_ref);
+  syclcompat::free(h_data, q);
+  syclcompat::free(h_ref, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -235,7 +239,8 @@ void test_memcpy3D_async_offset() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -312,7 +317,7 @@ void test_memcpy3D_async_offset() {
   syclcompat::get_default_queue().wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -330,7 +335,8 @@ void test_memcpy3D_async_offset_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -407,7 +413,7 @@ void test_memcpy3D_async_offset_q() {
   q.wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 
@@ -425,7 +431,8 @@ void test_memcpy3D_async_offsetZ() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data =
+      (float *)syclcompat::malloc_host(sizeof(float) * width * height * depth);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -502,7 +509,7 @@ void test_memcpy3D_async_offsetZ() {
   syclcompat::get_default_queue().wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data);
   sycl::free(d_data.get_data_ptr(), syclcompat::get_default_context());
 }
 
@@ -520,7 +527,8 @@ void test_memcpy3D_async_offsetZ_q() {
   sycl::id<3> cpyParm_from_pos_ct1(0, 0, 0), cpyParm_to_pos_ct1(0, 0, 0);
   sycl::range<3> cpyParm_size_ct1(0, 0, 0);
 
-  h_data = (float *)malloc(sizeof(float) * width * height * depth);
+  h_data = (float *)syclcompat::malloc_host(
+      sizeof(float) * width * height * depth, q);
   /*
     0.000000        1.000000        2.000000        3.000000
     4.000000        5.000000        6.000000        7.000000
@@ -597,7 +605,7 @@ void test_memcpy3D_async_offsetZ_q() {
   q.wait_and_throw();
   // Copy back to host data.
   check(h_data, Ref, out_width * out_height * out_depth);
-  free(h_data);
+  syclcompat::free(h_data, q);
   syclcompat::free(d_data.get_data_ptr(), q);
 }
 


### PR DESCRIPTION
There's a bug when using the `opencl:cpu` backend where adjacent tests sometimes allocate the same memory region for both `std::malloc` and `sycl::malloc_device`. This causes a crash with `-34`, `CL_INVALID_CONTEXT`.

This PR works around this by using `sycl::malloc_host` instead of `std::malloc` in the intermittently failing tests. A separate bug report will be submitted once a minimal reproducer has been developed.