### PR TITLE
[SYCL][Joint Matrix] Remove SG size attribute

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/element_wise_abc.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_abc.cpp
@@ -10,9 +10,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
+#include "../common.hpp"
 #include <cstddef>
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_abc_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops.cpp
@@ -10,15 +10,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_all_ops_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_half.cpp
@@ -11,15 +11,12 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_all_ops_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8.cpp
@@ -10,15 +10,12 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_all_ops_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8_packed.cpp
@@ -12,15 +12,12 @@
 
 // This test stores the matrix B that is VNNIed (packed).
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_all_ops_int8_packed_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
@@ -10,14 +10,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_all_ops_tf32_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_sizes.cpp
@@ -10,14 +10,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 
 #include "../element_wise_all_sizes_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/element_wise_ops.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_ops.cpp
@@ -10,13 +10,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../element_wise_ops_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/get_coord_float_matC.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coord_float_matC.cpp
@@ -12,12 +12,10 @@
 // XFAIL: cpu
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../get_coord_float_matC_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/get_coord_int8_matA.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coord_int8_matA.cpp
@@ -12,12 +12,10 @@
 // XFAIL: cpu
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../get_coord_int8_matA_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/get_coord_int8_matB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coord_int8_matB.cpp
@@ -13,12 +13,10 @@
 // XFAIL: *
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../get_coord_int8_matB_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_all_sizes.cpp
@@ -11,12 +11,10 @@
 // RUN: %{run} %t.out
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 // Sub-matrix N dimension
 static constexpr size_t SN = 16;
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
@@ -10,15 +10,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-constexpr size_t SG_SZ = 32;
-constexpr size_t TN = 16;
+#define SG_SZ 32
 
 #include "../joint_matrix_apply_bf16_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache.cpp
@@ -13,7 +13,7 @@
 #include "../common.hpp"
 #include <cstddef>
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache_init.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache_init.cpp
@@ -13,7 +13,7 @@
 #include "../common.hpp"
 #include <cstddef>
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache_unroll.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache_unroll.cpp
@@ -19,7 +19,7 @@
 #include "../common.hpp"
 #include <cstddef>
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
@@ -16,7 +16,7 @@
 #include "../common.hpp"
 #include <cstddef>
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16.cpp
@@ -11,14 +11,10 @@
 // RUN: %{run} %t.out
 
 #include "../common.hpp"
-#include <iostream>
-#include <sycl/sycl.hpp>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bfloat16_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_16x16x16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_16x16x16.cpp
@@ -14,7 +14,6 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
 #define SG_SZ 32

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_array.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_array.cpp
@@ -13,7 +13,7 @@
 #include "../common.hpp"
 #include <cstddef>
 
-constexpr std::size_t SG_SZ = 32;
+#define SG_SZ 32
 static constexpr int TN = 16;
 
 #include "../joint_matrix_bfloat16_array_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
@@ -16,14 +16,10 @@
 // XFAIL: gpu
 
 #include "../common.hpp"
-#include <iostream>
-#include <sycl/sycl.hpp>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_rowmajorA_rowmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_rowmajorA_rowmajorB.cpp
@@ -17,10 +17,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_colA_rowB_colC.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_colA_rowB_colC.cpp
@@ -14,7 +14,7 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_colA_rowB_colC_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_down_convert.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_down_convert.cpp
@@ -12,6 +12,6 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 
 #include "../joint_matrix_down_convert_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_half.cpp
@@ -13,10 +13,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -17,10 +17,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_int8_colmajorA_colmajorB_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_vnni.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_int8_vnni.cpp
@@ -14,10 +14,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_int8_vnni_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_out_bounds.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_out_bounds.cpp
@@ -14,7 +14,7 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 constexpr size_t MATRIX_K = 1024 + 24;
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_ss_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_ss_int8.cpp
@@ -12,10 +12,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_ss_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_su_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_su_int8.cpp
@@ -12,10 +12,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_su_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_tf32.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_tf32.cpp
@@ -14,10 +14,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_tf32_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_transposeC.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_transposeC.cpp
@@ -14,7 +14,7 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_transposeC_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_unaligned_k.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_unaligned_k.cpp
@@ -14,7 +14,7 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 static constexpr size_t MATRIX_K = 1024 + 14;
 

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_us_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_us_int8.cpp
@@ -12,10 +12,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_us_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_uu_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_uu_int8.cpp
@@ -12,10 +12,9 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 32;
+#define SG_SZ 32
 constexpr size_t TN = 16;
 
 #include "../joint_matrix_uu_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_abc.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_abc.cpp
@@ -10,9 +10,9 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
+#include "../common.hpp"
 #include <cstddef>
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_abc_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops.cpp
@@ -11,15 +11,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_all_ops_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_half.cpp
@@ -11,15 +11,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_all_ops_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
@@ -11,15 +11,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_all_ops_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
@@ -13,15 +13,11 @@
 
 // This test stores the matrix B that is VNNIed (packed).
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_all_ops_int8_packed_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
@@ -11,15 +11,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_all_sizes_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_ops.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_ops.cpp
@@ -11,12 +11,9 @@
 // RUN: %{run} %t.out
 
 #include <iostream>
-#include <sycl/sycl.hpp>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../element_wise_ops_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/get_coord_float_matC.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/get_coord_float_matC.cpp
@@ -12,12 +12,9 @@
 // XFAIL: cpu
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 
 #include "../get_coord_float_matC_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/get_coord_int8_matA.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/get_coord_int8_matA.cpp
@@ -12,12 +12,9 @@
 // XFAIL: cpu
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 
 #include "../get_coord_int8_matA_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/get_coord_int8_matB.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/get_coord_int8_matB.cpp
@@ -12,12 +12,9 @@
 // XFAIL: *
 
 #include "../common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 
 #include "../get_coord_int8_matB_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_all_sizes.cpp
@@ -12,10 +12,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t SN = 8;
 
 #include "../joint_matrix_all_sizes_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_apply_bf16.cpp
@@ -10,15 +10,8 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
-
-#define SG_SZ 8
-constexpr size_t TN = 8;
 
 #include "../joint_matrix_apply_bf16_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache.cpp
@@ -13,7 +13,6 @@
 #include "../common.hpp"
 #include <cstddef>
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_init.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_init.cpp
@@ -13,7 +13,6 @@
 #include "../common.hpp"
 #include <cstddef>
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll.cpp
@@ -16,7 +16,6 @@
 #include "../common.hpp"
 #include <cstddef>
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
@@ -16,7 +16,6 @@
 #include "../common.hpp"
 #include <cstddef>
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bfloat16.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bfloat16.cpp
@@ -12,10 +12,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_bfloat16_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bfloat16_32x64.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bfloat16_32x64.cpp
@@ -14,10 +14,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_bfloat16_32x64_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bfloat16_array.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bfloat16_array.cpp
@@ -12,7 +12,6 @@
 
 #include "../common.hpp"
 
-#define SG_SZ 8
 static constexpr int TN = 8;
 
 #include "../joint_matrix_bfloat16_array_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_colA_rowB_colC.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_colA_rowB_colC.cpp
@@ -14,7 +14,6 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_colA_rowB_colC_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_half.cpp
@@ -13,10 +13,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_int8_vnni.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_int8_vnni.cpp
@@ -14,10 +14,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_int8_vnni_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_out_bounds.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_out_bounds.cpp
@@ -14,7 +14,6 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 static constexpr size_t MATRIX_K = 1024 + 24;
 

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_ss_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_ss_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_ss_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_su_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_su_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_su_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_transposeC.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_transposeC.cpp
@@ -14,7 +14,6 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_transposeC_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_unaligned_k.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_unaligned_k.cpp
@@ -14,7 +14,6 @@
 
 #include "../common.hpp"
 
-constexpr size_t SG_SZ = 8;
 constexpr size_t TN = 8;
 constexpr size_t MATRIX_K = 1024 + 14;
 

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_us_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_us_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_us_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_uu_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_uu_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "../common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 8
 constexpr size_t TN = 8;
 
 #include "../joint_matrix_uu_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/common.hpp
+++ b/sycl/test-e2e/Matrix/common.hpp
@@ -3,6 +3,7 @@
 #include <random>
 #include <sycl/sycl.hpp>
 
+using namespace sycl;
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 
 // Most of the time, failures related to floating-point calculations (both float
@@ -155,4 +156,15 @@ bool matrix_compare(unsigned int rows, unsigned int cols, T1 *src, T2 *ref) {
     }
   }
   return true;
+}
+
+template <typename KernelName>
+size_t get_wg_size(queue q) {
+  auto KernelID = get_kernel_id<KernelName>();
+  auto KB =
+      get_kernel_bundle<bundle_state::executable>(q.get_context(), {KernelID});
+  auto kernel = KB.get_kernel(KernelID);
+
+  return kernel.template get_info<info::kernel_device_specific::max_sub_group_size>(
+      q.get_device());
 }

--- a/sycl/test-e2e/Matrix/element_wise_abc.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_abc.cpp
@@ -10,9 +10,9 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
+#include "common.hpp"
 #include <cstddef>
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_abc_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_ops.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops.cpp
@@ -10,15 +10,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_all_ops_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_half.cpp
@@ -11,15 +11,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_all_ops_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_half_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_half_impl.hpp
@@ -1,15 +1,7 @@
 #define TM 8
 #define TK 16
 
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-private:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
+class imatrix;
 
 template <typename T, size_t M, size_t N>
 void assert_ops_ref(host_accessor<T, 2, access::mode::read> C,
@@ -21,16 +13,24 @@ void assert_ops_ref(host_accessor<T, 2, access::mode::read> C,
              std::numeric_limits<float>::epsilon());
     }
 }
