### PR TITLE
[SYCL] Error for conduit and register_map on annotated_arg/ptr

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -374,10 +374,12 @@ template <typename... Args> struct checkValidFPGAPropertySet {
   static constexpr bool value = !(!has_BufferLocation && has_InterfaceConfig);
 };
 
-template <typename... Args> struct hasConduitAndRegisterMap {
+template <typename... Args> struct checkHasConduitAndRegisterMap {
   using list = std::tuple<Args...>;
-  static constexpr bool value = ContainsProperty<conduit_key, list>::value &&
-                                ContainsProperty<register_map_key, list>::value;
+  static constexpr bool has_Conduit = ContainsProperty<conduit_key, list>::value;
+  static constexpr bool has_RegisterMap =
+      ContainsProperty<register_map_key, list>::value;
+  static constexpr bool value = !(has_Conduit && has_RegisterMap);
 };
 } // namespace detail
 

--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -376,7 +376,8 @@ template <typename... Args> struct checkValidFPGAPropertySet {
 
 template <typename... Args> struct checkHasConduitAndRegisterMap {
   using list = std::tuple<Args...>;
-  static constexpr bool has_Conduit = ContainsProperty<conduit_key, list>::value;
+  static constexpr bool has_Conduit =
+      ContainsProperty<conduit_key, list>::value;
   static constexpr bool has_RegisterMap =
       ContainsProperty<register_map_key, list>::value;
   static constexpr bool value = !(has_Conduit && has_RegisterMap);

--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -377,7 +377,8 @@ template <typename... Args> struct checkValidFPGAPropertySet {
 template <typename... Args> struct hasConduitAndRegisterMap {
   using list = std::tuple<Args...>;
   static constexpr bool value =
-      ContainsProperty<conduit, list>::value && ContainsProperty<register_map, list>::value;
+      ContainsProperty<conduit_key, list>::value &&
+      ContainsProperty<register_map_key, list>::value;
 };
 } // namespace detail
 

--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -376,9 +376,8 @@ template <typename... Args> struct checkValidFPGAPropertySet {
 
 template <typename... Args> struct hasConduitAndRegisterMap {
   using list = std::tuple<Args...>;
-  static constexpr bool value =
-      ContainsProperty<conduit_key, list>::value &&
-      ContainsProperty<register_map_key, list>::value;
+  static constexpr bool value = ContainsProperty<conduit_key, list>::value &&
+                                ContainsProperty<register_map_key, list>::value;
 };
 } // namespace detail
 

--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -373,6 +373,12 @@ template <typename... Args> struct checkValidFPGAPropertySet {
 
   static constexpr bool value = !(!has_BufferLocation && has_InterfaceConfig);
 };
+
+template <typename... Args> struct hasConduitAndRegisterMap {
+  using list = std::tuple<Args...>;
+  static constexpr bool value =
+      ContainsProperty<conduit, list>::value && ContainsProperty<register_map, list>::value;
+};
 } // namespace detail
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -93,7 +93,7 @@ public:
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static constexpr bool hasConduitAndRegisterMapProperties =
-      detail::hasConduitAndRegisterMap<Props...>::value;
+      detail::checkHasConduitAndRegisterMap<Props...>::value;
   static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");
@@ -209,7 +209,7 @@ public:
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static constexpr bool hasConduitAndRegisterMapProperties =
-      detail::hasConduitAndRegisterMap<Props...>::value;
+      detail::checkHasConduitAndRegisterMap<Props...>::value;
   static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -92,7 +92,9 @@ public:
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
-  static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
+  static constexpr bool hasConduitAndRegisterMapProperties =
+      detail::hasConduitAndRegisterMap<Props...>::value;
+  static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");
 
@@ -206,7 +208,9 @@ public:
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
-  static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
+  static constexpr bool hasConduitAndRegisterMapProperties =
+      detail::hasConduitAndRegisterMap<Props...>::value;
+  static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");
 

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -93,7 +93,7 @@ public:
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
-                "The properties conduit and register_map cannot be"
+                "The properties conduit and register_map cannot be "
                 "specified at the same time.");
 
   annotated_arg() noexcept = default;
@@ -207,7 +207,7 @@ public:
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
-                "The properties conduit and register_map cannot be"
+                "The properties conduit and register_map cannot be "
                 "specified at the same time.");
 
   annotated_arg() noexcept = default;

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -91,6 +91,10 @@ public:
   static_assert(detail::checkValidFPGAPropertySet<Props...>::value,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
+  // check if conduit and register_map properties are specified together
+  static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
+                "The properties conduit and register_map cannot be"
+                "specified at the same time.");
 
   annotated_arg() noexcept = default;
   annotated_arg(const annotated_arg &) = default;
