### PR TITLE
[NFC]Use Cast instead of dyn_cast in X86PreAMXConfig.cpp

### DIFF
--- a/llvm/lib/Target/X86/X86PreAMXConfig.cpp
+++ b/llvm/lib/Target/X86/X86PreAMXConfig.cpp
@@ -288,7 +288,7 @@ X86PreAMXConfig::getShapesAndConfigPosEnd(BasicBlock::iterator Iter,
 
   // See KeyAMX as TileStore if only TileLoad and TileStore.
   if (!KeyAMX)
-    KeyAMX = dyn_cast<IntrinsicInst>(&*PosEnd);
+    KeyAMX = cast<IntrinsicInst>(&*PosEnd);
 
   // Get Shapes in order.
   assert(Shapes.empty() && "Shapes should be clean.");


### PR DESCRIPTION
If we can reach the line 291, then we must have reached line 280 'PosEnd = I', so PosEnd must be type IntrinsicInst.