### PR TITLE
[SYCL][Bindless] Replace mipmap read_image with read_mipmap

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
@@ -1013,6 +1013,12 @@ images may be read from and written back to within the same kernel, however,
 reading from that same image again will result in undefined behaviour. A new 
 kernel must be submitted for the written data to be accessible.
 
+[NOTE]
+====
+Attempting to read an image with `read_mipmap` or any other defined read 
+function will result in undefined behaviour.
+====
+
 == Mipmapped images
 
 So far, we have described how to create and operate on standard bindless images.
@@ -1102,31 +1108,37 @@ level of a given top-level descriptor.
 
 === Reading a mipmap
 
-Inside the kernel, it's possible to read a mipmap via `read_image`, passing the 
+Inside the kernel, it's possible to read a mipmap via `read_mipmap`, passing the 
 `sampled_image_handle`, the coordinates, and either the level or anisotropic 
 gradient values.
 
-The method of sampling a mipmap is different based on which `read_image` 
+The method of sampling a mipmap is different based on which `read_mipmap` 
 function is used, and the sampler attributes passed upon creation of the 
 mipmap.
 
 ```c++
 // Nearest/linear filtering between mip levels
 template <typename DataT, typename CoordT>
-DataT read_image(const sampled_image_handle &ImageHandle,
-                 const CoordT &Coords,
-                 const float Level);
+DataT read_mipmap(const sampled_image_handle &ImageHandle,
+                  const CoordT &Coords,
+                  const float Level);
 
 // Anisotropic filtering
 template <typename DataT, typename CoordT>
-DataT read_image(const sampled_image_handle &ImageHandle,
-                 const CoordT &Coords,
-                 const CoordT &Dx, const CoordT &Dy);
+DataT read_mipmap(const sampled_image_handle &ImageHandle,
+                  const CoordT &Coords,
+                  const CoordT &Dx, const CoordT &Dy);
 ```
 
 Reading a mipmap follows the same restrictions on what coordinate types may be 
 used as laid out in <<reading_writing_inside_kernel>>, and the viewing gradients 
 are bound to the same type as used for the coordinates.
+
+[NOTE]
+====
+Attempting to read a mipmap with `read_image` or any other defined read function 
+will result in undefined behaviour.
+====
 
 == Interoperability
 
