### PR TITLE
[SYCL][Graph] Reenable passing Graph tests on Arc

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/basic_buffer.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target_2d.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target_offset.cpp"

--- a/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/temp_buffer_reinterpret.cpp"

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/usm_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/basic_buffer.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target_2d.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target_offset.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/temp_buffer_reinterpret.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/usm_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -6,9 +6,6 @@
 //
 // CHECK-NOT: LEAK
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 // Tests memcpy operation using device USM and an in-order queue.
 
 #include "../graph_common.hpp"


### PR DESCRIPTION
The following 13 graphs tests originally disabled by https://github.com/intel/llvm/issues/11434 now pass on the Arc post commit testing after the merge of https://github.com/intel/llvm/pull/11565

```
Unexpectedly Passed Tests (13):
  SYCL :: Graph/Explicit/basic_buffer.cpp
  SYCL :: Graph/Explicit/buffer_copy_host2target.cpp
  SYCL :: Graph/Explicit/buffer_copy_host2target_2d.cpp
  SYCL :: Graph/Explicit/buffer_copy_host2target_offset.cpp
  SYCL :: Graph/Explicit/temp_buffer_reinterpret.cpp
  SYCL :: Graph/Explicit/usm_copy.cpp
  SYCL :: Graph/RecordReplay/basic_buffer.cpp
  SYCL :: Graph/RecordReplay/buffer_copy_host2target.cpp
  SYCL :: Graph/RecordReplay/buffer_copy_host2target_2d.cpp
  SYCL :: Graph/RecordReplay/buffer_copy_host2target_offset.cpp
  SYCL :: Graph/RecordReplay/temp_buffer_reinterpret.cpp
  SYCL :: Graph/RecordReplay/usm_copy.cpp
  SYCL :: Graph/RecordReplay/usm_copy_in_order.cpp
```

There are some Graphs E2E tests which are still marked XFAIL on Arc, but the same subset failed(via XPASS) in two post-commit runs:

* https://github.com/intel/llvm/actions/runs/6576278057/job/17865822384
* https://github.com/intel/llvm/actions/runs/6572360130/job/17855217912