@@ -201,6 +205,10 @@ public:
   static_assert(detail::checkValidFPGAPropertySet<Props...>::value,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
+  // check if conduit and register_map properties are specified together
+  static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
+                "The properties conduit and register_map cannot be"
+                "specified at the same time.");
 
   annotated_arg() noexcept = default;
   annotated_arg(const annotated_arg &) = default;

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -200,6 +200,10 @@ public:
   static_assert(detail::checkValidFPGAPropertySet<Props...>::value,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
+  // check if conduit and register_map properties are specified together
+  static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
+                "The properties conduit and register_map cannot be"
+                "specified at the same time.");
 
   annotated_ptr() noexcept = default;
   annotated_ptr(const annotated_ptr &) = default;

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -202,7 +202,7 @@ public:
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
-                "The properties conduit and register_map cannot be"
+                "The properties conduit and register_map cannot be "
                 "specified at the same time.");
 
   annotated_ptr() noexcept = default;

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -202,7 +202,7 @@ public:
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static constexpr bool hasConduitAndRegisterMapProperties =
-      detail::hasConduitAndRegisterMap<Props...>::value;
+      detail::checkHasConduitAndRegisterMap<Props...>::value;
   static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -201,7 +201,9 @@ public:
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
-  static_assert(detail::hasConduitAndRegisterMap<Props...>::value,
+  static constexpr bool hasConduitAndRegisterMapProperties =
+      detail::hasConduitAndRegisterMap<Props...>::value;
+  static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");
 

--- a/sycl/test/extensions/annotated_arg/annotated_arg_for_ptr.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_for_ptr.cpp
@@ -16,8 +16,7 @@ using annotated_arg_t1 =
     annotated_arg<int *, decltype(properties(buffer_location<0>, awidth<32>,
                                              dwidth<32>))>;
 
-using annotated_arg_t2 =
-    annotated_arg<int, decltype(properties(register_map))>;
+using annotated_arg_t2 = annotated_arg<int, decltype(properties(register_map))>;
 
 using annotated_arg_t3 =
     annotated_arg<int *, decltype(properties(buffer_location<0>, awidth<32>))>;

--- a/sycl/test/extensions/annotated_arg/annotated_arg_for_ptr.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_for_ptr.cpp
@@ -17,7 +17,7 @@ using annotated_arg_t1 =
                                              dwidth<32>))>;
 
 using annotated_arg_t2 =
-    annotated_arg<int, decltype(properties(conduit, register_map))>;
+    annotated_arg<int, decltype(properties(register_map))>;
 
 using annotated_arg_t3 =
     annotated_arg<int *, decltype(properties(buffer_location<0>, awidth<32>))>;

--- a/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
@@ -8,7 +8,7 @@ using namespace ext::oneapi::experimental;
 using namespace ext::intel::experimental;
 
 void check_conduit_and_register_map_properties() {
-  // check for conduit and register_map properties specified for the same variable
+  // check for conduit and register_map properties specified together
   // expected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
   annotated_arg<int, decltype(properties{conduit, register_map})> a;
   // expected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}

--- a/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
@@ -13,7 +13,7 @@ void check_conduit_and_register_map_properties() {
   annotated_arg<int, decltype(properties{conduit, register_map})> a;
   // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
   annotated_arg<int *, decltype(properties{conduit, register_map})> b;
-  // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  // exptected-error@sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
   annotated_ptr<int, decltype(properties{conduit, register_map})> c;
 }
 

--- a/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
@@ -1,0 +1,23 @@
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+
+#include "sycl/sycl.hpp"
+#include <sycl/ext/intel/fpga_extensions.hpp>
+
+using namespace sycl;
+using namespace ext::oneapi::experimental;
+using namespace ext::intel::experimental;
+
+void check_conduit_and_register_map_properties() {
+  // check for conduit and register_map properties specified for the same variable
+  // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  annotated_arg<int, decltype(properties{conduit, register_map})> a;
+  // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  annotated_arg<int *, decltype(properties{conduit, register_map})> b;
+  // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  annotated_ptr<int, decltype(properties{conduit, register_map})> c;
+}
+
+int main() {
+  check_conduit_and_register_map_properties();
+  return 0;
+}

--- a/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_negative.cpp
@@ -9,11 +9,11 @@ using namespace ext::intel::experimental;
 
 void check_conduit_and_register_map_properties() {
   // check for conduit and register_map properties specified for the same variable
-  // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  // expected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
   annotated_arg<int, decltype(properties{conduit, register_map})> a;
-  // exptected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  // expected-error@sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
   annotated_arg<int *, decltype(properties{conduit, register_map})> b;
-  // exptected-error@sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
+  // expected-error@sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp:* {{The properties conduit and register_map cannot be specified at the same time.}}
   annotated_ptr<int, decltype(properties{conduit, register_map})> c;
 }
 

--- a/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
@@ -16,8 +16,8 @@ using annotated_ptr_t1 =
                                            dwidth<32>))>;
 
 using annotated_ptr_t2 =
-    annotated_ptr<int, decltype(properties(buffer_location<0>,
-                                           register_map, alignment<8>))>;
+    annotated_ptr<int, decltype(properties(buffer_location<0>, register_map,
+                                           alignment<8>))>;
 
 using annotated_ptr_t3 =
     annotated_ptr<int, decltype(properties(buffer_location<0>, awidth<32>))>;

--- a/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_ptr.cpp
@@ -16,7 +16,7 @@ using annotated_ptr_t1 =
                                            dwidth<32>))>;
 
 using annotated_ptr_t2 =
-    annotated_ptr<int, decltype(properties(buffer_location<0>, conduit,
+    annotated_ptr<int, decltype(properties(buffer_location<0>,
                                            register_map, alignment<8>))>;
 
 using annotated_ptr_t3 =


### PR DESCRIPTION
This change ensures that there is an error when the user tries to specify both the `conduit` property and the `register_map` property on `annotated_arg` or `annotated_ptr`. 

For example, the following variable: 

```cpp
annotated_arg<int, decltype(properties{conduit, register_map})> a;
```

will generate the following assertion failure: 

```
/p/psg/swip/w/yugteshs/sycl_include_1/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp:204:17: error: static assertion failed due to requirement 'hasConduitAndRegisterMapProperties': The properties conduit and register_map cannot be specified at the same time.
  204 |   static_assert(hasConduitAndRegisterMapProperties,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```