-template <typename T, size_t M, size_t N>
-void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const float ref) {
+
+template <typename T, size_t M, size_t N, typename OP>
+void matrix_verify_op(big_matrix<T, M, N> &A, const float ref, OP op) {
   buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
+
+  queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+  nd_range<2> r({M / TM, N / TN * wg_size}, {1, 1 * wg_size});
 
   q.submit([&](handler &cgh) {
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
 
-     cgh.parallel_for<class add_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<class imatrix>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);
@@ -41,191 +41,49 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
 
            joint_matrix_fill(sg, sub_a, 5);
 
-           joint_matrix_apply(sg, sub_a,
-                              [=](T &x) { x = x + static_cast<half>(2); });
+           joint_matrix_apply(sg, sub_a, op);
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
                accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const float ref) {
-  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class sub_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 5);
-
-           joint_matrix_apply(sg, sub_a,
-                              [=](T &x) { x = x - static_cast<half>(2); });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const float ref) {
-  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class mul_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 5);
-
-           joint_matrix_apply(sg, sub_a,
-                              [=](T &x) { x = x * static_cast<half>(3.0); });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const float ref) {
-  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class div_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 4);
-
-           joint_matrix_apply(sg, sub_a,
-                              [=](T &x) { x = x / static_cast<half>(2.0); });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                         const float ref) {
-  buffer<half, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class logic_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 5);
-
-           joint_matrix_apply(sg, sub_a, [](T &x) {
-             if (x) {
-               if (x > static_cast<half>(2.0) || x >= static_cast<half>(2.0) ||
-                   x < static_cast<half>(2.0) || x <= static_cast<half>(2.0)) {
-                 T val =
-                     (x != static_cast<half>(2.0)) ? x : static_cast<half>(2.0);
-                 val--;
-                 val++;
-                 if (x == static_cast<half>(2.0)) {
-                   val -= 2;
-                   val *= 3;
-                   val /= 2;
-                 } else {
-                   val += 2;
-                 }
-                 x = val;
-               }
-             }
-           });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-static constexpr size_t MATRIX_M = TM * 2;
-static constexpr size_t MATRIX_N = TN * 2;
-half A[MATRIX_M][MATRIX_N];
-float D[MATRIX_M][MATRIX_N];
-
-void matrix_ops_ref(float *D, int M, int N) {
-  for (int m = 0; m < M; m++)
-    for (int n = 0; n < N; n++) {
-      *(D + m * N + n) = 0;
-      *(D + m * N + n) *= 2;
-    }
 }
 
 int main() {
-
-  big_matrix<float, MATRIX_M, MATRIX_N> MD((float *)&D);
+  static constexpr size_t MATRIX_M = TM * 2;
+  static constexpr size_t MATRIX_N = TN * 2;
+  half A[MATRIX_M][MATRIX_N];
   big_matrix<half, MATRIX_M, MATRIX_N> MA((half *)&A);
 
-  size_t NDRangeM = MATRIX_M / TM;
-  size_t NDRangeN = MATRIX_N / TN;
-  queue q;
-  nd_range<2> r({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ});
-
-  matrix_verify_add<half, MATRIX_M, MATRIX_N>(q, MA, r, 7.0);
-  matrix_verify_sub<half, MATRIX_M, MATRIX_N>(q, MA, r, 3.0);
-  matrix_verify_mul<half, MATRIX_M, MATRIX_N>(q, MA, r, 15.0);
-  matrix_verify_div<half, MATRIX_M, MATRIX_N>(q, MA, r, 2.0);
-  matrix_verify_logic<half, MATRIX_M, MATRIX_N>(q, MA, r, 7.0);
+  matrix_verify_op<half, MATRIX_M, MATRIX_N>(
+      MA, 7.0, [=](auto &x) { x = x + static_cast<half>(2); });
+  matrix_verify_op<half, MATRIX_M, MATRIX_N>(
+      MA, 3.0, [=](auto &x) { x = x - static_cast<half>(2); });
+  matrix_verify_op<half, MATRIX_M, MATRIX_N>(
+      MA, 15.0, [=](auto &x) { x = x * static_cast<half>(3.0); });
+  matrix_verify_op<half, MATRIX_M, MATRIX_N>(
+      MA, 2.0, [=](auto &x) { x = x / static_cast<half>(2.0); });
+  matrix_verify_op<half, MATRIX_M, MATRIX_N>(MA, 7.0, [=](auto &x) {
+    if (x) {
+      if (x > static_cast<half>(2.0) || x >= static_cast<half>(2.0) ||
+          x < static_cast<half>(2.0) || x <= static_cast<half>(2.0)) {
+        half val = (x != static_cast<half>(2.0)) ? x : static_cast<half>(2.0);
+        val--;
+        val++;
+        if (x == static_cast<half>(2.0)) {
+          val -= 2;
+          val *= 3;
+          val /= 2;
+        } else {
+          val += 2;
+        }
+        x = val;
+      }
+    }
+  });
 
   return 0;
 }

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8.cpp
@@ -10,15 +10,11 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_all_ops_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8_impl.hpp
@@ -1,15 +1,7 @@
 #define TM 8
 #define TK 32
 
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-public:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
+class imatrix;
 
 template <typename T, size_t M, size_t N>
 void assert_ops_ref(host_accessor<T, 2, access::mode::read> C, const int ref) {
@@ -20,16 +12,24 @@ void assert_ops_ref(host_accessor<T, 2, access::mode::read> C, const int ref) {
              std::numeric_limits<int>::epsilon());
     }
 }
-template <typename T, size_t M, size_t N>
-void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
+
+template <typename T, size_t M, size_t N, typename OP>
+void matrix_verify_op(big_matrix<T, M, N> &A, const int ref, OP op) {
   buffer<int8_t, 2> bufA(A.get_data(), range<2>(M, N));
+
+  queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+  nd_range<2> r({M / TM, N / TN * wg_size}, {1, 1 * wg_size});
 
   q.submit([&](handler &cgh) {
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
 
-     cgh.parallel_for<class add_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<class imatrix>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);
@@ -40,177 +40,48 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
 
            joint_matrix_fill(sg, sub_a, 5);
 
-           joint_matrix_apply(sg, sub_a, [](T &x) { x = x + 2; });
+           joint_matrix_apply(sg, sub_a, op);
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
                accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
 }
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class sub_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 5);
-
-           joint_matrix_apply(sg, sub_a, [](T &x) { x = x - 2; });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class mul_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 5);
-
-           joint_matrix_apply(sg, sub_a, [](T &x) { x = x * 3; });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class div_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 4);
-
-           joint_matrix_apply(sg, sub_a, [](T &x) { x = x / 2; });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                         const int ref) {
-  buffer<int8_t, 2> bufA(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufA.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class logic_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, 5);
-
-           joint_matrix_apply(sg, sub_a, [](T &x) {
-             if (x) {
-               if (x > 2 || x >= 2 || x < 2 || x <= 2) {
-                 T val = (x != 2) ? x : 2;
-                 val--;
-                 val++;
-                 if (x == 2) {
-                   val -= 2;
-                   val *= 3;
-                   val /= 2;
-                 } else {
-                   val += 2;
-                 }
-                 x = val;
-               }
-             }
-           });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-               N);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufA.get_host_access(read_only), ref);
-}
-
-static constexpr size_t MATRIX_M = TM * 2;
-static constexpr size_t MATRIX_N = TN * 2;
-int8_t A[MATRIX_M][MATRIX_N];
-int D[MATRIX_M][MATRIX_N];
 
 int main() {
-
-  big_matrix<int, MATRIX_M, MATRIX_N> MD((int *)&D);
+  static constexpr size_t MATRIX_M = TM * 2;
+  static constexpr size_t MATRIX_N = TN * 2;
+  int8_t A[MATRIX_M][MATRIX_N];
   big_matrix<int8_t, MATRIX_M, MATRIX_N> MA((int8_t *)&A);
 
-  size_t NDRangeM = MATRIX_M / TM;
-  size_t NDRangeN = MATRIX_N / TN;
-  queue q;
-  nd_range<2> r({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ});
-
-  matrix_verify_add<int8_t, MATRIX_M, MATRIX_N>(q, MA, r, 7);
-  matrix_verify_sub<int8_t, MATRIX_M, MATRIX_N>(q, MA, r, 3);
-  matrix_verify_mul<int8_t, MATRIX_M, MATRIX_N>(q, MA, r, 15);
-  matrix_verify_div<int8_t, MATRIX_M, MATRIX_N>(q, MA, r, 2);
-  matrix_verify_logic<int8_t, MATRIX_M, MATRIX_N>(q, MA, r, 7);
+  matrix_verify_op<int8_t, MATRIX_M, MATRIX_N>(MA, 7,
+                                               [](auto &x) { x = x + 2; });
+  matrix_verify_op<int8_t, MATRIX_M, MATRIX_N>(MA, 3,
+                                               [](auto &x) { x = x - 2; });
+  matrix_verify_op<int8_t, MATRIX_M, MATRIX_N>(MA, 15,
+                                               [](auto &x) { x = x * 3; });
+  matrix_verify_op<int8_t, MATRIX_M, MATRIX_N>(MA, 2,
+                                               [](auto &x) { x = x / 2; });
+  matrix_verify_op<int8_t, MATRIX_M, MATRIX_N>(MA, 7, [](auto &x) {
+    if (x) {
+      if (x > 2 || x >= 2 || x < 2 || x <= 2) {
+        int8_t val = (x != 2) ? x : 2;
+        val--;
+        val++;
+        if (x == 2) {
+          val -= 2;
+          val *= 3;
+          val /= 2;
+        } else {
+          val += 2;
+        }
+        x = val;
+      }
+    }
+  });
 
   return 0;
 }

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
@@ -12,15 +12,11 @@
 
 // This test stores the matrix B that is VNNIed (packed).
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::intel;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_all_ops_int8_packed_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed_impl.hpp
@@ -1,15 +1,7 @@
 #define TM 8
 #define TK 32
 
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-public:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
+class imatrix;
 
 template <typename T, size_t M, size_t N>
 void assert_ops_ref(host_accessor<T, 2, access::mode::read> C, const int ref) {
@@ -20,207 +12,77 @@ void assert_ops_ref(host_accessor<T, 2, access::mode::read> C, const int ref) {
              std::numeric_limits<int>::epsilon());
     }
 }
