### PR TITLE
[SYCL][CUDA][HIP] Fix device architecture extension query

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -674,8 +674,9 @@ struct get_device_info_impl<
       Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
           Dev->getHandleRef(), PiInfoCode<info::device::version>::value,
           ResultSize, DeviceArch.get(), nullptr);
-      char* deviceArchRawPtr = const_cast<char *>(DeviceArch.get());
-      return MapArchIDToArchName(strtok_r(deviceArchRawPtr, ":", &deviceArchRawPtr));
+      char *deviceArchRawPtr = const_cast<char *>(DeviceArch.get());
+      return MapArchIDToArchName(
+          strtok_r(deviceArchRawPtr, ":", &deviceArchRawPtr));
     } else if (Dev->is_cpu() && backend::opencl == CurrentBackend) {
       auto MapArchIDToArchName = [](const int arch) {
         INTEL_CPU_ARCHES(CMP_INTEL);

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -674,7 +674,8 @@ struct get_device_info_impl<
       Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
           Dev->getHandleRef(), PiInfoCode<info::device::version>::value,
           ResultSize, DeviceArch.get(), nullptr);
-      return MapArchIDToArchName(strtok(DeviceArch.get(), ":"));
+      char* deviceArchRawPtr = const_cast<char *>(DeviceArch.get());
+      return MapArchIDToArchName(strtok_r(deviceArchRawPtr, ":", &deviceArchRawPtr));
     } else if (Dev->is_cpu() && backend::opencl == CurrentBackend) {
       auto MapArchIDToArchName = [](const int arch) {
         INTEL_CPU_ARCHES(CMP_INTEL);

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -674,9 +674,10 @@ struct get_device_info_impl<
       Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
           Dev->getHandleRef(), PiInfoCode<info::device::version>::value,
           ResultSize, DeviceArch.get(), nullptr);
-      char *deviceArchRawPtr = const_cast<char *>(DeviceArch.get());
-      return MapArchIDToArchName(
-          strtok_r(deviceArchRawPtr, ":", &deviceArchRawPtr));
+      std::string DeviceArchCopy(DeviceArch.get());
+      std::string DeviceArchSubstr =
+          DeviceArchCopy.substr(0, DeviceArchCopy.find(":"));
+      return MapArchIDToArchName(DeviceArchSubstr.data());
     } else if (Dev->is_cpu() && backend::opencl == CurrentBackend) {
       auto MapArchIDToArchName = [](const int arch) {
         INTEL_CPU_ARCHES(CMP_INTEL);

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -674,7 +674,7 @@ struct get_device_info_impl<
       Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
           Dev->getHandleRef(), PiInfoCode<info::device::version>::value,
           ResultSize, DeviceArch.get(), nullptr);
-      return MapArchIDToArchName(DeviceArch.get());
+      return MapArchIDToArchName(strtok(DeviceArch.get(), ":"));
     } else if (Dev->is_cpu() && backend::opencl == CurrentBackend) {
       auto MapArchIDToArchName = [](const int arch) {
         INTEL_CPU_ARCHES(CMP_INTEL);


### PR DESCRIPTION
Small fix to strip down additional CPU information from AMD query, like: `gfx90a:sramecc+:xnack-` to just `gfx90a`