### PR TITLE
[SYCL-MLIR][cgeist] Codegen specific memcpyable `sycl` constructors

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -44,7 +44,9 @@ template <typename SYCLTy> struct constructor_op {};
 template <typename SYCLTy>
 using constructor_op_t = typename constructor_op<SYCLTy>::type;
 
-template <> struct constructor_op<IDType> { using type = SYCLIDConstructorOp; };
+template <> struct constructor_op<IDType> {
+  using type = SYCLIDConstructorOp;
+};
 
 template <> struct constructor_op<RangeType> {
   using type = SYCLRangeConstructorOp;

--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.h
@@ -35,4 +35,25 @@ inline bool isSYCLOperation(Operation *op) {
 #define GET_OP_CLASSES
 #include "mlir/Dialect/SYCL/IR/SYCLOps.h.inc"
 
+namespace mlir {
+namespace sycl {
+/// Defines `constructor_op<SYCLTy>::type`, the type of the constructor
+/// operation for SYCLTy
+template <typename SYCLTy> struct constructor_op {};
+
+template <typename SYCLTy>
+using constructor_op_t = typename constructor_op<SYCLTy>::type;
+
+template <> struct constructor_op<IDType> { using type = SYCLIDConstructorOp; };
+
+template <> struct constructor_op<RangeType> {
+  using type = SYCLRangeConstructorOp;
+};
+
+template <> struct constructor_op<NdRangeType> {
+  using type = SYCLNDRangeConstructorOp;
+};
+} // namespace sycl
+} // namespace mlir
+
 #endif // MLIR_DIALECT_SYCL_IR_SYCLOPS_H

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -620,8 +620,8 @@ public:
         op->getLoc(), allocaType, ET,
         rewriter.create<arith::ConstantIntOp>(op.getLoc(), 1, 32));
     if (PT.getAddressSpace() != allocaType.getAddressSpace())
-      alloca =
-          rewriter.replaceOpWithNewOp<LLVM::AddrSpaceCastOp>(op, PT, alloca);
+      alloca = rewriter.create<LLVM::AddrSpaceCastOp>(op.getLoc(), PT, alloca);
+    rewriter.replaceOp(op, alloca);
     initialize(alloca, op, adaptor, rewriter);
   }
 };

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -610,12 +610,18 @@ public:
                ConversionPatternRewriter &rewriter) const final {
     const LLVMTypeConverter *typeConverter =
         ConvertOpToLLVMPattern<Op>::getTypeConverter();
+    auto PT =
+        cast<LLVM::LLVMPointerType>(typeConverter->convertType(op.getType()));
     Type ET = typeConverter->convertType(op.getType().getElementType());
+    auto allocaType = typeConverter->getPointerType(ET);
     // The constructor value corresponds with the value defined by the alloca
     // operation.
-    Value alloca = rewriter.replaceOpWithNewOp<LLVM::AllocaOp>(
-        op, typeConverter->getPointerType(ET), ET,
+    Value alloca = rewriter.create<LLVM::AllocaOp>(
+        op->getLoc(), allocaType, ET,
         rewriter.create<arith::ConstantIntOp>(op.getLoc(), 1, 32));
+    if (PT.getAddressSpace() != allocaType.getAddressSpace())
+      alloca =
+          rewriter.replaceOpWithNewOp<LLVM::AddrSpaceCastOp>(op, PT, alloca);
     initialize(alloca, op, adaptor, rewriter);
   }
 };

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -394,6 +394,11 @@ private:
   ValueCategory EvaluateExprAsBool(clang::Expr *E);
   void EmitAggregateCopy(mlir::Location Loc, ValueCategory Dest,
                          clang::QualType Ty, ValueCategory Src);
