### PR TITLE
[SYCL] Clarify runtime error for nested kernel submissions

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -752,7 +752,7 @@ protected:
       throw sycl::exception(
           make_error_code(errc::invalid),
           "Calls to sycl::queue::submit cannot be nested. Command group "
-          "function objects should call sycl::handler::submit instead.");
+          "function objects should use the sycl::handler API instead.");
     }
 
     auto SetMPreventSubmit = [&](bool Value) -> void {

--- a/sycl/test-e2e/Basic/nested_queue_submit.cpp
+++ b/sycl/test-e2e/Basic/nested_queue_submit.cpp
@@ -1,0 +1,34 @@
+// RUN: %{build} -I . -o %t.out
+// RUN: %{run} %t.out
+
+#include <cstdlib>
+#include <sycl/sycl.hpp>
+
+void nestedSubmit() {
+  uint32_t n = 1024;
+  float *ptr = (float *)malloc(n * sizeof(float));
+  sycl::queue q{};
+  {
+    sycl::buffer<float> buf(ptr, sycl::range<1>{n});
+    q.submit([&](sycl::handler &h) {
+      auto acc = buf.get_access<sycl::access::mode::write>(h);
+      q.parallel_for<class zero>(sycl::range<1>{n},
+                                 [=](sycl::id<1> i) { acc[i] = float(0.0); });
+    });
+  }
+  free(ptr);
+}
+
+int main() {
+  try {
+    nestedSubmit();
+  } catch (const sycl::exception &e) {
+    assert(e.code() == sycl::errc::invalid && "Invalid error code");
+    assert(std::string(e.what()) ==
+               "Calls to sycl::queue::submit cannot be nested. Command group "
+               "function objects should call sycl::handler::submit instead." &&
+           "Invalid e.what() string");
+  }
+  std::cout << "test passed" << std::endl;
+  return EXIT_SUCCESS;
+}

--- a/sycl/test-e2e/Basic/nested_queue_submit.cpp
+++ b/sycl/test-e2e/Basic/nested_queue_submit.cpp
@@ -26,7 +26,7 @@ int main() {
     assert(e.code() == sycl::errc::invalid && "Invalid error code");
     assert(std::string(e.what()) ==
                "Calls to sycl::queue::submit cannot be nested. Command group "
-               "function objects should call sycl::handler::submit instead." &&
+               "function objects should use the sycl::handler API instead." &&
            "Invalid e.what() string");
   }
   std::cout << "test passed" << std::endl;


### PR DESCRIPTION
As both `sycl::queue` and `sycl::handler` have similar `parallel_for` member functions, it's easy to confuse the two when writing a command group function. This change adds an exception with a clear error message when `queue::submit` is called from a command group function.