### PR TITLE
Revert "[SYCL] [FPGA] Leverage `add_ir_annotations_member` in latency controls (#11554)"

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_lsu.hpp
@@ -56,15 +56,32 @@ public:
     check_space<_space>();
     check_load();
 #if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
-    _T *P = Ptr;
-    if constexpr (!std::is_same_v<_propertiesT,
-                                  oneapi::experimental::empty_properties_t>) {
-      detail::AnnotatedMemberValue<_T *, _propertiesT> annotated_wrapper(Ptr);
-      P = annotated_wrapper.MValue;
+    // Get latency control properties
+    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
+        _propertiesT, latency_anchor_id_key,
+        detail::defaultLatencyAnchorIdProperty>::type;
+    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
+        _propertiesT, latency_constraint_key,
+        detail::defaultLatencyConstraintProperty>::type;
+
+    // Get latency control property values
+    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
+    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
+    static constexpr latency_control_type _control_type =
+        _latency_constraint_prop::type;
+    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
+
+    int32_t _control_type_code = 0; // latency_control_type::none is default
+    if constexpr (_control_type == latency_control_type::exact) {
+      _control_type_code = 1;
+    } else if constexpr (_control_type == latency_control_type::max) {
+      _control_type_code = 2;
+    } else if constexpr (_control_type == latency_control_type::min) {
+      _control_type_code = 3;
     }
-    return *__builtin_intel_fpga_mem(
-        P, _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
-        _cache_val);
+
+    return *__latency_control_mem_wrapper((_T *)Ptr, _anchor_id, _target_anchor,
+                                          _control_type_code, _relative_cycle);
 #else
     (void)Properties;
     return *Ptr;
@@ -84,15 +101,32 @@ public:
     check_space<_space>();
     check_store();
 #if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
-    _T *P = Ptr;
-    if constexpr (!std::is_same_v<_propertiesT,
-                                  oneapi::experimental::empty_properties_t>) {
-      detail::AnnotatedMemberValue<_T *, _propertiesT> annotated_wrapper(Ptr);
-      P = annotated_wrapper.MValue;
+    // Get latency control properties
+    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
+        _propertiesT, latency_anchor_id_key,
+        detail::defaultLatencyAnchorIdProperty>::type;
+    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
+        _propertiesT, latency_constraint_key,
+        detail::defaultLatencyConstraintProperty>::type;
+
+    // Get latency control property values
+    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
+    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
+    static constexpr latency_control_type _control_type =
+        _latency_constraint_prop::type;
+    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
+
+    int32_t _control_type_code = 0; // latency_control_type::none is default
+    if constexpr (_control_type == latency_control_type::exact) {
+      _control_type_code = 1;
+    } else if constexpr (_control_type == latency_control_type::max) {
+      _control_type_code = 2;
+    } else if constexpr (_control_type == latency_control_type::min) {
+      _control_type_code = 3;
     }
-    *__builtin_intel_fpga_mem(
-        P, _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
-        _cache_val) = Val;
+
+    *__latency_control_mem_wrapper((_T *)Ptr, _anchor_id, _target_anchor,
+                                   _control_type_code, _relative_cycle) = Val;
 #else
     (void)Properties;
     *Ptr = Val;
@@ -150,6 +184,19 @@ private:
     static_assert(_prefetch == 0,
                   "unable to implement a store LSU with a prefetcher.");
   }
+
+#if defined(__SYCL_DEVICE_ONLY__) && __has_builtin(__builtin_intel_fpga_mem)
+  // FPGA BE will recognize this function and extract its arguments.
+  // TODO: Pass latency control params via __builtin_intel_fpga_mem when ready.
+  template <typename _T>
+  static _T *__latency_control_mem_wrapper(_T *Ptr, int32_t AnchorID,
+                                           int32_t TargetAnchor, int32_t Type,
+                                           int32_t Cycle) {
+    return __builtin_intel_fpga_mem(
+        Ptr, _burst_coalesce | _cache | _dont_statically_coalesce | _prefetch,
+        _cache_val);
+  }
+#endif
 };
 
 } // namespace ext::intel::experimental

--- a/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_utils.hpp
@@ -9,7 +9,6 @@
 #pragma once
 
 #include <sycl/ext/oneapi/latency_control/properties.hpp> // for latency_co...
-#include <sycl/ext/oneapi/properties/properties.hpp> // for empty_properties_t
 
 #include <stdint.h>    // for int32_t
 #include <type_traits> // for conditional_t
