### PR TITLE
[SYCL] Add an user-defined copy constructor

### DIFF
--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -194,9 +194,9 @@ public:
     }
   }
 
-  XPTIScope(const XPTIScope &rhs) = default;
+  XPTIScope(const XPTIScope &rhs) = delete;
 
-  XPTIScope &operator=(const XPTIScope &rhs) = default;
+  XPTIScope &operator=(const XPTIScope &rhs) = delete;
 
   xpti::trace_event_data_t *traceEvent() { return MTraceEvent; }
 

--- a/sycl/source/detail/xpti_registry.hpp
+++ b/sycl/source/detail/xpti_registry.hpp
@@ -194,7 +194,9 @@ public:
     }
   }
 
-  XPTIScope &operator=(const XPTIScope &) = delete;
+  XPTIScope(const XPTIScope &rhs) = default;
+
+  XPTIScope &operator=(const XPTIScope &rhs) = default;
 
   xpti::trace_event_data_t *traceEvent() { return MTraceEvent; }
 


### PR DESCRIPTION
The static verifier reported a missing user defined copy constructor as delete to match to the existing assignment operator.