### PR TITLE
[SYCL][Joint Matrix] Fix typo in matrix_combinations on PVC

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -742,7 +742,7 @@ struct get_device_info_impl<
            matrix_type::sint32, matrix_type::sint32},
           {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::uint8,
            matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 16, 16, matrix_type::sint8, matrix_type::sint8,
+          {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::sint8,
            matrix_type::sint32, matrix_type::sint32},
           {8, 0, 0, 0, 16, 16, matrix_type::fp16, matrix_type::fp16,
            matrix_type::fp32, matrix_type::fp32},


### PR DESCRIPTION
According to
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_matrix/sycl_ext_oneapi_matrix.asciidoc#intel-xmx-supported-combinations 
for PVC: `matrix_type::sint8`, `matrix_type::sint8`, `matrix_type::sint32`, `<=8`, `16`, `32` but implementation had a typo: K == 16 instead of 32, fixed by this patch