### PR TITLE
[UR][L0] Propagate errors from `USMAllocationMakeResident`

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -53,14 +53,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/0x12cc/unified-runtime.git")
   # commit cf26de283a1233e6c93feb085acc10c566888b59
   # Merge: 3a3aae38 2fd9dea2
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
   # Date:   Wed Oct 25 10:36:48 2023 +0100
   #     Merge pull request #940 from Naghasan/victor/kernel-fusion-amd
   #     [UR][HIP] Enable kernel finalization using comgr
-  set(UNIFIED_RUNTIME_TAG cf26de283a1233e6c93feb085acc10c566888b59)
+  set(UNIFIED_RUNTIME_TAG f2be82325d4c1ccde957899f3d3635bca274396b)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
Do not merge. This PR is used to test changes in Unified Runtime.