### PR TITLE
[SYCL][Driver] Enable SPV_INTEL_optnone extension for non-fpga targets

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9948,7 +9948,8 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
                 ",+SPV_INTEL_hw_thread_queries"
                 ",+SPV_KHR_uniform_group_instructions"
                 ",+SPV_INTEL_masked_gather_scatter"
-                ",+SPV_INTEL_tensor_float32_conversion";
+                ",+SPV_INTEL_tensor_float32_conversion"
+                ",+SPV_INTEL_optnone";
     if (ShouldPreserveMetadata)
       ExtArg += ",+SPV_KHR_non_semantic_info";
 

--- a/clang/test/Driver/sycl-spirv-ext.c
+++ b/clang/test/Driver/sycl-spirv-ext.c
@@ -54,7 +54,8 @@
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_hw_thread_queries
 // CHECK-DEFAULT-SAME:,+SPV_KHR_uniform_group_instructions
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_masked_gather_scatter
-// CHECK-DEFAULT-SAME:,+SPV_INTEL_tensor_float32_conversion"
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_tensor_float32_conversion
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_optnone"
 // CHECK-FPGA-HW: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_add
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_min_max


### PR DESCRIPTION
This fixes loss of optnone attribute when generating spirv in O0 mode.