### PR TITLE
[SYCL] Fix SYCL kernel lambda argument type detection

### DIFF
--- a/sycl/test/basic_tests/handler/parallel_for_args.cpp
+++ b/sycl/test/basic_tests/handler/parallel_for_args.cpp
@@ -36,6 +36,14 @@ int main() {
   q.parallel_for(r2, [=](sycl::item<2> it) {});
   q.parallel_for(r3, [=](sycl::item<3> it) {});
 
+  q.parallel_for(r1, [=](sycl::item<1, false> it) {});
+  q.parallel_for(r2, [=](sycl::item<2, false> it) {});
+  q.parallel_for(r3, [=](sycl::item<3, false> it) {});
+
+  // int, size_t -> sycl::item
+  q.parallel_for(r1, [=](int it) {});
+  q.parallel_for(r1, [=](size_t it) {});
+
   // sycl::item -> sycl::id
   q.parallel_for(r1, [=](sycl::id<1> it) {});
   q.parallel_for(r2, [=](sycl::id<2> it) {});
@@ -50,6 +58,13 @@ int main() {
   q.parallel_for(r1, [=](sycl::item<1> it, sycl::kernel_handler kh) {});
   q.parallel_for(r2, [=](sycl::item<2> it, sycl::kernel_handler kh) {});
   q.parallel_for(r3, [=](sycl::item<3> it, sycl::kernel_handler kh) {});
+
+  q.parallel_for(r1, [=](int it, sycl::kernel_handler kh) {});
+  q.parallel_for(r1, [=](size_t it, sycl::kernel_handler kh) {});
+
+  q.parallel_for(r1, [=](sycl::item<1, false> it, sycl::kernel_handler kh) {});
+  q.parallel_for(r2, [=](sycl::item<2, false> it, sycl::kernel_handler kh) {});
+  q.parallel_for(r3, [=](sycl::item<3, false> it, sycl::kernel_handler kh) {});
 
   q.parallel_for(r1, [=](sycl::id<1> it, sycl::kernel_handler kh) {});
   q.parallel_for(r2, [=](sycl::id<2> it, sycl::kernel_handler kh) {});
@@ -90,5 +105,4 @@ int main() {
                  [=](ConvertibleFromNDItem<3> it, sycl::kernel_handler kh) {});
 
   // TODO: consider adding test cases for hierarchical parallelism
-  // TODO: consider adding cases for sycl::item with offset
 }


### PR DESCRIPTION
We have a helper which is used to extract a type of the first SYCL kernel lambda argument to do some error-checking and special handling based on that.

That check, however, was missing a case when a kernel lambda is also accepting `kernel_handler` argument, always falling back to a suggested type in that case. This led to a situations where we couldn't compile code like:

```c++
sycl::queue q;
q.parallel_for(sycl::range{1}, [=](sycl::item<1, false>, kernel_handler) {});
```

This patch adds extra specializations of some internal helpers to fix the error.

This is a follow-up from intel/llvm#11625