### PR TITLE
[UR] Bump tag to 534071e52f84bad1dd7fb210a360414507f3b3ae

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,13 +56,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 659d3f469faa99a886fa680a3d6d20449b109578
-  # Merge: 192e9404 f94550b4
+  # commit 534071e52f84bad1dd7fb210a360414507f3b3ae
+  # Merge: 9fc82304 d164792b
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Tue Nov 14 16:45:24 2023 +0000
-  #     Merge pull request #1059 from martygrant/martin/moveNativeCPUAdapterToUR
-  #     [NATIVECPU] Move Native CPU adapter to UR.
-  set(UNIFIED_RUNTIME_TAG 659d3f469faa99a886fa680a3d6d20449b109578)
+  # Date:   Wed Nov 15 10:51:54 2023 +0000
+  #     Merge pull request #1077 from fabiomestre/fabio/combines_fixes_cuda_hip
+  #     [CUDA][HIP] Combined CTS Fixes
+  set(UNIFIED_RUNTIME_TAG 534071e52f84bad1dd7fb210a360414507f3b3ae)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
Pulls in the following fixes to the CUDA and HIP adapters:

* [HIP] Correctly set HIP Kernel Buffer Arguments 
* [HIP] Fix host/device synchronization 
* [HIP][CTS] Fix Device CTS failures 
* [HIP] Fix get mem size segfault 
* [HIP] Implement urMemImageGetInfo
* [HIP] Define all UR entry points
* [CUDA] Add support for binary type query
* [CUDA] Update hint functions to only return warnings instead of errors