### PR TITLE
[SYCL-MLIR][cgeist] Define global variables in proper context

### DIFF
--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1557,7 +1557,7 @@ MLIRASTConsumer::getOrCreateLLVMGlobal(const clang::ValueDecl *FD,
   Type RT = getTypes().getMLIRType(FD->getType());
 
   OpBuilder Builder(Module->getContext());
-  Builder.setInsertionPointToStart(Module->getBody());
+  mlirclang::setInsertionPoint(Builder, FuncContext, *Module);
 
   auto Glob = Builder.create<LLVM::GlobalOp>(
       Module->getLoc(), RT, /*constant*/ false, Lnk, Name, Attribute());

--- a/polygeist/tools/cgeist/Test/Verification/use-global-in-namespace.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/use-global-in-namespace.cpp
@@ -3,6 +3,7 @@
 #include <sycl/sycl.hpp>
 
 namespace NS {
+// CHECK:         gpu.module @device_functions
 // CHECK-LABEL:     llvm.mlir.global internal @_ZN2NSL1CE() {addr_space = 0 : i32, sym_visibility = "private"} : f64 {
 // CHECK:             %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f64
 // CHECK:             llvm.return %[[VAL_0]] : f64

--- a/polygeist/tools/cgeist/Test/Verification/use-global-in-namespace.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/use-global-in-namespace.cpp
@@ -1,0 +1,18 @@
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -emit-mlir -O0 %s -o - -S -emit-mlir -fsycl-device-only | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+namespace NS {
+// CHECK-LABEL:     llvm.mlir.global internal @_ZN2NSL1CE() {addr_space = 0 : i32, sym_visibility = "private"} : f64 {
+// CHECK:             %[[VAL_0:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:             llvm.return %[[VAL_0]] : f64
+// CHECK:           }
+const double C = 0.0;
+}
+
+// CHECK-LABEL:     func.func @_Z3foov() -> (f64 {llvm.noundef})
+// CHECK:             %[[VAL_152:.*]] = llvm.mlir.addressof @_ZN2NSL1CE : !llvm.ptr
+// CHECK:             %[[VAL_153:.*]] = llvm.load %[[VAL_152]] : !llvm.ptr -> f64
+// CHECK:             return %[[VAL_153]] : f64
+// CHECK:           }
+SYCL_EXTERNAL double foo() { return NS::C; }


### PR DESCRIPTION
When a global variable is refercenced in device code, it should be defined in the device module.