### PR TITLE
[SYCL][ESIMD] Add compile time properties overload of USM block store

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -662,7 +662,7 @@ __esimd_lsc_load_stateless(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 ///
 /// @tparam Ty is element type.
 /// @tparam L1H is L1 cache hint.
-/// @tparam L3H is L3 cache hint.
+/// @tparam L2H is L2 cache hint.
 /// @tparam AddressScale is the address scale.
 /// @tparam ImmOffset is the immediate offset added to each address.
 /// @tparam DS is the data size.
@@ -672,7 +672,7 @@ __esimd_lsc_load_stateless(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 /// @param pred is predicates.
 /// @param addrs is the prefetch addresses.
 /// @param vals is values to store.
-template <typename Ty, __ESIMD_NS::cache_hint L1H, __ESIMD_NS::cache_hint L3H,
+template <typename Ty, __ESIMD_NS::cache_hint L1H, __ESIMD_NS::cache_hint L2H,
           uint16_t AddressScale, int ImmOffset, __ESIMD_DNS::lsc_data_size DS,
           __ESIMD_DNS::lsc_vector_size VS,
           __ESIMD_DNS::lsc_data_order _Transposed, int N>

--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -655,6 +655,39 @@ __esimd_lsc_load_stateless(__ESIMD_DNS::simd_mask_storage_t<N> pred,
 }
 #endif // __SYCL_DEVICE_ONLY__
 
+/// USM pointer scatter.
+/// Supported platforms: DG2, PVC
+///
+/// Scatters elements to specific address.
+///
+/// @tparam Ty is element type.
+/// @tparam L1H is L1 cache hint.
+/// @tparam L3H is L3 cache hint.
+/// @tparam AddressScale is the address scale.
+/// @tparam ImmOffset is the immediate offset added to each address.
+/// @tparam DS is the data size.
+/// @tparam VS is the number of elements to load per address.
+/// @tparam Transposed indicates if the data is transposed during the transfer.
+/// @tparam N is the SIMD size of operation (the number of addresses to access)
+/// @param pred is predicates.
+/// @param addrs is the prefetch addresses.
+/// @param vals is values to store.
+template <typename Ty, __ESIMD_NS::cache_hint L1H, __ESIMD_NS::cache_hint L3H,
+          uint16_t AddressScale, int ImmOffset, __ESIMD_DNS::lsc_data_size DS,
+          __ESIMD_DNS::lsc_vector_size VS,
+          __ESIMD_DNS::lsc_data_order _Transposed, int N>
+__ESIMD_INTRIN void __esimd_lsc_store_stateless(
+    __ESIMD_DNS::simd_mask_storage_t<N> pred,
+    __ESIMD_DNS::vector_type_t<uintptr_t, N> addrs,
+    __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_DNS::to_int<VS>()> vals)
+#ifdef __SYCL_DEVICE_ONLY__
+    ;
+#else  // __SYCL_DEVICE_ONLY__
+{
+  __ESIMD_UNSUPPORTED_ON_HOST;
+}
+#endif // __SYCL_DEVICE_ONLY__
+
 // \brief Raw sends.
 //
 // @param modifier	the send message flags (Bit-0: isSendc, Bit-1: isEOT).

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -1540,7 +1540,7 @@ block_store(T *ptr, simd<T, N> vals, simd_mask<1> pred,
   constexpr size_t Alignment =
       detail::getPropertyValue<PropertyListT, alignment_key>(DefaultAlignment);
 
-  detail::block_store_impl<T, N, L1Hint, L2Hint>(ptrr, vals, pred,
+  detail::block_store_impl<T, N, L1Hint, L2Hint>(ptr, vals, pred,
                                                  overaligned_tag<Alignment>{});
 }
 

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -574,6 +574,60 @@ __ESIMD_API
 #endif // !__ESIMD_FORCE_STATELESS_MEM
 }
 
+template <typename T, int NElts, cache_hint L1H = cache_hint::none,
+          cache_hint L2H = cache_hint::none, typename FlagsT>
+__ESIMD_API std::enable_if_t<__ESIMD_NS::is_simd_flag_type_v<FlagsT>>
+block_store_impl(T *p, __ESIMD_NS::simd<T, NElts> vals,
+                 __ESIMD_NS::simd_mask<1> pred, FlagsT flags) {
+  // detail::check_lsc_data_size<T, DS>();
+  detail::check_cache_hint<cache_action::store, L1H, L2H>();
+  constexpr auto Alignment =
+      FlagsT::template alignment<__ESIMD_DNS::__raw_t<T>>;
+  static_assert(
+      (Alignment >= __ESIMD_DNS::OperandSize::DWORD && sizeof(T) <= 4) ||
+          (Alignment >= __ESIMD_DNS::OperandSize::QWORD && sizeof(T) > 4),
+      "Incorrect alignment for the data type");
+
+  constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
+  constexpr int SmallIntFactor32Bit =
+      std::max(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+  static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
+                "Number of elements is not supported by Transposed store");
+
+  // If alignment >= 8 and (NElts * sizeof(T)) % 8 == 0) we can store QWORDs.
+  // Don't do it for 4-byte vectors (unless it is greater than 256-bytes),
+  // because it would require a bit-cast, which is supposed to be NO-OP, but
+  // might confuse GPU BE sometimes. 1- and 2-byte vectors are casted anyways.
+  constexpr bool Use64BitData =
+      Alignment >= __ESIMD_DNS::OperandSize::QWORD &&
+      (NElts * sizeof(T)) % sizeof(uint64_t) == 0 &&
+      (sizeof(T) != sizeof(uint32_t) || NElts * sizeof(T) > 256);
+
+  constexpr int SmallIntFactor =
+      Use64BitData ? SmallIntFactor64Bit : SmallIntFactor32Bit;
+  constexpr int FactoredNElts = NElts / SmallIntFactor;
+
+  detail::check_lsc_vector_size<FactoredNElts>();
+
+  using StoreType = __ESIMD_DNS::__raw_t<
+      std::conditional_t<SmallIntFactor == 1, T,
+                         std::conditional_t<Use64BitData, uint64_t, uint32_t>>>;
+  constexpr uint16_t AddressScale = 1;
+  constexpr int ImmOffset = 0;
+  constexpr lsc_data_size ActualDS =
+      Use64BitData ? lsc_data_size::u64 : lsc_data_size::u32;
+  constexpr lsc_vector_size VS = to_lsc_vector_size<FactoredNElts>();
+  constexpr auto Transposed = lsc_data_order::transpose;
+  constexpr int N = 1;
+  __ESIMD_NS::simd<uintptr_t, N> Addrs = reinterpret_cast<uintptr_t>(p);
+
+  __esimd_lsc_store_stateless<StoreType, L1H, L2H, AddressScale, ImmOffset,
+                              ActualDS, VS, Transposed, N>(
+      pred.data(), Addrs.data(),
+      sycl::bit_cast<__ESIMD_DNS::vector_type_t<StoreType, FactoredNElts>>(
+          vals.data()));
+}
+
 } // namespace detail
 
 /// Stores elements of the vector \p vals to a contiguous block of memory
@@ -593,7 +647,7 @@ __ESIMD_API
 template <typename Tx, int N,
           typename Flags = overaligned_tag<detail::OperandSize::OWORD>>
 __ESIMD_API std::enable_if_t<is_simd_flag_type_v<Flags>>
-block_store(Tx *addr, simd<Tx, N> vals, Flags = {}) {
+block_store(Tx *addr, simd<Tx, N> vals, Flags) {
   using T = typename detail::__raw_t<Tx>;
   using VecT = typename simd<T, N>::raw_vector_type;
   constexpr size_t Align = Flags::template alignment<simd<T, N>>;
@@ -1301,6 +1355,287 @@ block_load(AccessorT acc, simd_mask<1> pred, PropertyListT props = {}) {
   return block_load<T, N>(acc, 0, pred, PassThru, props);
 }
 
+/// Each of the following block store functions stores a contiguous memory block
+/// to the address referenced by the USM pointer 'ptr', or from 'ptr +
+/// offset', where 'offset' is the offset in bytes (not in elements!) with data
+/// specified by 'vals'.
+/// The parameter 'pred' is the one element predicate. If it is set to 1, then
+/// all 'N' elements are stored. Otherwise, the block store operation is a
+/// NO-OP. The parameter 'props' specifies the optional compile-time properties
+/// of the type esimd::properties and may include esimd::cache_hint_L1,
+/// esimd::cache_hint_L2, esimd::cache_hint_L3, esimd::alignment.
+///
+/// void block_store(T* ptr, simd<T, N> vals, props={}); // (1)
+/// void block_store(T* ptr, size_t byte_offset,         // (2)
+///                          simd<T, N> vals, props={});
+
+/// void block_store(T* ptr, simd<T, N> vals,            // (3)
+///             simd_mask<1> pred, props={});
+
+/// void block_store(T* ptr, size_t byte_offset,         // (4)
+/// simd<T, N> vals, simd_mask<1> pred, props={});
+///
+/// void block_store(T* ptr, simd<T, N> vals, props={}); // (1)
+/// This function stores a contiguous memory block to USM pointer \p ptr
+/// with data specified by \p vals.
+///
+/// There may be temporary restrictions depending on L1, L2 cache hints,
+/// See details in the 'Restrictions' section below. The restrictions will be
+/// relaxed in the future.
+///
+/// The parameter \p props specifies the optional compile-time properties
+/// of the type esimd::properties and may include esimd::cache_hint_L1,
+/// esimd::cache_hint_L2, esimd::alignment. Other properties are ignored.
+///
+/// Cache hints: If \p props does not specify any L1 or L2 cache hints, then
+/// the cache_hint::none value is assumed by default.
+///
+/// Alignment: If \p props does not specify the 'alignment' property, then
+/// the default assumed alignment is the minimally required element-size
+/// alignment. Note that additional/temporary restrictions may apply
+/// (see Restrictions below).
+///
+/// Restrictions - cache hint imposed - temporary:
+/// If L1 or L2 cache hint is passed, then:
+/// R1: The pointer must be at least 4-byte aligned for elements of 4-bytes or
+///     smaller and 8-byte aligned for 8-byte elements.
+/// R2: The number of elements for 8-byte data: 1, 2, 3, 4, 8, 16, 32, 64;
+///     for 4-byte data: 1, 2, 3, 4, 8, 16, 32, 64,
+///                      or 128(only if alignment is 8-bytes or more);
+///     for 2-byte data: 2, 4, 6, 8, 16, 32, 64, 128,
+///                      or 256(only if alignment is 8-bytes or more);
+///     for 1-byte data: 4, 8, 12, 16, 32, 64, 128, 256,
+///                      or 512(only if alignment is 8-bytes or more).
+/// R3: The target device must be DG2, PVC or newer GPU.
+template <typename T, int N,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, simd<T, N> vals, PropertyListT props = {}) {
+  constexpr auto L1Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L1_key>(
+          cache_hint::none);
+  constexpr auto L2Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L2_key>(
+          cache_hint::none);
+  static_assert(!PropertyListT::template has_property<cache_hint_L3_key>(),
+                "L3 cache hint is reserved. The old/experimental L3 LSC cache "
+                "hint is cache_level::L2 now.");
+  if constexpr (L1Hint != cache_hint::none || L2Hint != cache_hint::none) {
+    detail::check_cache_hint<detail::cache_action::store, L1Hint, L2Hint>();
+    constexpr int DefaultAlignment = (sizeof(T) <= 4) ? 4 : sizeof(T);
+    constexpr size_t Alignment =
+        detail::getPropertyValue<PropertyListT, alignment_key>(
+            DefaultAlignment);
+
+    simd_mask<1> Mask = 1;
+    detail::block_store_impl<T, N, L1Hint, L2Hint>(
+        ptr, vals, Mask, overaligned_tag<Alignment>{});
+  } else {
+    // If the alignment property is not passed, then assume the pointer
+    // is element-aligned.
+    constexpr size_t Alignment =
+        detail::getPropertyValue<PropertyListT, alignment_key>(sizeof(T));
+    block_store<T, N>(ptr, vals, overaligned_tag<Alignment>{});
+  }
+}
+
+/// void block_store(T* ptr, size_t byte_offset,         // (2)
+///                          simd<T, N> vals, props={});
+/// This function stores a contiguous memory block to USM pointer \p ptr and
+/// byte-offset \p byte_offset with data specified by \p vals.
+///
+/// There may be temporary restrictions depending on L1, L2 cache hints,
+/// See details in the 'Restrictions' section below. The restrictions will be
+/// relaxed in the future.
+///
+/// The parameter \p props specifies the optional compile-time properties
+/// of the type esimd::properties and may include esimd::cache_hint_L1,
+/// esimd::cache_hint_L2, esimd::alignment. Other properties are ignored.
+///
+/// Cache hints: If \p props does not specify any L1 or L2 cache hints, then
+/// the cache_hint::none value is assumed by default.
+///
+/// Alignment: If \p props does not specify the 'alignment' property, then
+/// the default assumed alignment is the minimally required element-size
+/// alignment. Note that additional/temporary restrictions may apply
+/// (see Restrictions below).
+///
+/// Restrictions - cache hint imposed - temporary:
+/// If L1 or L2 cache hint is passed, then:
+/// R1: The pointer must be at least 4-byte aligned for elements of 4-bytes or
+///     smaller and 8-byte aligned for 8-byte elements.
+/// R2: The number of elements for 8-byte data: 1, 2, 3, 4, 8, 16, 32, 64;
+///     for 4-byte data: 1, 2, 3, 4, 8, 16, 32, 64,
+///                      or 128(only if alignment is 8-bytes or more);
+///     for 2-byte data: 2, 4, 6, 8, 16, 32, 64, 128,
+///                      or 256(only if alignment is 8-bytes or more);
+///     for 1-byte data: 4, 8, 12, 16, 32, 64, 128, 256,
+///                      or 512(only if alignment is 8-bytes or more).
+/// R3: The target device must be DG2, PVC or newer GPU.
+template <typename T, int N,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, size_t byte_offset, simd<T, N> vals,
+            PropertyListT props = {}) {
+  T *AdjustedPtr =
+      reinterpret_cast<T *>(reinterpret_cast<int8_t *>(ptr) + byte_offset);
+  block_store<T, N>(AdjustedPtr, vals, props);
+}
+
+/// void block_store(T* ptr, simd<T, N> vals,            // (3)
+///             simd_mask<1> pred, props={});
+/// This function stores a contiguous memory block to USM pointer \p ptr
+/// with data specified by \p vals. If the predicate \p pred is set to 0,
+/// then the store is omitted.
+///
+/// There may be temporary restrictions depending on L1, L2 cache hints,
+/// See details in the 'Restrictions' section below. The restrictions will be
+/// relaxed in the future.
+///
+/// The parameter \p props specifies the optional compile-time properties
+/// of the type esimd::properties and may include esimd::cache_hint_L1,
+/// esimd::cache_hint_L2, esimd::alignment. Other properties are ignored.
+///
+/// Cache hints: If \p props does not specify any L1 or L2 cache hints, then
+/// the cache_hint::none value is assumed by default.
+///
+/// Alignment: If \p props does not specify the 'alignment' property, then
+/// the default assumed alignment is the minimally required element-size
+/// alignment. Note that additional/temporary restrictions may apply
+/// (see Restrictions below).
+///
+/// Restrictions - cache hint imposed - temporary:
+/// If L1 or L2 cache hint is passed, then:
+/// R1: The pointer must be at least 4-byte aligned for elements of 4-bytes or
+///     smaller and 8-byte aligned for 8-byte elements.
+/// R2: The number of elements for 8-byte data: 1, 2, 3, 4, 8, 16, 32, 64;
+///     for 4-byte data: 1, 2, 3, 4, 8, 16, 32, 64,
+///                      or 128(only if alignment is 8-bytes or more);
+///     for 2-byte data: 2, 4, 6, 8, 16, 32, 64, 128,
+///                      or 256(only if alignment is 8-bytes or more);
+///     for 1-byte data: 4, 8, 12, 16, 32, 64, 128, 256,
+///                      or 512(only if alignment is 8-bytes or more).
+/// R3: The target device must be DG2, PVC or newer GPU.
+template <typename T, int N,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, simd<T, N> vals, simd_mask<1> pred,
+            PropertyListT props = {}) {
+  constexpr auto L1Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L1_key>(
+          cache_hint::none);
+  constexpr auto L2Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L2_key>(
+          cache_hint::none);
+  static_assert(!PropertyListT::template has_property<cache_hint_L3_key>(),
+                "L3 cache hint is reserved. The old/experimental L3 LSC cache "
+                "hint is cache_level::L2 now.");
+
+  detail::check_cache_hint<detail::cache_action::store, L1Hint, L2Hint>();
+  constexpr size_t DefaultAlignment = (sizeof(T) <= 4) ? 4 : sizeof(T);
+  constexpr size_t Alignment =
+      detail::getPropertyValue<PropertyListT, alignment_key>(DefaultAlignment);
+
+  detail::block_store_impl<T, N, L1Hint, L2Hint>(ptr, vals, pred,
+                                                 overaligned_tag<Alignment>{});
+}
+
+/// void block_store(T* ptr, size_t byte_offset,         // (4)
+/// simd<T, N> vals, simd_mask<1> pred, props={});
+/// This function stores a contiguous memory block to USM pointer \p ptr
+/// and byte-offset \p byte_offset with data specified by \p vals.
+/// If the predicate \p pred is set to 0, then the store is omitted.
+///
+/// There may be temporary restrictions depending on L1, L2 cache hints,
+/// See details in the 'Restrictions' section below. The restrictions will be
+/// relaxed in the future.
+///
+/// The parameter \p props specifies the optional compile-time properties
+/// of the type esimd::properties and may include esimd::cache_hint_L1,
+/// esimd::cache_hint_L2, esimd::alignment. Other properties are ignored.
+///
+/// Cache hints: If \p props does not specify any L1 or L2 cache hints, then
+/// the cache_hint::none value is assumed by default.
+///
+/// Alignment: If \p props does not specify the 'alignment' property, then
+/// the default assumed alignment is the minimally required element-size
+/// alignment. Note that additional/temporary restrictions may apply
+/// (see Restrictions below).
+///
+/// Restrictions - cache hint imposed - temporary:
+/// If L1 or L2 cache hint is passed, then:
+/// R1: The pointer must be at least 4-byte aligned for elements of 4-bytes or
+///     smaller and 8-byte aligned for 8-byte elements.
+/// R2: The number of elements for 8-byte data: 1, 2, 3, 4, 8, 16, 32, 64;
+///     for 4-byte data: 1, 2, 3, 4, 8, 16, 32, 64,
+///                      or 128(only if alignment is 8-bytes or more);
+///     for 2-byte data: 2, 4, 6, 8, 16, 32, 64, 128,
+///                      or 256(only if alignment is 8-bytes or more);
+///     for 1-byte data: 4, 8, 12, 16, 32, 64, 128, 256,
+///                      or 512(only if alignment is 8-bytes or more).
+/// R3: The target device must be DG2, PVC or newer GPU.
+template <typename T, int N,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, size_t byte_offset, simd<T, N> vals, simd_mask<1> pred,
+            PropertyListT props = {}) {
+  T *AdjustedPtr =
+      reinterpret_cast<T *>(reinterpret_cast<int8_t *>(ptr) + byte_offset);
+  block_store<T, N>(AdjustedPtr, vals, pred, props);
+}
+
+template <typename T, int N, typename Toffset,
+          typename RegionTy = region1d_t<Toffset, N, 1>,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, simd_view<Toffset, RegionTy> vals,
+            PropertyListT props = {}) {
+  block_store<T, N>(ptr, vals.read(), props);
+}
+
+template <typename T, int N, typename Toffset,
+          typename RegionTy = region1d_t<Toffset, N, 1>,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, size_t byte_offset, simd_view<Toffset, RegionTy> vals,
+            PropertyListT props = {}) {
+  block_store<T, N>(ptr, byte_offset, vals.read(), props);
+}
+
+template <typename T, int N, typename Toffset,
+          typename RegionTy = region1d_t<Toffset, N, 1>,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, simd_view<Toffset, RegionTy> vals, simd_mask<1> pred,
+            PropertyListT props = {}) {
+  block_store<T, N>(ptr, vals.read(), pred, props);
+}
+
+template <typename T, int N, typename Toffset,
+          typename RegionTy = region1d_t<Toffset, N, 1>,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+block_store(T *ptr, size_t byte_offset, simd_view<Toffset, RegionTy> vals,
+            simd_mask<1> pred, PropertyListT props = {}) {
+  block_store<T, N>(ptr, byte_offset, vals.read(), pred, props);
+}
+
 /// @} sycl_esimd_memory_block
 
 /// Stores elements of a vector to a contiguous block of memory represented by
