### PR TITLE
[SYCL][Bindless] Update test with non-deprecated funcs

### DIFF
--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -86,8 +86,9 @@ bool run_test(sycl::range<NDims> globalSize, sycl::range<NDims> localSize) {
     syclexp::destroy_image_handle(imgIn, q);
     syclexp::destroy_image_handle(imgOut, q);
 
-    syclexp::free_image_mem(imgMemIn, dev, ctxt);
-    syclexp::free_image_mem(imgMemOut, dev, ctxt);
+    syclexp::free_image_mem(imgMemIn, syclexp::image_type::standard, dev, ctxt);
+    syclexp::free_image_mem(imgMemOut, syclexp::image_type::standard, dev,
+                            ctxt);
 
   } catch (sycl::exception e) {
     std::cerr << "SYCL exception caught! : " << e.what() << "\n";


### PR DESCRIPTION
Update `read_norm_types.cpp` test to use the newest API instead of the deprecated `free_image_mem`.