### PR TITLE
[SYCL] Don't load all fallback spirv when launching from SPIRV file

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -1522,16 +1522,13 @@ void ProgramManager::flushSpecConstants(const program_impl &Prg,
   Prg.flush_spec_constants(*Img, NativePrg);
 }
 
-// If the kernel is loaded from spv file, it may not include DeviceLib require
-// mask, sycl runtime won't know which fallback device libraries are needed. In
-// such case, the safest way is to load all fallback device libraries.
 uint32_t ProgramManager::getDeviceLibReqMask(const RTDeviceBinaryImage &Img) {
   const RTDeviceBinaryImage::PropertyRange &DLMRange =
       Img.getDeviceLibReqMask();
   if (DLMRange.isAvailable())
     return DeviceBinaryProperty(*(DLMRange.begin())).asUint32();
   else
-    return 0xFFFFFFFF;
+    return 0x0;
 }
 
 const KernelArgMask *


### PR DESCRIPTION
Currently, sycl-post-link tool scans user's device image to detect any undefined function call to items in fallback spirv devicelibs and create a property in final executable to tell which fallback devicelibs are really needed. SYCL runtime will load required fallback spirv libs according to this property.
However, if "SYCL_USE_KERNEL_SPIRV" is used, the kernel is launched from spv file and sycl-post-link tool is not involved to scan and generate the property. Previously, we just load and link all fallback spv files and underlying runtime will remove them when they don't need those code. However, we received a lot of complains about seeing a lot of unnecessary code from underlying runtime. So, this PR is to avoid loading this unnecessary code.
If anyone uses clang++ driver to generate spv file, this file won't depend on any functions from fallback spv since device code has to be linked with wrapper .obj to involve any functions from fallback spv.