### PR TITLE
[SYCL] Small patch on annotated USM allocation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
@@ -109,10 +109,9 @@ aligned_alloc_annotated(size_t alignment, size_t count,
                           "Unknown USM allocation kind was specified.");
 
   size_t combinedAlign = combine_align(alignment, alignFromPropList);
-  void *rawPtr =
-      sycl::aligned_alloc(std::max(sizeof(T), combinedAlign), count * sizeof(T),
-                          syclDevice, syclContext, kind, usmPropList);
-  return annotated_ptr<T, propertyListB>(static_cast<T *>(rawPtr));
+  T *rawPtr = sycl::aligned_alloc<T>(combinedAlign, count, syclDevice,
+                                     syclContext, kind, usmPropList);
+  return annotated_ptr<T, propertyListB>(rawPtr);
 }
 
 template <typename propertyListA = detail::empty_properties_t,

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
@@ -108,9 +108,10 @@ aligned_alloc_annotated(size_t alignment, size_t count,
     throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
                           "Unknown USM allocation kind was specified.");
 
-  void *rawPtr = sycl::aligned_alloc(
-      combine_align(alignment, alignFromPropList), count * sizeof(T),
-      syclDevice, syclContext, kind, usmPropList);
+  size_t combinedAlign = combine_align(alignment, alignFromPropList);
+  void *rawPtr =
+      sycl::aligned_alloc(std::max(sizeof(T), combinedAlign), count * sizeof(T),
+                          syclDevice, syclContext, kind, usmPropList);
   return annotated_ptr<T, propertyListB>(static_cast<T *>(rawPtr));
 }
 

--- a/sycl/test-e2e/Annotated_usm/annotated_usm_align.cpp
+++ b/sycl/test-e2e/Annotated_usm/annotated_usm_align.cpp
@@ -375,10 +375,10 @@ template <typename T> void testAlign(sycl::queue &q, unsigned align) {
       // 2),
       // nullptr is returned
       ,
-      [&]() { return TDevice(q, properties{alignment<5>}); },
-      [&]() { return TDevice(dev, Ctx, properties{alignment<10>}); },
-      [&]() { return THost(q, properties{alignment<25>}); },
-      [&]() { return THost(Ctx, properties{alignment<50>}); },
+      [&]() { return TDevice(q, properties{alignment<75>}); },
+      [&]() { return TDevice(dev, Ctx, properties{alignment<100>}); },
+      [&]() { return THost(q, properties{alignment<205>}); },
+      [&]() { return THost(Ctx, properties{alignment<500>}); },
       [&]() {
         return TAnnotated(q, alloc::device, properties{alignment<127>});
       },
@@ -405,18 +405,23 @@ template <typename T> void testAlign(sycl::queue &q, unsigned align) {
       // alignment
       // argument is not a power of 2, the result is nullptr
       ,
-      [&]() { return ATDevice(3, q); },
-      [&]() { return ATDevice(7, dev, Ctx); },
-      [&]() { return ATHost(7, q); },
-      [&]() { return ATHost(9, Ctx); },
-      [&]() { return ATAnnotated(15, q, alloc::device); },
-      [&]() { return ATAnnotated(17, dev, Ctx, alloc::host); }});
+      [&]() { return ATDevice(65, q); },
+      [&]() { return ATDevice(70, dev, Ctx); },
+      [&]() { return ATHost(174, q); },
+      [&]() { return ATHost(299, Ctx); },
+      [&]() { return ATAnnotated(550, q, alloc::device); },
+      [&]() { return ATAnnotated(1700, dev, Ctx, alloc::host); }});
 }
+
+struct alignas(64) MyStruct {
+  int x;
+};
 
 int main() {
   sycl::queue q;
   testAlign<char>(q, 4);
   testAlign<int>(q, 128);
   testAlign<std::complex<double>>(q, 4);
+  testAlign<MyStruct>(q, 4);
   return 0;
 }


### PR DESCRIPTION
This PR is a small change on the implementation of `aligned_alloc_annotated<T>`, which is a variant of the SYCL annotated USM allocation: 
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_usm_malloc_properties.asciidoc

Right now `aligned_alloc_annotated<T>` is implemented by calling `sycl::aligned_alloc` (allocation in bytes) with a specified alignment (which is a combination (i.e. least common multiple) of the compile-time `alignment<K>` property and the runtime argument), and then cast the returned pointer type from `void *` to `T*`

This does not cover the case where T has a extended alignment as follows
```
struct alignas(256) MyStruct {
  int x;
};
```
in this case, both the combined alignment and `alignof(T)` should be considered, and the greater value of the two should be the final alignment passed to the SYCL runtime. Therefore, this PR changes the impl by directly calling the SYCL core usm API: `aligned_alloc<T>`.

Some e2e tests are updated with this header change: when `alignof(T)` is large enough, the `aligned_alloc_annotated<T>` is no longer expected to return null when the specified alignment is not a power of 2, because `alignof(T)` (always a power of 2) is the final alignment passed to the SYCL runtime. Therefore, we bump up the specified alignments in these cases to make sure they are always larger the `alignof(T)`