### PR TITLE
[SYCL][COMPAT][Test] Fix mem leaks on syclcompat util tests

### DIFF
--- a/sycl/test-e2e/syclcompat/util/util_find_first_set.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_find_first_set.cpp
@@ -115,6 +115,8 @@ void test_find_first_set() {
   find_first_set_test(&host_test_result);
   assert(*test_result == 0);
   assert(host_test_result == 0);
+
+  sycl::free(test_result, q_ct1);
 }
 
 int main() {

--- a/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
@@ -138,6 +138,9 @@ void test_permute_sub_group_by_xor() {
 
   dev_ct1.queues_wait_and_throw();
   verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+
+  sycl::free(dev_data, *q_ct1);
+  sycl::free(dev_data_u, *q_ct1);
 }
 
 int main() {

--- a/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
@@ -136,6 +136,9 @@ void test_select_from_sub_group() {
 
   dev_ct1.queues_wait_and_throw();
   verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+
+  sycl::free(dev_data, *q_ct1);
+  sycl::free(dev_data_u, *q_ct1);
 }
 
 int main() {

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
@@ -135,6 +135,9 @@ void test_shift_sub_group_left() {
 
   dev_ct1.queues_wait_and_throw();
   verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+
+  sycl::free(dev_data, *q_ct1);
+  sycl::free(dev_data_u, *q_ct1);
 }
 
 int main() {

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
@@ -135,6 +135,9 @@ void test_shift_sub_group_right() {
 
   dev_ct1.queues_wait_and_throw();
   verify_data<unsigned int>(dev_data_u, expect2, DATA_NUM);
+
+  sycl::free(dev_data, *q_ct1);
+  sycl::free(dev_data_u, *q_ct1);
 }
 
 int main() {


### PR DESCRIPTION
A set of memory leaks were reported for SYCLcompat tests in issue https://github.com/intel/llvm/issues/11574

This PR addresses them.