### PR TITLE
Fix bad merge in BackendUtil.cpp

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -1079,8 +1079,6 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
           });
     }
 
-    const bool PrepareForThinOrUnifiedLTO =
-        PrepareForThinLTO || (PrepareForLTO && CodeGenOpts.UnifiedLTO);
     if (CodeGenOpts.DisableSYCLEarlyOpts) {
       MPM.addPass(PB.buildO0DefaultPipeline(OptimizationLevel::O0,
                                       PrepareForLTO || PrepareForThinLTO));


### PR DESCRIPTION
There have been some problems with the merge from llvm.org around the call to buildFatLOTDefaultPipeline(). I variable that got deleted upstream was renamed and kept here. This change is intended to get things back in sync.