@@ -1661,9 +1673,9 @@ try {
       float x = (static_cast<float>(id[0]) + 0.5f) / static_cast<float>(width);
       // Read mipmap level 0 with anisotropic filtering
       // and level 1 with level filtering
-      float px1 = sycl::ext::oneapi::experimental::read_image<float>(
+      float px1 = sycl::ext::oneapi::experimental::read_mipmap<float>(
           mipHandle, x, 0.0f, 0.0f);
-      float px2 = sycl::ext::oneapi::experimental::read_image<float>(
+      float px2 = sycl::ext::oneapi::experimental::read_mipmap<float>(
           mipHandle, x, 1.0f);
 
       sum = px1 + px2;
@@ -1981,4 +1993,6 @@ These features still need to be handled:
 |4.4|2023-09-12| - Added overload with `sycl::queue` to standalone functions
 |4.5|2023-09-14| - Update wording for allocating images + fix typo
 |4.6|2023-09-19| - Clarify restrictions on reading/writing coordinate types
+|4.7|2023-10-16| - Introduce `read_mipmap` for mipmap access and clarify reading 
+                   restrictions on image types
 |======================

--- a/sycl/include/sycl/ext/oneapi/bindless_images.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images.hpp
@@ -784,9 +784,9 @@ DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
  *  @return  Mipmap image data with LOD filtering
  */
 template <typename DataT, typename CoordT>
-DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
-                 const CoordT &coords [[maybe_unused]],
-                 const float level [[maybe_unused]]) {
+DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
+                  const CoordT &coords [[maybe_unused]],
+                  const float level [[maybe_unused]]) {
   detail::assert_sampled_coords<CoordT>();
   constexpr size_t coordSize = detail::coord_size<CoordT>();
   static_assert(coordSize == 1 || coordSize == 2 || coordSize == 4,
@@ -817,6 +817,78 @@ DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
  *  @return  Mipmap image data with anisotropic filtering
  */
 template <typename DataT, typename CoordT>
+DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
+                  const CoordT &coords [[maybe_unused]],
+                  const CoordT &dX [[maybe_unused]],
+                  const CoordT &dY [[maybe_unused]]) {
+  detail::assert_sampled_coords<CoordT>();
+  constexpr size_t coordSize = detail::coord_size<CoordT>();
+  static_assert(coordSize == 1 || coordSize == 2 || coordSize == 4,
+                "Expected input coordinates and gradients to have 1, 2, or 4 "
+                "components for 1D, 2D, and 3D images, respectively.");
+
+#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__NVPTX__)
+  return __invoke__ImageReadGrad<DataT>(imageHandle.raw_handle, coords, dX, dY);
+#else
+  // TODO: add SPIRV part for mipmap grad read
+#endif
+#else
+  assert(false); // Bindless images not yet implemented on host
+#endif
+}
+
+/**
+ *  @brief   [Deprecated] Read a mipmap image using its handle with LOD
+ *           filtering
+ *
+ *  @tparam  DataT The return type
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *           1D, 2D, and 3D, respectively
+ *  @param   imageHandle The mipmap image handle
+ *  @param   coords The coordinates at which to fetch mipmap image data
+ *  @param   level The mipmap level at which to sample
+ *  @return  Mipmap image data with LOD filtering
+ */
+template <typename DataT, typename CoordT>
+__SYCL_DEPRECATED("read_image for mipmaps is deprecated. "
+                  "Instead use read_mipmap.")
+DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
+                 const CoordT &coords [[maybe_unused]],
+                 const float level [[maybe_unused]]) {
+  detail::assert_sampled_coords<CoordT>();
+  constexpr size_t coordSize = detail::coord_size<CoordT>();
+  static_assert(coordSize == 1 || coordSize == 2 || coordSize == 4,
+                "Expected input coordinate to be have 1, 2, or 4 components "
+                "for 1D, 2D and 3D images, respectively.");
+
+#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__NVPTX__)
+  return __invoke__ImageReadLod<DataT>(imageHandle.raw_handle, coords, level);
+#else
+  // TODO: add SPIRV for mipmap level read
+#endif
+#else
+  assert(false); // Bindless images not yet implemented on host
+#endif
+}
+
+/**
+ *  @brief   [Deprecated] Read a mipmap image using its handle with anisotropic
+ *           filtering
+ *
+ *  @tparam  DataT The return type
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *           1D, 2D, and 3D, respectively
+ *  @param   imageHandle The mipmap image handle
+ *  @param   coords The coordinates at which to fetch mipmap image data
+ *  @param   dX Screen space gradient in the x dimension
+ *  @param   dY Screen space gradient in the y dimension
+ *  @return  Mipmap image data with anisotropic filtering
+ */
+template <typename DataT, typename CoordT>
+__SYCL_DEPRECATED("read_image for mipmaps is deprecated. "
+                  "Instead use read_mipmap.")
 DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
                  const CoordT &coords [[maybe_unused]],
                  const CoordT &dX [[maybe_unused]],

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
@@ -97,9 +97,9 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
         float x = float(id[0] + 0.5) / (float)N;
         // Extension: read mipmap level 0 with anisotropic filtering and level 1
         // with LOD
-        VecType px1 = sycl::ext::oneapi::experimental::read_image<VecType>(
+        VecType px1 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
             mipHandle, x, 0.0f);
-        VecType px2 = sycl::ext::oneapi::experimental::read_image<VecType>(
+        VecType px2 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
             mipHandle, x, 1.0f);
 
         sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
@@ -111,7 +111,7 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
             float fdim1 = float(dim1 + 0.5) / (float)height;
 
             // Extension: read mipmap level 1 with LOD
-            VecType px2 = sycl::ext::oneapi::experimental::read_image<VecType>(
+            VecType px2 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
                 mipHandle, sycl::float2(fdim0, fdim1), 1.0f);
 
             outAcc[sycl::id<2>{dim1, dim0}] = px2[0];

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
@@ -101,7 +101,7 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
 
             // Extension: read mipmap with anisotropic filtering with zero
             // viewing gradients
-            VecType px1 = sycl::ext::oneapi::experimental::read_image<VecType>(
+            VecType px1 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
                 mipHandle, sycl::float4(fdim0, fdim1, fdim2, (float)0),
                 sycl::float4(0.0f, 0.0f, 0.0f, 0.0f),
                 sycl::float4(0.0f, 0.0f, 0.0f, 0.0f));


### PR DESCRIPTION
- Deprecate `read_image` for mipmap access and introduce `read_mipmap` as the supported way to sample a mipmap
- Clarify this in the spec
- Note in the spec that using the wrong read with an image type will result in undefined behaviour