### PR TITLE
[SYCL][PI] Provide a preprocessor macro to locate the CUPTI library for XPTI tracing

### DIFF
--- a/sycl/plugins/cuda/CMakeLists.txt
+++ b/sycl/plugins/cuda/CMakeLists.txt
@@ -63,5 +63,10 @@ if (SYCL_ENABLE_XPTI_TRACING)
   )
 endif()
 
+if(CUDA_cupti_LIBRARY)
+  target_compile_definitions(pi_cuda PRIVATE
+    "-DCUPTI_LIB_PATH=\"${CUDA_cupti_LIBRARY}\"")
+endif()
+
 set_target_properties(pi_cuda PROPERTIES LINKER_LANGUAGE CXX)
 


### PR DESCRIPTION
This is a prerequisite for implementing dynamic loading of the CUPTI library when XPTI tracing is enabled.

See https://github.com/oneapi-src/unified-runtime/pull/1070