### PR TITLE
[OpenCL] Add Command Buffer extension to OpenCL adapter.

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -53,14 +53,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/martygrant/unified-runtime.git")
   # commit 036b9cfcd8fb4be9394449b5406e6402580a63c9
   # Merge: 2ab0734 86f96f0
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
   # Date:   Fri Oct 27 16:36:23 2023 +0100
   #     Merge pull request #961 from hdelan/change-unions-to-stdvariant
   #     [HIP][CUDA] Change unions in ur_mem_handle_t_ to stdvariant
-  set(UNIFIED_RUNTIME_TAG 036b9cfcd8fb4be9394449b5406e6402580a63c9)
+  set(UNIFIED_RUNTIME_TAG 6b423d8b1928c69e82e7c0221ac0d2b8f55b8d53)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
For https://github.com/oneapi-src/unified-runtime/pull/966