### PR TITLE
[SYCL][CUDA][NFC] Add nocudalib to rdc driver test

### DIFF
--- a/clang/test/Driver/sycl-cuda-rdc.cpp
+++ b/clang/test/Driver/sycl-cuda-rdc.cpp
@@ -4,7 +4,7 @@
 
 // UNSUPPORTED: system-windows
 
-// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_61 -fgpu-rdc %s 2>&1 \
+// RUN: %clangxx -### -fsycl -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --cuda-gpu-arch=sm_61 -fgpu-rdc -nocudalib %s 2>&1 \
 // RUN: | FileCheck %s -check-prefix=CHECK-SYCL_RDC_NVPTX
 
 // Verify that ptxas does not pass "-c"


### PR DESCRIPTION
The test will fail on machines without cudalib

clang: error: cannot find libdevice for sm_61; provide path to different
CUDA installation via '--cuda-path', or pass '-nocudalib' to build
without linking with libdevice

For the driver test, we don't really need the cudalib.
