### PR TITLE
[SYCL] Fix `operator-` for `sycl::vec<bool, N>`

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1060,7 +1060,11 @@ public:
 
   // operator -
   template <typename T = vec> EnableIfNotUsingArray<T> operator-() const {
-    return vec{-m_Data};
+    vec Ret{-m_Data};
+    if constexpr (std::is_same_v<Type, bool>) {
+      Ret.ConvertToDataT();
+    }
+    return Ret;
   }
 
   template <typename T = vec> EnableIfUsingArray<T> operator-() const {

--- a/sycl/test-e2e/Basic/vec_bool.cpp
+++ b/sycl/test-e2e/Basic/vec_bool.cpp
@@ -57,6 +57,31 @@ int main() {
   }
   check_result(resVec, expected);
 
+  // Test negate (operator -)
+  bool res = true;
+  {
+    sycl::buffer<bool, 1> bufResVec(&res, 1);
+
+    q.submit([&](sycl::handler &cgh) {
+       sycl::accessor accRes(bufResVec, cgh, sycl::write_only);
+       cgh.single_task([=]() {
+         std::array<bool, size> arrTrue;
+         for (int i = 0; i < size; ++i) {
+           arrTrue[i] = -(static_cast<bool>(1));
+         }
+         auto vecTrue = sycl::vec<bool, size>(static_cast<bool>(1));
+         sycl::vec<bool, size> resVec = -vecTrue;
+         // Check that the vector matches the array.
+         for (int i = 0; i < size; ++i) {
+           if (resVec[i] != arrTrue[i]) {
+             accRes[0] = false;
+           }
+         }
+       });
+     }).wait_and_throw();
+  }
+  assert(res && "Incorrect result");
+
   // Test left shift (operator <<) 1
   {
     init_arr(expected, true);


### PR DESCRIPTION
Since bool vectors have a backing storage of chars, the unary minus operator was in fact producing `(char)-1`, and thus not adhering to the ABI where bools should be either 0 or 1.

This could manifest itself in bugs, for instance where the "bool" elements wouldn't compare equal to other bools, such as those in arrays.

This only manifested itself in device code (possibly because the array of bools is also an array of bytes under the hood), hence the test case that differs in style somewhat from the rest.