+  mlir::Operation *
+  EmitSpecificSYCLConstructor(const clang::CXXConstructExpr *Expr,
+                              mlir::ValueRange Args);
+  mlir::Operation *EmitSYCLConstructor(const clang::CXXConstructExpr *Expr,
+                                       mlir::ValueRange Args);
 
 public:
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-capture.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-capture.cpp
@@ -42,6 +42,7 @@ int main(){
 // CHECK-LABEL:     func.func private @_ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlNS0_2idILi1EEEE_clES5_(
 // CHECK-SAME:                                                                                               %[[VAL_358:.*]]: memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>, 4>
 // CHECK-SAME:                                                                                               %[[VAL_359:.*]]: memref<?x!sycl_id_1_>
+// CHECK-NEXT:        %[[SIZE:.*]] = arith.constant 8 : i64
 // CHECK-NEXT:        %[[VAL_360:.*]] = arith.constant 1 : index
 // CHECK-NEXT:        %[[VAL_361:.*]] = arith.constant 0 : index
 // CHECK-NEXT:        %[[VAL_362:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
@@ -57,7 +58,10 @@ int main(){
 // CHECK-NEXT:        %[[VAL_372:.*]] = "polygeist.subindex"(%[[VAL_358]], %[[VAL_361]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>, 4>, index) -> memref<?x!sycl_accessor_1_f32_rw_dev, 4>
 // CHECK-NEXT:        %[[VAL_373:.*]] = memref.memory_space_cast %[[VAL_365]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
 // CHECK-NEXT:        %[[VAL_374:.*]] = memref.memory_space_cast %[[VAL_359]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// CHECK-NEXT:        sycl.constructor @id(%[[VAL_373]], %[[VAL_374]]) {MangledFunctionName = @_ZN4sycl3_V12idILi1EEC1ERKS2_} : (memref<?x!sycl_id_1_, 4>, memref<?x!sycl_id_1_, 4>)
+// CHECK-NEXT:        %[[VAL_405:.*]] = sycl.id.constructor(%[[VAL_374]]) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_id_1_, 4>
+// CHECK-NEXT:        %[[VAL_406:.*]] = "polygeist.memref2pointer"(%[[VAL_373]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
+// CHECK-NEXT:        %[[VAL_407:.*]] = "polygeist.memref2pointer"(%[[VAL_405]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
+// CHECK-NEXT:        "llvm.intr.memcpy"(%[[VAL_406]], %[[VAL_407]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
 // CHECK-NEXT:        %[[VAL_375:.*]] = affine.load %[[VAL_364]][0] : memref<1x!sycl_id_1_>
 // CHECK-NEXT:        affine.store %[[VAL_375]], %[[VAL_362]][0] : memref<1x!sycl_id_1_>
 // CHECK-NEXT:        %[[VAL_376:.*]] = sycl.accessor.subscript %[[VAL_372]]{{\[}}%[[VAL_363]]] : (memref<?x!sycl_accessor_1_f32_rw_dev, 4>, memref<?x!sycl_id_1_>) -> memref<?xf32, 4>

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -71,28 +71,44 @@
 // CHECK-DAG: func.func @_Z20__spirv_NumSubgroupsv()
 
 // Ensure the constructors are NOT filtered out, and sycl.cast is generated for cast from sycl.id or sycl.range to sycl.array.
-// CHECK-LABEL: func.func @_ZN4sycl3_V12idILi1EEC1ERKS2_
-// CHECK:          (%arg0: memref<?x!sycl_id_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
-// CHECK-SAME:      %arg1: memref<?x!sycl_id_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
-// CHECK-SAME:      attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKONCE:llvm.linkage = #llvm.linkage<linkonce_odr>]] 
-// CHECK-NEXT:   %0 = sycl.cast %arg0 : memref<?x!sycl_id_1_, 4> to memref<?x!sycl_array_1_, 4>
-//
-// CHECK-LABEL: func.func @_ZN4sycl3_V15rangeILi1EEC1ERKS2_
-// CHECK:          (%arg0: memref<?x!sycl_range_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef}, 
-// CHECK-SAME:      %arg1: memref<?x!sycl_range_1_, 4> {llvm.align = 8 : i64, llvm.dereferenceable = 8 : i64, llvm.noundef})
-// CHECK-SAME:     attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
-// CHECK-NEXT:   %0 = sycl.cast %arg0 : memref<?x!sycl_range_1_, 4> to memref<?x!sycl_array_1_, 4>
+// CHECK:           func.func @cons_0(%[[VAL_151:.*]]: memref<?x!sycl_id_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_id_1_, llvm.noundef}, %[[VAL_152:.*]]: memref<?x!sycl_range_1_> {llvm.align = 8 : i64, llvm.byval = !sycl_range_1_, llvm.noundef})
+// CHECK-SAME: attributes {[[SPIR_FUNCCC:llvm.cconv = #llvm.cconv<spir_funccc>]], [[LINKEXTERNAL:llvm.linkage = #llvm.linkage<external>]], {{.*}}} {
+// CHECK:             %[[VAL_153:.*]] = arith.constant 8 : i64
+// CHECK:             %[[VAL_154:.*]] = memref.alloca() : memref<1x!sycl_range_1_>
+// CHECK:             %[[VAL_155:.*]] = memref.cast %[[VAL_154]] : memref<1x!sycl_range_1_> to memref<?x!sycl_range_1_>
+// CHECK:             %[[VAL_156:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
+// CHECK:             %[[VAL_157:.*]] = memref.cast %[[VAL_156]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
+// CHECK:             %[[VAL_158:.*]] = memref.memory_space_cast %[[VAL_157]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
+// CHECK:             %[[VAL_159:.*]] = memref.memory_space_cast %[[VAL_151]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
+// CHECK:             %[[VAL_160:.*]] = sycl.id.constructor(%[[VAL_159]]) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_id_1_, 4>
+// CHECK:             %[[VAL_161:.*]] = "polygeist.memref2pointer"(%[[VAL_158]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
+// CHECK:             %[[VAL_162:.*]] = "polygeist.memref2pointer"(%[[VAL_160]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
+// CHECK:             "llvm.intr.memcpy"(%[[VAL_161]], %[[VAL_162]], %[[VAL_153]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
+// CHECK:             %[[VAL_163:.*]] = memref.memory_space_cast %[[VAL_155]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
+// CHECK:             %[[VAL_164:.*]] = memref.memory_space_cast %[[VAL_152]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
+// CHECK:             %[[VAL_165:.*]] = sycl.range.constructor(%[[VAL_164]]) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_range_1_, 4>
+// CHECK:             %[[VAL_166:.*]] = "polygeist.memref2pointer"(%[[VAL_163]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
+// CHECK:             %[[VAL_167:.*]] = "polygeist.memref2pointer"(%[[VAL_165]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
+// CHECK:             "llvm.intr.memcpy"(%[[VAL_166]], %[[VAL_167]], %[[VAL_153]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
+// CHECK:             return
 
 // CHECK-LLVM: define spir_func void @cons_0(ptr noundef byval([[ID_TYPE:%"class.sycl::_V1::id.1"]]) align 8 [[ARG0:%.*]], 
 // CHECK-LLVM-SAME:                          ptr noundef byval([[RANGE_TYPE:%"class.sycl::_V1::range.1"]]) align 8 [[ARG1:%.*]]) #[[FUNCATTRS:[0-9]+]]
-// CHECK-LLVM-DAG: [[RANGE:%.*]] = alloca [[RANGE_TYPE]]
-// CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
-// CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
-// CHECK-LLVM: [[ARG0_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
-// CHECK-LLVM: [[TMP:%.*]] = alloca [[ID_TYPE]]
-// CHECK-LLVM: [[TMP_AS:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
-// CHECK-LLVM: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[TMP_AS]], ptr addrspace(4) [[ARG0_AS]], i64 8, i1 false)
-// CHECK-LLVM: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[ID_AS]], ptr addrspace(4) [[TMP_AS]], i64 8, i1 false) 
+// CHECK-LLVM-NEXT:   [[RANGE:%.*]] = alloca [[RANGE_TYPE]], i64 1, align 8
+// CHECK-LLVM-NEXT:   [[ID:%.*]] = alloca [[ID_TYPE]], i64 1, align 8
+// CHECK-LLVM-NEXT:   [[ID_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:   [[ARG0_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:   [[TMP:%.*]] = alloca [[ID_TYPE]], align 8
+// CHECK-LLVM-NEXT:   [[TMP_AS:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[TMP_AS]], ptr addrspace(4) [[ARG0_AS]], i64 8, i1 false)
+// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[ID_AS]], ptr addrspace(4) [[TMP_AS]], i64 8, i1 false)
+// CHECK-LLVM-NEXT:   [[RANGE_AS:%.*]] = addrspacecast ptr [[RANGE]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:   [[ARG1_AS:%.*]] = addrspacecast ptr [[ARG1]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:   [[TMP:%.*]] = alloca [[RANGE_TYPE]], align 8
+// CHECK-LLVM-NEXT:   [[TMP_AS:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
+// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[TMP_AS]], ptr addrspace(4) [[ARG1_AS]], i64 8, i1 false)
+// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[RANGE_AS]], ptr addrspace(4) [[TMP_AS]], i64 8, i1 false)
+// CHECK-LLVM-NEXT:   ret void
 
 extern "C" SYCL_EXTERNAL void cons_0(sycl::id<1> i, sycl::range<1> r) {
   auto id = sycl::id<1>{i};
@@ -184,7 +200,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 }
 
 // CHECK-LABEL: func.func @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(
-// CHECK-SAME: {{.*}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE]], {{.*}}}
+// CHECK-SAME: {{.*}}) attributes {[[SPIR_FUNCCC]], [[LINKONCE:llvm.linkage = #llvm.linkage<linkonce_odr>]], {{.*}}}
 // CHECK: [[I:%.*]] = "polygeist.subindex"(%arg0, %c0) : (memref<?x!sycl_accessor_1_i32_w_dev, 4>, index) -> memref<?x!sycl_accessor_impl_device_1_, 4>
 // CHECK: sycl.constructor @AccessorImplDevice([[I]], {{%.*}}, {{%.*}}, {{%.*}}) {MangledFunctionName = @_ZN4sycl3_V16detail18AccessorImplDeviceILi1EEC1ENS0_2idILi1EEENS0_5rangeILi1EEES7_} : (memref<?x!sycl_accessor_impl_device_1_, 4>, memref<?x!sycl_id_1_>, memref<?x!sycl_range_1_>, memref<?x!sycl_range_1_>)
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/functions.cpp
@@ -131,12 +131,16 @@ SYCL_EXTERNAL void range_size(sycl::range<2> r) {
 // CHECK-MLIR: %{{.*}} = sycl.nd_range.get_global_range(%{{.*}}) : (memref<?x!sycl_nd_range_2_>) -> !sycl_range_2_
 
 // CHECK-MLIR:           func.func @_ZNK4sycl3_V18nd_rangeILi2EE16get_global_rangeEv(%[[VAL_0:.*]]: memref<?x!sycl_nd_range_2_, 4> {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 48 : i64, llvm.noundef}) -> !sycl_range_2_
+// CHECK-MLIR-NEXT:             %[[SIZE:.*]] = arith.constant 16 : i64
 // CHECK-MLIR-NEXT:             %[[VAL_1:.*]] = arith.constant 0 : index
 // CHECK-MLIR-NEXT:             %[[VAL_2:.*]] = memref.alloca() : memref<1x!sycl_range_2_>
 // CHECK-MLIR-NEXT:             %cast = memref.cast %alloca : memref<1x!sycl_range_2_> to memref<?x!sycl_range_2_>
 // CHECK-MLIR-NEXT:             %[[VAL_3:.*]] = "polygeist.subindex"(%[[VAL_0]], %[[VAL_1]]) : (memref<?x!sycl_nd_range_2_, 4>, index) -> memref<?x!sycl_range_2_, 4>
 // CHECK-MLIR-NEXT:             %[[VAL_4:.*]] = memref.memory_space_cast %cast : memref<?x!sycl_range_2_> to memref<?x!sycl_range_2_, 4>
-// CHECK-MLIR-NEXT:             sycl.constructor @range(%[[VAL_4]], %[[VAL_3]]) {MangledFunctionName = @{{.*}}} : (memref<?x!sycl_range_2_, 4>, memref<?x!sycl_range_2_, 4>)
+// CHECK-MLIR-NEXT:             %[[TMP:.*]] = sycl.range.constructor(%[[VAL_3]]) : (memref<?x!sycl_range_2_, 4>) -> memref<?x!sycl_range_2_, 4>
+// CHECK-MLIR-NEXT:             %[[DST_PTR:.*]] = "polygeist.memref2pointer"(%[[VAL_4]]) : (memref<?x!sycl_range_2_, 4>) -> !llvm.ptr<4> 
+// CHECK-MLIR-NEXT:             %[[SRC_PTR:.*]] = "polygeist.memref2pointer"(%[[TMP]]) : (memref<?x!sycl_range_2_, 4>) -> !llvm.ptr<4> 
+// CHECK-MLIR-NEXT:             "llvm.intr.memcpy"(%[[DST_PTR]], %[[SRC_PTR]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
 // CHECK-MLIR-NEXT:             %[[VAL_7:.*]] = affine.load %[[VAL_2]][0] : memref<1x!sycl_range_2_>
 // CHECK-MLIR-NEXT:             return %[[VAL_7]] : !sycl_range_2_
 // CHECK-MLIR-NEXT:           }

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -22,7 +22,10 @@
 // CHECK-MLIR:             %[[VAL_163:.*]] = "polygeist.subindex"(%[[VAL_162]], %[[VAL_153]]) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!sycl_range_1_>
 // CHECK-MLIR:             %[[VAL_164:.*]] = memref.memory_space_cast %[[VAL_160]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
 // CHECK-MLIR:             %[[VAL_165:.*]] = memref.memory_space_cast %[[VAL_151]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
-// CHECK-MLIR:             sycl.constructor @range(%[[VAL_164]], %[[VAL_165]]) {MangledFunctionName = @_ZN4sycl3_V15rangeILi1EEC1ERKS2_} : (memref<?x!sycl_range_1_, 4>, memref<?x!sycl_range_1_, 4>)
+// CHECK-MLIR:             %[[TMP:.*]] = sycl.range.constructor(%[[VAL_165]]) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_range_1_, 4>
+// CHECK-MLIR:             %[[DST_PTR:.*]] = "polygeist.memref2pointer"(%[[VAL_164]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
+// CHECK-MLIR:             %[[SRC_PTR:.*]] = "polygeist.memref2pointer"(%[[TMP]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
+// CHECK-MLIR:             "llvm.intr.memcpy"(%[[DST_PTR]], %[[SRC_PTR]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
 // CHECK-MLIR:             %[[VAL_166:.*]] = affine.load %[[VAL_159]][0] : memref<1x!sycl_range_1_>
 // CHECK-MLIR:             affine.store %[[VAL_166]], %[[VAL_163]][0] : memref<?x!sycl_range_1_>
 // CHECK-MLIR:             %[[VAL_167:.*]] = "polygeist.subindex"(%[[VAL_162]], %[[VAL_154]]) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!llvm.struct<(memref<?xi32, 4>)>>
@@ -48,19 +51,22 @@
 // CHECK-LLVM-NEXT:    %7 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 0
 // CHECK-LLVM-NEXT:    %8 = addrspacecast ptr %5 to ptr addrspace(4)
 // CHECK-LLVM-NEXT:    %9 = addrspacecast ptr %0 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    call spir_func void @_ZN4sycl3_V15rangeILi1EEC1ERKS2_(ptr addrspace(4) %8, ptr addrspace(4) %9)
-// CHECK-LLVM-NEXT:    %10 = load %"class.sycl::_V1::range.1", ptr %5, align 8
-// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::range.1" %10, ptr %7, align 8
-// CHECK-LLVM-NEXT:    %11 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 1
-// CHECK-LLVM-NEXT:    %12 = addrspacecast ptr %1 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr %4, ptr addrspace(4) %12, i64 8, i1 false)
-// CHECK-LLVM-NEXT:    %13 = load { ptr addrspace(4) }, ptr %4, align 8
-// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %13, ptr %11, align 8
-// CHECK-LLVM-NEXT:    %14 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
-// CHECK-LLVM-NEXT:    %15 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %14)
-// CHECK-LLVM-NEXT:    %16 = addrspacecast ptr %6 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %15, ptr %3, align 8
-// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %16, ptr %3)
+// CHECK-LLVM-NEXT:    %10 = alloca %"class.sycl::_V1::range.1", align 8
+// CHECK-LLVM-NEXT:    %11 = addrspacecast ptr %10 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) %11, ptr addrspace(4) %9, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) %8, ptr addrspace(4) %11, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    %12 = load %"class.sycl::_V1::range.1", ptr %5, align 8
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::range.1" %12, ptr %7, align 8
+// CHECK-LLVM-NEXT:    %13 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 1
+// CHECK-LLVM-NEXT:    %14 = addrspacecast ptr %1 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr %4, ptr addrspace(4) %14, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    %15 = load { ptr addrspace(4) }, ptr %4, align 8
+// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %15, ptr %13, align 8
+// CHECK-LLVM-NEXT:    %16 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
+// CHECK-LLVM-NEXT:    %17 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %16)
+// CHECK-LLVM-NEXT:    %18 = addrspacecast ptr %6 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %17, ptr %3, align 8
+// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %18, ptr %3)
 // CHECK-LLVM-NEXT:    call spir_func void @__itt_offload_wi_finish_wrapper()
 // CHECK-LLVM-NEXT:    ret void
 

--- a/sycl/test-e2e/xfail_tests.txt
+++ b/sycl/test-e2e/xfail_tests.txt
@@ -411,7 +411,6 @@ OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
 OptionalKernelFeatures/large-reqd-work-group-size.cpp
 OptionalKernelFeatures/no-fp64-optimization-declared-aspects.cpp
 OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
-Plugin/interop-level-zero-buffer-multi-dim.cpp
 Plugin/interop-level-zero-image-get-native-mem.cpp
 Printf/char.cpp
 Printf/double.cpp


### PR DESCRIPTION
Generating SYCL specific constructors operations leads to:

1. Not generating code for constructors being abstracted away;
2. Better lowering, as we control that explicitly.

Only supporting memcpyable constructors for now due to polygeist type system inconsistencies.