### PR TITLE
[CI] Skip lint job when disable-lint is set 

### DIFF
--- a/.github/workflows/sycl_linux_precommit.yml
+++ b/.github/workflows/sycl_linux_precommit.yml
@@ -27,7 +27,7 @@ jobs:
 
   lint:
     runs-on: [Linux, build]
-    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'ignore-lint') }}
+    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'disable-lint') }}
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
       options: -u 1001:1001

--- a/.github/workflows/sycl_linux_precommit.yml
+++ b/.github/workflows/sycl_linux_precommit.yml
@@ -27,6 +27,7 @@ jobs:
 
   lint:
     runs-on: [Linux, build]
+    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'ignore-lint') }}
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
       options: -u 1001:1001
@@ -57,7 +58,7 @@ jobs:
     needs: [lint, detect_changes]
     if: |
       always()
-      && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
+      && (success() || needs.lint.result == 'skipped')
     uses: ./.github/workflows/sycl_linux_build.yml
     with:
       build_ref: ${{ github.sha }}

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -66,7 +66,7 @@ jobs:
   build-win:
     if: |
       always()
-      && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
+      && success()
       && github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_windows_build.yml
 

--- a/.github/workflows/sycl_windows_precommit.yml
+++ b/.github/workflows/sycl_windows_precommit.yml
@@ -29,6 +29,7 @@ jobs:
 
   lint:
     runs-on: [Linux, build]
+    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'ignore-lint') }}
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
       options: -u 1001:1001
@@ -60,7 +61,7 @@ jobs:
     needs: [lint, detect_changes]
     if: |
       always()
-      && (success() || contains(github.event.pull_request.labels.*.name, 'ignore-lint'))
+      && (success() || needs.lint.result == 'skipped')
       && github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_windows_build.yml
     with:

--- a/.github/workflows/sycl_windows_precommit.yml
+++ b/.github/workflows/sycl_windows_precommit.yml
@@ -29,7 +29,7 @@ jobs:
 
   lint:
     runs-on: [Linux, build]
-    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'ignore-lint') }}
+    if: ${{ always() && !contains(github.event.pull_request.labels.*.name, 'disable-lint') }}
     container:
       image: ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:no-drivers
       options: -u 1001:1001


### PR DESCRIPTION
When we add `ignore-lint` label, CI will still run lint and show a failure despite we will ignore it and continue to do further tests.
Since we don't care about lint result, we should ignore running it to avoid wasting machine resource or causing confusion about check results.