### PR TITLE
[SYCL] fix a behavior mismatch in ann_ptr operator

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -583,10 +583,10 @@ Does not rebind the reference!
 a|
 [source,c++]
 ----
-T operatorOP=(const T &);
+T operatorOP(const T &);
 ----
 a|
-Where [code]#OP# is: [code]#pass:[+]#, [code]#-#,[code]#*#, [code]#/#, [code]#%#, [code]#+<<+#, [code]#>>#, [code]#&#, [code]#\|#, [code]#^#.
+Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#\|=#, [code]#^=#.
 
 Compound assignment operators. Return result by value.
 Available only if the corresponding non-compound operator is available for `T`.
@@ -594,7 +594,7 @@ Equivalent to:
 ```c++
 T tmp = *this;     // Reads from memory
                    // with annotations
-tmp OP= val;
+tmp OP val;
 *this = tmp;       // Writes to memory
                    // with annotations
 return tmp;

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -526,8 +526,8 @@ class annotated_ref {
     operator T() const;
     T operator=(const T &) const;
     T operator=(const annotated_ref&) const;
-    // OP is: +, -, *, /, %, <<, >>, &, |, ^
-    T operatorOP=(const T &) const;
+    // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
+    T operatorOP(const T &) const;
     T operator++() const;
     T operator++(int) const;
     T operator--() const;
@@ -603,14 +603,16 @@ return tmp;
 a|
 [source,c++]
 ----
-T operator++();
-T operator++(int);
-T operator--();
-T operator--(int);
+T operator++() const;
+T operator++(int) const;
+T operator--() const;
+T operator--(int) const;
 ----
 |
-increment and decrement operator of annotated_ref. The annotations are applied
-when the object `T` is loaded and stored to the memory.
+Increment and decrement operator of annotated_ref. Increment/Decrement the object `T`
+referenced by this wrapper via `T`'s Increment/Decrement operator.
+
+The annotations are applied when the object `T` is loaded and stored to the memory.
 |===
 
 == Issues related to `annotated_ptr`

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -526,12 +526,12 @@ class annotated_ref {
     operator T() const;
     T operator=(const T &) const;
     T operator=(const annotated_ref&) const;
-    // OP is: +=, -=, *=, /=, %=, <<=, >>=, &=, |=, ^=
-    T operatorOP(const T &) const;
-    T operator++();
-    T operator++(int);
-    T operator--();
-    T operator--(int);
+    // OP is: +, -, *, /, %, <<, >>, &, |, ^
+    T operatorOP=(const T &) const;
+    T operator++() const;
+    T operator++(int) const;
+    T operator--() const;
+    T operator--(int) const;
   };
 } // namespace sycl::ext::oneapi::experimental
 ```
@@ -583,10 +583,10 @@ Does not rebind the reference!
 a|
 [source,c++]
 ----
-T operatorOP(const T &);
+T operatorOP=(const T &);
 ----
 a|
-Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#\|=#, [code]#^=#.
+Where [code]#OP# is: [code]#pass:[+]#, [code]#-#,[code]#*#, [code]#/#, [code]#%#, [code]#+<<+#, [code]#>>#, [code]#&#, [code]#\|#, [code]#^#.
 
 Compound assignment operators. Return result by value.
 Available only if the corresponding non-compound operator is available for `T`.
@@ -594,7 +594,7 @@ Equivalent to:
 ```c++
 T tmp = *this;     // Reads from memory
                    // with annotations
-tmp = tmp OP val;
+tmp OP= val;
 *this = tmp;       // Writes to memory
                    // with annotations
 return tmp;

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -556,7 +556,7 @@ annotations when the object is loaded from memory.
 a|
 [source,c++]
 ----
-T operator=(const T &);
+T operator=(const T &) const;
 ----
 |
 Writes an object of type `T` to the location referenced by this wrapper,
@@ -566,14 +566,14 @@ applying the annotations when the object is stored to memory.
 a|
 [source,c++]
 ----
-T operator=(const annotated_ref& other);
+T operator=(const annotated_ref& other) const;
 ----
 a|
 Equivalent to:
 ```c++
-tmp T = other;   // Reads from memory
+T tmp = other;   // Reads from memory
                  // with annotations
-*this = T;       // Writes to memory
+*this = tmp;     // Writes to memory
                  // with annotations
 return T;
 ```
@@ -583,13 +583,13 @@ Does not rebind the reference!
 a|
 [source,c++]
 ----
-T operatorOP(const T &);
+T operatorOP(const T &) const;
 ----
 a|
 Where [code]#OP# is: [code]#pass:[+=]#, [code]#-=#,[code]#*=#, [code]#/=#, [code]#%=#, [code]#+<<=+#, [code]#>>=#, [code]#&=#, [code]#\|=#, [code]#^=#.
 
 Compound assignment operators. Return result by value.
-Available only if the corresponding non-compound operator is available for `T`.
+Available only if the corresponding assignment operator OP is available for `T`.
 Equivalent to:
 ```c++
 T tmp = *this;     // Reads from memory
@@ -610,7 +610,7 @@ T operator--(int) const;
 ----
 |
 Increment and decrement operator of annotated_ref. Increment/Decrement the object `T`
-referenced by this wrapper via `T`'s Increment/Decrement operator.
+referenced by this wrapper via ``T``'s Increment/Decrement operator.
 
 The annotations are applied when the object `T` is loaded and stored to the memory.
 |===

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -32,7 +32,12 @@ namespace experimental {
 
 namespace {
 #define PROPAGATE_OP(op)                                                       \
-  T operator op##=(const T &rhs) const { return *this = *this op rhs; }
+  T operator op##=(const T &rhs) const {                                       \
+    T t = *this;                                                               \
+    t op## = rhs;                                                              \
+    *this = t;                                                                 \
+    return t;                                                                  \
+  }
 
 // compare strings on compile time
 constexpr bool compareStrs(const char *Str1, const char *Str2) {
@@ -114,20 +119,34 @@ public:
   PROPAGATE_OP(<<)
   PROPAGATE_OP(>>)
 
-  T operator++() { return *this += 1; }
-
-  T operator++(int) {
-    const T t = *this;
-    *this = (t + 1);
+  T operator++() const {
+    T t = *this;
+    ++t;
+    *this = t;
     return t;
   }
 
-  T operator--() { return *this -= 1; }
+  T operator++(int) const {
+    T t1 = *this;
+    T t2 = t1;
+    t2++;
+    *this = t2;
+    return t1;
+  }
 
-  T operator--(int) {
-    const T t = *this;
-    *this = (t - 1);
+  T operator--() const {
+    T t = *this;
+    --t;
+    *this = t;
     return t;
+  }
+
+  T operator--(int) const {
+    T t1 = *this;
+    T t2 = t1;
+    t2--;
+    *this = t2;
+    return t1;
   }
 
   template <class T2, class P2> friend class annotated_ptr;


### PR DESCRIPTION
Fixed two issues:
1. For compound operators, there is an error in the specs. The `tmp = tmp Op rhs` statement is wrong since Op is defined as `+=` and for `+=` it will be `tmp = tmp += rhs`.  Correct the format
2. For compound operators and inc/dec operators, the old implementation is using the non-compound operator which is wrong.
i.e. If T is a customer type with only `+=` operator being defined,  when applying `+=` on `annotated_ref<T>`, the previous implementation errors out since there is no `+` defined in T.
3. Added the missing `const` to inc/dec operators