### PR TITLE
[SYCL] Fix `convert` to `sycl::vec<bool, N>`

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -695,6 +695,9 @@ public:
                        vec_data<DataT>::get(getValue(I)))));
       }
     }
+    if constexpr (std::is_same_v<convertT, bool>) {
+      Result.ConvertToDataT();
+    }
     return Result;
   }
 

--- a/sycl/test-e2e/Basic/vec_bool.cpp
+++ b/sycl/test-e2e/Basic/vec_bool.cpp
@@ -464,4 +464,31 @@ int main() {
      }).wait_and_throw();
   }
   check_result(resVec, expected);
+
+  // Test convert()
+  bool resConv = true;
+  {
+    sycl::buffer<bool, 1> bufResVec(&resConv, 1);
+
+    q.submit([&](sycl::handler &cgh) {
+       sycl::accessor accRes(bufResVec, cgh, sycl::write_only);
+       cgh.single_task([=]() {
+         // Check that converting a value not representable by a bool (2) is
+         // correctly converted to bool.
+         auto inputVec = sycl::vec<int, size>(2);
+         sycl::vec<bool, size> expectedVec;
+         for (size_t i = 0; i < size; ++i) {
+           expectedVec[i] = (bool)inputVec[i];
+         }
+         auto convertVec = inputVec.convert<bool>();
+         // Check that the two vectors are equal.
+         for (int i = 0; i < size; ++i) {
+           if (expectedVec[i] != convertVec[i]) {
+             accRes[0] = false;
+           }
+         }
+       });
+     }).wait_and_throw();
+  }
+  assert(resConv && "Incorrect result");
 }


### PR DESCRIPTION
Since vectors of bools are backed by byte-sized storage, we must ensure that conversion results from other vector types are correctly brought into the expected range of bools, e.g., `(char)0` or `(char)1`.