### PR TITLE
[SYCL][NFC] Update test comment

### DIFF
--- a/clang/test/SemaSYCL/lb_sm_90.cpp
+++ b/clang/test/SemaSYCL/lb_sm_90.cpp
@@ -1,7 +1,9 @@
 // RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -fsyntax-only -Wno-c++23-extensions -verify -S
 
 // Maximum work groups per multi-processor, mapped to maxclusterrank PTX
-// directive, is an SM_90 feature, make sure that no warnings/errors are issued.
+// directive, is an SM_90 feature. Attributes need to be used in sequence:
+// max_work_group_size, min_work_groups_per_cu, max_work_groups_per_mp, warn on
+// missing attributes in sequences.
 
 #include "sycl.hpp"
 


### PR DESCRIPTION
After adding a warning on incorrect launch bounds sequences this comment needed updating.
A follow up from: https://github.com/intel/llvm/pull/11832/files/d26a275df28690cb556d90b1db6b0e1c545e5385#r1388272985