### PR TITLE
[GENX] Cast device function call to correct type

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -69,12 +69,21 @@ class GENX_DeviceFunctionOp<string mnemonic, string fnName,
                             int arg, list<Trait> traits = []> 
   : GENX_Op<mnemonic, !listconcat(traits, [Pure])>, 
     Results<(outs LLVM_Type:$res)>, Arguments<(ins)> {
-  string llvmBuilder = ""
-    # "  llvm::Type *retType = builder.getInt64Ty();\n"
-    # "  llvm::Type *argType = builder.getInt32Ty();\n"
-    # "  llvm::Value *arg = llvm::ConstantInt::get(argType, " # arg # ");\n"
-    # "  $res = createDeviceFunctionCall(builder, \"" # fnName # "\",\n"
-    # "                             retType, { argType }, { arg });";
+  string llvmBuilder = [{
+    llvm::Type *retType = builder.getInt64Ty();
+    llvm::Type *argType = builder.getInt32Ty();
+    llvm::Value *val = llvm::ConstantInt::get(argType, }] # arg # [{);
+    llvm::CallInst *ci = createDeviceFunctionCall(builder, "}] # fnName # [{", retType, { argType }, { val });
+    llvm::Type *opRetType = cast<llvm::IntegerType>(
+        moduleTranslation.convertType(op->getResultTypes()[0]));
+    if (opRetType == retType)
+      $res = ci;
+    else {
+      llvm::Instruction::CastOps opcode =
+          llvm::CastInst::getCastOpcode(ci, false, opRetType, false);
+      $res = builder.CreateCast(opcode, ci, opRetType);
+    }
+  }];
 
   let assemblyFormat = "attr-dict `:` type($res)";
 }

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -73,7 +73,8 @@ class GENX_DeviceFunctionOp<string mnemonic, string fnName,
     llvm::Type *retType = builder.getInt64Ty();
     llvm::Type *argType = builder.getInt32Ty();
     llvm::Value *val = llvm::ConstantInt::get(argType, }] # arg # [{);
-    llvm::CallInst *ci = createDeviceFunctionCall(builder, "}] # fnName # [{", retType, { argType }, { val });
+    llvm::CallInst *ci = createDeviceFunctionCall(builder, "}] # fnName # [{",
+        retType, { argType }, { val });
     llvm::Type *opRetType = cast<llvm::IntegerType>(
         moduleTranslation.convertType(op->getResultTypes()[0]));
     if (opRetType == retType)

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -8,23 +8,23 @@ llvm.func @genx_special_regs() -> i32 {
   // CHECK: call i64 @_Z12get_local_idj(i32 1)
   %2 = genx.workitem.id.y : i32
   // CHECK: call i64 @_Z12get_local_idj(i32 2)
-  %3 = genx.workitem.id.z : i32
+  %3 = genx.workitem.id.z : i64
   // CHECK: call i64 @_Z12get_group_idj(i32 0)
   %4 = genx.workgroup.id.x : i32
   // CHECK: call i64 @_Z12get_group_idj(i32 1)
-  %5 = genx.workgroup.id.y : i32
+  %5 = genx.workgroup.id.y : i64
   // CHECK: call i64 @_Z12get_group_idj(i32 2)
   %6 = genx.workgroup.id.z : i32
   // CHECK: call i64 @_Z12get_local_sizej(i32 0)
   %7 = genx.workgroup.dim.x : i32
   // CHECK: call i64 @_Z12get_local_sizej(i32 1)
-  %8 = genx.workgroup.dim.y : i32
+  %8 = genx.workgroup.dim.y : i64
   // CHECK: call i64 @_Z12get_local_sizej(i32 2)
   %9 = genx.workgroup.dim.z : i32
   // CHECK: call i64 @_Z12get_global_sizej(i32 0)
   %10 = genx.grid.dim.x : i32
   // CHECK: call i64 @_Z12get_global_sizej(i32 1)
-  %11 = genx.grid.dim.y : i32
+  %11 = genx.grid.dim.y : i64
   // CHECK: call i64 @_Z12get_global_sizej(i32 2)
   %12 = genx.grid.dim.z : i32
   llvm.return %1 : i32

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -1,33 +1,33 @@
 // RUN: mlir-translate -mlir-to-llvmir -split-input-file %s | FileCheck %s
 
-llvm.func @genx_special_regs() -> i64 {
+llvm.func @genx_special_regs() -> i32 {
   // CHECK-LABEL: genx_special_regs
-  // CHECK: call i64 @_Z12get_local_idj(i32 0)
-  %1 = genx.workitem.id.x : i64
+  // CHECK: [[CI:%.*]] = call i64 @_Z12get_local_idj(i32 0)
+  // CHECK-NEXT: trunc i64 [[CI]] to i32
+  %1 = genx.workitem.id.x : i32
   // CHECK: call i64 @_Z12get_local_idj(i32 1)
-  %2 = genx.workitem.id.y : i64
+  %2 = genx.workitem.id.y : i32
   // CHECK: call i64 @_Z12get_local_idj(i32 2)
-  %3 = genx.workitem.id.z : i64
+  %3 = genx.workitem.id.z : i32
   // CHECK: call i64 @_Z12get_group_idj(i32 0)
-  %4 = genx.workgroup.id.x : i64
+  %4 = genx.workgroup.id.x : i32
   // CHECK: call i64 @_Z12get_group_idj(i32 1)
-  %5 = genx.workgroup.id.y : i64
+  %5 = genx.workgroup.id.y : i32
   // CHECK: call i64 @_Z12get_group_idj(i32 2)
-  %6 = genx.workgroup.id.z : i64
+  %6 = genx.workgroup.id.z : i32
   // CHECK: call i64 @_Z12get_local_sizej(i32 0)
-  %7 = genx.workgroup.dim.x : i64
+  %7 = genx.workgroup.dim.x : i32
   // CHECK: call i64 @_Z12get_local_sizej(i32 1)
-  %8 = genx.workgroup.dim.y : i64
+  %8 = genx.workgroup.dim.y : i32
   // CHECK: call i64 @_Z12get_local_sizej(i32 2)
-  %9 = genx.workgroup.dim.z : i64
+  %9 = genx.workgroup.dim.z : i32
   // CHECK: call i64 @_Z12get_global_sizej(i32 0)
-  %10 = genx.grid.dim.x : i64
+  %10 = genx.grid.dim.x : i32
   // CHECK: call i64 @_Z12get_global_sizej(i32 1)
-  %11 = genx.grid.dim.y : i64
+  %11 = genx.grid.dim.y : i32
   // CHECK: call i64 @_Z12get_global_sizej(i32 2)
-  %12 = genx.grid.dim.z : i64
-
-  llvm.return %1 : i64
+  %12 = genx.grid.dim.z : i32
+  llvm.return %1 : i32
 }
 
 // -----


### PR DESCRIPTION
Code generation of `%1 = genx.workitem.id.x : i32` was incorrect, as it always generate `call i64 @_Z12get_local_idj(i32 0)`. This PR adds a proper cast instruction to return the appropriate type.