### PR TITLE
[NFC][DEVOPS] CODEOWNERS: Remove esimd emulator plugin owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -41,9 +41,6 @@ sycl/test-e2e/Plugin/*level-zero* @intel/dpcpp-l0-pi-reviewers
 # Unified Runtime plugin
 sycl/plugins/unified_runtime/ @intel/dpcpp-l0-pi-reviewers
 
-# ESIMD CPU emulator plug-in
-sycl/plugins/esimd_emulator/ @intel/dpcpp-esimd-reviewers
-
 # CUDA and HIP plugins
 sycl/plugins/**/cuda/ @intel/llvm-reviewers-cuda
 sycl/plugins/**/hip/ @intel/llvm-reviewers-cuda


### PR DESCRIPTION
esimd emulator plugin was removed with https://github.com/intel/llvm/pull/11285. We can remove it from CODEOWNERS