### PR TITLE
[SYCL][COMPAT] Atomics: Support for multiple datatypes, remove runtime memoryOrder

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -836,154 +836,122 @@ wrong queue is used as an argument in any of the member functions of the
 #### Atomic Operations
 
 SYCLcompat provides an interface for common atomic operations (`add`, `sub`,
-`and`, `or`, `xor`, `min`, `max`, `exchange`, `compare_exchange`). While SYCL
-exposes atomic operations through member functions of `sycl::atomic_ref`, this
-library provides access via functions taking a standard pointer argument.
-Template arguments control the `sycl::memory_scope`, `sycl::memory_order` and
-`sycl::access::address_space` of these atomic operations. SYCLcompat also
-exposes overloads for these atomic functions which take a runtime memoryScope
-argument. Every atomic operation is implemented via an API function taking a raw
-pointer as the target. Additional overloads for
+`and`, `or`, `xor`, `min`, `max`, `inc`, `dec`, `exchange`, `compare_exchange`).
+While SYCL exposes atomic operations through member functions of
+`sycl::atomic_ref`, this library provides access via functions taking a standard
+pointer argument. Template arguments control the `sycl::memory_scope`,
+`sycl::memory_order` and `sycl::access::address_space` of these atomic
+operations. SYCLcompat also exposes overloads for these atomic functions which
+take a runtime memoryScope argument. Every atomic operation is implemented via
+an API function taking a raw pointer as the target. Additional overloads for
 `syclcompat::compare_exchange_strong` are provided which take a
