### PR TITLE
Updated tests after pulldown

### DIFF
--- a/clang/test/CodeGenSYCL/add_ir_attributes_function_virtual.cpp
+++ b/clang/test/CodeGenSYCL/add_ir_attributes_function_virtual.cpp
@@ -42,9 +42,9 @@ void foo() {
 // CHECK: define {{.*}}spir_func void @_ZN4Base11testVirtualEv{{.*}} #[[BaseAttrs:[0-9]+]]
 // CHECK: define {{.*}}spir_func void @_ZN8Derived111testVirtualEv{{.*}} #[[Derived1Attrs:[0-9]+]]
 // CHECK: define {{.*}}spir_func void @_ZN8Derived211testVirtualEv{{.*}} #[[Derived2Attrs:[0-9]+]]
-// CHECK: attributes #[[BaseAttrs]] = { {{.*}}"PropBase"="PropVal"{{.*}} }
-// CHECK: attributes #[[Derived1Attrs]] = { {{.*}}"PropDerived"="PropVal"{{.*}} }
 // CHECK: attributes #[[Derived2Attrs]] = {
 // CHECK-NOT: PropBase
 // CHECK-NOT: PropDerived
 // CHECK: }
+// CHECK: attributes #[[BaseAttrs]] = { {{.*}}"PropBase"="PropVal"{{.*}} }
+// CHECK: attributes #[[Derived1Attrs]] = { {{.*}}"PropDerived"="PropVal"{{.*}} }

--- a/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/CodeGenSYCL/device-indirectly-callable-attr.cpp
@@ -21,9 +21,9 @@ public:
   // CHECK-DAG: define {{.*}}spir_func noundef i32 @_Z5bar20{{.*}}#[[ATTRS_NOT_INDIR_CALL]]
   [[intel::device_indirectly_callable]] void foo() { bar20(10); }
 
-  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AC1Ev{{.*}}#[[ATTRS_INDIR_CALL_1:[0-9]+]]
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AC1Ev{{.*}}#[[ATTRS_INDIR_CALL]]
   [[intel::device_indirectly_callable]] A() {}
-  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AD1Ev{{.*}}#[[ATTRS_INDIR_CALL_1]]
+  // CHECK-DAG: define linkonce_odr spir_func void @_ZN1AD1Ev{{.*}}#[[ATTRS_INDIR_CALL]]
   [[intel::device_indirectly_callable]] ~A() {}
 
   template <typename T>
@@ -67,4 +67,3 @@ struct Finalizer1 : Base {
 
 // CHECK: attributes #[[ATTRS_INDIR_CALL]] = { {{.*}} "referenced-indirectly"
 // CHECK-NOT: attributes #[[ATTRS_NOT_INDIR_CALL]] = { {{.*}} "referenced-indirectly"
-// CHECK: attributes #[[ATTRS_INDIR_CALL_1]] = { {{.*}} "referenced-indirectly"


### PR DESCRIPTION
Affected by [clang][CodeGen] Ensure consistent mustprogress attribute emission

https://github.com/intel/llvm/commit/970bf07d0b184c7ec35