### PR TITLE
[DevOps] Fix CODEOWNERS after #11595

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -36,6 +36,7 @@ sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 
 # Level Zero plugin
 sycl/plugins/level_zero/ @intel/dpcpp-l0-pi-reviewers
+sycl/test-e2e/Plugin/*level-zero* @intel/dpcpp-l0-pi-reviewers
 
 # Unified Runtime plugin
 sycl/plugins/unified_runtime/ @intel/dpcpp-l0-pi-reviewers
@@ -84,6 +85,7 @@ esimd/ @intel/dpcpp-esimd-reviewers
 sycl/include/sycl/ext/intel/esimd.hpp @intel/dpcpp-esimd-reviewers
 sycl/doc/extensions/**/sycl_ext_intel_esimd/ @intel/dpcpp-esimd-reviewers
 llvm/lib/SYCLLowerIR/CMakeLists.txt @intel/dpcpp-tools-reviewers @intel/dpcpp-esimd-reviewers
+sycl/test-e2e/ESIMD/ @intel/dpcpp-esimd-reviewers
 
 # invoke_simd
 sycl/include/sycl/ext/oneapi/experimental/invoke_simd.hpp @intel/dpcpp-esimd-reviewers @rolandschulz
@@ -92,6 +94,7 @@ llvm/lib/SYCLLowerIR/LowerInvokeSimd.cpp @intel/dpcpp-esimd-reviewers
 llvm/include/llvm/SYCLLowerIR/LowerInvokeSimd.h @intel/dpcpp-esimd-reviewers
 invoke_simd/ @intel/dpcpp-esimd-reviewers
 InvokeSimd/ @intel/dpcpp-esimd-reviewers
+sycl/test-e2e/InvokeSimd/ @intel/dpcpp-esimd-reviewers
 
 # DevOps configs
 .github/ @intel/dpcpp-devops-reviewers
@@ -146,14 +149,10 @@ sycl/source/detail/bindless* @intel/bindless-images-reviewers
 sycl/plugins/unified_runtime/ur/adapters/**/image.* @intel/bindless-images-reviewers
 sycl/test-e2e/bindless_images/ @intel/bindless-images-reviewers
 
-# sycl e2e tests
-sycl/test-e2e/ @intel/llvm-reviewers-runtime
-sycl/test-e2e/Plugin/*level-zero* @intel/dpcpp-l0-pi-reviewers
-sycl/test-e2e/ESIMD/ @intel/dpcpp-esimd-reviewers
-sycl/test-e2e/InvokeSimd/ @intel/dpcpp-esimd-reviewers 
+# Miscellaneous sycl e2e tests
 sycl/test-e2e/BFloat16/ @intel/dpcpp-tools-reviewers @intel/llvm-reviewers-runtime
-sycl/test-e2e/AOT/ @intel/dpcpp-tools-reviewers 
-sycl/test-e2e/DeviceCodeSplit/ @intel/dpcpp-tools-reviewers 
+sycl/test-e2e/AOT/ @intel/dpcpp-tools-reviewers
+sycl/test-e2e/DeviceCodeSplit/ @intel/dpcpp-tools-reviewers
 sycl/test-e2e/SeparateCompile/ @intel/dpcpp-tools-reviewers
 sycl/test-e2e/Printf/ @intel/dpcpp-tools-reviewers @intel/llvm-reviewers-runtime
 sycl/test-e2e/SpecConstants/ @intel/dpcpp-tools-reviewers


### PR DESCRIPTION
That file is processed line-by-line, so `sycl/test-e2e` generic match by the end of it rewrites previous decisions. Don't do it.

Also, move plugin/esimd/invoke_simd e2e tests ownership to corresponding sections.