### PR TITLE
[SYCL][NFC] Add `cuda` requirement for CUDA tests

### DIFF
--- a/sycl-fusion/test/kernel-fusion/check-failed-remapping-cuda.ll
+++ b/sycl-fusion/test/kernel-fusion/check-failed-remapping-cuda.ll
@@ -1,3 +1,4 @@
+; REQUIRES: cuda
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext \
 ; RUN:   -passes=sycl-kernel-fusion --sycl-info-path %S/check-remapping.yaml \
 ; RUN:   -S %s | FileCheck %s

--- a/sycl-fusion/test/kernel-fusion/check-remapping-cuda.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-cuda.ll
@@ -1,3 +1,4 @@
+; REQUIRES: cuda
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext \
 ; RUN:   -passes=sycl-kernel-fusion --sycl-info-path %S/check-remapping.yaml \
 ; RUN:   -S %s | FileCheck %s

--- a/sycl-fusion/test/kernel-fusion/check-remapping-interproc-cuda.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-interproc-cuda.ll
@@ -1,3 +1,4 @@
+; REQUIRES: cuda
 ; RUN: opt -load-pass-plugin %shlibdir/SYCLKernelFusion%shlibext \
 ; RUN:   -passes=sycl-kernel-fusion --sycl-info-path %S/check-remapping.yaml \
 ; RUN:   -S %s | FileCheck %s


### PR DESCRIPTION
Certain kernel fusion test cases fail when run using a compiler that's not configured with the `--cuda` flag. This change disables these test cases when there's no CUDA support.