### PR TITLE
[MLIR][GENX] Add additional verification for genx.matrix.2Dblockstore and load

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -289,7 +289,7 @@ def GENX_Matrix2DBlockLoadOp : GENX_Op<"matrix.2Dblockload">,
     The 'genx.matrix.2Dblockload' operation loads a submatrix from an array in memory.
     $ptr - the base address of the memory array
     $base_width, $base_height, $base_pitch - the shape of the memory array
-    $x, $y, $tile_width, $tile_height - the starting offets and shape of the submatrix to load
+    $x, $y, $tile_width, $tile_height - the starting offsets and shape of the submatrix to load
     $elem_size_in_bits - 32 for f32, bf32; 16 for f16, int16, bf16; 8 for int8, int4, int2 and etc
     $v_blocks - number of blocks to load
     $transpose - transpose the submatrix in vector register (useful for 32 bit element types)
@@ -336,7 +336,7 @@ def GENX_Matrix2DBlockStoreOp : GENX_Op<"matrix.2Dblockstore">,
     The 'genx.matrix.2Dblockstore' operation stores to a submatrix from an array in memory.
     $ptr - the base address of the memory array
     $base_width, $base_height, $base_pitch - the shape of the memory array
-    $x, $y, $tile_width, $tile_height - the starting offets and shape of the submatrix to load
+    $x, $y, $tile_width, $tile_height - the starting offsets and shape of the submatrix to load
     $elem_size_in_bits - 32 for f32, bf32; 16 for f16, int16, bf16; 8 for int8, int4, int2 and etc
     $v_blocks - number of blocks to store
     $transpose - transpose the submatrix in vector register (useful for 32 bit element types)

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -162,6 +162,7 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
         "4th operand (base pitch) should be >= 2nd operand (base width)");
 
   uint32_t TileWidth = getTileWidth();
+  uint32_t TileHeight = getTileHeight();
   Type InputElemType = getPtr().getType().getElementType();
   switch (getElemSizeInBits()) {
     case 32:
@@ -171,6 +172,8 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
     if (TileWidth != 8)
       return this->emitOpError("tile_width for 32 bit elements should be equal "
                                "to systolic depth, i.e., 8 elements");
+    if (TileHeight != 8)
+      return this->emitOpError("tile_height for 32 bit elements should be 8");
       break;
 
     case 16:
@@ -180,6 +183,8 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
     if (TileWidth != 16)
       return this->emitOpError("tile_width for 16 bit elements should be equal "
                                "to systolic depth times 2, i.e., 16 elements");
+    if (TileHeight != 16)
+      return this->emitOpError("tile_height for 16 bit elements should be 16");
       break;
 
     case 8:
@@ -189,6 +194,8 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
     if (TileWidth != 32)
       return this->emitOpError("tile_width for 8 bit elements should be equal "
                                "to systolic depth times 4, i.e., 32 elements");
+    if (TileHeight != 32)
+      return this->emitOpError("tile_height for 8 bit elements should be 32");
       break;
 
     default:
@@ -218,6 +225,7 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
         "4th operand (base pitch) should be >= 2nd operand (base width)");
 
   uint32_t TileWidth = getTileWidth();
