### PR TITLE
[SYCL] Limit decorations to init function for annotated_arg/ptr classes

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -73,7 +73,7 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
   void __init([[__sycl_detail__::add_ir_attributes_kernel_parameter(
       detail::PropertyMetaInfo<Props>::name...,
       detail::PropertyMetaInfo<
-          Props>::value...)]] decorated_global_ptr<T>::pointer _obj) {
+          Props>::value...)]] typename decorated_global_ptr<T>::pointer _obj) {
     obj = _obj;
   }
 #endif

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -72,7 +72,8 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
 #ifdef __SYCL_DEVICE_ONLY__
   void __init([[__sycl_detail__::add_ir_attributes_kernel_parameter(
       detail::PropertyMetaInfo<Props>::name...,
-      detail::PropertyMetaInfo<Props>::value...)]] decorated_global_ptr<T>::pointer _obj) {
+      detail::PropertyMetaInfo<Props>::value...)]]
+        decorated_global_ptr<T>::pointer _obj) {
     obj = _obj;
   }
 #endif

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -65,20 +65,14 @@ class __SYCL_SPECIAL_CLASS
 __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
   using property_list_t = detail::properties_t<Props...>;
 
-#ifdef __SYCL_DEVICE_ONLY__
-  using global_pointer_t = typename decorated_global_ptr<T>::pointer;
-#else
-  using global_pointer_t = T *;
-#endif
-
-  global_pointer_t obj;
+  T * obj;
 
   template <typename T2, typename PropertyListT> friend class annotated_arg;
 
 #ifdef __SYCL_DEVICE_ONLY__
   void __init([[__sycl_detail__::add_ir_attributes_kernel_parameter(
       detail::PropertyMetaInfo<Props>::name...,
-      detail::PropertyMetaInfo<Props>::value...)]] global_pointer_t _obj) {
+      detail::PropertyMetaInfo<Props>::value...)]] decorated_global_ptr<T>::pointer _obj) {
     obj = _obj;
   }
 #endif
@@ -110,7 +104,7 @@ public:
 
   annotated_arg(T *_ptr,
                 const property_list_t &PropList = properties{}) noexcept
