### PR TITLE
[SYCL][test-e2e] Fix how clang++ is called

### DIFF
--- a/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
+++ b/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
-// RUN: clang++ -fsycl -fsycl-device-obj=spirv -c -o %t.o %s
-// RUN: clang++ -fsycl -o %t.out %t.o
+// RUN: %clangxx -fsycl -fsycl-device-obj=spirv -c -o %t.o %s
+// RUN: %clangxx -fsycl -o %t.out %t.o
 // RUN: %{run} %t.out
 
 // This test verifies SPIR-V based fat objects.


### PR DESCRIPTION
This test called clang++ directly. I think we need to use %clangxx

Thanks