### PR TITLE
[SYCL][CUDA] Issue warnings for incomplete launch bounds attribute set

### DIFF
--- a/clang/include/clang/Basic/DiagnosticCommonKinds.td
+++ b/clang/include/clang/Basic/DiagnosticCommonKinds.td
@@ -436,4 +436,10 @@ def warn_try_not_valid_on_target : Warning<
   "target '%0' does not support exception handling;"
   " 'catch' block is ignored">,
   InGroup<OpenMPTargetException>;
+
+// Launch bound
+def warn_launch_bounds_missing_attr: Warning<
+  "%0 attribute ignored, as it requires: maximum work group size"
+  "%select{| and minimum work groups per compute unit}1 to be also specified">,
+  InGroup<IgnoredAttributes>;
 }

--- a/clang/test/SemaSYCL/lb_sm_90.cpp
+++ b/clang/test/SemaSYCL/lb_sm_90.cpp
@@ -1,5 +1,4 @@
-// RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -fsyntax-only -Wno-c++23-extensions -verify
-// expected-no-diagnostics
+// RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -fsyntax-only -Wno-c++23-extensions -verify -S
 
 // Maximum work groups per multi-processor, mapped to maxclusterrank PTX
 // directive, is an SM_90 feature, make sure that no warnings/errors are issued.
@@ -13,18 +12,43 @@ public:
   operator()() const {}
 };
 
+// expected-warning@+1 {{'max_work_groups_per_mp' attribute ignored, as it requires: maximum work group size and minimum work groups per compute unit to be also specified}}
+template <int N1, int N2> class Functor_2 {
+public:
+  [[intel::max_work_group_size(1, 1, N1),
+    intel::max_work_groups_per_mp(N2)]] void
+  operator()() const {}
+};
+
 int main() {
   sycl::queue Q{};
 
   Q.submit([&](sycl::handler &cgh) {
-    cgh.single_task<class T1>( [=] [[intel::max_work_group_size(1, 1, 256),
-                                          intel::min_work_groups_per_cu(2),
-                                          intel::max_work_groups_per_mp(4)]] (
-) { volatile int A = 42; });
+    cgh.single_task<class T1>(
+        [=] [[intel::max_work_group_size(1, 1, 256),
+              intel::min_work_groups_per_cu(2),
+              intel::max_work_groups_per_mp(4)]] () { volatile int A = 42; });
+
+    // expected-warning@+2 {{'max_work_groups_per_mp' attribute ignored, as it requires: maximum work group size and minimum work groups per compute unit to be also specified}}
+    cgh.single_task<class T2>(
+        [=] [[intel::max_work_group_size(1, 1, 256),
+              intel::max_work_groups_per_mp(4)]] () { volatile int A = 42; });
+
+    // expected-warning@+2 {{'max_work_groups_per_mp' attribute ignored, as it requires: maximum work group size and minimum work groups per compute unit to be also specified}}
+    cgh.single_task<class T3>(
+        [=] [[intel::max_work_groups_per_mp(4)]] () { volatile int A = 42; });
+
+    // expected-warning@+2 {{'min_work_groups_per_cu' attribute ignored, as it requires: maximum work group size to be also specified}} cgh.single_task<class T4>(
+    cgh.single_task<class T4>(
+        [=] [[intel::min_work_groups_per_cu(4)]] () { volatile int A = 42; });
   });
 
   Q.submit([&](sycl::handler &cgh) {
     cgh.single_task<class F>(Functor<512, 8, 16>{});
+  });
+
+  Q.submit([&](sycl::handler &cgh) {
+    cgh.single_task<class F2>(Functor_2<512, 8>{});
   });
 
   return 0;


### PR DESCRIPTION
Cuda specifies the launch bounds as:
```
__launch_bounds__(maxThreadsPerBlock, minBlocksPerMultiprocessor, maxBlocksPerCluster)
```
making it impossible to specify `maxBlocksPerCluster` without the preceding two attributes (similarly for `minBlocksPerMultiprocessor`), issue warnings and ignore attributes if the condition is not met.