### PR TITLE
[SYCL] Fix build when not using XPTI tracing

### DIFF
--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -242,10 +242,11 @@ event handler::finalize() {
       auto [CmdTraceEvent, InstanceID] = emitKernelInstrumentationData(
           StreamID, MKernel, MCodeLoc, MKernelName, MQueue, MNDRDesc,
           KernelBundleImpPtr, MArgs);
-#endif
-
       auto EnqueueKernel = [&, CmdTraceEvent = CmdTraceEvent,
                             InstanceID = InstanceID]() {
+#else
+      auto EnqueueKernel = [&]() {
+#endif
         // 'Result' for single point of return
         pi_int32 Result = PI_ERROR_INVALID_VALUE;
 #ifdef XPTI_ENABLE_INSTRUMENTATION


### PR DESCRIPTION
The build was broken with:
```
/home/hugh/llvm/sycl/source/handler.cpp:247:48: error: ‘CmdTraceEvent’ was not declared in this scope
  247 |       auto EnqueueKernel = [&, CmdTraceEvent = CmdTraceEvent,
      |                                                ^~~~~~~~~~~~~
/home/hugh/llvm/sycl/source/handler.cpp:248:42: error: ‘InstanceID’ was not declared in this scope; did you mean ‘distance’?
  248 |                             InstanceID = InstanceID]() {
      |                                          ^~~~~~~~~~
      |                                          distance
```
When XPTI tracing is not used.