### PR TITLE
[Driver][SYCL] Adjust debug format for SYCL device on Windows

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -194,7 +194,8 @@ public:
     return false;
   }
   llvm::codegenoptions::DebugInfoFormat getDefaultDebugFormat() const override {
-    if (this->IsSYCLNativeCPU)
+    if (this->IsSYCLNativeCPU ||
+        this->HostTC.getTriple().isWindowsMSVCEnvironment())
       return this->HostTC.getDefaultDebugFormat();
     return ToolChain::getDefaultDebugFormat();
   }

--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -154,3 +154,12 @@
 // RUN: %clang -fsycl -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx908 -Xsycl-target-backend=nvptx64-nvidia-cuda --offload-arch=sm_86 -c -ccc-print-phases %s 2>&1 | FileCheck %s --check-prefix=MULTIPLE_TARGETS
 // MULTIPLE_TARGETS: offload, "device-sycl (nvptx64-nvidia-cuda:sm_86)"
 // MULTIPLE_TARGETS: offload, "device-sycl (amdgcn-amd-amdhsa:gfx908)"
+
+/// Verify debug format for spir target.
+// RUN: %clang -### -target x86_64-windows-msvc -fsycl -g -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=DEBUG-WIN %s
+// RUN: %clang_cl -### -fsycl -Zi -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=DEBUG-WIN %s
+// DEBUG-WIN: {{.*}}"-fsycl-is-device"{{.*}}"-gcodeview"
+// DEBUG-WIN: {{.*}}"-fsycl-is-host"{{.*}}"-gcodeview"
+// DEBUG-WIN-NOT: dwarf-version


### PR DESCRIPTION
Setting debug information is determined by using -g, as opposed to earlier representation using -Zi specifically for Windows.  The use of codeview is dependent on the target.

When we know that the host target is MSVC based, use the host toolchain setting of the debug format as opposed to the default toolchain which defaults to dwarf.