### PR TITLE
[SYCL][NFC] Don't output file to source tree in lb_sm_90 test

### DIFF
--- a/clang/test/SemaSYCL/lb_sm_90.cpp
+++ b/clang/test/SemaSYCL/lb_sm_90.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -fsyntax-only -Wno-c++23-extensions -verify -S
+// RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -fsyntax-only -Wno-c++23-extensions -verify -S -o %t
 
 // Maximum work groups per multi-processor, mapped to maxclusterrank PTX
 // directive, is an SM_90 feature. Attributes need to be used in sequence:


### PR DESCRIPTION
The current test will leave a temp file lb_sm_90.s in the source tree,
this will cause UNRESOLVED test in incremental builds.
