### PR TITLE
[NFC][DEVOPS]Codeowners: Have UR reviewers own plugins and tests that are part of UR

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -34,12 +34,14 @@ sycl/doc/design/ @intel/llvm-reviewers-runtime
 sycl/doc/design/spirv-extensions/ @intel/dpcpp-spirv-doc-reviewers
 sycl/doc/extensions/ @intel/dpcpp-specification-reviewers
 
-# Level Zero plugin
-sycl/plugins/level_zero/ @intel/dpcpp-l0-pi-reviewers
-sycl/test-e2e/Plugin/*level-zero* @intel/dpcpp-l0-pi-reviewers
+# Unified Runtime 
+sycl/plugins @intel/unified-runtime-reviewers
+sycl/test-e2e/Plugin/ @intel/unified-runtime-reviewers
 
-# Unified Runtime plugin
-sycl/plugins/unified_runtime/ @intel/dpcpp-l0-pi-reviewers
+# Win Proxy Loader
+sycl/pi_win_proxy_loader @intel/llvm-reviewers-runtime
+sycl/plugins/common_win_pi_trace @intel/llvm-reviewers-runtime
+sycl/test-e2e/Plugin/dll-detach-order.cpp @intel/llvm-reviewers-runtime
 
 # CUDA and HIP plugins
 sycl/plugins/**/cuda/ @intel/llvm-reviewers-cuda


### PR DESCRIPTION
have intel/unified-runtime-reviewers own plugins until they are fully gone as part of UR removal
have intel-reviewers-runtime owner pi_win_proxy_loader until its no longer needed (can be removed once plugins are no longer used)