### PR TITLE
[SYCL][Graph] Mark re-enabled Graph Arc tests as unsupported

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/basic_buffer.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target_2d.cpp"

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/buffer_copy_host2target_offset.cpp"

--- a/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/temp_buffer_reinterpret.cpp"

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/usm_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/basic_buffer.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target_2d.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/buffer_copy_host2target_offset.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/temp_buffer_reinterpret.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/usm_copy.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -6,6 +6,9 @@
 //
 // CHECK-NOT: LEAK
 
+// https://github.com/intel/llvm/issues/11434
+// UNSUPPORTED: gpu-intel-dg2
+
 // Tests memcpy operation using device USM and an in-order queue.
 
 #include "../graph_common.hpp"


### PR DESCRIPTION
PR #11602 renabled some Graph test-e2e tests which started passing on Arc in post-commit CI after the merge of https://github.com/intel/llvm/pull/11565. However, these passes are not guaranteed to be deterministic. See post-commit https://github.com/intel/llvm/actions/runs/6580530144/job/17879085527 run where `Graph/RecordReplay/buffer_copy_host2target_offset.cpp` failed after being renabled.

Mark the tests reenabled by #11602 as unsupported to keep post-commit CI clean by skipping the tests on Arc, until support for the Arc target in the Graph tests can be investigated properly.