### PR TITLE
[SYCL][E2E] dmem_varied.cpp test missing required sync point

### DIFF
--- a/sycl/test-e2e/USM/dmem_varied.cpp
+++ b/sycl/test-e2e/USM/dmem_varied.cpp
@@ -79,12 +79,12 @@ int main() {
   }
 
   q.submit([&](handler &h) {
-    h.single_task<class foo1>([=]() {
-      for (size_t i = 0; i < count; ++i) {
-        *ptrs[i] = 1;
-      }
-    });
-  }).wait();
+     h.single_task<class foo1>([=]() {
+       for (size_t i = 0; i < count; ++i) {
+         *ptrs[i] = 1;
+       }
+     });
+   }).wait();
 
   size_t *res =
       (size_t *)aligned_alloc_shared(alignof(size_t), sizeof(size_t), q);

--- a/sycl/test-e2e/USM/dmem_varied.cpp
+++ b/sycl/test-e2e/USM/dmem_varied.cpp
@@ -84,7 +84,7 @@ int main() {
         *ptrs[i] = 1;
       }
     });
-  });
+  }).wait();
 
   size_t *res =
       (size_t *)aligned_alloc_shared(alignof(size_t), sizeof(size_t), q);


### PR DESCRIPTION
Test is missing required wait() between initializing ptrs and reading it. This is causing flaky failures.