### PR TITLE
[SYCL][Graph] Verbose E2E error messages

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/depends_on.cpp
+++ b/sycl/test-e2e/Graph/Explicit/depends_on.cpp
@@ -41,7 +41,7 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Ref, "Ref"));
+    assert(check_value(i, Ref, Output[i], "Output"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Explicit/depends_on.cpp
+++ b/sycl/test-e2e/Graph/Explicit/depends_on.cpp
@@ -37,11 +37,11 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  constexpr int ref = 42 * 2;
+  constexpr int Ref = 42 * 2;
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == ref);
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Ref, "Ref"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
@@ -82,7 +82,7 @@ int main() {
 
   const int Expected = 22;
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, Arr[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Arr[i], "Arr"));
   }
 
   // Free the allocated memory

--- a/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
@@ -80,8 +80,9 @@ int main() {
 
   Queue.wait();
 
+  const int Expected = 22;
   for (size_t i = 0; i < N; i++) {
-    assert(Arr[i] == 22);
+    assert(check_value(i, Arr[i], Expected, "Expected"));
   }
 
   // Free the allocated memory

--- a/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
@@ -42,8 +42,9 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), X, N * sizeof(int)).wait();
 
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 8);
+  const int Expected = 8;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   sycl::free(X, Queue);
 

