### PR TITLE
[SYCL-MLIR][cgeist] Lower memcpyable constructors to memcpy intrinsic

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Analysis/UniformityAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/UniformityAnalysis.cpp
@@ -504,7 +504,8 @@ bool UniformityAnalysis::anyModifierUniformityIs(
             [&](auto) { return Uniformity::isUniform(kind); })
         .Case<memref::StoreOp, affine::AffineStoreOp, sycl::SYCLConstructorOp,
               sycl::SYCLIDConstructorOp, sycl::SYCLRangeConstructorOp,
-              sycl::SYCLNDRangeConstructorOp, LLVM::StoreOp, LLVM::MemsetOp>(
+              sycl::SYCLNDRangeConstructorOp, LLVM::StoreOp, LLVM::MemsetOp,
+              LLVM::MemcpyOp>(
             [&](auto op) { return anyOfUniformityIs(op.getOperands(), kind); })
         .Default([](auto *op) {
           llvm::errs() << "op: " << *op << "\n";

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -392,6 +392,8 @@ private:
                                         bool isReference);
   ValueCategory EmitConditionalOperatorLValue(clang::ConditionalOperator *E);
   ValueCategory EvaluateExprAsBool(clang::Expr *E);
+  void EmitAggregateCopy(mlir::Location Loc, ValueCategory Dest,
+                         clang::QualType Ty, ValueCategory Src);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,

--- a/polygeist/tools/cgeist/Test/Verification/complex.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/complex.cpp
@@ -42,6 +42,7 @@ complex<float> init_complex(){
 }
 
 // CHECK-LABEL:   func.func @_Z9init_realv() -> !llvm.struct<(struct<(f32, f32)>)> 
+// CHECK-NEXT:      %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-NEXT:      %[[VAL_0:.*]] = arith.constant 1.500000e+00 : f32
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 0.000000e+00 : f32
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
@@ -49,7 +50,7 @@ complex<float> init_complex(){
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      call @_ZNSt7complexIfEC1Eff(%[[VAL_4]], %[[VAL_1]], %[[VAL_1]]) : (!llvm.ptr, f32, f32) -> ()
 // CHECK-NEXT:      %[[VAL_5:.*]] = call @_ZNSt7complexIfEaSEf(%[[VAL_4]], %[[VAL_0]]) : (!llvm.ptr, f32) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:      return %[[VAL_6]] : !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:    }
@@ -67,16 +68,6 @@ complex<float> init_complex(){
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_7]] : !llvm.struct<(f32, f32)>, !llvm.ptr
 // CHECK-NEXT:      return %[[VAL_0]] : !llvm.ptr
-// CHECK-NEXT:    }
-
-// CHECK-LABEL:   func.func @_ZNSt7complexIfEC1ERKS0_(
-// CHECK-SAME:                                        %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                                        %[[VAL_1:.*]]: !llvm.ptr)
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f32, f32)>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<(f32, f32)>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f32, f32)>)>
-// CHECK-NEXT:      llvm.store %[[VAL_3]], %[[VAL_4]] : !llvm.struct<(f32, f32)>, !llvm.ptr
-// CHECK-NEXT:      return
 // CHECK-NEXT:    }
 
 complex<float> init_real(){
@@ -141,12 +132,13 @@ float access_imag(complex<float> c){
 // CHECK-LABEL:   func.func @_ZStmlIfESt7complexIT_ERKS2_S4_(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                                               %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.struct<(struct<(f32, f32)>)> 
+// CHECK-NEXT:      %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_4]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_0]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_5:.*]] = call @_ZNSt7complexIfEmLIfEERS0_RKS_IT_E(%[[VAL_4]], %[[VAL_1]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:      return %[[VAL_6]] : !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:    }
@@ -172,13 +164,14 @@ complex<float> multiply_complex(complex<float> a, complex<float> b){
 // CHECK-LABEL:   func.func @_ZStmlIfESt7complexIT_ERKS2_RKS1_(
 // CHECK-SAME:                                                 %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                                                 %[[VAL_1:.*]]: memref<?xf32>) -> !llvm.struct<(struct<(f32, f32)>)> 
+// CHECK-NEXT:      %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_4]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_0]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_5:.*]] = affine.load %[[VAL_1]][0] : memref<?xf32>
 // CHECK-NEXT:      %[[VAL_6:.*]] = call @_ZNSt7complexIfEmLEf(%[[VAL_4]], %[[VAL_5]]) : (!llvm.ptr, f32) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:      return %[[VAL_7]] : !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:    }
@@ -202,12 +195,13 @@ complex<float> multiply_float(complex<float> a, float b){
 // CHECK-LABEL:   func.func @_ZStplIfESt7complexIT_ERKS2_S4_(
 // CHECK-SAME:                                               %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                                               %[[VAL_1:.*]]: !llvm.ptr) -> !llvm.struct<(struct<(f32, f32)>)> 
+// CHECK-NEXT:      %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_4]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_0]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_5:.*]] = call @_ZNSt7complexIfEpLIfEERS0_RKS_IT_E(%[[VAL_4]], %[[VAL_1]]) : (!llvm.ptr, !llvm.ptr) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:      return %[[VAL_6]] : !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:    }
@@ -233,13 +227,14 @@ complex<float> add_complex(complex<float> a, complex<float> b){
 // CHECK-LABEL:   func.func @_ZStplIfESt7complexIT_ERKS2_RKS1_(
 // CHECK-SAME:                                                 %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                                                 %[[VAL_1:.*]]: memref<?xf32>) -> !llvm.struct<(struct<(f32, f32)>)> 
+// CHECK-NEXT:      %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:      %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f32, f32)>)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_4]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_0]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_5:.*]] = affine.load %[[VAL_1]][0] : memref<?xf32>
 // CHECK-NEXT:      %[[VAL_6:.*]] = call @_ZNSt7complexIfEpLEf(%[[VAL_4]], %[[VAL_5]]) : (!llvm.ptr, f32) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZNSt7complexIfEC1ERKS0_(%[[VAL_3]], %[[VAL_4]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_7:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:      return %[[VAL_7]] : !llvm.struct<(struct<(f32, f32)>)>
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/consabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/consabi.cpp
@@ -15,37 +15,11 @@ QStream ilaunch_kernel(QStream x) {
 }
 
 // CHECK-LABEL:   func.func @_Z14ilaunch_kernel7QStream(
-// CHECK-SAME:                                          %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.struct<(struct<(f64, f64)>, i32)> attributes {llvm.linkage = #llvm.linkage<external>} {
-// CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(struct<(f64, f64)>, i32)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZN7QStreamC1EOS_(%[[VAL_2]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:      return %[[VAL_3]] : !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:    }
-
-// CHECK-LABEL:   func.func @_ZN7QStreamC1EOS_(
-// CHECK-SAME:                                 %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                                 %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:      call @_ZN1DC1EOS_(%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr) -> ()
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> i32
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(struct<(f64, f64)>, i32)>
-// CHECK-NEXT:      llvm.store %[[VAL_5]], %[[VAL_6]] : i32, !llvm.ptr
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
-
-// CHECK-LABEL:   func.func @_ZN1DC1EOS_(
-// CHECK-SAME:                           %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                           %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> f64
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
-// CHECK-NEXT:      llvm.store %[[VAL_3]], %[[VAL_4]] : f64, !llvm.ptr
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
-// CHECK-NEXT:      %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> f64
-// CHECK-NEXT:      %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f64, f64)>
-// CHECK-NEXT:      llvm.store %[[VAL_6]], %[[VAL_7]] : f64, !llvm.ptr
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
+// CHECK-SAME:                                          %[[VAL_0:.*]]: !llvm.ptr) -> !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK:           %[[VAL_1:.*]] = arith.constant 24 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(f64, f64)>, i32)> : (i64) -> !llvm.ptr
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_0]], %[[VAL_1]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+// CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK:           return %[[VAL_4]] : !llvm.struct<(struct<(f64, f64)>, i32)>
+// CHECK:         }

--- a/polygeist/tools/cgeist/Test/Verification/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/constructors.cpp
@@ -43,23 +43,10 @@ B getB(int x, const M &m) { return {x, m}; }
 // CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr,
 // CHECK-SAME:                          %[[VAL_1:.*]]: i32,
 // CHECK-SAME:                          %[[VAL_2:.*]]: !llvm.ptr)
+// CHECK:           %[[SIZE:.*]] = arith.constant 16 : i64
 // CHECK:           %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(f32, f64)>)>
 // CHECK:           llvm.store %[[VAL_1]], %[[VAL_3]] : i32, !llvm.ptr
 // CHECK:           %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32, struct<(f32, f64)>)>
-// CHECK:           call @[[M_CTOR:.*]](%[[VAL_4]], %[[VAL_2]]) : (!llvm.ptr, !llvm.ptr) -> ()
-// CHECK:           return
-// CHECK:         }
-
-// CHECK:         func.func @[[M_CTOR]](
-// CHECK-SAME:                          %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                          %[[VAL_1:.*]]: !llvm.ptr)
-// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f64)>
-// CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> f32
-// CHECK:           %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f64)>
-// CHECK:           llvm.store %[[VAL_3]], %[[VAL_4]] : f32, !llvm.ptr
-// CHECK:           %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f64)>
-// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_5]] : !llvm.ptr -> f64
-// CHECK:           %[[VAL_7:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(f32, f64)>
-// CHECK:           llvm.store %[[VAL_6]], %[[VAL_7]] : f64, !llvm.ptr
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_2]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK:           return
 // CHECK:         }

--- a/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
@@ -23,9 +23,6 @@ private:
   int d[10];
 };
 
-void foo(A);
-void foo_mv(A &&);
-
 // CHECK-LABEL:   func.func @_Z3barv()
 // CHECK:           %[[VAL_0:.*]] = arith.constant 72 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
@@ -33,50 +30,38 @@ void foo_mv(A &&);
 // CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)> : (i64) -> !llvm.ptr
 // CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)> : (i64) -> !llvm.ptr
 // CHECK:           "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[VAL_0]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
-// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>
-// CHECK:           llvm.store %[[VAL_5]], %[[VAL_2]] : !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>, !llvm.ptr
-// CHECK:           call @_Z3foo1A(%[[VAL_2]]) : (!llvm.ptr) -> ()
-// CHECK:           call @_Z6foo_mvO1A(%[[VAL_4]]) : (!llvm.ptr) -> ()
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_2]], %[[VAL_4]], %[[VAL_0]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK:           return
 // CHECK:         }
-
 void bar() {
   A a;
-  foo(a);
-  foo_mv(std::move(a));
+  A cpy(a);
+  A mv(std::move(a));
 }
 
 union U {
   U(const A &a) : a(a) {}
-  U(int i) : i(i) {}
+  U() : i(0) {}
 
   int i;
   A a;
 };
 
-void foo_u(U);
-void foo_u_mv(U &&);
-
-// CHECK-LABEL:   func.func @_Z5bar_ui(
-// CHECK-SAME:                         %[[VAL_0:.*]]: i32)
-// CHECK:           %[[VAL_1:.*]] = arith.constant 72 : i64
-// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
-// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
-// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
-// CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
-// CHECK:           call @_ZN1UC1Ei(%[[VAL_5]], %[[VAL_0]]) : (!llvm.ptr, i32) -> ()
-// CHECK:           "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_5]], %[[VAL_1]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
-// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)>
-// CHECK:           llvm.store %[[VAL_6]], %[[VAL_3]] : !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)>, !llvm.ptr
-// CHECK:           call @_Z5foo_u1U(%[[VAL_3]]) : (!llvm.ptr) -> ()
-// CHECK:           call @_Z8foo_u_mvO1U(%[[VAL_5]]) : (!llvm.ptr) -> ()
+// CHECK-LABEL:   func.func @_Z5bar_uv()
+// CHECK:           %[[VAL_0:.*]] = arith.constant 72 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
+// CHECK:           call @_ZN1UC1Ev(%[[VAL_4]]) : (!llvm.ptr) -> ()
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[VAL_0]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_2]], %[[VAL_4]], %[[VAL_0]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK:           return
 // CHECK:         }
-
-void bar_u(int i) {
-  U u(i);
-  foo_u(u);
-  foo_u_mv(std::move(u));
+void bar_u() {
+  U u;
+  U cpu(u);
+  U mv(std::move(u));
 }
 
 class Empty {};

--- a/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
@@ -1,5 +1,9 @@
 // RUN: cgeist -O0 %s --function=* -S | FileCheck %s
 
+#include <utility>
+
+// A and C present trivial copy and move constructors.
+
 class C {
 public:
   C() = default;
@@ -20,6 +24,7 @@ private:
 };
 
 void foo(A);
+void foo_mv(A &&);
 
 // CHECK-LABEL:   func.func @_Z3barv()
 // CHECK:           %[[VAL_0:.*]] = arith.constant 72 : i64
@@ -31,12 +36,14 @@ void foo(A);
 // CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>
 // CHECK:           llvm.store %[[VAL_5]], %[[VAL_2]] : !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>, !llvm.ptr
 // CHECK:           call @_Z3foo1A(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK:           call @_Z6foo_mvO1A(%[[VAL_4]]) : (!llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 
 void bar() {
   A a;
   foo(a);
+  foo_mv(std::move(a));
 }
 
 union U {
@@ -48,6 +55,7 @@ union U {
 };
 
 void foo_u(U);
+void foo_u_mv(U &&);
 
 // CHECK-LABEL:   func.func @_Z5bar_ui(
 // CHECK-SAME:                         %[[VAL_0:.*]]: i32)
@@ -61,10 +69,12 @@ void foo_u(U);
 // CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)>
 // CHECK:           llvm.store %[[VAL_6]], %[[VAL_3]] : !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)>, !llvm.ptr
 // CHECK:           call @_Z5foo_u1U(%[[VAL_3]]) : (!llvm.ptr) -> ()
+// CHECK:           call @_Z8foo_u_mvO1U(%[[VAL_5]]) : (!llvm.ptr) -> ()
 // CHECK:           return
 // CHECK:         }
 
 void bar_u(int i) {
   U u(i);
   foo_u(u);
+  foo_u_mv(std::move(u));
 }

--- a/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
@@ -1,0 +1,70 @@
+// RUN: cgeist -O0 %s --function=* -S | FileCheck %s
+
+class C {
+public:
+  C() = default;
+  C(const C &) = default;
+  C(C &&) = default;
+private:
+  long long a;
+  double b;
+  void *c;
+};
+
+class A {
+private:
+  int a;
+  float b;
+  C c;
+  int d[10];
+};
+
+void foo(A);
+
+// CHECK-LABEL:   func.func @_Z3barv()
+// CHECK:           %[[VAL_0:.*]] = arith.constant 72 : i64
+// CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)> : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)> : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)> : (i64) -> !llvm.ptr
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_3]], %[[VAL_4]], %[[VAL_0]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+// CHECK:           %[[VAL_5:.*]] = llvm.load %[[VAL_3]] : !llvm.ptr -> !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>
+// CHECK:           llvm.store %[[VAL_5]], %[[VAL_2]] : !llvm.struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>, !llvm.ptr
+// CHECK:           call @_Z3foo1A(%[[VAL_2]]) : (!llvm.ptr) -> ()
+// CHECK:           return
+// CHECK:         }
+
+void bar() {
+  A a;
+  foo(a);
+}
+
+union U {
+  U(const A &a) : a(a) {}
+  U(int i) : i(i) {}
+
+  int i;
+  A a;
+};
+
+void foo_u(U);
+
+// CHECK-LABEL:   func.func @_Z5bar_ui(
+// CHECK-SAME:                         %[[VAL_0:.*]]: i32)
+// CHECK:           %[[VAL_1:.*]] = arith.constant 72 : i64
+// CHECK:           %[[VAL_2:.*]] = arith.constant 1 : i64
+// CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_4:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
+// CHECK:           %[[VAL_5:.*]] = llvm.alloca %[[VAL_2]] x !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)> : (i64) -> !llvm.ptr
+// CHECK:           call @_ZN1UC1Ei(%[[VAL_5]], %[[VAL_0]]) : (!llvm.ptr, i32) -> ()
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_4]], %[[VAL_5]], %[[VAL_1]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
+// CHECK:           %[[VAL_6:.*]] = llvm.load %[[VAL_4]] : !llvm.ptr -> !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)>
+// CHECK:           llvm.store %[[VAL_6]], %[[VAL_3]] : !llvm.struct<(struct<(i32, f32, struct<(i64, f64, ptr)>, array<10 x i32>)>)>, !llvm.ptr
+// CHECK:           call @_Z5foo_u1U(%[[VAL_3]]) : (!llvm.ptr) -> ()
+// CHECK:           return
+// CHECK:         }
+
+void bar_u(int i) {
+  U u(i);
+  foo_u(u);
+}

--- a/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/memcpyconstructor.cpp
@@ -78,3 +78,17 @@ void bar_u(int i) {
   foo_u(u);
   foo_u_mv(std::move(u));
 }
+
+class Empty {};
+
+// COM: Lowers to nop as no action shall be performed in the constructor.
+
+// CHECK-LABEL:   func.func @_Z9bar_emptyv()
+// CHECK:           return
+// CHECK:         }
+
+void bar_empty() {
+  Empty e;
+  Empty cpy(e);
+  Empty mv(std::move(e));
+}

--- a/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/refptrabi.cpp
@@ -18,9 +18,10 @@ float ll(void* data) {
 
 // CHECK-LABEL:   func.func @ll(
 // CHECK-SAME:                  %[[VAL_0:.*]]: !llvm.ptr) -> f32 attributes {llvm.linkage = #llvm.linkage<external>} {
+// CHECK-NEXT:      %[[SIZE:.*]] = arith.constant 2 : i64
 // CHECK-NEXT:      %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:      %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i16)> : (i64) -> !llvm.ptr
-// CHECK-NEXT:      call @_ZN4HalfC1ERKS_(%[[VAL_2]], %[[VAL_0]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK-NEXT:      "llvm.intr.memcpy"(%[[VAL_2]], %[[VAL_0]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:      %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<(i16)>
 // CHECK-NEXT:      %[[VAL_4:.*]] = call @thing(%[[VAL_3]]) : (!llvm.struct<(i16)>) -> f32
 // CHECK-NEXT:      return %[[VAL_4]] : f32

--- a/polygeist/tools/cgeist/Test/Verification/reinterpret_cast.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/reinterpret_cast.cpp
@@ -43,22 +43,14 @@ fooint32 &reinterpret_float(foofloat &f) {
 
 // CHECK-LABEL:   func.func @_Z17reinterpret_float8foofloat(
 // CHECK-SAME:                                              %[[VAL_0:.*]]: !llvm.struct<(f32)>) -> !llvm.struct<(i32)>
+// CHECK:           %[[SIZE:.*]] = arith.constant 4 : i64
 // CHECK:           %[[VAL_1:.*]] = arith.constant 1 : i64
 // CHECK:           %[[VAL_2:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(i32)> : (i64) -> !llvm.ptr
 // CHECK:           %[[VAL_3:.*]] = llvm.alloca %[[VAL_1]] x !llvm.struct<(f32)> : (i64) -> !llvm.ptr
 // CHECK:           llvm.store %[[VAL_0]], %[[VAL_3]] : !llvm.struct<(f32)>, !llvm.ptr
-// CHECK:           call @_ZN8fooint32C1ERKS_(%[[VAL_2]], %[[VAL_3]]) : (!llvm.ptr, !llvm.ptr) -> ()
+// CHECK:           "llvm.intr.memcpy"(%[[VAL_2]], %[[VAL_3]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK:           %[[VAL_4:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> !llvm.struct<(i32)>
 // CHECK:           return %[[VAL_4]] : !llvm.struct<(i32)>
-// CHECK:         }
-
-// CHECK-LABEL:   func.func @_ZN8fooint32C1ERKS_(
-// CHECK-SAME:                                   %[[VAL_0:.*]]: !llvm.ptr, %[[VAL_1:.*]]: !llvm.ptr)
-// CHECK:           %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32)>
-// CHECK:           %[[VAL_3:.*]] = llvm.load %[[VAL_2]] : !llvm.ptr -> i32
-// CHECK:           %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i32)>
-// CHECK:           llvm.store %[[VAL_3]], %[[VAL_4]] : i32, !llvm.ptr
-// CHECK:           return
 // CHECK:         }
 
 fooint32 reinterpret_float(foofloat f) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -8,6 +8,7 @@
 // CHECK-MLIR-LABEL: gpu.func @_ZTSN4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EE
 // CHECK-MLIR-SAME:        %[[VAL_151:.*]]: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef},
 // CHECK-MLIR-SAME:        %[[VAL_152:.*]]: !llvm.ptr {llvm.align = 8 : i64, llvm.byval = !llvm.struct<(memref<?xi32, 1>)>, llvm.noundef}
+// CHECK-MLIR:             %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-MLIR:             %[[VAL_153:.*]] = arith.constant 0 : index
 // CHECK-MLIR:             %[[VAL_154:.*]] = arith.constant 1 : index
 // CHECK-MLIR:             %[[VAL_155:.*]] = arith.constant 1 : i64
@@ -26,8 +27,7 @@
 // CHECK-MLIR:             affine.store %[[VAL_166]], %[[VAL_163]][0] : memref<?x!sycl_range_1_>
 // CHECK-MLIR:             %[[VAL_167:.*]] = "polygeist.subindex"(%[[VAL_162]], %[[VAL_154]]) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!llvm.struct<(memref<?xi32, 4>)>>
 // CHECK-MLIR:             %[[VAL_168:.*]] = llvm.addrspacecast %[[VAL_152]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-MLIR:             %[[VAL_169:.*]] = llvm.addrspacecast %[[VAL_158]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-MLIR:             func.call @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(%[[VAL_169]], %[[VAL_168]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-MLIR:             "llvm.intr.memcpy"(%[[VAL_158]], %[[VAL_168]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr<4>, i64) -> ()
 // CHECK-MLIR:             %[[VAL_170:.*]] = llvm.load %[[VAL_158]] : !llvm.ptr -> !llvm.struct<(memref<?xi32, 4>)>
 // CHECK-MLIR:             affine.store %[[VAL_170]], %[[VAL_167]][0] : memref<?x!llvm.struct<(memref<?xi32, 4>)>>
 // CHECK-MLIR:             %[[VAL_171:.*]] = sycl.call @declptr() {MangledFunctionName = @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v} : () -> memref<?x!sycl_item_1_, 4>
@@ -53,15 +53,14 @@
 // CHECK-LLVM-NEXT:    store %"class.sycl::_V1::range.1" %10, ptr %7, align 8
 // CHECK-LLVM-NEXT:    %11 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 1
 // CHECK-LLVM-NEXT:    %12 = addrspacecast ptr %1 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    %13 = addrspacecast ptr %4 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    call spir_func void @_ZZ4testRN4sycl3_V15queueEENUlNS0_2idILi1EEEE_C1ERKS5_(ptr addrspace(4) %13, ptr addrspace(4) %12)
-// CHECK-LLVM-NEXT:    %14 = load { ptr addrspace(4) }, ptr %4, align 8
-// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %14, ptr %11, align 8
-// CHECK-LLVM-NEXT:    %15 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
-// CHECK-LLVM-NEXT:    %16 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %15)
-// CHECK-LLVM-NEXT:    %17 = addrspacecast ptr %6 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %16, ptr %3, align 8
-// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %17, ptr %3)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr %4, ptr addrspace(4) %12, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    %13 = load { ptr addrspace(4) }, ptr %4, align 8
+// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %13, ptr %11, align 8
+// CHECK-LLVM-NEXT:    %14 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
+// CHECK-LLVM-NEXT:    %15 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %14)
+// CHECK-LLVM-NEXT:    %16 = addrspacecast ptr %6 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %15, ptr %3, align 8
+// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %16, ptr %3)
 // CHECK-LLVM-NEXT:    call spir_func void @__itt_offload_wi_finish_wrapper()
 // CHECK-LLVM-NEXT:    ret void
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/structvec.cpp
@@ -17,28 +17,16 @@ struct structvec {
 // CHECK-LABEL:     func.func @_Z10test_store9structvecic(
 // CHECK-SAME:          %[[VAL_151:.*]]: !llvm.ptr {llvm.align = 2 : i64, llvm.byval = !llvm.struct<(vector<2xi8>)>, llvm.noundef}, 
 // CHECK-SAME:          %[[VAL_152:.*]]: i32 {llvm.noundef}, %[[VAL_153:.*]]: i8 {llvm.noundef, llvm.signext}) -> !llvm.struct<(vector<2xi8>)>
+// CHECK-NEXT:        %[[SIZE:.*]] = arith.constant 2 : i64
 // CHECK-NEXT:        %[[VAL_154:.*]] = arith.constant 1 : i64
 // CHECK-NEXT:        %[[VAL_155:.*]] = llvm.alloca %[[VAL_154]] x !llvm.struct<(vector<2xi8>)> : (i64) -> !llvm.ptr
 // CHECK-NEXT:        %[[VAL_156:.*]] = llvm.getelementptr inbounds %[[VAL_151]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(vector<2xi8>)>
 // CHECK-NEXT:        %[[VAL_157:.*]] = llvm.load %[[VAL_156]] : !llvm.ptr -> vector<2xi8>
 // CHECK-NEXT:        %[[VAL_158:.*]] = vector.insertelement %[[VAL_153]], %[[VAL_157]]{{\[}}%[[VAL_152]] : i32] : vector<2xi8>
 // CHECK-NEXT:        llvm.store %[[VAL_158]], %[[VAL_156]] : vector<2xi8>, !llvm.ptr
-// CHECK-NEXT:        %[[VAL_159:.*]] = llvm.addrspacecast %[[VAL_155]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-NEXT:        %[[VAL_160:.*]] = llvm.addrspacecast %[[VAL_151]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-NEXT:        call @_ZN9structvecC1EOS_(%[[VAL_159]], %[[VAL_160]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-NEXT:        "llvm.intr.memcpy"(%[[VAL_155]], %[[VAL_151]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:        %[[VAL_161:.*]] = llvm.load %[[VAL_155]] : !llvm.ptr -> !llvm.struct<(vector<2xi8>)>
 // CHECK-NEXT:        return %[[VAL_161]] : !llvm.struct<(vector<2xi8>)>
-// CHECK-NEXT:      }
-
-
-// CHECK-LABEL:     func.func @_ZN9structvecC1EOS_(
-// CHECK-SAME:          %[[VAL_162:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable_or_null = 2 : i64, llvm.noundef}
-// CHECK-SAME:          %[[VAL_163:.*]]: !llvm.ptr<4> {llvm.align = 2 : i64, llvm.dereferenceable = 2 : i64, llvm.noundef})
-// CHECK-NEXT:        %[[VAL_164:.*]] = llvm.getelementptr inbounds %[[VAL_163]][0, 0] : (!llvm.ptr<4>) -> !llvm.ptr<4>, !llvm.struct<(vector<2xi8>)>
-// CHECK-NEXT:        %[[VAL_165:.*]] = llvm.load %[[VAL_164]] : !llvm.ptr<4> -> vector<2xi8>
-// CHECK-NEXT:        %[[VAL_166:.*]] = llvm.getelementptr inbounds %[[VAL_162]][0, 0] : (!llvm.ptr<4>) -> !llvm.ptr<4>, !llvm.struct<(vector<2xi8>)>
-// CHECK-NEXT:        llvm.store %[[VAL_165]], %[[VAL_166]] : vector<2xi8>, !llvm.ptr<4>
-// CHECK-NEXT:        return
 // CHECK-NEXT:      }
 
 SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
@@ -76,9 +64,7 @@ SYCL_EXTERNAL structvec test_store(structvec sv, int idx, char el) {
 // CHECK-NEXT:        call @_ZN9structvecC1ESt16initializer_listIcE(%[[VAL_186]], %[[VAL_173]]) : (!llvm.ptr<4>, !llvm.ptr) -> ()
 // CHECK-NEXT:        %[[VAL_187:.*]] = llvm.load %[[VAL_177]] : !llvm.ptr -> !llvm.struct<(vector<2xi8>)>
 // CHECK-NEXT:        llvm.store %[[VAL_187]], %[[VAL_172]] : !llvm.struct<(vector<2xi8>)>, !llvm.ptr
-// CHECK-NEXT:        %[[VAL_188:.*]] = llvm.addrspacecast %[[VAL_171]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-NEXT:        %[[VAL_189:.*]] = llvm.addrspacecast %[[VAL_172]] : !llvm.ptr to !llvm.ptr<4>
-// CHECK-NEXT:        call @_ZN9structvecC1EOS_(%[[VAL_188]], %[[VAL_189]]) : (!llvm.ptr<4>, !llvm.ptr<4>) -> ()
+// CHECK-NEXT:        "llvm.intr.memcpy"(%[[VAL_171]], %[[VAL_172]], %[[VAL_167]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()
 // CHECK-NEXT:        %[[VAL_190:.*]] = llvm.load %[[VAL_171]] : !llvm.ptr -> !llvm.struct<(vector<2xi8>)>
 // CHECK-NEXT:        return %[[VAL_190]] : !llvm.struct<(vector<2xi8>)>
 // CHECK-NEXT:      }

--- a/polygeist/tools/cgeist/Test/elaborated-init.cpp
+++ b/polygeist/tools/cgeist/Test/elaborated-init.cpp
@@ -10,19 +10,6 @@ void testArrayInitExpr()
   };
 }
 
-// CHECK-LABEL:   func.func private @_ZZ17testArrayInitExprvEN3$_0C1EOS_(
-// CHECK-SAME:                                                           %[[VAL_0:.*]]: !llvm.ptr,
-// CHECK-SAME:                                                           %[[VAL_1:.*]]: !llvm.ptr) attributes {llvm.linkage = #llvm.linkage<internal>} {
-// CHECK-NEXT:      %[[VAL_2:.*]] = llvm.getelementptr inbounds %[[VAL_0]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<4 x i32>)>
-// CHECK-NEXT:      %[[VAL_3:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x i32>
-// CHECK-NEXT:      %[[VAL_4:.*]] = llvm.getelementptr inbounds %[[VAL_1]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(array<4 x i32>)>
-// CHECK-NEXT:      %[[VAL_5:.*]] = llvm.getelementptr inbounds %[[VAL_4]][0, 0] : (!llvm.ptr) -> !llvm.ptr, !llvm.array<4 x i32>
-// CHECK-NEXT:      affine.for %[[VAL_6:.*]] = 0 to 4 {
-// CHECK-NEXT:        %[[VAL_7:.*]] = arith.index_cast %[[VAL_6]] : index to i64
-// CHECK-NEXT:        %[[VAL_8:.*]] = llvm.getelementptr %[[VAL_3]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:        %[[VAL_9:.*]] = llvm.getelementptr %[[VAL_5]]{{\[}}%[[VAL_7]]] : (!llvm.ptr, i64) -> !llvm.ptr, i32
-// CHECK-NEXT:        %[[VAL_10:.*]] = llvm.load %[[VAL_9]] : !llvm.ptr -> i32
-// CHECK-NEXT:        llvm.store %[[VAL_10]], %[[VAL_8]] : i32, !llvm.ptr
-// CHECK-NEXT:      }
-// CHECK-NEXT:      return
-// CHECK-NEXT:    }
+// CHECK-LABEL:   func.func @_Z17testArrayInitExprv()
+// CHECK:           %[[VAL_0:.*]] = arith.constant 16 : i64
+// CHECK:           "llvm.intr.memcpy"(%{{.*}}, %{{.*}}, %[[VAL_0]]) <{isVolatile = false}> : (!llvm.ptr, !llvm.ptr, i64) -> ()


### PR DESCRIPTION
Replace constructors which are equivalent to a `memcpy` intrinsic with `llvm.intr.memcpy`. These constructors must:

- Not be SYCL constructors, be copy or move constructors and:
  - Be trivial and belong to record types not inserting extra padding, or
  - Belong to unions and be defaulted.

SYCL constructors are not lowered to `llvm.intr.memcpy` at this stage, as this would lead to information loss. Instead, they shall be lowered when lowering from `sycl` to `llvm`.