### PR TITLE
[SYCL][InvokeSimd] Allow uniform structure arguments and return

### DIFF
--- a/sycl/test/invoke_simd/struct-arg.cpp
+++ b/sycl/test/invoke_simd/struct-arg.cpp
@@ -1,15 +1,14 @@
-// RUN: not %clangxx -fsycl -fsycl-device-only -S %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: not %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -Xclang -fsycl-allow-func-ptr -S %s -o /dev/null -DUNIFORM
+
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 #include <sycl/sycl.hpp>
 
 using namespace sycl::ext::oneapi::experimental;
 using namespace sycl;
 namespace esimd = sycl::ext::intel::esimd;
-
-[[intel::device_indirectly_callable]] void
-callee(simd<int, 8>, std::tuple<simd<int, 4>, simd<int, 4>>) {
-  return std::make_tuple(simd<int, 4>(), simd<int, 4>());
-}
+struct Foo {};
+[[intel::device_indirectly_callable]] void callee(simd<int, 8>, Foo) {}
 
 void foo() {
   constexpr unsigned Size = 1024;
@@ -20,13 +19,17 @@ void foo() {
   queue q;
   auto e = q.submit([&](handler &cgh) {
     cgh.parallel_for(Range, [=](nd_item<1> ndi) {
-      std::tuple<simd<int, 4>, simd<int, 4>> arg;
+      Foo arg;
+#ifdef UNIFORM
+      invoke_simd(ndi.get_sub_group(), callee, 0, uniform{arg});
+#else
       invoke_simd(ndi.get_sub_group(), callee, 0, arg);
+#endif
     });
   });
 }
 
 int main() {
   foo();
-  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement '!callable_has_struct_arg': invoke_simd does not support callables with structure arguments{{.*}}
+  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement '!has_non_uniform_struct_arg': Structure arguments must be uniform{{.*}}
 }


### PR DESCRIPTION
This is supposed to be allowed.

Uniform struct return already worked actually, I just reworded the error and function.