### PR TITLE
[SYCL] Address unused-private-field error 

### DIFF
--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -87,4 +87,3 @@ jobs:
     name: macOS
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_macos_build_and_test.yml
-

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -87,3 +87,4 @@ jobs:
     name: macOS
     if: github.repository == 'intel/llvm'
     uses: ./.github/workflows/sycl_macos_build_and_test.yml
+

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -352,6 +352,9 @@ public:
            "bundle_state::ext_oneapi_source required");
     assert(Language == syclex::source_language::opencl &&
            "TODO: add other Languages. Must be OpenCL");
+    if (Language != syclex::source_language::opencl)
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "OpenCLC only supported language at this time");
 
     // if successful, the log is empty. if failed, throws an error with the
     // compilation log.

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -353,8 +353,9 @@ public:
     assert(Language == syclex::source_language::opencl &&
            "TODO: add other Languages. Must be OpenCL");
     if (Language != syclex::source_language::opencl)
-      throw sycl::exception(make_error_code(errc::invalid),
-                            "OpenCLC only supported language at this time");
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "OpenCL C is the only supported language at this time");
 
     // if successful, the log is empty. if failed, throws an error with the
     // compilation log.

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler.cpp
@@ -9,7 +9,8 @@
 // REQUIRES: ocloc
 
 // UNSUPPORTED: (gpu-intel-dg2 && level_zero) || (gpu-intel-pvc && level_zero)
-// seems to be an incompatibility with the KernelCompiler on L0 with DG2 and PVC
+// Seems to be an incompatibility with the KernelCompiler on L0 with DG2 and
+// PVC.
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler.cpp
@@ -8,6 +8,9 @@
 
 // REQUIRES: ocloc
 
+// UNSUPPORTED: (gpu-intel-dg2 && level_zero) || (gpu-intel-pvc && level_zero)
+// seems to be an incompatibility with the KernelCompiler on L0 with DG2 and PVC
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
@@ -9,7 +9,8 @@
 // REQUIRES: ocloc
 
 // UNSUPPORTED: (gpu-intel-dg2 && level_zero) || (gpu-intel-pvc && level_zero)
-// seems to be an incompatibility with the KernelCompiler on L0 with DG2 and PVC
+// Seems to be an incompatibility with the KernelCompiler on L0 with DG2 and
+// PVC.
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
@@ -8,6 +8,9 @@
 
 // REQUIRES: ocloc
 
+// UNSUPPORTED: (gpu-intel-dg2 && level_zero) || (gpu-intel-pvc && level_zero)
+// seems to be an incompatibility with the KernelCompiler on L0 with DG2 and PVC
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
During post-commit testing, the self build is failing with an `unused-private-field` error naming the `kernel_bundle_impl.Language` member as being unused. That member is only used in asserts right now in the existing code, so I am assuming this is the problem.   Here am I adding an explicit check that should avoid the error. 