### PR TITLE
[ESIMD][NFC] Fix several NFC issues in atomic_update() implementation

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -207,34 +207,6 @@ enum class atomic_op : uint8_t {
 /// @} sycl_esimd_core
 
 namespace detail {
-template <__ESIMD_NS::native::lsc::atomic_op Op> constexpr int get_num_args() {
-  if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::inc ||
-                Op == __ESIMD_NS::native::lsc::atomic_op::dec ||
-                Op == __ESIMD_NS::native::lsc::atomic_op::load) {
-    return 0;
-  } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::store ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::add ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::sub ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::smin ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::smax ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::umin ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::umax ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::fadd ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::fsub ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::fmin ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::fmax ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::bit_and ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::bit_or ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::bit_xor) {
-    return 1;
-  } else if constexpr (Op == __ESIMD_NS::native::lsc::atomic_op::cmpxchg ||
-                       Op == __ESIMD_NS::native::lsc::atomic_op::fcmpxchg) {
-    return 2;
-  } else {
-    return -1; // error
-  }
-}
-
 template <__ESIMD_NS::atomic_op Op> constexpr bool has_lsc_equivalent() {
   switch (Op) {
   case __ESIMD_NS::atomic_op::xchg:
@@ -276,7 +248,7 @@ constexpr __ESIMD_NS::native::lsc::atomic_op to_lsc_atomic_op() {
     return __ESIMD_NS::native::lsc::atomic_op::fmax;
   case __ESIMD_NS::atomic_op::fmin:
     return __ESIMD_NS::native::lsc::atomic_op::fmin;
-  case __ESIMD_NS::atomic_op::fcmpwr:
+  case __ESIMD_NS::atomic_op::fcmpxchg:
     return __ESIMD_NS::native::lsc::atomic_op::fcmpxchg;
   case __ESIMD_NS::atomic_op::fadd:
     return __ESIMD_NS::native::lsc::atomic_op::fadd;
@@ -323,7 +295,7 @@ constexpr __ESIMD_NS::atomic_op to_atomic_op() {
   case __ESIMD_NS::native::lsc::atomic_op::fmin:
     return __ESIMD_NS::atomic_op::fmin;
   case __ESIMD_NS::native::lsc::atomic_op::fcmpxchg:
-    return __ESIMD_NS::atomic_op::fcmpwr;
+    return __ESIMD_NS::atomic_op::fcmpxchg;
   case __ESIMD_NS::native::lsc::atomic_op::fadd:
     return __ESIMD_NS::atomic_op::fadd;
   case __ESIMD_NS::native::lsc::atomic_op::fsub:
@@ -336,17 +308,38 @@ constexpr __ESIMD_NS::atomic_op to_atomic_op() {
 }
 
 template <__ESIMD_NS::atomic_op Op> constexpr int get_num_args() {
-  if constexpr (has_lsc_equivalent<Op>()) {
-    return get_num_args<to_lsc_atomic_op<Op>()>();
-  } else {
-    switch (Op) {
-    case __ESIMD_NS::atomic_op::xchg:
-    case __ESIMD_NS::atomic_op::predec:
-      return 1;
-    default:
-      return -1; // error
-    }
+  switch (Op) {
+  case __ESIMD_NS::atomic_op::inc:
+  case __ESIMD_NS::atomic_op::dec:
+  case __ESIMD_NS::atomic_op::load:
+    return 0;
+  case __ESIMD_NS::atomic_op::xchg:
+  case __ESIMD_NS::atomic_op::predec:
+  case __ESIMD_NS::atomic_op::store:
+  case __ESIMD_NS::atomic_op::add:
+  case __ESIMD_NS::atomic_op::sub:
+  case __ESIMD_NS::atomic_op::smin:
+  case __ESIMD_NS::atomic_op::smax:
+  case __ESIMD_NS::atomic_op::umin:
+  case __ESIMD_NS::atomic_op::umax:
+  case __ESIMD_NS::atomic_op::fadd:
+  case __ESIMD_NS::atomic_op::fsub:
+  case __ESIMD_NS::atomic_op::fmin:
+  case __ESIMD_NS::atomic_op::fmax:
+  case __ESIMD_NS::atomic_op::bit_and:
+  case __ESIMD_NS::atomic_op::bit_or:
+  case __ESIMD_NS::atomic_op::bit_xor:
+    return 1;
+  case __ESIMD_NS::atomic_op::cmpxchg:
+  case __ESIMD_NS::atomic_op::fcmpxchg:
+    return 2;
+  default:
+    return -1; // error
   }
+}
+
+template <__ESIMD_NS::native::lsc::atomic_op Op> constexpr int get_num_args() {
+  return get_num_args<to_atomic_op<Op>()>();
 }
 
 } // namespace detail

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -450,7 +450,7 @@ __esimd_lsc_store2d_stateless(__ESIMD_DNS::simd_mask_storage_t<N> Pred,
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -461,10 +461,9 @@ __esimd_lsc_store2d_stateless(__ESIMD_DNS::simd_mask_storage_t<N> Pred,
 /// @tparam N is the SIMD size of operation (the number of addresses to access)
 /// @param pred is predicates.
 /// @param offsets is the zero-based offsets.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOpOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_slm_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
@@ -481,7 +480,7 @@ __esimd_lsc_xatomic_slm_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -493,10 +492,9 @@ __esimd_lsc_xatomic_slm_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param pred is predicates.
 /// @param offsets is the zero-based offsets.
 /// @param src0 is the first atomic operand.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_slm_1(
@@ -515,7 +513,7 @@ __esimd_lsc_xatomic_slm_1(
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -528,10 +526,9 @@ __esimd_lsc_xatomic_slm_1(
 /// @param offsets is the zero-based offsets.
 /// @param src0 is the first atomic operand.
 /// @param src1 is the second atomic operand.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_slm_2(
@@ -551,7 +548,7 @@ __esimd_lsc_xatomic_slm_2(
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -564,10 +561,9 @@ __esimd_lsc_xatomic_slm_2(
 /// @param pred is predicates.
 /// @param offsets is the zero-based offsets.
 /// @param surf_ind is the surface index.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N,
           typename SurfIndAliasTy>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
@@ -586,7 +582,7 @@ __esimd_lsc_xatomic_bti_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -600,10 +596,9 @@ __esimd_lsc_xatomic_bti_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param offsets is the zero-based offsets.
 /// @param src0 is the first atomic operand.
 /// @param surf_ind is the surface index.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N,
           typename SurfIndAliasTy>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
@@ -624,7 +619,7 @@ __esimd_lsc_xatomic_bti_1(
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -639,10 +634,9 @@ __esimd_lsc_xatomic_bti_1(
 /// @param src0 is the first atomic operand.
 /// @param src1 is the second atomic operand.
 /// @param surf_ind is the surface index.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N,
           typename SurfIndAliasTy>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
@@ -664,7 +658,7 @@ __esimd_lsc_xatomic_bti_2(
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -675,10 +669,9 @@ __esimd_lsc_xatomic_bti_2(
 /// @tparam N is the SIMD size of operation (the number of addresses to access)
 /// @param pred is predicates.
 /// @param addrs is the prefetch addresses.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_stateless_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
@@ -695,7 +688,7 @@ __esimd_lsc_xatomic_stateless_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -708,10 +701,9 @@ __esimd_lsc_xatomic_stateless_0(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param pred is predicates.
 /// @param addrs is the prefetch addresses.
 /// @param src0 is the first atomic operand.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_stateless_1(
@@ -730,7 +722,7 @@ __esimd_lsc_xatomic_stateless_1(
 /// Supported platforms: DG2, PVC
 ///
 /// @tparam Ty is element type.
-/// @tparam Op is operation type.
+/// @tparam InternalOp is operation type.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AddressScale is the address scale.
@@ -743,10 +735,9 @@ __esimd_lsc_xatomic_stateless_1(
 /// @param addrs is the prefetch addresses.
 /// @param src0 is the first atomic operand.
 /// @param src1 is the second atomic operand.
-template <typename Ty, __ESIMD_NS::native::lsc::atomic_op Op,
-          __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
+template <typename Ty, int InternalOp, __ESIMD_ENS::cache_hint L1H,
+          __ESIMD_ENS::cache_hint L3H, uint16_t AddressScale, int ImmOffset,
+          __ESIMD_ENS::lsc_data_size DS, __ESIMD_EDNS::lsc_vector_size VS,
           __ESIMD_EDNS::lsc_data_order _Transposed, int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()>
 __esimd_lsc_xatomic_stateless_2(

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2723,6 +2723,8 @@ namespace detail {
 // the input type 'T' and operation 'Op'.
 template <typename T, __ESIMD_NS::atomic_op Op>
 constexpr int lsc_to_internal_atomic_op() {
+  constexpr __ESIMD_NS::native::lsc::atomic_op LSCOp =
+      __ESIMD_DNS::to_lsc_atomic_op<Op>();
   return static_cast<int>(LSCOp);
 }
 } // namespace detail

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2714,6 +2714,19 @@ lsc_store_2d(config_2d_mem_access<T, BlockWidth, BlockHeight, NBlocks> &payload,
       payload.get_raw_data(), Data, exDesc, desc);
 }
 
+namespace detail {
+
+// lsc_atomic_update() operations may share atomic_op values for data types
+// of the same (fp vs integral) class for convenience (e.g. re-use 'fmax' for
+// all FP types). In fact those data types may require using different internal
+// opcodes. This function returns the corresponding internal opcode for
+// the input type 'T' and operation 'Op'.
+template <typename T, __ESIMD_NS::atomic_op Op>
+constexpr int lsc_to_internal_atomic_op() {
+  return static_cast<int>(LSCOp);
+}
+} // namespace detail
+
 /// SLM atomic.
 /// Supported platforms: DG2, PVC
 /// VISA instruction: lsc_atomic_<OP>.slm
@@ -2735,9 +2748,7 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   static_assert(sizeof(T) == 2 || sizeof(T) == 4, "Unsupported data type");
   __ESIMD_EDNS::check_lsc_vector_size<1>();
   __ESIMD_EDNS::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 0>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 0>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
   constexpr lsc_data_size _DS =
@@ -2746,8 +2757,9 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_slm_0<MsgT, _Op, cache_hint::none, cache_hint::none,
+      __esimd_lsc_xatomic_slm_0<MsgT, IOp, cache_hint::none, cache_hint::none,
                                 _AddressScale, _ImmOffset, _DS, _VS,
                                 _Transposed, N>(pred.data(), offsets.data());
   return detail::lsc_format_ret<T>(Tmp);
@@ -2779,9 +2791,7 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   static_assert(sizeof(T) == 2 || sizeof(T) == 4, "Unsupported data type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 1>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 1>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
   constexpr lsc_data_size _DS =
@@ -2790,9 +2800,10 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Msg_data = detail::lsc_format_input<MsgT>(src0);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_slm_1<MsgT, _Op, cache_hint::none, cache_hint::none,
+      __esimd_lsc_xatomic_slm_1<MsgT, IOp, cache_hint::none, cache_hint::none,
                                 _AddressScale, _ImmOffset, _DS, _VS,
                                 _Transposed, N>(pred.data(), offsets.data(),
                                                 Msg_data.data());
@@ -2825,9 +2836,7 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
                 "Unsupported data type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 2>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 2>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
   constexpr lsc_data_size _DS =
@@ -2836,10 +2845,11 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Msg_data0 = detail::lsc_format_input<MsgT>(src0);
   __ESIMD_NS::simd<MsgT, N> Msg_data1 = detail::lsc_format_input<MsgT>(src1);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_slm_2<MsgT, _Op, cache_hint::none, cache_hint::none,
+      __esimd_lsc_xatomic_slm_2<MsgT, IOp, cache_hint::none, cache_hint::none,
                                 _AddressScale, _ImmOffset, _DS, _VS,
                                 _Transposed, N>(
           pred.data(), offsets.data(), Msg_data0.data(), Msg_data1.data());
@@ -2864,18 +2874,15 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           lsc_data_size DS = lsc_data_size::default_size,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset>
-__ESIMD_API std::enable_if_t<
-    __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 0,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<__ESIMD_DNS::get_num_args<Op>() == 0,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
                   __ESIMD_NS::simd_mask<N> pred) {
   static_assert(std::is_integral_v<Toffset>, "Unsupported offset type");
   static_assert(sizeof(T) > 1, "Unsupported data type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 0>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 0>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -2885,10 +2892,11 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
   addrs += convert<uintptr_t>(offsets);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_stateless_0<MsgT, _Op, L1H, L3H, _AddressScale,
+      __esimd_lsc_xatomic_stateless_0<MsgT, IOp, L1H, L3H, _AddressScale,
                                       _ImmOffset, _DS, _VS, _Transposed, N>(
           pred.data(), addrs.data());
   return detail::lsc_format_ret<T>(Tmp);
@@ -2899,9 +2907,8 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset,
           typename RegionTy = __ESIMD_NS::region1d_t<Toffset, N, 1>>
-__ESIMD_API std::enable_if_t<
-    __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 0,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<__ESIMD_DNS::get_num_args<Op>() == 0,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, __ESIMD_NS::simd_view<Toffset, RegionTy> offsets,
                   __ESIMD_NS::simd_mask<N> pred = 1) {
   return lsc_atomic_update<Op, T, N, DS, L1H, L3H>(p, offsets.read(), pred);
@@ -2911,10 +2918,9 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           lsc_data_size DS = lsc_data_size::default_size,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset>
-__ESIMD_API std::enable_if_t<
-    std::is_integral_v<Toffset> &&
-        __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 0,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<std::is_integral_v<Toffset> &&
+                                 __ESIMD_DNS::get_num_args<Op>() == 0,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd_mask<N> pred = 1) {
   return lsc_atomic_update<Op, T, N, DS, L1H, L3H>(
       p, __ESIMD_NS::simd<Toffset, N>(offset), pred);
@@ -2939,18 +2945,15 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           lsc_data_size DS = lsc_data_size::default_size,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset>
-__ESIMD_API std::enable_if_t<
-    __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 1,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<__ESIMD_DNS::get_num_args<Op>() == 1,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
                   __ESIMD_NS::simd<T, N> src0, __ESIMD_NS::simd_mask<N> pred) {
   static_assert(std::is_integral_v<Toffset>, "Unsupported offset type");
   static_assert(sizeof(T) > 1, "Unsupported data type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 1>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 1>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -2960,11 +2963,12 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Msg_data = detail::lsc_format_input<MsgT>(src0);
   __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
   addrs += convert<uintptr_t>(offsets);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_stateless_1<MsgT, _Op, L1H, L3H, _AddressScale,
+      __esimd_lsc_xatomic_stateless_1<MsgT, IOp, L1H, L3H, _AddressScale,
                                       _ImmOffset, _DS, _VS, _Transposed, N>(
           pred.data(), addrs.data(), Msg_data.data());
   return detail::lsc_format_ret<T>(Tmp);
@@ -2975,9 +2979,8 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset,
           typename RegionTy = __ESIMD_NS::region1d_t<Toffset, N, 1>>
-__ESIMD_API std::enable_if_t<
-    __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 1,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<__ESIMD_DNS::get_num_args<Op>() == 1,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, __ESIMD_NS::simd_view<Toffset, RegionTy> offsets,
                   __ESIMD_NS::simd<T, N> src0,
                   __ESIMD_NS::simd_mask<N> pred = 1) {
@@ -2989,13 +2992,12 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           lsc_data_size DS = lsc_data_size::default_size,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset>
-__ESIMD_API std::enable_if_t<
-    std::is_integral_v<Toffset> &&
-        __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 1 &&
-        ((Op != __ESIMD_NS::atomic_op::store &&
-          Op != __ESIMD_NS::atomic_op::xchg) ||
-         N == 1),
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<std::is_integral_v<Toffset> &&
+                                 __ESIMD_DNS::get_num_args<Op>() == 1 &&
+                                 ((Op != __ESIMD_NS::atomic_op::store &&
+                                   Op != __ESIMD_NS::atomic_op::xchg) ||
+                                  N == 1),
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd<T, N> src0,
                   __ESIMD_NS::simd_mask<N> pred = 1) {
   return lsc_atomic_update<Op, T, N, DS, L1H, L3H>(
@@ -3021,9 +3023,8 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           lsc_data_size DS = lsc_data_size::default_size,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset>
-__ESIMD_API std::enable_if_t<
-    __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 2,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<__ESIMD_DNS::get_num_args<Op>() == 2,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
                   __ESIMD_NS::simd<T, N> src0, __ESIMD_NS::simd<T, N> src1,
                   __ESIMD_NS::simd_mask<N> pred) {
@@ -3031,9 +3032,7 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
   static_assert(sizeof(T) > 1, "Unsupported data type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 2>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 2>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -3043,12 +3042,13 @@ lsc_atomic_update(T *p, __ESIMD_NS::simd<Toffset, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Msg_data0 = detail::lsc_format_input<MsgT>(src0);
   __ESIMD_NS::simd<MsgT, N> Msg_data1 = detail::lsc_format_input<MsgT>(src1);
   __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
   addrs += convert<uintptr_t>(offsets);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_stateless_2<MsgT, _Op, L1H, L3H, _AddressScale,
+      __esimd_lsc_xatomic_stateless_2<MsgT, IOp, L1H, L3H, _AddressScale,
                                       _ImmOffset, _DS, _VS, _Transposed, N>(
           pred.data(), addrs.data(), Msg_data0.data(), Msg_data1.data());
   return detail::lsc_format_ret<T>(Tmp);
@@ -3059,9 +3059,8 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset,
           typename RegionTy = __ESIMD_NS::region1d_t<Toffset, N, 1>>
-__ESIMD_API std::enable_if_t<
-    __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 2,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<__ESIMD_DNS::get_num_args<Op>() == 2,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, __ESIMD_NS::simd_view<Toffset, RegionTy> offsets,
                   __ESIMD_NS::simd<T, N> src0, __ESIMD_NS::simd<T, N> src1,
                   __ESIMD_NS::simd_mask<N> pred = 1) {
@@ -3073,10 +3072,9 @@ template <__ESIMD_NS::atomic_op Op, typename T, int N,
           lsc_data_size DS = lsc_data_size::default_size,
           cache_hint L1H = cache_hint::none, cache_hint L3H = cache_hint::none,
           typename Toffset>
-__ESIMD_API std::enable_if_t<
-    std::is_integral_v<Toffset> &&
-        __ESIMD_DNS::get_num_args<__ESIMD_DNS::to_lsc_atomic_op<Op>()>() == 2,
-    __ESIMD_NS::simd<T, N>>
+__ESIMD_API std::enable_if_t<std::is_integral_v<Toffset> &&
+                                 __ESIMD_DNS::get_num_args<Op>() == 2,
+                             __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd<T, N> src0,
                   __ESIMD_NS::simd<T, N> src1,
                   __ESIMD_NS::simd_mask<N> pred = 1) {
@@ -3120,9 +3118,7 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
                 "Unsupported offset type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 0>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 0>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -3132,9 +3128,10 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_bti_0<MsgT, _Op, L1H, L3H, _AddressScale, _ImmOffset,
+      __esimd_lsc_xatomic_bti_0<MsgT, IOp, L1H, L3H, _AddressScale, _ImmOffset,
                                 _DS, _VS, _Transposed, N>(pred.data(),
                                                           offsets.data(), si);
   return detail::lsc_format_ret<T>(Tmp);
@@ -3206,9 +3203,7 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
                 "Unsupported offset type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 1>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 1>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -3218,10 +3213,11 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Msg_data = detail::lsc_format_input<MsgT>(src0);
   auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_bti_1<MsgT, _Op, L1H, L3H, _AddressScale, _ImmOffset,
+      __esimd_lsc_xatomic_bti_1<MsgT, IOp, L1H, L3H, _AddressScale, _ImmOffset,
                                 _DS, _VS, _Transposed, N>(
           pred.data(), offsets.data(), Msg_data.data(), si);
   return detail::lsc_format_ret<T>(Tmp);
@@ -3295,9 +3291,7 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
                 "Unsupported offset type");
   detail::check_lsc_vector_size<1>();
   detail::check_lsc_data_size<T, DS>();
-  constexpr __ESIMD_NS::native::lsc::atomic_op _Op =
-      __ESIMD_DNS::to_lsc_atomic_op<Op>();
-  __ESIMD_EDNS::check_lsc_atomic<_Op, T, N, 2>();
+  __ESIMD_DNS::check_atomic<Op, T, N, 2>();
   detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
   constexpr uint16_t _AddressScale = 1;
   constexpr int _ImmOffset = 0;
@@ -3307,11 +3301,12 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
   constexpr detail::lsc_data_order _Transposed =
       detail::lsc_data_order::nontranspose;
   using MsgT = typename detail::lsc_expand_type<T>::type;
+  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
   __ESIMD_NS::simd<MsgT, N> Msg_data0 = detail::lsc_format_input<MsgT>(src0);
   __ESIMD_NS::simd<MsgT, N> Msg_data1 = detail::lsc_format_input<MsgT>(src1);
   auto si = __ESIMD_NS::get_surface_index(acc);
   __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_bti_2<MsgT, _Op, L1H, L3H, _AddressScale, _ImmOffset,
+      __esimd_lsc_xatomic_bti_2<MsgT, IOp, L1H, L3H, _AddressScale, _ImmOffset,
                                 _DS, _VS, _Transposed, N>(
           pred.data(), offsets.data(), Msg_data0.data(), Msg_data1.data(), si);
   return detail::lsc_format_ret<T>(Tmp);

--- a/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
@@ -254,7 +254,7 @@ bool test(queue q, const Config &cfg) {
                 // do compare-and-swap in a loop until we get expected value;
                 // arg0 and arg1 must provide values which guarantee the loop
                 // is not endless:
-                for (auto old_val =
+                for (simd<T, N> old_val =
                          atomic_update<op>(arr, offsets, new_val, exp_val, m);
                      any(old_val < exp_val, !m);
                      old_val =
@@ -503,11 +503,11 @@ template <class T, int N, class C, C Op> struct ImplLoadBase {
 template <class T, int N, class C, C Op> struct ImplStoreBase {
   static constexpr C atomic_op = Op;
   static constexpr int n_args = 1;
-  static constexpr T base = (T)(2 + FPDELTA);
 
   static T init(int i, const Config &cfg) { return 0; }
 
   static T gold(int i, const Config &cfg) {
+    T base = (T)(2 + FPDELTA);
 #ifndef USE_SCALAR_OFFSET
     T gold = is_updated(i, N, cfg) ? base : init(i, cfg);
 #else
@@ -516,7 +516,10 @@ template <class T, int N, class C, C Op> struct ImplStoreBase {
     return gold;
   }
 
-  static T arg0(int i) { return base; }
+  static T arg0(int i) {
+    T base = (T)(2 + FPDELTA);
+    return base;
+  }
 };
 
 template <class T, int N, class C, C Op> struct ImplAdd {
@@ -545,9 +548,9 @@ template <class T, int N, class C, C Op> struct ImplAdd {
 template <class T, int N, class C, C Op> struct ImplSub {
   static constexpr C atomic_op = Op;
   static constexpr int n_args = 1;
-  static constexpr T base = (T)(5 + FPDELTA);
 
   static T init(int i, const Config &cfg) {
+    T base = (T)(5 + FPDELTA);
 #ifndef USE_SCALAR_OFFSET
     return (T)(cfg.repeat * cfg.threads_per_group * cfg.n_groups *
                    (T)(1 + FPDELTA) +
@@ -561,6 +564,7 @@ template <class T, int N, class C, C Op> struct ImplSub {
   }
 
   static T gold(int i, const Config &cfg) {
+    T base = (T)(5 + FPDELTA);
 #ifndef USE_SCALAR_OFFSET
     T gold = is_updated(i, N, cfg) ? base : init(i, cfg);
 #else
@@ -695,11 +699,14 @@ struct ImplDec : ImplDecBase<T, N, DWORDAtomicOp, DWORDAtomicOp::dec> {};
 template <class T, int N, class C, C Op> struct ImplCmpxchgBase {
   static constexpr C atomic_op = Op;
   static constexpr int n_args = 2;
-  static constexpr T base = (T)(2 + FPDELTA);
 
-  static T init(int i, const Config &cfg) { return base - 1; }
+  static T init(int i, const Config &cfg) {
+    T base = (T)(1 + FPDELTA);
+    return base;
+  }
 
   static T gold(int i, const Config &cfg) {
+    T base = (T)(2 + FPDELTA);
 #ifndef USE_SCALAR_OFFSET
     T gold = is_updated(i, N, cfg)
 #else
@@ -711,10 +718,16 @@ template <class T, int N, class C, C Op> struct ImplCmpxchgBase {
   }
 
   // "Replacement value" argument in CAS
-  static inline T arg0(int i) { return i + base; }
+  static inline T arg0(int i) {
+    T base = (T)(i + 2 + FPDELTA);
+    return base;
+  }
 
   // "Expected value" argument in CAS
-  static inline T arg1(int i) { return i + base - 1; }
+  static inline T arg1(int i) {
+    T base = (T)(i + 1 + FPDELTA);
+    return base;
+  }
 };
 
 #ifndef USE_DWORD_ATOMICS
@@ -841,6 +854,7 @@ bool test_fp_types_and_sizes(queue q, const Config &cfg) {
   return passed;
 }
 
+#ifndef SKIP_MAIN
 int main(void) {
   queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
 
@@ -901,3 +915,4 @@ int main(void) {
   std::cout << (passed ? "Passed\n" : "FAILED\n");
   return passed ? 0 : 1;
 }
+#endif // SKIP_MAIN


### PR DESCRIPTION
- Added a routine to convert atomic_op to internal integer opcode that might be different depending on the data type;
- Simplified calls of get_num_args() by removing some redundant LSC <-> non-LSC opcode conversions;
- Use fcmpxchg instead of obsolete/less-common fcmpwr alias-sets;
- Outlined FP types check for atomics into a macro __ESIMD_FP_ATOMIC_OP_TYPE_CHECK that may be re-defined if necessary;
- NFC changes in lsc/atomic_smoke.cpp test to avoid potential problems with some types that may not have all required constexpr constructors.