### PR TITLE
[SYCL][Graph] Add missing no_immediate_command_list property

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -62,7 +62,7 @@ event run_kernels_usm_with_barrier(queue Q, const size_t Size, T *DataA,
 }
 
 int main() {
-  queue Queue;
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
   using T = int;
 


### PR DESCRIPTION
All the SYCL-Graph tests currently require the `no_immediate_command_list` to be set on queue creation to run portably across all hardware. This property was missing from the `barrier_with_work.cpp` test, resulting in fails on some hardware.