--- a/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
@@ -44,7 +44,7 @@ int main() {
 
   const int Expected = 8;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   sycl::free(X, Queue);
 

--- a/sycl/test-e2e/Graph/Explicit/single_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/single_node.cpp
@@ -31,20 +31,22 @@ int main() {
 
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 0);
+  int Expected = 0;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   auto ExecGraph = Graph.finalize();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 0);
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 3);
+  Expected = 3;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Explicit/single_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/single_node.cpp
@@ -33,20 +33,20 @@ int main() {
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   int Expected = 0;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   auto ExecGraph = Graph.finalize();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   Expected = 3;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
@@ -85,8 +85,10 @@ int main() {
   free(PtrC, Queue);
   free(PtrOut, Queue);
 
-  assert(ReferenceC == DataC);
-  assert(ReferenceOut == DataOut);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+    assert(check_value(i, ReferenceOut[i], DataOut[i], "DataOut"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
@@ -51,9 +51,9 @@ int main() {
   host_accessor HostAccC(BufferC);
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == HostAccA[i]);
-    assert(ReferenceB[i] == HostAccB[i]);
-    assert(ReferenceC[i] == HostAccC[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
+    assert(check_value(i, ReferenceB[i], HostAccB[i], "HostAccB"));
+    assert(check_value(i, ReferenceC[i], HostAccC[i], "HostAccC"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
@@ -63,9 +63,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
@@ -58,9 +58,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
@@ -61,9 +61,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
@@ -58,9 +58,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
@@ -57,9 +57,11 @@ int main() {
   free(PtrB, Queue);
   delete[] PtrC;
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
@@ -16,7 +16,7 @@ int main() {
 
   // Create reference data for output
   std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
-  for (unsigned i = 0; i < Iterations; i++) {
+  for (size_t i = 0; i < Iterations; i++) {
     for (size_t j = 0; j < Size; j++) {
       ReferenceA[j] = ReferenceB[j];
       ReferenceA[j] += ModValue;
@@ -120,9 +120,9 @@ int main() {
   host_accessor HostAccC(BufferC);
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == HostAccA[i]);
-    assert(ReferenceB[i] == HostAccB[i]);
-    assert(ReferenceC[i] == HostAccC[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
+    assert(check_value(i, ReferenceB[i], HostAccB[i], "HostAccB"));
+    assert(check_value(i, ReferenceC[i], HostAccC[i], "HostAccC"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
@@ -17,7 +17,7 @@ int main() {
 
   // Create reference data for output
   std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
-  for (unsigned i = 0; i < Iterations; i++) {
+  for (size_t i = 0; i < Iterations; i++) {
     for (size_t j = 0; j < Size * Size; j++) {
       ReferenceA[j] = ReferenceB[j];
       ReferenceA[j] += ModValue;
@@ -116,9 +116,10 @@ int main() {
 
   for (size_t i = 0; i < Size; i++) {
     for (size_t j = 0; j < Size; j++) {
-      assert(ReferenceA[i * Size + j] == HostAccA[i][j]);
-      assert(ReferenceB[i * Size + j] == HostAccB[i][j]);
-      assert(ReferenceC[i * Size + j] == HostAccC[i][j]);
+      const size_t index = i * Size + j;
+      assert(check_value(index, ReferenceA[index], HostAccA[i][j], "HostAccA"));
+      assert(check_value(index, ReferenceB[index], HostAccB[i][j], "HostAccB"));
+      assert(check_value(index, ReferenceC[index], HostAccC[i][j], "HostAccC"));
     }
   }
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
@@ -38,7 +38,7 @@ int main() {
   host_accessor HostAccA(BufferA);
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == HostAccA[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
@@ -39,7 +39,8 @@ int main() {
 
   for (size_t i = 0; i < Size; i++) {
     for (size_t j = 0; j < Size; j++) {
-      assert(ReferenceA[i * Size + j] == HostAccA[i][j]);
+      const size_t index = i * Size + j;
+      assert(check_value(index, ReferenceA[index], HostAccA[i][j], "HostAccA"));
     }
   }
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
@@ -42,7 +42,7 @@ int main() {
   host_accessor HostAccA(BufferA);
 
   for (size_t i = 0; i < Size + Offset; i++) {
-    assert(ReferenceA[i] == HostAccA[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
@@ -53,8 +53,8 @@ int main() {
   host_accessor HostAccB(BufferB);
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == HostAccA[i]);
-    assert(ReferenceB[i] == HostAccB[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
+    assert(check_value(i, ReferenceB[i], HostAccB[i], "HostAccB"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
@@ -37,8 +37,8 @@ int main() {
   }
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == DataA[i]);
-    assert(ReferenceB[i] == DataB[i]);
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
@@ -40,8 +40,8 @@ int main() {
   host_accessor HostAccA(BufferA);
 
   for (size_t i = 0; i < Size * Size; i++) {
-    assert(ReferenceA[i] == DataA[i]);
-    assert(ReferenceB[i] == DataB[i]);
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
@@ -41,8 +41,8 @@ int main() {
   }
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == DataA[i]);
-    assert(ReferenceB[i] == DataB[i]);
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
@@ -46,7 +46,7 @@ int main() {
 
     const int Zero = 0;
     for (size_t i = 0; i < N; i++) {
-      assert(check_value(i, Arr[i], Zero, "Zero"));
+      assert(check_value(i, Zero, Arr[i], "Arr"));
     }
 
     // Buffer elements set to 4
@@ -61,7 +61,7 @@ int main() {
     auto ExecGraph = Graph.finalize();
 
     for (size_t i = 0; i < N; i++) {
-      assert(check_value(i, Arr[i], Zero, "Zero"));
+      assert(check_value(i, Zero, Arr[i], "Arr"));
     }
 
     // Buffer elements set to 8
@@ -99,7 +99,7 @@ int main() {
 
   const int Expected = 22;
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, Arr[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Arr[i], "Arr"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
@@ -44,8 +44,9 @@ int main() {
       });
     });
 
+    const int Zero = 0;
     for (size_t i = 0; i < N; i++) {
-      assert(Arr[i] == 0);
+      assert(check_value(i, Arr[i], Zero, "Zero"));
     }
 
     // Buffer elements set to 4
@@ -60,7 +61,7 @@ int main() {
     auto ExecGraph = Graph.finalize();
 
     for (size_t i = 0; i < N; i++) {
-      assert(Arr[i] == 0);
+      assert(check_value(i, Arr[i], Zero, "Zero"));
     }
 
     // Buffer elements set to 8
@@ -96,8 +97,9 @@ int main() {
     Queue.wait();
   }
 
+  const int Expected = 22;
   for (size_t i = 0; i < N; i++) {
-    assert(Arr[i] == 22);
+    assert(check_value(i, Arr[i], Expected, "Expected"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/double_buffer.cpp
@@ -56,7 +56,7 @@ int main() {
   add_nodes(GraphUpdate, Queue, Size, PtrA, PtrB, PtrC);
 
   event Event;
-  for (unsigned i = 0; i < Iterations; i++) {
+  for (size_t i = 0; i < Iterations; i++) {
     Event = Queue.submit([&](handler &CGH) {
       CGH.depends_on(Event);
       CGH.ext_oneapi_graph(ExecGraph);
@@ -90,13 +90,15 @@ int main() {
   free(PtrB2, Queue);
   free(PtrC2, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
 
-  assert(ReferenceA2 == DataA2);
-  assert(ReferenceB2 == DataB2);
-  assert(ReferenceC2 == DataC2);
+    assert(check_value(i, ReferenceA2[i], DataA2[i], "DataA2"));
+    assert(check_value(i, ReferenceB2[i], DataB2[i], "DataB2"));
+    assert(check_value(i, ReferenceC2[i], DataC2[i], "DataC2"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Inputs/empty_node.cpp
@@ -52,7 +52,7 @@ int main() {
 
   const int Expected = 1;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, HostData[i], Expected, "Expected"));
+    assert(check_value(i, Expected, HostData[i], "HostData"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Inputs/empty_node.cpp
@@ -50,8 +50,9 @@ int main() {
   std::vector<int> HostData(N);
   Queue.memcpy(HostData.data(), Arr, N * sizeof(int)).wait();
 
-  for (int i = 0; i < N; i++)
-    assert(HostData[i] == 1);
+  const int Expected = 1;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, HostData[i], Expected, "Expected"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
@@ -137,9 +137,9 @@ int main() {
   host_accessor HostAccC(BufferC);
 
   for (size_t i = 0; i < Size; i++) {
-    assert(ReferenceA[i] == HostAccA[i]);
-    assert(ReferenceB[i] == HostAccB[i]);
-    assert(ReferenceC[i] == HostAccC[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
+    assert(check_value(i, ReferenceB[i], HostAccB[i], "HostAccB"));
+    assert(check_value(i, ReferenceC[i], HostAccC[i], "HostAccC"));
   }
 
   return 0;

--- a/sycl/test-e2e/Graph/Inputs/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Inputs/executable_graph_update.cpp
@@ -89,13 +89,15 @@ int main() {
   free(PtrB2, Queue);
   free(PtrC2, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
 
-  assert(ReferenceA == DataA2);
-  assert(ReferenceB == DataB2);
-  assert(ReferenceC == DataC2);
+    assert(check_value(i, ReferenceA[i], DataA2[i], "DataA2"));
+    assert(check_value(i, ReferenceB[i], DataB2[i], "DataB2"));
+    assert(check_value(i, ReferenceC[i], DataC2[i], "DataC2"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/executable_graph_update_ordering.cpp
@@ -126,14 +126,16 @@ int main() {
   free(PtrB2, Queue);
   free(PtrC2, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
-  assert(ReferenceC == HostTaskOutput);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+    assert(check_value(i, ReferenceC[i], HostTaskOutput[i], "HostTaskOutput"));
 
-  assert(ReferenceA == DataA2);
-  assert(ReferenceB == DataB2);
-  assert(ReferenceC == DataC2);
+    assert(check_value(i, ReferenceA[i], DataA2[i], "DataA2"));
+    assert(check_value(i, ReferenceB[i], DataB2[i], "DataB2"));
+    assert(check_value(i, ReferenceC[i], DataC2[i], "DataC2"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/host_task.cpp
+++ b/sycl/test-e2e/Graph/Inputs/host_task.cpp
@@ -82,7 +82,9 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(Reference == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
@@ -54,9 +54,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/multiple_kernel_bundles.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_kernel_bundles.cpp
@@ -107,7 +107,7 @@ int main() {
 
   host_accessor HostAccA(BufferA);
   for (size_t i = 0; i < Size; i++)
-    assert(ReferenceA[i] == HostAccA[i]);
+    assert(check_value(i, ReferenceA[i], HostAccA[i], "HostAccA"));
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Inputs/queue_shortcuts.cpp
@@ -59,9 +59,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
@@ -22,26 +22,29 @@ int main() {
 
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 0);
+  int Expected = 0;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   auto ExecGraph = Graph.finalize();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 0);
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 1);
+  Expected = 1;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == 2);
+  Expected = 2;
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Expected, "Expected"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
@@ -24,27 +24,27 @@ int main() {
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   int Expected = 0;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   auto ExecGraph = Graph.finalize();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   Expected = 1;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   Expected = 2;
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
@@ -118,9 +118,12 @@ int main() {
   free(PtrC, Queue);
   free(PtrOut, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
-  assert(ReferenceOut == DataOut);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+    assert(check_value(i, ReferenceOut[i], DataOut[i], "DataOut"));
+  }
+
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
@@ -66,7 +66,7 @@ int main() {
 
   const int Ref = ((1 * 3 + 2) * 2 * 3 + 2) * -1;
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, Output[i], Ref, "Ref"));
+    assert(check_value(i, Ref, Output[i], "Output"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
@@ -64,9 +64,9 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), X, N * sizeof(int), Event3).wait();
 
-  const int ref = ((1 * 3 + 2) * 2 * 3 + 2) * -1;
+  const int Ref = ((1 * 3 + 2) * 2 * 3 + 2) * -1;
   for (size_t i = 0; i < N; i++) {
-    assert(Output[i] == ref);
+    assert(check_value(i, Output[i], Ref, "Ref"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
@@ -61,8 +61,9 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), X, N * sizeof(int), E).wait();
 
+  const int Expected = -5;
   for (size_t i = 0; i < N; i++) {
-    assert(Output[i] == -5);
+    assert(check_value(i, Output[i], Expected, "Expected"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
@@ -63,7 +63,7 @@ int main() {
 
   const int Expected = -5;
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
@@ -131,8 +131,8 @@ int main() {
   Queue.memcpy(Output.data(), Z, N * sizeof(int), E).wait();
 
   for (size_t i = 0; i < N; i++) {
-    int ref = reference(i);
-    assert(Output[i] == ref);
+    int Ref = reference(i);
+    assert(check_value(i, Output[i], Ref, "Ref"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
@@ -132,7 +132,7 @@ int main() {
 
   for (size_t i = 0; i < N; i++) {
     int Ref = reference(i);
-    assert(check_value(i, Output[i], Ref, "Ref"));
+    assert(check_value(i, Ref, Output[i], "Output"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
@@ -93,8 +93,8 @@ int main() {
 
   const int NegThree = -3;
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, OutputA[i], NegThree, "NegThree"));
-    assert(check_value(i, OutputB[i], refB(i), "refB"));
+    assert(check_value(i, NegThree, OutputA[i], "OutputA"));
+    assert(check_value(i, refB(i), OutputB[i], "OutputB"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
@@ -91,9 +91,10 @@ int main() {
     return result;
   };
 
+  const int NegThree = -3;
   for (size_t i = 0; i < N; i++) {
-    assert(OutputA[i] == -3);
-    assert(OutputB[i] == refB(i));
+    assert(check_value(i, OutputA[i], NegThree, "NegThree"));
+    assert(check_value(i, OutputB[i], refB(i), "refB"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
@@ -58,9 +58,11 @@ int main() {
     Queue.wait_and_throw();
   }
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
@@ -16,7 +16,7 @@ int main() {
 
   // Create reference data for output
   std::vector<T> ReferenceA(DataA), ReferenceB(DataB), ReferenceC(DataC);
-  for (unsigned i = 0; i < Iterations; i++) {
+  for (size_t i = 0; i < Iterations; i++) {
     for (size_t j = 0; j < Size; j++) {
       ReferenceA[j] = ReferenceB[j];
       ReferenceA[j] += ModValue;
@@ -115,9 +115,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
@@ -22,7 +22,7 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Output[i], Pattern, "Pattern"));
+    assert(check_value(i, Pattern, Output[i], "Output"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
@@ -21,8 +21,8 @@ int main() {
 
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
-  for (int i = 0; i < N; i++)
-    assert(Output[i] == Pattern);
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Output[i], Pattern, "Pattern"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
@@ -23,7 +23,7 @@ int main() {
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Arr[i], Pattern, "Pattern"));
+    assert(check_value(i, Pattern, Arr[i], "Arr"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
@@ -22,8 +22,8 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  for (int i = 0; i < N; i++)
-    assert(Arr[i] == Pattern);
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Arr[i], Pattern, "Pattern"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
@@ -24,7 +24,7 @@ int main() {
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
   for (size_t i = 0; i < N; i++)
-    assert(check_value(i, Arr[i], Pattern, "Pattern"));
+    assert(check_value(i, Pattern, Arr[i], "Arr"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
@@ -23,8 +23,8 @@ int main() {
 
   Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(ExecGraph); }).wait();
 
-  for (int i = 0; i < N; i++)
-    assert(Arr[i] == Pattern);
+  for (size_t i = 0; i < N; i++)
+    assert(check_value(i, Arr[i], Pattern, "Pattern"));
 
   sycl::free(Arr, Queue);
 

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -67,9 +67,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -113,9 +113,11 @@ int main() {
   free(PtrB, Queue);
   free(PtrC, Queue);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -79,7 +79,7 @@ int main() {
 
     host_accessor HostAccC(BufferC);
     for (size_t i = 0; i < Size; i++) {
-      assert(ReferenceC[i] == HostAccC[i]);
+      assert(check_value(i, ReferenceC[i], HostAccC[i], "HostAccC"));
     }
   }
 

--- a/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
@@ -45,7 +45,7 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, Output[i], ExpectedValue, "ExpectedValue"));
+    assert(check_value(i, ExpectedValue, Output[i], "Output"));
   }
 
   sycl::free(Arr, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
@@ -45,7 +45,7 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Arr, N * sizeof(int)).wait();
   for (size_t i = 0; i < N; i++) {
-    assert(Output[i] == ExpectedValue);
+    assert(check_value(i, Output[i], ExpectedValue, "ExpectedValue"));
   }
 
   sycl::free(Arr, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -76,8 +76,9 @@ int main() {
   std::vector<int> Output(N);
   Queue.memcpy(Output.data(), Z, N * sizeof(int)).wait();
 
+  const int Expected = 2;
   for (size_t i = 0; i < N; i++) {
-    assert(Output[i] == 2);
+    assert(check_value(i, Output[i], Expected, "Expected"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -78,7 +78,7 @@ int main() {
 
   const int Expected = 2;
   for (size_t i = 0; i < N; i++) {
-    assert(check_value(i, Output[i], Expected, "Expected"));
+    assert(check_value(i, Expected, Output[i], "Output"));
   }
 
   sycl::free(X, Queue);

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -432,3 +432,16 @@ private:
   std::condition_variable cv;
   std::size_t threadNum;
 };
+
+template <typename T>
+bool inline check_value(const size_t index, const T &Ref, const T &Got,
+                        const std::string &VariableName) {
+  if (Got != Ref) {
+    std::cout << "Unexpected value at index " << index << " for "
+              << VariableName << ": " << Got << " (got) vs " << Ref
+              << " (expected)" << std::endl;
+    return false;
+  }
+
+  return true;
+}

--- a/sycl/test-e2e/Graph/submission_while_executing.cpp
+++ b/sycl/test-e2e/Graph/submission_while_executing.cpp
@@ -115,9 +115,11 @@ int main() {
   calculate_reference_data(NumIterations + SuccessfulSubmissions, LargeSize,
                            ReferenceA, ReferenceB, ReferenceC);
 
-  assert(ReferenceA == DataA);
-  assert(ReferenceB == DataB);
-  assert(ReferenceC == DataC);
+  for (size_t i = 0; i < Size; i++) {
+    assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
+    assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
+    assert(check_value(i, ReferenceC[i], DataC[i], "DataC"));
+  }
 
   return 0;
 }


### PR DESCRIPTION
The current error output from Graph E2E tests isn't particularly informative on the data that caused an assert to fail verification. As asserts are done on the whole container, rather than individual values. This change verifies each value individually so that a
more informative error message can be printed when the assert fails. This is helpful for debugging
issues that appear in CI but are hard to reproduce locally.