### PR TITLE
[SYCL][Graph] Add new 'are_graphs_supported' helper function

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/add_node_while_recording.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_node_while_recording.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,6 +12,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   bool Success = false;
 

--- a/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/assume_buffer_outlives_graph_property.cpp
+++ b/sycl/test-e2e/Graph/Explicit/assume_buffer_outlives_graph_property.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_buffer.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_system.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_system.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_2d.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_offsets.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_ordering.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/cycle_error.cpp
+++ b/sycl/test-e2e/Graph/Explicit/cycle_error.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -16,6 +15,10 @@ void CreateGraphWithCyclesTest(bool DisableCycleChecks) {
   const size_t Iterations = DisableCycleChecks ? 2 : 1;
 
   queue Queue;
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   property_list Props;
 

--- a/sycl/test-e2e/Graph/Explicit/cycle_error.cpp
+++ b/sycl/test-e2e/Graph/Explicit/cycle_error.cpp
@@ -17,7 +17,7 @@ void CreateGraphWithCyclesTest(bool DisableCycleChecks) {
   queue Queue;
 
   if (!are_graphs_supported(Queue)) {
-    return 0;
+    return;
   }
 
   property_list Props;

--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph.cpp
@@ -1,10 +1,9 @@
 // RUN: %{build} -o %t.out
-// RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %}
-// RUN: %if windows %{ %{run} %t.out %}
+// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %} %else %{ %{run} %t.out %}
 // Windows output format differs from linux format.
 // The filecheck-based output checking is suited to linux standards.
 // On Windows, we only test that printing takes place correctly and does not
-// trigger errors or throw execeptions.
+// trigger errors or throw exceptions.
 //
 // CHECK: digraph dot {
 // CHECK-NEXT: "0x[[#%x,NODE1:]]"

--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero || cuda, gpu
 // RUN: %{build} -o %t.out
 // RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %}
 // RUN: %if windows %{ %{run} %t.out %}

--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %} %else %{ %{run} %t.out %}
+// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph_verbose.dot %} %else %{ %{run} %t.out %}
 // Windows output format differs from linux format.
 // The filecheck-based output checking is suited to linux standards.
 // On Windows, we only test that printing takes place correctly and does not

--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
@@ -1,6 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph_verbose.dot %}
-// RUN: %if windows %{ %{run} %t.out %}
+// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %} %else %{ %{run} %t.out %}
 // Windows output format differs from linux format.
 // The filecheck-based output checking is suited to linux standards.
 // On Windows, we only test that printing takes place correctly and does not

--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero || cuda, gpu
 // RUN: %{build} -o %t.out
 // RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph_verbose.dot %}
 // RUN: %if windows %{ %{run} %t.out %}

--- a/sycl/test-e2e/Graph/Explicit/depends_on.cpp
+++ b/sycl/test-e2e/Graph/Explicit/depends_on.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,8 +12,11 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as reduction support is not complete.
+// Skip as reduction support is not complete.
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_buffer_reduction.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as reduction support is not complete.
+// Skip as reduction support is not complete.
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/dotp_usm_reduction.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as executable graph update isn't implemented yet
+// Skip as executable graph update isn't implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update isn't implemented yet
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/double_buffer.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update isn't implemented yet
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/empty_node.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/enqueue_ordering.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -12,8 +11,11 @@
 
 #include "../graph_common.hpp"
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out 2>&1 | FileCheck %s
+// RUN: %if ext_oneapi_level_zero || ext_oneapi_cuda %{ %{run} %t.out 2>&1 | FileCheck %s %} %else %{ %{run} %t.out %}
 //
 // CHECK: complete
 //

--- a/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Explicit/event_status_querying.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update not implemented yet
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as executable graph update not implemented yet
+// Skip as executable graph update not implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update not implemented yet
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update_ordering.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/executable_graph_update_ordering.cpp
@@ -5,9 +5,9 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as executable graph update and host tasks both aren't
+// Skip as executable graph update and host tasks both aren't
 // implemented.
