### PR TITLE
[SYCL][ESIMD][E2E] Require O2 for InlineAsm global test

### DIFF
--- a/sycl/test-e2e/ESIMD/InlineAsm/asm_glb.cpp
+++ b/sycl/test-e2e/ESIMD/InlineAsm/asm_glb.cpp
@@ -5,7 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -o %t.out
+// Force -O2 as it currently fails in O0 due to missing VC support
+// RUN: %{build} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 #include "../esimd_test_utils.hpp"


### PR DESCRIPTION
This started causing a hang on a newer GPU driver with O0, we have an internal tracker for this. Force O2 for now.