### PR TITLE
[Driver][SYCL] Disable parallel for range rounding at -O0

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5456,7 +5456,6 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         }
       }
     }
-
     // Add any predefined macros associated with intel_gpu* type targets
     // passed in with -fsycl-targets
     // TODO: Macros are populated during device compilations and saved for

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5398,16 +5398,11 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         break;
       }
     }
-    // At any optimization leve below -O3, imply -fsycl-disable-range-rounding.
-    bool DisableRangeRounding = true;
+    // At -O0, imply -fsycl-disable-range-rounding.
+    bool DisableRangeRounding = false;
     if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {
-      bool IsO3 = false;
-      if (A->getOption().matches(options::OPT_O)) {
-        StringRef Val(A->getValue());
-        IsO3 = Val.equals("3");
-      }
-      if (IsO3 || A->getOption().matches(options::OPT_Ofast))
-        DisableRangeRounding = false;
+      if (A->getOption().matches(options::OPT_O0))
+        DisableRangeRounding = true;
     }
     if (DisableRangeRounding || HasFPGA)
       CmdArgs.push_back("-fsycl-disable-range-rounding");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5443,6 +5443,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
         }
       }
     }
+
+    // At -O0, imply -D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__
+    if (Arg *A = Args.getLastArg(options::OPT_O_Group)) {
+      if (A->getOption().matches(options::OPT_O0))
+        CmdArgs.push_back("-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__");
+    }
+
     // Add any predefined macros associated with intel_gpu* type targets
     // passed in with -fsycl-targets
     // TODO: Macros are populated during device compilations and saved for

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -434,18 +434,17 @@
 // RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
 // RUN: %clang_cl -### -fsycl -fsycl-targets=spir64 -Od %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
-// RUN:        -fsycl-targets=spir64 -O2 %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
-// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64 -O2 %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
 // CHK-DISABLE-RANGE-ROUNDING: "-fsycl-disable-range-rounding"
 
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
-// RUN:        -fsycl-targets=spir64 -O3 %s 2>&1 \
+// RUN:        -fsycl-targets=spir64 -O2 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
+// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64 -O2 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
-// RUN:        -fsycl-targets=spir64 -Ofast %s 2>&1 \
+// RUN:        -fsycl-targets=spir64 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
+// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
 // CHK-RANGE-ROUNDING-NOT: "-fsycl-disable-range-rounding"
 

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -421,16 +421,33 @@
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O0 %s
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64 -O0 -O2 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O2 %s
-// CHK-TOOLS-IMPLIED-OPTS-O0: clang{{.*}} "-fsycl-is-device"
-// CHK-TOOLS-IMPLIED-OPTS-O0-SAME: "-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__"
-// CHK-TOOLS-IMPLIED-OPTS-O0: clang{{.*}} "-fsycl-is-host"
-// CHK-TOOLS-IMPLIED-OPTS-O0-SAME: "-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__"
 // CHK-TOOLS-IMPLIED-OPTS-O0-NOT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-cl-opt-disable"
 // CHK-TOOLS-IMPLIED-OPTS-O2-NOT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-cl-opt-disable"
 
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown -Xsycl-target-linker "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-OPTS2 %s
 // CHK-TOOLS-OPTS2: clang-offload-wrapper{{.*}} "-link-opts=-DFOO1 -DFOO2"
+
+/// -fsycl-disable-range-rounding settings
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
+// RUN:        -fsycl-targets=spir64 -O0 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
+// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64 -Od %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
+// RUN:        -fsycl-targets=spir64 -O2 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
+// RUN: %clang_cl -### -fsycl -fsycl-targets=spir64 -O2 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-DISABLE-RANGE-ROUNDING %s
+// CHK-DISABLE-RANGE-ROUNDING: "-fsycl-disable-range-rounding"
+
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
+// RUN:        -fsycl-targets=spir64 -O3 %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl \
+// RUN:        -fsycl-targets=spir64 -Ofast %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHK-RANGE-ROUNDING %s
+// CHK-RANGE-ROUNDING-NOT: "-fsycl-disable-range-rounding"
 
 /// ###########################################################################
 

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -421,6 +421,10 @@
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O0 %s
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64 -O0 -O2 %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS-O2 %s
+// CHK-TOOLS-IMPLIED-OPTS-O0: clang{{.*}} "-fsycl-is-device"
+// CHK-TOOLS-IMPLIED-OPTS-O0-SAME: "-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__"
+// CHK-TOOLS-IMPLIED-OPTS-O0: clang{{.*}} "-fsycl-is-host"
+// CHK-TOOLS-IMPLIED-OPTS-O0-SAME: "-D__SYCL_DISABLE_PARALLEL_FOR_RANGE_ROUNDING__"
 // CHK-TOOLS-IMPLIED-OPTS-O0-NOT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-cl-opt-disable"
 // CHK-TOOLS-IMPLIED-OPTS-O2-NOT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-cl-opt-disable"
 

--- a/sycl/test/basic_tests/parallel_for_type_check.cpp
+++ b/sycl/test/basic_tests/parallel_for_type_check.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -O0 -c -emit-llvm -S -o - %s | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -c -emit-llvm -S -o - %s | FileCheck %s
 
 // This test performs basic type check for sycl::id that is used in result type.
 // Check that sycl::id is converted from sycl::item.

--- a/sycl/test/basic_tests/parallel_for_type_check.cpp
+++ b/sycl/test/basic_tests/parallel_for_type_check.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -O3 -c -emit-llvm -S -o - %s | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -c -emit-llvm -S -o - %s | FileCheck %s
 
 // This test performs basic type check for sycl::id that is used in result type.
 // Check that sycl::id is converted from sycl::item.

--- a/sycl/test/basic_tests/parallel_for_type_check.cpp
+++ b/sycl/test/basic_tests/parallel_for_type_check.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -c -emit-llvm -S -o - %s | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-device-only -D__SYCL_INTERNAL_API -O3 -c -emit-llvm -S -o - %s | FileCheck %s
 
 // This test performs basic type check for sycl::id that is used in result type.
 // Check that sycl::id is converted from sycl::item.


### PR DESCRIPTION
When using -O0 to disable optimizations, also set -fsycl-disable-range-rounding to further disable optimizations to improve debugability.