### PR TITLE
[SYCL][ESIMD][E2E] Add ze_debug as unsupported for slm_init_no_inline

### DIFF
--- a/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
+++ b/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
@@ -1,6 +1,7 @@
 // TODO: Investigate fail of this test on Gen12 platform
 // REQUIRES-INTEL-DRIVER: lin: 26516, win: 101.4827
 // REQUIRES: gpu-intel-pvc
+// TODO: Support ze_debug once GPU hang introduced in new GPU driver is solved
 // UNSUPPORTED: ze_debug
 // DEFINE: %{inlineflags} = %if cl_options %{/clang:-fno-inline-functions%} %else %{-fno-inline-functions%}
 // RUN: %{build} %{inlineflags} -o %t.out

--- a/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
+++ b/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
@@ -1,6 +1,7 @@
 // TODO: Investigate fail of this test on Gen12 platform
 // REQUIRES-INTEL-DRIVER: lin: 26516, win: 101.4827
 // REQUIRES: gpu-intel-pvc
+// UNSUPPORTED: ze_debug
 // DEFINE: %{inlineflags} = %if cl_options %{/clang:-fno-inline-functions%} %else %{-fno-inline-functions%}
 // RUN: %{build} %{inlineflags} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
QA asked us to do this.