### PR TITLE
[SYCL][HIP][CUDA] Enable cuda / hip support for empty_zero_dim_accessor test.

### DIFF
--- a/sycl/test-e2e/Basic/accessor/empty_zero_dim_accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/empty_zero_dim_accessor.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Disabled for HIP (https://github.com/intel/llvm/issues/10358) and CUDA
-// (https://github.com/intel/llvm/issues/10360)
-// UNSUPPORTED: cuda || hip
-
 // https://github.com/intel/llvm/issues/11434
 // XFAIL: gpu-intel-dg2
 


### PR DESCRIPTION
Locally, on a machine with NVIDIA gpu verified to work. 