+  uint32_t TileHeight = getTileHeight();
   Type InputElemType = getPtr().getType().getElementType();
   switch (getElemSizeInBits()) {
     case 32:
@@ -227,6 +235,8 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
     if (TileWidth != 8)
       return this->emitOpError("tile_width for 32 bit elements should be equal "
                                "to systolic depth, i.e., 8 elements");
+    if (TileHeight != 8)
+      return this->emitOpError("tile_height for 32 bit elements should be 8");
       break;
 
     case 16:
@@ -236,6 +246,8 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
     if (TileWidth != 16)
       return this->emitOpError("tile_width for 16 bit elements should be equal "
                                "to systolic depth times 2, i.e., 16 elements");
+    if (TileHeight != 16)
+      return this->emitOpError("tile_height for 16 bit elements should be 16");
       break;
 
     case 8:
@@ -245,6 +257,8 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
     if (TileWidth != 32)
       return this->emitOpError("tile_width for 8 bit elements should be equal "
                                "to systolic depth times 4, i.e., 32 elements");
+    if (TileHeight != 32)
+      return this->emitOpError("tile_height for 8 bit elements should be 32");
       break;
 
     default:

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -161,34 +161,34 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
     return this->emitOpError(
         "4th operand (base pitch) should be >= 2nd operand (base width)");
 
-  uint32_t tile_width = getTileWidth();
+  uint32_t TileWidth = getTileWidth();
   Type InputElemType = getPtr().getType().getElementType();
   switch (getElemSizeInBits()) {
     case 32:
     if (!InputElemType.isF32()) // || !InputElemType.isBFloat32Type();
       return this->emitOpError(
          "element of size 32 should be of type bf32 or f32");
-    if (tile_width != 8)
+    if (TileWidth != 8)
       return this->emitOpError("tile_width for 32 bit elements should be equal "
-                               "to systolic depth, i.e., 8 bits");
+                               "to systolic depth, i.e., 8 elements");
       break;
 
     case 16:
-    if (!InputElemType.isF16() || !InputElemType.isBF16())
+    if (!InputElemType.isF16() && !InputElemType.isBF16())
       return this->emitOpError(
           "element of size 16 should be of type bf16 or f16");
-    if (tile_width != 16)
+    if (TileWidth != 16)
       return this->emitOpError("tile_width for 16 bit elements should be equal "
-                               "to systolic depth times 2, i.e., 16 bits");
+                               "to systolic depth times 2, i.e., 16 elements");
       break;
 
     case 8:
     if (!InputElemType.isInteger(8))
       return this->emitOpError(
           "element of size 8 should be of type int8 or uint8");
-    if (tile_width != 32)
+    if (TileWidth != 32)
       return this->emitOpError("tile_width for 8 bit elements should be equal "
-                               "to systolic depth times 4, i.e., 32 bits");
+                               "to systolic depth times 4, i.e., 32 elements");
       break;
 
     default:
@@ -217,34 +217,34 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
     return this->emitOpError(
         "4th operand (base pitch) should be >= 2nd operand (base width)");
 
-  uint32_t tile_width = getTileWidth();
+  uint32_t TileWidth = getTileWidth();
   Type InputElemType = getPtr().getType().getElementType();
   switch (getElemSizeInBits()) {
     case 32:
     if (!InputElemType.isF32()) // || !InputElemType.isBFloat32Type();
       return this->emitOpError(
          "element of size 32 should be of type bf32 or f32");
-    if (tile_width != 8)
+    if (TileWidth != 8)
       return this->emitOpError("tile_width for 32 bit elements should be equal "
-                               "to systolic depth, i.e., 8 bits");
+                               "to systolic depth, i.e., 8 elements");
       break;
 
     case 16:
-    if (!InputElemType.isF16() || !InputElemType.isBF16())
+    if (!InputElemType.isF16() && !InputElemType.isBF16())
       return this->emitOpError(
           "element of size 16 should be of type bf16 or f16");
-    if (tile_width != 16)
+    if (TileWidth != 16)
       return this->emitOpError("tile_width for 16 bit elements should be equal "
-                               "to systolic depth times 2, i.e., 16 bits");
+                               "to systolic depth times 2, i.e., 16 elements");
       break;
 
     case 8:
     if (!InputElemType.isInteger(8))
       return this->emitOpError(
           "element of size 8 should be of type int8 or uint8");
