### PR TITLE
[SYCL] Provide initialization for variable

### DIFF
--- a/sycl/include/sycl/group_algorithm.hpp
+++ b/sycl/include/sycl/group_algorithm.hpp
@@ -843,7 +843,7 @@ joint_exclusive_scan(Group g, InPtr first, InPtr last, OutPtr result, T init,
     return ((v + divisor - 1) / divisor) * divisor;
   };
   typename std::remove_const<typename detail::remove_pointer<InPtr>::type>::type
-      x;
+      x = {};
   T carry = init;
   for (ptrdiff_t chunk = 0; chunk < roundup(N, stride); chunk += stride) {
     ptrdiff_t i = chunk + offset;
@@ -1034,7 +1034,7 @@ joint_inclusive_scan(Group g, InPtr first, InPtr last, OutPtr result,
     return ((v + divisor - 1) / divisor) * divisor;
   };
   typename std::remove_const<typename detail::remove_pointer<InPtr>::type>::type
-      x;
+      x = {};
   T carry = init;
   for (ptrdiff_t chunk = 0; chunk < roundup(N, stride); chunk += stride) {
     ptrdiff_t i = chunk + offset;


### PR DESCRIPTION
As far as the compiler is concerned, the variable `x` is uninitialized on some control-flow paths and is passed to the function `(ex|in)clusive_scan_over_group`.

In terms of LLVM, the function parameter that `x` is passed to is likely marked `noundef`. This can lead the compiler to take advantage of `undef` rules and assume that the control path in which `x` is defined must happen (otherwise it'd be undefined), and it can essentially remove the guarding `i < N` around the memory accesses. This is, of course, dangerous.

Though, in practice, this is often avoided because the scan function is inlined before LLVM makes that assumption, this should not be relied upon. I've chosen to zero-initialize it. The value of `init` cannot be used because it may be out of bounds for the type pointed to by `InPtr`, which can introduce new UB into the program.