### PR TITLE
[SYCL][FPBuiltin][SPIRV] Enable SPV_INTEL_fp_max_error extension for SYCL offloads to CPU backends

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10003,12 +10003,20 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
   TranslatorArgs.push_back("-o");
   TranslatorArgs.push_back(Output.getFilename());
   if (JA.isDeviceOffloading(Action::OFK_SYCL)) {
+    const toolchains::SYCLToolChain &TC =
+        static_cast<const toolchains::SYCLToolChain &>(getToolChain());
+    llvm::Triple Triple = TC.getTriple();
+    bool IsCPU = Triple.isSPIR() &&
+                 Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64;
     TranslatorArgs.push_back("-spirv-max-version=1.4");
     TranslatorArgs.push_back("-spirv-debug-info-version=ocl-100");
     // Prevent crash in the translator if input IR contains DIExpression
     // operations which don't have mapping to OpenCL.DebugInfo.100 spec.
     TranslatorArgs.push_back("-spirv-allow-extra-diexpressions");
-    TranslatorArgs.push_back("-spirv-allow-unknown-intrinsics=llvm.genx.");
+    std::string UnknownIntrinsics("-spirv-allow-unknown-intrinsics=llvm.genx.");
+    if (IsCPU)
+      UnknownIntrinsics += ",llvm.fpbuiltin";
+    TranslatorArgs.push_back(TCArgs.MakeArgString(UnknownIntrinsics));
     bool CreatingSyclSPIRVFatObj =
         C.getDriver().getFinalPhase(C.getArgs()) != phases::Link &&
         TCArgs.getLastArgValue(options::OPT_fsycl_device_obj_EQ)
@@ -10067,11 +10075,10 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
                 ",+SPV_INTEL_optnone";
     if (ShouldPreserveMetadata)
       ExtArg += ",+SPV_KHR_non_semantic_info";
+    if (IsCPU)
+      ExtArg += ",+SPV_INTEL_fp_max_error";
 
     TranslatorArgs.push_back(TCArgs.MakeArgString(ExtArg));
-
-    const toolchains::SYCLToolChain &TC =
-        static_cast<const toolchains::SYCLToolChain &>(getToolChain());
 
     // Handle -Xspirv-translator
     TC.TranslateTargetOpt(

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -143,7 +143,7 @@
 // CHK-TOOLS-AOT: llvm-link{{.*}} "[[OUTPUT1]]" "-o" "[[OUTPUT2:.+\.bc]]"
 // CHK-TOOLS-AOT: sycl-post-link{{.*}} "-o" "[[OUTPUT2_T:.+\.table]]" "[[OUTPUT2]]"
 // CHK-TOOLS-AOT: file-table-tform{{.*}} "-extract=Code" "-drop_titles" "-o" "[[OUTPUT2_1:.+\.txt]]" "[[OUTPUT2_T]]"
-// CHK-TOOLS-CPU: llvm-spirv{{.*}} "-o" "[[OUTPUT3_T:.+\.txt]]" "-spirv-max-version=1.4" "-spirv-debug-info-version=ocl-100" "-spirv-allow-extra-diexpressions" "-spirv-allow-unknown-intrinsics=llvm.genx." {{.*}} "[[OUTPUT2_1]]"
+// CHK-TOOLS-CPU: llvm-spirv{{.*}} "-o" "[[OUTPUT3_T:.+\.txt]]" "-spirv-max-version=1.4" "-spirv-debug-info-version=ocl-100" "-spirv-allow-extra-diexpressions" "-spirv-allow-unknown-intrinsics=llvm.genx.,llvm.fpbuiltin" {{.*}} "[[OUTPUT2_1]]"
 // CHK-TOOLS-GEN: llvm-spirv{{.*}} "-o" "[[OUTPUT3_T:.+\.txt]]" "-spirv-max-version=1.4" "-spirv-debug-info-version=ocl-100" "-spirv-allow-extra-diexpressions" "-spirv-allow-unknown-intrinsics=llvm.genx." {{.*}} "[[OUTPUT2_1]]"
 // CHK-TOOLS-FPGA: llvm-spirv{{.*}} "-o" "[[OUTPUT3_T:.+\.txt]]" "-spirv-max-version=1.4" "-spirv-debug-info-version=ocl-100" "-spirv-allow-extra-diexpressions" "-spirv-allow-unknown-intrinsics=llvm.genx." {{.*}} "[[OUTPUT2_1]]"
 // CHK-TOOLS-FPGA-HW: aoc{{.*}} "-o" "[[OUTPUT4_T:.+\.aocx]]" "[[OUTPUT3_T]]"

--- a/clang/test/Driver/sycl-spirv-ext.c
+++ b/clang/test/Driver/sycl-spirv-ext.c
@@ -18,12 +18,10 @@
 // RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
-// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
 // RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
 // RUN: %clang -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
-// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN:  | FileCheck %s -check-prefixes=CHECK-CPU
 
 // CHECK-DEFAULT: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float_add
@@ -85,3 +83,38 @@
 // CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_dsp_control
 // CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_memory_accesses
 // CHECK-FPGA-HW-SAME:,+SPV_INTEL_fpga_memory_attributes"
+// CHECK-CPU: llvm-spirv{{.*}}"-spirv-allow-unknown-intrinsics=llvm.genx.,llvm.fpbuiltin"
+// CHECK-CPU-SAME: {{.*}}"-spirv-ext=-all
+// CHECK-CPU-SAME:,+SPV_EXT_shader_atomic_float_add
+// CHECK-CPU-SAME:,+SPV_EXT_shader_atomic_float_min_max
+// CHECK-CPU-SAME:,+SPV_KHR_no_integer_wrap_decoration,+SPV_KHR_float_controls
+// CHECK-CPU-SAME:,+SPV_KHR_expect_assume,+SPV_KHR_linkonce_odr
+// CHECK-CPU-SAME:,+SPV_INTEL_subgroups,+SPV_INTEL_media_block_io
+// CHECK-CPU-SAME:,+SPV_INTEL_device_side_avc_motion_estimation
+// CHECK-CPU-SAME:,+SPV_INTEL_fpga_loop_controls
+// CHECK-CPU-SAME:,+SPV_INTEL_unstructured_loop_controls,+SPV_INTEL_fpga_reg
+// CHECK-CPU-SAME:,+SPV_INTEL_blocking_pipes,+SPV_INTEL_function_pointers
+// CHECK-CPU-SAME:,+SPV_INTEL_kernel_attributes,+SPV_INTEL_io_pipes
+// CHECK-CPU-SAME:,+SPV_INTEL_inline_assembly,+SPV_INTEL_arbitrary_precision_integers
+// CHECK-CPU-SAME:,+SPV_INTEL_float_controls2
+// CHECK-CPU-SAME:,+SPV_INTEL_vector_compute,+SPV_INTEL_fast_composite
+// CHECK-CPU-SAME:,+SPV_INTEL_arbitrary_precision_fixed_point
+// CHECK-CPU-SAME:,+SPV_INTEL_arbitrary_precision_floating_point
+// CHECK-CPU-SAME:,+SPV_INTEL_variable_length_array,+SPV_INTEL_fp_fast_math_mode
+// CHECK-CPU-SAME:,+SPV_INTEL_long_constant_composite
+// CHECK-CPU-SAME:,+SPV_INTEL_arithmetic_fence
+// CHECK-CPU-SAME:,+SPV_INTEL_cache_controls
+// CHECK-CPU-SAME:,+SPV_INTEL_fpga_buffer_location
+// CHECK-CPU-SAME:,+SPV_INTEL_fpga_argument_interfaces
+// CHECK-CPU-SAME:,+SPV_INTEL_fpga_invocation_pipelining_attributes
+// CHECK-CPU-SAME:,+SPV_INTEL_fpga_latency_control
+// CHECK-CPU-SAME:,+SPV_INTEL_token_type
+// CHECK-CPU-SAME:,+SPV_INTEL_bfloat16_conversion
+// CHECK-CPU-SAME:,+SPV_INTEL_joint_matrix
+// CHECK-CPU-SAME:,+SPV_INTEL_hw_thread_queries
+// CHECK-CPU-SAME:,+SPV_KHR_uniform_group_instructions
+// CHECK-CPU-SAME:,+SPV_INTEL_masked_gather_scatter
+// CHECK-CPU-SAME:,+SPV_INTEL_tensor_float32_conversion
+// CHECK-CPU-SAME:,+SPV_INTEL_optnone
+// CHECK-CPU-SAME:,+SPV_INTEL_fp_max_error"
+


### PR DESCRIPTION
This extension is currently enabled for SYCL offloads to CPU backends. It will eventually be eventually be enabled by default for all backends.

Thanks