### PR TITLE
[SYCL] Fix strict alias violations in vec representation

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -950,16 +950,16 @@ public:
           (std::is_fundamental_v<vec_data_t<T>> ||                             \
            std::is_same_v<typename std::remove_const_t<T>, half>),             \
       vec>                                                                     \
-  operator BINOP(const T & Rhs) const {                                        \
+  operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
   }                                                                            \
-  vec &operator OPASSIGN(const vec & Rhs) {                                    \
+  vec &operator OPASSIGN(const vec &Rhs) {                                     \
     *this = *this BINOP Rhs;                                                   \
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
   typename std::enable_if_t<Num != 1, vec &> operator OPASSIGN(                \
-      const DataT & Rhs) {                                                     \
+      const DataT &Rhs) {                                                      \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
   }

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -950,16 +950,16 @@ public:
           (std::is_fundamental_v<vec_data_t<T>> ||                             \
            std::is_same_v<typename std::remove_const_t<T>, half>),             \
       vec>                                                                     \
-  operator BINOP(const T &Rhs) const {                                         \
+  operator BINOP(const T & Rhs) const {                                        \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
   }                                                                            \
-  vec &operator OPASSIGN(const vec &Rhs) {                                     \
+  vec &operator OPASSIGN(const vec & Rhs) {                                    \
     *this = *this BINOP Rhs;                                                   \
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
   typename std::enable_if_t<Num != 1, vec &> operator OPASSIGN(                \
-      const DataT &Rhs) {                                                      \
+      const DataT & Rhs) {                                                     \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
   }
@@ -983,16 +983,16 @@ public:
           (std::is_fundamental_v<vec_data_t<T>> ||                             \
            std::is_same_v<typename std::remove_const_t<T>, half>),             \
       vec>                                                                     \
-  operator BINOP(const T &Rhs) const {                                         \
+  operator BINOP(const T & Rhs) const {                                        \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
   }                                                                            \
-  vec &operator OPASSIGN(const vec &Rhs) {                                     \
+  vec &operator OPASSIGN(const vec & Rhs) {                                    \
     *this = *this BINOP Rhs;                                                   \
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
   typename std::enable_if_t<Num != 1, vec &> operator OPASSIGN(                \
-      const DataT &Rhs) {                                                      \
+      const DataT & Rhs) {                                                     \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
   }

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -314,19 +314,6 @@ template <typename Type, int NumElements> class vec {
 
 #if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 
-  // This represents HOW  we will approach the underlying value, so as to
-  // benefit from vector speed improvements
-  using VectorDataType =
-      typename detail::VecStorage<DataT, NumElements>::VectorDataType;
-
-  VectorDataType &getAsVector() {
-    return *reinterpret_cast<VectorDataType *>(m_Data.data());
-  }
-
-  const VectorDataType &getAsVector() const {
-    return *reinterpret_cast<const VectorDataType *>(m_Data.data());
-  }
-
   static constexpr size_t AdjustedNum = (NumElements == 3) ? 4 : NumElements;
   static constexpr size_t Sz = sizeof(DataT) * AdjustedNum;
   static constexpr bool IsSizeGreaterThanMaxAlign =
@@ -516,7 +503,8 @@ public:
 
 #ifdef __SYCL_DEVICE_ONLY__
 #if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
-  using vector_t = VectorDataType;
+  using vector_t =
+      typename detail::VecStorage<DataT, NumElements>::VectorDataType;
 #else
   using vector_t = DataType;
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
@@ -713,7 +701,7 @@ public:
     if constexpr (!IsUsingArrayOnDevice) {
       return m_Data;
     } else {
-      auto ptr = bit_cast<const VectorDataType *>((&m_Data)->data());
+      auto ptr = bit_cast<const vector_t *>((&m_Data)->data());
       return *ptr;
     }
   }
@@ -788,32 +776,32 @@ public:
                   "Unsupported convertT");
     using T = vec_data_t<DataT>;
     using R = vec_data_t<convertT>;
+    using OpenCLT = detail::ConvertToOpenCLType_t<T>;
+    using OpenCLR = detail::ConvertToOpenCLType_t<R>;
     vec<convertT, NumElements> Result;
-#if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
-    if constexpr (NativeVec && vec<convertT, NumElements>::NativeVec) {
-#ifdef __SYCL_DEVICE_ONLY__
-      // If both vectors are representable as native vectors, then we can use
-      // a single vector-wide operation to do a conversion:
-      Result.m_Data = detail::convertImpl<
-          T, R, roundingMode, NumElements, VectorDataType,
-          typename vec<convertT, NumElements>::VectorDataType>(m_Data);
-#endif // __SYCL_DEVICE_ONLY
-    } else {
-#endif // __INTEL_PREVIEW_BREAKING_CHANGES
-
+#if defined(__INTEL_PREVIEW_BREAKING_CHANGES) && defined(__SYCL_DEVICE_ONLY__)
+    using OpenCLVecT = OpenCLT __attribute__((ext_vector_type(NumElements)));
+    using OpenCLVecR = OpenCLR __attribute__((ext_vector_type(NumElements)));
+    if constexpr (NativeVec && vec<convertT, NumElements>::NativeVec &&
+                  std::is_convertible_v<decltype(m_Data), OpenCLVecT> &&
+                  std::is_convertible_v<decltype(Result.m_Data), OpenCLR>) {
+      // If both vectors are representable as native vectors and these native
+      // vectors can be converted to valid OpenCL representations, then we can
+      // use a single vector-wide operation to do a conversion:
+      Result.m_Data = detail::convertImpl<T, R, roundingMode, NumElements,
+                                          OpenCLVecT, OpenCLVecR>(m_Data);
+    } else
+#endif // defined(__INTEL_PREVIEW_BREAKING_CHANGES) &&
+       // defined(__SYCL_DEVICE_ONLY__)
+    {
       // Otherwise, we fallback to per-element conversion:
-      using OpenCLT = detail::ConvertToOpenCLType_t<vec_data_t<DataT>>;
-      using OpenCLR = detail::ConvertToOpenCLType_t<vec_data_t<convertT>>;
       for (size_t I = 0; I < NumElements; ++I) {
         Result.setValue(
             I, vec_data<convertT>::get(
                    detail::convertImpl<T, R, roundingMode, 1, OpenCLT, OpenCLR>(
                        vec_data<DataT>::get(getValue(I)))));
       }
-
-#if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
     }
-#endif // defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 
     if constexpr (std::is_same_v<convertT, bool>) {
       Result.ConvertToDataT();
@@ -982,7 +970,7 @@ public:
   vec operator BINOP(const vec &Rhs) const {                                   \
     vec Ret{};                                                                 \
     if constexpr (NativeVec)                                                   \
-      Ret.getAsVector() = getAsVector() BINOP Rhs.getAsVector();               \
+      Ret.m_Data = m_Data BINOP Rhs.m_Data;                                    \
     else                                                                       \
       for (size_t I = 0; I < NumElements; ++I)                                 \
         Ret.setValue(I, (DataT)(vec_data<DataT>::get(getValue(                 \
@@ -995,16 +983,16 @@ public:
           (std::is_fundamental_v<vec_data_t<T>> ||                             \
            std::is_same_v<typename std::remove_const_t<T>, half>),             \
       vec>                                                                     \
-  operator BINOP(const T & Rhs) const {                                        \
+  operator BINOP(const T &Rhs) const {                                         \
     return *this BINOP vec(static_cast<const DataT &>(Rhs));                   \
   }                                                                            \
-  vec &operator OPASSIGN(const vec & Rhs) {                                    \
+  vec &operator OPASSIGN(const vec &Rhs) {                                     \
     *this = *this BINOP Rhs;                                                   \
     return *this;                                                              \
   }                                                                            \
   template <int Num = NumElements>                                             \
   typename std::enable_if_t<Num != 1, vec &> operator OPASSIGN(                \
-      const DataT & Rhs) {                                                     \
+      const DataT &Rhs) {                                                      \
     *this = *this BINOP vec(Rhs);                                              \
     return *this;                                                              \
   }
@@ -2258,14 +2246,10 @@ template <typename T, int N> struct VecStorageImpl {
   using VectorDataType = T __attribute__((ext_vector_type(N)));
 };
 #else // __SYCL_DEVICE_ONLY__
-
-template <typename T, int N> struct VecStorageImpl;
-#define __SYCL_DEFINE_VECSTORAGE_IMPL(type, cl_type, num)                      \
-  template <> struct VecStorageImpl<type, num> {                               \
-    using DataType = std::array<type, (num == 3) ? 4 : num>;                   \
-    using VectorDataType = ::cl_##cl_type##num;                                \
-  };
-#endif // SYCL_DEVICE_ONLY
+template <typename T, int N> struct VecStorageImpl {
+  using DataType = std::array<T, (N == 3) ? 4 : N>;
+};
+#endif // __SYCL_DEVICE_ONLY__
 #endif // defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 
 #if !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
@@ -2283,7 +2267,6 @@ template <typename T, int N> struct VecStorageImpl;
     using DataType = ::cl_##cl_type##num;                                      \
   };
 #endif // __SYCL_USE_EXT_VECTOR_TYPE__
-#endif // !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 
 #ifndef __SYCL_USE_EXT_VECTOR_TYPE__
 #define __SYCL_DEFINE_VECSTORAGE_IMPL_FOR_TYPE(type, cl_type)                  \
@@ -2307,12 +2290,15 @@ __SYCL_DEFINE_VECSTORAGE_IMPL_FOR_TYPE(double, double)
 #undef __SYCL_DEFINE_VECSTORAGE_IMPL_FOR_TYPE
 #undef __SYCL_DEFINE_VECSTORAGE_IMPL
 #endif // ifndef __SYCL_USE_EXT_VECTOR_TYPE__
+#endif // !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 
 // Single element bool
 template <> struct VecStorage<bool, 1, void> {
   using DataType = bool;
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType = bool;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
@@ -2324,30 +2310,53 @@ struct VecStorage<bool, N, typename std::enable_if_t<isValidVectorSize(N)>> {
                                                 std::int32_t, std::int64_t>,
                               N>::DataType;
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType =
       typename VecStorageImpl<select_apply_cl_t<bool, std::int8_t, std::int16_t,
                                                 std::int32_t, std::int64_t>,
                               N>::VectorDataType;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
+
+#if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
+// Single element byte. Multiple elements will propagate through a later
+// specialization.
+template <> struct VecStorage<std::byte, 1, void> {
+  using DataType = std::int8_t;
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __SYCL_DEVICE_ONLY__
+  using VectorDataType = std::int8_t;
+#endif // __SYCL_DEVICE_ONLY__
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+};
+#endif // (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
 
 // Single element signed integers
 template <typename T>
 struct VecStorage<T, 1, typename std::enable_if_t<is_sigeninteger_v<T>>> {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   using DataType = select_apply_cl_t<T, std::int8_t, std::int16_t, std::int32_t,
                                      std::int64_t>;
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#else // __INTEL_PREVIEW_BREAKING_CHANGES
+  using DataType = T;
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType = DataType;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
 // Single element unsigned integers
 template <typename T>
 struct VecStorage<T, 1, typename std::enable_if_t<is_sugeninteger_v<T>>> {
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
   using DataType = select_apply_cl_t<T, std::uint8_t, std::uint16_t,
                                      std::uint32_t, std::uint64_t>;
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#else // __INTEL_PREVIEW_BREAKING_CHANGES
+  using DataType = T;
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType = DataType;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
@@ -2355,10 +2364,11 @@ struct VecStorage<T, 1, typename std::enable_if_t<is_sugeninteger_v<T>>> {
 template <typename T>
 struct VecStorage<
     T, 1, typename std::enable_if_t<!is_half_v<T> && is_sgenfloat_v<T>>> {
-  using DataType =
-      select_apply_cl_t<T, std::false_type, std::false_type, float, double>;
+  using DataType = T;
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType = DataType;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 // Multiple elements signed/unsigned integers and floating-point (except half)
@@ -2371,9 +2381,11 @@ struct VecStorage<
   using DataType =
       typename VecStorageImpl<typename VecStorage<T, 1>::DataType, N>::DataType;
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType =
       typename VecStorageImpl<typename VecStorage<T, 1>::DataType,
                               N>::VectorDataType;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
 
@@ -2381,22 +2393,27 @@ struct VecStorage<
 template <> struct VecStorage<half, 1, void> {
   using DataType = sycl::detail::half_impl::StorageT;
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __SYCL_DEVICE_ONLY__
   using VectorDataType = sycl::detail::half_impl::StorageT;
+#endif // __SYCL_DEVICE_ONLY__
 #endif // __INTEL_PREVIEW_BREAKING_CHANGES
 };
+
 // Multiple elements half
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#if defined(__INTEL_PREVIEW_BREAKING_CHANGES) && defined(__SYCL_DEVICE_ONLY__)
 #define __SYCL_DEFINE_HALF_VECSTORAGE(Num)                                     \
   template <> struct VecStorage<half, Num, void> {                             \
     using DataType = sycl::detail::half_impl::Vec##Num##StorageT;              \
     using VectorDataType = sycl::detail::half_impl::Vec##Num##StorageT;        \
   };
-#else // __INTEL_PREVIEW_BREAKING_CHANGES
+#else // defined(__INTEL_PREVIEW_BREAKING_CHANGES) &&
+      // defined(__SYCL_DEVICE_ONLY__)
 #define __SYCL_DEFINE_HALF_VECSTORAGE(Num)                                     \
   template <> struct VecStorage<half, Num, void> {                             \
     using DataType = sycl::detail::half_impl::Vec##Num##StorageT;              \
   };
-#endif
+#endif // defined(__INTEL_PREVIEW_BREAKING_CHANGES) &&
+       // defined(__SYCL_DEVICE_ONLY__)
 
 __SYCL_DEFINE_HALF_VECSTORAGE(2)
 __SYCL_DEFINE_HALF_VECSTORAGE(3)


### PR DESCRIPTION
Parts of the vector implementation violates strict aliasing by representing vectors of certain types by another element type and reinterpret-casting to the right type to correctly pass references along. This may especially affect fundamental integral types that are not the default fixed-width integer type of the system.