### PR TITLE
[UR] Bump UR tag to 04799e7 to get OpenCL adapter fixes

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,13 +56,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 534071e52f84bad1dd7fb210a360414507f3b3ae
-  # Merge: 9fc82304 d164792b
+  # commit 04799e735a7ddd0839568b25bf03fa8f77160b7d
+  # Merge: 534071e5 4cf02cb9
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Wed Nov 15 10:51:54 2023 +0000
-  #     Merge pull request #1077 from fabiomestre/fabio/combines_fixes_cuda_hip
-  #     [CUDA][HIP] Combined CTS Fixes
-  set(UNIFIED_RUNTIME_TAG 534071e52f84bad1dd7fb210a360414507f3b3ae)
+  # Date:   Mon Nov 20 10:24:50 2023 +0000
+  #     Merge pull request #1048 from callumfare/opencl_fix_urMemBufferCreate_leak
+  #     [OpenCL] Fix memory leak and coverity issue with struct-to-array casts
+  set(UNIFIED_RUNTIME_TAG 04799e735a7ddd0839568b25bf03fa8f77160b7d)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
Includes UR changes from [ [OpenCL] Fix memory leak and coverity issue with struct-to-array casts #1048 ](https://github.com/oneapi-src/unified-runtime/pull/1048).