### PR TITLE
Fix crash when using -ffp-accuracy and std:: trigonometric functions.

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5684,10 +5684,11 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
     if (!getLangOpts().FPAccuracyFuncMap.empty() ||
         !getLangOpts().FPAccuracyVal.empty()) {
       const auto *FD = dyn_cast_if_present<FunctionDecl>(TargetDecl);
-      assert(FD && "expecting a function");
+      if (FD) {
       CI = EmitFPBuiltinIndirectCall(IRFuncTy, IRCallArgs, CalleePtr, FD);
       if (CI)
         return RValue::get(CI);
+      }
     }
     CI = Builder.CreateCall(IRFuncTy, CalleePtr, IRCallArgs, BundleList);
   } else {

--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -5685,9 +5685,9 @@ RValue CodeGenFunction::EmitCall(const CGFunctionInfo &CallInfo,
         !getLangOpts().FPAccuracyVal.empty()) {
       const auto *FD = dyn_cast_if_present<FunctionDecl>(TargetDecl);
       if (FD) {
-      CI = EmitFPBuiltinIndirectCall(IRFuncTy, IRCallArgs, CalleePtr, FD);
-      if (CI)
-        return RValue::get(CI);
+        CI = EmitFPBuiltinIndirectCall(IRFuncTy, IRCallArgs, CalleePtr, FD);
+        if (CI)
+          return RValue::get(CI);
       }
     }
     CI = Builder.CreateCall(IRFuncTy, CalleePtr, IRCallArgs, BundleList);

--- a/sycl/test/basic_tests/fp-accuracy.cpp
+++ b/sycl/test/basic_tests/fp-accuracy.cpp
@@ -8,12 +8,8 @@ int main() {
   double Value = 5.;
 
   deviceQueue.submit([&](handler &cgh) {
-    cgh.single_task<class Kernel0>(
-      [=]() {
-	double res=  std::sin(Value);
-      });
+    cgh.single_task<class Kernel0>([=]() { double res=  std::sin(Value); });
    });
 
   return 0;
 }
-

--- a/sycl/test/basic_tests/fp-accuracy.cpp
+++ b/sycl/test/basic_tests/fp-accuracy.cpp
@@ -11,5 +11,8 @@ int main() {
     cgh.single_task<class Kernel0>([=]() { double res = std::sin(Value); });
   });
 
+  deviceQueue.submit([&](handler &cgh) {
+    cgh.single_task<class Kernel1>([=]() { double res = sycl::sin(Value); });
+  });
   return 0;
 }

--- a/sycl/test/basic_tests/fp-accuracy.cpp
+++ b/sycl/test/basic_tests/fp-accuracy.cpp
@@ -1,0 +1,19 @@
+// RUN: %clangxx -%fsycl-host-only -c -ffp-accuracy=high -faltmathlib=SVMLAltMathLibrary -fno-math-errno %s
+
+#include <sycl/sycl.hpp> 
+using namespace sycl;
+
+int main() {
+  queue deviceQueue;
+  double Value = 5.;
+
+  deviceQueue.submit([&](handler &cgh) {
+    cgh.single_task<class Kernel0>(
+      [=]() {
+	double res=  std::sin(Value);
+      });
+   });
+
+  return 0;
+}
+

--- a/sycl/test/basic_tests/fp-accuracy.cpp
+++ b/sycl/test/basic_tests/fp-accuracy.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -%fsycl-host-only -c -ffp-accuracy=high -faltmathlib=SVMLAltMathLibrary -fno-math-errno %s
 
-#include <sycl/sycl.hpp> 
+#include <sycl/sycl.hpp>
 using namespace sycl;
 
 int main() {
@@ -8,8 +8,8 @@ int main() {
   double Value = 5.;
 
   deviceQueue.submit([&](handler &cgh) {
-    cgh.single_task<class Kernel0>([=]() { double res=  std::sin(Value); });
-   });
+    cgh.single_task<class Kernel0>([=]() { double res = std::sin(Value); });
+  });
 
   return 0;
 }


### PR DESCRIPTION
This is to fix a crash in the host compilation when calling any std:: trigonometric function.