### PR TITLE
[SYCL][ESIMD][NFC] Replace the uses of std::max in ESIMD with ternary op

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -247,7 +247,7 @@ block_load_impl(const T *p, simd_mask<1> pred, FlagsT flags) {
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      (std::max)(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed load");
 
@@ -333,7 +333,7 @@ block_load_impl(const T *p, simd_mask<1> pred, simd<T, NElts> pass_thru,
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      (std::max)(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed load");
 
@@ -430,7 +430,7 @@ __ESIMD_API
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      (std::max)(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed load");
 
@@ -529,7 +529,7 @@ __ESIMD_API
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      (std::max)(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed load");
 
@@ -586,9 +586,7 @@ block_store_impl(T *p, simd<T, NElts> vals, simd_mask<1> pred, FlagsT flags) {
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      sizeof(uint32_t) / sizeof(T) > static_cast<size_t>(1)
-          ? sizeof(uint32_t) / sizeof(T)
-          : static_cast<size_t>(1);
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(NElts > 0 && NElts % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed store");
 
@@ -2614,7 +2612,7 @@ slm_block_load(uint32_t byte_offset, simd_mask<1> pred,
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      (std::max)(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(N > 0 && N % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed load");
 
@@ -2700,7 +2698,7 @@ slm_block_load(uint32_t offset, simd_mask<1> pred, simd<T, N> pass_thru,
 
   constexpr int SmallIntFactor64Bit = sizeof(uint64_t) / sizeof(T);
   constexpr int SmallIntFactor32Bit =
-      (std::max)(static_cast<size_t>(1), sizeof(uint32_t) / sizeof(T));
+      sizeof(uint32_t) / sizeof(T) > 1 ? sizeof(uint32_t) / sizeof(T) : 1;
   static_assert(N > 0 && N % SmallIntFactor32Bit == 0,
                 "Number of elements is not supported by Transposed load");
 

--- a/sycl/include/sycl/ext/intel/esimd/xmx/dpas.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/xmx/dpas.hpp
@@ -89,8 +89,11 @@ constexpr int verify_parameters_and_deduce_exec_size() {
                 "Cannot deduce element size of input arguments");
   verify_repeat_count<RepeatCount, AElemBitSize, BElemBitSize, IsDPASW>();
 
+  constexpr int MaxElemBitSize =
+      AElemBitSize > BElemBitSize ? AElemBitSize : BElemBitSize;
+  constexpr int MaxElemsInDword = 32 / MaxElemBitSize;
   constexpr int OpsPerChannel =
-      (std::max)((std::min)(32 / (std::max)(AElemBitSize, BElemBitSize), 8), 1);
+      MaxElemsInDword > 8 ? 8 : (MaxElemsInDword < 1 ? 1 : MaxElemsInDword);
 
   // A(_Mx_K) * B(_Kx_N) + C(_Mx_N)
   // where:


### PR DESCRIPTION
Even though std::max is completely legal/correct to use in SYCL/ESIMD especially in 'constexpr' context, it may cause problems on Windows in some non-trivial configurations with some odd order of includes of system and SYCL header files.