### PR TITLE
[SYCL] Fix post-commit issues after PR#11548

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -239,9 +239,11 @@ event handler::finalize() {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
       // uint32_t StreamID, uint64_t InstanceID, xpti_td* TraceEvent,
       int32_t StreamID = xptiRegisterStream(detail::SYCL_STREAM_NAME);
-      auto [CmdTraceEvent, InstanceID] = emitKernelInstrumentationData(
+      auto InstrumentationData = emitKernelInstrumentationData(
           StreamID, MKernel, MCodeLoc, MKernelName, MQueue, MNDRDesc,
           KernelBundleImpPtr, MArgs);
+      auto CmdTraceEvent = InstrumentationData.first;
+      auto InstanceID = InstrumentationData.second;
 #endif
 
       auto EnqueueKernel = [&]() {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -239,14 +239,13 @@ event handler::finalize() {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
       // uint32_t StreamID, uint64_t InstanceID, xpti_td* TraceEvent,
       int32_t StreamID = xptiRegisterStream(detail::SYCL_STREAM_NAME);
-      auto InstrumentationData = emitKernelInstrumentationData(
+      auto [CmdTraceEvent, InstanceID] = emitKernelInstrumentationData(
           StreamID, MKernel, MCodeLoc, MKernelName, MQueue, MNDRDesc,
           KernelBundleImpPtr, MArgs);
-      auto CmdTraceEvent = InstrumentationData.first;
-      auto InstanceID = InstrumentationData.second;
 #endif
 
-      auto EnqueueKernel = [&]() {
+      auto EnqueueKernel = [&, CmdTraceEvent = CmdTraceEvent,
+                            InstanceID = InstanceID]() {
         // 'Result' for single point of return
         pi_int32 Result = PI_ERROR_INVALID_VALUE;
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/tools/sycl-trace/sycl_trace_collector.cpp
+++ b/sycl/tools/sycl-trace/sycl_trace_collector.cpp
@@ -52,7 +52,7 @@ void TraceDiagnosticsMessage(xpti::trace_event_data_t * /*Parent*/,
 
 void TraceTaskExecutionSignals(xpti::trace_event_data_t * /*Parent*/,
                                xpti::trace_event_data_t *Event,
-                               const void *UserData, uint64_t InstanceID,
+                               const void *, uint64_t InstanceID,
                                bool IsBegin) {
   if (!Event)
     return;
@@ -76,7 +76,7 @@ void TraceTaskExecutionSignals(xpti::trace_event_data_t * /*Parent*/,
 
 void TraceQueueLifetimeSignals(xpti::trace_event_data_t * /*Parent*/,
                                xpti::trace_event_data_t *Event,
-                               const void *UserData, bool IsCreation) {
+                               const void *, bool IsCreation) {
   if (!Event)
     return;
 

--- a/sycl/tools/sycl-trace/sycl_trace_collector.cpp
+++ b/sycl/tools/sycl-trace/sycl_trace_collector.cpp
@@ -52,8 +52,8 @@ void TraceDiagnosticsMessage(xpti::trace_event_data_t * /*Parent*/,
 
 void TraceTaskExecutionSignals(xpti::trace_event_data_t * /*Parent*/,
                                xpti::trace_event_data_t *Event,
-                               const void *, uint64_t InstanceID,
-                               bool IsBegin) {
+                               [[maybe_unused]] const void *UserData,
+                               uint64_t InstanceID, bool IsBegin) {
   if (!Event)
     return;
 
@@ -76,7 +76,8 @@ void TraceTaskExecutionSignals(xpti::trace_event_data_t * /*Parent*/,
 
 void TraceQueueLifetimeSignals(xpti::trace_event_data_t * /*Parent*/,
                                xpti::trace_event_data_t *Event,
-                               const void *, bool IsCreation) {
+                               [[maybe_unused]] const void *UserData,
+                               bool IsCreation) {
   if (!Event)
     return;
 


### PR DESCRIPTION
* Fix unused parameters of function.
* Fix error caused by capturing structured binding which is available in C++20 only.