### PR TITLE
[SYCL][CUDA][HIP] Fix enable-global-offset flag

### DIFF
--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -59,9 +59,9 @@ ModulePass *llvm::createGlobalOffsetPassLegacy() {
   return new GlobalOffsetLegacy();
 }
 
-// Recursive helper function to collect Loads from GEPs in a BFS fashion. 
+// Recursive helper function to collect Loads from GEPs in a BFS fashion.
 static void getLoads(Instruction *P, SmallVectorImpl<Instruction *> &Traversed,
-              SmallVectorImpl<LoadInst *> &Loads) {
+                     SmallVectorImpl<LoadInst *> &Loads) {
   Traversed.push_back(P);
   if (auto *L = dyn_cast<LoadInst>(P)) // Base case for recursion
     Loads.push_back(L);

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -96,6 +96,8 @@ PreservedAnalyses GlobalOffsetPass::run(Module &M, ModuleAnalysisManager &) {
     for (LoadInst *L : LI)
       L->replaceAllUsesWith(ConstantInt::get(L->getType(), 0));
 
+    // PtrUses is returned by `getLoads` in topological order.
+    // Walk it backwards so we don't violate users
     for (auto *I : reverse(PtrUses))
       I->eraseFromParent();
 

--- a/llvm/test/CodeGen/AMDGPU/global-offset-removal.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-removal.ll
@@ -1,0 +1,18 @@
+; RUN: opt -bugpoint-enable-legacy-pm -globaloffset -enable-global-offset=false %s -S -o - | FileCheck %s
+
+; This test checks that the implicit offset intrinsic is correctly removed
+
+declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+; CHECK-NOT: llvm.amdgcn.implicit.offset
+
+define weak_odr dso_local i64 @_ZTS14example_kernel() {
+entry:
+; CHECK-NOT: @llvm.amdgcn.implicit.offset()
+; CHECK-NOT: getelementptr
+; CHECK-NOT: load
+  %0 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+  %1 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 1
+  %2 = load i32, ptr addrspace(5) %1, align 4
+  %3 = zext i32 %2 to i64
+  ret i64 %3
+}

--- a/llvm/test/CodeGen/AMDGPU/global-offset-removal.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-removal.ll
@@ -10,6 +10,8 @@ entry:
 ; CHECK-NOT: @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: getelementptr
 ; CHECK-NOT: load
+; CHECK: [[REG:%[0-9]+]] = zext i{{[0-9]+}} 0 to i{{[0-9]+}}
+; CHECK: ret i{{[0-9]+}} [[REG]]
   %0 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
   %1 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 1
   %2 = load i32, ptr addrspace(5) %1, align 4

--- a/llvm/test/CodeGen/NVPTX/global-offset-removal.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-removal.ll
@@ -11,6 +11,8 @@ entry:
 ; CHECK-NOT: @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: getelementptr
 ; CHECK-NOT: load
+; CHECK: [[REG:%[0-9]+]] = zext i{{[0-9]+}} 0 to i{{[0-9]+}}
+; CHECK: ret i{{[0-9]+}} [[REG]]
   %0 = tail call ptr @llvm.nvvm.implicit.offset()
   %1 = getelementptr inbounds i32, ptr %0, i64 1
   %2 = load i32, ptr %1, align 4

--- a/llvm/test/CodeGen/NVPTX/global-offset-removal.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-removal.ll
@@ -1,0 +1,19 @@
+; RUN: opt -bugpoint-enable-legacy-pm -globaloffset -enable-global-offset=false %s -S -o - | FileCheck %s
+target triple = "nvptx64-nvidia-cuda"
+
+; This test checks that the implicit offset intrinsic is correctly removed
+
+declare ptr @llvm.nvvm.implicit.offset()
+; CHECK-NOT: llvm.nvvm.implicit.offset
+
+define weak_odr dso_local i64 @_ZTS14example_kernel() {
+entry:
+; CHECK-NOT: @llvm.nvvm.implicit.offset()
+; CHECK-NOT: getelementptr
+; CHECK-NOT: load
+  %0 = tail call ptr @llvm.nvvm.implicit.offset()
+  %1 = getelementptr inbounds i32, ptr %0, i64 1
+  %2 = load i32, ptr %1, align 4
+  %3 = zext i32 %2 to i64
+  ret i64 %3
+}


### PR DESCRIPTION
- Modify the globaloffset pass to remove calls to the `llvm.nvvm.implicit.offset` and `llvm.amdgcn.implicit.offset` from the IR during the SYCL  globaloffset pass when `-enable-global-offset=false`. 
Remove their respective uses, i.e. GEPs and Loads and replace further uses of the latter with 0 constants.
Ensure that these intrinsics do not occur anymore during target lowering.
Before, in some cases a compilation error was thrown because the intrinsic could not be selected for the AMDGPU and NVPTX targets.
Based on the inspection of the IR, any calls of the intrinsic were probably expected to be fully removed after the globaloffset pass.

- Replace Loads from the intrinsic with known constants and enable further optimization of the IR to remove dead code.
  In our observed cases, several kernels with implicit global offset failed to remove useless stores to the stack.