### PR TITLE
[SYCL][Test E2E] Add 2 extra characters to escaping function

### DIFF
--- a/sycl/test-e2e/Config/select_device.cpp
+++ b/sycl/test-e2e/Config/select_device.cpp
@@ -73,7 +73,7 @@ struct DevDescT {
 };
 
 static void addEscapeSymbolToSpecialCharacters(std::string &str) {
-  std::vector<std::string> specialCharacters{"(", ")", "[", "]", "."};
+  std::vector<std::string> specialCharacters{"(", ")", "[", "]", ".", "+", "-"};
   for (const auto &character : specialCharacters) {
     size_t pos = 0;
     while ((pos = str.find(character, pos)) != std::string::npos) {


### PR DESCRIPTION
Fixes generating filters like this one: `DeviceName:{{gfx90a:sramecc\+:xnack\-}},DriverVersion:{{HIP 50422.80}}`