@@ -1310,8 +1645,8 @@ block_load(AccessorT acc, simd_mask<1> pred, PropertyListT props = {}) {
 ///    1, 2, 4 or 8 owords long.
 /// @tparam AccessorTy Accessor type (auto-deduced).
 /// @param acc The accessor to store to.
-/// @param offset The offset to store at. It is in bytes and must be a multiple
-///   of \c 16.
+/// @param offset The offset to store at. It is in bytes and must be a
+/// multiple of \c 16.
 /// @param vals The vector to store.
 ///
 template <typename Tx, int N, typename AccessorTy,

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -1493,9 +1493,8 @@ block_store(T *ptr, size_t byte_offset, simd<T, N> vals,
 /// with data specified by \p vals. If the predicate \p pred is set to 0,
 /// then the store is omitted.
 ///
-/// There may be temporary restrictions depending on L1, L2 cache hints,
-/// See details in the 'Restrictions' section below. The restrictions will be
-/// relaxed in the future.
+/// There are temporary restrictions.  See details in the 'Restrictions'
+/// section below. The restrictions will be relaxed in the future.
 ///
 /// The parameter \p props specifies the optional compile-time properties
 /// of the type esimd::properties and may include esimd::cache_hint_L1,
@@ -1505,14 +1504,11 @@ block_store(T *ptr, size_t byte_offset, simd<T, N> vals,
 /// the cache_hint::none value is assumed by default.
 ///
 /// Alignment: If \p props does not specify the 'alignment' property, then
-/// the default assumed alignment is 16 bytes if \p props does not specify any
-/// L1 or L2 cache hints and \p pred is set to 1, and
-/// the minimally required element-size alignment otherwise.
-/// Note that additional/temporary restrictions may apply
-/// (see Restrictions below).
+/// the default assumed alignment is the minimally required element-size
+/// alignment. Note that additional/temporary restrictions apply (see
+/// Restrictions below).
 ///
-/// Restrictions - cache hint or predicate imposed - temporary:
-/// If a predicate, L1 or L2 cache hint is passed, then:
+/// Restrictions - predicate imposed - temporary:
 /// R1: The pointer must be at least 4-byte aligned for elements of 4-bytes or
 ///     smaller and 8-byte aligned for 8-byte elements.
 /// R2: The number of elements for 8-byte data: 1, 2, 3, 4, 8, 16, 32, 64;
@@ -1539,25 +1535,13 @@ block_store(T *ptr, simd<T, N> vals, simd_mask<1> pred,
   static_assert(!PropertyListT::template has_property<cache_hint_L3_key>(),
                 "L3 cache hint is reserved. The old/experimental L3 LSC cache "
                 "hint is cache_level::L2 now.");
-  bool ShouldUseOWordDefaultAlign =
-      pred == 1 && L1Hint == cache_hint::none && L2Hint == cache_hint::none;
-  if (ShouldUseOWordDefaultAlign) {
-    constexpr size_t DefaultAlignment = detail::OperandSize::OWORD;
-    constexpr size_t Alignment =
-        detail::getPropertyValue<PropertyListT, alignment_key>(
-            DefaultAlignment);
 
-    detail::block_store_impl<T, N, L1Hint, L2Hint>(
-        ptr, vals, pred, overaligned_tag<Alignment>{});
-  } else {
-    constexpr size_t DefaultAlignment = (sizeof(T) <= 4) ? 4 : sizeof(T);
-    constexpr size_t Alignment =
-        detail::getPropertyValue<PropertyListT, alignment_key>(
-            DefaultAlignment);
+  constexpr size_t DefaultAlignment = (sizeof(T) <= 4) ? 4 : sizeof(T);
+  constexpr size_t Alignment =
+      detail::getPropertyValue<PropertyListT, alignment_key>(DefaultAlignment);
 
-    detail::block_store_impl<T, N, L1Hint, L2Hint>(
-        ptr, vals, pred, overaligned_tag<Alignment>{});
-  }
+  detail::block_store_impl<T, N, L1Hint, L2Hint>(ptrr, vals, pred,
+                                                 overaligned_tag<Alignment>{});
 }
 
 /// void block_store(T* ptr, size_t byte_offset,         // (4)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -282,39 +282,6 @@ __ESIMD_INTRIN void __esimd_lsc_store_bti(
 }
 #endif // __SYCL_DEVICE_ONLY__
 
-/// USM pointer scatter.
-/// Supported platforms: DG2, PVC
-///
-/// Scatters elements to specific address.
-///
-/// @tparam Ty is element type.
-/// @tparam L1H is L1 cache hint.
-/// @tparam L3H is L3 cache hint.
-/// @tparam AddressScale is the address scale.
-/// @tparam ImmOffset is the immediate offset added to each address.
-/// @tparam DS is the data size.
-/// @tparam VS is the number of elements to load per address.
-/// @tparam Transposed indicates if the data is transposed during the transfer.
-/// @tparam N is the SIMD size of operation (the number of addresses to access)
-/// @param pred is predicates.
-/// @param addrs is the prefetch addresses.
-/// @param vals is values to store.
-template <typename Ty, __ESIMD_ENS::cache_hint L1H, __ESIMD_ENS::cache_hint L3H,
-          uint16_t AddressScale, int ImmOffset, __ESIMD_ENS::lsc_data_size DS,
-          __ESIMD_EDNS::lsc_vector_size VS,
-          __ESIMD_EDNS::lsc_data_order _Transposed, int N>
-__ESIMD_INTRIN void __esimd_lsc_store_stateless(
-    __ESIMD_DNS::simd_mask_storage_t<N> pred,
-    __ESIMD_DNS::vector_type_t<uintptr_t, N> addrs,
-    __ESIMD_DNS::vector_type_t<Ty, N * __ESIMD_EDNS::to_int<VS>()> vals)
-#ifdef __SYCL_DEVICE_ONLY__
-    ;
-#else  // __SYCL_DEVICE_ONLY__
-{
-  __ESIMD_UNSUPPORTED_ON_HOST;
-}
-#endif // __SYCL_DEVICE_ONLY__
-
 /// 2D USM pointer block load.
 /// Supported platforms: PVC
 ///

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -1781,62 +1781,8 @@ template <typename T, int NElts, lsc_data_size DS = lsc_data_size::default_size,
 __ESIMD_API std::enable_if_t<__ESIMD_NS::is_simd_flag_type_v<FlagsT>>
 lsc_block_store(T *p, __ESIMD_NS::simd<T, NElts> vals,
                 __ESIMD_NS::simd_mask<1> pred = 1, FlagsT flags = FlagsT{}) {
-  detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_cache_hint<detail::lsc_action::store, L1H, L3H>();
-  constexpr auto Alignment =
-      FlagsT::template alignment<__ESIMD_DNS::__raw_t<T>>;
-  static_assert(
-      (Alignment >= __ESIMD_DNS::OperandSize::DWORD && sizeof(T) <= 4) ||
-          (Alignment >= __ESIMD_DNS::OperandSize::QWORD && sizeof(T) > 4),
-      "Incorrect alignment for the data type");
-
-  // Prepare template arguments for the call of intrinsic.
-  constexpr uint16_t _AddressScale = 1;
-  constexpr int _ImmOffset = 0;
-  constexpr lsc_data_size _DS = detail::finalize_data_size<T, DS>();
-  static_assert(_DS == lsc_data_size::u16 || _DS == lsc_data_size::u8 ||
-                    _DS == lsc_data_size::u32 || _DS == lsc_data_size::u64,
-                "Conversion data types are not supported");
-  constexpr detail::lsc_data_order _Transposed =
-      detail::lsc_data_order::transpose;
-  constexpr int N = 1;
-  __ESIMD_NS::simd<uintptr_t, N> Addrs = reinterpret_cast<uintptr_t>(p);
-
-  constexpr int SmallIntFactor32Bit =
-      (_DS == lsc_data_size::u16) ? 2 : (_DS == lsc_data_size::u8 ? 4 : 1);
-  static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
-                "Number of elements is not supported by Transposed store");
-
-  constexpr bool Use64BitData =
-      Alignment >= __ESIMD_DNS::OperandSize::QWORD &&
-      (sizeof(T) == 8 ||
-       (DS == lsc_data_size::default_size && NElts / SmallIntFactor32Bit > 64 &&
-        (NElts * sizeof(T)) % 8 == 0));
-  constexpr int SmallIntFactor64Bit =
-      (_DS == lsc_data_size::u16)
-          ? 4
-          : (_DS == lsc_data_size::u8 ? 8
-                                      : (_DS == lsc_data_size::u32 ? 2 : 1));
-  constexpr int SmallIntFactor =
-      Use64BitData ? SmallIntFactor64Bit : SmallIntFactor32Bit;
-  constexpr int FactoredNElts = NElts / SmallIntFactor;
-  constexpr lsc_data_size ActualDS = Use64BitData
-                                         ? __ESIMD_ENS::lsc_data_size::u64
-                                         : __ESIMD_ENS::lsc_data_size::u32;
-
-  detail::check_lsc_vector_size<FactoredNElts>();
-  constexpr detail::lsc_vector_size _VS =
-      detail::to_lsc_vector_size<FactoredNElts>();
-
-  using StoreType = __ESIMD_DNS::__raw_t<
-      std::conditional_t<SmallIntFactor == 1, T,
-                         std::conditional_t<Use64BitData, uint64_t, uint32_t>>>;
-
-  __esimd_lsc_store_stateless<StoreType, L1H, L3H, _AddressScale, _ImmOffset,
-                              ActualDS, _VS, _Transposed, N>(
-      pred.data(), Addrs.data(),
-      sycl::bit_cast<__ESIMD_DNS::vector_type_t<StoreType, FactoredNElts>>(
-          vals.data()));
+  return __ESIMD_DNS::block_store_impl<T, NElts, L1H, L3H>(p, vals, pred,
+                                                           flags);
 }
 
 /// A variation of lsc_block_store without predicate parameter to simplify

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -1765,7 +1765,7 @@ lsc_scatter(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 ///
 /// @tparam T is element type.
 /// @tparam NElts is the number of elements to store per address.
-/// @tparam DS is the data size.
+/// @tparam DS is the data size (unused/obsolete).
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @param p is the base pointer.

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/block_load.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/block_load.hpp
@@ -13,48 +13,10 @@
 #include <iostream>
 
 #include "../../esimd_test_utils.hpp"
+#include "common.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
-
-template <typename Key, typename PropertiesT>
-constexpr cache_hint getCacheHint(PropertiesT) {
-  if constexpr (PropertiesT::template has_property<Key>()) {
-    constexpr auto ValueT = PropertiesT::template get_property<Key>();
-    return ValueT.hint;
-  } else {
-    return cache_hint::none;
-  }
-}
-
-template <typename PropertiesT>
-constexpr size_t getAlignment(PropertiesT, size_t DefaultAlignment) {
-  if constexpr (PropertiesT::template has_property<
-                    sycl::ext::intel::esimd::alignment_key>()) {
-    constexpr auto ValueT = PropertiesT::template get_property<
-        sycl::ext::intel::esimd::alignment_key>();
-    return ValueT.value;
-  } else {
-    return DefaultAlignment;
-  }
-}
-
-template <typename T, uint16_t N, bool UseMask, typename PropertiesT>
-constexpr size_t getAlignment(PropertiesT Props) {
-  constexpr cache_hint L1Hint =
-      getCacheHint<sycl::ext::intel::esimd::cache_hint_L1_key>(Props);
-  constexpr cache_hint L2Hint =
-      getCacheHint<sycl::ext::intel::esimd::cache_hint_L2_key>(Props);
-  constexpr bool RequiresPVC =
-      L1Hint != cache_hint::none || L2Hint != cache_hint::none || UseMask;
-
-  constexpr bool IsMaxLoadSizePVC = RequiresPVC && (N * sizeof(T) > 256);
-  constexpr size_t RequiredAlignment =
-      IsMaxLoadSizePVC ? 8 : (RequiresPVC ? 4 : sizeof(T));
-  constexpr size_t RequestedAlignment = getAlignment(Props, RequiredAlignment);
-  static_assert(RequestedAlignment >= RequiredAlignment, "Too small alignment");
-  return RequestedAlignment;
-}
 
 // Returns true iff verification is passed.
 template <typename T>

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/block_store.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/block_store.hpp
@@ -1,0 +1,178 @@
+//==------- block_store.hpp - DPC++ ESIMD on-device test ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-------------------------------------------------------------------===//
+
+#include "common.hpp"
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+template <typename T, uint16_t N, bool UseMask, bool UseProperties,
+          typename StorePropertiesT>
+bool testUSM(queue Q, uint32_t Groups, uint32_t Threads,
+             StorePropertiesT StoreProperties) {
+
+  uint16_t Size = Groups * Threads * N;
+  using Tuint = sycl::_V1::ext::intel::esimd::detail::uint_type_t<sizeof(T)>;
+
+  std::cout << "USM case: T=" << esimd_test::type_name<T>() << ",N=" << N
+            << ",UseMask=" << UseMask << ",UseProperties=" << UseProperties
+            << std::endl;
+
+  sycl::range<1> GlobalRange{Groups};
+  sycl::range<1> LocalRange{Threads};
+  sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
+  constexpr size_t Alignment = getAlignment<T, N, UseMask>(StoreProperties);
+  T *Out = sycl::aligned_alloc_shared<T>(Alignment, Size, Q);
+  T Out_val = esimd_test::getRandomValue<T>();
+  for (int i = 0; i < Size; i++)
+    Out[i] = Out_val;
+
+  try {
+    Q.submit([&](handler &cgh) {
+       cgh.parallel_for(Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
+         uint16_t GlobalID = ndi.get_global_id(0);
+         uint32_t ElemOff = GlobalID * N;
+         //  TODO: these 2 lines work-around the problem with scalar
+         //  conversions to bfloat16. It could be just: "simd<T, N>
+         //  PassThru(ElemOffset, 1);"
+         simd<uint32_t, N> PassThruInt(ElemOff, 1);
+         simd<T, N> Vals = PassThruInt;
+         if constexpr (UseMask) {
+           simd_mask<1> Mask = (GlobalID + 1) % 1;
+           block_store(Out + ElemOff, Vals, Mask, StorePropertiesT{});
+           Vals = block_load<T, N>(Out + ElemOff);
+           Vals += 1;
+           block_store(Out, ElemOff * sizeof(T), Vals, Mask,
+                       StorePropertiesT{});
+           Vals = block_load<T, N>(Out + ElemOff);
+           Vals += 2;
+           auto View = Vals.template select<N, 1>();
+           block_store<T, N>(Out, ElemOff * sizeof(T), View, Mask,
+                             StorePropertiesT{});
+           Vals = block_load<T, N>(Out + ElemOff);
+           Vals += 3;
+           View = Vals.template select<N, 1>();
+           block_store<T, N>(Out + ElemOff, View, Mask, StorePropertiesT{});
+         } else {
+           if constexpr (UseProperties)
+             block_store(Out + ElemOff, Vals, StorePropertiesT{});
+
+           else
+             block_store(Out + ElemOff, Vals);
+
+           Vals = block_load<T, N>(Out + ElemOff);
+           Vals += 1;
+           if constexpr (UseProperties)
+             block_store(Out, ElemOff * sizeof(T), Vals, StorePropertiesT{});
+           else
+             block_store(Out, ElemOff * sizeof(T), Vals);
+
+           Vals = block_load<T, N>(Out + ElemOff);
+           Vals += 2;
+           auto View = Vals.template select<N, 1>();
+           if constexpr (UseProperties)
+             block_store<T, N>(Out, ElemOff * sizeof(T), View,
+                               StorePropertiesT{});
+           else
+             block_store<T, N>(Out, ElemOff * sizeof(T), View);
+
+           Vals = block_load<T, N>(Out + ElemOff);
+           Vals += 3;
+           View = Vals.template select<N, 1>();
+           if constexpr (UseProperties)
+             block_store<T, N>(Out + ElemOff, View, StorePropertiesT{});
+           else
+             block_store<T, N>(Out + ElemOff, View);
+         }
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    sycl::free(Out, Q);
+    return false;
+  }
+
+  bool Passed = true;
+
+  for (int i = 0; i < Size; i++) {
+    bool IsMaskSet = (i / N + 1) % 1;
+    Tuint Expected = sycl::bit_cast<Tuint>(Out_val);
+    if (!UseMask || IsMaskSet)
+      Expected = sycl::bit_cast<Tuint>((T)(i + 6));
+    Tuint Computed = sycl::bit_cast<Tuint>(Out[i]);
+    if (Computed != Expected) {
+      Passed = false;
+      std::cout << "Out[" << i << "] = " << std::to_string(Computed) << " vs "
+                << std::to_string(Expected) << std::endl;
+    }
+  }
+
+  sycl::free(Out, Q);
+
+  return Passed;
+}
+
+template <typename T, bool TestPVCFeatures> bool test_block_store(queue Q) {
+  constexpr bool CheckMask = true;
+  constexpr bool CheckProperties = true;
+  properties AlignOnlyProps{alignment<sizeof(T)>};
+
+  bool Passed = true;
+
+  // Test block_store() that is available on Gen12 and PVC.
+  Passed &= testUSM<T, 1, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  Passed &= testUSM<T, 2, !CheckMask, CheckProperties>(Q, 1, 4, AlignOnlyProps);
+  Passed &= testUSM<T, 3, !CheckMask, CheckProperties>(Q, 2, 8, AlignOnlyProps);
+  Passed &= testUSM<T, 4, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  Passed &= testUSM<T, 8, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  Passed &=
+      testUSM<T, 16, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  Passed &=
+      testUSM<T, 32, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  // Intentionally check non-power-of-2 simd size - it must work.
+  Passed &=
+      testUSM<T, 33, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  // TODO: Enable after failure fixed
+  // Passed &=
+  //    testUSM<T, 67, !CheckMask, CheckProperties>(Q, 1, 4, AlignOnlyProps);
+  // Intentionally check big simd size - it must work.
+  Passed &=
+      testUSM<T, 128, !CheckMask, CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  Passed &=
+      testUSM<T, 256, !CheckMask, CheckProperties>(Q, 1, 4, AlignOnlyProps);
+
+  // Test block_store() without passing compile-time properties argument.
+  Passed &=
+      testUSM<T, 16, !CheckMask, !CheckProperties>(Q, 2, 4, AlignOnlyProps);
+  Passed &=
+      testUSM<T, 32, !CheckMask, !CheckProperties>(Q, 2, 4, AlignOnlyProps);
+
+  if constexpr (TestPVCFeatures) {
+    // Using cache hints adds the requirement to run tests on PVC.
+    // Also, PVC variant currently requires power-or-two elements and
+    // the number of bytes loaded per call must not exceed 512.
+    properties PVCProps{cache_hint_L1<cache_hint::write_back>,
+                        cache_hint_L2<cache_hint::write_back>, alignment<16>};
+
+    if constexpr (sizeof(T) >= 4) // only d/q words are supported now
+      Passed &= testUSM<T, 1, !CheckMask, CheckProperties>(Q, 2, 4, PVCProps);
+    if constexpr (sizeof(T) >= 2) // only d/q words are supported now
+      Passed &= testUSM<T, 2, !CheckMask, CheckProperties>(Q, 5, 5, PVCProps);
+    Passed &= testUSM<T, 4, !CheckMask, CheckProperties>(Q, 5, 5, PVCProps);
+    Passed &= testUSM<T, 8, !CheckMask, CheckProperties>(Q, 5, 5, PVCProps);
+    Passed &= testUSM<T, 16, CheckMask, CheckProperties>(Q, 5, 5, PVCProps);
+    Passed &= testUSM<T, 32, !CheckMask, CheckProperties>(Q, 2, 4, PVCProps);
+    Passed &= testUSM<T, 64, !CheckMask, CheckProperties>(Q, 7, 1, PVCProps);
+    if constexpr (128 * sizeof(T) <= 512)
+      Passed &= testUSM<T, 128, CheckMask, CheckProperties>(Q, 1, 4, PVCProps);
+    if constexpr (256 * sizeof(T) <= 512)
+      Passed &= testUSM<T, 256, CheckMask, CheckProperties>(Q, 1, 4, PVCProps);
+  } // TestPVCFeatures
+
+  return Passed;
+}

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/common.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/common.hpp
@@ -1,0 +1,54 @@
+//==------- common.hpp - DPC++ ESIMD on-device test ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+#include "../../esimd_test_utils.hpp"
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+template <typename Key, typename PropertiesT>
+constexpr cache_hint getCacheHint(PropertiesT) {
+  if constexpr (PropertiesT::template has_property<Key>()) {
+    constexpr auto ValueT = PropertiesT::template get_property<Key>();
+    return ValueT.hint;
+  } else {
+    return cache_hint::none;
+  }
+}
+
+template <typename PropertiesT>
+constexpr size_t getAlignment(PropertiesT, size_t DefaultAlignment) {
+  if constexpr (PropertiesT::template has_property<
+                    sycl::ext::intel::esimd::alignment_key>()) {
+    constexpr auto ValueT = PropertiesT::template get_property<
+        sycl::ext::intel::esimd::alignment_key>();
+    return ValueT.value;
+  } else {
+    return DefaultAlignment;
+  }
+}
+
+template <typename T, uint16_t N, bool UseMask, typename PropertiesT>
+constexpr size_t getAlignment(PropertiesT Props) {
+  constexpr cache_hint L1Hint =
+      getCacheHint<sycl::ext::intel::esimd::cache_hint_L1_key>(Props);
+  constexpr cache_hint L2Hint =
+      getCacheHint<sycl::ext::intel::esimd::cache_hint_L2_key>(Props);
+  constexpr bool RequiresPVC =
+      L1Hint != cache_hint::none || L2Hint != cache_hint::none || UseMask;
+
+  constexpr bool IsMaxLoadSizePVC = RequiresPVC && (N * sizeof(T) > 256);
+  constexpr size_t RequiredAlignment =
+      IsMaxLoadSizePVC ? 8 : (RequiresPVC ? 4 : sizeof(T));
+  constexpr size_t RequestedAlignment = getAlignment(Props, RequiredAlignment);
+  static_assert(RequestedAlignment >= RequiredAlignment, "Too small alignment");
+  return RequestedAlignment;
+}

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_usm.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_usm.cpp
@@ -1,0 +1,37 @@
+//==------- block_store_usm.cpp - DPC++ ESIMD on-device test ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies esimd::block_store() functions accepting USM pointer
+// and optional compile-time esimd::properties.
+// The block_store() calls in this test do not use cache-hint
+// properties to not impose using PVC features.
+
+#include "Inputs/block_store.hpp"
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  constexpr bool TestPVCFeatures = true;
+  bool Passed = true;
+
+  Passed &= test_block_store<int8_t, !TestPVCFeatures>(Q);
+  Passed &= test_block_store<int16_t, !TestPVCFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp16))
+    Passed &= test_block_store<sycl::half, !TestPVCFeatures>(Q);
+  Passed &= test_block_store<uint32_t, !TestPVCFeatures>(Q);
+  Passed &= test_block_store<float, !TestPVCFeatures>(Q);
+  Passed &= test_block_store<int64_t, !TestPVCFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp64))
+    Passed &= test_block_store<double, !TestPVCFeatures>(Q);
+
+  std::cout << (Passed ? "Passed\n" : "FAILED\n");
+  return Passed ? 0 : 1;
+}

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_usm_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_usm_pvc.cpp
@@ -1,0 +1,42 @@
+//==--- block_store_usm_pvc.cpp - DPC++ ESIMD on-device test----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies esimd::block_store() functions accepting USM pointer
+// and optional compile-time esimd::properties.
+// The block_store() calls in this test use cache-hint
+// properties which require PVC+ target device.
+
+#include "Inputs/block_store.hpp"
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  constexpr bool TestPVCFeatures = true;
+  bool Passed = true;
+
+  Passed &= test_block_store<int8_t, TestPVCFeatures>(Q);
+  Passed &= test_block_store<int16_t, TestPVCFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp16))
+    Passed &= test_block_store<sycl::half, TestPVCFeatures>(Q);
+  Passed &= test_block_store<uint32_t, TestPVCFeatures>(Q);
+  Passed &= test_block_store<float, TestPVCFeatures>(Q);
+  Passed &= test_block_store<ext::intel::experimental::esimd::tfloat32,
+                             TestPVCFeatures>(Q);
+  Passed &= test_block_store<ext::intel::experimental::esimd::tfloat32,
+                             !TestPVCFeatures>(Q);
+  Passed &= test_block_store<int64_t, TestPVCFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp64))
+    Passed &= test_block_store<double, TestPVCFeatures>(Q);
+
+  std::cout << (Passed ? "Passed\n" : "FAILED\n");
+  return Passed ? 0 : 1;
+}


### PR DESCRIPTION
This change adds the groundwork for adding overloads of the block_store APIs accepting compile time properties. We have 8 overloads total, with various combinations of offset, predicate and simd_view.