-      : obj(global_pointer_t(_ptr)) {
+      : obj(_ptr) {
     (void)PropList;
   }
 
@@ -120,7 +114,7 @@ public:
   // `PropertyValueTs...` must have the same property value.
   template <typename... PropertyValueTs>
   annotated_arg(T *_ptr, const PropertyValueTs &...props) noexcept
-      : obj(global_pointer_t(_ptr)) {
+      : obj(_ptr) {
     static constexpr bool has_same_properties = std::is_same<
         property_list_t,
         detail::merged_properties_t<property_list_t,

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -72,8 +72,8 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
 #ifdef __SYCL_DEVICE_ONLY__
   void __init([[__sycl_detail__::add_ir_attributes_kernel_parameter(
       detail::PropertyMetaInfo<Props>::name...,
-      detail::PropertyMetaInfo<
-          Props>::value...)]] typename decorated_global_ptr<T>::pointer _obj) {
+      detail::PropertyMetaInfo<Props>::value...)]]
+              typename decorated_global_ptr<T>::pointer _obj) {
     obj = _obj;
   }
 #endif

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -72,8 +72,8 @@ __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
 #ifdef __SYCL_DEVICE_ONLY__
   void __init([[__sycl_detail__::add_ir_attributes_kernel_parameter(
       detail::PropertyMetaInfo<Props>::name...,
-      detail::PropertyMetaInfo<Props>::value...)]]
-        decorated_global_ptr<T>::pointer _obj) {
+      detail::PropertyMetaInfo<
+          Props>::value...)]] decorated_global_ptr<T>::pointer _obj) {
     obj = _obj;
   }
 #endif

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -65,7 +65,7 @@ class __SYCL_SPECIAL_CLASS
 __SYCL_TYPE(annotated_arg) annotated_arg<T *, detail::properties_t<Props...>> {
   using property_list_t = detail::properties_t<Props...>;
 
-  T * obj;
+  T *obj;
 
   template <typename T2, typename PropertyListT> friend class annotated_arg;
 
@@ -114,8 +114,7 @@ public:
   // variadic properties. The same property in `Props...` and
   // `PropertyValueTs...` must have the same property value.
   template <typename... PropertyValueTs>
-  annotated_arg(T *_ptr, const PropertyValueTs &...props) noexcept
-      : obj(_ptr) {
+  annotated_arg(T *_ptr, const PropertyValueTs &...props) noexcept : obj(_ptr) {
     static constexpr bool has_same_properties = std::is_same<
         property_list_t,
         detail::merged_properties_t<property_list_t,

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -190,7 +190,6 @@ __SYCL_TYPE(annotated_ptr) annotated_ptr<T, detail::properties_t<Props...>> {
   using reference = sycl::ext::oneapi::experimental::annotated_ref<
       T, typename unpack<filtered_properties>::type>;
 
-#ifdef __SYCL_DEVICE_ONLY__
 #ifdef __ENABLE_USM_ADDR_SPACE__
   using global_pointer_t = std::conditional_t<
       detail::IsUsmKindDevice<property_list_t>::value,
@@ -202,11 +201,8 @@ __SYCL_TYPE(annotated_ptr) annotated_ptr<T, detail::properties_t<Props...>> {
 #else
   using global_pointer_t = typename decorated_global_ptr<T>::pointer;
 #endif // __ENABLE_USM_ADDR_SPACE__
-#else
-  using global_pointer_t = T *;
-#endif // __SYCL_DEVICE_ONLY__
 
-  global_pointer_t m_Ptr;
+  T * m_Ptr;
 
   template <typename T2, typename PropertyListT> friend class annotated_ptr;
 
@@ -245,7 +241,7 @@ public:
 
   explicit annotated_ptr(T *Ptr,
                          const property_list_t & = properties{}) noexcept
-      : m_Ptr(global_pointer_t(Ptr)) {}
+      : m_Ptr(Ptr) {}
 
   // Constructs an annotated_ptr object from a raw pointer and variadic
   // properties. The new property set contains all properties of the input
@@ -253,7 +249,7 @@ public:
   // `PropertyValueTs...` must have the same property value.
   template <typename... PropertyValueTs>
   explicit annotated_ptr(T *Ptr, const PropertyValueTs &...props) noexcept
-      : m_Ptr(global_pointer_t(Ptr)) {
+      : m_Ptr(Ptr) {
     static constexpr bool has_same_properties = std::is_same<
         property_list_t,
         detail::merged_properties_t<property_list_t,

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -202,7 +202,7 @@ __SYCL_TYPE(annotated_ptr) annotated_ptr<T, detail::properties_t<Props...>> {
   using global_pointer_t = typename decorated_global_ptr<T>::pointer;
 #endif // __ENABLE_USM_ADDR_SPACE__
 
-  T * m_Ptr;
+  T *m_Ptr;
 
   template <typename T2, typename PropertyListT> friend class annotated_ptr;
 


### PR DESCRIPTION
annotated_arg/annotated_ptr are special classes and arguments of the __init() member function become kernel arguments. The classes have decorated_global_ptr or other such type applied on the class members to indicate that these must be in global address-space (or other address space as indicated by the applied type). The goal of applying the type on the member was to ensure that class member gets captured as a global address space pointer when set as kernel argument.

However, the type was applied on class constructor arguments as well. This PR restricts the type to only be present on the __init member function argument, otherwise the presence of the type on constructors causes functional errors on certain backends when objects are constructed in the kernel body. The object constructed inside kernel body also gets a global address space cast generated by the compiler when the decorated_global_ptr type is applied on ctor arguments. This is problematic for example when the object is constructed from a pointer to some array defined inside the kernel.