-// XFAIL: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/host_task.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/host_task.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task.cpp
@@ -5,8 +5,8 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as host tasks aren't implemented yet.
-// XFAIL: *
+// Skip as host tasks aren't implemented yet.
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/kernel_bundle.cpp
+++ b/sycl/test-e2e/Graph/Explicit/kernel_bundle.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %if ext_oneapi_cuda %{ %{run} %t.out %}
 // RUN: %if ext_oneapi_level_zero %{env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s %}

--- a/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/multiple_kernel_bundles.cpp
+++ b/sycl/test-e2e/Graph/Explicit/multiple_kernel_bundles.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
+++ b/sycl/test-e2e/Graph/Explicit/node_ordering.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -12,8 +11,11 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Explicit/repeated_exec.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/single_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/single_node.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -11,8 +10,11 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/stream.cpp
+++ b/sycl/test-e2e/Graph/Explicit/stream.cpp
@@ -5,7 +5,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as sycl streams aren't implemented yet
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/stream.cpp
+++ b/sycl/test-e2e/Graph/Explicit/stream.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out %GPU_CHECK_PLACEHOLDER 2>&1 | FileCheck %s %}
@@ -6,7 +5,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as sycl streams aren't implemented yet
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/stream.cpp
+++ b/sycl/test-e2e/Graph/Explicit/stream.cpp
@@ -4,7 +4,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as sycl streams aren't implemented yet
+// Skip as sycl streams aren't implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_execute_without_parent.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_multiple_submission.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_nested.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as reduction support is not complete.
+// Skip as reduction support is not complete.
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_reduction.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_two_parent_graphs.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Explicit/temp_buffer_reinterpret.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_host.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Inputs/add_nodes_after_finalize.cpp
@@ -7,6 +7,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = unsigned int;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size), DataOut(Size);

--- a/sycl/test-e2e/Graph/Inputs/assume_buffer_outlives_graph_property.cpp
+++ b/sycl/test-e2e/Graph/Inputs/assume_buffer_outlives_graph_property.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue;
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = unsigned short;
 
   buffer<T> Buffer{range<1>{1}};

--- a/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = unsigned short;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
@@ -7,6 +7,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   const unsigned NumThreads = std::thread::hardware_concurrency();

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   if (!Queue.get_device().has(sycl::aspect::usm_host_allocations)) {
     return 0;
   }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {
     return 0;
   }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {
     return 0;
   }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   if (!Queue.get_device().has(sycl::aspect::usm_system_allocations)) {
     return 0;
   }

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
@@ -5,6 +5,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   const T ModValue = 7;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   const T ModValue = 7;

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size * Size), DataB(Size * Size);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_offset.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size + Offset), DataB(Size);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_offsets.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   size_t OffsetSrc = 2 * size_t(Size / 4);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size * Size), DataB(Size * Size);

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_offset.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size);

--- a/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_ordering.cpp
@@ -15,6 +15,10 @@ int main() {
 
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   const size_t N = 10;
   std::vector<int> Arr(N, 0);
 

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = unsigned short;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = unsigned short;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_buffer_reduction.cpp
@@ -3,8 +3,11 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   int DotpData = 0;
 

--- a/sycl/test-e2e/Graph/Inputs/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/dotp_usm_reduction.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   int *Dotp = malloc_device<int>(1, Queue);

--- a/sycl/test-e2e/Graph/Inputs/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/double_buffer.cpp
@@ -7,6 +7,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Inputs/empty_node.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   auto MyProperties = property_list{exp_ext::property::graph::no_cycle_check()};
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device(),
                                MyProperties};

