### PR TITLE
[SYCL-MLIR][cgeist] Contract FP operations

### DIFF
--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -2167,12 +2167,8 @@ static std::optional<ValueCategory> tryEmitFMulAdd(const BinOpInfo &Op,
                               ValueCategory RHS, bool NegLHS, bool NegMul,
                               bool NegAdd) -> std::optional<ValueCategory> {
     auto LHSOp = LHS.val.getDefiningOp<arith::MulFOp>();
-    if (LHSOp && (LHS.val.use_empty() || NegLHS)) {
-      // If we looked through fneg, erase it.
-      if (NegLHS)
-        Original.val.getDefiningOp()->erase();
+    if (LHSOp && (LHS.val.use_empty() || NegLHS))
       return LHS.FMA(Builder, Loc, RHS, NegMul, NegAdd);
-    }
     return {};
   };
   std::optional<ValueCategory> Res =

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -820,13 +820,9 @@ ValueCategory ValueCategory::FMA(OpBuilder &Builder, Location Loc,
   if (NegAdd)
     Addend = Addend.FNeg(Builder, Loc);
 
-  ValueCategory FMulAdd(
+  return ValueCategory(
       Builder.create<math::FmaOp>(Loc, MulOp0, MulOp1, Addend.val),
       /*IsReference=*/false);
-
-  MulOp.erase();
-
-  return FMulAdd;
 }
 
 ValueCategory ValueCategory::CAdd(OpBuilder &Builder, Location Loc,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -8,6 +8,7 @@
 
 #include "ValueCategory.h"
 #include "Lib/TypeUtils.h"
+#include "mlir/Dialect/Math/IR/Math.h"
 #include "mlir/Dialect/Polygeist/IR/PolygeistOps.h"
 #include "mlir/Dialect/Vector/IR/VectorOps.h"
 #include "mlir/Support/LLVM.h"
@@ -802,6 +803,30 @@ ValueCategory ValueCategory::Add(OpBuilder &Builder, Location Loc, Value RHS,
 ValueCategory ValueCategory::FAdd(OpBuilder &Builder, Location Loc,
                                   Value RHS) const {
   return FPBinOp<arith::AddFOp>(Builder, Loc, val, RHS);
+}
+
+ValueCategory ValueCategory::FMA(OpBuilder &Builder, Location Loc,
+                                 ValueCategory Addend, bool NegMul,
+                                 bool NegAdd) const {
+  auto MulOp = val.getDefiningOp<arith::MulFOp>();
+
+  assert(MulOp && "Expecting arith.mul operation");
+
+  Value MulOp0 = MulOp.getLhs();
+  Value MulOp1 = MulOp.getRhs();
+  if (NegMul)
+    MulOp0 =
+        ValueCategory(MulOp0, /*IsReference=*/false).FNeg(Builder, Loc).val;
+  if (NegAdd)
+    Addend = Addend.FNeg(Builder, Loc);
+
+  ValueCategory FMulAdd(
+      Builder.create<math::FmaOp>(Loc, MulOp0, MulOp1, Addend.val),
+      /*IsReference=*/false);
+
+  MulOp.erase();
+
+  return FMulAdd;
 }
 
 ValueCategory ValueCategory::CAdd(OpBuilder &Builder, Location Loc,

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -180,6 +180,8 @@ public:
                     bool HasNSW = false) const;
   ValueCategory FAdd(mlir::OpBuilder &Builder, mlir::Location Loc,
                      mlir::Value RHS) const;
+  ValueCategory FMA(mlir::OpBuilder &Builder, mlir::Location Loc,
+                    ValueCategory Addend, bool NegMul, bool NegAdd) const;
   ValueCategory Sub(mlir::OpBuilder &Builder, mlir::Location Loc,
                     mlir::Value RHS, bool HasNUW = false,
                     bool HasNSW = false) const;

--- a/polygeist/tools/cgeist/Test/Verification/fmuladd.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/fmuladd.cpp
@@ -1,0 +1,166 @@
+// RUN: cgeist -w -o - -S --function=* %s | FileCheck %s
+
+using double2 = double __attribute__((ext_vector_type(2)));
+
+template <typename T>
+T test_simple_lhs(T a, T b, T c) {
+  return a * b + c;
+}
+
+template <typename T>
+T test_negmul_lhs(T a, T b, T c) {
+  return -(a * b) + c;
+}
+
+template <typename T>
+T test_negadd_lhs(T a, T b, T c) {
+  return a * b - c;
+}
+
+template <typename T>
+T test_negmul_negadd_lhs(T a, T b, T c) {
+  return -(a * b) - c;
+}
+
+template <typename T>
+T test_simple_rhs(T a, T b, T c) {
+  return a + b * c;
+}
+
+template <typename T>
+T test_negmul_rhs(T a, T b, T c) {
+  return a + -(b * c);
+}
+
+template <typename T>
+T test_negadd_rhs(T a, T b, T c) {
+  return a - b * c;
+}
+
+template <typename T>
+T test_negmul_negadd_rhs(T a, T b, T c) {
+  return a - -(b * c);
+}
+
+#define TEST_TYPE(type)                                         \
+  template type test_simple_lhs(type a, type b, type c);        \
+  template type test_negmul_lhs(type a, type b, type c);        \
+  template type test_negadd_lhs(type a, type b, type c);        \
+  template type test_negmul_negadd_lhs(type a, type b, type c); \
+  template type test_simple_rhs(type a, type b, type c);        \
+  template type test_negmul_rhs(type a, type b, type c);        \
+  template type test_negadd_rhs(type a, type b, type c);        \
+  template type test_negmul_negadd_rhs(type a, type b, type c);
+
+TEST_TYPE(float)
+
+// CHECK-LABEL:   func.func @_Z15test_simple_lhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32,
+// CHECK-SAME:                                                 %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = math.fma %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : f32
+// CHECK:           return %[[VAL_3]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negmul_lhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_0]] : f32
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_3]], %[[VAL_1]], %[[VAL_2]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negadd_lhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_2]] : f32
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_0]], %[[VAL_1]], %[[VAL_3]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z22test_negmul_negadd_lhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                        %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_0]] : f32
+// CHECK:           %[[VAL_4:.*]] = arith.negf %[[VAL_2]] : f32
+// CHECK:           %[[VAL_5:.*]] = math.fma %[[VAL_3]], %[[VAL_1]], %[[VAL_4]] : f32
+// CHECK:           return %[[VAL_5]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_simple_rhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = math.fma %[[VAL_1]], %[[VAL_2]], %[[VAL_0]] : f32
+// CHECK:           return %[[VAL_3]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negmul_rhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_1]] : f32
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_3]], %[[VAL_2]], %[[VAL_0]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negadd_rhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                 %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_1]] : f32
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_3]], %[[VAL_2]], %[[VAL_0]] : f32
+// CHECK:           return %[[VAL_4]] : f32
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z22test_negmul_negadd_rhsIfET_S0_S0_S0_(
+// CHECK-SAME:                                                        %[[VAL_0:.*]]: f32, %[[VAL_1:.*]]: f32, %[[VAL_2:.*]]: f32) -> f32
+// CHECK:           %[[VAL_3:.*]] = math.fma %[[VAL_1]], %[[VAL_2]], %[[VAL_0]] : f32
+// CHECK:           return %[[VAL_3]] : f32
+// CHECK:         }
+
+TEST_TYPE(double2)
+
+// CHECK-LABEL:   func.func @_Z15test_simple_lhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = math.fma %[[VAL_0]], %[[VAL_1]], %[[VAL_2]] : vector<2xf64>
+// CHECK:           return %[[VAL_3]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negmul_lhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_0]] : vector<2xf64>
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_3]], %[[VAL_1]], %[[VAL_2]] : vector<2xf64>
+// CHECK:           return %[[VAL_4]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negadd_lhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_2]] : vector<2xf64>
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_0]], %[[VAL_1]], %[[VAL_3]] : vector<2xf64>
+// CHECK:           return %[[VAL_4]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z22test_negmul_negadd_lhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                            %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_0]] : vector<2xf64>
+// CHECK:           %[[VAL_4:.*]] = arith.negf %[[VAL_2]] : vector<2xf64>
+// CHECK:           %[[VAL_5:.*]] = math.fma %[[VAL_3]], %[[VAL_1]], %[[VAL_4]] : vector<2xf64>
+// CHECK:           return %[[VAL_5]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_simple_rhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = math.fma %[[VAL_1]], %[[VAL_2]], %[[VAL_0]] : vector<2xf64>
+// CHECK:           return %[[VAL_3]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negmul_rhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_1]] : vector<2xf64>
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_3]], %[[VAL_2]], %[[VAL_0]] : vector<2xf64>
+// CHECK:           return %[[VAL_4]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z15test_negadd_rhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                     %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = arith.negf %[[VAL_1]] : vector<2xf64>
+// CHECK:           %[[VAL_4:.*]] = math.fma %[[VAL_3]], %[[VAL_2]], %[[VAL_0]] : vector<2xf64>
+// CHECK:           return %[[VAL_4]] : vector<2xf64>
+// CHECK:         }
+
+// CHECK-LABEL:   func.func @_Z22test_negmul_negadd_rhsIDv2_dET_S1_S1_S1_(
+// CHECK-SAME:                                                            %[[VAL_0:.*]]: vector<2xf64>, %[[VAL_1:.*]]: vector<2xf64>, %[[VAL_2:.*]]: vector<2xf64>) -> vector<2xf64>
+// CHECK:           %[[VAL_3:.*]] = math.fma %[[VAL_1]], %[[VAL_2]], %[[VAL_0]] : vector<2xf64>
+// CHECK:           return %[[VAL_3]] : vector<2xf64>
+// CHECK:         }