@@ -32,23 +31,28 @@ struct _GetValue<_Type, _T1, _T...> {
                          _GetValue<_Type, _T...>>::value;
 };
 
-template <typename T, typename PropertyListT =
-                          ext::oneapi::experimental::empty_properties_t>
-class AnnotatedMemberValue {
-  static_assert(oneapi::experimental::is_property_list<PropertyListT>::value,
-                "Property list is invalid.");
+// Get the specified property from the given compile-time property list. If
+// the property is not provided in the property list, get the default version of
+// this property.
+template <typename PropListT, typename PropKeyT, typename DefaultPropValT,
+          typename = void>
+struct GetOrDefaultValT {
+  using type = DefaultPropValT;
+};
+template <typename PropListT, typename PropKeyT, typename DefaultPropValT>
+struct GetOrDefaultValT<
+    PropListT, PropKeyT, DefaultPropValT,
+    std::enable_if_t<PropListT::template has_property<PropKeyT>()>> {
+  using type = decltype(PropListT::template get_property<PropKeyT>());
 };
 
-template <typename T, typename... Props>
-class AnnotatedMemberValue<
-    T, oneapi::experimental::detail::properties_t<Props...>> {
-public:
-  AnnotatedMemberValue() {}
-  AnnotatedMemberValue(T Value) : MValue(Value) {}
-  T MValue [[__sycl_detail__::add_ir_annotations_member(
-      ext::oneapi::experimental::detail::PropertyMetaInfo<Props>::name...,
-      ext::oneapi::experimental::detail::PropertyMetaInfo<Props>::value...)]];
-};
+// Default latency_anchor_id property for latency control, indicating the
+// applied operation is not an anchor.
+using defaultLatencyAnchorIdProperty = latency_anchor_id_key::value_t<-1>;
+// Default latency_constraint property for latency control, indicating the
+// applied operation is not a non-anchor.
+using defaultLatencyConstraintProperty =
+    latency_constraint_key::value_t<0, latency_control_type::none, 0>;
 
 } // namespace ext::intel::experimental::detail
 } // namespace _V1

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -136,19 +136,36 @@ public:
   template <typename _functionPropertiesT>
   static _dataT read(bool &Success, _functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
+    // Get latency control properties
+    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_anchor_id_key,
+        detail::defaultLatencyAnchorIdProperty>::type;
+    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_constraint_key,
+        detail::defaultLatencyConstraintProperty>::type;
+
+    // Get latency control property values
+    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
+    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
+    static constexpr latency_control_type _control_type =
+        _latency_constraint_prop::type;
+    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
+
+    int32_t _control_type_code = 0; // latency_control_type::none is default
+    if constexpr (_control_type == latency_control_type::exact) {
+      _control_type_code = 1;
+    } else if constexpr (_control_type == latency_control_type::max) {
+      _control_type_code = 2;
+    } else if constexpr (_control_type == latency_control_type::min) {
+      _control_type_code = 3;
+    }
+
     __ocl_RPipeTy<_dataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
     _dataT TempData;
-    if constexpr (std::is_same_v<_functionPropertiesT,
-                                 oneapi::experimental::empty_properties_t>) {
-      Success = !static_cast<bool>(
-          __spirv_ReadPipe(_RPipe, &TempData, m_Size, m_Alignment));
-    } else {
-      detail::AnnotatedMemberValue<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
-          annotated_wrapper(_RPipe);
-      Success = !static_cast<bool>(__spirv_ReadPipe(
-          annotated_wrapper.MValue, &TempData, m_Size, m_Alignment));
-    }
+    Success = !static_cast<bool>(__latency_control_nb_read_wrapper(
+        _RPipe, &TempData, _anchor_id, _target_anchor, _control_type_code,
+        _relative_cycle));
     return TempData;
 #else
     (void)Success;
@@ -168,18 +185,35 @@ public:
   template <typename _functionPropertiesT>
   static void write(const _dataT &Data, bool &Success, _functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
+    // Get latency control properties
+    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_anchor_id_key,
+        detail::defaultLatencyAnchorIdProperty>::type;
+    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_constraint_key,
+        detail::defaultLatencyConstraintProperty>::type;
+
+    // Get latency control property values
+    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
+    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
+    static constexpr latency_control_type _control_type =
+        _latency_constraint_prop::type;
+    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
+
+    int32_t _control_type_code = 0; // latency_control_type::none is default
+    if constexpr (_control_type == latency_control_type::exact) {
+      _control_type_code = 1;
+    } else if constexpr (_control_type == latency_control_type::max) {
+      _control_type_code = 2;
+    } else if constexpr (_control_type == latency_control_type::min) {
+      _control_type_code = 3;
+    }
+
     __ocl_WPipeTy<_dataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
-    if constexpr (std::is_same_v<_functionPropertiesT,
-                                 oneapi::experimental::empty_properties_t>) {
-      Success = !static_cast<bool>(
-          __spirv_WritePipe(_WPipe, &Data, m_Size, m_Alignment));
-    } else {
-      detail::AnnotatedMemberValue<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
-          annotated_wrapper(_WPipe);
-      Success = !static_cast<bool>(__spirv_WritePipe(
-          annotated_wrapper.MValue, &Data, m_Size, m_Alignment));
-    }
+    Success = !static_cast<bool>(__latency_control_nb_write_wrapper(
+        _WPipe, &Data, _anchor_id, _target_anchor, _control_type_code,
+        _relative_cycle));
 #else
     (void)Success;
     (void)Data;
@@ -247,18 +281,36 @@ public:
   template <typename _functionPropertiesT>
   static _dataT read(_functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
+    // Get latency control properties
+    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_anchor_id_key,
+        detail::defaultLatencyAnchorIdProperty>::type;
+    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_constraint_key,
+        detail::defaultLatencyConstraintProperty>::type;
+
+    // Get latency control property values
+    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
+    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
+    static constexpr latency_control_type _control_type =
+        _latency_constraint_prop::type;
+    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
+
+    int32_t _control_type_code = 0; // latency_control_type::none is default
+    if constexpr (_control_type == latency_control_type::exact) {
+      _control_type_code = 1;
+    } else if constexpr (_control_type == latency_control_type::max) {
+      _control_type_code = 2;
+    } else if constexpr (_control_type == latency_control_type::min) {
+      _control_type_code = 3;
+    }
+
     __ocl_RPipeTy<_dataT> _RPipe =
         __spirv_CreatePipeFromPipeStorage_read<_dataT>(&m_Storage);
     _dataT TempData;
-    if constexpr (std::is_same_v<_functionPropertiesT,
-                                 oneapi::experimental::empty_properties_t>) {
-      __spirv_ReadPipeBlockingINTEL(_RPipe, &TempData, m_Size, m_Alignment);
-    } else {
-      detail::AnnotatedMemberValue<__ocl_RPipeTy<_dataT>, _functionPropertiesT>
-          annotated_wrapper(_RPipe);
-      __spirv_ReadPipeBlockingINTEL(annotated_wrapper.MValue, &TempData, m_Size,
-                                    m_Alignment);
-    }
+    __latency_control_bl_read_wrapper(_RPipe, &TempData, _anchor_id,
+                                      _target_anchor, _control_type_code,
+                                      _relative_cycle);
     return TempData;
 #else
     throw sycl::exception(
@@ -275,17 +327,35 @@ public:
   template <typename _functionPropertiesT>
   static void write(const _dataT &Data, _functionPropertiesT) {
 #ifdef __SYCL_DEVICE_ONLY__
+    // Get latency control properties
+    using _latency_anchor_id_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_anchor_id_key,
+        detail::defaultLatencyAnchorIdProperty>::type;
+    using _latency_constraint_prop = typename detail::GetOrDefaultValT<
+        _functionPropertiesT, latency_constraint_key,
+        detail::defaultLatencyConstraintProperty>::type;
+
+    // Get latency control property values
+    static constexpr int32_t _anchor_id = _latency_anchor_id_prop::value;
+    static constexpr int32_t _target_anchor = _latency_constraint_prop::target;
+    static constexpr latency_control_type _control_type =
+        _latency_constraint_prop::type;
+    static constexpr int32_t _relative_cycle = _latency_constraint_prop::cycle;
+
+    int32_t _control_type_code = 0; // latency_control_type::none is default
+    if constexpr (_control_type == latency_control_type::exact) {
+      _control_type_code = 1;
+    } else if constexpr (_control_type == latency_control_type::max) {
+      _control_type_code = 2;
+    } else if constexpr (_control_type == latency_control_type::min) {
+      _control_type_code = 3;
+    }
+
     __ocl_WPipeTy<_dataT> _WPipe =
         __spirv_CreatePipeFromPipeStorage_write<_dataT>(&m_Storage);
-    if constexpr (std::is_same_v<_functionPropertiesT,
-                                 oneapi::experimental::empty_properties_t>) {
-      __spirv_WritePipeBlockingINTEL(_WPipe, &Data, m_Size, m_Alignment);
-    } else {
-      detail::AnnotatedMemberValue<__ocl_WPipeTy<_dataT>, _functionPropertiesT>
-          annotated_wrapper(_WPipe);
-      __spirv_WritePipeBlockingINTEL(annotated_wrapper.MValue, &Data, m_Size,
-                                     m_Alignment);
-    }
+    __latency_control_bl_write_wrapper(_WPipe, &Data, _anchor_id,
+                                       _target_anchor, _control_type_code,
+                                       _relative_cycle);
 #else
     (void)Data;
     throw sycl::exception(
@@ -331,6 +401,45 @@ public:
       m_uses_valid,
       m_first_symbol_in_high_order_bits,
       m_protocol};
+
+#ifdef __SYCL_DEVICE_ONLY__
+private:
+  // FPGA BE will recognize this function and extract its arguments.
+  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
+  template <typename _T>
+  static int32_t __latency_control_nb_read_wrapper(
+      __ocl_RPipeTy<_T> Pipe, _T *Data, int32_t /* AnchorID */,
+      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
+    return __spirv_ReadPipe(Pipe, Data, m_Size, m_Alignment);
+  }
+
+  // FPGA BE will recognize this function and extract its arguments.
+  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
+  template <typename _T>
+  static int32_t __latency_control_nb_write_wrapper(
+      __ocl_WPipeTy<_T> Pipe, const _T *Data, int32_t /* AnchorID */,
+      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
+    return __spirv_WritePipe(Pipe, Data, m_Size, m_Alignment);
+  }
+
+  // FPGA BE will recognize this function and extract its arguments.
+  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
+  template <typename _T>
+  static void __latency_control_bl_read_wrapper(
+      __ocl_RPipeTy<_T> Pipe, _T *Data, int32_t /* AnchorID */,
+      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
+    return __spirv_ReadPipeBlockingINTEL(Pipe, Data, m_Size, m_Alignment);
+  }
+
+  // FPGA BE will recognize this function and extract its arguments.
+  // TODO: Pass latency control parameters via the __spirv_* builtin when ready.
+  template <typename _T>
+  static void __latency_control_bl_write_wrapper(
+      __ocl_WPipeTy<_T> Pipe, const _T *Data, int32_t /* AnchorID*/,
+      int32_t /* TargetAnchor */, int32_t /* Type */, int32_t /* Cycle */) {
+    return __spirv_WritePipeBlockingINTEL(Pipe, Data, m_Size, m_Alignment);
+  }
+#endif // __SYCL_DEVICE_ONLY__
 };
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
@@ -17,11 +17,11 @@ namespace sycl {
 inline namespace _V1 {
 namespace ext::intel::experimental {
 
-enum class latency_control_type : int {
-  none = 0, // default
-  exact = 1,
-  max = 2,
-  min = 3
+enum class latency_control_type {
+  none, // default
+  exact,
+  max,
+  min
 };
 
 struct latency_anchor_id_key {
@@ -83,22 +83,6 @@ struct IsCompileTimeProperty<intel::experimental::latency_anchor_id_key>
 template <>
 struct IsCompileTimeProperty<intel::experimental::latency_constraint_key>
     : std::true_type {};
-
-template <int Anchor>
-struct PropertyMetaInfo<
-    intel::experimental::latency_anchor_id_key::value_t<Anchor>> {
-  static constexpr const char *name = "sycl-latency-anchor-id";
-  static constexpr int value = Anchor;
-};
-
-template <int Target, intel::experimental::latency_control_type Type, int Cycle>
-struct PropertyMetaInfo<
-    intel::experimental::latency_constraint_key::value_t<Target, Type, Cycle>> {
-  static constexpr const char *name = "sycl-latency-constraint";
-  static constexpr const char *value =
-      SizeListToStr<static_cast<size_t>(Target), static_cast<size_t>(Type),
-                    static_cast<size_t>(Cycle)>::value;
-};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental


### PR DESCRIPTION
This reverts commit b60828d9d6cc5968209cdd94086a22e6d5088602.

We are looking for improving the clang-generated IR for latency controls further, so backing out my previous header change for 2024.1 for now.