### PR TITLE
[SYCL-MLIR][loop-restructure] Preserve block arguments

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopRestructure.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopRestructure.cpp
@@ -426,7 +426,7 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
           for (const BlockArgument &Arg : B->getArguments())
             preserveValueIfNeeded(Arg);
         }
-        for (auto &O : *(Block *)B) {
+        for (auto &O : *B) {
           for (auto V : O.getResults())
             preserveValueIfNeeded(V);
         }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopRestructure.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopRestructure.cpp
@@ -410,7 +410,7 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
               Block *blk = user->getBlock();
               while (blk->getParent() != &region)
                 blk = blk->getParentOp()->getBlock();
-              return !L->contains((Wrapper *)blk);
+              return !L->contains(reinterpret_cast<Wrapper *>(blk));
             })) {
           preservedVals.emplace_back(V, headerArgumentTypes.size());
           headerArgumentTypes.push_back(V.getType());

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopRestructure.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopRestructure.cpp
@@ -419,9 +419,13 @@ void LoopRestructure::runOnRegion(DominanceInfo &domInfo, Region &region) {
           header->addArgument(V.getType(), V.getLoc());
         }
       };
-      for (auto *B : L->getBlocks()) {
-        for (const BlockArgument &Arg : B->blk.getArguments())
-          preserveValueIfNeeded(Arg);
+      for (Wrapper *W : L->getBlocks()) {
+        Block *B = &W->blk;
+        if (B != header) {
+          // Do not add twice
+          for (const BlockArgument &Arg : B->getArguments())
+            preserveValueIfNeeded(Arg);
+        }
         for (auto &O : *(Block *)B) {
           for (auto V : O.getResults())
             preserveValueIfNeeded(V);

--- a/polygeist/test/polygeist-opt/loop-restructure-keep-block-arg.mlir
+++ b/polygeist/test/polygeist-opt/loop-restructure-keep-block-arg.mlir
@@ -1,0 +1,57 @@
+// RUN: polygeist-opt --allow-unregistered-dialect --loop-restructure %s | FileCheck %s
+
+// CHECK-LABEL:   func.func @test_do_while() -> i32
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.undef : i32
+// CHECK:           %[[VAL_2:.*]]:2 = scf.while (%[[VAL_3:.*]] = %[[VAL_0]], %[[VAL_4:.*]] = %[[VAL_1]]) : (i32, i32) -> (i32, i32) {
+// CHECK:             %[[VAL_5:.*]]:3 = scf.execute_region -> (i1, i32, i32) {
+// CHECK:               %[[VAL_6:.*]] = "get"() : () -> i32
+// CHECK:               cf.switch %[[VAL_6]] : i32, [
+// CHECK:                 default: ^bb3(%[[VAL_3]] : i32),
+// CHECK:                 0: ^bb1,
+// CHECK:                 1: ^bb2
+// CHECK:               ]
+// CHECK:             ^bb1:
+// CHECK:               %[[VAL_7:.*]] = "caseA"() : () -> i32
+// CHECK:               cf.br ^bb2
+// CHECK:             ^bb2:
+// CHECK:               %[[VAL_8:.*]] = "caseB"() : () -> i32
+// CHECK:               cf.br ^bb3(%[[VAL_8]] : i32)
+// CHECK:             ^bb3(%[[VAL_9:.*]]: i32):
+// CHECK:               %[[VAL_10:.*]] = "cond"() : () -> i1
+// CHECK:               %[[VAL_11:.*]] = arith.constant false
+// CHECK:               %[[VAL_12:.*]] = arith.constant true
+// CHECK:               %[[VAL_13:.*]] = arith.select %[[VAL_10]], %[[VAL_12]], %[[VAL_11]] : i1
+// CHECK:               %[[VAL_14:.*]] = arith.select %[[VAL_10]], %[[VAL_9]], %[[VAL_3]] : i32
+// CHECK:               %[[VAL_15:.*]] = arith.select %[[VAL_10]], %[[VAL_9]], %[[VAL_9]] : i32
+// CHECK:               scf.yield %[[VAL_13]], %[[VAL_14]], %[[VAL_15]] : i1, i32, i32
+// CHECK:             }
+// CHECK:             scf.condition(%[[VAL_5]]#0) %[[VAL_5]]#1, %[[VAL_5]]#2 : i32, i32
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i32):
+// CHECK:             scf.yield %[[VAL_17]], %[[VAL_18]] : i32, i32
+// CHECK:           }
+// CHECK:           return %[[VAL_2]]#1 : i32
+// CHECK:         }
+func.func @test_do_while() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
+  %0 = arith.constant 0 : i32
+  cf.br ^bb1(%0 : i32)
+^bb1(%1: i32):  // 2 preds: ^bb0, ^bb4
+  %2 = "get"() : () -> i32
+  cf.switch %2 : i32, [
+    default: ^bb4(%1 : i32),
+    0: ^bb2,
+    1: ^bb3
+  ]
+^bb2:  // pred: ^bb1
+  %3 = "caseA"() : () -> i32
+  cf.br ^bb3
+^bb3:  // 2 preds: ^bb1, ^bb2
+  %4 = "caseB"() : () -> i32
+  cf.br ^bb4(%4 : i32)
+^bb4(%5: i32):  // 2 preds: ^bb1, ^bb3
+  %6 = "cond"() : () -> i1
+  cf.cond_br %6, ^bb1(%5 : i32), ^bb5
+^bb5:  // pred: ^bb4
+  return %5 : i32
+}

--- a/polygeist/test/polygeist-opt/loop-restructure-keep-block-arg.mlir
+++ b/polygeist/test/polygeist-opt/loop-restructure-keep-block-arg.mlir
@@ -31,6 +31,7 @@
 // CHECK:           ^bb0(%[[VAL_17:.*]]: i32, %[[VAL_18:.*]]: i32):
 // CHECK:             scf.yield %[[VAL_17]], %[[VAL_18]] : i32, i32
 // CHECK:           }
+// CHECK:           "use"(%[[VAL_2]]#0) : (i32) -> ()
 // CHECK:           return %[[VAL_2]]#1 : i32
 // CHECK:         }
 func.func @test_do_while() -> i32 attributes {llvm.linkage = #llvm.linkage<external>} {
@@ -53,5 +54,6 @@ func.func @test_do_while() -> i32 attributes {llvm.linkage = #llvm.linkage<exter
   %6 = "cond"() : () -> i1
   cf.cond_br %6, ^bb1(%5 : i32), ^bb5
 ^bb5:  // pred: ^bb4
+  "use"(%1) : (i32) -> ()
   return %5 : i32
 }

--- a/polygeist/tools/cgeist/Test/Verification/do-while-switch.c
+++ b/polygeist/tools/cgeist/Test/Verification/do-while-switch.c
@@ -1,0 +1,54 @@
+// RUN: cgeist -o - -S --function=test_do_while %s | FileCheck %s
+
+enum Kind { A, B };
+
+enum Kind get();
+int cond();
+int caseA();
+int caseB();
+
+// CHECK-LABEL:   func.func @test_do_while() -> i32
+// CHECK:           %[[VAL_0:.*]] = arith.constant 0 : i32
+// CHECK:           %[[VAL_1:.*]] = llvm.mlir.undef : i32
+// CHECK:           %[[VAL_2:.*]]:2 = scf.while (%[[VAL_3:.*]] = %[[VAL_1]]) : (i32) -> (i32, i32) {
+// CHECK:             %[[VAL_4:.*]]:3 = scf.execute_region -> (i1, i32, i32) {
+// CHECK:               %[[VAL_5:.*]] = func.call @get() : () -> i32
+// CHECK:               cf.switch %[[VAL_5]] : i32, [
+// CHECK:                 default: ^bb3(%[[VAL_3]] : i32),
+// CHECK:                 0: ^bb2,
+// CHECK:                 1: ^bb1
+// CHECK:               ]
+// CHECK:             ^bb1:
+// CHECK:               %[[VAL_6:.*]] = func.call @caseB() : () -> i32
+// CHECK:               cf.br ^bb3(%[[VAL_6]] : i32)
+// CHECK:             ^bb2:
+// CHECK:               %[[VAL_7:.*]] = func.call @caseA() : () -> i32
+// CHECK:               cf.br ^bb3(%[[VAL_7]] : i32)
+// CHECK:             ^bb3(%[[VAL_8:.*]]: i32):
+// CHECK:               %[[VAL_9:.*]] = func.call @cond() : () -> i32
+// CHECK:               %[[VAL_10:.*]] = arith.cmpi ne, %[[VAL_9]], %[[VAL_0]] : i32
+// CHECK:               %[[VAL_11:.*]] = arith.select %[[VAL_10]], %[[VAL_8]], %[[VAL_3]] : i32
+// CHECK:               scf.yield %[[VAL_10]], %[[VAL_11]], %[[VAL_8]] : i1, i32, i32
+// CHECK:             }
+// CHECK:             scf.condition(%[[VAL_4]]#0) %[[VAL_4]]#1, %[[VAL_4]]#2 : i32, i32
+// CHECK:           } do {
+// CHECK:           ^bb0(%[[VAL_13:.*]]: i32, %[[VAL_14:.*]]: i32):
+// CHECK:             scf.yield %[[VAL_13]] : i32
+// CHECK:           }
+// CHECK:           return %[[VAL_2]]#1 : i32
+// CHECK:         }
+int test_do_while() {
+  int res;
+  do {
+    switch (get()) {
+    case A:
+      res = caseA();
+      break;
+
+    case B:
+      res = caseB();
+      break;
+    }
+  } while (cond());
+  return res;
+}


### PR DESCRIPTION
When arguments of the loop's blocks are used outside the loop, preserve them as it is done with operation-defined values.

Loop header arguments are skipped as those are already added by default.