-template <typename T, size_t M, size_t N>
-void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufB(A.get_data(), range<2>(M, N));
+
+template <typename T, size_t M, size_t N, typename OP>
+void matrix_verify_op(big_matrix<T, M, N> &A, const int ref, OP op) {
+  buffer<T, 2> bufB(A.get_data(), range<2>(M, N));
+
+  queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+  nd_range<2> r({M / TM, N / TN * wg_size}, {1, 1 * wg_size});
 
   q.submit([&](handler &cgh) {
      auto accA = bufB.get_access<access::mode::read_write>(cgh);
 
-     cgh.parallel_for<class add_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<class imatrix>(
+         r, [accA](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);
            const auto sg_starty = global_idy - spmd_item.get_local_id(1);
 
            sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, int8_t, use::b, TK, TN,
-                        layout::ext_intel_packed>
+           joint_matrix<sub_group, T, use::b, TK, TN, layout::ext_intel_packed>
                sub_b;
 
            joint_matrix_fill(sg, sub_b, 5);
 
-           joint_matrix_apply(sg, sub_b, [](int8_t &x) { x = x + 2; });
+           joint_matrix_apply(sg, sub_b, op);
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_b,
                accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
+                   (sg_startx * TM) * N * 4 + sg_starty / wg_size * TN * 4,
                N * 4);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
 }
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_sub(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufB(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufB.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class sub_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, int8_t, use::b, TK, TN,
-                        layout::ext_intel_packed>
-               sub_b;
-
-           joint_matrix_fill(sg, sub_b, 5);
-
-           joint_matrix_apply(sg, sub_b, [](int8_t &x) { x = x - 2; });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_b,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
-               N * 4);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_mul(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufB(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufB.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class mul_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, int8_t, use::b, TK, TN,
-                        layout::ext_intel_packed>
-               sub_b;
-
-           joint_matrix_fill(sg, sub_b, 5);
-
-           joint_matrix_apply(sg, sub_b, [](int8_t &x) { x = x * 3; });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_b,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
-               N * 4);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_div(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const int ref) {
-  buffer<int8_t, 2> bufB(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufB.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class div_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, int8_t, use::b, TK, TN,
-                        layout::ext_intel_packed>
-               sub_b;
-
-           joint_matrix_fill(sg, sub_b, 4);
-
-           joint_matrix_apply(sg, sub_b, [](int8_t &x) { x = x / 2; });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_b,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
-               N * 4);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
-}
-
-template <typename T, size_t M, size_t N>
-void matrix_verify_logic(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                         const int ref) {
-  buffer<int8_t, 2> bufB(A.get_data(), range<2>(M, N));
-
-  q.submit([&](handler &cgh) {
-     auto accA = bufB.get_access<access::mode::read_write>(cgh);
-
-     cgh.parallel_for<class logic_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, int8_t, use::b, TK, TN,
-                        layout::ext_intel_packed>
-               sub_b;
-
-           joint_matrix_fill(sg, sub_b, 5);
-
-           joint_matrix_apply(sg, sub_b, [](T &x) {
-             if (x) {
-               if (x > 2 || x >= 2 || x < 2 || x <= 2) {
-                 T val = (x != 2) ? x : 2;
-                 val--;
-                 val++;
-                 if (x == 2) {
-                   val -= 2;
-                   val *= 3;
-                   val /= 2;
-                 } else {
-                   val += 2;
-                 }
-                 x = val;
-               }
-             }
-           });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_b,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N * 4 + sg_starty / SG_SZ * TN * 4,
-               N * 4);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<T, M, N>(bufB.get_host_access(read_only), ref);
-}
-
-static constexpr size_t MATRIX_M = TM * 2;
-static constexpr size_t MATRIX_N = TN * 2;
-int8_t B[MATRIX_M][MATRIX_N];
-int D[MATRIX_M][MATRIX_N];
 
 int main() {
-
-  big_matrix<int, MATRIX_M, MATRIX_N> MD((int *)&D);
+  static constexpr size_t MATRIX_M = TM * 2;
+  static constexpr size_t MATRIX_N = TN * 2;
+  int8_t B[MATRIX_M][MATRIX_N];
   big_matrix<int8_t, MATRIX_M, MATRIX_N> MB((int8_t *)&B);
 
-  size_t NDRangeM = MATRIX_M / TM;
-  size_t NDRangeN = MATRIX_N / TN;
-  queue q;
-  nd_range<2> r({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ});
-
-  matrix_verify_add<int8_t, MATRIX_M, MATRIX_N>(q, MB, r, 7);
-  matrix_verify_sub<int8_t, MATRIX_M, MATRIX_N>(q, MB, r, 3);
-  matrix_verify_mul<int8_t, MATRIX_M, MATRIX_N>(q, MB, r, 15);
-  matrix_verify_div<int8_t, MATRIX_M, MATRIX_N>(q, MB, r, 2);
-  matrix_verify_logic<int8_t, MATRIX_M, MATRIX_N>(q, MB, r, 7);
+  matrix_verify_add<int8_t, MATRIX_M, MATRIX_N>(MB, 7,
+                                                [](int8_t &x) { x = x + 2; });
+  matrix_verify_sub<int8_t, MATRIX_M, MATRIX_N>(MB, 3,
+                                                [](int8_t &x) { x = x - 2; });
+  matrix_verify_mul<int8_t, MATRIX_M, MATRIX_N>(MB, 15,
+                                                [](int8_t &x) { x = x * 3; });
+  matrix_verify_div<int8_t, MATRIX_M, MATRIX_N>(MB, 2,
+                                                [](int8_t &x) { x = x / 2; });
+  matrix_verify_logic<int8_t, MATRIX_M, MATRIX_N>(MB, 7, [](T &x) {
+    if (x) {
+      if (x > 2 || x >= 2 || x < 2 || x <= 2) {
+        T val = (x != 2) ? x : 2;
+        val--;
+        val++;
+        if (x == 2) {
+          val -= 2;
+          val *= 3;
+          val /= 2;
+        } else {
+          val += 2;
+        }
+        x = val;
+      }
+    }
+  });
 
   return 0;
 }

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
@@ -10,14 +10,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_all_ops_tf32_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_tf32_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_tf32_impl.hpp
@@ -1,16 +1,6 @@
 #define TM 8
 #define TK 8
 
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-public:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
-
 template <typename T, size_t M, size_t N>
 void assert_ops_ref(host_accessor<T, 2, access::mode::read> C,
                     const float ref) {
@@ -21,16 +11,25 @@ void assert_ops_ref(host_accessor<T, 2, access::mode::read> C,
              std::numeric_limits<float>::epsilon());
     }
 }
-template <typename T, typename Ts, size_t M, size_t K>
-void matrix_verify_add(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
-                       const float ref) {
+
+template <typename T, typename Ts, size_t M, size_t K, class kernel_name,
+          typename OP>
+void matrix_verify_op(big_matrix<Ts, M, K> &A, const float ref, OP op) {
   buffer<Ts, 2> bufA(A.get_data(), range<2>(M, K));
+
+  queue q;
+  size_t wg_size = get_wg_size<kernel_name>(q);
+  nd_range<2> r({M / TM, K / TK * wg_size}, {1, 1 * wg_size});
 
   q.submit([&](handler &cgh) {
      sycl::accessor accA{bufA, cgh, sycl::read_write};
 
-     cgh.parallel_for<class add_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<kernel_name>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);
@@ -41,182 +40,50 @@ void matrix_verify_add(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
 
            joint_matrix_fill(sg, sub_a, round_to_tf32(5.0));
 
-           joint_matrix_apply(sg, sub_a,
-                              [&](float &x) { x = x + round_to_tf32(2); });
+           joint_matrix_apply(sg, sub_a, op);
 
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
                accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
+                   (sg_startx * TM) * K + sg_starty / wg_size * TK,
                K);
          }); // parallel for
    }).wait();
   assert_ops_ref<Ts, M, K>(bufA.get_host_access(sycl::read_only), ref);
 }
-
-template <typename T, typename Ts, size_t M, size_t K>
-void matrix_verify_sub(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
-                       const float ref) {
-  buffer<Ts, 2> bufA(A.get_data(), range<2>(M, K));
-
-  q.submit([&](handler &cgh) {
-     sycl::accessor accA{bufA, cgh, sycl::read_write};
-
-     cgh.parallel_for<class sub_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, round_to_tf32(5.0));
-
-           joint_matrix_apply(sg, sub_a,
-                              [&](float &x) { x = x - round_to_tf32(2); });
-
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
-               K);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<Ts, M, K>(bufA.get_host_access(sycl::read_only), ref);
-}
-
-template <typename T, typename Ts, size_t M, size_t K>
-void matrix_verify_mul(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
-                       const float ref) {
-  buffer<Ts, 2> bufA(A.get_data(), range<2>(M, K));
-
-  q.submit([&](handler &cgh) {
-     sycl::accessor accA{bufA, cgh, sycl::read_write};
-
-     cgh.parallel_for<class mul_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-           joint_matrix_fill(sg, sub_a, round_to_tf32(5.0));
-
-           joint_matrix_apply(sg, sub_a,
-                              [&](float &x) { x = x * round_to_tf32(3.0); });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
-               K);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<Ts, M, K>(bufA.get_host_access(sycl::read_only), ref);
-}
-
-template <typename T, typename Ts, size_t M, size_t K>
-void matrix_verify_div(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
-                       const float ref) {
-  buffer<Ts, 2> bufA(A.get_data(), range<2>(M, K));
-
-  q.submit([&](handler &cgh) {
-     sycl::accessor accA{bufA, cgh, sycl::read_write};
-
-     cgh.parallel_for<class div_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, round_to_tf32(4.0));
-
-           joint_matrix_apply(sg, sub_a,
-                              [&](float &x) { x = x / round_to_tf32(2); });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
-               K);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<Ts, M, K>(bufA.get_host_access(sycl::read_only), ref);
-}
-
-template <typename T, typename Ts, size_t M, size_t K>
-void matrix_verify_logic(queue q, big_matrix<Ts, M, K> &A, nd_range<2> &r,
-                         const float ref) {
-  buffer<Ts, 2> bufA(A.get_data(), range<2>(M, K));
-
-  q.submit([&](handler &cgh) {
-     sycl::accessor accA{bufA, cgh, sycl::read_write};
-     cgh.parallel_for<class logic_matrix>(
-         r, [accA](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
-           const auto global_idx = spmd_item.get_global_id(0);
-           const auto global_idy = spmd_item.get_global_id(1);
-           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
-
-           sub_group sg = spmd_item.get_sub_group();
-           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
-
-           joint_matrix_fill(sg, sub_a, round_to_tf32(5.0));
-
-           joint_matrix_apply(sg, sub_a, [&](float &x) {
-             if (x) {
-               if (x > 2 || x >= 2 || x < 2 || x <= 2) {
-                 float val = (x != 2) ? x : 2;
-                 val--;
-                 val++;
-                 if (x == 2) {
-                   val -= 2;
-                   val *= 3;
-                   val /= 2;
-                 } else {
-                   val += 2;
-                 }
-                 x = val;
-               }
-             }
-           });
-           ext::intel::experimental::matrix::joint_matrix_store(
-               sg, sub_a,
-               accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
-               K);
-         }); // parallel for
-   }).wait();
-  assert_ops_ref<Ts, M, K>(bufA.get_host_access(sycl::read_only), ref);
-}
-
-static constexpr size_t MATRIX_M = TM * 2;
-static constexpr size_t MATRIX_K = TK * 2;
-float A[MATRIX_M][MATRIX_K];
-float D[MATRIX_M][MATRIX_K];
 
 int main() {
-
-  big_matrix<float, MATRIX_M, MATRIX_K> MD((float *)&D);
+  static constexpr size_t MATRIX_M = TM * 2;
+  static constexpr size_t MATRIX_K = TK * 2;
+  float A[MATRIX_M][MATRIX_K];
   big_matrix<float, MATRIX_M, MATRIX_K> MA((float *)&A);
 
-  size_t NDRangeM = MATRIX_M / TM;
-  size_t NDRangeK = MATRIX_K / TK;
-  queue q;
-  nd_range<2> r({NDRangeM, NDRangeK * SG_SZ}, {1, 1 * SG_SZ});
-
-  matrix_verify_add<precision::tf32, float, MATRIX_M, MATRIX_K>(q, MA, r, 7.0);
-  matrix_verify_sub<precision::tf32, float, MATRIX_M, MATRIX_K>(q, MA, r, 3.0);
-  matrix_verify_mul<precision::tf32, float, MATRIX_M, MATRIX_K>(q, MA, r, 15.0);
-  matrix_verify_div<precision::tf32, float, MATRIX_M, MATRIX_K>(q, MA, r, 2.0);
-  matrix_verify_logic<precision::tf32, float, MATRIX_M, MATRIX_K>(q, MA, r,
-                                                                  7.0);
+  matrix_verify_op<precision::tf32, float, MATRIX_M, MATRIX_K, class jm_add>(
+      MA, 7.0, [&](float &x) { x = x + round_to_tf32(2); });
+  matrix_verify_op<precision::tf32, float, MATRIX_M, MATRIX_K, class jm_sub>(
+      MA, 3.0, [&](float &x) { x = x - round_to_tf32(2); });
+  matrix_verify_op<precision::tf32, float, MATRIX_M, MATRIX_K, class jm_mul>(
+      MA, 15.0, [&](float &x) { x = x * round_to_tf32(3.0); });
+  matrix_verify_op<precision::tf32, float, MATRIX_M, MATRIX_K, class jm_div>(
+      MA, 2.0, [&](float &x) { x = x / round_to_tf32(2); });
+  matrix_verify_op<precision::tf32, float, MATRIX_M, MATRIX_K, class jm_logic>(
+      MA, 7.0, [&](float &x) {
+        if (x) {
+          if (x > 2 || x >= 2 || x < 2 || x <= 2) {
+            float val = (x != 2) ? x : 2;
+            val--;
+            val++;
+            if (x == 2) {
+              val -= 2;
+              val *= 3;
+              val /= 2;
+            } else {
+              val += 2;
+            }
+            x = val;
+          }
+        }
+      });
 
   return 0;
 }

--- a/sycl/test-e2e/Matrix/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_sizes.cpp
@@ -10,14 +10,8 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
-
-#define SG_SZ 16
 
 #include "element_wise_all_sizes_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_all_sizes_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_sizes_impl.hpp
@@ -1,22 +1,5 @@
 static constexpr size_t M_MULTIPLIER = 16;
 
-static float make_fp32(bfloat16 x) {
-  unsigned int y = *((int *)&x);
-  y = y << 16;
-  float *res = reinterpret_cast<float *>(&y);
-  return *res;
-}
-
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-public:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
-
 template <typename T, size_t M, size_t N>
 void assert_ops_ref(host_accessor<T, 2, access::mode::read_write> C,
                     const T ref) {
@@ -32,7 +15,7 @@ void assert_ops_ref(host_accessor<T, 2, access::mode::read_write> C,
     }
 }
 
-template <typename T, typename T1, size_t TM, size_t TK>
+template <typename T, typename T1, size_t TM, size_t TK, class kernel_name>
 void matrix_verify_add(const T1 val1, const T1 val2, const T1 result) {
   static constexpr size_t M = TM * M_MULTIPLIER;
   static constexpr size_t K = 128;
@@ -40,8 +23,11 @@ void matrix_verify_add(const T1 val1, const T1 val2, const T1 result) {
 
   size_t NDRangeM = M / TM;
   size_t NDRangeK = K / TK;
+
   queue q;
-  nd_range<2> r({NDRangeM, NDRangeK * SG_SZ}, {1, 1 * SG_SZ});
+  size_t wg_size = get_wg_size<kernel_name>(q);
+
+  nd_range<2> r({NDRangeM, NDRangeK * wg_size}, {1, 1 * wg_size});
   big_matrix<T, M, K> A((T *)&MatA);
 
   buffer<T, 2> bufA(A.get_data(), range<2>(M, K));
@@ -49,8 +35,12 @@ void matrix_verify_add(const T1 val1, const T1 val2, const T1 result) {
   q.submit([&](handler &cgh) {
      sycl::accessor accA{bufA, cgh, sycl::read_write};
 
-     cgh.parallel_for(
-         r, [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<kernel_name>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);
@@ -66,41 +56,41 @@ void matrix_verify_add(const T1 val1, const T1 val2, const T1 result) {
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
                accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * K + sg_starty / SG_SZ * TK,
+                   (sg_startx * TM) * K + sg_starty / wg_size * TK,
                K);
          }); // parallel for
    }).wait();
   assert_ops_ref<T, M, K>(bufA.get_host_access(), result);
 }
 
-template <typename Ta, size_t tM, size_t tK> void add_ref() {
+template <typename Ta, size_t tM, size_t tK, class kernel_name> void add_ref() {
   if constexpr (std::is_same_v<Ta, bfloat16>) {
     // Tests whether 5 + 2 = 7 operation is successful.
-    matrix_verify_add<bfloat16, bfloat16, tM, tK>(bfloat16(5.0), bfloat16(2.0),
-                                                  bfloat16(7.0));
+    matrix_verify_add<bfloat16, bfloat16, tM, tK, kernel_name>(
+        bfloat16(5.0), bfloat16(2.0), bfloat16(7.0));
   }
   if constexpr (std::is_same_v<Ta, int8_t>) {
-    matrix_verify_add<int8_t, int, tM, tK>(5 /*val1*/, 2 /*val2*/,
-                                           7 /*result*/);
+    matrix_verify_add<int8_t, int, tM, tK, kernel_name>(5 /*val1*/, 2 /*val2*/,
+                                                        7 /*result*/);
   }
 }
 
 int main() {
-  add_ref<bfloat16, 1 /*TM*/, 16 /*TK*/>();
-  add_ref<bfloat16, 2 /*TM*/, 16 /*TK*/>();
-  add_ref<bfloat16, 3 /*TM*/, 16 /*TK*/>();
-  add_ref<bfloat16, 4 /*TM*/, 16 /*TK*/>();
-  add_ref<bfloat16, 5 /*TM*/, 16 /*TK*/>();
-  add_ref<bfloat16, 6 /*TM*/, 16 /*TK*/>();
-  add_ref<bfloat16, 7 /*TM*/, 16 /*TK*/>();
+  add_ref<bfloat16, 1 /*TM*/, 16 /*TK*/, bf16_1>();
+  add_ref<bfloat16, 2 /*TM*/, 16 /*TK*/, bf16_2>();
+  add_ref<bfloat16, 3 /*TM*/, 16 /*TK*/, bf16_3>();
+  add_ref<bfloat16, 4 /*TM*/, 16 /*TK*/, bf16_4>();
+  add_ref<bfloat16, 5 /*TM*/, 16 /*TK*/, bf16_5>();
+  add_ref<bfloat16, 6 /*TM*/, 16 /*TK*/, bf16_6>();
+  add_ref<bfloat16, 7 /*TM*/, 16 /*TK*/, bf16_7>();
 
-  add_ref<int8_t, 1 /*TM*/, 32 /*TK*/>();
-  add_ref<int8_t, 2 /*TM*/, 32 /*TK*/>();
-  add_ref<int8_t, 3 /*TM*/, 32 /*TK*/>();
-  add_ref<int8_t, 4 /*TM*/, 32 /*TK*/>();
-  add_ref<int8_t, 5 /*TM*/, 32 /*TK*/>();
-  add_ref<int8_t, 6 /*TM*/, 32 /*TK*/>();
-  add_ref<int8_t, 7 /*TM*/, 32 /*TK*/>();
+  add_ref<int8_t, 1 /*TM*/, 32 /*TK*/, int8_1>();
+  add_ref<int8_t, 2 /*TM*/, 32 /*TK*/, int8_2>();
+  add_ref<int8_t, 3 /*TM*/, 32 /*TK*/, int8_3>();
+  add_ref<int8_t, 4 /*TM*/, 32 /*TK*/, int8_4>();
+  add_ref<int8_t, 5 /*TM*/, 32 /*TK*/, int8_5>();
+  add_ref<int8_t, 6 /*TM*/, 32 /*TK*/, int8_6>();
+  add_ref<int8_t, 7 /*TM*/, 32 /*TK*/, int8_7>();
 
   std::cout << "Passed\n";
 }

--- a/sycl/test-e2e/Matrix/element_wise_ops.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_ops.cpp
@@ -10,13 +10,10 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "element_wise_ops_impl.hpp"

--- a/sycl/test-e2e/Matrix/element_wise_ops_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_ops_impl.hpp
@@ -1,15 +1,7 @@
 #define TM 8
 #define TK 32
 
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-public:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
+class imatrix;
 
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
@@ -30,15 +22,20 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N,
-          K](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -59,7 +56,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -70,7 +67,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                     (k * TK / 4) * (N * 4) + sg_starty / wg_size * TN * 4,
                  N * 4);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
@@ -78,7 +75,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/get_coord_float_matC.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_float_matC.cpp
@@ -12,12 +12,9 @@
 // XFAIL: cpu
 
 #include "common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 
 #include "get_coord_float_matC_impl.hpp"

--- a/sycl/test-e2e/Matrix/get_coord_float_matC_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_float_matC_impl.hpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 constexpr size_t TM = 8;
 
+class imatrix;
+
 // clang-format off
 /*
 Here's how the data is distributed for sub group size = 16 on PVC
@@ -25,13 +27,19 @@ void matrix_sum_rows(big_matrix<T1, M, N> &C, float *sum_rows) {
   buffer<float> sum_rows_v(sum_rows, M);
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto v = sum_rows_v.get_access<access::mode::read_write>(cgh);
 
-     cgh.parallel_for(
-         nd_range<2>({M / TM, N / TN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<class imatrix>(
+         nd_range<2>({M / TM, N / TN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -46,7 +54,7 @@ void matrix_sum_rows(big_matrix<T1, M, N> &C, float *sum_rows) {
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
 
            float sum_local_rows[M] = {0};
@@ -59,7 +67,7 @@ void matrix_sum_rows(big_matrix<T1, M, N> &C, float *sum_rows) {
              sum_local_rows[i] =
                  reduce_over_group(sg, sum_local_rows[i], sycl::plus<>());
              // only Groups leader perform the global reduction
-             if (global_idy % SG_SZ == 0) {
+             if (global_idy % wg_size == 0) {
                sycl::atomic_ref<float, sycl::memory_order::relaxed,
                                 sycl::memory_scope::device>
                    aref(v[i]);

--- a/sycl/test-e2e/Matrix/get_coord_int8_matA.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matA.cpp
@@ -12,12 +12,9 @@
 // XFAIL: cpu
 
 #include "common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 
 #include "get_coord_int8_matA_impl.hpp"

--- a/sycl/test-e2e/Matrix/get_coord_int8_matA_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matA_impl.hpp
@@ -9,6 +9,8 @@
 constexpr size_t TM = 8;
 constexpr size_t TK = 32;
 
+class imatrix;
+
 template <typename T, size_t M, size_t K>
 void sum_rows_ref(host_accessor<T, 2, access::mode::read_write> A,
                   host_accessor<int, 1, access::mode::read_write> sum_rows) {
@@ -71,45 +73,56 @@ W0 --> 0 0 1 1 2 2 3 3 .... 7 7
 // clang-format on
 
 template <typename T, size_t M, size_t K>
-void matrix_sum_rows(queue q, big_matrix<T, M, K> &A, nd_range<2> &r) {
+void matrix_sum_rows(big_matrix<T, M, K> &A) {
   buffer<int8_t, 2> bufA(A.get_data(), range<2>(M, K));
 
   // size of vector is equal to number of rows in big matrix
   int sum_rows[M] = {0};
   buffer<int> sum_rows_v(sum_rows, M);
+
+  queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+  nd_range<2> r({M / TM, K / TK * wg_size}, {1, 1 * wg_size});
+
   q.submit([&](handler &cgh) {
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto v = sum_rows_v.get_access<access::mode::atomic>(cgh);
 
-     cgh.parallel_for(r, [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(
-                             SG_SZ)]] {
-       const auto global_idx = spmd_item.get_global_id(0);
-       const auto global_idy = spmd_item.get_global_id(1);
-       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+     cgh.parallel_for<class imatrix>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
+           const auto global_idx = spmd_item.get_global_id(0);
+           const auto global_idy = spmd_item.get_global_id(1);
+           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
 
-       sycl::sub_group sg = spmd_item.get_sub_group();
-       joint_matrix<sub_group, int8_t, use::a, TM, TK, layout::row_major> sub_a;
-       joint_matrix_load(sg, sub_a,
-                         accA.template get_multi_ptr<access::decorated::no>() +
-                             (sg_startx * TM * K) + sg_starty / SG_SZ * TK,
-                         K);
+           sycl::sub_group sg = spmd_item.get_sub_group();
+           joint_matrix<sub_group, int8_t, use::a, TM, TK, layout::row_major>
+               sub_a;
+           joint_matrix_load(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM * K) + sg_starty / wg_size * TK,
+               K);
 
-       int32_t sum_local_rows[M] = {0};
+           int32_t sum_local_rows[M] = {0};
 
-       ext::intel::experimental::matrix::joint_matrix_apply(
-           sg, sub_a, [&](int8_t &x, size_t row, size_t col) {
-             sum_local_rows[row + global_idx * TM] += x;
-           });
-       for (int i = 0; i < M; ++i) {
-         sum_local_rows[i] =
-             reduce_over_group(sg, sum_local_rows[i], sycl::plus<>());
+           ext::intel::experimental::matrix::joint_matrix_apply(
+               sg, sub_a, [&](int8_t &x, size_t row, size_t col) {
+                 sum_local_rows[row + global_idx * TM] += x;
+               });
+           for (int i = 0; i < M; ++i) {
+             sum_local_rows[i] =
+                 reduce_over_group(sg, sum_local_rows[i], sycl::plus<>());
 
-         // only Groups leader performs the global reduction
-         if (global_idy % SG_SZ == 0)
-           atomic_fetch_add(v[i], sum_local_rows[i]);
-       }
-     }); // parallel for
+             // only Groups leader performs the global reduction
+             if (global_idy % wg_size == 0)
+               atomic_fetch_add(v[i], sum_local_rows[i]);
+           }
+         }); // parallel for
    }).wait();
   sum_rows_ref<T, M, K>(bufA.get_host_access(), sum_rows_v.get_host_access());
 }
@@ -121,18 +134,13 @@ int main() {
 
   big_matrix<int8_t, MATRIX_M, MATRIX_K> MA((int8_t *)&A);
 
-  size_t NDRangeM = MATRIX_M / TM;
-  size_t NDRangeK = MATRIX_K / TK;
-  queue q;
-  nd_range<2> r({NDRangeM, NDRangeK * SG_SZ}, {1, 1 * SG_SZ});
-
   for (int i = 0; i < MATRIX_M; i++) {
     for (int j = 0; j < MATRIX_K; j++) {
       A[i][j] = i + j;
     }
   }
 
-  matrix_sum_rows<int8_t, MATRIX_M, MATRIX_K>(q, MA, r);
+  matrix_sum_rows<int8_t, MATRIX_M, MATRIX_K>(MA);
   std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test-e2e/Matrix/get_coord_int8_matB.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matB.cpp
@@ -12,12 +12,9 @@
 // XFAIL: *
 
 #include "common.hpp"
-#include <iostream>
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 
 #include "get_coord_int8_matB_impl.hpp"

--- a/sycl/test-e2e/Matrix/get_coord_int8_matB_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matB_impl.hpp
@@ -8,6 +8,8 @@
 constexpr size_t TK = 32;
 constexpr size_t VF = 4;
 
+class imatrix;
+
 template <typename T, size_t K, size_t N>
 void sum_cols_ref(host_accessor<T, 2, access::mode::read_write> B,
                   host_accessor<int, 1, access::mode::read_write> sum_cols) {
@@ -92,55 +94,63 @@ wi [1,0] -->    i=0, [8, 0]
 // clang-format on
 
 template <typename T, size_t K, size_t N>
-void matrix_sum_cols(queue q, big_matrix<T, K, N> &B,
-                     big_matrix<T, K / VF, N * VF> &Bvnni, nd_range<2> &r) {
+void matrix_sum_cols(big_matrix<T, K, N> &B,
+                     big_matrix<T, K / VF, N * VF> &Bvnni) {
   buffer<int8_t, 2> bufB(B.get_data(), range<2>(K, N));
   buffer<int8_t, 2> bufBvnni(Bvnni.get_data(), range<2>(K / VF, N * VF));
 
   int sum_cols[N] = {0};
   buffer<int> sum_cols_v(sum_cols, N);
 
+  queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+  nd_range<2> r({K / TK, N / TN * wg_size}, {1, 1 * wg_size});
+
   q.submit([&](handler &cgh) {
      auto accB = bufBvnni.get_access<access::mode::read_write>(cgh);
      auto v = sum_cols_v.get_access<access::mode::atomic>(cgh);
 
-     cgh.parallel_for(r, [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(
-                             SG_SZ)]] {
-       const auto global_idx = spmd_item.get_global_id(0);
-       const auto global_idy = spmd_item.get_global_id(1);
-       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+     cgh.parallel_for<class imatrix>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
+           const auto global_idx = spmd_item.get_global_id(0);
+           const auto global_idy = spmd_item.get_global_id(1);
+           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
 
-       sycl::sub_group sg = spmd_item.get_sub_group();
+           sycl::sub_group sg = spmd_item.get_sub_group();
 
-       joint_matrix<sub_group, int8_t, use::b, TK, TN, layout::ext_intel_packed>
-           sub_b;
+           joint_matrix<sub_group, int8_t, use::b, TK, TN,
+                        layout::ext_intel_packed>
+               sub_b;
 
-       joint_matrix_load(sg, sub_b,
-                         accB.template get_multi_ptr<access::decorated::no>() +
-                             (sg_startx * (TK / VF) * N * VF) +
-                             sg_starty / SG_SZ * TN * VF,
-                         N * VF);
+           joint_matrix_load(
+               sg, sub_b,
+               accB.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * (TK / VF) * N * VF) +
+                   sg_starty / wg_size * TN * VF,
+               N * VF);
 
-       int32_t sum_local_cols[N] = {0};
-       ext::intel::experimental::matrix::joint_matrix_apply(
-           sg, sub_b, [&](int8_t &x, size_t row, size_t col) {
-             // the coordinates returned are in the logical range [K,N]
-             // If users want to retrieve the VNNIed coordinates, they can be
-             // obtained using
-             // colVNNI = col/VF
-             // rowVNNI = row*VF
-             size_t global_index = col + global_idy / SG_SZ * TN;
-             sum_local_cols[global_index] += x;
-           });
+           int32_t sum_local_cols[N] = {0};
+           ext::intel::experimental::matrix::joint_matrix_apply(
+               sg, sub_b, [&](int8_t &x, size_t row, size_t col) {
+                 // the coordinates returned are in the logical range [K,N]
+                 // If users want to retrieve the VNNIed coordinates, they can
+                 // be obtained using colVNNI = col/VF rowVNNI = row*VF
+                 size_t global_index = col + global_idy / wg_size * TN;
+                 sum_local_cols[global_index] += x;
+               });
 
-       for (int i = 0; i < N; i++) {
-         sum_local_cols[i] =
-             reduce_over_group(sg, sum_local_cols[i], sycl::plus<>());
-         if (global_idy % SG_SZ == 0)
-           atomic_fetch_add(v[i], sum_local_cols[i]);
-       }
-     }); // parallel for
+           for (int i = 0; i < N; i++) {
+             sum_local_cols[i] =
+                 reduce_over_group(sg, sum_local_cols[i], sycl::plus<>());
+             if (global_idy % wg_size == 0)
+               atomic_fetch_add(v[i], sum_local_cols[i]);
+           }
+         }); // parallel for
    }).wait();
   sum_cols_ref<T, K, N>(bufB.get_host_access(), sum_cols_v.get_host_access());
 }
@@ -156,11 +166,6 @@ int main() {
   int8_t Bvnni[MATRIX_K / VF][MATRIX_N * VF];
   big_matrix<int8_t, MATRIX_K / VF, MATRIX_N * VF> MBvnni((int8_t *)&Bvnni);
 
-  size_t NDRangeK = MATRIX_K / TK;
-  size_t NDRangeN = MATRIX_N / TN;
-  queue q;
-  nd_range<2> r({NDRangeK, NDRangeN * SG_SZ}, {1, 1 * SG_SZ});
-
   for (int i = 0; i < MATRIX_K; i++) {
     for (int j = 0; j < MATRIX_N; j++) {
       B[i][j] = i + j;
@@ -168,7 +173,7 @@ int main() {
   }
   matrix_vnni<int8_t>(MATRIX_K, MATRIX_N, *B, *Bvnni, VF);
   // This test calculates sum of columns in the non VNNI B matrix
-  matrix_sum_cols<int8_t, MATRIX_K, MATRIX_N>(q, MB, MBvnni, r);
+  matrix_sum_cols<int8_t, MATRIX_K, MATRIX_N>(MB, MBvnni);
   std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_all_sizes.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 // Sub-matrix N dimension
 static constexpr size_t SN = 16;
 

--- a/sycl/test-e2e/Matrix/joint_matrix_all_sizes_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_all_sizes_impl.hpp
@@ -1,7 +1,7 @@
 static constexpr size_t M_MULTIPLIER = 16;
 
 template <typename T1, typename T2, size_t M, size_t N, size_t K,
-          int vnniFactor, size_t TM, size_t TN, size_t TK>
+          int vnniFactor, size_t TM, size_t TN, size_t TK, class kernel_name>
 void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                      big_matrix<T2, K / vnniFactor, N * vnniFactor> &B) {
   size_t NDRangeM = M / TM;
@@ -11,15 +11,19 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
   buffer<T1, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<kernel_name>(q);
+
   q.submit([&](handler &cgh) {
      sycl::accessor accC{bufC, cgh, sycl::read_write};
      sycl::accessor accA{bufA, cgh, sycl::read_only};
      sycl::accessor accB{bufB, cgh, sycl::read_only};
 
-     cgh.parallel_for(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
-
+     cgh.parallel_for<class kernel_name>(
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -39,7 +43,7 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -51,21 +55,21 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
                      (k * TK / vnniFactor) * (N * vnniFactor) +
-                     sg_starty / SG_SZ * TN * vnniFactor,
+                     sg_starty / wg_size * TN * vnniFactor,
                  N * vnniFactor);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();
 }
 
 template <typename Ta, typename Tc, int vnni_factor, size_t tM, size_t tN,
-          size_t tK>
+          size_t tK, class kernel_name>
 int init_and_multiply() {
   static constexpr size_t MATRIX_M = tM * M_MULTIPLIER;
   static constexpr size_t MATRIX_N = 128;
@@ -92,7 +96,7 @@ int init_and_multiply() {
       (Ta *)&Bvnni);
 
   matrix_multiply<Tc, Ta, MATRIX_M, MATRIX_N, MATRIX_K, vnni_factor, tM, tN,
-                  tK>(MC, MA, MBvnni);
+                  tK, kernel_name>(MC, MA, MBvnni);
   matrix_multiply_ref((Ta *)A, (Ta *)B, (Tc *)D, MATRIX_M, MATRIX_N, MATRIX_K);
 
   bool res = matrix_compare(MATRIX_M, MATRIX_N, (Tc *)C, (Tc *)D);
@@ -102,23 +106,23 @@ int init_and_multiply() {
 
 int main() {
   int errors = 0;
-  errors += init_and_multiply<bfloat16, float, 2, 1, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 2, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 3, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 4, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 5, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 6, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 7, SN, 16>();
-  errors += init_and_multiply<bfloat16, float, 2, 8, SN, 16>();
+  errors += init_and_multiply<bfloat16, float, 2, 1, SN, 16, bf16_1>();
+  errors += init_and_multiply<bfloat16, float, 2, 2, SN, 16, bf16_2>();
+  errors += init_and_multiply<bfloat16, float, 2, 3, SN, 16, bf16_3>();
+  errors += init_and_multiply<bfloat16, float, 2, 4, SN, 16, bf16_4>();
+  errors += init_and_multiply<bfloat16, float, 2, 5, SN, 16, bf16_5>();
+  errors += init_and_multiply<bfloat16, float, 2, 6, SN, 16, bf16_6>();
+  errors += init_and_multiply<bfloat16, float, 2, 7, SN, 16, bf16_7>();
+  errors += init_and_multiply<bfloat16, float, 2, 8, SN, 16, bf16_8>();
 
-  errors += init_and_multiply<int8_t, int32_t, 4, 1, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 2, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 3, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 4, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 5, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 6, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 7, SN, 32>();
-  errors += init_and_multiply<int8_t, int32_t, 4, 8, SN, 32>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 1, SN, 32, int8_1>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 2, SN, 32, int8_2>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 3, SN, 32, int8_3>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 4, SN, 32, int8_4>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 5, SN, 32, int8_5>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 6, SN, 32, int8_6>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 7, SN, 32, int8_7>();
+  errors += init_and_multiply<int8_t, int32_t, 4, 8, SN, 32, int8_8>();
 
   return errors;
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_bf16.cpp
@@ -10,15 +10,8 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-#include <iostream>
-#include <random>
-#include <sycl/sycl.hpp>
+#include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
-using bfloat16 = sycl::ext::oneapi::bfloat16;
-
-#define SG_SZ 16
-constexpr size_t TN = 16;
 
 #include "joint_matrix_apply_bf16_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_bf16_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_bf16_impl.hpp
@@ -1,57 +1,43 @@
-
 #define TM 8
 #define TK 16
-
-static float make_fp32(bfloat16 x) {
-  unsigned int y = sycl::bit_cast<uint16_t>(x);
-  y = y << 16;
-  float *res = reinterpret_cast<float *>(&y);
-  return *res;
-}
-
-template <typename T, size_t NUM_ROWS, size_t NUM_COLS> struct big_matrix {
-public:
-  T *mat;
-
-public:
-  T *get_data() { return mat; }
-  void set_data(T *data) { mat = data; }
-  big_matrix(T *data) : mat(data) {}
-};
 
 template <typename T> struct apply_add {
   void operator()(T &x) const { x = x + bfloat16(2); }
 };
 
-template <typename T, size_t M, size_t N, typename F>
-void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
-                       const float ref, F &&lambda) {
-  buffer<bfloat16, 2> bufA(A.get_data(), range<2>(M, N));
+template <typename T, size_t M, size_t K, class kernel_name, typename F>
+void matrix_verify_add(big_matrix<T, M, K> &A, const float ref, F &&lambda) {
+  buffer<bfloat16, 2> bufA(A.get_data(), range<2>(M, K));
+
+  queue q;
+  size_t wg_size = get_wg_size<kernel_name>(q);
+  nd_range<2> r({M / TM, K / TK * wg_size}, {1, 1 * wg_size});
 
   q.submit([&](handler &cgh) {
      accessor accA{bufA, cgh};
 
-     cgh.parallel_for(r, [accA, lambda](
-                             nd_item<2> spmd_item) [[intel::reqd_sub_group_size(
-                             SG_SZ)]] {
-       const auto global_idx = spmd_item.get_global_id(0);
-       const auto global_idy = spmd_item.get_global_id(1);
-       const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-       const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+     cgh.parallel_for<kernel_name>(
+         r, [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+                [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
+           const auto global_idx = spmd_item.get_global_id(0);
+           const auto global_idy = spmd_item.get_global_id(1);
+           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
 
-       sub_group sg = spmd_item.get_sub_group();
-       joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
+           sub_group sg = spmd_item.get_sub_group();
+           joint_matrix<sub_group, T, use::a, TM, TK, layout::row_major> sub_a;
+           joint_matrix_fill(sg, sub_a, bfloat16(5.0));
+           joint_matrix_apply(sg, sub_a, lambda);
 
-       joint_matrix_fill(sg, sub_a, bfloat16(5.0));
-
-       joint_matrix_apply(sg, sub_a, lambda);
-
-       ext::intel::experimental::matrix::joint_matrix_store(
-           sg, sub_a,
-           accA.template get_multi_ptr<access::decorated::no>() +
-               (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-           N);
-     }); // parallel for
+           ext::intel::experimental::matrix::joint_matrix_store(
+               sg, sub_a,
+               accA.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * K + sg_starty / wg_size * TK,
+               K);
+         }); // parallel for
    }).wait();
   // Check if the results are correct
   {
@@ -63,33 +49,16 @@ void matrix_verify_add(queue q, big_matrix<T, M, N> &A, nd_range<2> &r,
   }
 }
 
-static constexpr size_t MATRIX_M = TM * 2;
-static constexpr size_t MATRIX_N = TN * 2;
-bfloat16 A[MATRIX_M][MATRIX_N];
-float D[MATRIX_M][MATRIX_N];
-
-void matrix_ops_ref(float *D, int M, int N) {
-  for (int m = 0; m < M; m++)
-    for (int n = 0; n < N; n++) {
-      *(D + m * N + n) = 0;
-      *(D + m * N + n) *= 2;
-    }
-}
-
 int main() {
+  static constexpr size_t MATRIX_M = TM * 2;
+  static constexpr size_t MATRIX_K = TK * 2;
+  bfloat16 A[MATRIX_M][MATRIX_K];
+  big_matrix<bfloat16, MATRIX_M, MATRIX_K> MA((bfloat16 *)&A);
 
-  big_matrix<float, MATRIX_M, MATRIX_N> MD((float *)&D);
-  big_matrix<bfloat16, MATRIX_M, MATRIX_N> MA((bfloat16 *)&A);
-
-  size_t NDRangeM = MATRIX_M / TM;
-  size_t NDRangeN = MATRIX_N / TN;
-  queue q;
-  nd_range<2> r({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ});
-
-  matrix_verify_add<bfloat16, MATRIX_M, MATRIX_N>(
-      q, MA, r, 7.0, [=](bfloat16 &x) { x = x + bfloat16(2); });
-  matrix_verify_add<bfloat16, MATRIX_M, MATRIX_N>(q, MA, r, 7.0,
-                                                  apply_add<bfloat16>());
+  matrix_verify_add<bfloat16, MATRIX_M, MATRIX_K, class add1>(
+      MA, 7.0, [=](bfloat16 &x) { x = x + bfloat16(2); });
+  matrix_verify_add<bfloat16, MATRIX_M, MATRIX_K, class add2>(
+      MA, 7.0, apply_add<bfloat16>());
   std::cout << "Passed\n";
   return 0;
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache.cpp
@@ -13,7 +13,6 @@
 #include "common.hpp"
 #include <cstddef>
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_init.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_init.cpp
@@ -12,7 +12,7 @@
 
 #include "common.hpp"
 #include <cstddef>
-#define SG_SZ 16
+
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll.cpp
@@ -19,7 +19,6 @@
 #include "common.hpp"
 #include <cstddef>
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_unroll_init.cpp
@@ -16,7 +16,6 @@
 #include "common.hpp"
 #include <cstddef>
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bf16_fill_k_cache_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bfloat16_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_16x16x16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_16x16x16.cpp
@@ -14,10 +14,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TM = 16;
 constexpr size_t TN = 16;
 constexpr size_t TK = 16;

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_array.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_array.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 #include "common.hpp"
-#define SG_SZ 16
+
 static constexpr int TN = 16;
 
 #include "joint_matrix_bfloat16_array_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
@@ -17,10 +17,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_colmajorA_colmajorB_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 16
 
+class imatrix;
+
 template <typename T1, typename T2, size_t M, size_t N, size_t K>
 void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                      big_matrix<T2, K, N> &B) {
@@ -11,15 +13,19 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
   buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
-
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -40,7 +46,7 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -51,14 +57,14 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (sg_starty / SG_SZ * TN) * K + k * TK,
+                     (sg_starty / wg_size * TN) * K + k * TK,
                  K);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 16
 
+class imatrix;
+
 template <typename T1, typename T2, size_t M, size_t N, size_t K>
 void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                      big_matrix<T2, K / 2, N * 2> &B) {
@@ -11,15 +13,19 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
   buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
-
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -41,7 +47,7 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
@@ -52,14 +58,14 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                     (k * TK / 2) * (N * 2) + sg_starty / wg_size * TN * 2,
                  N * 2);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_packedB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_packedB_impl.hpp
@@ -1,3 +1,5 @@
+class imatrix;
+
 template <typename T1, typename T2, size_t M, size_t N, size_t K>
 void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                      big_matrix<T2, K / 2, N * 2> &B) {
@@ -8,15 +10,19 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
   buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
-
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -38,7 +44,7 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) { //
              joint_matrix_load(
@@ -50,14 +56,14 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
+                     (k * TK / 2) * (N * 2) + sg_starty / wg_size * TN * 2,
                  N * 2);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_rowmajorA_rowmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_rowmajorA_rowmajorB.cpp
@@ -15,10 +15,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_rowmajorA_rowmajorB_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 16
 
+class imatrix;
+
 template <typename T1, typename T2, size_t M, size_t N, size_t K>
 void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
                      big_matrix<T2, K, N> &B) {
@@ -11,15 +13,19 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
   buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
-
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -40,7 +46,7 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -51,14 +57,14 @@ void matrix_multiply(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK) * (N) + sg_starty / SG_SZ * TN,
+                     (k * TK) * (N) + sg_starty / wg_size * TN,
                  N);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_colA_rowB_colC.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_colA_rowB_colC.cpp
@@ -14,7 +14,6 @@
 
 #include "common.hpp"
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 
 #include "joint_matrix_colA_rowB_colC_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_down_convert.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_down_convert.cpp
@@ -11,7 +11,4 @@
 // RUN: %{run} %t.out
 
 #include "common.hpp"
-
-constexpr size_t SG_SZ = 16;
-
 #include "joint_matrix_down_convert_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_down_convert_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_down_convert_impl.hpp
@@ -5,15 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#include <iostream>
-
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
 constexpr size_t TM = 8;
 // TN and TK must be the same for this test.
 constexpr size_t TN = 16;
 constexpr size_t TK = 16;
+
+class imatrix;
 
 template <typename T1, typename T2, size_t M, size_t N, size_t K>
 void matrix_copy(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A) {
@@ -23,13 +22,19 @@ void matrix_copy(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A) {
   buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::write>(cgh);
 
-     cgh.parallel_for(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+     cgh.parallel_for<class imatrix>(
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -46,13 +51,13 @@ void matrix_copy(big_matrix<T1, M, N> &C, big_matrix<T2, M, K> &A) {
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            joint_matrix_copy(sg, sub_c, sub_a);
            ext::intel::experimental::matrix::joint_matrix_store(
                sg, sub_a,
                accA.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_half.cpp
@@ -13,10 +13,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_half_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_half_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 16
 
+class imatrix;
+
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
           size_t NUM_COLS_C>
@@ -19,56 +21,61 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<float, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, SG_SZ}),
-         [accA, accB, accC, M, N, K](nd_item<2> spmd_item)
-             [[intel::reqd_sub_group_size(SG_SZ)]] {
-               // The submatrix API has to be accessed by all the workitems in a
-               // subgroup these functions will be called once by the subgroup
-               // no code divergence between the workitems
-               const auto global_idx = spmd_item.get_global_id(0);
-               const auto global_idy = spmd_item.get_global_id(1);
-               const auto sg_startx = global_idx - spmd_item.get_local_id(0);
-               const auto sg_starty = global_idy - spmd_item.get_local_id(1);
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
+           // The submatrix API has to be accessed by all the workitems in a
+           // subgroup these functions will be called once by the subgroup
+           // no code divergence between the workitems
+           const auto global_idx = spmd_item.get_global_id(0);
+           const auto global_idy = spmd_item.get_global_id(1);
+           const auto sg_startx = global_idx - spmd_item.get_local_id(0);
+           const auto sg_starty = global_idy - spmd_item.get_local_id(1);
 
-               sub_group sg = spmd_item.get_sub_group();
-               joint_matrix<sub_group, half, use::a, TM, TK, layout::row_major>
-                   sub_a;
-               // For B, we assume B has been already VNNIed.
-               joint_matrix<sub_group, half, use::b, TK, TN,
-                            layout::ext_intel_packed>
-                   sub_b;
-               joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
+           sub_group sg = spmd_item.get_sub_group();
+           joint_matrix<sub_group, half, use::a, TM, TK, layout::row_major>
+               sub_a;
+           // For B, we assume B has been already VNNIed.
+           joint_matrix<sub_group, half, use::b, TK, TN,
+                        layout::ext_intel_packed>
+               sub_b;
+           joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
 
-               joint_matrix_load(
-                   sg, sub_c,
-                   accC.template get_multi_ptr<access::decorated::no>() +
-                       (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-                   N, layout::row_major);
-               for (int k = 0; k < K / TK; k += 1) {
-                 joint_matrix_load(
-                     sg, sub_a,
-                     accA.template get_multi_ptr<access::decorated::no>() +
-                         (sg_startx * TM) * K + k * TK,
-                     K);
-                 joint_matrix_load(
-                     sg, sub_b,
-                     accB.template get_multi_ptr<access::decorated::no>() +
-                         (k * TK / 2) * (N * 2) + sg_starty / SG_SZ * TN * 2,
-                     N * 2);
-                 joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
-               }
-               joint_matrix_store(
-                   sg, sub_c,
-                   accC.template get_multi_ptr<access::decorated::no>() +
-                       (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
-                   N, layout::row_major);
-             }); // parallel for
+           joint_matrix_load(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
+               N, layout::row_major);
+           for (int k = 0; k < K / TK; k += 1) {
+             joint_matrix_load(
+                 sg, sub_a,
+                 accA.template get_multi_ptr<access::decorated::no>() +
+                     (sg_startx * TM) * K + k * TK,
+                 K);
+             joint_matrix_load(
+                 sg, sub_b,
+                 accB.template get_multi_ptr<access::decorated::no>() +
+                     (k * TK / 2) * (N * 2) + sg_starty / wg_size * TN * 2,
+                 N * 2);
+             joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
+           }
+           joint_matrix_store(
+               sg, sub_c,
+               accC.template get_multi_ptr<access::decorated::no>() +
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
+               N, layout::row_major);
+         }); // parallel for
    }).wait();
 }
 

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp
@@ -17,10 +17,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_int8_colmajorA_colmajorB_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_colmajorA_colmajorB_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 32
 
+class imatrix;
+
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
           size_t NUM_COLS_C>
@@ -17,15 +19,19 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N, K](nd_item<2> spmd_item)
-
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -52,14 +58,14 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (sg_starty / SG_SZ * TN) * K + k * TK,
+                     (sg_starty / wg_size * TN) * K + k * TK,
                  K);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_vnni.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_vnni.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_int8_vnni_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_int8_vnni_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_int8_vnni_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 32
 
+class imatrix;
+
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
           size_t NUM_COLS_C>
@@ -18,15 +20,20 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N,
-          K](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -53,14 +60,14 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK) * N + sg_starty / SG_SZ * TN,
+                     (k * TK) * N + sg_starty / wg_size * TN,
                  N);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_out_bounds.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_out_bounds.cpp
@@ -14,7 +14,6 @@
 
 #include "common.hpp"
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 constexpr size_t MATRIX_K = 1024 + 24;
 

--- a/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
@@ -1,10 +1,9 @@
-#include <iostream>
-
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
 constexpr size_t TM = 8;
 constexpr size_t TK = 16;
+
+class imatrix;
 
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
@@ -26,11 +25,15 @@ void matrix_multiply(T1 *C, T2 *A, T2 *B, queue q, unsigned int vnniFactor) {
   auto pC = address_space_cast<sycl::access::address_space::global_space,
                                sycl::access::decorated::no>(C);
 
-  q.submit([&](handler &cgh) {
-     cgh.parallel_for(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
+  size_t wg_size = get_wg_size<imatrix>(q);
 
+  q.submit([&](handler &cgh) {
+     cgh.parallel_for<class imatrix>(
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -59,14 +62,14 @@ void matrix_multiply(T1 *C, T2 *A, T2 *B, queue q, unsigned int vnniFactor) {
              // Assume we alreay in vnni format.
              // bounds-checked load where width and height are added
              joint_matrix_load_checked(
-                 sg, sub_b, pB + k * N + sg_starty / SG_SZ * TN * vnniFactor,
+                 sg, sub_b, pB + k * N + sg_starty / wg_size * TN * vnniFactor,
                  N * vnniFactor, K / vnniFactor, N * vnniFactor);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            // bounds-checked store where width and height are added
            joint_matrix_store_checked(
-               sg, sub_c, pC + (sg_startx * TM) * N + sg_starty / SG_SZ * TN, N,
-               layout::row_major, M, N);
+               sg, sub_c, pC + (sg_startx * TM) * N + sg_starty / wg_size * TN,
+               N, layout::row_major, M, N);
          }); // parallel for
    }).wait();
 }

--- a/sycl/test-e2e/Matrix/joint_matrix_ss_int8.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_ss_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_ss_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_ss_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_ss_int8_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 32
 
+class imatrix;
+
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
           size_t NUM_COLS_C>
@@ -20,15 +22,20 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N,
-          K](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -56,14 +63,14 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                     (k * TK / 4) * (N * 4) + sg_starty / wg_size * TN * 4,
                  N * 4);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_su_int8.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_su_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_su_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_su_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_su_int8_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 32
 
+class imatrix;
+
 template <typename T1, typename T2, typename T3, size_t NUM_ROWS_A,
           size_t NUM_COLS_A, size_t NUM_ROWS_B, size_t NUM_COLS_B,
           size_t NUM_ROWS_C, size_t NUM_COLS_C>
@@ -20,15 +22,20 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N,
-          K](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -49,7 +56,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -60,14 +67,14 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                     (k * TK / 4) * (N * 4) + sg_starty / wg_size * TN * 4,
                  N * 4);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_tf32.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tf32.cpp
@@ -14,10 +14,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_tf32_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_tf32_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_tf32_impl.hpp
@@ -1,6 +1,8 @@
 constexpr size_t TM = 8;
 constexpr size_t TK = 8;
 
+class imatrix;
+
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
           size_t NUM_COLS_C>
@@ -19,15 +21,19 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<float, 2> bufC((float *)C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
-
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
          {
            // The matrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -48,7 +54,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K; k += TK) {
              joint_matrix_load(
@@ -59,7 +65,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k) * (N) + sg_starty / SG_SZ * TN,
+                     (k) * (N) + sg_starty / wg_size * TN,
                  N);
              // If no rounding to tf32 function is called, joint_matrix_mad
              // function will work on truncated floats.
@@ -73,7 +79,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_transposeC.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_transposeC.cpp
@@ -14,7 +14,6 @@
 
 #include "common.hpp"
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 
 #include "joint_matrix_transposeC_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_unaligned_k.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_unaligned_k.cpp
@@ -14,7 +14,6 @@
 
 #include "common.hpp"
 
-constexpr size_t SG_SZ = 16;
 constexpr size_t TN = 16;
 static constexpr size_t MATRIX_K = 1024 + 14;
 

--- a/sycl/test-e2e/Matrix/joint_matrix_us_int8.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_us_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_us_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_us_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_us_int8_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 32
 
+class imatrix;
+
 template <typename T1, typename T2, typename T3, size_t NUM_ROWS_A,
           size_t NUM_COLS_A, size_t NUM_ROWS_B, size_t NUM_COLS_B,
           size_t NUM_ROWS_C, size_t NUM_COLS_C>
@@ -20,16 +22,19 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N, K](nd_item<2> spmd_item)
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
              [[intel::reqd_sub_group_size(SG_SZ)]]
-
+#endif
          {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
@@ -51,7 +56,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -63,14 +68,14 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                     (k * TK / 4) * (N * 4) + sg_starty / wg_size * TN * 4,
                  N * 4);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();

--- a/sycl/test-e2e/Matrix/joint_matrix_uu_int8.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_uu_int8.cpp
@@ -12,10 +12,8 @@
 
 #include "common.hpp"
 
-using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 
-#define SG_SZ 16
 constexpr size_t TN = 16;
 
 #include "joint_matrix_uu_int8_impl.hpp"

--- a/sycl/test-e2e/Matrix/joint_matrix_uu_int8_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_uu_int8_impl.hpp
@@ -1,6 +1,8 @@
 #define TM 8
 #define TK 32
 
+class imatrix;
+
 template <typename T1, typename T2, size_t NUM_ROWS_A, size_t NUM_COLS_A,
           size_t NUM_ROWS_B, size_t NUM_COLS_B, size_t NUM_ROWS_C,
           size_t NUM_COLS_C>
@@ -20,15 +22,20 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
   buffer<int32_t, 2> bufC(C.get_data(), range<2>(M, N));
 
   queue q;
+  size_t wg_size = get_wg_size<imatrix>(q);
+
   q.submit([&](handler &cgh) {
      auto accC = bufC.get_access<access::mode::read_write>(cgh);
      auto accA = bufA.get_access<access::mode::read_write>(cgh);
      auto accB = bufB.get_access<access::mode::read_write>(cgh);
 
      cgh.parallel_for<class imatrix>(
-         nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
-         [accA, accB, accC, M, N,
-          K](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+         nd_range<2>({NDRangeM, NDRangeN * wg_size}, {1, 1 * wg_size}),
+         [=](nd_item<2> spmd_item)
+#ifdef SG_SZ
+             [[intel::reqd_sub_group_size(SG_SZ)]]
+#endif
+         {
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems
@@ -49,7 +56,7 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
            joint_matrix_load(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
            for (int k = 0; k < K / TK; k += 1) {
              joint_matrix_load(
@@ -61,14 +68,14 @@ void matrix_multiply(big_matrix<T1, NUM_ROWS_C, NUM_COLS_C> &C,
              joint_matrix_load(
                  sg, sub_b,
                  accB.template get_multi_ptr<access::decorated::no>() +
-                     (k * TK / 4) * (N * 4) + sg_starty / SG_SZ * TN * 4,
+                     (k * TK / 4) * (N * 4) + sg_starty / wg_size * TN * 4,
                  N * 4);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            joint_matrix_store(
                sg, sub_c,
                accC.template get_multi_ptr<access::decorated::no>() +
-                   (sg_startx * TM) * N + sg_starty / SG_SZ * TN,
+                   (sg_startx * TM) * N + sg_starty / wg_size * TN,
                N, layout::row_major);
          }); // parallel for
    }).wait();


### PR DESCRIPTION
Remove intel::reqd_sub_group_size(SG_SZ) attribute for tests in the main and XMX8 Matrix folders,
since IGC will be able to define default SG_SZ,
if not set by attribute.