### PR TITLE
[ESIMD] Fix implementations of block_load(usm, ...) and block_load(acc)

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -212,7 +212,7 @@ __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<T, N * __ESIMD_DNS::to_int<VS>()>
 __esimd_lsc_load_merge_bti(
     __ESIMD_DNS::simd_mask_storage_t<N> pred,
     __ESIMD_DNS::vector_type_t<uint32_t, N> offsets, SurfIndAliasT surf_ind,
-    __ESIMD_DNS::vector_type_t<T, N * __ESIMD_DNS::to_int<VS>()> PassThru = 0)
+    __ESIMD_DNS::vector_type_t<T, N * __ESIMD_DNS::to_int<VS>()> PassThru)
 #ifdef __SYCL_DEVICE_ONLY__
     ;
 #else  // __SYCL_DEVICE_ONLY__

--- a/sycl/test/esimd/memory_properties.cpp
+++ b/sycl/test/esimd/memory_properties.cpp
@@ -135,7 +135,7 @@ foo(AccType &acc, float *ptrf, int byte_offset32, size_t byte_offset64) {
   // not power-of-two because only svm/legacy block_load supports
   // non-power-of-two vector lengths now.
 
-  // CHECK: call <4 x float> @llvm.genx.oword.ld.unaligned.v4f32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK: call <4 x float> @llvm.genx.oword.ld.v4f32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})
   auto z1 = block_load<float, 4>(acc, props_c);
 
   // CHECK: call <8 x i32> @llvm.genx.oword.ld.unaligned.v8i32(i32 0, i32 {{[^)]+}}, i32 {{[^)]+}})


### PR DESCRIPTION
1) Fix the big mess in E2E test for block_load(). Test did not really
   check the mask variant. It also used wrong alignments.

2) Fix the comments for USM and ACC block_load implementations. 
3) Minor optimization for ACC block_load functions that do not accept
   the byte_offset operand. We can assume align16 for them.