-    if (tile_width != 32)
+    if (TileWidth != 32)
       return this->emitOpError("tile_width for 8 bit elements should be equal "
-                               "to systolic depth times 4, i.e., 32 bits");
+                               "to systolic depth times 4, i.e., 32 elements");
       break;
 
     default:

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -165,7 +165,7 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
   Type InputElemType = getPtr().getType().getElementType();
   switch (getElemSizeInBits()) {
     case 32:
-    if (!InputElemType.isF32()) // || !InputElemType.isBFloat32Type();
+    if (!InputElemType.isF32())
       return this->emitOpError(
          "element of size 32 should be of type bf32 or f32");
     if (TileWidth != 8)
@@ -221,7 +221,7 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
   Type InputElemType = getPtr().getType().getElementType();
   switch (getElemSizeInBits()) {
     case 32:
-    if (!InputElemType.isF32()) // || !InputElemType.isBFloat32Type();
+    if (!InputElemType.isF32())
       return this->emitOpError(
          "element of size 32 should be of type bf32 or f32");
     if (TileWidth != 8)

--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -161,6 +161,39 @@ LogicalResult GENX::Matrix2DBlockLoadOp::verify() {
     return this->emitOpError(
         "4th operand (base pitch) should be >= 2nd operand (base width)");
 
+  uint32_t tile_width = getTileWidth();
+  Type InputElemType = getPtr().getType().getElementType();
+  switch (getElemSizeInBits()) {
+    case 32:
+    if (!InputElemType.isF32()) // || !InputElemType.isBFloat32Type();
+      return this->emitOpError(
+         "element of size 32 should be of type bf32 or f32");
+    if (tile_width != 8)
+      return this->emitOpError("tile_width for 32 bit elements should be equal "
+                               "to systolic depth, i.e., 8 bits");
+      break;
+
+    case 16:
+    if (!InputElemType.isF16() || !InputElemType.isBF16())
+      return this->emitOpError(
+          "element of size 16 should be of type bf16 or f16");
+    if (tile_width != 16)
+      return this->emitOpError("tile_width for 16 bit elements should be equal "
+                               "to systolic depth times 2, i.e., 16 bits");
+      break;
+
+    case 8:
+    if (!InputElemType.isInteger(8))
+      return this->emitOpError(
+          "element of size 8 should be of type int8 or uint8");
+    if (tile_width != 32)
+      return this->emitOpError("tile_width for 8 bit elements should be equal "
+                               "to systolic depth times 4, i.e., 32 bits");
+      break;
+
+    default:
+    return this->emitOpError("element size should be 8, 16 or 32 bits");
+  }
   return success();
 }
 
@@ -184,5 +217,38 @@ LogicalResult GENX::Matrix2DBlockStoreOp::verify() {
     return this->emitOpError(
         "4th operand (base pitch) should be >= 2nd operand (base width)");
 
+  uint32_t tile_width = getTileWidth();
+  Type InputElemType = getPtr().getType().getElementType();
+  switch (getElemSizeInBits()) {
+    case 32:
+    if (!InputElemType.isF32()) // || !InputElemType.isBFloat32Type();
+      return this->emitOpError(
+         "element of size 32 should be of type bf32 or f32");
+    if (tile_width != 8)
+      return this->emitOpError("tile_width for 32 bit elements should be equal "
+                               "to systolic depth, i.e., 8 bits");
+      break;
+
+    case 16:
+    if (!InputElemType.isF16() || !InputElemType.isBF16())
+      return this->emitOpError(
+          "element of size 16 should be of type bf16 or f16");
+    if (tile_width != 16)
+      return this->emitOpError("tile_width for 16 bit elements should be equal "
+                               "to systolic depth times 2, i.e., 16 bits");
+      break;
+
+    case 8:
+    if (!InputElemType.isInteger(8))
+      return this->emitOpError(
+          "element of size 8 should be of type int8 or uint8");
+    if (tile_width != 32)
+      return this->emitOpError("tile_width for 8 bit elements should be equal "
+                               "to systolic depth times 4, i.e., 32 bits");
+      break;
+
+    default:
+    return this->emitOpError("element size should be 8, 16 or 32 bits");
+  }
   return success();
 }

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -154,6 +154,30 @@ func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_hei
 
 // -----
 
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op tile_height for 32 bit elements should be 8}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=8:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32) -> vector<8xf32>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op tile_height for 16 bit elements should be 16}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=16:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op tile_height for 8 bit elements should be 32}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8:i32, tile_width=32:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<32xi8>
+  llvm.return
+}
+
+// -----
+
 func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op expecting 'elem_size_in_bits' to be 8, 16, or 32}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=64:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
@@ -223,6 +247,30 @@ func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_h
 func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi8>) {
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_width for 8 bit elements should be equal to systolic depth times 4, i.e., 32 elements}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<4xi8>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xf32>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_height for 32 bit elements should be 8}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=8:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32, vector<8xf32>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<16xf16>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_height for 16 bit elements should be 16}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=16:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32, vector<16xf16>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<32xi8>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_height for 8 bit elements should be 32}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8:i32, tile_width=32:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<32xi8>)
   llvm.return
 }
 

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -106,6 +106,38 @@ func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i3
 
 // -----
 
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 32 should be of type bf32 or f32}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<4xi8>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 16 should be of type bf16 or f16}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 16 should be of type bf16 or f16}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<4xi8>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 8 should be of type int8 or uint8}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
+  llvm.return
+}
+
+// -----
+
 func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op expecting 'elem_size_in_bits' to be 8, 16, or 32}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=64:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
