### PR TITLE
[UR] Use the unified-runtime repo version of ur.hpp

### DIFF
--- a/sycl/plugins/unified_runtime/ur/ur.hpp
+++ b/sycl/plugins/unified_runtime/ur/ur.hpp
@@ -7,6 +7,10 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 
+#if defined(__HIP_PLATFORM_AMD__) || defined(CUDA_VERSION)
+#include_next <ur/ur.hpp>
+#else
+
 #include <atomic>
 #include <cassert>
 #include <cstdint>
@@ -283,3 +287,4 @@ protected:
   void *param_value;
   size_t *param_value_size_ret;
 };
+#endif


### PR DESCRIPTION
The in tree UR repo comes ahead of the _deps UR repo in the include path. `<ur/ur.hpp>` is in both repos so we want to get the most up to date version from the fetched UR repo (at least for HIP and CUDA)