--- a/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/Inputs/event_status_querying.cpp
@@ -36,6 +36,10 @@ std::string event_status_name(sycl::info::event_command_status status) {
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   const T ModValue = 7;

--- a/sycl/test-e2e/Graph/Inputs/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/Inputs/executable_graph_update.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/Inputs/executable_graph_update_ordering.cpp
@@ -7,6 +7,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {

--- a/sycl/test-e2e/Graph/Inputs/host_task.cpp
+++ b/sycl/test-e2e/Graph/Inputs/host_task.cpp
@@ -5,6 +5,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {

--- a/sycl/test-e2e/Graph/Inputs/kernel_bundle.cpp
+++ b/sycl/test-e2e/Graph/Inputs/kernel_bundle.cpp
@@ -14,6 +14,10 @@ int main() {
               Dev,
               {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   sycl::kernel_id KernelID = sycl::get_kernel_id<Kernel1Name>();
 
   sycl::kernel_bundle KernelBundleInput =

--- a/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/multiple_kernel_bundles.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_kernel_bundles.cpp
@@ -18,6 +18,10 @@ int main() {
               Dev,
               {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   sycl::kernel_id Kernel1ID = sycl::get_kernel_id<Kernel1Name>();
   sycl::kernel_id Kernel2ID = sycl::get_kernel_id<Kernel2Name>();
 

--- a/sycl/test-e2e/Graph/Inputs/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Inputs/queue_shortcuts.cpp
@@ -5,6 +5,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Inputs/repeated_exec.cpp
@@ -3,8 +3,11 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_handler_api.cpp
@@ -36,6 +36,10 @@ int main() {
   queue Queue{ExceptionHandler,
               {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   unsigned Errors = 0;
   if (!test_default_values(Queue)) {
     std::cout << "Test for default values of specialization constants failed!"

--- a/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Inputs/spec_constants_kernel_bundle_api.cpp
@@ -33,6 +33,10 @@ int main() {
   queue Queue{ExceptionHandler,
               {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   unsigned Errors = 0;
   if (!test_default_values(Queue)) {
     std::cout << "Test for default values of specialization constants failed!"

--- a/sycl/test-e2e/Graph/Inputs/stream.cpp
+++ b/sycl/test-e2e/Graph/Inputs/stream.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   size_t WorkItems = 16;

--- a/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = short;
 
   // Values used to modify data inside kernels.

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_execute_without_parent.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_multiple_submission.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_nested.cpp
@@ -26,6 +26,10 @@ int reference(size_t i) {
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph XSubSubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_reduction.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph_two_parent_graphs.cpp
@@ -6,6 +6,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph GraphA{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph GraphB{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
@@ -8,6 +8,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);

--- a/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_copy.cpp
@@ -5,6 +5,10 @@
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   using T = int;
 
   const T ModValue = 7;

--- a/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill.cpp
@@ -3,15 +3,18 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   const size_t N = 10;
   int *Arr = malloc_device<int>(N, Queue);
 
-  int Pattern = 3.14f;
+  int Pattern = 3;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_host.cpp
@@ -3,8 +3,12 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   if (!Queue.get_device().has(sycl::aspect::usm_host_allocations)) {
     return 0;
   }
@@ -14,7 +18,7 @@ int main() {
   const size_t N = 10;
   int *Arr = malloc_host<int>(N, Queue);
 
-  int Pattern = 3.14f;
+  int Pattern = 3;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_fill_shared.cpp
@@ -3,8 +3,11 @@
 #include "../graph_common.hpp"
 
 int main() {
-
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations)) {
     return 0;
@@ -15,7 +18,7 @@ int main() {
   const size_t N = 10;
   int *Arr = malloc_shared<int>(N, Queue);
 
-  int Pattern = 3.14f;
+  int Pattern = 3;
   auto NodeA =
       add_node(Graph, Queue, [&](handler &CGH) { CGH.fill(Arr, Pattern, N); });
 

--- a/sycl/test-e2e/Graph/RecordReplay/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/add_nodes_after_finalize.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,6 +12,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/RecordReplay/assume_buffer_outlives_graph_property.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/assume_buffer_outlives_graph_property.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -63,6 +62,10 @@ event run_kernels_usm_with_barrier(queue Q, const size_t Size, T *DataA,
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_buffer.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_system.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_system.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_2d.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_offsets.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_offsets.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_ordering.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_ordering.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/concurrent_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/concurrent_queue.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,6 +12,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   bool Success = false;
 

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph.cpp
@@ -1,10 +1,9 @@
 // RUN: %{build} -o %t.out
-// RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %}
-// RUN: %if windows %{ %{run} %t.out %}
+// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %} %else %{ %{run} %t.out %}
 // Windows output format differs from linux format.
 // The filecheck-based output checking is suited to linux standards.
 // On Windows, we only test that printing takes place correctly and does not
-// trigger errors or throw execeptions.
+// trigger errors or throw exceptions.
 //
 // CHECK: digraph dot {
 // CHECK-NEXT: "0x[[#%x,NODE1:]]"

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero || cuda, gpu
 // RUN: %{build} -o %t.out
 // RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %}
 // RUN: %if windows %{ %{run} %t.out %}

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %} %else %{ %{run} %t.out %}
+// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph_verbose.dot %} %else %{ %{run} %t.out %}
 // Windows output format differs from linux format.
 // The filecheck-based output checking is suited to linux standards.
 // On Windows, we only test that printing takes place correctly and does not

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
@@ -1,10 +1,9 @@
 // RUN: %{build} -o %t.out
-// RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph_verbose.dot %}
-// RUN: %if windows %{ %{run} %t.out %}
+// RUN: %if linux && (ext_oneapi_level_zero || ext_oneapi_cuda) %{ %{run} %t.out ; FileCheck %s --input-file graph.dot %} %else %{ %{run} %t.out %}
 // Windows output format differs from linux format.
 // The filecheck-based output checking is suited to linux standards.
 // On Windows, we only test that printing takes place correctly and does not
-// trigger errors or throw execeptions.
+// trigger errors or throw exceptions.
 //
 //
 // CHECK: digraph dot {

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero || cuda, gpu
 // RUN: %{build} -o %t.out
 // RUN: %if linux %{ %{run} %t.out ; FileCheck %s --input-file graph_verbose.dot %}
 // RUN: %if windows %{ %{run} %t.out %}

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as reduction support is not complete.
+// Skip as reduction support is not complete.
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_buffer_reduction.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -15,6 +14,10 @@ int main() {
       property::queue::in_order{},
       sycl::ext::intel::property::queue::no_immediate_command_list{}};
   queue Queue{Properties};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -17,6 +16,10 @@ int main() {
       property::queue::in_order{},
       sycl::ext::intel::property::queue::no_immediate_command_list{}};
   queue Queue{Properties};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -16,6 +15,11 @@ int main() {
       property::queue::in_order{},
       sycl::ext::intel::property::queue::no_immediate_command_list{}};
   queue QueueA{Properties};
+
+  if (!are_graphs_supported(QueueA)) {
+    return 0;
+  }
+
   queue QueueB{QueueA.get_context(), QueueA.get_device(), Properties};
 
   exp_ext::command_graph Graph{QueueA.get_context(), QueueA.get_device()};

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as reduction support is not complete.
+// Skip as reduction support is not complete.
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_usm_reduction.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update not yet implemented
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as executable graph update not yet implemented
+// Skip as executable graph update not yet implemented
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/double_buffer.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update not yet implemented
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/empty_node.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/empty_node.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out 2>&1 | FileCheck %s
+// RUN: %if ext_oneapi_level_zero || ext_oneapi_cuda %{ %{run} %t.out 2>&1 | FileCheck %s %} %else %{ %{run} %t.out %}
 //
 // CHECK: complete
 //

--- a/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/event_status_querying.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out 2>&1 | FileCheck %s
 //

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
@@ -11,6 +10,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   context InOrderContext;
 

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_devices.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_devices.cpp
@@ -32,6 +32,10 @@ int main() {
 
   queue Queue{Dev1};
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Dev0};
 
   std::error_code ExceptionCode = make_error_code(sycl::errc::success);

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as executable graph update not implemented yet
+// Skip as executable graph update not implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update not implemented yet
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as executable graph update not implemented yet
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update_ordering.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/executable_graph_update_ordering.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/executable_graph_update_ordering.cpp
@@ -5,9 +5,9 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as executable graph update and host tasks both aren't
+// Skip as executable graph update and host tasks both aren't
 // implemented.
-// XFAIL: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,6 +12,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   Graph.begin_recording(Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
@@ -5,8 +5,8 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as host tasks are not implemented yet
-// XFAIL: *
+// Skip as host tasks aren't implemented yet.
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/kernel_bundle.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/kernel_bundle.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %if ext_oneapi_cuda %{ %{run} %t.out %}
 // RUN: %if ext_oneapi_level_zero %{env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s %}

--- a/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/multiple_kernel_bundles.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/multiple_kernel_bundles.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/repeated_exec.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,6 +12,11 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   bool ChangedState = Graph.end_recording();

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/stream.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/stream.cpp
@@ -5,7 +5,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as sycl::stream is not implemented yet
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/stream.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/stream.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out %GPU_CHECK_PLACEHOLDER
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out %GPU_CHECK_PLACEHOLDER 2>&1 | FileCheck %s %}
@@ -6,7 +5,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as sycl::stream is not implemented yet
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/stream.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/stream.cpp
@@ -4,7 +4,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as sycl::stream is not implemented yet
+// Skip as sycl::stream is not implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_execute_without_parent.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -15,6 +14,10 @@ int main() {
       property::queue::in_order{},
       sycl::ext::intel::property::queue::no_immediate_command_list{}};
   queue Queue{Properties};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   exp_ext::command_graph SubGraph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_multiple_submission.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_nested.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// XFAIL: *
+// UNSUPPORTED: *
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
@@ -5,7 +5,7 @@
 //
 // CHECK-NOT: LEAK
 
-// Expected fail as reduction support is not complete.
+// Skip as reduction support is not complete.
 // REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_reduction.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Expected fail as reduction support is not complete.
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_two_parent_graphs.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -7,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Fail that needs investigation
-// XFAIL: *
+// UNSUPPORTED: *
 
 // This test creates a temporary buffer which is used in kernels, but
 // destroyed before finalization and execution of the graph.
@@ -16,6 +15,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -6,7 +6,7 @@
 // CHECK-NOT: LEAK
 
 // Fail that needs investigation
-// UNSUPPORTED: *
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 // This test creates a temporary buffer which is used in kernels, but
 // destroyed before finalization and execution of the graph.

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -5,8 +5,9 @@
 //
 // CHECK-NOT: LEAK
 
-// Fail that needs investigation
-// REQUIRES: NOT_YET_IMPLEMENTED
+// This test should be removed as using buffers that don't exceed the
+// lifetime of the graph doesn't satisfy the graphs extension spec.
+// XFAIL: *
 
 // This test creates a temporary buffer which is used in kernels, but
 // destroyed before finalization and execution of the graph.

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -5,9 +5,10 @@
 //
 // CHECK-NOT: LEAK
 
-// This test should be removed as using buffers that don't exceed the
-// lifetime of the graph doesn't satisfy the graphs extension spec.
-// XFAIL: *
+// This test should be removed or modified as using buffers that don't exceed
+// the lifetime of the graph doesn't satisfy valid usage of the graphs
+// extension.
+// REQUIRES: NOT_YET_IMPLEMENTED
 
 // This test creates a temporary buffer which is used in kernels, but
 // destroyed before finalization and execution of the graph.

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer_reinterpret.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -26,9 +25,12 @@ void run_some_kernel(queue Queue, int *Data) {
 }
 
 int main() {
-
   queue Queue{default_selector_v,
               {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -15,6 +14,10 @@ int main() {
       property::queue::in_order{},
       sycl::ext::intel::property::queue::no_immediate_command_list{}};
   queue Queue{Properties};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill_host.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill_shared.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG

--- a/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using ZE_DEBUG
@@ -13,6 +12,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
   {

--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build_pthread_inc} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
@@ -20,6 +19,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   using T = int;
 

--- a/sycl/test-e2e/Graph/device_query.cpp
+++ b/sycl/test-e2e/Graph/device_query.cpp
@@ -10,6 +10,10 @@
 int main() {
   queue Queue;
 
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
   auto Device = Queue.get_device();
 
   exp_ext::graph_support_level SupportsGraphs =

--- a/sycl/test-e2e/Graph/empty_graph.cpp
+++ b/sycl/test-e2e/Graph/empty_graph.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -9,6 +8,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/finalize_twice.cpp
+++ b/sycl/test-e2e/Graph/finalize_twice.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -8,6 +7,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/graph_common.hpp
+++ b/sycl/test-e2e/Graph/graph_common.hpp
@@ -457,3 +457,12 @@ bool inline check_value(const size_t index, const T &Ref, const T &Got,
 
   return true;
 }
+
+bool are_graphs_supported(queue &Queue) {
+  auto Device = Queue.get_device();
+
+  exp_ext::graph_support_level SupportsGraphs =
+      Device.get_info<exp_ext::info::device::graph_support>();
+
+  return SupportsGraphs != exp_ext::graph_support_level::unsupported;
+}

--- a/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
+++ b/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
@@ -16,7 +16,7 @@ sycl::ext::oneapi::experimental::device_global<int, TestProperties>
 
 enum OperationPath { Explicit, RecordReplay, Shortcut };
 
-template <OperationPath PathKind, typename T> void test(queue Queue) {
+template <OperationPath PathKind> void test(queue Queue) {
   int MemcpyWrite = 42, CopyWrite = 24, MemcpyRead = 1, CopyRead = 2;
 
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};

--- a/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
+++ b/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
@@ -22,7 +22,7 @@ template <OperationPath PathKind, typename T> void test(queue Queue) {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   if constexpr (PathKind != OperationPath::Explicit) {
-    Graph.begin_recording(Q);
+    Graph.begin_recording(Queue);
   }
 
   // Copy from device globals before having written anything.

--- a/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
+++ b/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
@@ -17,11 +16,10 @@ sycl::ext::oneapi::experimental::device_global<int, TestProperties>
 
 enum OperationPath { Explicit, RecordReplay, Shortcut };
 
-template <OperationPath PathKind> void test() {
-  queue Q{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+template <OperationPath PathKind, typename T> void test(queue Queue) {
   int MemcpyWrite = 42, CopyWrite = 24, MemcpyRead = 1, CopyRead = 2;
 
-  exp_ext::command_graph Graph{Q.get_context(), Q.get_device()};
+  exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   if constexpr (PathKind != OperationPath::Explicit) {
     Graph.begin_recording(Q);
@@ -31,10 +29,10 @@ template <OperationPath PathKind> void test() {
   std::error_code ExceptionCode = make_error_code(sycl::errc::success);
   try {
     if constexpr (PathKind == OperationPath::Shortcut) {
-      Q.memcpy(&MemcpyRead, MemcpyDeviceGlobal);
+      Queue.memcpy(&MemcpyRead, MemcpyDeviceGlobal);
     }
     if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q.submit([&](handler &CGH) {
+      Queue.submit([&](handler &CGH) {
         return CGH.memcpy(&MemcpyRead, MemcpyDeviceGlobal);
       });
     }
@@ -51,10 +49,10 @@ template <OperationPath PathKind> void test() {
   ExceptionCode = make_error_code(sycl::errc::success);
   try {
     if constexpr (PathKind == OperationPath::Shortcut) {
-      Q.copy(CopyDeviceGlobal, &CopyRead);
+      Queue.copy(CopyDeviceGlobal, &CopyRead);
     }
     if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q.submit(
+      Queue.submit(
           [&](handler &CGH) { return CGH.copy(CopyDeviceGlobal, &CopyRead); });
     }
     if constexpr (PathKind == OperationPath::Explicit) {
@@ -70,10 +68,10 @@ template <OperationPath PathKind> void test() {
   ExceptionCode = make_error_code(sycl::errc::success);
   try {
     if constexpr (PathKind == OperationPath::Shortcut) {
-      Q.memcpy(MemcpyDeviceGlobal, &MemcpyWrite);
+      Queue.memcpy(MemcpyDeviceGlobal, &MemcpyWrite);
     }
     if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q.submit([&](handler &CGH) {
+      Queue.submit([&](handler &CGH) {
         return CGH.memcpy(MemcpyDeviceGlobal, &MemcpyWrite);
       });
     }
@@ -90,9 +88,9 @@ template <OperationPath PathKind> void test() {
   ExceptionCode = make_error_code(sycl::errc::success);
   try {
     if constexpr (PathKind == OperationPath::Shortcut) {
-      Q.copy(&CopyWrite, CopyDeviceGlobal);
+      Queue.copy(&CopyWrite, CopyDeviceGlobal);
     } else if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q.submit(
+      Queue.submit(
           [&](handler &CGH) { return CGH.copy(&CopyWrite, CopyDeviceGlobal); });
     } else if constexpr (PathKind == OperationPath::Explicit) {
       Graph.add(
@@ -106,9 +104,9 @@ template <OperationPath PathKind> void test() {
   ExceptionCode = make_error_code(sycl::errc::success);
   try {
     if constexpr (PathKind == OperationPath::Shortcut) {
-      Q.memcpy(&MemcpyRead, MemcpyDeviceGlobal);
+      Queue.memcpy(&MemcpyRead, MemcpyDeviceGlobal);
     } else if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q.submit([&](handler &CGH) {
+      Queue.submit([&](handler &CGH) {
         return CGH.memcpy(&MemcpyRead, MemcpyDeviceGlobal);
       });
     } else if constexpr (PathKind == OperationPath::Explicit) {
@@ -124,9 +122,9 @@ template <OperationPath PathKind> void test() {
   ExceptionCode = make_error_code(sycl::errc::success);
   try {
     if constexpr (PathKind == OperationPath::Shortcut) {
-      Q.copy(CopyDeviceGlobal, &CopyRead);
+      Queue.copy(CopyDeviceGlobal, &CopyRead);
     } else if constexpr (PathKind == OperationPath::RecordReplay) {
-      Q.submit(
+      Queue.submit(
           [&](handler &CGH) { return CGH.copy(CopyDeviceGlobal, &CopyRead); });
     } else if constexpr (PathKind == OperationPath::Explicit) {
       Graph.add(
@@ -143,8 +141,14 @@ template <OperationPath PathKind> void test() {
 }
 
 int main() {
-  test<OperationPath::Explicit>();
-  test<OperationPath::RecordReplay>();
-  test<OperationPath::Shortcut>();
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
+
+  test<OperationPath::Explicit>(Queue);
+  test<OperationPath::RecordReplay>(Queue);
+  test<OperationPath::Shortcut>(Queue);
   return 0;
 }

--- a/sycl/test-e2e/Graph/immediate_command_list_error.cpp
+++ b/sycl/test-e2e/Graph/immediate_command_list_error.cpp
@@ -18,6 +18,10 @@ int main() {
       QueueImmediate.get_device(),
       {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
 
+  if (!are_graphs_supported(QueueNoImmediate)) {
+    return 0;
+  }
+
   exp_ext::command_graph Graph{QueueNoImmediate.get_context(),
                                QueueNoImmediate.get_device()};
 

--- a/sycl/test-e2e/Graph/invalid_depends_on.cpp
+++ b/sycl/test-e2e/Graph/invalid_depends_on.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -9,6 +8,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/invalid_event_wait.cpp
+++ b/sycl/test-e2e/Graph/invalid_event_wait.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -9,6 +8,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/invalid_queue_wait.cpp
+++ b/sycl/test-e2e/Graph/invalid_queue_wait.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -8,6 +7,10 @@
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
                                                  Queue.get_device()};

--- a/sycl/test-e2e/Graph/submission_while_executing.cpp
+++ b/sycl/test-e2e/Graph/submission_while_executing.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if ext_oneapi_level_zero %{env ZE_DEBUG=4 %{run} %t.out 2>&1 | FileCheck %s %}
@@ -19,6 +18,10 @@ isSubmittedOrRunningCommand(sycl::info::event_command_status Status) {
 
 int main() {
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   using T = int;
 


### PR DESCRIPTION
Add new 'are_graphs_supported' helper function to determine platform support for Graphs
at runtime rather than the lit '// REQUIRES: <platform>' check at compile time.

Fixed a bug in the usm_variant tests of trying to instantiate an int with a float value.

This PR has been create in order to simplify the PR for adding OpenCL support to the SYCL Graph tests https://github.com/intel/llvm/pull/11718.