### PR TITLE
[SYCL-MLIR][sycl] Abstract-away casts from SYCL constructors memref operands

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLOps.td
@@ -64,6 +64,8 @@ class SYCLConstructor<string name, list<Trait> traits = []>
   let assemblyFormat = [{
     `(` operands `)` attr-dict `:` functional-type(operands, results)
   }];
+
+  let hasFolder = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -619,7 +621,6 @@ def SYCLNDRangeConstructorOp : SYCLConstructor<"nd_range"> {
                         ::mlir::MemoryEffects::Effect>> &effects);
   }];
   let hasVerifier = true;
-  let hasCanonicalizer = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -716,7 +717,6 @@ def SYCLIDConstructorOp : SYCLConstructor<"id"> {
                         ::mlir::MemoryEffects::Effect>> &effects);
   }];
   let hasVerifier = true;
-  let hasFolder = true;
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/polygeist/tools/cgeist/Test/Verification/sycl/array-capture.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/array-capture.cpp
@@ -57,8 +57,7 @@ int main(){
 // CHECK-NEXT:        %[[VAL_371:.*]] = llvm.load %[[VAL_370]] : !llvm.ptr<4> -> f32
 // CHECK-NEXT:        %[[VAL_372:.*]] = "polygeist.subindex"(%[[VAL_358]], %[[VAL_361]]) : (memref<?x!llvm.struct<(!sycl_accessor_1_f32_rw_dev, array<8 x f32>)>, 4>, index) -> memref<?x!sycl_accessor_1_f32_rw_dev, 4>
 // CHECK-NEXT:        %[[VAL_373:.*]] = memref.memory_space_cast %[[VAL_365]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// CHECK-NEXT:        %[[VAL_374:.*]] = memref.memory_space_cast %[[VAL_359]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// CHECK-NEXT:        %[[VAL_405:.*]] = sycl.id.constructor(%[[VAL_374]]) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_id_1_, 4>
+// CHECK-NEXT:        %[[VAL_405:.*]] = sycl.id.constructor(%[[VAL_359]]) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_id_1_, 4>
 // CHECK-NEXT:        %[[VAL_406:.*]] = "polygeist.memref2pointer"(%[[VAL_373]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
 // CHECK-NEXT:        %[[VAL_407:.*]] = "polygeist.memref2pointer"(%[[VAL_405]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
 // CHECK-NEXT:        "llvm.intr.memcpy"(%[[VAL_406]], %[[VAL_407]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -79,14 +79,12 @@
 // CHECK:             %[[VAL_156:.*]] = memref.alloca() : memref<1x!sycl_id_1_>
 // CHECK:             %[[VAL_157:.*]] = memref.cast %[[VAL_156]] : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
 // CHECK:             %[[VAL_158:.*]] = memref.memory_space_cast %[[VAL_157]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// CHECK:             %[[VAL_159:.*]] = memref.memory_space_cast %[[VAL_151]] : memref<?x!sycl_id_1_> to memref<?x!sycl_id_1_, 4>
-// CHECK:             %[[VAL_160:.*]] = sycl.id.constructor(%[[VAL_159]]) : (memref<?x!sycl_id_1_, 4>) -> memref<?x!sycl_id_1_, 4>
+// CHECK:             %[[VAL_160:.*]] = sycl.id.constructor(%[[VAL_151]]) : (memref<?x!sycl_id_1_>) -> memref<?x!sycl_id_1_, 4>
 // CHECK:             %[[VAL_161:.*]] = "polygeist.memref2pointer"(%[[VAL_158]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
 // CHECK:             %[[VAL_162:.*]] = "polygeist.memref2pointer"(%[[VAL_160]]) : (memref<?x!sycl_id_1_, 4>) -> !llvm.ptr<4>
 // CHECK:             "llvm.intr.memcpy"(%[[VAL_161]], %[[VAL_162]], %[[VAL_153]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
 // CHECK:             %[[VAL_163:.*]] = memref.memory_space_cast %[[VAL_155]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
-// CHECK:             %[[VAL_164:.*]] = memref.memory_space_cast %[[VAL_152]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
-// CHECK:             %[[VAL_165:.*]] = sycl.range.constructor(%[[VAL_164]]) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_range_1_, 4>
+// CHECK:             %[[VAL_165:.*]] = sycl.range.constructor(%[[VAL_152]]) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_range_1_, 4>
 // CHECK:             %[[VAL_166:.*]] = "polygeist.memref2pointer"(%[[VAL_163]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
 // CHECK:             %[[VAL_167:.*]] = "polygeist.memref2pointer"(%[[VAL_165]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
 // CHECK:             "llvm.intr.memcpy"(%[[VAL_166]], %[[VAL_167]], %[[VAL_153]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
@@ -97,16 +95,14 @@
 // CHECK-LLVM-NEXT:   [[RANGE:%.*]] = alloca [[RANGE_TYPE]], i64 1, align 8
 // CHECK-LLVM-NEXT:   [[ID:%.*]] = alloca [[ID_TYPE]], i64 1, align 8
 // CHECK-LLVM-NEXT:   [[ID_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
-// CHECK-LLVM-NEXT:   [[ARG0_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
 // CHECK-LLVM-NEXT:   [[TMP:%.*]] = alloca [[ID_TYPE]], align 8
 // CHECK-LLVM-NEXT:   [[TMP_AS:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
-// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[TMP_AS]], ptr addrspace(4) [[ARG0_AS]], i64 8, i1 false)
+// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) [[TMP_AS]], ptr [[ARG0]], i64 8, i1 false)
 // CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[ID_AS]], ptr addrspace(4) [[TMP_AS]], i64 8, i1 false)
 // CHECK-LLVM-NEXT:   [[RANGE_AS:%.*]] = addrspacecast ptr [[RANGE]] to ptr addrspace(4)
-// CHECK-LLVM-NEXT:   [[ARG1_AS:%.*]] = addrspacecast ptr [[ARG1]] to ptr addrspace(4)
 // CHECK-LLVM-NEXT:   [[TMP:%.*]] = alloca [[RANGE_TYPE]], align 8
 // CHECK-LLVM-NEXT:   [[TMP_AS:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
-// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[TMP_AS]], ptr addrspace(4) [[ARG1_AS]], i64 8, i1 false)
+// CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) [[TMP_AS]], ptr [[ARG1]], i64 8, i1 false)
 // CHECK-LLVM-NEXT:   call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[RANGE_AS]], ptr addrspace(4) [[TMP_AS]], i64 8, i1 false)
 // CHECK-LLVM-NEXT:   ret void
 
@@ -169,8 +165,7 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK:             %[[VAL_200:.*]] = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK:             %[[VAL_201:.*]] = memref.cast %[[VAL_200]] : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK:             %[[VAL_202:.*]] = memref.memory_space_cast %[[VAL_201]] : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK:             %[[VAL_203:.*]] = memref.memory_space_cast %[[VAL_198]] : memref<?x!sycl_item_2_> to memref<?x!sycl_item_2_, 4>
-// CHECK:             %[[VAL_204:.*]] = sycl.id.constructor(%[[VAL_203]]) : (memref<?x!sycl_item_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK:             %[[VAL_204:.*]] = sycl.id.constructor(%[[VAL_198]]) : (memref<?x!sycl_item_2_>) -> memref<?x!sycl_id_2_, 4>
 // CHECK:             %[[VAL_205:.*]] = "polygeist.memref2pointer"(%[[VAL_202]]) : (memref<?x!sycl_id_2_, 4>) -> !llvm.ptr<4>
 // CHECK:             %[[VAL_206:.*]] = "polygeist.memref2pointer"(%[[VAL_204]]) : (memref<?x!sycl_id_2_, 4>) -> !llvm.ptr<4>
 // CHECK:             "llvm.intr.memcpy"(%[[VAL_205]], %[[VAL_206]], %[[VAL_199]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
@@ -179,13 +174,12 @@ extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
 // CHECK-LLVM: define spir_func void @cons_3(ptr noundef byval([[ITEM_TYPE:%"class.sycl::_V1::item.2.true"]]) align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]  
 // CHECK-LLVM: [[ID_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
-// CHECK-LLVM: [[ITEM_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
 // CHECK-LLVM: [[ID2:%.*]] = alloca %"class.sycl::_V1::id.2", align 8
 // CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast ptr [[ID2]] to ptr addrspace(4)
-// CHECK-LLVM: [[GEP0:%.*]] = getelementptr inbounds %"class.sycl::_V1::item.2.true", ptr addrspace(4) [[ITEM_AS]], i32 0, i32 0, i32 1, i32 0, i32 0, i32 0
-// CHECK-LLVM: [[D0:%.*]] = load i64, ptr addrspace(4) [[GEP0]], align 8
-// CHECK-LLVM: [[GEP1:%.*]] = getelementptr inbounds %"class.sycl::_V1::item.2.true", ptr addrspace(4) [[ITEM_AS]], i32 0, i32 0, i32 1, i32 0, i32 0, i32 1
-// CHECK-LLVM: [[V1:%.*]] = load i64, ptr addrspace(4) [[GEP1]], align 8
+// CHECK-LLVM: [[GEP0:%.*]] = getelementptr inbounds %"class.sycl::_V1::item.2.true", ptr [[ARG0]], i32 0, i32 0, i32 1, i32 0, i32 0, i32 0
+// CHECK-LLVM: [[D0:%.*]] = load i64, ptr [[GEP0]], align 8
+// CHECK-LLVM: [[GEP1:%.*]] = getelementptr inbounds %"class.sycl::_V1::item.2.true", ptr [[ARG0]], i32 0, i32 0, i32 1, i32 0, i32 0, i32 1
+// CHECK-LLVM: [[V1:%.*]] = load i64, ptr [[GEP1]], align 8
 // CHECK-LLVM: [[GEP2:%.*]] = getelementptr inbounds %"class.sycl::_V1::id.2", ptr [[ID2]], i32 0, i32 0, i32 0, i32 0
 // CHECK-LLVM: store i64 [[D0]], ptr [[GEP2]], align 8
 // CHECK-LLVM: [[GEP3:%.*]] = getelementptr inbounds %"class.sycl::_V1::id.2", ptr [[ID2]], i32 0, i32 0, i32 0, i32 1
@@ -202,8 +196,7 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-NEXT: %alloca = memref.alloca() : memref<1x!sycl_id_2_>
 // CHECK-NEXT: %cast = memref.cast %alloca : memref<1x!sycl_id_2_> to memref<?x!sycl_id_2_>
 // CHECK-NEXT: %memspacecast = memref.memory_space_cast %cast : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %memspacecast_0 = memref.memory_space_cast %arg0 : memref<?x!sycl_id_2_> to memref<?x!sycl_id_2_, 4>
-// CHECK-NEXT: %[[VAL_212:.*]] = sycl.id.constructor(%memspacecast_0) : (memref<?x!sycl_id_2_, 4>) -> memref<?x!sycl_id_2_, 4>
+// CHECK-NEXT: %[[VAL_212:.*]] = sycl.id.constructor(%arg0) : (memref<?x!sycl_id_2_>) -> memref<?x!sycl_id_2_, 4>
 // CHECK-NEXT: %[[VAL_213:.*]] = "polygeist.memref2pointer"(%memspacecast) : (memref<?x!sycl_id_2_, 4>) -> !llvm.ptr<4>
 // CHECK-NEXT: %[[VAL_214:.*]] = "polygeist.memref2pointer"(%[[VAL_212]]) : (memref<?x!sycl_id_2_, 4>) -> !llvm.ptr<4>
 // CHECK-NEXT: "llvm.intr.memcpy"(%[[VAL_213]], %[[VAL_214]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
@@ -211,10 +204,9 @@ extern "C" SYCL_EXTERNAL void cons_3(sycl::item<2, true> val) {
 // CHECK-LLVM: define spir_func void @cons_4(ptr noundef byval([[ID_TYPE:%"class.sycl::_V1::id.2"]]) align 8 [[ARG0:%.*]]) #[[FUNCATTRS]]
 // CHECK-LLVM-DAG: [[ID:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast ptr [[ID]] to ptr addrspace(4)
-// CHECK-LLVM: [[ID2_AS:%.*]] = addrspacecast ptr [[ARG0]] to ptr addrspace(4)
 // CHECK-LLVM: [[TMP:%.*]] = alloca [[ID_TYPE]]
 // CHECK-LLVM: [[TMP_AS:%.*]] = addrspacecast ptr [[TMP]] to ptr addrspace(4)
-// CHECK-LLVM: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[TMP_AS]], ptr addrspace(4) [[ID2_AS]], i64 16, i1 false)
+// CHECK-LLVM: call void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) [[TMP_AS]], ptr [[ARG0]], i64 16, i1 false)
 // CHECK-LLVM: call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) [[ID1_AS]], ptr addrspace(4) [[TMP_AS]], i64 16, i1 false) 
 
 extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -21,8 +21,7 @@
 // CHECK-MLIR:             %[[VAL_162:.*]] = memref.cast %[[VAL_161]] : memref<1x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>> to memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>
 // CHECK-MLIR:             %[[VAL_163:.*]] = "polygeist.subindex"(%[[VAL_162]], %[[VAL_153]]) : (memref<?x!llvm.struct<(!sycl_range_1_, !llvm.struct<(memref<?xi32, 4>)>)>>, index) -> memref<?x!sycl_range_1_>
 // CHECK-MLIR:             %[[VAL_164:.*]] = memref.memory_space_cast %[[VAL_160]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
-// CHECK-MLIR:             %[[VAL_165:.*]] = memref.memory_space_cast %[[VAL_151]] : memref<?x!sycl_range_1_> to memref<?x!sycl_range_1_, 4>
-// CHECK-MLIR:             %[[TMP:.*]] = sycl.range.constructor(%[[VAL_165]]) : (memref<?x!sycl_range_1_, 4>) -> memref<?x!sycl_range_1_, 4>
+// CHECK-MLIR:             %[[TMP:.*]] = sycl.range.constructor(%[[VAL_151]]) : (memref<?x!sycl_range_1_>) -> memref<?x!sycl_range_1_, 4>
 // CHECK-MLIR:             %[[DST_PTR:.*]] = "polygeist.memref2pointer"(%[[VAL_164]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
 // CHECK-MLIR:             %[[SRC_PTR:.*]] = "polygeist.memref2pointer"(%[[TMP]]) : (memref<?x!sycl_range_1_, 4>) -> !llvm.ptr<4>
 // CHECK-MLIR:             "llvm.intr.memcpy"(%[[DST_PTR]], %[[SRC_PTR]], %[[SIZE]]) <{isVolatile = false}> : (!llvm.ptr<4>, !llvm.ptr<4>, i64) -> ()
@@ -50,23 +49,22 @@
 // CHECK-LLVM-NEXT:    %6 = alloca { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, i64 1, align 8
 // CHECK-LLVM-NEXT:    %7 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 0
 // CHECK-LLVM-NEXT:    %8 = addrspacecast ptr %5 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    %9 = addrspacecast ptr %0 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    %10 = alloca %"class.sycl::_V1::range.1", align 8
-// CHECK-LLVM-NEXT:    %11 = addrspacecast ptr %10 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) %11, ptr addrspace(4) %9, i64 8, i1 false)
-// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) %8, ptr addrspace(4) %11, i64 8, i1 false)
-// CHECK-LLVM-NEXT:    %12 = load %"class.sycl::_V1::range.1", ptr %5, align 8
-// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::range.1" %12, ptr %7, align 8
-// CHECK-LLVM-NEXT:    %13 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 1
-// CHECK-LLVM-NEXT:    %14 = addrspacecast ptr %1 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr %4, ptr addrspace(4) %14, i64 8, i1 false)
-// CHECK-LLVM-NEXT:    %15 = load { ptr addrspace(4) }, ptr %4, align 8
-// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %15, ptr %13, align 8
-// CHECK-LLVM-NEXT:    %16 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
-// CHECK-LLVM-NEXT:    %17 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %16)
-// CHECK-LLVM-NEXT:    %18 = addrspacecast ptr %6 to ptr addrspace(4)
-// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %17, ptr %3, align 8
-// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %18, ptr %3)
+// CHECK-LLVM-NEXT:    %9 = alloca %"class.sycl::_V1::range.1", align 8
+// CHECK-LLVM-NEXT:    %10 = addrspacecast ptr %9 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p4.p0.i64(ptr addrspace(4) %10, ptr %0, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p4.p4.i64(ptr addrspace(4) %8, ptr addrspace(4) %10, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    %11 = load %"class.sycl::_V1::range.1", ptr %5, align 8
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::range.1" %11, ptr %7, align 8
+// CHECK-LLVM-NEXT:    %12 = getelementptr { %"class.sycl::_V1::range.1", { ptr addrspace(4) } }, ptr %6, i32 0, i32 1
+// CHECK-LLVM-NEXT:    %13 = addrspacecast ptr %1 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr %4, ptr addrspace(4) %13, i64 8, i1 false)
+// CHECK-LLVM-NEXT:    %14 = load { ptr addrspace(4) }, ptr %4, align 8
+// CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %14, ptr %12, align 8
+// CHECK-LLVM-NEXT:    %15 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
+// CHECK-LLVM-NEXT:    %16 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %15)
+// CHECK-LLVM-NEXT:    %17 = addrspacecast ptr %6 to ptr addrspace(4)
+// CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %16, ptr %3, align 8
+// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %17, ptr %3)
 // CHECK-LLVM-NEXT:    call spir_func void @__itt_offload_wi_finish_wrapper()
 // CHECK-LLVM-NEXT:    ret void
 


### PR DESCRIPTION
As we only take the first argument from the constructors, we can abstract some casts: `memref.memory_space_cast` and `memref.cast` not modifying the layout.