@@ -127,5 +159,34 @@ func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i
   %base_pitch = llvm.mlir.constant(2 : i32) : i32
   // expected-error @+1 {{'genx.matrix.2Dblockstore' op 4th operand (base pitch) should be >= 2nd operand (base width)}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  llvm.return
+}
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<16xi8>) {
+// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 32 should be of type bf32 or f32}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<4xi8>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
+// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 16 should be of type bf16 or f16}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  llvm.return
+}
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<16xi8>) {
+// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 16 should be of type bf16 or f16}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<4xi8>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
+// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 8 should be of type int8 or uint8}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
   llvm.return
 }

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -107,32 +107,48 @@ func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i3
 // -----
 
 func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 32 should be of type bf32 or f32}}
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<4xi8>
+ // expected-error @+1 {{'genx.matrix.2Dblockload' op element of size 32 should be of type bf32 or f32}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=8:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<8xi8>
   llvm.return
 }
 
 // -----
 
 func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 16 should be of type bf16 or f16}}
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op element of size 16 should be of type bf16 or f16}}
   %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
   llvm.return
 }
 
 // -----
 
-func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 16 should be of type bf16 or f16}}
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<4xi8>
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op element of size 8 should be of type int8 or uint8}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
   llvm.return
 }
 
 // -----
 
-func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // expected-error @+1 {{'genx.matrix.2Dblockload' element of size 8 should be of type int8 or uint8}}
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op tile_width for 32 bit elements should be equal to systolic depth, i.e., 8 elements}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=5:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32) -> vector<5xf32>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op tile_width for 16 bit elements should be equal to systolic depth times 2, i.e., 16 elements}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<4xf16>
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockload(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // expected-error @+1 {{'genx.matrix.2Dblockload' op tile_width for 8 bit elements should be equal to systolic depth times 4, i.e., 32 elements}}
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32) -> vector<4xi8>
   llvm.return
 }
 
@@ -162,31 +178,51 @@ func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i
   llvm.return
 }
 
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<16xi8>) {
-// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 32 should be of type bf32 or f32}}
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op element of size 16 should be of type bf16 or f16}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op element of size 8 should be of type int8 or uint8}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  llvm.return
+}
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi8>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op element of size 32 should be of type bf32 or f32}}
   genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<4xi8>)
   llvm.return
 }
 
 // -----
 
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
-// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 16 should be of type bf16 or f16}}
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
-  llvm.return
-}
-// -----
-
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<16xi8>) {
-// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 16 should be of type bf16 or f16}}
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<4xi8>)
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xf32>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_width for 32 bit elements should be equal to systolic depth, i.e., 8 elements}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32, vector<4xf32>)
   llvm.return
 }
 
 // -----
 
-func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i32>, %base_height : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
-// expected-error @+1 {{'genx.matrix.2Dblockstore' element of size 8 should be of type int8 or uint8}}
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xf16>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_width for 16 bit elements should be equal to systolic depth times 2, i.e., 16 elements}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=16:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32, vector<4xf16>)
   llvm.return
 }
+
+// -----
+
+func.func @matrix_2Dblockstore(%ptr : !llvm.ptr<i8>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi8>) {
+  // expected-error @+1 {{'genx.matrix.2Dblockstore' op tile_width for 8 bit elements should be equal to systolic depth times 4, i.e., 32 elements}}
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=8:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i8>, i32, i32, i32, i32, i32, vector<4xi8>)
+  llvm.return
+}
+

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -75,8 +75,8 @@ llvm.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>)
 }
 
 func.func @genx.2Dblockload(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK: %0 = genx.matrix.2Dblockload %arg0, %arg1, %arg2, %arg3, %arg4, %arg5 {elem_size_in_bits = 16 : i32, tile_height = 8 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=16:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
+  // CHECK: %0 = genx.matrix.2Dblockload %arg0, %arg1, %arg2, %arg3, %arg4, %arg5 {elem_size_in_bits = 16 : i32, tile_height = 16 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=16:i32, tile_height=16:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
   llvm.return
 }
 

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -74,14 +74,14 @@ llvm.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>)
   llvm.return
 }
 
