### PR TITLE
[SYCL][Graph] Finalize Graph for single device

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -865,22 +865,20 @@ void executable_command_graph::finalizeImpl() {
   // Create PI command-buffers for each device in the finalized context
   impl->schedule();
 
-  auto Context = impl->getContext();
-  for (const auto &Device : Context.get_devices()) {
-    bool CmdBufSupport =
-        Device.get_info<
-            ext::oneapi::experimental::info::device::graph_support>() ==
-        graph_support_level::native;
+  auto Device = impl->getGraphImpl()->getDevice();
+  bool CmdBufSupport =
+      Device
+          .get_info<ext::oneapi::experimental::info::device::graph_support>() ==
+      graph_support_level::native;
 
 #if FORCE_EMULATION_MODE
-    // Above query should still succeed in emulation mode, but ignore the
-    // result and use emulation.
-    CmdBufSupport = false;
+  // Above query should still succeed in emulation mode, but ignore the
+  // result and use emulation.
+  CmdBufSupport = false;
 #endif
 
-    if (CmdBufSupport) {
-      impl->createCommandBuffers(Device);
-    }
+  if (CmdBufSupport) {
+    impl->createCommandBuffers(Device);
   }
 }
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2650,6 +2650,11 @@ pi_int32 ExecCGCommand::enqueueImpCommandBuffer() {
   auto RawEvents = getPiEvents(EventImpls);
   flushCrossQueueDeps(EventImpls, getWorkerQueue());
 
+  // Any non-allocation dependencies need to be waited on here since subsequent
+  // submissions of the command buffer itself will not receive dependencies on
+  // them, e.g. initial copies from host to device
+  waitForEvents(MQueue, MPreparedDepsEvents, MEvent->getHandleRef());
+
   sycl::detail::pi::PiEvent *Event =
       (MQueue->has_discard_events_support() &&
        MCommandGroup->getRequirements().size() == 0)


### PR DESCRIPTION
Only finalize a modifiable `command_graph` for the SYCL device that was passed on construction. We
currently finalize for every device in the context, which is unnecessary overhead and may lead to
unintended interactions with buffers used in these contexts.

PR also includes code to start waiting on for deps when adding commands to a command graph. This prevents issues where allocation commands with dependent copies could be delayed due to device being busy and execute in an incorrect order with regards to future command graph executions.