### PR TITLE
[SYCL][Joint Matrix][E2E] Remove xfail for GPU for 2 tests

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_16x16x16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_16x16x16.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-// XFAIL: *
+// XFAIL: cpu
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_32x64x16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_32x64x16.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
 // RUN: %{run} %t.out
 
-// XFAIL: *
+// XFAIL: cpu
 
 #include "common.hpp"
 


### PR DESCRIPTION
Remove XFAIL for GPU for joint_matrix_bfloat16_16x16x16 and joint_matrix_bfloat16_32x64x16 tests