### PR TITLE
[SYCL] reenable ann_arg/ptr e2e test on windows

### DIFF
--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: accelerator
+// REQUIRES: accelerator, opencl-aot
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -3,8 +3,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// https://github.com/intel/llvm/issues/11224
-// UNSUPPORTED: windows
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -96,10 +96,10 @@ int main() {
     d_ptr[i] = i;
 
   // testing arithmetic overloaded operators
-  annotated_arg<MyStruct<int>)> e = MyStruct(5);
-  annotated_arg<MyStruct<int>)> f = MyStruct(6);
-  annotated_arg<MyStruct<int>)> g = MyStruct(3);
-  annotated_arg<MyStruct<int>)> h = MyStruct(2);
+  annotated_arg<MyStruct<int>> e = MyStruct(5);
+  annotated_arg<MyStruct<int>> f = MyStruct(6);
+  annotated_arg<MyStruct<int>> g = MyStruct(3);
+  annotated_arg<MyStruct<int>> h = MyStruct(2);
 
   auto *r1 = malloc_shared<MyStruct<int>>(5, Q);
   auto *r2 = malloc_shared<MyStruct<int>>(5, Q);
@@ -116,9 +116,9 @@ int main() {
   auto *r6 = malloc_shared<MyStruct<bool>>(3, Q);
 
   // testing bit shift overloaded operators
-  annotated_arg<MyStruct<int>)> x = MyStruct(1);
-  annotated_arg<MyStruct<int>)> y = MyStruct(2);
-  annotated_arg<MyStruct<int>)> z = MyStruct(4);
+  annotated_arg<MyStruct<int>> x = MyStruct(1);
+  annotated_arg<MyStruct<int>> y = MyStruct(2);
+  annotated_arg<MyStruct<int>> z = MyStruct(4);
 
   auto *r7 = malloc_shared<MyStruct<int>>(2, Q);
   auto *r8 = malloc_shared<MyStruct<int>>(2, Q);

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: accelerator, opencl-aot
+// UNSUPPORTED: gpu
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -106,9 +106,9 @@ int main() {
   auto *r3 = malloc_shared<MyStruct<int>>(5, Q);
 
   // testing logical overloaded operators
-  annotated_arg<MyStruct<bool>)> m =
+  annotated_arg<MyStruct<bool>> m =
       MyStruct(true);
-  annotated_arg<MyStruct<bool>)> n =
+  annotated_arg<MyStruct<bool>> n =
       MyStruct(false);
 
   auto *r4 = malloc_shared<MyStruct<bool>>(3, Q);

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -106,10 +106,8 @@ int main() {
   auto *r3 = malloc_shared<MyStruct<int>>(5, Q);
 
   // testing logical overloaded operators
-  annotated_arg<MyStruct<bool>> m =
-      MyStruct(true);
-  annotated_arg<MyStruct<bool>> n =
-      MyStruct(false);
+  annotated_arg<MyStruct<bool>> m = MyStruct(true);
+  annotated_arg<MyStruct<bool>> n = MyStruct(false);
 
   auto *r4 = malloc_shared<MyStruct<bool>>(3, Q);
   auto *r5 = malloc_shared<MyStruct<bool>>(3, Q);

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: gpu
-//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
@@ -98,19 +96,19 @@ int main() {
     d_ptr[i] = i;
 
   // testing arithmetic overloaded operators
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> e = MyStruct(5);
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> f = MyStruct(6);
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> g = MyStruct(3);
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> h = MyStruct(2);
+  annotated_arg<MyStruct<int>)> e = MyStruct(5);
+  annotated_arg<MyStruct<int>)> f = MyStruct(6);
+  annotated_arg<MyStruct<int>)> g = MyStruct(3);
+  annotated_arg<MyStruct<int>)> h = MyStruct(2);
 
   auto *r1 = malloc_shared<MyStruct<int>>(5, Q);
   auto *r2 = malloc_shared<MyStruct<int>>(5, Q);
   auto *r3 = malloc_shared<MyStruct<int>>(5, Q);
 
   // testing logical overloaded operators
-  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> m =
+  annotated_arg<MyStruct<bool>)> m =
       MyStruct(true);
-  annotated_arg<MyStruct<bool>, decltype(properties{conduit})> n =
+  annotated_arg<MyStruct<bool>)> n =
       MyStruct(false);
 
   auto *r4 = malloc_shared<MyStruct<bool>>(3, Q);
@@ -118,9 +116,9 @@ int main() {
   auto *r6 = malloc_shared<MyStruct<bool>>(3, Q);
 
   // testing bit shift overloaded operators
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> x = MyStruct(1);
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> y = MyStruct(2);
-  annotated_arg<MyStruct<int>, decltype(properties{conduit})> z = MyStruct(4);
+  annotated_arg<MyStruct<int>)> x = MyStruct(1);
+  annotated_arg<MyStruct<int>)> y = MyStruct(2);
+  annotated_arg<MyStruct<int>)> z = MyStruct(4);
 
   auto *r7 = malloc_shared<MyStruct<int>>(2, Q);
   auto *r8 = malloc_shared<MyStruct<int>>(2, Q);
@@ -260,7 +258,7 @@ int main() {
   assert(is_device_copyable<device_copyable_annotated_arg>::value &&
          "annotated_arg<device_copyable_class> is not device copyable.");
   using device_copyable_annotated_arg_with_properties =
-      annotated_arg<device_copyable_class, decltype(properties{conduit})>;
+      annotated_arg<device_copyable_class>;
   assert(is_device_copyable<
              device_copyable_annotated_arg_with_properties>::value &&
          "annotated_arg<device_copyable_class, properties> is not device "

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: accelerator
+// REQUIRES: accelerator, opencl-aot
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
@@ -1,8 +1,8 @@
+// REQUIRES: accelerator
+//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// https://github.com/intel/llvm/issues/11224
-// UNSUPPORTED: windows
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: gpu
-//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: accelerator, opencl-aot
+// UNSUPPORTED: gpu
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
reenable ann_arg/ptr e2e test on windows, tagged with unsupported: gpu

issue https://github.com/intel/llvm/issues/11224