-func.func @genx.2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK: %0 = genx.matrix.2Dblockload %arg0, %arg1, %arg2, %arg3, %arg4, %arg5 {elem_size_in_bits = 32 : i32, tile_height = 8 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<8xi32>
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=16:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<8xi32>
+func.func @genx.2Dblockload(%ptr : !llvm.ptr<f16>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+  // CHECK: %0 = genx.matrix.2Dblockload %arg0, %arg1, %arg2, %arg3, %arg4, %arg5 {elem_size_in_bits = 16 : i32, tile_height = 8 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=16:i32, tile_width=16:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f16>, i32, i32, i32, i32, i32) -> vector<16xf16>
   llvm.return
 }
 
-func.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
-  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 8 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<8xi32>)
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=16:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<8xi32>)
+func.func @genx.2Dblockstore(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xf32>) {
+  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 8 : i32, tile_width = 8 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32, vector<8xf32>)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=8:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32, vector<8xf32>)
   llvm.return
 }

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -75,13 +75,13 @@ llvm.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>)
 }
 
 func.func @genx.2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
-  // CHECK: %0 = genx.matrix.2Dblockload %arg0, %arg1, %arg2, %arg3, %arg4, %arg5 {elem_size_in_bits = 32 : i32, tile_height = 1 : i32, tile_width = 4 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
+  // CHECK: %0 = genx.matrix.2Dblockload %arg0, %arg1, %arg2, %arg3, %arg4, %arg5 {elem_size_in_bits = 32 : i32, tile_height = 8 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<8xi32>
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=16:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<8xi32>
   llvm.return
 }
 
 func.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
-  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 1 : i32, tile_width = 4 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  // CHECK: genx.matrix.2Dblockstore %arg0, %arg1, %arg2, %arg3, %arg4, %arg5, %arg6 {elem_size_in_bits = 32 : i32, tile_height = 8 : i32, tile_width = 16 : i32, transpose = false, v_blocks = 1 : i32, vnni_transform = false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<8xi32>)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=16:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<8xi32>)
   llvm.return
 }

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -103,18 +103,18 @@ llvm.func @genx.dpas.i8(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi
 
 // -----
 
-llvm.func @genx.2Dblockload(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
+llvm.func @genx.2Dblockload(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32) {
   // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64
-  // CHECK-NEXT: call <4 x i32> @llvm.genx.GenISA.LSC2DBlockRead.v4i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false)
-  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32) -> vector<4xi32>
+  // CHECK-NEXT: call <8 x float> @llvm.genx.GenISA.LSC2DBlockRead.v8f32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 8, i32 8, i32 1, i1 false, i1 false)
+  %0 = genx.matrix.2Dblockload %ptr, %base_width, %base_height, %base_pitch, %x, %y {elem_size_in_bits=32:i32, tile_width=8:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32) -> vector<8xf32>
   llvm.return
 }
 
 // -----
 
-llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<i32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<4xi32>) {
+llvm.func @genx.2Dblockstore(%ptr : !llvm.ptr<f32>, %base_width : i32, %base_height : i32, %base_pitch : i32, %x : i32, %y : i32, %stored_val : vector<8xf32>) {
   // CHECK: [[PTR:%.*]] = ptrtoint ptr %0 to i64
-  // CHECK-NEXT: call void @llvm.genx.GenISA.LSC2DBlockWrite.v4i32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 4, i32 1, i32 1, i1 false, i1 false, <4 x i32> %6)
-  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=4:i32, tile_height=1:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<i32>, i32, i32, i32, i32, i32, vector<4xi32>)
+  // CHECK-NEXT: call void @llvm.genx.GenISA.LSC2DBlockWrite.v8f32(i64 [[PTR]], i32 %1, i32 %2, i32 %3, i32 %4, i32 %5, i32 32, i32 8, i32 8, i32 1, i1 false, i1 false, <8 x float> %6)
+  genx.matrix.2Dblockstore %ptr, %base_width, %base_height, %base_pitch, %x, %y, %stored_val {elem_size_in_bits=32:i32, tile_width=8:i32, tile_height=8:i32, v_blocks=1:i32, transpose=false, vnni_transform=false} : (!llvm.ptr<f32>, i32, i32, i32, i32, i32, vector<8xf32>)
   llvm.return
 }


### PR DESCRIPTION
1. Added restrictions and corresponding tests for input type, tile_width and tile_height
2. Made tile_height, tile_width and type corrections in existing genx.mlir tests
