### PR TITLE
chore: migrate AWS SDK for JavaScript v2 APIs to v3

### DIFF
--- a/devops/actions/aws-ec2/aws-ec2.js
+++ b/devops/actions/aws-ec2/aws-ec2.js
@@ -1,8 +1,6 @@
 const core   = require('@actions/core');
 const github = require('@actions/github');
-const AWS    = require('aws-sdk');
-
-const { EC2, waitUntilInstanceRunning } = require("@aws-sdk/client-ec2");
+const { EC2, waitUntilInstanceRunning } = require('@aws-sdk/client-ec2');
 
 // shortcut to reference current repo
 const repo = `${github.context.repo.owner}/${github.context.repo.repo}`;
@@ -221,15 +219,6 @@ async function stop(param_label) {
 
 (async function() {
   try {
-    // provide AWS credentials
-    // JS SDK v3 does not support global configuration.
-    // Codemod has attempted to pass values to each service client in this file.
-    // You may need to update clients outside of this file, if they use global config.
-    AWS.config.update({
-      accessKeyId:     core.getInput("AWS_ACCESS_KEY"),
-      secretAccessKey: core.getInput("AWS_SECRET_KEY"),
-      region:          core.getInput("aws-region")
-    });
     // mode is start or stop
     const mode = core.getInput("mode");
     const runs_on_list = core.getInput("runs-on-list") ? JSON.parse(core.getInput("runs-on-list")) : [];

--- a/devops/actions/aws-ec2/aws-ec2.js
+++ b/devops/actions/aws-ec2/aws-ec2.js
@@ -40,7 +40,6 @@ async function start(param_type, param_label, param_ami, param_spot, param_disk,
       accessKeyId:     core.getInput("AWS_ACCESS_KEY"),
       secretAccessKey: core.getInput("AWS_SECRET_KEY")
     },
-
     region:          core.getInput("aws-region")
   });
 
@@ -144,7 +143,6 @@ async function stop(param_label) {
       accessKeyId:     core.getInput("AWS_ACCESS_KEY"),
       secretAccessKey: core.getInput("AWS_SECRET_KEY")
     },
-
     region:          core.getInput("aws-region")
   });
 

--- a/devops/actions/aws-ec2/package.json
+++ b/devops/actions/aws-ec2/package.json
@@ -4,6 +4,6 @@
   "dependencies": {
     "@actions/core": "1.10.0",
     "@actions/github": "5.0.3",
-    "aws-sdk": "2.1179.0"
+    "@aws-sdk/client-ec2": "3.451.0"
   }
 }


### PR DESCRIPTION
From AWS SDK for JavaScript v2 [README](https://github.com/aws/aws-sdk-js):
> We are formalizing our plans to make the Maintenance Announcement (Phase 2) for AWS SDK for JavaScript v2 in 2023.

This PR migrates AWS SDK for JavaScript v2 APIs to v3 using [aws-sdk-js-codemod](https://www.npmjs.com/package/aws-sdk-js-codemod).

```console
$ npx aws-sdk-js-codemod@0.28.2 -t v2-to-v3 devops/actions/**/*.js
```