### PR TITLE
[SYCL-MLIR][mlir-translate] Set call attributes following callee

### DIFF
--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -196,6 +196,7 @@ convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
           moduleTranslation.lookupFunction(attr.getValue());
       call = builder.CreateCall(callee, operandsRef);
       call->setCallingConv(callee->getCallingConv());
+      call->setAttributes(callee->getAttributes());
     } else {
       llvm::FunctionType *calleeType = llvm::cast<llvm::FunctionType>(
           moduleTranslation.convertType(callOp.getCalleeFunctionType()));

--- a/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/LLVMIR/LLVMToLLVMIRTranslation.cpp
@@ -196,6 +196,8 @@ convertOperationImpl(Operation &opInst, llvm::IRBuilderBase &builder,
           moduleTranslation.lookupFunction(attr.getValue());
       call = builder.CreateCall(callee, operandsRef);
       call->setCallingConv(callee->getCallingConv());
+      // FIXME: This is just a temporary solution. Arguments should be attached
+      // to the operation and translated, not taken from callee.
       call->setAttributes(callee->getAttributes());
     } else {
       llvm::FunctionType *calleeType = llvm::cast<llvm::FunctionType>(

--- a/mlir/test/Target/LLVMIR/llvmir.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir.mlir
@@ -2300,6 +2300,22 @@ llvm.func @streaming_func() attributes {arm_streaming} {
 
 // -----
 
+// CHECK: declare nonnull ptr @func_with_attrs(ptr noundef byval({ i64, i64, ptr }) align 8 dereferenceable_or_null(8), i8 noundef zeroext, i64)
+llvm.func external @func_with_attrs(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef, llvm.byval = !llvm.struct<(i64, i64, !llvm.ptr)>}, %arg1: i8 {llvm.zeroext, llvm.noundef}, %arg2: i64) -> (!llvm.ptr {llvm.nonnull})
+
+// CHECK-LABEL: define void @caller(
+// CHECK-SAME:                      ptr noundef byval({ i64, i64, ptr }) align 8 dereferenceable_or_null(8) %[[#ARG0:]],
+// CHECK-SAME:                      i8 noundef %[[#ARG1:]],
+// CHECK-SAME:                      i64 noundef %[[#ARG2:]]
+// CHECK:         {{.*}} = call nonnull ptr @func_with_attrs(ptr noundef byval({ i64, i64, ptr }) align 8 dereferenceable_or_null(8) %[[#ARG0]], i8 noundef zeroext %[[#ARG1]], i64 %[[#ARG2]])
+// CHECK:         ret void
+llvm.func @caller(%arg0: !llvm.ptr {llvm.align = 8 : i64, llvm.dereferenceable_or_null = 8 : i64, llvm.noundef, llvm.byval = !llvm.struct<(i64, i64, !llvm.ptr)>}, %arg1: i8 {llvm.noundef}, %arg2: i64 {llvm.noundef}) {
+  %res = llvm.call @func_with_attrs(%arg0, %arg1, %arg2) : (!llvm.ptr, i8, i64) -> !llvm.ptr
+  llvm.return
+}
+
+// -----
+
 //
 // arm_locally_streaming attribute.
 //

--- a/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/constructors.cpp
@@ -153,7 +153,7 @@ extern "C" SYCL_EXTERNAL void cons_1() {
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ID1:%.*]] = alloca [[ID_TYPE:%"class.sycl::_V1::id.2"]]
 // CHECK-LLVM: [[ID1_AS:%.*]] = addrspacecast ptr [[ID1]] to ptr addrspace(4)
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(ptr addrspace(4) [[ID1_AS]], i64 %0, i64 %1)
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V12idILi2EEC1ILi2EEENSt9enable_ifIXeqT_Li2EEmE4typeEm(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) [[ID1_AS]], i64 noundef %0, i64 noundef %1)
 
 extern "C" SYCL_EXTERNAL void cons_2(size_t a, size_t b) {
   auto id = sycl::id<2>{a, b};
@@ -222,7 +222,7 @@ extern "C" SYCL_EXTERNAL void cons_4(sycl::id<2> val) {
 // CHECK-LLVM-SAME:  #[[FUNCATTRS]]
 // CHECK-LLVM: [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", i64 1, align 8
 // CHECK-LLVM: [[ACAST:%.*]] = addrspacecast ptr [[ACCESSOR]] to ptr addrspace(4)
-// CHECK-LLVM: call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) [[ACAST]])
+// CHECK-LLVM: call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) noundef align 8 dereferenceable_or_null(32) [[ACAST]])
 
 extern "C" SYCL_EXTERNAL void cons_5() {
   auto accessor = sycl::accessor<sycl::cl_int, 1, sycl::access::mode::write>{};
@@ -236,7 +236,7 @@ extern "C" SYCL_EXTERNAL void cons_5() {
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_6(
 // CHECK-LLVM-SAME:                                i32 noundef %{{.*}}) #[[FUNCATTRS]]
-// CHECK-LLVM:         call spir_func void @[[VEC_SPLAT_CTR:.*]](ptr addrspace(4) %{{.*}}, ptr addrspace(4) %{{.*}})
+// CHECK-LLVM:         call spir_func void @[[VEC_SPLAT_CTR:.*]](ptr addrspace(4) noundef align 32 dereferenceable_or_null(32) %{{.*}}, ptr addrspace(4) noundef align 4 dereferenceable(4) %{{.*}})
 // CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_SPLAT_CTR]](ptr addrspace(4) noundef align 32 dereferenceable_or_null(32) %{{.*}}, ptr addrspace(4) noundef align 4 dereferenceable(4) %{{.*}}) #[[FUNCATTRS]] {
 // CHECK-LLVM:         %[[VECINIT:.*]] = insertelement <8 x i32> undef, i32 %{{.*}}, i32 0
 // CHECK-LLVM:         %{{.*}} = shufflevector <8 x i32> %[[VECINIT]], <8 x i32> undef, <8 x i32> zeroinitializer
@@ -252,7 +252,7 @@ extern "C" SYCL_EXTERNAL void cons_6(int Arg) {
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_7(
 // CHECK-LLVM-SAME:                                float noundef %[[ARG0:.*]], float noundef %[[ARG1:.*]], float noundef %[[ARG2:.*]], float noundef %[[ARG3:.*]]) #[[FUNCATTRS]]
-// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_CTR:.*]](ptr addrspace(4) %{{.*}}, float %[[ARG0]], float %[[ARG1]], float %[[ARG2]], float %[[ARG3]])
+// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_CTR:.*]](ptr addrspace(4) noundef align 16 dereferenceable_or_null(16) %{{.*}}, float noundef %[[ARG0]], float noundef %[[ARG1]], float noundef %[[ARG2]], float noundef %[[ARG3]])
 // CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_CTR]](ptr addrspace(4) noundef align 16 {{.*}}, float noundef {{.*}}, float noundef {{.*}}, float noundef {{.*}}, float noundef {{.*}}) #[[FUNCATTRS]]
 extern "C" SYCL_EXTERNAL void cons_7(float A, float B, float C, float D) {
   auto vec = sycl::vec<sycl::cl_float, 4>{A, B, C, D};
@@ -265,7 +265,7 @@ extern "C" SYCL_EXTERNAL void cons_7(float A, float B, float C, float D) {
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_8(
 // CHECK-LLVM-SAME:                                 ptr addrspace(4) noundef align 64 dereferenceable(128) %[[ARG0:.*]]) #[[FUNCATTRS]] {
-// CHECK-LLVM:          call spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(ptr addrspace(4) %{{.*}}, ptr addrspace(4) %[[ARG0]])
+// CHECK-LLVM:          call spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(ptr addrspace(4) noundef align 64 dereferenceable_or_null(128) %{{.*}}, ptr addrspace(4) noundef align 64 dereferenceable(128) %[[ARG0]])
 // CHECK-LLVM:        define linkonce_odr spir_func void @_ZN4sycl3_V13vecIdLi16EEC1ERKS2_(ptr addrspace(4) noundef align 64 dereferenceable_or_null(128) %{{.*}}, ptr addrspace(4) noundef align 64 dereferenceable(128) %{{.*}}) #[[FUNCATTRS]] {
 extern "C" SYCL_EXTERNAL void cons_8(const sycl::vec<sycl::cl_double, 16> &Other) {
   auto vec = sycl::vec<sycl::cl_double, 16>{Other};
@@ -278,7 +278,7 @@ extern "C" SYCL_EXTERNAL void cons_8(const sycl::vec<sycl::cl_double, 16> &Other
 
 // CHECK-LLVM-LABEL:  define spir_func void @cons_9(
 // CHECK-LLVM-SAME:                                 <3 x i8> noundef %[[ARG0:.*]]) #[[FUNCATTRS]] {
-// CHECK-LLVM:          call spir_func void @[[VEC_NATIVE_CTR:.*]](ptr addrspace(4) %{{.*}}, <3 x i8> %[[ARG0]])
+// CHECK-LLVM:          call spir_func void @[[VEC_NATIVE_CTR:.*]](ptr addrspace(4) noundef align 4 dereferenceable_or_null(4) %{{.*}}, <3 x i8> noundef %[[ARG0]])
 // CHECK-LLVM:        define linkonce_odr spir_func void @[[VEC_NATIVE_CTR]](ptr addrspace(4) noundef align 4 dereferenceable_or_null(4) %{{.*}}, <3 x i8> noundef %{{.*}}) #[[FUNCATTRS]] {
 extern "C" SYCL_EXTERNAL void cons_9(const sycl::vec<sycl::cl_char, 3>::vector_t Native) {
   auto vec = sycl::vec<sycl::cl_char, 3>{Native};
@@ -291,7 +291,7 @@ extern "C" SYCL_EXTERNAL void cons_9(const sycl::vec<sycl::cl_char, 3>::vector_t
 
 // CHECK-LLVM-LABEL: define spir_func void @cons_10(
 // CHECK-LLVM-SAME:                                 ptr addrspace(4) noundef align 64 dereferenceable(64) %[[ARG0:.*]], ptr addrspace(4) noundef align 32 dereferenceable(32) %[[ARG1:.*]], ptr addrspace(4) noundef align 16 dereferenceable(16) %[[ARG2:.*]], i64 noundef %{{.*}}, i64 noundef %{{.*}}) #[[FUNCATTRS]] {
-// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_VEC_CTR:.*]](ptr addrspace(4) %{{.*}}, ptr addrspace(4) %[[ARG0]], ptr addrspace(4) %[[ARG1]], ptr addrspace(4) %[[ARG2]], ptr addrspace(4) %{{.*}}, ptr addrspace(4) %{{.*}})
+// CHECK-LLVM:         call spir_func void @[[VEC_INITLIST_VEC_CTR:.*]](ptr addrspace(4) noundef align 64 dereferenceable_or_null(128) %{{.*}}, ptr addrspace(4) noundef align 64 dereferenceable(64) %[[ARG0]], ptr addrspace(4) noundef align 32 dereferenceable(32) %[[ARG1]], ptr addrspace(4) noundef align 16 dereferenceable(16) %[[ARG2]], ptr addrspace(4) noundef align 8 dereferenceable(8) %{{.*}}, ptr addrspace(4) noundef align 8 dereferenceable(8) %{{.*}})
 // CHECK-LLVM:       define linkonce_odr spir_func void @[[VEC_INITLIST_VEC_CTR]](ptr addrspace(4) noundef align 64 dereferenceable_or_null(128) %{{.*}}, ptr addrspace(4) noundef align 64 dereferenceable(64) %{{.*}}, ptr addrspace(4) noundef align 32 dereferenceable(32) %{{.*}}, ptr addrspace(4) noundef align 16 dereferenceable(16) %{{.*}}, ptr addrspace(4) noundef align 8 dereferenceable(8) %{{.*}}, ptr addrspace(4) noundef align 8 dereferenceable(8) %{{.*}}) #[[FUNCATTRS]] {
 
 extern "C" SYCL_EXTERNAL void cons_10(const sycl::long8 &A,

--- a/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/issue7835.cpp
@@ -60,11 +60,11 @@
 // CHECK-LLVM-NEXT:    call void @llvm.memcpy.p0.p4.i64(ptr %4, ptr addrspace(4) %13, i64 8, i1 false)
 // CHECK-LLVM-NEXT:    %14 = load { ptr addrspace(4) }, ptr %4, align 8
 // CHECK-LLVM-NEXT:    store { ptr addrspace(4) } %14, ptr %12, align 8
-// CHECK-LLVM-NEXT:    %15 = call spir_func ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
-// CHECK-LLVM-NEXT:    %16 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) %15)
+// CHECK-LLVM-NEXT:    %15 = call spir_func noundef ptr addrspace(4) @_ZN4sycl3_V16detail7declptrINS0_4itemILi1ELb1EEEEEPT_v()
+// CHECK-LLVM-NEXT:    %16 = call spir_func %"class.sycl::_V1::item.1.true" @_ZN4sycl3_V16detail7Builder10getElementILi1ELb1EEEDTcl7getItemIXT_EXT0_EEEEPNS0_4itemIXT_EXT0_EEE(ptr addrspace(4) noundef %15)
 // CHECK-LLVM-NEXT:    %17 = addrspacecast ptr %6 to ptr addrspace(4)
 // CHECK-LLVM-NEXT:    store %"class.sycl::_V1::item.1.true" %16, ptr %3, align 8
-// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) %17, ptr %3)
+// CHECK-LLVM-NEXT:    call spir_func void @_ZNK4sycl3_V16detail18RoundedRangeKernelINS0_4itemILi1ELb1EEELi1EZ4testRNS0_5queueEEUlNS0_2idILi1EEEE_EclES4_(ptr addrspace(4) noundef align 8 dereferenceable_or_null(16) %17, ptr noundef byval(%"class.sycl::_V1::item.1.true") align 8 %3)
 // CHECK-LLVM-NEXT:    call spir_func void @__itt_offload_wi_finish_wrapper()
 // CHECK-LLVM-NEXT:    ret void
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/sycl_extern_func.cpp
@@ -19,7 +19,7 @@
 // CHECK-LLVM-SAME:  #[[FUNCATTRS0:[0-9]+]] {
 // CHECK-LLVM-NEXT:  [[ACCESSOR:%.*]] = alloca %"class.sycl::_V1::accessor.1", i64 1, align 8
 // CHECK-LLVM-NEXT:  [[ACAST:%.*]] = addrspacecast ptr [[ACCESSOR]] to ptr addrspace(4)
-// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) [[ACAST]])
+// CHECK-LLVM-NEXT:  call spir_func void @_ZN4sycl3_V18accessorIiLi1ELNS0_6access4modeE1025ELNS2_6targetE2014ELNS2_11placeholderE0ENS0_3ext6oneapi22accessor_property_listIJEEEEC1Ev(ptr addrspace(4) noundef align 8 dereferenceable_or_null(32) [[ACAST]])
 
 // CHECK-LLVM-LABEL: define weak_odr spir_kernel void @_ZTSZZ16host_single_taskvENKUlRN4sycl3_V17handlerEE_clES2_E18kernel_single_task
 // CHECK-LLVM-SAME: #[[FUNCATTRS1:[0-9]+]]

--- a/polygeist/tools/cgeist/Test/Verification/sycl/usm-wrapper.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/usm-wrapper.cpp
@@ -1,5 +1,7 @@
 // RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -o - -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 %s | FileCheck %s
 
+// COM: Test `foo` is called with the right parameters. In order to do so, we need to add call-site attributes.
+
 #include <sycl/sycl.hpp>
 
 struct wrapper { std::size_t a; std::size_t b; float *c; };

--- a/polygeist/tools/cgeist/Test/Verification/sycl/usm-wrapper.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/usm-wrapper.cpp
@@ -1,0 +1,33 @@
+// RUN: clang++ -fsycl -fsycl-device-only -S -emit-llvm -o - -fsycl-targets=spir64-unknown-unknown-syclmlir -O3 %s | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+struct wrapper { std::size_t a; std::size_t b; float *c; };
+
+SYCL_EXTERNAL void foo(sycl::id<1>, wrapper);
+
+// CHECK-LABEL: define spir_func void @_Z4testN4sycl3_V12idILi1EEE7wrapper(
+// CHECK-SAME:                                                             ptr nocapture noundef readonly byval(%"class.sycl::_V1::id.1") align 8 %[[#ARG0:]],
+// CHECK-SAME:                                                             ptr nocapture noundef readonly byval({ i64, i64, ptr addrspace(4) }) align 8 %[[#ARG1:]])
+// CHECK:         %[[#WRAPPER_ALLOCA:]] = alloca { i64, i64, ptr addrspace(4) }, align 8
+// CHECK:         %[[#ID_ALLOCA:]] = alloca %"class.sycl::_V1::id.1", align 8
+// CHECK:         %[[GS:.*]] = load i64, ptr %[[#ARG0]], align 1
+// CHECK:         %[[M0:.*]] = load i64, ptr %[[#ARG1]], align 1
+// CHECK:         %[[M1_PTR:.*]] = getelementptr inbounds i8, ptr %[[#ARG1]], i64 8
+// CHECK:         %[[M1:.*]] = load i64, ptr %[[M1_PTR]], align 1
+// CHECK:         %[[M2_PTR:.*]] = getelementptr inbounds i8, ptr %[[#ARG1]], i64 16
+// CHECK:         %[[M2:.*]] = load ptr addrspace(4), ptr %[[M2_PTR]], align 1
+// CHECK:         store i64 %[[GS]], ptr %[[#ID_ALLOCA]], align 8
+// CHECK:         store i64 %[[M0]], ptr %[[#WRAPPER_ALLOCA]], align 8
+// CHECK:         %[[CPY_M1_PTR:.*]] = getelementptr inbounds { i64, i64, ptr addrspace(4) }, ptr %[[#WRAPPER_ALLOCA]], i64 0, i32 1
+// CHECK:         store i64 %[[M1]], ptr %[[CPY_M1_PTR]], align 8
+// CHECK:         %[[CPY_M2_PTR:.*]] = getelementptr inbounds { i64, i64, ptr addrspace(4) }, ptr %[[#WRAPPER_ALLOCA]], i64 0, i32 2
+// CHECK:         store ptr addrspace(4) %[[M2]], ptr %[[CPY_M2_PTR]], align 8
+// CHECK:         tail call spir_func void @_Z3fooN4sycl3_V12idILi1EEE7wrapper(ptr noundef nonnull byval(%"class.sycl::_V1::id.1") align 8 %[[#ID_ALLOCA]], ptr noundef nonnull byval({ i64, i64, ptr addrspace(4) }) align 8 %[[#WRAPPER_ALLOCA]])
+// CHECK:         ret void
+
+// CHECK: declare spir_func void @_Z3fooN4sycl3_V12idILi1EEE7wrapper(ptr noundef byval(%"class.sycl::_V1::id.1") align 8, ptr noundef byval({ i64, i64, ptr addrspace(4) }) align 8)
+
+SYCL_EXTERNAL void test(sycl::id<1> i, wrapper w) {
+  foo(i, w);
+}


### PR DESCRIPTION
Make translated call instructions attributes the same as those in the callee function.