--- a/polygeist/tools/cgeist/Test/Verification/fmuladd.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/fmuladd.cpp
@@ -1,4 +1,9 @@
 // RUN: cgeist -w -o - -S --function=* %s | FileCheck %s
+// RUN: cgeist -omit-fp-contract -w -o - -S --function=* %s | FileCheck %s --check-prefix=CHECK-OMIT
+
+// COM: -omit-fp-contract should yield no 'math.fma' operations
+
+// CHECK-OMIT-NOT: math.fma
 
 using double2 = double __attribute__((ext_vector_type(2)));
 

--- a/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
+++ b/polygeist/tools/cgeist/Test/Verification/gettimeofday.c
@@ -20,7 +20,6 @@ double alloc() {
 // CHECK-NEXT:      %[[VAL_8:.*]] = llvm.getelementptr inbounds %[[VAL_2]][0, 1] : (!llvm.ptr) -> !llvm.ptr, !llvm.struct<(i64, i64)>
 // CHECK-NEXT:      %[[VAL_9:.*]] = llvm.load %[[VAL_8]] : !llvm.ptr -> i64
 // CHECK-NEXT:      %[[VAL_10:.*]] = arith.sitofp %[[VAL_9]] : i64 to f64
-// CHECK-NEXT:      %[[VAL_11:.*]] = arith.mulf %[[VAL_10]], %[[VAL_0]] : f64
-// CHECK-NEXT:      %[[VAL_12:.*]] = arith.addf %[[VAL_7]], %[[VAL_11]] : f64
-// CHECK-NEXT:      return %[[VAL_12]] : f64
+// CHECK-NEXT:      %[[VAL_11:.*]] = math.fma %[[VAL_10]], %[[VAL_0]], %[[VAL_7]] : f64
+// CHECK-NEXT:      return %[[VAL_11]] : f64
 // CHECK-NEXT:    }

--- a/polygeist/tools/cgeist/Test/Verification/raiseToAffine.c
+++ b/polygeist/tools/cgeist/Test/Verification/raiseToAffine.c
@@ -19,9 +19,8 @@ void matmul(DATA_TYPE A[N][K], DATA_TYPE B[K][M], DATA_TYPE C[N][M]) {
       for (k = 0; k < K; k++)
         // GEMMSIGNED: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x400xf32>
         // GEMMSIGNED: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
-        // GEMMSIGNED: {{.*}} = arith.mulf
         // GEMMSIGNED: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
-        // GEMMSIGNED: {{.*}} = arith.addf
+        // GEMMSIGNED: {{.*}} = math.fma
         // GEMMSIGNED: affine.store {{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
         C[i][j] += A[i][k] * B[k][j];
 }
@@ -40,9 +39,8 @@ void matmul_unsigned_cmp(float A[100][200], float B[200][300], float C[100][300]
       for (k = 0; k < 200; k++) {
         // GEMMUNSIGNED: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x200xf32>
         // GEMMUNSIGNED: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
-        // GEMMUNSIGNED: {{.*}} = arith.mulf
         // GEMMUNSIGNED: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
-        // GEMMUNSIGNED: {{.*}} = arith.addf
+        // GEMMUNSIGNED: {{.*}} = math.fma
         // GEMMUNSIGNED: affine.store {{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
         C[i][j] += A[i][k] * B[k][j];
       }

--- a/polygeist/tools/cgeist/Test/Verification/raiseToAffineUnsignedCmp.c
+++ b/polygeist/tools/cgeist/Test/Verification/raiseToAffineUnsignedCmp.c
@@ -13,9 +13,8 @@ void matmul(float A[100][200], float B[200][300], float C[100][300]) {
       for (k = 0; k < 200; k++) {
         // CHECK: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x200xf32>
         // CHECK: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
-        // CHECK: {{.*}} = arith.mulf
         // CHECK: {{.*}} = affine.load %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
-        // CHECK: {{.*}} = arith.addf
+        // CHECK: {{.*}} = math.fma
         // CHECK: affine.store {{.*}}, %{{.*}}[%{{.*}}, %{{.*}}] : memref<?x300xf32>
         C[i][j] += A[i][k] * B[k][j];
       }

--- a/polygeist/tools/cgeist/Test/Verification/sgesv.c
+++ b/polygeist/tools/cgeist/Test/Verification/sgesv.c
@@ -30,34 +30,32 @@ void kernel_correlation(int n, double alpha, double beta,
 
 }
 
-// CHECK:   func @{{.*}}kernel_correlation{{.*}}(%arg0: i32{{.*}}, %arg1: f64{{.*}}, %arg2: f64{{.*}}, %arg3: memref<?x28xf64>{{.*}}llvm.noalias{{.*}}, %arg4: memref<?x28xf64>{{.*}}llvm.noalias{{.*}}, %arg5: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg6: memref<?xf64>{{.*}}llvm.noalias{{.*}}, %arg7: memref<?xf64>{{.*}}llvm.noalias{{.*}})
-// CHECK-NEXT:     %cst = arith.constant 0.000000e+00 : f64
-// CHECK-NEXT:     %0 = arith.index_cast %arg0 : i32 to index
-// CHECK-NEXT:     affine.for %arg8 = 0 to %0 {
-// CHECK-NEXT:       affine.store %cst, %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       affine.store %cst, %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %1 = affine.load %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %2 = affine.load %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %3:2 = affine.for %arg9 = 0 to %0 iter_args(%arg10 = %1, %arg11 = %2) -> (f64, f64) {
-// CHECK-NEXT:         %9 = affine.load %arg3[%arg8, %arg9] : memref<?x28xf64>
-// CHECK-NEXT:         %10 = affine.load %arg6[%arg9] : memref<?xf64>
-// CHECK-NEXT:         %11 = arith.mulf %9, %10 : f64
-// CHECK-NEXT:         %12 = arith.addf %11, %arg10 : f64
-// CHECK-NEXT:         %13 = affine.load %arg4[%arg8, %arg9] : memref<?x28xf64>
-// CHECK-NEXT:         %14 = arith.mulf %13, %10 : f64
-// CHECK-NEXT:         %15 = arith.addf %14, %arg11 : f64
-// CHECK-NEXT:         affine.yield %12, %15 : f64, f64
-// CHECK-NEXT:       }
-// CHECK-NEXT:       affine.store %3#1, %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:       affine.store %3#0, %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %4 = affine.load %arg5[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %5 = arith.mulf %arg1, %4 : f64
-// CHECK-NEXT:       %6 = affine.load %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:       %7 = arith.mulf %arg2, %6 : f64
-// CHECK-NEXT:       %8 = arith.addf %5, %7 : f64
-// CHECK-NEXT:       affine.store %8, %arg7[%arg8] : memref<?xf64>
-// CHECK-NEXT:     }
-// CHECK-NEXT:     return
-// CHECK-NEXT:   }
+// CHECK-LABEL:   func.func @kernel_correlation(
+// CHECK-SAME:                                  %[[VAL_0:.*]]: i32 {llvm.noundef}, %[[VAL_1:.*]]: f64 {llvm.noundef}, %[[VAL_2:.*]]: f64 {llvm.noundef}, %[[VAL_3:.*]]: memref<?x28xf64> {llvm.noalias, llvm.noundef}, %[[VAL_4:.*]]: memref<?x28xf64> {llvm.noalias, llvm.noundef}, %[[VAL_5:.*]]: memref<?xf64> {llvm.noalias, llvm.noundef}, %[[VAL_6:.*]]: memref<?xf64> {llvm.noalias, llvm.noundef}, %[[VAL_7:.*]]: memref<?xf64> {llvm.noalias, llvm.noundef})
+// CHECK:           %[[VAL_8:.*]] = arith.constant 0.000000e+00 : f64
+// CHECK:           %[[VAL_9:.*]] = arith.index_cast %[[VAL_0]] : i32 to index
+// CHECK:           affine.for %[[VAL_10:.*]] = 0 to %[[VAL_9]] {
+// CHECK:             affine.store %[[VAL_8]], %[[VAL_5]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             affine.store %[[VAL_8]], %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             %[[VAL_11:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             %[[VAL_12:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             %[[VAL_13:.*]]:2 = affine.for %[[VAL_14:.*]] = 0 to %[[VAL_9]] iter_args(%[[VAL_15:.*]] = %[[VAL_11]], %[[VAL_16:.*]] = %[[VAL_12]]) -> (f64, f64) {
+// CHECK:               %[[VAL_17:.*]] = affine.load %[[VAL_3]]{{\[}}%[[VAL_10]], %[[VAL_14]]] : memref<?x28xf64>
+// CHECK:               %[[VAL_18:.*]] = affine.load %[[VAL_6]]{{\[}}%[[VAL_14]]] : memref<?xf64>
+// CHECK:               %[[VAL_19:.*]] = math.fma %[[VAL_17]], %[[VAL_18]], %[[VAL_15]] : f64
+// CHECK:               %[[VAL_20:.*]] = affine.load %[[VAL_4]]{{\[}}%[[VAL_10]], %[[VAL_14]]] : memref<?x28xf64>
+// CHECK:               %[[VAL_21:.*]] = math.fma %[[VAL_20]], %[[VAL_18]], %[[VAL_16]] : f64
+// CHECK:               affine.yield %[[VAL_19]], %[[VAL_21]] : f64, f64
+// CHECK:             }
+// CHECK:             affine.store %[[VAL_22:.*]]#1, %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             affine.store %[[VAL_22]]#0, %[[VAL_5]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             %[[VAL_23:.*]] = affine.load %[[VAL_5]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             %[[VAL_24:.*]] = affine.load %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:             %[[VAL_25:.*]] = arith.mulf %[[VAL_2]], %[[VAL_24]] : f64
+// CHECK:             %[[VAL_26:.*]] = math.fma %[[VAL_1]], %[[VAL_23]], %[[VAL_25]] : f64
+// CHECK:             affine.store %[[VAL_26]], %[[VAL_7]]{{\[}}%[[VAL_10]]] : memref<?xf64>
+// CHECK:           }
+// CHECK:           return
+// CHECK:         }
 
 // FULLRANK: func @kernel_correlation(%{{.*}}: i32, %{{.*}}: f64, %{{.*}}: f64, %{{.*}}: memref<28x28xf64>, %{{.*}}: memref<28x28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>, %{{.*}}: memref<28xf64>)

--- a/polygeist/tools/cgeist/Test/polybench/datamining/correlation/correlation.c
+++ b/polygeist/tools/cgeist/Test/polybench/datamining/correlation/correlation.c
@@ -1,19 +1,19 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 -lm && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 -lm && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 -lm && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
 
-// RUN: cgeist %s %stdinclude -O3 -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s %stdinclude -O3 -S | FileCheck %s
 
 /**
  * This version is stamped on May 10, 2016

--- a/polygeist/tools/cgeist/Test/polybench/datamining/covariance/covariance.c
+++ b/polygeist/tools/cgeist/Test/polybench/datamining/covariance/covariance.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/gemm/gemm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/gemm/gemm.c
@@ -1,16 +1,16 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
-// RUN: cgeist %s %stdinclude -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
+// RUN: cgeist -omit-fp-contract %s %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s %stdinclude -S --memref-fullrank | FileCheck %s --check-prefix=FULLRANK
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/gemver/gemver.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/gemver/gemver.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/gesummv/gesummv.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/gesummv/gesummv.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/symm/symm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/symm/symm.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/syr2k/syr2k.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/syr2k/syr2k.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/syrk/syrk.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/syrk/syrk.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/trmm/trmm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/blas/trmm/trmm.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/2mm/2mm.c
@@ -1,18 +1,18 @@
-// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s -O3 %polyverify %stdinclude -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s -O3 %polyverify %stdinclude -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 // COM: Missing allockind and allocsize attributes
-// RUN: cgeist -O2 -raise-scf-to-affine %s %stdinclude -S -D POLYBENCH_USE_RESTRICT -enable-attributes
-// RUN: cgeist -O2 -raise-scf-to-affine %s %stdinclude -S | FileCheck %s --check-prefixes=CHECK,NRESTRICT
+// RUN: cgeist -omit-fp-contract -O2 -raise-scf-to-affine %s %stdinclude -S -D POLYBENCH_USE_RESTRICT -enable-attributes
+// RUN: cgeist -omit-fp-contract -O2 -raise-scf-to-affine %s %stdinclude -S | FileCheck %s --check-prefixes=CHECK,NRESTRICT
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/3mm/3mm.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/3mm/3mm.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/atax/atax.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/atax/atax.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/bicg/bicg.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/bicg/bicg.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/doitgen/doitgen.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/doitgen/doitgen.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/mvt/mvt.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/kernels/mvt/mvt.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/cholesky/cholesky.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/cholesky/cholesky.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 -lm && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 -lm && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 -lm && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/durbin/durbin.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/durbin/durbin.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/gramschmidt/gramschmidt.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/gramschmidt/gramschmidt.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 -lm && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 -lm && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 -lm && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/lu/lu.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/lu/lu.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/ludcmp/ludcmp.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/ludcmp/ludcmp.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/trisolv/trisolv.c
+++ b/polygeist/tools/cgeist/Test/polybench/linear-algebra/solvers/trisolv/trisolv.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/medley/deriche/deriche.c
+++ b/polygeist/tools/cgeist/Test/polybench/medley/deriche/deriche.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm -lm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm -lm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm -lm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm -lm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm -lm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm -lm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/medley/floyd-warshall/floyd-warshall.c
+++ b/polygeist/tools/cgeist/Test/polybench/medley/floyd-warshall/floyd-warshall.c
@@ -1,15 +1,15 @@
-// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/medley/nussinov/Nussinov.orig.c
+++ b/polygeist/tools/cgeist/Test/polybench/medley/nussinov/Nussinov.orig.c
@@ -1,5 +1,5 @@
-// RUN: cgeist %s %stdinclude -S | FileCheck %s
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm | FileCheck %s --check-prefix EXEC
 // requires loop restructure use after while fix
 // XFAIL: *
 /**

--- a/polygeist/tools/cgeist/Test/polybench/medley/nussinov/nussinov.c
+++ b/polygeist/tools/cgeist/Test/polybench/medley/nussinov/nussinov.c
@@ -1,21 +1,21 @@
 // Copyright (C) Codeplay Software Limited
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
 
-// RUN: cgeist %s %stdinclude -O3 -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s %stdinclude -O3 -S | FileCheck %s
 
 /**
  * This version is stamped on May 10, 2016

--- a/polygeist/tools/cgeist/Test/polybench/stencils/adi/adi.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/adi/adi.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/stencils/fdtd-2d/fdtd-2d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/fdtd-2d/fdtd-2d.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/stencils/heat-3d/heat-3d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/heat-3d/heat-3d.c
@@ -1,14 +1,14 @@
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-1d/jacobi-1d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-1d/jacobi-1d.c
@@ -1,15 +1,15 @@
-// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s -O3 %polyverify %stdinclude -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s -O3 %polyverify %stdinclude -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s -O3 %polyexec %stdinclude -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s -O3 %polyverify %stdinclude -detect-reduction -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-2d/jacobi-2d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/jacobi-2d/jacobi-2d.c
@@ -1,15 +1,15 @@
-// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/stencils/seidel-2d/seidel-2d.c
+++ b/polygeist/tools/cgeist/Test/polybench/stencils/seidel-2d/seidel-2d.c
@@ -1,15 +1,15 @@
-// RUN: cgeist %s -O2 %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s -O2 %stdinclude -S | FileCheck %s
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2
-// RUN: cgeist %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
+// RUN: cgeist -omit-fp-contract %s %polyexec %stdinclude -O3 -o %s.execm && %s.execm > %s.mlir.time; cat %s.mlir.time | FileCheck %s --check-prefix EXEC
 // RUN: clang %s -O3 %polyexec %stdinclude -o %s.exec2 && %s.exec2 > %s.clang.time; cat %s.clang.time | FileCheck %s --check-prefix EXEC
 // RUN: rm -f %s.exec2 %s.execm %s.mlir.time %s.clang.time 
 
 // RUN: clang %s -O3 %stdinclude %polyverify -o %s.exec1 && %s.exec1 &> %s.out1
-// RUN: cgeist %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
+// RUN: cgeist -omit-fp-contract %s %polyverify %stdinclude -detect-reduction -O3 -o %s.execm && %s.execm &> %s.out2
 // RUN: rm -f %s.exec1 %s.execm
 // RUN: diff %s.out1 %s.out2
 // RUN: rm -f %s.out1 %s.out2

--- a/polygeist/tools/cgeist/Test/polybench/utilities/polybench.c
+++ b/polygeist/tools/cgeist/Test/polybench/utilities/polybench.c
@@ -1,4 +1,4 @@
-// RUN: cgeist %s polybench_alloc_data %stdinclude -S | FileCheck %s
+// RUN: cgeist -omit-fp-contract %s polybench_alloc_data %stdinclude -S | FileCheck %s
 // XFAIL: *
 /**
  * This version is stamped on May 10, 2016


### PR DESCRIPTION
If the language options allow that, contract FP
operations (multiplication and addition) to `math.fma`. These are lowered to `llvm.fma.*` intrinsics in later stages of the pipeline.

The new `-omit-fp-contract` option overrides this behavior and always generates regular `arith.mul` and `arith.add` operations.

**Note:** `polybench` tests add this flag to avoid needing to be updated.