### PR TITLE
[SYCL][CUDA] Xfail ext-native-math.cpp test.

### DIFF
--- a/sycl/test-e2e/DeviceLib/built-ins/ext_native_math.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/ext_native_math.cpp
@@ -1,3 +1,4 @@
+// XFAIL: cuda
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/11562

This test failure has been reproduced locally on CUDA 12.1 and 12.2. Earlier versions appear to work. https://github.com/intel/llvm/pull/11436/files could also be related to this failure.