### PR TITLE
[clangd] Avoid clangd crash with -fsycl flag

### DIFF
--- a/clang-tools-extra/clangd/Compiler.cpp
+++ b/clang-tools-extra/clangd/Compiler.cpp
@@ -89,6 +89,12 @@ void disableUnsupportedOptions(CompilerInvocation &CI) {
   CI.getLangOpts().ProfileListFiles.clear();
   CI.getLangOpts().XRayAlwaysInstrumentFiles.clear();
   CI.getLangOpts().XRayNeverInstrumentFiles.clear();
+  if (CI.getLangOpts().SYCLIsDevice) {
+    CI.getLangOpts().SYCLIsDevice = false;
+    CI.getLangOpts().SYCLUnnamedLambda = false;
+    CI.getLangOpts().DeclareSPIRVBuiltins = false;
+    CI.getTargetOpts().Triple = CI.getTargetOpts().HostTriple;
+  }
 }
 
 std::unique_ptr<CompilerInvocation>

--- a/clang-tools-extra/clangd/test/sycl.test
+++ b/clang-tools-extra/clangd/test/sycl.test
@@ -1,0 +1,40 @@
+# RUN: rm -rf %t.dir/* && mkdir -p %t.dir
+# RUN: echo '[{"directory": "%/t.dir", "command": "clang++ -fsycl main.cpp", "file": "main.cpp"}]' > %t.dir/compile_commands.json
+# RUN: sed -e "s|INPUT_DIR|%/t.dir|g" %s > %t.test.1
+
+# On Windows, we need the URI in didOpen to look like "uri":"file:///C:/..."
+# (with the extra slash in the front), so we add it here.
+# RUN: sed -E -e 's|"file://([A-Z]):/|"file:///\1:/|g' %t.test.1 > %t.test
+
+# RUN: clangd -lit-test < %t.test | FileCheck -strict-whitespace %t.test
+
+{"jsonrpc":"2.0","id":0,"method":"initialize","params":{"initializationOptions":{"compilationDatabasePath":"INPUT_DIR"}}}
+---
+{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"uri":"test:///main.cpp","languageId":"cpp","version":1,"text":"#include <sycl/sycl.hpp>\nsycl::queue q{};"}}}
+---
+{"jsonrpc":"2.0","id":1,"method":"textDocument/symbolInfo","params":{
+  "textDocument":{"uri":"test:///main.cpp"},
+  "position":{"line":1,"character":13}
+}}
+#      CHECK:  "id": 1
+# CHECK-NEXT:  "jsonrpc": "2.0",
+# CHECK-NEXT:  "result": [
+# CHECK-NEXT:    {
+# CHECK-NEXT:      "containerName": "sycl::queue::",
+# CHECK-NEXT:      "declarationRange": {
+# CHECK-NEXT:        "range": {
+# CHECK-NEXT:          "end": {
+# CHECK-NEXT:            "character": 16,
+# CHECK-NEXT:            "line": 124
+# CHECK-NEXT:          },
+# CHECK-NEXT:          "start": {
+# CHECK-NEXT:            "character": 11,
+# CHECK-NEXT:            "line": 124
+# CHECK-NEXT:          }
+# CHECK-NEXT:        },
+# CHECK-NEXT:        "uri": "file://{{.*}}/include/sycl/queue.hpp"
+# CHECK-NEXT:      },
+---
+{"jsonrpc":"2.0","id":3,"method":"shutdown"}
+---
+{"jsonrpc":"2.0","method":"exit"}


### PR DESCRIPTION
Add four extra option resets in `disableUnsupportedOptions` when parsing SYCL code. All four are needed to make clangd happily parse code when `-fsycl` is specified in compile commands. Without each of them, the following happens:
* without `SYCLIsDevice=false`: crash on !nullptr assert
* without `DeclareSPIRVBuiltins=false`: crash on !nullptr assert
* without `SYCLUnnamedLambda=false`: `ref_non_value` error, `'T' does not refer to a value`
* without `Triple=HostTriple`: `pp_file_not_found` error, `'gnu/stubs-32.h' file not found`

Fixes intel/llvm#11088 and clangd/clangd#1097


Also add a LIT test which parses the following code:
```cpp
#include <sycl/sycl.hpp>
sycl::queue q{};
```
and checks `symbolInfo` for the symbol `q` against a reference.