### PR TITLE
[SYCL] Shortening error messages in annotated_arg/ptr assertion failures

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -54,8 +54,9 @@ annotated_arg(annotated_arg<T, old>, properties<std::tuple<ArgT...>>)
 template <typename T, typename PropertyListT = empty_properties_t>
 class annotated_arg {
   // This should always fail when instantiating the unspecialized version.
-  static_assert(is_property_list<PropertyListT>::value,
-                "Property list is invalid.");
+  static constexpr bool is_valid_property_list =
+      is_property_list<PropertyListT>::value;
+  static_assert(is_valid_property_list, "Property list is invalid.");
 };
 
 // Partial specialization for pointer type
@@ -83,12 +84,17 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
 #endif
 
 public:
-  static_assert(is_property_list<property_list_t>::value,
-                "Property list is invalid.");
-  static_assert(check_property_list<T *, Props...>::value,
+  static constexpr bool is_valid_property_list =
+      is_property_list<property_list_t>::value;
+  static_assert(is_valid_property_list, "Property list is invalid.");
+  static constexpr bool contains_valid_properties =
+      check_property_list<T *, Props...>::value;
+  static_assert(contains_valid_properties,
                 "The property list contains invalid property.");
   // check the set if FPGA specificed properties are used
-  static_assert(detail::checkValidFPGAPropertySet<Props...>::value,
+  static constexpr bool hasValidFPGAProperties =
+      detail::checkValidFPGAPropertySet<Props...>::value;
+  static_assert(hasValidFPGAProperties,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
 
@@ -109,11 +115,12 @@ public:
   template <typename... PropertyValueTs>
   annotated_arg(T *_ptr, const PropertyValueTs &...props) noexcept
       : obj(global_pointer_t(_ptr)) {
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<
             property_list_t,
             detail::merged_properties_t<property_list_t,
-                                        decltype(properties{props...})>>::value,
+                                        decltype(properties{props...})>>::value;
+    static_assert(has_same_properties,
         "The property list must contain all properties of the input of the "
         "constructor");
   }
@@ -125,14 +132,17 @@ public:
   template <typename T2, typename PropertyList2>
   explicit annotated_arg(const annotated_arg<T2, PropertyList2> &other) noexcept
       : obj(other.obj) {
-    static_assert(std::is_convertible<T2, T *>::value,
+    static constexpr bool is_input_convertible =
+        std::is_convertible<T2, T *>::value;
+    static_assert(is_input_convertible,
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<
             property_list_t,
-            detail::merged_properties_t<property_list_t, PropertyList2>>::value,
+            detail::merged_properties_t<property_list_t, PropertyList2>>::value;
+    static_assert(has_same_properties,
         "The constructed annotated_arg type must contain all the properties of "
         "the input annotated_arg");
   }
@@ -146,13 +156,16 @@ public:
                          const PropertyListV &proplist) noexcept
       : obj(other.obj) {
     (void)proplist;
-    static_assert(std::is_convertible<T2, T *>::value,
+    static constexpr bool is_input_convertible =
+        std::is_convertible<T2, T *>::value;
+    static_assert(is_input_convertible,
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<property_list_t, detail::merged_properties_t<
-                                          PropertyListU, PropertyListV>>::value,
+                                          PropertyListU, PropertyListV>>::value;
+    static_assert(has_same_properties,
         "The property list of constructed annotated_arg type must be the union "
         "of the input property lists");
   }
@@ -192,13 +205,19 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T, detail::properties_t<Props...>> {
 #endif
 
 public:
-  static_assert(is_device_copyable_v<T>, "Type T must be device copyable.");
-  static_assert(is_property_list<property_list_t>::value,
-                "Property list is invalid.");
-  static_assert(check_property_list<T, Props...>::value,
+  static constexpr bool is_device_copyable = is_device_copyable_v<T>;
+  static_assert(is_device_copyable, "Type T must be device copyable.");
+  static constexpr bool is_valid_property_list =
+      is_property_list<property_list_t>::value;
+  static_assert(is_valid_property_list, "Property list is invalid.");
+  static constexpr bool contains_valid_properties =
+      check_property_list<T, Props...>::value;
+  static_assert(contains_valid_properties,
                 "The property list contains invalid property.");
   // check the set if FPGA specificed properties are used
-  static_assert(detail::checkValidFPGAPropertySet<Props...>::value,
+  static constexpr bool hasValidFPGAProperties =
+      detail::checkValidFPGAPropertySet<Props...>::value;
+  static_assert(hasValidFPGAProperties,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
 
@@ -218,11 +237,12 @@ public:
   // `PropertyValueTs...` must have the same property value.
   template <typename... PropertyValueTs>
   annotated_arg(const T &_obj, PropertyValueTs... props) noexcept : obj(_obj) {
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<
             property_list_t,
             detail::merged_properties_t<property_list_t,
-                                        decltype(properties{props...})>>::value,
+                                        decltype(properties{props...})>>::value;
+    static_assert(has_same_properties,
         "The property list must contain all properties of the input of the "
         "constructor");
   }
@@ -234,14 +254,17 @@ public:
   template <typename T2, typename PropertyList2>
   explicit annotated_arg(const annotated_arg<T2, PropertyList2> &other) noexcept
       : obj(other.obj) {
-    static_assert(std::is_convertible<T2, T>::value,
+    static constexpr bool is_input_convertible =
+        std::is_convertible<T2, T>::value;
+    static_assert(is_input_convertible,
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<
             property_list_t,
             detail::merged_properties_t<property_list_t, PropertyList2>>::value,
+    static_assert(has_same_properties,
         "The constructed annotated_arg type must contain all the properties of "
         "the input annotated_arg");
   }
@@ -255,13 +278,16 @@ public:
                          const PropertyListV &proplist) noexcept
       : obj(other.obj) {
     (void)proplist;
-    static_assert(std::is_convertible<T2, T>::value,
+    static constexpr bool is_input_convertible =
+        std::is_convertible<T2, T>::value;
+    static_assert(is_input_convertible,
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<property_list_t, detail::merged_properties_t<
-                                          PropertyListU, PropertyListV>>::value,
+                                          PropertyListU, PropertyListV>>::value;
+    static_assert(has_same_properties,
         "The property list of constructed annotated_arg type must be the union "
         "of the input property lists");
   }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -115,12 +115,12 @@ public:
   template <typename... PropertyValueTs>
   annotated_arg(T *_ptr, const PropertyValueTs &...props) noexcept
       : obj(global_pointer_t(_ptr)) {
-    static constexpr bool has_same_properties =
-        std::is_same<
-            property_list_t,
-            detail::merged_properties_t<property_list_t,
-                                        decltype(properties{props...})>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<property_list_t,
+                                    decltype(properties{props...})>>::value;
+    static_assert(
+        has_same_properties,
         "The property list must contain all properties of the input of the "
         "constructor");
   }
@@ -138,11 +138,11 @@ public:
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static constexpr bool has_same_properties =
-        std::is_same<
-            property_list_t,
-            detail::merged_properties_t<property_list_t, PropertyList2>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<property_list_t, PropertyList2>>::value;
+    static_assert(
+        has_same_properties,
         "The constructed annotated_arg type must contain all the properties of "
         "the input annotated_arg");
   }
@@ -162,10 +162,11 @@ public:
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static constexpr bool has_same_properties =
-        std::is_same<property_list_t, detail::merged_properties_t<
-                                          PropertyListU, PropertyListV>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<PropertyListU, PropertyListV>>::value;
+    static_assert(
+        has_same_properties,
         "The property list of constructed annotated_arg type must be the union "
         "of the input property lists");
   }
@@ -237,12 +238,12 @@ public:
   // `PropertyValueTs...` must have the same property value.
   template <typename... PropertyValueTs>
   annotated_arg(const T &_obj, PropertyValueTs... props) noexcept : obj(_obj) {
-    static constexpr bool has_same_properties =
-        std::is_same<
-            property_list_t,
-            detail::merged_properties_t<property_list_t,
-                                        decltype(properties{props...})>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<property_list_t,
+                                    decltype(properties{props...})>>::value;
+    static_assert(
+        has_same_properties,
         "The property list must contain all properties of the input of the "
         "constructor");
   }
@@ -260,11 +261,11 @@ public:
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static constexpr bool has_same_properties =
-        std::is_same<
-            property_list_t,
-            detail::merged_properties_t<property_list_t, PropertyList2>>::value,
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<property_list_t, PropertyList2>>::value,
+    static_assert(
+        has_same_properties,
         "The constructed annotated_arg type must contain all the properties of "
         "the input annotated_arg");
   }
@@ -284,10 +285,11 @@ public:
                   "The underlying data type of the input annotated_arg is not "
                   "compatible");
 
-    static constexpr bool has_same_properties =
-        std::is_same<property_list_t, detail::merged_properties_t<
-                                          PropertyListU, PropertyListV>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<PropertyListU, PropertyListV>>::value;
+    static_assert(
+        has_same_properties,
         "The property list of constructed annotated_arg type must be the union "
         "of the input property lists");
   }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -143,8 +143,8 @@ public:
         detail::merged_properties_t<property_list_t, PropertyList2>>::value;
     static_assert(
         has_same_properties,
-        "The constructed annotated_arg type must contain all the properties of "
-        "the input annotated_arg");
+        "The constructed annotated_arg type must contain all the properties "
+        "of the input annotated_arg");
   }
 
   // Constructs an annotated_arg object from another annotated_arg object and a

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -263,11 +263,11 @@ public:
 
     static constexpr bool has_same_properties = std::is_same<
         property_list_t,
-        detail::merged_properties_t<property_list_t, PropertyList2>>::value,
+        detail::merged_properties_t<property_list_t, PropertyList2>>::value;
     static_assert(
         has_same_properties,
-        "The constructed annotated_arg type must contain all the properties of "
-        "the input annotated_arg");
+        "The constructed annotated_arg type must contain all the properties "
+        "of the input annotated_arg");
   }
 
   // Constructs an annotated_arg object from another annotated_arg object and a

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -223,12 +223,12 @@ public:
   template <typename... PropertyValueTs>
   explicit annotated_ptr(T *Ptr, const PropertyValueTs &...props) noexcept
       : m_Ptr(global_pointer_t(Ptr)) {
-    static constexpr bool has_same_properties =
-        std::is_same<
-            property_list_t,
-            detail::merged_properties_t<property_list_t,
-                                        decltype(properties{props...})>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<property_list_t,
+                                    decltype(properties{props...})>>::value;
+    static_assert(
+        has_same_properties,
         "The property list must contain all properties of the input of the "
         "constructor");
   }
@@ -242,15 +242,16 @@ public:
       : m_Ptr(other.m_Ptr) {
     static constexpr bool is_input_convertible =
         std::is_convertible<T2 *, T *>::value;
-    static_assert(is_input_convertible,
+    static_assert(
+        is_input_convertible,
         "The underlying pointer type of the input annotated_ptr is not "
         "convertible to the target pointer type");
 
-    static constexpr bool has_same_properties =
-        std::is_same<
-            property_list_t,
-            detail::merged_properties_t<property_list_t, PropertyList2>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<property_list_t, PropertyList2>>::value;
+    static_assert(
+        has_same_properties,
         "The constructed annotated_ptr type must contain all the properties "
         "of the input annotated_ptr");
   }
@@ -265,14 +266,16 @@ public:
       : m_Ptr(other.m_Ptr) {
     static constexpr bool is_input_convertible =
         std::is_convertible<T2 *, T *>::value;
-    static_assert(is_input_convertible,
+    static_assert(
+        is_input_convertible,
         "The underlying pointer type of the input annotated_ptr is not "
         "convertible to the target pointer type");
 
-    static constexpr bool has_same_properties =
-        std::is_same<property_list_t, detail::merged_properties_t<
-                                          PropertyListU, PropertyListV>>::value;
-    static_assert(has_same_properties,
+    static constexpr bool has_same_properties = std::is_same<
+        property_list_t,
+        detail::merged_properties_t<PropertyListU, PropertyListV>>::value;
+    static_assert(
+        has_same_properties,
         "The property list of constructed annotated_ptr type must be the "
         "union of the input property lists");
   }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -62,8 +62,9 @@ struct PropertiesFilter {
 template <typename T, typename PropertyListT = empty_properties_t>
 class annotated_ref {
   // This should always fail when instantiating the unspecialized version.
-  static_assert(is_property_list<PropertyListT>::value,
-                "Property list is invalid.");
+  static constexpr bool is_valid_property_list =
+      is_property_list<PropertyListT>::value;
+  static_assert(is_valid_property_list, "Property list is invalid.");
 };
 
 template <typename T, typename... Props>
@@ -146,8 +147,9 @@ annotated_ptr(annotated_ptr<T, old>, properties<std::tuple<ArgT...>>)
 template <typename T, typename PropertyListT = empty_properties_t>
 class annotated_ptr {
   // This should always fail when instantiating the unspecialized version.
-  static_assert(is_property_list<PropertyListT>::value,
-                "Property list is invalid.");
+  static constexpr bool is_valid_property_list =
+      is_property_list<PropertyListT>::value;
+  static_assert(is_valid_property_list, "Property list is invalid.");
 };
 
 template <typename T, typename... Props>
@@ -192,12 +194,17 @@ __SYCL_TYPE(annotated_ptr) annotated_ptr<T, detail::properties_t<Props...>> {
 #endif
 
 public:
-  static_assert(is_property_list<property_list_t>::value,
-                "Property list is invalid.");
-  static_assert(check_property_list<T *, Props...>::value,
+  static constexpr bool is_valid_property_list =
+      is_property_list<property_list_t>::value;
+  static_assert(is_valid_property_list, "Property list is invalid.");
+  static constexpr bool contains_valid_properties =
+      check_property_list<T *, Props...>::value;
+  static_assert(contains_valid_properties,
                 "The property list contains invalid property.");
   // check the set if FPGA specificed properties are used
-  static_assert(detail::checkValidFPGAPropertySet<Props...>::value,
+  static constexpr bool hasValidFPGAProperties =
+      detail::checkValidFPGAPropertySet<Props...>::value;
+  static_assert(hasValidFPGAProperties,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.)"
                 "can only be set with BufferLocation together.");
 
@@ -216,11 +223,12 @@ public:
   template <typename... PropertyValueTs>
   explicit annotated_ptr(T *Ptr, const PropertyValueTs &...props) noexcept
       : m_Ptr(global_pointer_t(Ptr)) {
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<
             property_list_t,
             detail::merged_properties_t<property_list_t,
-                                        decltype(properties{props...})>>::value,
+                                        decltype(properties{props...})>>::value;
+    static_assert(has_same_properties,
         "The property list must contain all properties of the input of the "
         "constructor");
   }
@@ -232,18 +240,19 @@ public:
   template <typename T2, typename PropertyList2>
   explicit annotated_ptr(const annotated_ptr<T2, PropertyList2> &other) noexcept
       : m_Ptr(other.m_Ptr) {
-    static_assert(
-        std::is_convertible<T2 *, T *>::value,
+    static constexpr bool is_input_convertible =
+        std::is_convertible<T2 *, T *>::value;
+    static_assert(is_input_convertible,
         "The underlying pointer type of the input annotated_ptr is not "
         "convertible to the target pointer type");
 
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<
             property_list_t,
-            detail::merged_properties_t<property_list_t, PropertyList2>>::value,
+            detail::merged_properties_t<property_list_t, PropertyList2>>::value;
+    static_assert(has_same_properties,
         "The constructed annotated_ptr type must contain all the properties "
-        "of "
-        "the input annotated_ptr");
+        "of the input annotated_ptr");
   }
 
   // Constructs an annotated_ptr object from another annotated_ptr object and
@@ -254,17 +263,18 @@ public:
   explicit annotated_ptr(const annotated_ptr<T2, PropertyListU> &other,
                          const PropertyListV &) noexcept
       : m_Ptr(other.m_Ptr) {
-    static_assert(
-        std::is_convertible<T2 *, T *>::value,
+    static constexpr bool is_input_convertible =
+        std::is_convertible<T2 *, T *>::value;
+    static_assert(is_input_convertible,
         "The underlying pointer type of the input annotated_ptr is not "
         "convertible to the target pointer type");
 
-    static_assert(
+    static constexpr bool has_same_properties =
         std::is_same<property_list_t, detail::merged_properties_t<
-                                          PropertyListU, PropertyListV>>::value,
+                                          PropertyListU, PropertyListV>>::value;
+    static_assert(has_same_properties,
         "The property list of constructed annotated_ptr type must be the "
-        "union "
-        "of the input property lists");
+        "union of the input property lists");
   }
 
   reference operator*() const noexcept { return reference(m_Ptr); }

--- a/sycl/include/sycl/ext/oneapi/experimental/common_annotated_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/common_annotated_properties/properties.hpp
@@ -50,7 +50,9 @@ template <typename T, typename Prop, typename... Props>
 struct check_property_list<T, Prop, Props...>
     : std::conditional_t<is_valid_property<T, Prop>::value,
                          check_property_list<T, Props...>, std::false_type> {
-  static_assert(is_valid_property<T, Prop>::value,
+  static constexpr bool is_valid_property_for_given_type =
+      is_valid_property<T, Prop>::value;
+  static_assert(is_valid_property_for_given_type,
                 "Property is invalid for the given type.");
 };
 


### PR DESCRIPTION
This change shortens the error messages for the static assertion failures for annotated_arg/ptr. The check is first assigned to a boolean variable that is named to represent the check and this variable is used in the static assertion. This prevents the props for annotated_arg/ptr to printed in the error message. 

For example, the following static assertion: 

```
error: static assertion failed due to requirement 'is_valid_property<ac_int<17, true>, sycl::ext::oneapi::experimental::property_value<sycl::ext::intel::experimental::buffer_location_key, std::integral_constant<int, 0>>>::value': Property is invalid for the given type.
   57 |   static_assert(is_valid_property<T, Prop>::value,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

will look like this: 

```
error: static assertion failed due to requirement 'is_valid_property_for_given_type': Property is invalid for the given type.
   59 |   static_assert(is_valid_property_for_given_type,
      |                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```