### PR TITLE
[SYCL][Doc] Update doc for ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -90,9 +90,9 @@ Notes:
   `info::partition_affinity_domain::next_partitionable`.
   (See the SYCL 2020 specification for a precise definition.)
   The root device is determined by the underlying backend.
-- When using the Level Zero or OpenCL backends, see also the documentation of
-  the [`ZE_FLAT_DEVICE_HIERARCHY`][ze-env] environment variable because it
-  affects how these backends expose root devices to SYCL.
+- When using the Level Zero backend, see also the documentation of the
+  [`ZE_FLAT_DEVICE_HIERARCHY`][ze-env] environment variable because it affects
+  how this backend exposes root devices to SYCL.
   For Intel GPUs, the sub-device and sub-sub-device syntax can be used to
   expose tiles or CCSs to the SYCL application as SYCL root devices, however
   the exact mapping is determined by the `ZE_FLAT_DEVICE_HIERARCHY` environment

--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -84,9 +84,22 @@ The following examples further illustrate the usage of this environment variable
 Notes:
 - The backend argument is always required. An error will be thrown if it is absent.
 - Additionally, the backend MUST be followed by colon ( `:` ) and at least one device specifier of some sort, else an error is thrown.
-- For sub-devices and sub-sub-devices, the parent device must support partitioning (`info::partition_property::partition_by_affinity_domain` and `info::partition_affinity_domain::next_partitionable`. See the SYCL 2020 specification for a precise definition.) For Intel GPUs, the sub-device and sub-sub-device syntax can be used to expose tiles or CCSs to the SYCL application as root devices.  The exact mapping between sub-device, sub-sub-device, tiles, and CCSs is specific to the hardware.
+- The sub-device and sub-sub-device syntax attempt to partition the root device
+  according to the rules defined by
+  `info::partition_property::partition_by_affinity_domain` and
+  `info::partition_affinity_domain::next_partitionable`.
+  (See the SYCL 2020 specification for a precise definition.)
+  The root device is determined by the underlying backend.
+- When using the Level Zero or OpenCL backends, see also the documentation of
+  the [`ZE_FLAT_DEVICE_HIERARCHY`][ze-env] environment variable because it
+  affects how these backends expose root devices to SYCL.
+  For Intel GPUs, the sub-device and sub-sub-device syntax can be used to
+  expose tiles or CCSs to the SYCL application as SYCL root devices, however
+  the exact mapping is determined by the `ZE_FLAT_DEVICE_HIERARCHY` environment
+  variable.
 - The semi-colon character ( `;` ) and the exclamation mark character ( `!`  ) are treated specially by many shells, so you may need to enclose the string in quotes if the selection string contains these characters.
 
+[ze-env]: https://spec.oneapi.io/level-zero/latest/core/PROG.html#environment-variables
 
 
 ### `SYCL_DEVICE_ALLOWLIST`


### PR DESCRIPTION
Level Zero added a new environment variable `ZE_FLAT_DEVICE_HIERARCHY` that affects the way devices are exposed to high-level languages like SYCL.  Describe how this affects `ONEAPI_DEVICE_SELECTOR`.