### PR TITLE
[SYCL][CUDA] Add missing rintf

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -158,6 +158,10 @@ float atanhf(float x) { return __devicelib_atanhf(x); }
 extern "C" SYCL_EXTERNAL float __nv_nearbyintf(float);
 DEVICE_EXTERN_C_INLINE
 float nearbyintf(float x) { return __nv_nearbyintf(x); }
+
+extern "C" SYCL_EXTERNAL float __nv_rintf(float);
+DEVICE_EXTERN_C_INLINE
+float rintf(float x) { return __nv_rintf(x); }
 #endif // __NVPTX__
 
 #endif // __SPIR__ || __NVPTX__

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -147,6 +147,10 @@ double scalbn(double x, int exp) { return __devicelib_scalbn(x, exp); }
 extern "C" SYCL_EXTERNAL double __nv_nearbyint(double);
 DEVICE_EXTERN_C_INLINE
 double nearbyint(double x) { return __nv_nearbyint(x); }
+
+extern "C" SYCL_EXTERNAL double __nv_rint(double);
+DEVICE_EXTERN_C_INLINE
+double rint(double x) { return __nv_rint(x); }
 #endif // __NVPTX__
 
 #if defined(_MSC_VER)


### PR DESCRIPTION
`rintf` was missing for NVPTX.