-`sycl::multi_ptr` instead of a raw pointer. Addition and subtraction make use of
-`arith_t` to differentiate between numeric and pointer arithmetics.
+`sycl::multi_ptr` instead of a raw pointer. The type of the operand for most
+atomic operations is defined as `syclcompat::type_identity_t<T>` to avoid
+template deduction issues when an operand of a different type (e.g. double
+literal) is supplied. Atomic addition and subtraction free functions make use of
+`syclcompat::arith_t<T>` to differentiate between numeric and pointer
+arithmetics.
 
 The available operations are exposed as follows:
 
 ``` c++
 namespace syclcompat {
 
+template <class T> struct type_identity {
+  using type = T;
+};
+template <class T> using type_identity_t = typename type_identity<T>::type;
+
 template <typename T> struct arith {
   using type = std::conditional_t<std::is_pointer_v<T>, std::ptrdiff_t, T>;
 };
 template <typename T> using arith_t = typename arith<T>::type;
 
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 T atomic_fetch_add(T *addr, arith_t<T> operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_add(T *addr, arith_t<T> operand,
-                   sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_sub(T *addr, arith_t<T> operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_sub(T *addr, arith_t<T> operand,
-                          sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_and(T *addr, T operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_and(T *addr, T operand, sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_or(T *addr, T operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_or(T *addr, T operand, sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_xor(T *addr, T operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_xor(T *addr, T operand, sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_min(T *addr, T operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_min(T *addr, T operand, sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_max(T *addr, T operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_fetch_max(T *addr, T operand, sycl::memory_order memoryOrder);
 
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_fetch_sub(T *addr, arith_t<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_fetch_and(T *addr, type_identity<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_fetch_or(T *addr, type_identity<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_fetch_xor(T *addr, type_identity<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_fetch_min(T *addr, type_identity<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_fetch_max(T *addr, type_identity<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 unsigned int atomic_fetch_compare_inc(unsigned int *addr,
                                       unsigned int operand);
+
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-unsigned int atomic_fetch_compare_inc(unsigned int *addr,
-                                      unsigned int operand,
-                                      sycl::memory_order memoryOrder);
-
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_exchange(T *addr, T operand);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-T atomic_exchange(T *addr, T operand, sycl::memory_order memoryOrder);
+unsigned int atomic_fetch_compare_dec(unsigned int *addr,
+                                      unsigned int operand);
 
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
+T atomic_exchange(T *addr, type_identity<T> operand);
+
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
+          sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 T atomic_compare_exchange_strong(
-    sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
+    sycl::multi_ptr<T, sycl::access::address_space::generic_space> addr,
     T expected, T desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed);
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+template <sycl::access::address_space addressSpace =
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 T atomic_compare_exchange_strong(
     T *addr, T expected, T desired,
     sycl::memory_order success = sycl::memory_order::relaxed,

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -49,7 +49,7 @@ namespace syclcompat {
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -66,7 +66,7 @@ inline T atomic_fetch_add(T *addr, arith_t<T> operand) {
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -84,7 +84,7 @@ inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -102,7 +102,7 @@ inline T atomic_fetch_and(T *addr, type_identity_t<T> operand) {
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -120,7 +120,7 @@ inline T atomic_fetch_or(T *addr, type_identity_t<T> operand) {
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -136,7 +136,7 @@ inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand) {
 /// \param operand. \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -153,7 +153,7 @@ inline T atomic_fetch_min(T *addr, type_identity_t<T> operand) {
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -170,7 +170,7 @@ inline T atomic_fetch_max(T *addr, type_identity_t<T> operand) {
 /// \param memoryOrder The memory ordering used.
 /// \returns The old value stored in \p addr.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 unsigned int atomic_fetch_compare_dec(unsigned int *addr,
@@ -199,7 +199,7 @@ unsigned int atomic_fetch_compare_dec(unsigned int *addr,
 /// \param memoryOrder The memory ordering used.
 /// \returns The old value stored in \p addr.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
@@ -225,7 +225,7 @@ inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
@@ -246,12 +246,12 @@ inline T atomic_exchange(T *addr, type_identity_t<T> operand) {
 /// \param fail The memory ordering used when comparison fails.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>
 T atomic_compare_exchange_strong(
-    sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
+    sycl::multi_ptr<T, sycl::access::address_space::generic_space> addr,
     type_identity_t<T> expected, type_identity_t<T> desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
@@ -272,7 +272,7 @@ T atomic_compare_exchange_strong(
 /// \param fail The memory ordering used when comparison fails.
 /// \returns The value at the \p addr before the call.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
+              sycl::access::address_space::generic_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device,
           typename T>

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -235,35 +235,6 @@ inline T atomic_exchange(T *addr, type_identity_t<T> operand) {
   return atm.exchange(operand);
 }
 
-/// Atomically exchange the value at the address addr with the value operand.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The value to be exchanged with the value pointed by \p
-/// addr. \param memoryOrder The memory ordering used. \returns The value at
-/// the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_exchange(T *addr, type_identity_t<T> operand,
-                         sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_exchange<T, addressSpace, sycl::memory_order::relaxed,
-                           memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_exchange<T, addressSpace, sycl::memory_order::acq_rel,
-                           memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_exchange<T, addressSpace, sycl::memory_order::seq_cst,
-                           memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
-}
-
 /// Atomically compare the value at \p addr to the value expected and exchange
 /// with the value desired if the value at \p addr is equal to the value
 /// expected. Returns the value at the \p addr before the call.

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -59,36 +59,6 @@ inline T atomic_fetch_add(T *addr, arith_t<T> operand) {
   return atm.fetch_add(operand);
 }
 
-/// Atomically add the value operand to the value at the addr and assign the
-/// result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The value to add to the value at \p addr.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_add(T *addr, arith_t<T> operand,
-                          sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::relaxed,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::acq_rel,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_add<T, addressSpace, sycl::memory_order::seq_cst,
-                            memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
-}
-
 /// Atomically subtract the value operand from the value at the addr and
 /// assign the result to the value at addr.
 /// \param [in, out] addr The pointer to the data.
@@ -104,36 +74,6 @@ inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_sub(operand);
-}
-
-/// Atomically subtract the value operand from the value at the addr and
-/// assign the result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The value to subtract from the value at \p addr.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_sub(T *addr, arith_t<T> operand,
-                          sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::relaxed,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::acq_rel,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_sub<T, addressSpace, sycl::memory_order::seq_cst,
-                            memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
 }
 
 /// Atomically perform a bitwise AND between the value operand and the value
@@ -154,36 +94,6 @@ inline T atomic_fetch_and(T *addr, type_identity_t<T> operand) {
   return atm.fetch_and(operand);
 }
 
-/// Atomically perform a bitwise AND between the value operand and the value
-/// at the addr and assign the result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The value to use in bitwise AND operation with the value at
-/// the \p addr.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_and(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_and<T, addressSpace, sycl::memory_order::relaxed,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_and<T, addressSpace, sycl::memory_order::acq_rel,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_and<T, addressSpace, sycl::memory_order::seq_cst,
-                            memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
-}
-
 /// Atomically or the value at the addr with the value operand, and assign
 /// the result to the value at addr.
 /// \param [in, out] addr The pointer to the data.
@@ -200,36 +110,6 @@ inline T atomic_fetch_or(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_or(operand);
-}
-
-/// Atomically or the value at the addr with the value operand, and assign
-/// the result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The value to use in bitwise OR operation with the value at
-/// the \p addr.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_or(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_or<T, addressSpace, sycl::memory_order::relaxed,
-                           memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_or<T, addressSpace, sycl::memory_order::acq_rel,
-                           memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_or<T, addressSpace, sycl::memory_order::seq_cst,
-                           memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
 }
 
 /// Atomically xor the value at the addr with the value operand, and assign
@@ -250,36 +130,6 @@ inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand) {
   return atm.fetch_xor(operand);
 }
 
-/// Atomically xor the value at the addr with the value operand, and assign
-/// the result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The value to use in bitwise XOR operation with the value at
-/// the \p addr.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::relaxed,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::acq_rel,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_xor<T, addressSpace, sycl::memory_order::seq_cst,
-                            memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
-}
-
 /// Atomically calculate the minimum of the value at addr and the value
 /// operand and assign the result to the value at addr.
 /// \param [in, out] addr The pointer to the data.
@@ -294,35 +144,6 @@ inline T atomic_fetch_min(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_min(operand);
-}
-
-/// Atomically calculate the minimum of the value at addr and the value
-/// operand and assign the result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_min(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_min<T, addressSpace, sycl::memory_order::relaxed,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_min<T, addressSpace, sycl::memory_order::acq_rel,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_min<T, addressSpace, sycl::memory_order::seq_cst,
-                            memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
 }
 
 /// Atomically calculate the maximum of the value at addr and the value
@@ -340,35 +161,6 @@ inline T atomic_fetch_max(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_max(operand);
-}
-
-/// Atomically calculate the maximum of the value at addr and the value
-/// operand and assign the result to the value at addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand.
-/// \param memoryOrder The memory ordering used.
-/// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_max(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_max<T, addressSpace, sycl::memory_order::relaxed,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_max<T, addressSpace, sycl::memory_order::acq_rel,
-                            memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_max<T, addressSpace, sycl::memory_order::seq_cst,
-                            memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
 }
 
 /// Atomically set \p operand to the value stored in \p addr, if old value
@@ -407,34 +199,6 @@ unsigned int atomic_fetch_compare_dec(unsigned int *addr,
 /// \param memoryOrder The memory ordering used.
 /// \returns The old value stored in \p addr.
 template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space>
-unsigned int atomic_fetch_compare_dec(unsigned int *addr, unsigned int operand,
-                                      sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_compare_dec<addressSpace, sycl::memory_order::relaxed,
-                                    sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_compare_dec<addressSpace, sycl::memory_order::acq_rel,
-                                    sycl::memory_scope::device>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_compare_dec<addressSpace, sycl::memory_order::seq_cst,
-                                    sycl::memory_scope::device>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
-}
-
-/// Atomically increment the value stored in \p addr if old value stored in \p
-/// addr is less than \p operand, else set 0 to the value stored in \p addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The threshold value.
-/// \param memoryOrder The memory ordering used.
-/// \returns The old value stored in \p addr.
-template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
@@ -453,36 +217,6 @@ inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
       break;
   }
   return old;
-}
-
-/// Atomically increment the value stored in \p addr if old value stored in \p
-/// addr is less than \p operand, else set 0 to the value stored in \p addr.
-/// \param [in, out] addr The pointer to the data.
-/// \param operand The threshold value.
-/// \param memoryOrder The memory ordering used.
-/// \returns The old value stored in \p addr.
-template <sycl::access::address_space addressSpace =
-              sycl::access::address_space::global_space,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
-                                             unsigned int operand,
-                                             sycl::memory_order memoryOrder) {
-  switch (memoryOrder) {
-  case sycl::memory_order::relaxed:
-    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::relaxed,
-                                    memoryScope>(addr, operand);
-  case sycl::memory_order::acq_rel:
-    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::acq_rel,
-                                    memoryScope>(addr, operand);
-  case sycl::memory_order::seq_cst:
-    return atomic_fetch_compare_inc<addressSpace, sycl::memory_order::seq_cst,
-                                    memoryScope>(addr, operand);
-  default:
-    assert(false &&
-           "Invalid memory_order for atomics. Valid memory_order for "
-           "atomics are: sycl::memory_order::relaxed, "
-           "sycl::memory_order::acq_rel, sycl::memory_order::seq_cst!");
-  }
 }
 
 /// Atomically exchange the value at the address addr with the value operand.

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -48,11 +48,11 @@ namespace syclcompat {
 /// \param operand The value to add to the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_add(T *addr, arith_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -65,11 +65,11 @@ inline T atomic_fetch_add(T *addr, arith_t<T> operand) {
 /// \param operand The value to subtract from the value at \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -83,11 +83,11 @@ inline T atomic_fetch_sub(T *addr, arith_t<T> operand) {
 /// the \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_and(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -101,11 +101,11 @@ inline T atomic_fetch_and(T *addr, type_identity_t<T> operand) {
 /// the \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_or(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -119,11 +119,11 @@ inline T atomic_fetch_or(T *addr, type_identity_t<T> operand) {
 /// the \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -135,11 +135,11 @@ inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand) {
 /// \param [in, out] addr The pointer to the data.
 /// \param operand. \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_min(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -152,11 +152,11 @@ inline T atomic_fetch_min(T *addr, type_identity_t<T> operand) {
 /// \param operand.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_fetch_max(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -224,11 +224,11 @@ inline unsigned int atomic_fetch_compare_inc(unsigned int *addr,
 /// \param operand The value to be exchanged with the value pointed by \p addr.
 /// \param memoryOrder The memory ordering used.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 inline T atomic_exchange(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
@@ -245,11 +245,11 @@ inline T atomic_exchange(T *addr, type_identity_t<T> operand) {
 /// \param success The memory ordering used when comparison succeeds.
 /// \param fail The memory ordering used when comparison fails.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 T atomic_compare_exchange_strong(
     sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
     type_identity_t<T> expected, type_identity_t<T> desired,
@@ -271,11 +271,11 @@ T atomic_compare_exchange_strong(
 /// \param success The memory ordering used when comparison succeeds.
 /// \param fail The memory ordering used when comparison fails.
 /// \returns The value at the \p addr before the call.
-template <typename T,
-          sycl::access::address_space addressSpace =
+template <sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
-          sycl::memory_scope memoryScope = sycl::memory_scope::device>
+          sycl::memory_scope memoryScope = sycl::memory_scope::device,
+          typename T>
 T atomic_compare_exchange_strong(
     T *addr, type_identity_t<T> expected, type_identity_t<T> desired,
     sycl::memory_order success = sycl::memory_order::relaxed,

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -148,7 +148,7 @@ template <typename T,
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_and(T *addr, T operand) {
+inline T atomic_fetch_and(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_and(operand);
@@ -165,7 +165,7 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_and(T *addr, T operand, sycl::memory_order memoryOrder) {
+inline T atomic_fetch_and(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_and<T, addressSpace, sycl::memory_order::relaxed,
@@ -196,7 +196,7 @@ template <typename T,
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_or(T *addr, T operand) {
+inline T atomic_fetch_or(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_or(operand);
@@ -213,7 +213,7 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_or(T *addr, T operand, sycl::memory_order memoryOrder) {
+inline T atomic_fetch_or(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_or<T, addressSpace, sycl::memory_order::relaxed,
@@ -244,7 +244,7 @@ template <typename T,
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_xor(T *addr, T operand) {
+inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_xor(operand);
@@ -261,7 +261,7 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_xor(T *addr, T operand, sycl::memory_order memoryOrder) {
+inline T atomic_fetch_xor(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_xor<T, addressSpace, sycl::memory_order::relaxed,
@@ -290,7 +290,7 @@ template <typename T,
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_min(T *addr, T operand) {
+inline T atomic_fetch_min(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_min(operand);
@@ -306,7 +306,7 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_min(T *addr, T operand, sycl::memory_order memoryOrder) {
+inline T atomic_fetch_min(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_min<T, addressSpace, sycl::memory_order::relaxed,
@@ -336,7 +336,7 @@ template <typename T,
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_max(T *addr, T operand) {
+inline T atomic_fetch_max(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.fetch_max(operand);
@@ -352,7 +352,7 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_fetch_max(T *addr, T operand, sycl::memory_order memoryOrder) {
+inline T atomic_fetch_max(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_fetch_max<T, addressSpace, sycl::memory_order::relaxed,
@@ -495,7 +495,7 @@ template <typename T,
               sycl::access::address_space::global_space,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_exchange(T *addr, T operand) {
+inline T atomic_exchange(T *addr, type_identity_t<T> operand) {
   auto atm =
       sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(addr[0]);
   return atm.exchange(operand);
@@ -510,7 +510,7 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_exchange(T *addr, T operand, sycl::memory_order memoryOrder) {
+inline T atomic_exchange(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_exchange<T, addressSpace, sycl::memory_order::relaxed,
@@ -546,7 +546,7 @@ template <typename T,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_compare_exchange_strong(
     sycl::multi_ptr<T, sycl::access::address_space::global_space> addr,
-    T expected, T desired,
+    type_identity_t<T> expected, type_identity_t<T> desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
   auto atm = sycl::atomic_ref<T, memoryOrder, memoryScope, addressSpace>(*addr);
@@ -571,7 +571,7 @@ template <typename T,
           sycl::memory_order memoryOrder = sycl::memory_order::relaxed,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
 T atomic_compare_exchange_strong(
-    T *addr, T expected, T desired,
+    T *addr, type_identity_t<T> expected, type_identity_t<T> desired,
     sycl::memory_order success = sycl::memory_order::relaxed,
     sycl::memory_order fail = sycl::memory_order::relaxed) {
   auto atm =

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -38,12 +38,9 @@
 #include <sycl/memory_enums.hpp>
 #include <sycl/multi_ptr.hpp>
 
-namespace syclcompat {
+#include <syclcompat/traits.hpp>
 
-template <typename T> struct arith {
-  using type = std::conditional_t<std::is_pointer_v<T>, std::ptrdiff_t, T>;
-};
-template <typename T> using arith_t = typename arith<T>::type;
+namespace syclcompat {
 
 /// Atomically add the value operand to the value at the addr and assign the
 /// result to the value at addr.

--- a/sycl/include/syclcompat/atomic.hpp
+++ b/sycl/include/syclcompat/atomic.hpp
@@ -244,7 +244,8 @@ template <typename T,
           sycl::access::address_space addressSpace =
               sycl::access::address_space::global_space,
           sycl::memory_scope memoryScope = sycl::memory_scope::device>
-inline T atomic_exchange(T *addr, type_identity_t<T> operand, sycl::memory_order memoryOrder) {
+inline T atomic_exchange(T *addr, type_identity_t<T> operand,
+                         sycl::memory_order memoryOrder) {
   switch (memoryOrder) {
   case sycl::memory_order::relaxed:
     return atomic_exchange<T, addressSpace, sycl::memory_order::relaxed,

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -47,6 +47,7 @@
 #include <sycl/usm.hpp>
 
 #include <syclcompat/device.hpp>
+#include <syclcompat/traits.hpp>
 
 #if defined(__linux__)
 #include <sys/mman.h>
@@ -564,13 +565,6 @@ static sycl::event memcpy_async(void *to_ptr, const void *from_ptr, size_t size,
   return detail::memcpy(q, to_ptr, from_ptr, size);
 }
 
-namespace detail {
-template <class T> struct dont_deduce {
-  using type = T;
-};
-template <class T> using dont_deduce_t = typename dont_deduce<T>::type;
-} // namespace detail
-
 /// Asynchronously copies \p count T's from the address specified by \p
 /// from_ptr to the address specified by \p to_ptr. The return of the function
 /// does NOT guarantee the copy is completed.
@@ -582,8 +576,8 @@ template <class T> using dont_deduce_t = typename dont_deduce<T>::type;
 /// \param q Queue to execute the copy task.
 /// \returns no return value.
 template <typename T>
-static sycl::event memcpy_async(detail::dont_deduce_t<T> *to_ptr,
-                                const detail::dont_deduce_t<T> *from_ptr,
+static sycl::event memcpy_async(type_identity_t<T> *to_ptr,
+                                const type_identity_t<T> *from_ptr,
                                 size_t count,
                                 sycl::queue q = get_default_queue()) {
   return detail::memcpy(q, static_cast<void *>(to_ptr),
@@ -601,8 +595,8 @@ static sycl::event memcpy_async(detail::dont_deduce_t<T> *to_ptr,
 /// \param q Queue to execute the copy task.
 /// \returns no return value.
 template <typename T>
-static void memcpy(detail::dont_deduce_t<T> *to_ptr,
-                   const detail::dont_deduce_t<T> *from_ptr, size_t count,
+static void memcpy(type_identity_t<T> *to_ptr,
+                   const type_identity_t<T> *from_ptr, size_t count,
                    sycl::queue q = get_default_queue()) {
   detail::memcpy(q, static_cast<void *>(to_ptr),
                  static_cast<const void *>(from_ptr), count * sizeof(T))

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -576,10 +576,9 @@ static sycl::event memcpy_async(void *to_ptr, const void *from_ptr, size_t size,
 /// \param q Queue to execute the copy task.
 /// \returns no return value.
 template <typename T>
-static sycl::event memcpy_async(type_identity_t<T> *to_ptr,
-                                const type_identity_t<T> *from_ptr,
-                                size_t count,
-                                sycl::queue q = get_default_queue()) {
+static sycl::event
+memcpy_async(type_identity_t<T> *to_ptr, const type_identity_t<T> *from_ptr,
+             size_t count, sycl::queue q = get_default_queue()) {
   return detail::memcpy(q, static_cast<void *>(to_ptr),
                         static_cast<const void *>(from_ptr), count * sizeof(T));
 }

--- a/sycl/include/syclcompat/traits.hpp
+++ b/sycl/include/syclcompat/traits.hpp
@@ -1,0 +1,44 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  traits.hpp
+ *
+ *  Description:
+ *    Type traits for the SYCL compatibility extension
+ **************************************************************************/
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+namespace syclcompat {
+
+// Equivalent to C++20's std::type_identity (used to create non-deduced
+// contexts)
+template <class T> struct type_identity {
+  using type = T;
+};
+template <class T> using type_identity_t = typename type_identity<T>::type;
+
+// Defines the operand type for arithemtic operations on T. This is identity
+// for all types except pointers, for which it is std::ptrdiff_t
+template <typename T> struct arith {
+  using type = std::conditional_t<std::is_pointer_v<T>, std::ptrdiff_t, T>;
+};
+template <typename T> using arith_t = typename arith<T>::type;
+
+} // namespace syclcompat

--- a/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
@@ -54,21 +54,13 @@
 // In every case we test two API overloads, one taking an explicit runtime
 // memory_order argument. We use `relaxed` in every case because these tests
 // are *not* checking the memory_order semantics, just the API.
-template <typename T1, typename T2, bool orderArg = false>
+template <typename T1, typename T2>
 inline void atomic_fetch_add_kernel(T1 *data, T2 operand) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_fetch_add(data, operand, sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_fetch_add(data, operand);
-  }
 }
-template <typename T1, typename T2, bool orderArg = false>
+template <typename T1, typename T2>
 inline void atomic_fetch_sub_kernel(T1 *data, T2 operand) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_fetch_sub(data, operand, sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_fetch_sub(data, operand);
-  }
 }
 
 template <typename T> void test_atomic_arith() {
@@ -83,10 +75,6 @@ template <typename T> void test_atomic_arith() {
   AtomicLauncher<atomic_fetch_add_kernel<T, T>, T>(grid, threads)
       .launch_test(init, sum, operand);
   AtomicLauncher<atomic_fetch_sub_kernel<T, T>, T>(grid, threads)
-      .launch_test(sum, init, operand);
-  AtomicLauncher<atomic_fetch_add_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(init, sum, operand);
-  AtomicLauncher<atomic_fetch_sub_kernel<T, T, true>, T>(grid, threads)
       .launch_test(sum, init, operand);
 }
 
@@ -108,11 +96,6 @@ template <typename T> void test_atomic_ptr_arith() {
   AtomicLauncher<atomic_fetch_sub_kernel<T, std::ptrdiff_t>, T>(grid, threads)
       .launch_test(final, init, operand);
 
-  AtomicLauncher<atomic_fetch_add_kernel<T, std::ptrdiff_t, true>, T>(grid, threads)
-      .launch_test(init, final, operand);
-
-  AtomicLauncher<atomic_fetch_sub_kernel<T, std::ptrdiff_t, true>, T>(grid, threads)
-      .launch_test(final, init, operand);
   syclcompat::free(init);
 }
 
@@ -133,12 +116,6 @@ void test_atomic_arith_t1_t2() {
       .launch_test(init, sum, operand);
   AtomicLauncher<atomic_fetch_sub_kernel<data_t, operand_t>, data_t>(grid,
                                                                      threads)
-      .launch_test(sum, init, operand);
-  AtomicLauncher<atomic_fetch_add_kernel<data_t, operand_t, true>, data_t>(
-      grid, threads)
-      .launch_test(init, sum, operand);
-  AtomicLauncher<atomic_fetch_sub_kernel<data_t, operand_t, true>, data_t>(
-      grid, threads)
       .launch_test(sum, init, operand);
 }
 

--- a/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
@@ -35,8 +35,8 @@
 // RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 
-#include <type_traits>
 #include <cstddef>
+#include <type_traits>
 
 #include <sycl/sycl.hpp>
 
@@ -56,11 +56,11 @@
 // are *not* checking the memory_order semantics, just the API.
 template <typename T1, typename T2>
 inline void atomic_fetch_add_kernel(T1 *data, T2 operand) {
-    syclcompat::atomic_fetch_add(data, operand);
+  syclcompat::atomic_fetch_add(data, operand);
 }
 template <typename T1, typename T2>
 inline void atomic_fetch_sub_kernel(T1 *data, T2 operand) {
-    syclcompat::atomic_fetch_sub(data, operand);
+  syclcompat::atomic_fetch_sub(data, operand);
 }
 
 template <typename T> void test_atomic_arith() {
@@ -98,7 +98,6 @@ template <typename T> void test_atomic_ptr_arith() {
 
   syclcompat::free(init);
 }
-
 
 void test_atomic_arith_t1_t2() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;

--- a/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
@@ -36,6 +36,7 @@
 // RUN: %{run} %t.out
 
 #include <type_traits>
+#include <cstddef>
 
 #include <sycl/sycl.hpp>
 
@@ -53,16 +54,16 @@
 // In every case we test two API overloads, one taking an explicit runtime
 // memory_order argument. We use `relaxed` in every case because these tests
 // are *not* checking the memory_order semantics, just the API.
-template <typename T, bool orderArg = false>
-inline void atomic_fetch_add_kernel(T *data, syclcompat::arith_t<T> operand) {
+template <typename T1, typename T2, bool orderArg = false>
+inline void atomic_fetch_add_kernel(T1 *data, T2 operand) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_add(data, operand, sycl::memory_order::relaxed);
   } else {
     syclcompat::atomic_fetch_add(data, operand);
   }
 }
-template <typename T, bool orderArg = false>
-inline void atomic_fetch_sub_kernel(T *data, syclcompat::arith_t<T> operand) {
+template <typename T1, typename T2, bool orderArg = false>
+inline void atomic_fetch_sub_kernel(T1 *data, T2 operand) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_sub(data, operand, sycl::memory_order::relaxed);
   } else {
@@ -79,13 +80,13 @@ template <typename T> void test_atomic_arith() {
   constexpr T init = static_cast<T>(0);
   constexpr T operand = static_cast<T>(1);
 
-  AtomicLauncher<atomic_fetch_add_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_add_kernel<T, T>, T>(grid, threads)
       .launch_test(init, sum, operand);
-  AtomicLauncher<atomic_fetch_sub_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_sub_kernel<T, T>, T>(grid, threads)
       .launch_test(sum, init, operand);
-  AtomicLauncher<atomic_fetch_add_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_add_kernel<T, T, true>, T>(grid, threads)
       .launch_test(init, sum, operand);
-  AtomicLauncher<atomic_fetch_sub_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_sub_kernel<T, T, true>, T>(grid, threads)
       .launch_test(sum, init, operand);
 }
 
@@ -101,21 +102,50 @@ template <typename T> void test_atomic_ptr_arith() {
   T final = init + (grid.x * threads.x);
   constexpr std::ptrdiff_t operand = static_cast<std::ptrdiff_t>(1);
 
-  AtomicLauncher<atomic_fetch_add_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_add_kernel<T, std::ptrdiff_t>, T>(grid, threads)
       .launch_test(init, final, operand);
 
-  AtomicLauncher<atomic_fetch_sub_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_sub_kernel<T, std::ptrdiff_t>, T>(grid, threads)
       .launch_test(final, init, operand);
 
-  AtomicLauncher<atomic_fetch_add_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_add_kernel<T, std::ptrdiff_t, true>, T>(grid, threads)
       .launch_test(init, final, operand);
 
-  AtomicLauncher<atomic_fetch_sub_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_sub_kernel<T, std::ptrdiff_t, true>, T>(grid, threads)
       .launch_test(final, init, operand);
   syclcompat::free(init);
+}
+
+
+void test_atomic_arith_t1_t2() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  using data_t = float;
+  using operand_t = int;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+  constexpr data_t sum = static_cast<data_t>(grid.x * threads.x);
+  constexpr data_t init = static_cast<data_t>(0);
+  constexpr operand_t operand = static_cast<operand_t>(1);
+
+  AtomicLauncher<atomic_fetch_add_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(init, sum, operand);
+  AtomicLauncher<atomic_fetch_sub_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(sum, init, operand);
+  AtomicLauncher<atomic_fetch_add_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(init, sum, operand);
+  AtomicLauncher<atomic_fetch_sub_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(sum, init, operand);
 }
 
 int main() {
   INSTANTIATE_ALL_TYPES(atomic_value_type_list, test_atomic_arith);
   INSTANTIATE_ALL_TYPES(atomic_ptr_type_list, test_atomic_ptr_arith);
+  test_atomic_arith_t1_t2();
+
+  return 0;
 }

--- a/sycl/test-e2e/syclcompat/atomic/atomic_bitwise.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_bitwise.cpp
@@ -56,8 +56,8 @@
 // In every case we test two API overloads, one taking an explicit runtime
 // memory_order argument. We use `relaxed` in every case because these tests
 // are *not* checking the memory_order semantics, just the API.
-template <typename T, bool orderArg = false>
-void atomic_fetch_and_kernel(T *data, T operand, T operand0) {
+template <typename T1, typename T2, bool orderArg = false>
+void atomic_fetch_and_kernel(T1 *data, T2 operand, T2 operand0) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_and(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
@@ -67,8 +67,8 @@ void atomic_fetch_and_kernel(T *data, T operand, T operand0) {
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
   }
 }
-template <typename T, bool orderArg = false>
-void atomic_fetch_or_kernel(T *data, T operand, T operand0) {
+template <typename T1, typename T2, bool orderArg = false>
+void atomic_fetch_or_kernel(T1 *data, T2 operand, T2 operand0) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_or(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
@@ -78,8 +78,8 @@ void atomic_fetch_or_kernel(T *data, T operand, T operand0) {
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
   }
 }
-template <typename T, bool orderArg = false>
-void atomic_fetch_xor_kernel(T *data, T operand, T operand0) {
+template <typename T1, typename T2, bool orderArg = false>
+void atomic_fetch_xor_kernel(T1 *data, T2 operand, T2 operand0) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_xor(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
@@ -97,30 +97,30 @@ template <typename T> void test_atomic_and() {
   constexpr syclcompat::dim3 threads{32};
 
   // All 0 -> 0
-  AtomicLauncher<atomic_fetch_and_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_and_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
                    static_cast<T>(0));
 
   // All 1 -> 1
-  AtomicLauncher<atomic_fetch_and_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_and_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(1));
   // Most 1, one 0 -> 0
-  AtomicLauncher<atomic_fetch_and_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_and_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(0));
 
   // All 0 -> 0
-  AtomicLauncher<atomic_fetch_and_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_and_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
                    static_cast<T>(0));
 
   // All 1 -> 1
-  AtomicLauncher<atomic_fetch_and_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_and_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(1));
   // Most 1, one 0 -> 0
-  AtomicLauncher<atomic_fetch_and_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_and_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(0));
 }
@@ -132,36 +132,36 @@ template <typename T> void test_atomic_or() {
   constexpr syclcompat::dim3 threads{32};
 
   // All 0 -> 0
-  AtomicLauncher<atomic_fetch_or_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
                    static_cast<T>(0));
   // All 1 -> 1
-  AtomicLauncher<atomic_fetch_or_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(1));
   // Most 1, one 0 -> 1
-  AtomicLauncher<atomic_fetch_or_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(0));
   // Init 1, all 0 -> 1
-  AtomicLauncher<atomic_fetch_or_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(0),
                    static_cast<T>(0));
 
   // All 0 -> 0
-  AtomicLauncher<atomic_fetch_or_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
                    static_cast<T>(0));
   // All 1 -> 1
-  AtomicLauncher<atomic_fetch_or_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(1));
   // Most 1, one 0 -> 1
-  AtomicLauncher<atomic_fetch_or_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(0));
   // Init 1, all 0 -> 1
-  AtomicLauncher<atomic_fetch_or_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_or_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(0),
                    static_cast<T>(0));
 }
@@ -173,42 +173,197 @@ template <typename T> void test_atomic_xor() {
   constexpr syclcompat::dim3 threads{2}; // 2 threads, 3 values inc. init
 
   // 000 -> 0
-  AtomicLauncher<atomic_fetch_xor_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
                    static_cast<T>(0));
   // 111 -> 1
-  AtomicLauncher<atomic_fetch_xor_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(1));
   // 110 -> 0
-  AtomicLauncher<atomic_fetch_xor_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(0));
   // 010 -> 1
-  AtomicLauncher<atomic_fetch_xor_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(0));
 
   // 000 -> 0
-  AtomicLauncher<atomic_fetch_xor_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0),
                    static_cast<T>(0));
   // 111 -> 1
-  AtomicLauncher<atomic_fetch_xor_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(1));
   // 110 -> 0
-  AtomicLauncher<atomic_fetch_xor_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(1), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(0));
   // 010 -> 1
-  AtomicLauncher<atomic_fetch_xor_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_xor_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(1),
                    static_cast<T>(0));
+}
+
+void test_atomic_and_t1_t2() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  using data_t = long;
+  using operand_t = unsigned int;
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(0),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_and_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(1));
+  // Most 1, one 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(0),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(0),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_and_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(1));
+  // Most 1, one 0 -> 0
+  AtomicLauncher<atomic_fetch_and_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<operand_t>(0),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+}
+
+void test_atomic_or_t1_t2() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  using data_t = long;
+  using operand_t = unsigned int;
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t>, data_t>(grid,
+                                                                    threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(0),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t>, data_t>(grid,
+                                                                    threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(1));
+  // Most 1, one 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t>, data_t>(grid,
+                                                                    threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+  // Init 1, all 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t>, data_t>(grid,
+                                                                    threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+
+  // All 0 -> 0
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(0),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+  // All 1 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(1));
+  // Most 1, one 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+  // Init 1, all 0 -> 1
+  AtomicLauncher<atomic_fetch_or_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+}
+
+void test_atomic_xor_t1_t2() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{1};
+  constexpr syclcompat::dim3 threads{2}; // 2 threads, 3 values inc. init
+
+  using data_t = long;
+  using operand_t = unsigned int;
+
+  // 000 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(0),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+  // 111 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(1));
+  // 110 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(0),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+  // 010 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t>, data_t>(grid,
+                                                                     threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+
+  // 000 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(0),
+                   static_cast<operand_t>(0), static_cast<operand_t>(0));
+  // 111 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(1));
+  // 110 -> 0
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(1), static_cast<data_t>(0),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
+  // 010 -> 1
+  AtomicLauncher<atomic_fetch_xor_kernel<data_t, operand_t, true>, data_t>(
+      grid, threads)
+      .launch_test(static_cast<data_t>(0), static_cast<data_t>(1),
+                   static_cast<operand_t>(1), static_cast<operand_t>(0));
 }
 
 int main() {
   INSTANTIATE_ALL_TYPES(integral_type_list, test_atomic_and);
   INSTANTIATE_ALL_TYPES(integral_type_list, test_atomic_or);
   INSTANTIATE_ALL_TYPES(integral_type_list, test_atomic_xor);
+
+  // Avoid combinatorial explosion by only testing the interface
+  test_atomic_and_t1_t2();
+  test_atomic_or_t1_t2();
+  test_atomic_xor_t1_t2();
+
+  return 0;
 }

--- a/sycl/test-e2e/syclcompat/atomic/atomic_bitwise.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_bitwise.cpp
@@ -58,18 +58,18 @@
 // are *not* checking the memory_order semantics, just the API.
 template <typename T1, typename T2>
 void atomic_fetch_and_kernel(T1 *data, T2 operand, T2 operand0) {
-    syclcompat::atomic_fetch_and(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
+  syclcompat::atomic_fetch_and(
+      data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
 }
 template <typename T1, typename T2>
 void atomic_fetch_or_kernel(T1 *data, T2 operand, T2 operand0) {
-    syclcompat::atomic_fetch_or(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
+  syclcompat::atomic_fetch_or(
+      data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
 }
 template <typename T1, typename T2>
 void atomic_fetch_xor_kernel(T1 *data, T2 operand, T2 operand0) {
-    syclcompat::atomic_fetch_xor(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
+  syclcompat::atomic_fetch_xor(
+      data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
 }
 
 template <typename T> void test_atomic_and() {

--- a/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
@@ -55,20 +55,20 @@
 // are *not* checking the memory_order semantics, just the API.
 template <typename T>
 inline void atomic_fetch_compare_inc_kernel(T *data, T operand) {
-    syclcompat::atomic_fetch_compare_inc(data, operand);
+  syclcompat::atomic_fetch_compare_inc(data, operand);
 }
 template <typename T>
 inline void atomic_fetch_compare_dec_kernel(T *data, T operand) {
-    syclcompat::atomic_fetch_compare_dec(data, operand);
+  syclcompat::atomic_fetch_compare_dec(data, operand);
 }
 template <typename T1, typename T2>
 inline void atomic_exchange_kernel(T1 *data, T2 operand) {
-    syclcompat::atomic_exchange(data, operand);
+  syclcompat::atomic_exchange(data, operand);
 }
 template <typename T1, typename T2, typename T3>
 inline void atomic_compare_exchange_strong_kernel(T1 *data, T2 expected,
                                                   T3 desired) {
-    syclcompat::atomic_compare_exchange_strong(data, expected, desired);
+  syclcompat::atomic_compare_exchange_strong(data, expected, desired);
 }
 
 void test_atomic_comp_inc() {
@@ -135,10 +135,12 @@ template <typename T> void test_atomic_exch_strong() {
   constexpr syclcompat::dim3 grid{4};
   constexpr syclcompat::dim3 threads{32};
 
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid,
+                                                                    threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
                    static_cast<T>(1));
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid,
+                                                                    threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(2));
 }
@@ -154,9 +156,11 @@ template <typename T> void test_atomic_ptr_exch_strong() {
   T ptr2 = (T)syclcompat::malloc(sizeof(ValType));
   T ptr3 = (T)syclcompat::malloc(sizeof(ValType));
 
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid,
+                                                                    threads)
       .launch_test(ptr1, ptr2, ptr1, ptr2);
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid,
+                                                                    threads)
       .launch_test(ptr1, ptr1, ptr2, ptr3);
   syclcompat::free(ptr1);
   syclcompat::free(ptr2);

--- a/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
@@ -53,41 +53,22 @@
 // In every case we test two API overloads, one taking an explicit runtime
 // memory_order argument. We use `relaxed` in every case because these tests
 // are *not* checking the memory_order semantics, just the API.
-template <typename T, bool orderArg = false>
+template <typename T>
 inline void atomic_fetch_compare_inc_kernel(T *data, T operand) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_fetch_compare_inc(data, operand,
-                                         sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_fetch_compare_inc(data, operand);
-  }
 }
-template <typename T, bool orderArg = false>
+template <typename T>
 inline void atomic_fetch_compare_dec_kernel(T *data, T operand) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_fetch_compare_dec(data, operand,
-                                         sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_fetch_compare_dec(data, operand);
-  }
 }
-template <typename T1, typename T2, bool orderArg = false>
+template <typename T1, typename T2>
 inline void atomic_exchange_kernel(T1 *data, T2 operand) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_exchange(data, operand, sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_exchange(data, operand);
-  }
 }
-template <typename T1, typename T2, typename T3, bool orderArg = false>
+template <typename T1, typename T2, typename T3>
 inline void atomic_compare_exchange_strong_kernel(T1 *data, T2 expected,
                                                   T3 desired) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_compare_exchange_strong(data, expected, desired,
-                                               sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_compare_exchange_strong(data, expected, desired);
-  }
 }
 
 void test_atomic_comp_inc() {
@@ -101,13 +82,6 @@ void test_atomic_comp_inc() {
       .launch_test(0, 6, 6);
   AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int>, unsigned int>(
       grid, threads)
-      .launch_test(1, 0, 6);
-
-  AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int, true>,
-                 unsigned int>(grid, threads)
-      .launch_test(0, 6, 6);
-  AtomicLauncher<atomic_fetch_compare_inc_kernel<unsigned int, true>,
-                 unsigned int>(grid, threads)
       .launch_test(1, 0, 6);
 }
 
@@ -123,13 +97,6 @@ void test_atomic_comp_dec() {
   AtomicLauncher<atomic_fetch_compare_dec_kernel<unsigned int>, unsigned int>(
       grid, threads)
       .launch_test(0, 6, 11);
-
-  AtomicLauncher<atomic_fetch_compare_dec_kernel<unsigned int, true>,
-                 unsigned int>(grid, threads)
-      .launch_test(6, 0, 0);
-  AtomicLauncher<atomic_fetch_compare_dec_kernel<unsigned int, true>,
-                 unsigned int>(grid, threads)
-      .launch_test(0, 6, 11);
 }
 
 template <typename T> void test_atomic_exch() {
@@ -141,10 +108,6 @@ template <typename T> void test_atomic_exch() {
   AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(1));
   AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
-      .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
-  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(1));
-  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
 }
 
@@ -162,10 +125,6 @@ template <typename T> void test_atomic_ptr_exch() {
       .launch_test(ptr1, ptr2, ptr2);
   AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
       .launch_test(ptr1, ptr1, ptr1);
-  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(ptr1, ptr2, ptr2);
-  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(ptr1, ptr1, ptr1);
   syclcompat::free(ptr1);
   syclcompat::free(ptr2);
 }
@@ -180,14 +139,6 @@ template <typename T> void test_atomic_exch_strong() {
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
                    static_cast<T>(1));
   AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
-      .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
-                   static_cast<T>(2));
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
-                                                                    threads)
-      .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
-                   static_cast<T>(1));
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
-                                                                    threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(2));
 }
@@ -207,12 +158,6 @@ template <typename T> void test_atomic_ptr_exch_strong() {
       .launch_test(ptr1, ptr2, ptr1, ptr2);
   AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
       .launch_test(ptr1, ptr1, ptr2, ptr3);
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
-                                                                    threads)
-      .launch_test(ptr1, ptr2, ptr1, ptr2);
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
-                                                                    threads)
-      .launch_test(ptr1, ptr1, ptr2, ptr3);
   syclcompat::free(ptr1);
   syclcompat::free(ptr2);
   syclcompat::free(ptr3);
@@ -230,12 +175,6 @@ void test_atomic_exch_t1_t2() {
   AtomicLauncher<atomic_exchange_kernel<float, int>, float>(grid, threads)
       .launch_test(static_cast<float>(0), static_cast<float>(0),
                    static_cast<int>(0));
-  AtomicLauncher<atomic_exchange_kernel<float, int, true>, float>(grid, threads)
-      .launch_test(static_cast<float>(0), static_cast<float>(1),
-                   static_cast<int>(1));
-  AtomicLauncher<atomic_exchange_kernel<float, int, true>, float>(grid, threads)
-      .launch_test(static_cast<float>(0), static_cast<float>(0),
-                   static_cast<int>(0));
 }
 
 void test_atomic_exch_strong_t1_t2_t3() {
@@ -250,16 +189,6 @@ void test_atomic_exch_strong_t1_t2_t3() {
                    static_cast<int>(0), static_cast<unsigned>(1));
   AtomicLauncher<atomic_compare_exchange_strong_kernel<float, int, unsigned>,
                  float>(grid, threads)
-      .launch_test(static_cast<float>(0), static_cast<float>(0),
-                   static_cast<int>(1), static_cast<unsigned>(2));
-  AtomicLauncher<
-      atomic_compare_exchange_strong_kernel<float, int, unsigned, true>, float>(
-      grid, threads)
-      .launch_test(static_cast<float>(0), static_cast<float>(1),
-                   static_cast<int>(0), static_cast<unsigned>(1));
-  AtomicLauncher<
-      atomic_compare_exchange_strong_kernel<float, int, unsigned, true>, float>(
-      grid, threads)
       .launch_test(static_cast<float>(0), static_cast<float>(0),
                    static_cast<int>(1), static_cast<unsigned>(2));
 }

--- a/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
@@ -71,17 +71,17 @@ inline void atomic_fetch_compare_dec_kernel(T *data, T operand) {
     syclcompat::atomic_fetch_compare_dec(data, operand);
   }
 }
-template <typename T, bool orderArg = false>
-inline void atomic_exchange_kernel(T *data, T operand) {
+template <typename T1, typename T2, bool orderArg = false>
+inline void atomic_exchange_kernel(T1 *data, T2 operand) {
   if constexpr (orderArg) {
     syclcompat::atomic_exchange(data, operand, sycl::memory_order::relaxed);
   } else {
     syclcompat::atomic_exchange(data, operand);
   }
 }
-template <typename T, bool orderArg = false>
-inline void atomic_compare_exchange_strong_kernel(T *data, T expected,
-                                                  T desired) {
+template <typename T1, typename T2, typename T3, bool orderArg = false>
+inline void atomic_compare_exchange_strong_kernel(T1 *data, T2 expected,
+                                                  T3 desired) {
   if constexpr (orderArg) {
     syclcompat::atomic_compare_exchange_strong(data, expected, desired,
                                                sycl::memory_order::relaxed);
@@ -138,13 +138,13 @@ template <typename T> void test_atomic_exch() {
   constexpr syclcompat::dim3 grid{4};
   constexpr syclcompat::dim3 threads{32};
 
-  AtomicLauncher<atomic_exchange_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(1));
-  AtomicLauncher<atomic_exchange_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
-  AtomicLauncher<atomic_exchange_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(1));
-  AtomicLauncher<atomic_exchange_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(0));
 }
 
@@ -158,13 +158,13 @@ template <typename T> void test_atomic_ptr_exch() {
   T ptr1 = (T)syclcompat::malloc(sizeof(ValType));
   T ptr2 = (T)syclcompat::malloc(sizeof(ValType));
 
-  AtomicLauncher<atomic_exchange_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
       .launch_test(ptr1, ptr2, ptr2);
-  AtomicLauncher<atomic_exchange_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T>, T>(grid, threads)
       .launch_test(ptr1, ptr1, ptr1);
-  AtomicLauncher<atomic_exchange_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
       .launch_test(ptr1, ptr2, ptr2);
-  AtomicLauncher<atomic_exchange_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_exchange_kernel<T, T, true>, T>(grid, threads)
       .launch_test(ptr1, ptr1, ptr1);
   syclcompat::free(ptr1);
   syclcompat::free(ptr2);
@@ -176,17 +176,17 @@ template <typename T> void test_atomic_exch_strong() {
   constexpr syclcompat::dim3 grid{4};
   constexpr syclcompat::dim3 threads{32};
 
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
                    static_cast<T>(1));
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(2));
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, true>, T>(grid,
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
                                                                     threads)
       .launch_test(static_cast<T>(0), static_cast<T>(1), static_cast<T>(0),
                    static_cast<T>(1));
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, true>, T>(grid,
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
                                                                     threads)
       .launch_test(static_cast<T>(0), static_cast<T>(0), static_cast<T>(1),
                    static_cast<T>(2));
@@ -203,19 +203,65 @@ template <typename T> void test_atomic_ptr_exch_strong() {
   T ptr2 = (T)syclcompat::malloc(sizeof(ValType));
   T ptr3 = (T)syclcompat::malloc(sizeof(ValType));
 
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
       .launch_test(ptr1, ptr2, ptr1, ptr2);
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T>, T>(grid, threads)
       .launch_test(ptr1, ptr1, ptr2, ptr3);
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, true>, T>(grid,
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
                                                                     threads)
       .launch_test(ptr1, ptr2, ptr1, ptr2);
-  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, true>, T>(grid,
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<T, T, T, true>, T>(grid,
                                                                     threads)
       .launch_test(ptr1, ptr1, ptr2, ptr3);
   syclcompat::free(ptr1);
   syclcompat::free(ptr2);
   syclcompat::free(ptr3);
+}
+
+void test_atomic_exch_t1_t2() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  AtomicLauncher<atomic_exchange_kernel<float, int>, float>(grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(1),
+                   static_cast<int>(1));
+  AtomicLauncher<atomic_exchange_kernel<float, int>, float>(grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(0),
+                   static_cast<int>(0));
+  AtomicLauncher<atomic_exchange_kernel<float, int, true>, float>(grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(1),
+                   static_cast<int>(1));
+  AtomicLauncher<atomic_exchange_kernel<float, int, true>, float>(grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(0),
+                   static_cast<int>(0));
+}
+
+void test_atomic_exch_strong_t1_t2_t3() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<float, int, unsigned>,
+                 float>(grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(1),
+                   static_cast<int>(0), static_cast<unsigned>(1));
+  AtomicLauncher<atomic_compare_exchange_strong_kernel<float, int, unsigned>,
+                 float>(grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(0),
+                   static_cast<int>(1), static_cast<unsigned>(2));
+  AtomicLauncher<
+      atomic_compare_exchange_strong_kernel<float, int, unsigned, true>, float>(
+      grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(1),
+                   static_cast<int>(0), static_cast<unsigned>(1));
+  AtomicLauncher<
+      atomic_compare_exchange_strong_kernel<float, int, unsigned, true>, float>(
+      grid, threads)
+      .launch_test(static_cast<float>(0), static_cast<float>(0),
+                   static_cast<int>(1), static_cast<unsigned>(2));
 }
 
 int main() {
@@ -227,4 +273,7 @@ int main() {
 
   test_atomic_comp_inc();
   test_atomic_comp_dec();
+  test_atomic_exch_t1_t2();
+  test_atomic_exch_strong_t1_t2_t3();
+  return 0;
 }

--- a/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
@@ -116,35 +116,35 @@ template <memory_order order> void test_acquire_local() {
        auto error =
            error_buf.template get_access<access::mode::read_write>(cgh);
        local_accessor<int, 1> val(2, cgh);
-       cgh.parallel_for(
-           nd_range<1>(global_size, local_size), [=](nd_item<1> it) {
-             size_t lid = it.get_local_id(0);
-             val[0] = 0;
-             val[1] = 0;
-             it.barrier(access::fence_space::local_space);
-             volatile int *val_p = val.get_pointer();
-             auto atm0 =
-                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                            address_space::local_space>(val[0]);
-             auto atm1 =
-                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                            address_space::local_space>(val[1]);
-             for (int i = 0; i < N_iters; i++) {
-               if (it.get_local_id(0) == 0) {
-                 syclcompat::atomic_fetch_add<address_space::local_space,
-                                              order>(&val[0], 1);
-                 val_p[1]++;
-               } else {
-                 // syclcompat:: doesn't offer load/store so using
-                 // sycl::atomic_ref here
-                 int tmp1 = atm1.load(memory_order::acquire);
-                 int tmp0 = atm0.load(memory_order::relaxed);
-                 if (tmp0 < tmp1) {
-                   error[0] = 1;
-                 }
-               }
+       cgh.parallel_for(nd_range<1>(global_size, local_size), [=](nd_item<1>
+                                                                      it) {
+         size_t lid = it.get_local_id(0);
+         val[0] = 0;
+         val[1] = 0;
+         it.barrier(access::fence_space::local_space);
+         volatile int *val_p = val.get_pointer();
+         auto atm0 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[0]);
+         auto atm1 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[1]);
+         for (int i = 0; i < N_iters; i++) {
+           if (it.get_local_id(0) == 0) {
+             syclcompat::atomic_fetch_add<address_space::local_space, order>(
+                 &val[0], 1);
+             val_p[1]++;
+           } else {
+             // syclcompat:: doesn't offer load/store so using
+             // sycl::atomic_ref here
+             int tmp1 = atm1.load(memory_order::acquire);
+             int tmp0 = atm0.load(memory_order::relaxed);
+             if (tmp0 < tmp1) {
+               error[0] = 1;
              }
-           });
+           }
+         }
+       });
      }).wait_and_throw();
   }
   assert(error == 0);
@@ -217,35 +217,35 @@ template <memory_order order> void test_release_local() {
        auto error =
            error_buf.template get_access<access::mode::read_write>(cgh);
        local_accessor<int, 1> val(2, cgh);
-       cgh.parallel_for(
-           nd_range<1>(global_size, local_size), [=](nd_item<1> it) {
-             size_t lid = it.get_local_id(0);
-             val[0] = 0;
-             val[1] = 0;
-             it.barrier(access::fence_space::local_space);
-             volatile int *val_p = val.get_pointer();
-             auto atm0 =
-                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                            address_space::local_space>(val[0]);
-             auto atm1 =
-                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                            address_space::local_space>(val[1]);
-             for (int i = 0; i < N_iters; i++) {
-               if (it.get_local_id(0) == 0) {
-                 val_p[0]++;
-                 syclcompat::atomic_fetch_add<address_space::local_space,
-                                              order>(&val[1], 1);
-               } else {
-                 // syclcompat:: doesn't offer load/store so using
-                 // sycl::atomic_ref here
-                 int tmp1 = atm1.load(memory_order::acquire);
-                 int tmp0 = atm0.load(memory_order::relaxed);
-                 if (tmp0 < tmp1) {
-                   error[0] = 1;
-                 }
-               }
+       cgh.parallel_for(nd_range<1>(global_size, local_size), [=](nd_item<1>
+                                                                      it) {
+         size_t lid = it.get_local_id(0);
+         val[0] = 0;
+         val[1] = 0;
+         it.barrier(access::fence_space::local_space);
+         volatile int *val_p = val.get_pointer();
+         auto atm0 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[0]);
+         auto atm1 =
+             atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                        address_space::local_space>(val[1]);
+         for (int i = 0; i < N_iters; i++) {
+           if (it.get_local_id(0) == 0) {
+             val_p[0]++;
+             syclcompat::atomic_fetch_add<address_space::local_space, order>(
+                 &val[1], 1);
+           } else {
+             // syclcompat:: doesn't offer load/store so using
+             // sycl::atomic_ref here
+             int tmp1 = atm1.load(memory_order::acquire);
+             int tmp0 = atm0.load(memory_order::relaxed);
+             if (tmp0 < tmp1) {
+               error[0] = 1;
              }
-           });
+           }
+         }
+       });
      }).wait_and_throw();
   }
   assert(error == 0);

--- a/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
@@ -48,7 +48,7 @@ using namespace sycl;
 
 using address_space = sycl::access::address_space;
 
-template <memory_order order, bool orderArg = false>
+template <memory_order order>
 void test_acquire_global() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
@@ -77,13 +77,9 @@ void test_acquire_global() {
                         address_space::global_space>(val[1]);
          for (int i = 0; i < N_iters; i++) {
            if (it.get_id(0) == 0) {
-             if constexpr (orderArg) {
-               syclcompat::atomic_fetch_add<int, address_space::global_space>(
-                   &val[0], 1, order);
-             } else {
+
                syclcompat::atomic_fetch_add<int, address_space::global_space,
                                             order>(&val[0], 1);
-             }
              val_p[1]++;
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
@@ -101,7 +97,7 @@ void test_acquire_global() {
   assert(error == 0);
 }
 
-template <memory_order order, bool orderArg = false> void test_acquire_local() {
+template <memory_order order> void test_acquire_local() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   const size_t local_size = 256;
@@ -136,13 +132,8 @@ template <memory_order order, bool orderArg = false> void test_acquire_local() {
                         address_space::local_space>(val[1]);
          for (int i = 0; i < N_iters; i++) {
            if (it.get_local_id(0) == 0) {
-             if constexpr (orderArg) {
-               syclcompat::atomic_fetch_add<int, address_space::local_space>(
-                   &val[0], 1, order);
-             } else {
                syclcompat::atomic_fetch_add<int, address_space::local_space,
                                             order>(&val[0], 1);
-             }
              val_p[1]++;
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
@@ -160,7 +151,7 @@ template <memory_order order, bool orderArg = false> void test_acquire_local() {
   assert(error == 0);
 }
 
-template <memory_order order, bool orderArg = false>
+template <memory_order order>
 void test_release_global() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
@@ -190,13 +181,8 @@ void test_release_global() {
          for (int i = 0; i < N_iters; i++) {
            if (it.get_id(0) == 0) {
              val_p[0]++;
-             if constexpr (orderArg) {
-               syclcompat::atomic_fetch_add<int, address_space::global_space>(
-                   &val[1], 1, order);
-             } else {
                syclcompat::atomic_fetch_add<int, address_space::global_space,
                                             order>(&val[1], 1);
-             }
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
              // here
@@ -213,7 +199,7 @@ void test_release_global() {
   assert(error == 0);
 }
 
-template <memory_order order, bool orderArg = false> void test_release_local() {
+template <memory_order order> void test_release_local() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   const size_t local_size = 256;
@@ -249,13 +235,8 @@ template <memory_order order, bool orderArg = false> void test_release_local() {
          for (int i = 0; i < N_iters; i++) {
            if (it.get_local_id(0) == 0) {
              val_p[0]++;
-             if constexpr (orderArg) {
-               syclcompat::atomic_fetch_add<int, address_space::local_space>(
-                   &val[1], 1, order);
-             } else {
                syclcompat::atomic_fetch_add<int, address_space::local_space,
                                             order>(&val[1], 1);
-             }
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
              // here
@@ -287,11 +268,6 @@ int main() {
     test_acquire_local<memory_order::acq_rel>();
     test_release_global<memory_order::acq_rel>();
     test_release_local<memory_order::acq_rel>();
-    // Test alternative API
-    test_acquire_global<memory_order::acq_rel, true>();
-    test_acquire_local<memory_order::acq_rel, true>();
-    test_release_global<memory_order::acq_rel, true>();
-    test_release_local<memory_order::acq_rel, true>();
   }
 
   if (is_supported(supported_memory_orders, memory_order::seq_cst)) {
@@ -299,11 +275,6 @@ int main() {
     test_acquire_local<memory_order::seq_cst>();
     test_release_global<memory_order::seq_cst>();
     test_release_local<memory_order::seq_cst>();
-    // Test alternative API
-    test_acquire_global<memory_order::seq_cst, true>();
-    test_acquire_local<memory_order::seq_cst, true>();
-    test_release_global<memory_order::seq_cst, true>();
-    test_release_local<memory_order::seq_cst, true>();
   }
 
   return 0;

--- a/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
@@ -48,8 +48,7 @@ using namespace sycl;
 
 using address_space = sycl::access::address_space;
 
-template <memory_order order>
-void test_acquire_global() {
+template <memory_order order> void test_acquire_global() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   const size_t N_items = 256;
@@ -78,8 +77,8 @@ void test_acquire_global() {
          for (int i = 0; i < N_iters; i++) {
            if (it.get_id(0) == 0) {
 
-               syclcompat::atomic_fetch_add<int, address_space::global_space,
-                                            order>(&val[0], 1);
+             syclcompat::atomic_fetch_add<int, address_space::global_space,
+                                          order>(&val[0], 1);
              val_p[1]++;
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
@@ -117,42 +116,41 @@ template <memory_order order> void test_acquire_local() {
        auto error =
            error_buf.template get_access<access::mode::read_write>(cgh);
        local_accessor<int, 1> val(2, cgh);
-       cgh.parallel_for(nd_range<1>(global_size, local_size), [=](nd_item<1>
-                                                                      it) {
-         size_t lid = it.get_local_id(0);
-         val[0] = 0;
-         val[1] = 0;
-         it.barrier(access::fence_space::local_space);
-         volatile int *val_p = val.get_pointer();
-         auto atm0 =
-             atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                        address_space::local_space>(val[0]);
-         auto atm1 =
-             atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                        address_space::local_space>(val[1]);
-         for (int i = 0; i < N_iters; i++) {
-           if (it.get_local_id(0) == 0) {
-               syclcompat::atomic_fetch_add<int, address_space::local_space,
-                                            order>(&val[0], 1);
-             val_p[1]++;
-           } else {
-             // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
-             // here
-             int tmp1 = atm1.load(memory_order::acquire);
-             int tmp0 = atm0.load(memory_order::relaxed);
-             if (tmp0 < tmp1) {
-               error[0] = 1;
+       cgh.parallel_for(
+           nd_range<1>(global_size, local_size), [=](nd_item<1> it) {
+             size_t lid = it.get_local_id(0);
+             val[0] = 0;
+             val[1] = 0;
+             it.barrier(access::fence_space::local_space);
+             volatile int *val_p = val.get_pointer();
+             auto atm0 =
+                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                            address_space::local_space>(val[0]);
+             auto atm1 =
+                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                            address_space::local_space>(val[1]);
+             for (int i = 0; i < N_iters; i++) {
+               if (it.get_local_id(0) == 0) {
+                 syclcompat::atomic_fetch_add<int, address_space::local_space,
+                                              order>(&val[0], 1);
+                 val_p[1]++;
+               } else {
+                 // syclcompat:: doesn't offer load/store so using
+                 // sycl::atomic_ref here
+                 int tmp1 = atm1.load(memory_order::acquire);
+                 int tmp0 = atm0.load(memory_order::relaxed);
+                 if (tmp0 < tmp1) {
+                   error[0] = 1;
+                 }
+               }
              }
-           }
-         }
-       });
+           });
      }).wait_and_throw();
   }
   assert(error == 0);
 }
 
-template <memory_order order>
-void test_release_global() {
+template <memory_order order> void test_release_global() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   const size_t N_items = 256;
@@ -181,8 +179,8 @@ void test_release_global() {
          for (int i = 0; i < N_iters; i++) {
            if (it.get_id(0) == 0) {
              val_p[0]++;
-               syclcompat::atomic_fetch_add<int, address_space::global_space,
-                                            order>(&val[1], 1);
+             syclcompat::atomic_fetch_add<int, address_space::global_space,
+                                          order>(&val[1], 1);
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
              // here
@@ -219,35 +217,35 @@ template <memory_order order> void test_release_local() {
        auto error =
            error_buf.template get_access<access::mode::read_write>(cgh);
        local_accessor<int, 1> val(2, cgh);
-       cgh.parallel_for(nd_range<1>(global_size, local_size), [=](nd_item<1>
-                                                                      it) {
-         size_t lid = it.get_local_id(0);
-         val[0] = 0;
-         val[1] = 0;
-         it.barrier(access::fence_space::local_space);
-         volatile int *val_p = val.get_pointer();
-         auto atm0 =
-             atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                        address_space::local_space>(val[0]);
-         auto atm1 =
-             atomic_ref<int, memory_order::relaxed, memory_scope::device,
-                        address_space::local_space>(val[1]);
-         for (int i = 0; i < N_iters; i++) {
-           if (it.get_local_id(0) == 0) {
-             val_p[0]++;
-               syclcompat::atomic_fetch_add<int, address_space::local_space,
-                                            order>(&val[1], 1);
-           } else {
-             // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
-             // here
-             int tmp1 = atm1.load(memory_order::acquire);
-             int tmp0 = atm0.load(memory_order::relaxed);
-             if (tmp0 < tmp1) {
-               error[0] = 1;
+       cgh.parallel_for(
+           nd_range<1>(global_size, local_size), [=](nd_item<1> it) {
+             size_t lid = it.get_local_id(0);
+             val[0] = 0;
+             val[1] = 0;
+             it.barrier(access::fence_space::local_space);
+             volatile int *val_p = val.get_pointer();
+             auto atm0 =
+                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                            address_space::local_space>(val[0]);
+             auto atm1 =
+                 atomic_ref<int, memory_order::relaxed, memory_scope::device,
+                            address_space::local_space>(val[1]);
+             for (int i = 0; i < N_iters; i++) {
+               if (it.get_local_id(0) == 0) {
+                 val_p[0]++;
+                 syclcompat::atomic_fetch_add<int, address_space::local_space,
+                                              order>(&val[1], 1);
+               } else {
+                 // syclcompat:: doesn't offer load/store so using
+                 // sycl::atomic_ref here
+                 int tmp1 = atm1.load(memory_order::acquire);
+                 int tmp0 = atm0.load(memory_order::relaxed);
+                 if (tmp0 < tmp1) {
+                   error[0] = 1;
+                 }
+               }
              }
-           }
-         }
-       });
+           });
      }).wait_and_throw();
   }
   assert(error == 0);

--- a/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
@@ -77,8 +77,8 @@ template <memory_order order> void test_acquire_global() {
          for (int i = 0; i < N_iters; i++) {
            if (it.get_id(0) == 0) {
 
-             syclcompat::atomic_fetch_add<int, address_space::global_space,
-                                          order>(&val[0], 1);
+             syclcompat::atomic_fetch_add<address_space::global_space, order>(
+                 &val[0], 1);
              val_p[1]++;
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
@@ -131,7 +131,7 @@ template <memory_order order> void test_acquire_local() {
                             address_space::local_space>(val[1]);
              for (int i = 0; i < N_iters; i++) {
                if (it.get_local_id(0) == 0) {
-                 syclcompat::atomic_fetch_add<int, address_space::local_space,
+                 syclcompat::atomic_fetch_add<address_space::local_space,
                                               order>(&val[0], 1);
                  val_p[1]++;
                } else {
@@ -179,8 +179,8 @@ template <memory_order order> void test_release_global() {
          for (int i = 0; i < N_iters; i++) {
            if (it.get_id(0) == 0) {
              val_p[0]++;
-             syclcompat::atomic_fetch_add<int, address_space::global_space,
-                                          order>(&val[1], 1);
+             syclcompat::atomic_fetch_add<address_space::global_space, order>(
+                 &val[1], 1);
            } else {
              // syclcompat:: doesn't offer load/store so using sycl::atomic_ref
              // here
@@ -233,7 +233,7 @@ template <memory_order order> void test_release_local() {
              for (int i = 0; i < N_iters; i++) {
                if (it.get_local_id(0) == 0) {
                  val_p[0]++;
-                 syclcompat::atomic_fetch_add<int, address_space::local_space,
+                 syclcompat::atomic_fetch_add<address_space::local_space,
                                               order>(&val[1], 1);
                } else {
                  // syclcompat:: doesn't offer load/store so using

--- a/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
@@ -55,13 +55,13 @@
 // are *not* checking the memory_order semantics, just the API.
 template <typename T1, typename T2>
 inline void atomic_fetch_min_kernel(T1 *data, T2 operand, T2 operand0) {
-    syclcompat::atomic_fetch_min(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
+  syclcompat::atomic_fetch_min(
+      data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
 }
 template <typename T1, typename T2>
 inline void atomic_fetch_max_kernel(T1 *data, T2 operand, T2 operand0) {
-    syclcompat::atomic_fetch_max(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
+  syclcompat::atomic_fetch_max(
+      data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
 }
 
 template <typename T> void test_atomic_minmax() {

--- a/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
@@ -53,27 +53,15 @@
 // In every case we test two API overloads, one taking an explicit runtime
 // memory_order argument. We use `relaxed` in every case because these tests
 // are *not* checking the memory_order semantics, just the API.
-template <typename T1, typename T2, bool orderArg = false>
+template <typename T1, typename T2>
 inline void atomic_fetch_min_kernel(T1 *data, T2 operand, T2 operand0) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_fetch_min(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
-        sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_fetch_min(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
-  }
 }
-template <typename T1, typename T2, bool orderArg = false>
+template <typename T1, typename T2>
 inline void atomic_fetch_max_kernel(T1 *data, T2 operand, T2 operand0) {
-  if constexpr (orderArg) {
-    syclcompat::atomic_fetch_max(
-        data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
-        sycl::memory_order::relaxed);
-  } else {
     syclcompat::atomic_fetch_max(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
-  }
 }
 
 template <typename T> void test_atomic_minmax() {
@@ -86,12 +74,6 @@ template <typename T> void test_atomic_minmax() {
       .launch_test(static_cast<T>(100), static_cast<T>(1), static_cast<T>(200),
                    static_cast<T>(1));
   AtomicLauncher<atomic_fetch_max_kernel<T, T>, T>(grid, threads)
-      .launch_test(static_cast<T>(100), static_cast<T>(200),
-                   static_cast<T>(200), static_cast<T>(1));
-  AtomicLauncher<atomic_fetch_min_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(static_cast<T>(100), static_cast<T>(1), static_cast<T>(200),
-                   static_cast<T>(1));
-  AtomicLauncher<atomic_fetch_max_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(100), static_cast<T>(200),
                    static_cast<T>(200), static_cast<T>(1));
 }
@@ -108,12 +90,6 @@ template <typename T> void test_signed_atomic_minmax() {
   AtomicLauncher<atomic_fetch_max_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(-40), static_cast<T>(-30),
                    static_cast<T>(-30), static_cast<T>(-100));
-  AtomicLauncher<atomic_fetch_min_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(static_cast<T>(-1), static_cast<T>(-4), static_cast<T>(-4),
-                   static_cast<T>(100));
-  AtomicLauncher<atomic_fetch_max_kernel<T, T, true>, T>(grid, threads)
-      .launch_test(static_cast<T>(-40), static_cast<T>(-30),
-                   static_cast<T>(-30), static_cast<T>(-100));
 }
 
 void test_signed_atomic_minmax_t1_t2() {
@@ -126,14 +102,6 @@ void test_signed_atomic_minmax_t1_t2() {
       .launch_test(static_cast<float>(-1), static_cast<float>(-4),
                    static_cast<int>(-4), static_cast<int>(100));
   AtomicLauncher<atomic_fetch_max_kernel<float, int>, float>(grid, threads)
-      .launch_test(static_cast<float>(-40), static_cast<float>(-30),
-                   static_cast<int>(-30), static_cast<int>(-100));
-  AtomicLauncher<atomic_fetch_min_kernel<float, int, true>, float>(grid,
-                                                                   threads)
-      .launch_test(static_cast<float>(-1), static_cast<float>(-4),
-                   static_cast<int>(-4), static_cast<int>(100));
-  AtomicLauncher<atomic_fetch_max_kernel<float, int, true>, float>(grid,
-                                                                   threads)
       .launch_test(static_cast<float>(-40), static_cast<float>(-30),
                    static_cast<int>(-30), static_cast<int>(-100));
 }

--- a/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
@@ -53,8 +53,8 @@
 // In every case we test two API overloads, one taking an explicit runtime
 // memory_order argument. We use `relaxed` in every case because these tests
 // are *not* checking the memory_order semantics, just the API.
-template <typename T, bool orderArg = false>
-inline void atomic_fetch_min_kernel(T *data, T operand, T operand0) {
+template <typename T1, typename T2, bool orderArg = false>
+inline void atomic_fetch_min_kernel(T1 *data, T2 operand, T2 operand0) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_min(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
@@ -64,8 +64,8 @@ inline void atomic_fetch_min_kernel(T *data, T operand, T operand0) {
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand));
   }
 }
-template <typename T, bool orderArg = false>
-inline void atomic_fetch_max_kernel(T *data, T operand, T operand0) {
+template <typename T1, typename T2, bool orderArg = false>
+inline void atomic_fetch_max_kernel(T1 *data, T2 operand, T2 operand0) {
   if constexpr (orderArg) {
     syclcompat::atomic_fetch_max(
         data, (syclcompat::global_id::x() == 0 ? operand0 : operand),
@@ -82,16 +82,16 @@ template <typename T> void test_atomic_minmax() {
   constexpr syclcompat::dim3 grid{4};
   constexpr syclcompat::dim3 threads{32};
 
-  AtomicLauncher<atomic_fetch_min_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_min_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(100), static_cast<T>(1), static_cast<T>(200),
                    static_cast<T>(1));
-  AtomicLauncher<atomic_fetch_max_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_max_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(100), static_cast<T>(200),
                    static_cast<T>(200), static_cast<T>(1));
-  AtomicLauncher<atomic_fetch_min_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_min_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(100), static_cast<T>(1), static_cast<T>(200),
                    static_cast<T>(1));
-  AtomicLauncher<atomic_fetch_max_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_max_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(100), static_cast<T>(200),
                    static_cast<T>(200), static_cast<T>(1));
 }
@@ -102,22 +102,46 @@ template <typename T> void test_signed_atomic_minmax() {
   constexpr syclcompat::dim3 grid{4};
   constexpr syclcompat::dim3 threads{32};
 
-  AtomicLauncher<atomic_fetch_min_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_min_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(-1), static_cast<T>(-4), static_cast<T>(-4),
                    static_cast<T>(100));
-  AtomicLauncher<atomic_fetch_max_kernel<T>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_max_kernel<T, T>, T>(grid, threads)
       .launch_test(static_cast<T>(-40), static_cast<T>(-30),
                    static_cast<T>(-30), static_cast<T>(-100));
-  AtomicLauncher<atomic_fetch_min_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_min_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(-1), static_cast<T>(-4), static_cast<T>(-4),
                    static_cast<T>(100));
-  AtomicLauncher<atomic_fetch_max_kernel<T, true>, T>(grid, threads)
+  AtomicLauncher<atomic_fetch_max_kernel<T, T, true>, T>(grid, threads)
       .launch_test(static_cast<T>(-40), static_cast<T>(-30),
                    static_cast<T>(-30), static_cast<T>(-100));
 }
 
+void test_signed_atomic_minmax_t1_t2() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{4};
+  constexpr syclcompat::dim3 threads{32};
+
+  AtomicLauncher<atomic_fetch_min_kernel<float, int>, float>(grid, threads)
+      .launch_test(static_cast<float>(-1), static_cast<float>(-4),
+                   static_cast<int>(-4), static_cast<int>(100));
+  AtomicLauncher<atomic_fetch_max_kernel<float, int>, float>(grid, threads)
+      .launch_test(static_cast<float>(-40), static_cast<float>(-30),
+                   static_cast<int>(-30), static_cast<int>(-100));
+  AtomicLauncher<atomic_fetch_min_kernel<float, int, true>, float>(grid,
+                                                                   threads)
+      .launch_test(static_cast<float>(-1), static_cast<float>(-4),
+                   static_cast<int>(-4), static_cast<int>(100));
+  AtomicLauncher<atomic_fetch_max_kernel<float, int, true>, float>(grid,
+                                                                   threads)
+      .launch_test(static_cast<float>(-40), static_cast<float>(-30),
+                   static_cast<int>(-30), static_cast<int>(-100));
+}
+
 int main() {
   INSTANTIATE_ALL_TYPES(atomic_value_type_list, test_atomic_minmax);
-
   INSTANTIATE_ALL_TYPES(signed_type_list, test_signed_atomic_minmax);
+  test_signed_atomic_minmax_t1_t2();
+
+  return 0;
 }


### PR DESCRIPTION
This PR replaces #11338, following discussion with DPCT team. Change summary:
 - Remove runtime `memoryOrder` option (no longer needed)
 - Define `type_identity_t` and use it to avoid template deduction errors.
 - New tests for the above (e.g. `int *` addr with `unsigned int` operand)
 - New free function `atomic_fetch_compare_dec`