### PR TITLE
[SYCL][COMPLEX] Split complex header file and tests into multiple files

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/complex/complex.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/complex.hpp
@@ -1,0 +1,16 @@
+//===- complex.hpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifdef SYCL_EXT_ONEAPI_COMPLEX
+
+#include "./detail/complex.hpp"
+#include "./detail/complex_math.hpp"
+
+#endif // SYCL_EXT_ONEAPI_COMPLEX

--- a/sycl/include/sycl/ext/oneapi/experimental/complex/detail/common.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/detail/common.hpp
@@ -23,11 +23,9 @@ namespace experimental {
 /// FORWARD DECLARATIONS
 ////////////////////////////////////////////////////////////////////////////////
 
-template <class _Tp>
-struct is_genfloat;
+template <class _Tp> struct is_genfloat;
 
-template <class _Tp, class _Enable = void>
-class complex;
+template <class _Tp, class _Enable = void> class complex;
 
 template <class _Tp>
 class complex<_Tp, typename std::enable_if_t<is_genfloat<_Tp>::value>>;
@@ -37,16 +35,17 @@ class complex<_Tp, typename std::enable_if_t<is_genfloat<_Tp>::value>>;
 ////////////////////////////////////////////////////////////////////////////////
 
 template <class _Tp>
-struct is_genfloat : std::integral_constant<bool,
-  std::is_same_v<_Tp, double> ||
-  std::is_same_v<_Tp, float> ||
-  std::is_same_v<_Tp, sycl::half>> {};
+struct is_genfloat
+    : std::integral_constant<bool, std::is_same_v<_Tp, double> ||
+                                       std::is_same_v<_Tp, float> ||
+                                       std::is_same_v<_Tp, sycl::half>> {};
 
 template <class _Tp>
-struct is_gencomplex : std::integral_constant<bool,
-  std::is_same_v<_Tp, complex<double>> ||
-  std::is_same_v<_Tp, complex<float>> ||
-  std::is_same_v<_Tp, complex<sycl::half>>> {};
+struct is_gencomplex
+    : std::integral_constant<bool,
+                             std::is_same_v<_Tp, complex<double>> ||
+                                 std::is_same_v<_Tp, complex<float>> ||
+                                 std::is_same_v<_Tp, complex<sycl::half>>> {};
 
 ////////////////////////////////////////////////////////////////////////////////
 /// DEFINES

--- a/sycl/include/sycl/ext/oneapi/experimental/complex/detail/common.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/detail/common.hpp
@@ -1,0 +1,63 @@
+//===- common.hpp ---------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <type_traits>
+
+#include <sycl/half_type.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+
+namespace ext {
+namespace oneapi {
+namespace experimental {
+
+////////////////////////////////////////////////////////////////////////////////
+/// FORWARD DECLARATIONS
+////////////////////////////////////////////////////////////////////////////////
+
+template <class _Tp>
+struct is_genfloat;
+
+template <class _Tp, class _Enable = void>
+class complex;
+
+template <class _Tp>
+class complex<_Tp, typename std::enable_if_t<is_genfloat<_Tp>::value>>;
+
+////////////////////////////////////////////////////////////////////////////////
+/// TRAITS
+////////////////////////////////////////////////////////////////////////////////
+
+template <class _Tp>
+struct is_genfloat : std::integral_constant<bool,
+  std::is_same_v<_Tp, double> ||
+  std::is_same_v<_Tp, float> ||
+  std::is_same_v<_Tp, sycl::half>> {};
+
+template <class _Tp>
+struct is_gencomplex : std::integral_constant<bool,
+  std::is_same_v<_Tp, complex<double>> ||
+  std::is_same_v<_Tp, complex<float>> ||
+  std::is_same_v<_Tp, complex<sycl::half>>> {};
+
+////////////////////////////////////////////////////////////////////////////////
+/// DEFINES
+////////////////////////////////////////////////////////////////////////////////
+
+#define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
+  inline __attribute__((__visibility__("hidden"), __always_inline__))
+
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex.hpp
@@ -1,0 +1,388 @@
+//===- complex.hpp --------------------------------------------------------===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "common.hpp"
+
+#include <sycl/stream.hpp>
+
+#include <complex>
+
+namespace sycl {
+inline namespace _V1 {
+
+namespace ext {
+namespace oneapi {
+namespace experimental {
+
+template <class _Tp>
+class complex<_Tp, typename std::enable_if_t<is_genfloat<_Tp>::value>> {
+public:
+  typedef _Tp value_type;
+
+private:
+  value_type __re_;
+  value_type __im_;
+
+public:
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
+      value_type __re = value_type(), value_type __im = value_type())
+      : __re_(__re), __im_(__im) {}
+
+  template <typename _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
+      : __re_(__c.real()), __im_(__c.imag()) {}
+
+  template <class _Xp, typename = std::enable_if_t<is_genfloat<_Xp>::value>>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
+      const std::complex<_Xp> &__c)
+      : __re_(static_cast<value_type>(__c.real())),
+        __im_(static_cast<value_type>(__c.imag())) {}
+
+  template <class _Xp, typename = std::enable_if_t<is_genfloat<_Xp>::value>>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+  operator std::complex<_Xp>() const {
+    return std::complex<_Xp>(static_cast<_Xp>(__re_), static_cast<_Xp>(__im_));
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type real() const {
+    return __re_;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type imag() const {
+    return __im_;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(value_type __re) {
+    __re_ = __re;
+    __im_ = value_type();
+    return *this;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator+=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ += __re;
+    return __c;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator-=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ -= __re;
+    return __c;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator*=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ *= __re;
+    __c.__im_ *= __re;
+    return __c;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator/=(complex<value_type> &__c, value_type __re) {
+    __c.__re_ /= __re;
+    __c.__im_ /= __re;
+    return __c;
+  }
+
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
+    __re_ = __c.real();
+    __im_ = __c.imag();
+    return *this;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator+=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x.__re_ += __y.real();
+    __x.__im_ += __y.imag();
+    return __x;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator-=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x.__re_ -= __y.real();
+    __x.__im_ -= __y.imag();
+    return __x;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator*=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x = __x * complex(__y.real(), __y.imag());
+    return __x;
+  }
+  template <class _Xp>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
+  operator/=(complex<value_type> &__x, const complex<_Xp> &__y) {
+    __x = __x / complex(__y.real(), __y.imag());
+    return __x;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const complex<value_type> &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__x);
+    __t += __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const complex<value_type> &__x, value_type __y) {
+    complex<value_type> __t(__x);
+    __t += __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(value_type __x, const complex<value_type> &__y) {
+    complex<value_type> __t(__y);
+    __t += __x;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator+(const complex<value_type> &__x) {
+    return __x;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const complex<value_type> &__x, const complex<value_type> &__y) {
+    complex<value_type> __t(__x);
+    __t -= __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const complex<value_type> &__x, value_type __y) {
+    complex<value_type> __t(__x);
+    __t -= __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(value_type __x, const complex<value_type> &__y) {
+    complex<value_type> __t(-__y);
+    __t += __x;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator-(const complex<value_type> &__x) {
+    return complex<value_type>(-__x.__re_, -__x.__im_);
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator*(const complex<value_type> &__z, const complex<value_type> &__w) {
+    value_type __a = __z.__re_;
+    value_type __b = __z.__im_;
+    value_type __c = __w.__re_;
+    value_type __d = __w.__im_;
+    value_type __ac = __a * __c;
+    value_type __bd = __b * __d;
+    value_type __ad = __a * __d;
+    value_type __bc = __b * __c;
+    value_type __x = __ac - __bd;
+    value_type __y = __ad + __bc;
+    if (sycl::isnan(__x) && sycl::isnan(__y)) {
+      bool __recalc = false;
+      if (sycl::isinf(__a) || sycl::isinf(__b)) {
+        __a = sycl::copysign(sycl::isinf(__a) ? value_type(1) : value_type(0),
+                             __a);
+        __b = sycl::copysign(sycl::isinf(__b) ? value_type(1) : value_type(0),
+                             __b);
+        if (sycl::isnan(__c))
+          __c = sycl::copysign(value_type(0), __c);
+        if (sycl::isnan(__d))
+          __d = sycl::copysign(value_type(0), __d);
+        __recalc = true;
+      }
+      if (sycl::isinf(__c) || sycl::isinf(__d)) {
+        __c = sycl::copysign(sycl::isinf(__c) ? value_type(1) : value_type(0),
+                             __c);
+        __d = sycl::copysign(sycl::isinf(__d) ? value_type(1) : value_type(0),
+                             __d);
+        if (sycl::isnan(__a))
+          __a = sycl::copysign(value_type(0), __a);
+        if (sycl::isnan(__b))
+          __b = sycl::copysign(value_type(0), __b);
+        __recalc = true;
+      }
+      if (!__recalc && (sycl::isinf(__ac) || sycl::isinf(__bd) ||
+                        sycl::isinf(__ad) || sycl::isinf(__bc))) {
+        if (sycl::isnan(__a))
+          __a = sycl::copysign(value_type(0), __a);
+        if (sycl::isnan(__b))
+          __b = sycl::copysign(value_type(0), __b);
+        if (sycl::isnan(__c))
+          __c = sycl::copysign(value_type(0), __c);
+        if (sycl::isnan(__d))
+          __d = sycl::copysign(value_type(0), __d);
+        __recalc = true;
+      }
+      if (__recalc) {
+        __x = value_type(INFINITY) * (__a * __c - __b * __d);
+        __y = value_type(INFINITY) * (__a * __d + __b * __c);
+      }
+    }
+    return complex<value_type>(__x, __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator*(const complex<value_type> &__x, value_type __y) {
+    complex<value_type> __t(__x);
+    __t *= __y;
+    return __t;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator*(value_type __x, const complex<value_type> &__y) {
+    complex<value_type> __t(__y);
+    __t *= __x;
+    return __t;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator/(const complex<value_type> &__z, const complex<value_type> &__w) {
+    int __ilogbw = 0;
+    value_type __a = __z.__re_;
+    value_type __b = __z.__im_;
+    value_type __c = __w.__re_;
+    value_type __d = __w.__im_;
+    value_type __logbw =
+        sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
+    if (sycl::isfinite(__logbw)) {
+      __ilogbw = static_cast<int>(__logbw);
+      __c = sycl::ldexp(__c, -__ilogbw);
+      __d = sycl::ldexp(__d, -__ilogbw);
+    }
+    value_type __denom = __c * __c + __d * __d;
+    value_type __x = sycl::ldexp((__a * __c + __b * __d) / __denom, -__ilogbw);
+    value_type __y = sycl::ldexp((__b * __c - __a * __d) / __denom, -__ilogbw);
+    if (sycl::isnan(__x) && sycl::isnan(__y)) {
+      if ((__denom == value_type(0)) &&
+          (!sycl::isnan(__a) || !sycl::isnan(__b))) {
+        __x = sycl::copysign(value_type(INFINITY), __c) * __a;
+        __y = sycl::copysign(value_type(INFINITY), __c) * __b;
+      } else if ((sycl::isinf(__a) || sycl::isinf(__b)) &&
+                 sycl::isfinite(__c) && sycl::isfinite(__d)) {
+        __a = sycl::copysign(sycl::isinf(__a) ? value_type(1) : value_type(0),
+                             __a);
+        __b = sycl::copysign(sycl::isinf(__b) ? value_type(1) : value_type(0),
+                             __b);
+        __x = value_type(INFINITY) * (__a * __c + __b * __d);
+        __y = value_type(INFINITY) * (__b * __c - __a * __d);
+      } else if (sycl::isinf(__logbw) && __logbw > value_type(0) &&
+                 sycl::isfinite(__a) && sycl::isfinite(__b)) {
+        __c = sycl::copysign(sycl::isinf(__c) ? value_type(1) : value_type(0),
+                             __c);
+        __d = sycl::copysign(sycl::isinf(__d) ? value_type(1) : value_type(0),
+                             __d);
+        __x = value_type(0) * (__a * __c + __b * __d);
+        __y = value_type(0) * (__b * __c - __a * __d);
+      }
+    }
+    return complex<value_type>(__x, __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator/(const complex<value_type> &__x, value_type __y) {
+    return complex<value_type>(__x.__re_ / __y, __x.__im_ / __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
+  operator/(value_type __x, const complex<value_type> &__y) {
+    complex<value_type> __t(__x);
+    __t /= __y;
+    return __t;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator==(const complex<value_type> &__x, const complex<value_type> &__y) {
+    return __x.__re_ == __y.__re_ && __x.__im_ == __y.__im_;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator==(const complex<value_type> &__x, value_type __y) {
+    return __x.__re_ == __y && __x.__im_ == 0;
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator==(value_type __x, const complex<value_type> &__y) {
+    return __x == __y.__re_ && 0 == __y.__im_;
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator!=(const complex<value_type> &__x, const complex<value_type> &__y) {
+    return !(__x == __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator!=(const complex<value_type> &__x, value_type __y) {
+    return !(__x == __y);
+  }
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
+  operator!=(value_type __x, const complex<value_type> &__y) {
+    return !(__x == __y);
+  }
+
+  template <class _CharT, class _Traits>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend std::basic_istream<_CharT, _Traits> &
+  operator>>(std::basic_istream<_CharT, _Traits> &__is,
+             complex<value_type> &__x) {
+    if (__is.good()) {
+      ws(__is);
+      if (__is.peek() == _CharT('(')) {
+        __is.get();
+        value_type __r;
+        __is >> __r;
+        if (!__is.fail()) {
+          ws(__is);
+          _CharT __c = __is.peek();
+          if (__c == _CharT(',')) {
+            __is.get();
+            value_type __i;
+            __is >> __i;
+            if (!__is.fail()) {
+              ws(__is);
+              __c = __is.peek();
+              if (__c == _CharT(')')) {
+                __is.get();
+                __x = complex<value_type>(__r, __i);
+              } else
+                __is.setstate(__is.failbit);
+            } else
+              __is.setstate(__is.failbit);
+          } else if (__c == _CharT(')')) {
+            __is.get();
+            __x = complex<value_type>(__r, value_type(0));
+          } else
+            __is.setstate(__is.failbit);
+        } else
+          __is.setstate(__is.failbit);
+      } else {
+        value_type __r;
+        __is >> __r;
+        if (!__is.fail())
+          __x = complex<value_type>(__r, value_type(0));
+        else
+          __is.setstate(__is.failbit);
+      }
+    } else
+      __is.setstate(__is.failbit);
+    return __is;
+  }
+
+  template <class _CharT, class _Traits>
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend std::basic_ostream<_CharT, _Traits> &
+  operator<<(std::basic_ostream<_CharT, _Traits> &__os,
+             const complex<value_type> &__x) {
+    std::basic_ostringstream<_CharT, _Traits> __s;
+    __s.flags(__os.flags());
+    __s.imbue(__os.getloc());
+    __s.precision(__os.precision());
+    __s << '(' << __x.__re_ << ',' << __x.__im_ << ')';
+    return __os << __s.str();
+  }
+
+  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend const sycl::stream &
+  operator<<(const sycl::stream &__ss, const complex<value_type> &_x) {
+    return __ss << "(" << _x.__re_ << "," << _x.__im_ << ")";
+  }
+};
+
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex_math.hpp
@@ -1,4 +1,4 @@
-//===- sycl_complex.hpp ---------------------------------------------------===//
+//===- complex_math.hpp ---------------------------------------------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -8,37 +8,26 @@
 
 #pragma once
 
-#ifdef SYCL_EXT_ONEAPI_COMPLEX
+#include "common.hpp"
 
-#define _SYCL_EXT_CPLX_INLINE_VISIBILITY                                       \
-  inline __attribute__((__visibility__("hidden"), __always_inline__))
+#include <sycl/builtins.hpp>
 
-#include <complex>
-#include <sstream> // for std::basic_ostringstream
-#include <sycl/sycl.hpp>
-#include <type_traits>
+#include <math.h>
 
 namespace sycl {
 inline namespace _V1 {
+
 namespace ext {
 namespace oneapi {
 namespace experimental {
 
-using std::enable_if;
-using std::integral_constant;
-using std::is_floating_point;
-using std::is_integral;
-using std::is_same;
-
-using std::basic_istream;
-using std::basic_ostream;
-using std::basic_ostringstream;
-
-using std::declval;
+////////////////////////////////////////////////////////////////////////////////
+/// TRAITS
+////////////////////////////////////////////////////////////////////////////////
 
 namespace cplx::detail {
 
-template <bool _Val> using _BoolConstant = integral_constant<bool, _Val>;
+template <bool _Val> using _BoolConstant = std::integral_constant<bool, _Val>;
 
 template <class _Tp, class _Up>
 using _IsNotSame = _BoolConstant<!__is_same(_Tp, _Up)>;
@@ -56,7 +45,7 @@ template <class _Tp> struct __numeric_type {
   static double __test(unsigned long long);
   static double __test(double);
 
-  typedef decltype(__test(declval<_Tp>())) type;
+  typedef decltype(__test(std::declval<_Tp>())) type;
   static const bool value = _IsNotSame<type, void>::value;
 };
 
@@ -65,8 +54,8 @@ template <> struct __numeric_type<void> {
 };
 
 template <class _A1, class _A2 = void, class _A3 = void,
-          bool = __numeric_type<_A1>::value &&__numeric_type<_A2>::value
-              &&__numeric_type<_A3>::value>
+          bool = __numeric_type<_A1>::value && __numeric_type<_A2>::value &&
+                 __numeric_type<_A3>::value>
 class __promote_imp {
 public:
   static const bool value = false;
@@ -102,431 +91,30 @@ public:
 
 template <class _A1, class _A2 = void, class _A3 = void>
 class __promote : public __promote_imp<_A1, _A2, _A3> {};
-} // namespace cplx::detail
 
-template <class _Tp, class _Enable = void> class complex;
-
-template <class _Tp>
-struct is_gencomplex
-    : std::integral_constant<bool,
-                             std::is_same_v<_Tp, complex<double>> ||
-                                 std::is_same_v<_Tp, complex<float>> ||
-                                 std::is_same_v<_Tp, complex<sycl::half>>> {};
-
-template <class _Tp>
-struct is_genfloat
-    : std::integral_constant<bool, std::is_same_v<_Tp, double> ||
-                                       std::is_same_v<_Tp, float> ||
-                                       std::is_same_v<_Tp, sycl::half>> {};
-
-template <class _Tp>
-class complex<_Tp, typename std::enable_if_t<is_genfloat<_Tp>::value>> {
-public:
-  typedef _Tp value_type;
-
-private:
-  value_type __re_;
-  value_type __im_;
-
-public:
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
-      value_type __re = value_type(), value_type __im = value_type())
-      : __re_(__re), __im_(__im) {}
-
-  template <typename _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(const complex<_Xp> &__c)
-      : __re_(__c.real()), __im_(__c.imag()) {}
-
-  template <class _Xp, typename = std::enable_if_t<is_genfloat<_Xp>::value>>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr complex(
-      const std::complex<_Xp> &__c)
-      : __re_(static_cast<value_type>(__c.real())),
-        __im_(static_cast<value_type>(__c.imag())) {}
-
-  template <class _Xp, typename = std::enable_if_t<is_genfloat<_Xp>::value>>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-  operator std::complex<_Xp>() const {
-    return std::complex<_Xp>(static_cast<_Xp>(__re_), static_cast<_Xp>(__im_));
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type real() const {
-    return __re_;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr value_type imag() const {
-    return __im_;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void real(value_type __re) { __re_ = __re; }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY void imag(value_type __im) { __im_ = __im; }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(value_type __re) {
-    __re_ = __re;
-    __im_ = value_type();
-    return *this;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator+=(complex<value_type> &__c, value_type __re) {
-    __c.__re_ += __re;
-    return __c;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator-=(complex<value_type> &__c, value_type __re) {
-    __c.__re_ -= __re;
-    return __c;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator*=(complex<value_type> &__c, value_type __re) {
-    __c.__re_ *= __re;
-    __c.__im_ *= __re;
-    return __c;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator/=(complex<value_type> &__c, value_type __re) {
-    __c.__re_ /= __re;
-    __c.__im_ /= __re;
-    return __c;
-  }
-
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY complex &operator=(const complex<_Xp> &__c) {
-    __re_ = __c.real();
-    __im_ = __c.imag();
-    return *this;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator+=(complex<value_type> &__x, const complex<_Xp> &__y) {
-    __x.__re_ += __y.real();
-    __x.__im_ += __y.imag();
-    return __x;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator-=(complex<value_type> &__x, const complex<_Xp> &__y) {
-    __x.__re_ -= __y.real();
-    __x.__im_ -= __y.imag();
-    return __x;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator*=(complex<value_type> &__x, const complex<_Xp> &__y) {
-    __x = __x * complex(__y.real(), __y.imag());
-    return __x;
-  }
-  template <class _Xp>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex &
-  operator/=(complex<value_type> &__x, const complex<_Xp> &__y) {
-    __x = __x / complex(__y.real(), __y.imag());
-    return __x;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator+(const complex<value_type> &__x, const complex<value_type> &__y) {
-    complex<value_type> __t(__x);
-    __t += __y;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator+(const complex<value_type> &__x, value_type __y) {
-    complex<value_type> __t(__x);
-    __t += __y;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator+(value_type __x, const complex<value_type> &__y) {
-    complex<value_type> __t(__y);
-    __t += __x;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator+(const complex<value_type> &__x) {
-    return __x;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator-(const complex<value_type> &__x, const complex<value_type> &__y) {
-    complex<value_type> __t(__x);
-    __t -= __y;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator-(const complex<value_type> &__x, value_type __y) {
-    complex<value_type> __t(__x);
-    __t -= __y;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator-(value_type __x, const complex<value_type> &__y) {
-    complex<value_type> __t(-__y);
-    __t += __x;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator-(const complex<value_type> &__x) {
-    return complex<value_type>(-__x.__re_, -__x.__im_);
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator*(const complex<value_type> &__z, const complex<value_type> &__w) {
-    value_type __a = __z.__re_;
-    value_type __b = __z.__im_;
-    value_type __c = __w.__re_;
-    value_type __d = __w.__im_;
-    value_type __ac = __a * __c;
-    value_type __bd = __b * __d;
-    value_type __ad = __a * __d;
-    value_type __bc = __b * __c;
-    value_type __x = __ac - __bd;
-    value_type __y = __ad + __bc;
-    if (sycl::isnan(__x) && sycl::isnan(__y)) {
-      bool __recalc = false;
-      if (sycl::isinf(__a) || sycl::isinf(__b)) {
-        __a = sycl::copysign(sycl::isinf(__a) ? value_type(1) : value_type(0),
-                             __a);
-        __b = sycl::copysign(sycl::isinf(__b) ? value_type(1) : value_type(0),
-                             __b);
-        if (sycl::isnan(__c))
-          __c = sycl::copysign(value_type(0), __c);
-        if (sycl::isnan(__d))
-          __d = sycl::copysign(value_type(0), __d);
-        __recalc = true;
-      }
-      if (sycl::isinf(__c) || sycl::isinf(__d)) {
-        __c = sycl::copysign(sycl::isinf(__c) ? value_type(1) : value_type(0),
-                             __c);
-        __d = sycl::copysign(sycl::isinf(__d) ? value_type(1) : value_type(0),
-                             __d);
-        if (sycl::isnan(__a))
-          __a = sycl::copysign(value_type(0), __a);
-        if (sycl::isnan(__b))
-          __b = sycl::copysign(value_type(0), __b);
-        __recalc = true;
-      }
-      if (!__recalc && (sycl::isinf(__ac) || sycl::isinf(__bd) ||
-                        sycl::isinf(__ad) || sycl::isinf(__bc))) {
-        if (sycl::isnan(__a))
-          __a = sycl::copysign(value_type(0), __a);
-        if (sycl::isnan(__b))
-          __b = sycl::copysign(value_type(0), __b);
-        if (sycl::isnan(__c))
-          __c = sycl::copysign(value_type(0), __c);
-        if (sycl::isnan(__d))
-          __d = sycl::copysign(value_type(0), __d);
-        __recalc = true;
-      }
-      if (__recalc) {
-        __x = value_type(INFINITY) * (__a * __c - __b * __d);
-        __y = value_type(INFINITY) * (__a * __d + __b * __c);
-      }
-    }
-    return complex<value_type>(__x, __y);
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator*(const complex<value_type> &__x, value_type __y) {
-    complex<value_type> __t(__x);
-    __t *= __y;
-    return __t;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator*(value_type __x, const complex<value_type> &__y) {
-    complex<value_type> __t(__y);
-    __t *= __x;
-    return __t;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator/(const complex<value_type> &__z, const complex<value_type> &__w) {
-    int __ilogbw = 0;
-    value_type __a = __z.__re_;
-    value_type __b = __z.__im_;
-    value_type __c = __w.__re_;
-    value_type __d = __w.__im_;
-    value_type __logbw =
-        sycl::logb(sycl::fmax(sycl::fabs(__c), sycl::fabs(__d)));
-    if (sycl::isfinite(__logbw)) {
-      __ilogbw = static_cast<int>(__logbw);
-      __c = sycl::ldexp(__c, -__ilogbw);
-      __d = sycl::ldexp(__d, -__ilogbw);
-    }
-    value_type __denom = __c * __c + __d * __d;
-    value_type __x = sycl::ldexp((__a * __c + __b * __d) / __denom, -__ilogbw);
-    value_type __y = sycl::ldexp((__b * __c - __a * __d) / __denom, -__ilogbw);
-    if (sycl::isnan(__x) && sycl::isnan(__y)) {
-      if ((__denom == value_type(0)) &&
-          (!sycl::isnan(__a) || !sycl::isnan(__b))) {
-        __x = sycl::copysign(value_type(INFINITY), __c) * __a;
-        __y = sycl::copysign(value_type(INFINITY), __c) * __b;
-      } else if ((sycl::isinf(__a) || sycl::isinf(__b)) &&
-                 sycl::isfinite(__c) && sycl::isfinite(__d)) {
-        __a = sycl::copysign(sycl::isinf(__a) ? value_type(1) : value_type(0),
-                             __a);
-        __b = sycl::copysign(sycl::isinf(__b) ? value_type(1) : value_type(0),
-                             __b);
-        __x = value_type(INFINITY) * (__a * __c + __b * __d);
-        __y = value_type(INFINITY) * (__b * __c - __a * __d);
-      } else if (sycl::isinf(__logbw) && __logbw > value_type(0) &&
-                 sycl::isfinite(__a) && sycl::isfinite(__b)) {
-        __c = sycl::copysign(sycl::isinf(__c) ? value_type(1) : value_type(0),
-                             __c);
-        __d = sycl::copysign(sycl::isinf(__d) ? value_type(1) : value_type(0),
-                             __d);
-        __x = value_type(0) * (__a * __c + __b * __d);
-        __y = value_type(0) * (__b * __c - __a * __d);
-      }
-    }
-    return complex<value_type>(__x, __y);
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator/(const complex<value_type> &__x, value_type __y) {
-    return complex<value_type>(__x.__re_ / __y, __x.__im_ / __y);
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend complex<value_type>
-  operator/(value_type __x, const complex<value_type> &__y) {
-    complex<value_type> __t(__x);
-    __t /= __y;
-    return __t;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator==(const complex<value_type> &__x, const complex<value_type> &__y) {
-    return __x.__re_ == __y.__re_ && __x.__im_ == __y.__im_;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator==(const complex<value_type> &__x, value_type __y) {
-    return __x.__re_ == __y && __x.__im_ == 0;
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator==(value_type __x, const complex<value_type> &__y) {
-    return __x == __y.__re_ && 0 == __y.__im_;
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator!=(const complex<value_type> &__x, const complex<value_type> &__y) {
-    return !(__x == __y);
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator!=(const complex<value_type> &__x, value_type __y) {
-    return !(__x == __y);
-  }
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend constexpr bool
-  operator!=(value_type __x, const complex<value_type> &__y) {
-    return !(__x == __y);
-  }
-
-  template <class _CharT, class _Traits>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend std::basic_istream<_CharT, _Traits> &
-  operator>>(std::basic_istream<_CharT, _Traits> &__is,
-             complex<value_type> &__x) {
-    if (__is.good()) {
-      ws(__is);
-      if (__is.peek() == _CharT('(')) {
-        __is.get();
-        value_type __r;
-        __is >> __r;
-        if (!__is.fail()) {
-          ws(__is);
-          _CharT __c = __is.peek();
-          if (__c == _CharT(',')) {
-            __is.get();
-            value_type __i;
-            __is >> __i;
-            if (!__is.fail()) {
-              ws(__is);
-              __c = __is.peek();
-              if (__c == _CharT(')')) {
-                __is.get();
-                __x = complex<value_type>(__r, __i);
-              } else
-                __is.setstate(__is.failbit);
-            } else
-              __is.setstate(__is.failbit);
-          } else if (__c == _CharT(')')) {
-            __is.get();
-            __x = complex<value_type>(__r, value_type(0));
-          } else
-            __is.setstate(__is.failbit);
-        } else
-          __is.setstate(__is.failbit);
-      } else {
-        value_type __r;
-        __is >> __r;
-        if (!__is.fail())
-          __x = complex<value_type>(__r, value_type(0));
-        else
-          __is.setstate(__is.failbit);
-      }
-    } else
-      __is.setstate(__is.failbit);
-    return __is;
-  }
-
-  template <class _CharT, class _Traits>
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend std::basic_ostream<_CharT, _Traits> &
-  operator<<(std::basic_ostream<_CharT, _Traits> &__os,
-             const complex<value_type> &__x) {
-    std::basic_ostringstream<_CharT, _Traits> __s;
-    __s.flags(__os.flags());
-    __s.imbue(__os.getloc());
-    __s.precision(__os.precision());
-    __s << '(' << __x.__re_ << ',' << __x.__im_ << ')';
-    return __os << __s.str();
-  }
-
-  _SYCL_EXT_CPLX_INLINE_VISIBILITY friend const sycl::stream &
-  operator<<(const sycl::stream &__ss, const complex<value_type> &_x) {
-    return __ss << "(" << _x.__re_ << "," << _x.__im_ << ")";
-  }
-};
-
-namespace cplx::detail {
-template <class _Tp, bool = std::is_integral<_Tp>::value,
-          bool = is_genfloat<_Tp>::value>
+template <class _Tp, bool = std::is_integral<_Tp>::value, bool = is_genfloat<_Tp>::value>
 struct __libcpp_complex_overload_traits {};
 
 // Integral Types
-template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, true, false> {
+template <class _Tp>
+struct __libcpp_complex_overload_traits<_Tp, true, false> {
   typedef double _ValueType;
   typedef complex<double> _ComplexType;
 };
 
 // Floating point types
-template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
+template <class _Tp>
+struct __libcpp_complex_overload_traits<_Tp, false, true> {
   typedef _Tp _ValueType;
   typedef complex<_Tp> _ComplexType;
 };
+
 } // namespace cplx::detail
 
-// real
 
-template <class _Tp>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
-    real(const complex<_Tp> &__c) {
-  return __c.real();
-}
-
-template <class _Tp>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename cplx::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
-    real(_Tp __re) {
-  return __re;
-}
-
-// imag
-
-template <class _Tp>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
-    imag(const complex<_Tp> &__c) {
-  return __c.imag();
-}
-
-template <class _Tp>
-__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
-    typename cplx::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
-    imag(_Tp) {
-  return 0;
-}
+////////////////////////////////////////////////////////////////////////////////
+/// FUNCTIONS
+////////////////////////////////////////////////////////////////////////////////
 
 // abs
 
@@ -1006,13 +594,41 @@ __DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY
   return complex<_Tp>(__z.imag(), -__z.real());
 }
 
+// real
+
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    real(const complex<_Tp> &__c) {
+  return __c.real();
+}
+
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename cplx::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
+    real(_Tp __re) {
+  return __re;
+}
+
+// imag
+
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename std::enable_if_t<is_genfloat<_Tp>::value, _Tp>
+    imag(const complex<_Tp> &__c) {
+  return __c.imag();
+}
+
+template <class _Tp>
+__DPCPP_SYCL_EXTERNAL _SYCL_EXT_CPLX_INLINE_VISIBILITY constexpr
+    typename cplx::detail::__libcpp_complex_overload_traits<_Tp>::_ValueType
+    imag(_Tp) {
+  return 0;
+}
+
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext
 
 } // namespace _V1
 } // namespace sycl
-
-#undef _SYCL_EXT_CPLX_INLINE_VISIBILITY
-
-#endif // SYCL_EXT_ONEAPI_COMPLEX

--- a/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/complex/detail/complex_math.hpp
@@ -92,25 +92,23 @@ public:
 template <class _A1, class _A2 = void, class _A3 = void>
 class __promote : public __promote_imp<_A1, _A2, _A3> {};
 
-template <class _Tp, bool = std::is_integral<_Tp>::value, bool = is_genfloat<_Tp>::value>
+template <class _Tp, bool = std::is_integral<_Tp>::value,
+          bool = is_genfloat<_Tp>::value>
 struct __libcpp_complex_overload_traits {};
 
 // Integral Types
-template <class _Tp>
-struct __libcpp_complex_overload_traits<_Tp, true, false> {
+template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, true, false> {
   typedef double _ValueType;
   typedef complex<double> _ComplexType;
 };
 
 // Floating point types
-template <class _Tp>
-struct __libcpp_complex_overload_traits<_Tp, false, true> {
+template <class _Tp> struct __libcpp_complex_overload_traits<_Tp, false, true> {
   typedef _Tp _ValueType;
   typedef complex<_Tp> _ComplexType;
 };
 
 } // namespace cplx::detail
-
 
 ////////////////////////////////////////////////////////////////////////////////
 /// FUNCTIONS

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -35,7 +35,7 @@
 
 #include <cassert>
 #include <complex>
-#include <sycl/ext/oneapi/experimental/sycl_complex.hpp>
+#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
 #include <sycl/sycl.hpp>
 #include <type_traits>
 

--- a/sycl/test-e2e/Complex/sycl_complex_helper.hpp
+++ b/sycl/test-e2e/Complex/sycl_complex_helper.hpp
@@ -2,7 +2,7 @@
 #include <iomanip>
 
 #define SYCL_EXT_ONEAPI_COMPLEX
-#include <sycl/ext/oneapi/experimental/sycl_complex.hpp>
+#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl::ext::oneapi;

--- a/sycl/test/basic_tests/macros_no_rdc.cpp
+++ b/sycl/test/basic_tests/macros_no_rdc.cpp
@@ -25,4 +25,4 @@
 #include <sycl/sycl.hpp>
 #include "ext/oneapi/bfloat16.hpp"
 #include "ext/intel/esimd.hpp"
-#include "ext/oneapi/experimental/sycl_complex.hpp"
+#include "ext/oneapi/experimental/complex/complex.hpp"

--- a/sycl/test/extensions/complex/complex.cpp
+++ b/sycl/test/extensions/complex/complex.cpp
@@ -2,7 +2,7 @@
 
 #define SYCL_EXT_ONEAPI_COMPLEX
 
-#include <sycl/ext/oneapi/experimental/sycl_complex.hpp>
+#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl::ext::oneapi::experimental;
@@ -24,8 +24,8 @@ template <template <typename> typename action> void test_valid_types() {
   template <typename T> struct test##_##op_name##_##types {                    \
     bool operator()() {                                                        \
       static_assert(                                                           \
-          std::is_same_v<complex<T>, decltype(declval<complex<T>>()            \
-                                                  op declval<complex<T>>())>); \
+          std::is_same_v<complex<T>, decltype(std::declval<complex<T>>()            \
+                                                  op std::declval<complex<T>>())>); \
       return true;                                                             \
     }                                                                          \
   };

--- a/sycl/test/extensions/complex/complex.cpp
+++ b/sycl/test/extensions/complex/complex.cpp
@@ -24,8 +24,9 @@ template <template <typename> typename action> void test_valid_types() {
   template <typename T> struct test##_##op_name##_##types {                    \
     bool operator()() {                                                        \
       static_assert(                                                           \
-          std::is_same_v<complex<T>, decltype(std::declval<complex<T>>()            \
-                                                  op std::declval<complex<T>>())>); \
+          std::is_same_v<complex<T>,                                           \
+                         decltype(std::declval<complex<T>>()                   \
+                                      op std::declval<complex<T>>())>);        \
       return true;                                                             \
     }                                                                          \
   };


### PR DESCRIPTION
This PR is the first step toward restructuring the `complex` API.

As discussed in https://github.com/intel/llvm/pull/8647 and https://github.com/intel/llvm/pull/10854, the goal here is to clean the future-to-be `complex` API.

To simplify the review of these changes, a new PR (this PR) is created to not overload https://github.com/intel/llvm/pull/8647.
IF/WHEN this will be approved, the second step which does the same for the `marray`'s complex specialization will be pushed onto https://github.com/intel/llvm/pull/8647

Here's an overview of what has changed:

For the users, the only change is the include.
Instead of including `<sycl/ext/oneapi/experimental/sycl_complex.hpp>`, it will now be `<sycl/ext/oneapi/experimental/complex/complex.hpp>`

The `complex.hpp` header files include all the `complex/detail` header file (the `complex` API), in order to abstract the headers needed for the users.

However, the users can include (if necessary) the specific component of the API located in `complex/detail`.

Here's the overview of what the complex directory will contain when the whole API is merged.

```
- complex
  - complex.hpp
  - detail
    - complex.hpp
    - complex_math.hpp
    - complex_group_algorithm.hpp
    - marray.hpp
    - marray_math.hpp
    - marray_group_algorithm.hpp
    - common.hpp
```

Finally, here's the overview of the `sycl/test/extension`

```
- complex
  - complex.cpp
  - marray.cpp
```

@gmlueck @steffenlarsen 