### PR TITLE
 [SYCL] Extend global offset intrinsic removal

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -12,6 +12,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/SYCLLowerIR/TargetHelpers.h"
+#include "llvm/Transforms/Utils/Cloning.h"  
 
 namespace llvm {
 
@@ -84,11 +85,10 @@ private:
   /// pointer to the implicit argument (either a func argument or a bitcast
   /// turning it to the correct type) and a pointer to the copy of the provided
   /// CallInst inside the new function.
-  std::tuple<Function *, Value *, CallInst *>
+  std::pair<Function *, Value *>
   addOffsetArgumentToFunction(Module &M, Function *Func,
                               Type *ImplicitArgumentType = nullptr,
-                              bool KeepOriginal = false,
-                              CallInst *CI = nullptr);
+                              bool KeepOriginal = false);
 
   /// Create a mapping of kernel entry points to their metadata nodes. While
   /// iterating over kernels make sure that a given kernel entry point has no
@@ -105,7 +105,9 @@ private:
 private:
   // Keep track of all non offset functions that have already been cloned
   // to avoid processing them
-  llvm::SmallPtrSet<Function *, 8> ClonedNonOffsetFunctions;
+  llvm::SmallPtrSet<Function *, 8> Clones;
+
+  llvm::ValueToValueMapTy GlobalVMap;
   /// Keep track of which functions have been processed to avoid processing
   /// twice.
   llvm::DenseMap<Function *, Value *> ProcessedFunctions;

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -43,34 +43,34 @@ private:
   /// \param Func Kernel to be processed.
   void processKernelEntryPoint(Function *Func);
 
-  /// This function adds an implicit parameter to the function containing a
-  /// call instruction to the implicit offset intrinsic or another function
-  /// (which eventually calls the instrinsic). If the call instruction is to
-  /// the implicit offset intrinsic, then the intrinisic is replaced with the
-  /// parameter that was added.
+  /// For a function containing a call instruction to the implicit offset
+  /// intrinsic or another function which eventually calls the intrinsic,
+  /// this function clones the function and adds an implicit parameter to the
+  /// clone.
+  /// If the call instruction is to the implicit offset intrinsic then the
+  /// intrinsic inside the cloned function is replaced with the parameter that
+  /// was added.
   ///
-  /// Once the function, say `F`, containing a call to `Callee` has the
-  /// implicit parameter added, callers of `F` are processed by recursively
-  /// calling this function, passing `F` to `CalleeWithImplicitParam`.
-  ///
-  /// Since the cloning of entry points may alter the users of a function, the
-  /// cloning must be done as early as possible, as to ensure that no users are
-  /// added to previous callees in the call-tree.
+  /// Once the clone of a function, say `F`, containing a call to `Callee`
+  /// has the implicit parameter added, callers of `F` are processed by
+  /// getting cloned and their clones are processed by recursively calling the
+  /// clone of 'F', passing `F` to `CalleeWithImplicitParam`.
   ///
   /// \param Callee is the function (to which this transformation has already
   /// been applied), or to the implicit offset intrinsic.
   ///
   /// \param CalleeWithImplicitParam indicates whether Callee is to the
   /// implicit intrinsic (when `nullptr`) or to another function (not
-  /// `nullptr`) - this is used to know whether calls to it needs to have the
-  /// implicit parameter added to it or replaced with the implicit parameter.
+  /// `nullptr`) - this is used to know whether calls to it inside clones need
+  /// to have the implicit parameter added to it or be replaced with the
+  /// implicit  parameter.
   void addImplicitParameterToCallers(Module &M, Value *Callee,
                                      Function *CalleeWithImplicitParam);
 
-  /// For a given function `Func` extend signature to contain an implicit
-  /// offset argument.
+  /// For a given function `Func` create a clone and extend its signature to
+  /// contain an implicit offset argument.
   ///
-  /// \param Func A function to add offset to.
+  /// \param Func A function to be cloned and add offset to.
   ///
   /// \param ImplicitArgumentType Architecture dependant type of the implicit
   /// argument holding the global offset.
@@ -81,17 +81,13 @@ private:
   ///
   /// \param IsKernel Indicates whether Func is a kernel entry point.
   ///
-  /// \param CI A pointer to a CallInstruction in the old function.
-  ///
-  /// \returns A tuple of new function with the offset argument added, a
+  /// \returns A pair of the new function with the offset argument added, a
   /// pointer to the implicit argument (either a func argument or a bitcast
-  /// turning it to the correct type) and a pointer to the copy of the provided
-  /// CallInst inside the new function.
+  /// turning it to the correct type).
   std::pair<Function *, Value *>
   addOffsetArgumentToFunction(Module &M, Function *Func,
                               Type *ImplicitArgumentType = nullptr,
-                              bool KeepOriginal = false,
-                              bool IsKernel = false);
+                              bool KeepOriginal = false, bool IsKernel = false);
 
   /// Create a mapping of kernel entry points to their metadata nodes. While
   /// iterating over kernels make sure that a given kernel entry point has no
@@ -106,13 +102,12 @@ private:
                           SmallVectorImpl<KernelPayload> &KernelPayloads);
 
 private:
-  // Keep track of all non offset functions that have already been cloned
-  // to avoid processing them
+  /// Keep track of all cloned offset functions to avoid processing them.
   llvm::SmallPtrSet<Function *, 8> Clones;
-
+  /// Save clone mappings to obtain pointers to CallInsts during processing.
   llvm::ValueToValueMapTy GlobalVMap;
-  /// Keep track of which functions have been processed to avoid processing
-  /// twice.
+  /// Keep track of which non-offset functions have been processed to avoid
+  /// processing twice.
   llvm::DenseMap<Function *, Value *> ProcessedFunctions;
   /// Keep a map of all entry point functions with metadata.
   llvm::DenseMap<Function *, MDNode *> EntryPointMetadata;

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -79,6 +79,8 @@ private:
   /// keep it intact and create a clone of it with `_wit_offset` appended to
   /// the name.
   ///
+  /// \param IsKernel Indicates whether Func is a kernel entry point.
+  ///
   /// \param CI A pointer to a CallInstruction in the old function.
   ///
   /// \returns A tuple of new function with the offset argument added, a
@@ -88,7 +90,8 @@ private:
   std::pair<Function *, Value *>
   addOffsetArgumentToFunction(Module &M, Function *Func,
                               Type *ImplicitArgumentType = nullptr,
-                              bool KeepOriginal = false);
+                              bool KeepOriginal = false,
+                              bool IsKernel = false);
 
   /// Create a mapping of kernel entry points to their metadata nodes. While
   /// iterating over kernels make sure that a given kernel entry point has no

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -81,13 +81,17 @@ private:
   /// keep it intact and create a clone of it with `_wit_offset` appended to
   /// the name.
   ///
-  /// \returns A pair of new function with the offset argument added and a
+  /// \param CI A pointer to a CallInstruction in the old function.
+  ///
+  /// \returns A tuple of new function with the offset argument added, a
   /// pointer to the implicit argument (either a func argument or a bitcast
-  /// turning it to the correct type).
-  std::pair<Function *, Value *>
+  /// turning it to the correct type) and a pointer to the copy of the provided
+  /// CallInst inside the new function.
+  std::tuple<Function *, Value *, CallInst *>
   addOffsetArgumentToFunction(Module &M, Function *Func,
                               Type *ImplicitArgumentType = nullptr,
-                              bool KeepOriginal = false);
+                              bool KeepOriginal = false,
+                              CallInst *CI = nullptr);
 
   /// Create a mapping of kernel entry points to their metadata nodes. While
   /// iterating over kernels make sure that a given kernel entry point has no
@@ -102,6 +106,9 @@ private:
                           SmallVectorImpl<KernelPayload> &KernelPayloads);
 
 private:
+  // Keep track of all non offset functions that have already been cloned
+  // to avoid processing them
+  llvm::SmallPtrSet<Function *, 8> ClonedNonOffsetFunctions;
   /// Keep track of which functions have been processed to avoid processing
   /// twice.
   llvm::DenseMap<Function *, Value *> ProcessedFunctions;

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -38,9 +38,6 @@ private:
   /// `Func` belongs, contains both the original function and its clone with the
   /// signature extended with the implicit offset parameter and `_with_offset`
   /// appended to the name.
-  /// An alloca of 3 zeros (corresponding to offsets in x, y and z) is added to
-  /// the original kernel, in order to keep the interface of kernel's call
-  /// graph unified, regardless of the fact if the global offset has been used.
   ///
   /// \param Func Kernel to be processed.
   void processKernelEntryPoint(Function *Func);

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -12,7 +12,7 @@
 #include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/SYCLLowerIR/TargetHelpers.h"
-#include "llvm/Transforms/Utils/Cloning.h"  
+#include "llvm/Transforms/Utils/Cloning.h"
 
 namespace llvm {
 

--- a/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
+++ b/llvm/include/llvm/SYCLLowerIR/GlobalOffset.h
@@ -44,7 +44,7 @@ private:
   void processKernelEntryPoint(Function *Func);
 
   /// For a function containing a call instruction to the implicit offset
-  /// intrinsic or another function which eventually calls the intrinsic,
+  /// intrinsic, or another function which eventually calls the intrinsic,
   /// this function clones the function and adds an implicit parameter to the
   /// clone.
   /// If the call instruction is to the implicit offset intrinsic then the

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -309,8 +309,8 @@ std::pair<Function *, Value *> GlobalOffsetPass::addOffsetArgumentToFunction(
     // In order to keep the signatures of functions called by the kernel
     // unified, the pass has to copy global offset to an array allocated in
     // addrspace(3). This is done as kernels can't allocate and fill the
-    // array in constant address space, which would be required for the case
-    // with no global offset.
+    // array in constant address space.
+    // Not required any longer, but left due to deprecatedness.
     if (IsKernel && AT == ArchType::AMDHSA) {
       BasicBlock *EntryBlock = &NewFunc->getEntryBlock();
       IRBuilder<> Builder(EntryBlock, EntryBlock->getFirstInsertionPt());

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -158,10 +158,9 @@ void GlobalOffsetPass::processKernelEntryPoint(Function *Func) {
   auto *KernelMetadata = M.getNamedMetadata(getAnnotationString(AT).c_str());
   assert(KernelMetadata && "IR compiled must have correct annotations");
 
-  auto *NewFunc = addOffsetArgumentToFunction(
+  auto *NewFunc = std::get<0>(addOffsetArgumentToFunction(
                       M, Func, KernelImplicitArgumentType->getPointerTo(),
-                      /*KeepOriginal=*/true)
-                      .first;
+                      /*KeepOriginal=*/true));
   Argument *NewArgument = std::prev(NewFunc->arg_end());
 
   ClonedNonOffsetFunctions.insert(Func);

--- a/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
+++ b/llvm/lib/SYCLLowerIR/GlobalOffset.cpp
@@ -192,14 +192,12 @@ void GlobalOffsetPass::addImplicitParameterToCallers(
 
     // Only original function uses are considered.
     // Clones are processed through a global VMap.
-    if (Clones.contains(Caller)) {
+    if (Clones.contains(Caller))
       continue;
-    }
 
     // Kernel entry points need additional processing and change Metdadata.
-    if (EntryPointMetadata.count(Caller) != 0) {
+    if (EntryPointMetadata.count(Caller) != 0)
       processKernelEntryPoint(Caller);
-    }
 
     // Determine if `Caller` needs to be processed or if this is
     // another callsite from a non-offset function
@@ -212,7 +210,8 @@ void GlobalOffsetPass::addImplicitParameterToCallers(
       NewFunc = Caller;
     } else {
       std::tie(NewFunc, ImplicitOffset) =
-          addOffsetArgumentToFunction(M, Caller, nullptr,
+          addOffsetArgumentToFunction(M, Caller,
+                                      /*KernelImplicitArgumentType*/ nullptr,
                                       /*KeepOriginal=*/true);
     }
     CallToOld = cast<CallInst>(GlobalVMap[CallToOld]);

--- a/llvm/test/CodeGen/AMDGPU/global-offset-dbg.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-dbg.ll
@@ -11,7 +11,7 @@ declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: llvm.amdgcn.implicit.offset
 
 define weak_odr dso_local i64 @_ZTS14other_function() !dbg !11 {
-; CHECK: define weak_odr dso_local i64 @_ZTS14other_function(ptr addrspace(5) %0) !dbg !11 {
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function() !dbg !11 {
   %1 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
   %2 = getelementptr inbounds i32, ptr addrspace(5) %1, i64 2
   %3 = load i32, ptr addrspace(5) %2, align 4
@@ -19,20 +19,19 @@ define weak_odr dso_local i64 @_ZTS14other_function() !dbg !11 {
   ret i64 %4
 }
 
+; CHECK:  weak_odr dso_local i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0) !dbg !14 {
+
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS14example_kernel() !dbg !14 {
-; CHECK: define weak_odr dso_local void @_ZTS14example_kernel() !dbg !14 {
+; CHECK: define weak_odr dso_local void @_ZTS14example_kernel() !dbg !15 {
 entry:
   %0 = call i64 @_ZTS14other_function(), !dbg !15
-; CHECK: %2 = call i64 @_ZTS14other_function(ptr addrspace(5) %1), !dbg !15
+; CHECK: %0 = call i64 @_ZTS14other_function(), !dbg !16
   ret void
 }
 
-; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byref([3 x i32]) %0) !dbg !16 {
-; CHECK:  %1 = alloca [3 x i32], align 4, addrspace(5), !dbg !17
-; CHECK:  %2 = addrspacecast ptr %0 to ptr addrspace(4), !dbg !17
-; CHECK:  call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false), !dbg !17
-; CHECK:  %3 = call i64 @_ZTS14other_function(ptr addrspace(5) %1), !dbg !17
+; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byval([3 x i32]) %0) !dbg !17 {
+; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0), !dbg !18
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}
@@ -53,5 +52,8 @@ entry:
 !13 = !{null}
 !14 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !15 = !DILocation(line: 1, column: 2, scope: !14)
-; CHECK: !16 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-; CHECK: !17 = !DILocation(line: 1, column: 2, scope: !16)
+; CHECK: !14 = distinct !DISubprogram(name: "other_function", scope: !1, file: !1, line: 3, type: !12, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2) 
+; CHECK: !15 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+; CHECK: !16 = !DILocation(line: 1, column: 2, scope: !15)
+; CHECK: !17 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+; CHECK: !18 = !DILocation(line: 1, column: 2, scope: !17)

--- a/llvm/test/CodeGen/AMDGPU/global-offset-dbg.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-dbg.ll
@@ -30,8 +30,8 @@ entry:
   ret void
 }
 
-; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byval([3 x i32]) %0) !dbg !17 {
-; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0), !dbg !18
+; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byref([3 x i32]) %0) !dbg !17 {
+; CHECK: call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %1), !dbg !18
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}

--- a/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
@@ -60,7 +60,10 @@ entry:
 
 ; CHECK: define weak_odr dso_local void @_ZTS12some_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14mixed_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
+; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
+; CHECK:   %3 = call i64 @_ZTS14mixed_function_with_offset(ptr addrspace(5) %1)
 ; CHECK:   ret void
 ; CHECK: }
 

--- a/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
@@ -1,0 +1,75 @@
+; RUN: opt -bugpoint-enable-legacy-pm -globaloffset %s -S -o - | FileCheck %s
+; ModuleID = 'intrinsic-function-mix.bc'
+source_filename = "global-offset-intrinsic-function-mix.ll"
+
+target datalayout =
+"e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-v2048:2048-n32:64-S32-A5-G1-ni:7"
+target triple = "amdgcn-amd-amdhsa"
+
+; This test checks that the pass works with functions containing calls to the
+; intrinsic and calls to function functions that call the intrinsic
+
+declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+; CHECK-NOT: llvm.amdgcn.implicit.offset
+
+define weak_odr dso_local i64 @_ZTS15other_function() {
+; CHECK: define weak_odr dso_local i64 @_ZTS15other_function() {
+  %1 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+; CHECK-NOT: tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+  %2 = getelementptr inbounds i32, ptr addrspace(5) %1, i64 2
+  %3 = load i32, ptr addrspace(5) %2, align 4
+  %4 = zext i32 %3 to i64
+; CHECK: %1 = zext i32 0 to i64
+  ret i64 %4
+}
+
+; CHECK: define weak_odr dso_local i64 @_ZTS15other_function_with_offset(ptr addrspace(5) %0) {  
+; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: %3 = load i32, ptr addrspace(5) %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
+
+define weak_odr dso_local i64 @_ZTS14mixed_function() {
+; CHECK: define weak_odr dso_local i64 @_ZTS14mixed_function() {
+  %1 = call i64 @_ZTS15other_function()
+; CHECK: %1 = call i64 @_ZTS15other_function()
+  %2 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+; CHECK-NOT: tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+  %3 = getelementptr inbounds i32, ptr addrspace(5) %2, i64 2
+  %4 = load i32, ptr addrspace(5) %3, align 4
+  %5 = zext i32 %4 to i64
+; CHECK: %2 = zext i32 0 to i64
+  ret i64 %1
+}
+
+; CHECK: define weak_odr dso_local i64 @_ZTS14mixed_function_with_offset(ptr addrspace(5) %0) {
+; CHECK: %2 = call i64 @_ZTS15other_function_with_offset(ptr addrspace(5) %0)
+; CHECK: %3 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: %4 = load i32, ptr addrspace(5) %3, align 4
+; CHECK: %5 = zext i32 %4 to i64
+; CHECK: ret i64 %2
+
+; Function Attrs: noinline
+define weak_odr dso_local void @_ZTS12some_kernel() {
+entry:
+  %0 = call i64 @_ZTS14mixed_function()
+; CHECK: %0 = call i64 @_ZTS14mixed_function()
+  ret void
+}
+
+; CHECK: define weak_odr dso_local void @_ZTS12some_kernel_with_offset(ptr byref([3 x i32]) %0) {
+; CHECK: entry:
+; CHECK:   %1 = call i64 @_ZTS14mixed_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   ret void
+; CHECK: }
+
+!amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5}
+
+!0 = distinct !{ptr @_ZTS12some_kernel, !"kernel", i32 1}
+!1 = !{null, !"align", i32 8}
+!2 = !{null, !"align", i32 8, !"align", i32 65544, !"align", i32 131080}
+!3 = !{null, !"align", i32 16}
+!4 = !{null, !"align", i32 16, !"align", i32 65552, !"align", i32 131088}
+!5 = !{i32 1, i32 4}
+; CHECK: !6 = !{ptr @_ZTS12some_kernel_with_offset, !"kernel", i32 1}

--- a/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
@@ -7,7 +7,7 @@ target datalayout =
 target triple = "amdgcn-amd-amdhsa"
 
 ; This test checks that the pass works with functions containing calls to the
-; intrinsic and calls to function functions that call the intrinsic
+; intrinsic and calls to other functions that call the intrinsic
 
 declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: llvm.amdgcn.implicit.offset

--- a/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-intrinsic-function-mix.ll
@@ -23,7 +23,7 @@ define weak_odr dso_local i64 @_ZTS15other_function() {
   ret i64 %4
 }
 
-; CHECK: define weak_odr dso_local i64 @_ZTS15other_function_with_offset(ptr addrspace(5) %0) {  
+; CHECK: define weak_odr dso_local i64 @_ZTS15other_function_with_offset(ptr addrspace(5) %0) {
 ; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
 ; CHECK: %3 = load i32, ptr addrspace(5) %2, align 4
 ; CHECK: %4 = zext i32 %3 to i64

--- a/llvm/test/CodeGen/AMDGPU/global-offset-multiple-calls-from-one-function.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-multiple-calls-from-one-function.ll
@@ -6,56 +6,60 @@ target datalayout = "e-p:64:64-p1:64:64-p2:32:32-p3:32:32-p4:64:64-p5:32:32-p6:3
 target triple = "amdgcn-amd-amdhsa"
 
 ; This test checks that when there are multiple calls to a function that uses
-; the intrinsic that the caller and the callee only have a single clone each
-; with the offset parameter. It also checks that the clone with multiple calls
-; to other functions that has a variant that takes an offset parameter will have
+; the intrinsic that the caller and the callee have two clones each - one with
+; the offset parameter and one without. It also checks that a clone with
+; multiple calls to other functions that have a clone as well will have
 ; all calls redirected to the corresponding variants.
 
 declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 
 define weak_odr dso_local i64 @_ZTS14other_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS14other_function(ptr addrspace(5) %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function() {
   %1 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: tail call ptr addrspace(5)* @llvm.amdgcn.implicit.offset()
   %2 = getelementptr inbounds i32, ptr addrspace(5) %1, i64 2
-; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
   %3 = load i32, ptr addrspace(5) %2, align 4
   %4 = zext i32 %3 to i64
+; CHECK %1 = zext i32 0 to i64
 
   %5 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: tail call ptr addrspace(5)* @llvm.amdgcn.implicit.offset()
   %6 = getelementptr inbounds i32, ptr addrspace(5) %5, i64 2
-; CHECK: %5 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
   %7 = load i32, ptr addrspace(5) %6, align 4
   %8 = zext i32 %7 to i64
+; CHECK: %2 = zext i32 0 to i64
 
   ret i64 %4
+; CHECK: ret i64 %1
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0) {
+; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: %3 = load i32, ptr addrspace(5) %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: %5 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: %6 = load i32, ptr addrspace(5) %5, align 4
+; CHECK: %7 = zext i32 %6 to i64
+; CHECK: ret i64 %4
+; CHECK: }
 
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS14example_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4, addrspace(5)
-; CHECK: call void @llvm.memset.p5.i64(ptr addrspace(5) nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr addrspace(5) %0, i32 0, i32 0
   %0 = call i64 @_ZTS14other_function()
-; CHECK: %2 = call i64 @_ZTS14other_function(ptr addrspace(5) %1)
+; CHECK: %0 = call i64 @_ZTS14other_function()
   %1 = call i64 @_ZTS14other_function()
-; CHECK: %3 = call i64 @_ZTS14other_function(ptr addrspace(5) %1)
+; CHECK: %1 = call i64 @_ZTS14other_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
-; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
-; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
-; CHECK:   %3 = call i64 @_ZTS14other_function(ptr addrspace(5) %1)
-; CHECK:   %4 = call i64 @_ZTS14other_function(ptr addrspace(5) %1)
+; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   %2 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0)
 ; CHECK:   ret void
 ; CHECK: }
-
 !amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3}
 ; CHECK: !amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5}
 

--- a/llvm/test/CodeGen/AMDGPU/global-offset-multiple-calls-from-one-function.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-multiple-calls-from-one-function.ll
@@ -56,10 +56,14 @@ entry:
 
 ; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0)
-; CHECK:   %2 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
+; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
+; CHECK:   %3 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %1)
+; CHECK:   %4 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %1)
 ; CHECK:   ret void
 ; CHECK: }
+
 !amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3}
 ; CHECK: !amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5}
 

--- a/llvm/test/CodeGen/AMDGPU/global-offset-multiple-entry-points.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-multiple-entry-points.ll
@@ -57,9 +57,13 @@ entry:
 
 ; CHECK: define weak_odr dso_local void @_ZTS12first_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14first_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
+; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
+; CHECK:   %3 = call i64 @_ZTS14first_function_with_offset(ptr addrspace(5) %1)
 ; CHECK:   ret void
 ; CHECK: }
+
 
 define weak_odr dso_local i64 @_ZTS15second_function() {
 ; CHECK: define weak_odr dso_local i64 @_ZTS15second_function() {
@@ -82,7 +86,10 @@ entry:
 
 ; CHECK: define weak_odr dso_local void @_ZTS13second_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS15second_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
+; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
+; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
+; CHECK:   %3 = call i64 @_ZTS15second_function_with_offset(ptr addrspace(5) %1)
 ; CHECK:   ret void
 ; CHECK: }
 

--- a/llvm/test/CodeGen/AMDGPU/global-offset-multiple-entry-points.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-multiple-entry-points.ll
@@ -64,7 +64,6 @@ entry:
 ; CHECK:   ret void
 ; CHECK: }
 
-
 define weak_odr dso_local i64 @_ZTS15second_function() {
 ; CHECK: define weak_odr dso_local i64 @_ZTS15second_function() {
   %1 = call i64 @_ZTS15common_function()

--- a/llvm/test/CodeGen/AMDGPU/global-offset-multiple-entry-points.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-multiple-entry-points.ll
@@ -19,81 +19,91 @@ entry:
 }
 
 define weak_odr dso_local i64 @_ZTS15common_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS15common_function(ptr addrspace(5) %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS15common_function() {
   %1 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
-; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
   %2 = getelementptr inbounds i32, ptr addrspace(5) %1, i64 2
   %3 = load i32, ptr addrspace(5) %2, align 4
   %4 = zext i32 %3 to i64
+; CHECK: %1 = zext i32 0 to i64
   ret i64 %4
 }
 
+; CHECK: define weak_odr dso_local i64 @_ZTS15common_function_with_offset(ptr addrspace(5) %0) {  
+; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: %3 = load i32, ptr addrspace(5) %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
+
 define weak_odr dso_local i64 @_ZTS14first_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS14first_function(ptr addrspace(5) %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS14first_function() {
   %1 = call i64 @_ZTS15common_function()
-; CHECK: %2 = call i64 @_ZTS15common_function(ptr addrspace(5) %0)
+; CHECK: %1 = call i64 @_ZTS15common_function()
   ret i64 %1
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS14first_function_with_offset(ptr addrspace(5) %0) {
+; CHECK: %2 = call i64 @_ZTS15common_function_with_offset(ptr addrspace(5) %0)
+; CHECK: ret i64 %2
 
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS12first_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4
-; CHECK: call void @llvm.memset.p5.i64(ptr addrspace(5) nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr addrspace(5) %0, i32 0, i32 0
   %0 = call i64 @_ZTS14first_function()
-; CHECK: %2 = call i64 @_ZTS14first_function(ptr addrspace(5) %1)
+; CHECK: %0 = call i64 @_ZTS14first_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS12first_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
-; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
-; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
-; CHECK:   %3 = call i64 @_ZTS14first_function(ptr addrspace(5) %1)
+; CHECK:   %1 = call i64 @_ZTS14first_function_with_offset(ptr addrspace(5) %0)
 ; CHECK:   ret void
 ; CHECK: }
 
 define weak_odr dso_local i64 @_ZTS15second_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS15second_function(ptr addrspace(5) %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS15second_function() {
   %1 = call i64 @_ZTS15common_function()
-; CHECK: %2 = call i64 @_ZTS15common_function(ptr addrspace(5) %0)
+; CHECK: %1 = call i64 @_ZTS15common_function()
   ret i64 %1
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS15second_function_with_offset(ptr addrspace(5) %0) { 
+; CHECK: %2 = call i64 @_ZTS15common_function_with_offset(ptr addrspace(5) %0)
+; CHECK: ret i64 %2
 
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS13second_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4
-; CHECK: call void @llvm.memset.p5.i64(ptr addrspace(5) nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr addrspace(5) %0, i32 0, i32 0
   %0 = call i64 @_ZTS15second_function()
-; CHECK: %2 = call i64 @_ZTS15second_function(ptr addrspace(5) %1)
+; CHECK: %0 = call i64 @_ZTS15second_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS13second_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
-; CHECK:   %2 = addrspacecast ptr %0 to ptr addrspace(4)
-; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
-; CHECK:   %3 = call i64 @_ZTS15second_function(ptr addrspace(5) %1)
+; CHECK:   %1 = call i64 @_ZTS15second_function_with_offset(ptr addrspace(5) %0)
 ; CHECK:   ret void
 ; CHECK: }
 
 ; This function doesn't get called by a kernel entry point.
 define weak_odr dso_local i64 @_ZTS15no_entry_point() {
-; CHECK: define weak_odr dso_local i64 @_ZTS15no_entry_point(ptr addrspace(5) %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS15no_entry_point() {
   %1 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
   %2 = getelementptr inbounds i32, ptr addrspace(5) %1, i64 2
-; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
   %3 = load i32, ptr addrspace(5) %2, align 4
   %4 = zext i32 %3 to i64
+; CHECK: %1 = zext i32 0 to i64
   ret i64 %4
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS15no_entry_point_with_offset(ptr addrspace(5) %0) {
+; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5)  %0, i64 2
+; CHECK: %3 = load i32, ptr addrspace(5) %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
 
 !amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5, !6}
 ; CHECK: !amdgcn.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5, !6, !7, !8}

--- a/llvm/test/CodeGen/AMDGPU/global-offset-simple.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-simple.ll
@@ -38,7 +38,9 @@ entry:
 
 ; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0)
+; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
+; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
+; CHECK:   %3 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %1)
 ; CHECK:   ret void
 ; CHECK: }
 

--- a/llvm/test/CodeGen/AMDGPU/global-offset-simple.ll
+++ b/llvm/test/CodeGen/AMDGPU/global-offset-simple.ll
@@ -11,8 +11,7 @@ declare ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: llvm.amdgcn.implicit.offset
 
 define weak_odr dso_local i64 @_ZTS14other_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS14other_function(ptr addrspace(5) %0) {
-; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function() {
   %1 = tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
 ; CHECK-NOT: tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
   %2 = getelementptr inbounds i32, ptr addrspace(5) %1, i64 2
@@ -21,22 +20,25 @@ define weak_odr dso_local i64 @_ZTS14other_function() {
   ret i64 %4
 }
 
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0) {
+; CHECK-NOT: tail call ptr addrspace(5) @llvm.amdgcn.implicit.offset()
+; CHECK: %2 = getelementptr inbounds i32, ptr addrspace(5) %0, i64 2
+; CHECK: %3 = load i32, ptr addrspace(5) %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
+
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS14example_kernel() {
 entry:
-; CHECK:   %0 = alloca [3 x i32], align 4, addrspace(5)
-; CHECK:   call void @llvm.memset.p5.i64(ptr addrspace(5) nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK:   %1 = getelementptr inbounds [3 x i32], ptr addrspace(5) %0, i32 0, i32 0
   %0 = call i64 @_ZTS14other_function()
-; CHECK:   %2 = call i64 @_ZTS14other_function(ptr addrspace(5) %1)
+; CHECK: %0 = call i64 @_ZTS14other_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byref([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = alloca [3 x i32], align 4, addrspace(5)
-; CHECK:   call void @llvm.memcpy.p5.p4.i64(ptr addrspace(5) align 4 %1, ptr addrspace(4) align 1 %2, i64 12, i1 false)
-; CHECK:   %3 = call i64 @_ZTS14other_function(ptr addrspace(5) %1)
+; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr addrspace(5) %0)
 ; CHECK:   ret void
 ; CHECK: }
 

--- a/llvm/test/CodeGen/NVPTX/global-offset-dbg.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-dbg.ll
@@ -10,7 +10,7 @@ declare ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: llvm.nvvm.implicit.offset
 
 define weak_odr dso_local i64 @_ZTS14other_function() !dbg !11 {
-; CHECK: define weak_odr dso_local i64 @_ZTS14other_function(ptr %0) !dbg !11 {
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function() !dbg !11 {
   %1 = tail call ptr @llvm.nvvm.implicit.offset()
   %2 = getelementptr inbounds i32, ptr %1, i64 2
   %3 = load i32, ptr %2, align 4
@@ -18,17 +18,19 @@ define weak_odr dso_local i64 @_ZTS14other_function() !dbg !11 {
   ret i64 %4
 }
 
+; CHECK:  weak_odr dso_local i64 @_ZTS14other_function_with_offset(ptr %0) !dbg !14 {
+
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS14example_kernel() !dbg !14 {
-; CHECK: define weak_odr dso_local void @_ZTS14example_kernel() !dbg !14 {
+; CHECK: define weak_odr dso_local void @_ZTS14example_kernel() !dbg !15 {
 entry:
   %0 = call i64 @_ZTS14other_function(), !dbg !15
-; CHECK: %2 = call i64 @_ZTS14other_function(ptr %1), !dbg !15
+; CHECK: %0 = call i64 @_ZTS14other_function(), !dbg !16
   ret void
 }
 
-; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byval([3 x i32]) %0) !dbg !16 {
-; CHECK:   %1 = call i64 @_ZTS14other_function(ptr %0), !dbg !17
+; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byval([3 x i32]) %0) !dbg !17 {
+; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr %0), !dbg !18
 
 !llvm.dbg.cu = !{!0}
 !llvm.module.flags = !{!3, !4}
@@ -50,5 +52,8 @@ entry:
 !13 = !{null}
 !14 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
 !15 = !DILocation(line: 1, column: 2, scope: !14)
-; CHECK: !16 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
-; CHECK: !17 = !DILocation(line: 1, column: 2, scope: !16)
+; CHECK: !14 = distinct !DISubprogram(name: "other_function", scope: !1, file: !1, line: 3, type: !12, scopeLine: 3, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2) 
+; CHECK: !15 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+; CHECK: !16 = !DILocation(line: 1, column: 2, scope: !15)
+; CHECK: !17 = distinct !DISubprogram(name: "example_kernel", scope: !1, file: !1, line: 10, type: !12, scopeLine: 10, flags: DIFlagPrototyped, spFlags: DISPFlagDefinition, unit: !0, retainedNodes: !2)
+; CHECK: !18 = !DILocation(line: 1, column: 2, scope: !17)

--- a/llvm/test/CodeGen/NVPTX/global-offset-intrinsic-function-mix.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-intrinsic-function-mix.ll
@@ -1,0 +1,74 @@
+; RUN: opt -bugpoint-enable-legacy-pm -globaloffset %s -S -o - | FileCheck %s
+; ModuleID = 'intrinsic-function-mix.bc'
+source_filename = "global-offset-intrinsic-function-mix.ll"
+target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
+target triple = "nvptx64-nvidia-cuda"
+
+; This test checks that the pass works with functions containing calls to the
+; intrinsic and calls to functions that call the intrinsic
+
+declare ptr @llvm.nvvm.implicit.offset()
+; CHECK-NOT: declare ptr @llvm.nvvm.implicit.offset()
+
+define weak_odr dso_local i64 @_ZTS15other_function() {
+; CHECK: define weak_odr dso_local i64 @_ZTS15other_function() {
+  %1 = tail call ptr @llvm.nvvm.implicit.offset()
+; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
+  %2 = getelementptr inbounds i32, ptr %1, i64 2
+  %3 = load i32, ptr %2, align 4
+  %4 = zext i32 %3 to i64
+; CHECK: %1 = zext i32 0 to i64
+  ret i64 %4
+}
+
+; CHECK: define weak_odr dso_local i64 @_ZTS15other_function_with_offset(ptr %0) {  
+; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %3 = load i32, ptr %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
+
+define weak_odr dso_local i64 @_ZTS14mixed_function() {
+; CHECK: define weak_odr dso_local i64 @_ZTS14mixed_function() {
+  %1 = call i64 @_ZTS15other_function()
+; CHECK: %1 = call i64 @_ZTS15other_function()
+  %2 = tail call ptr @llvm.nvvm.implicit.offset()
+; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
+  %3 = getelementptr inbounds i32, ptr %2, i64 2
+  %4 = load i32, ptr %3, align 4
+  %5 = zext i32 %4 to i64
+; CHECK: %2 = zext i32 0 to i64
+  ret i64 %1
+}
+
+; CHECK: define weak_odr dso_local i64 @_ZTS14mixed_function_with_offset(ptr %0) {
+; CHECK: %2 = call i64 @_ZTS15other_function_with_offset(ptr %0)
+; CHECK: %3 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %4 = load i32, ptr %3, align 4
+; CHECK: %5 = zext i32 %4 to i64
+; CHECK: ret i64 %2
+
+; Function Attrs: noinline
+define weak_odr dso_local void @_ZTS12some_kernel() {
+entry:
+  %0 = call i64 @_ZTS14mixed_function()
+; CHECK: %0 = call i64 @_ZTS14mixed_function()
+  ret void
+}
+
+; CHECK: define weak_odr dso_local void @_ZTS12some_kernel_with_offset(ptr byval([3 x i32]) %0) {
+; CHECK: entry:
+; CHECK:   %1 = call i64 @_ZTS14mixed_function_with_offset(ptr %0)
+; CHECK:   ret void
+; CHECK: }
+
+!nvvm.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5}
+!nvvmir.version = !{!5}
+
+!0 = distinct !{ptr @_ZTS12some_kernel, !"kernel", i32 1}
+!1 = !{null, !"align", i32 8}
+!2 = !{null, !"align", i32 8, !"align", i32 65544, !"align", i32 131080}
+!3 = !{null, !"align", i32 16}
+!4 = !{null, !"align", i32 16, !"align", i32 65552, !"align", i32 131088}
+!5 = !{i32 1, i32 4}
+; CHECK: !6 = !{ptr @_ZTS12some_kernel_with_offset, !"kernel", i32 1}

--- a/llvm/test/CodeGen/NVPTX/global-offset-multiple-calls-from-one-function.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-multiple-calls-from-one-function.ll
@@ -5,50 +5,58 @@ target datalayout = "e-i64:64-i128:128-v16:16-v32:32-n16:32:64"
 target triple = "nvptx64-nvidia-cuda"
 
 ; This test checks that when there are multiple calls to a function that uses
-; the intrinsic that the caller and the callee only have a single clone each
-; with the offset parameter. It also checks that the clone with multiple calls
-; to other functions that has a variant that takes an offset parameter will have
+; the intrinsic that the caller and the callee have two clones each - one with
+; the offset parameter and one without. It also checks that a clone with
+; multiple calls to other functions that have a clone as well will have
 ; all calls redirected to the corresponding variants.
 
 declare ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: declare ptr @llvm.nvvm.implicit.offset()
 
 define weak_odr dso_local i64 @_ZTS14other_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS14other_function(ptr %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function() {
   %1 = tail call ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
   %2 = getelementptr inbounds i32, ptr %1, i64 2
-; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
   %3 = load i32, ptr %2, align 4
   %4 = zext i32 %3 to i64
+; CHECK %1 = zext i32 0 to i64
 
   %5 = tail call ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
   %6 = getelementptr inbounds i32, ptr %5, i64 2
-; CHECK: %5 = getelementptr inbounds i32, ptr %0, i64 2
   %7 = load i32, ptr %6, align 4
   %8 = zext i32 %7 to i64
+; CHECK: %2 = zext i32 0 to i64
 
   ret i64 %4
+; CHECK: ret i64 %1
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function_with_offset(ptr %0) {
+; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %3 = load i32, ptr %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: %5 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %6 = load i32, ptr %5, align 4
+; CHECK: %7 = zext i32 %6 to i64
+; CHECK: ret i64 %4
+; CHECK: }
 
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS14example_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4
-; CHECK: call void @llvm.memset.p0.i64(ptr nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr %0, i32 0, i32 0
   %0 = call i64 @_ZTS14other_function()
-; CHECK: %2 = call i64 @_ZTS14other_function(ptr %1)
+; CHECK: %0 = call i64 @_ZTS14other_function()
   %1 = call i64 @_ZTS14other_function()
-; CHECK: %3 = call i64 @_ZTS14other_function(ptr %1)
+; CHECK: %1 = call i64 @_ZTS14other_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byval([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14other_function(ptr %0)
-; CHECK:   %2 = call i64 @_ZTS14other_function(ptr %0)
+; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr %0)
+; CHECK:   %2 = call i64 @_ZTS14other_function_with_offset(ptr %0)
 ; CHECK:   ret void
 ; CHECK: }
 

--- a/llvm/test/CodeGen/NVPTX/global-offset-multiple-entry-points.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-multiple-entry-points.ll
@@ -18,75 +18,91 @@ entry:
 }
 
 define weak_odr dso_local i64 @_ZTS15common_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS15common_function(ptr %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS15common_function() {
   %1 = tail call ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
-; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
   %2 = getelementptr inbounds i32, ptr %1, i64 2
   %3 = load i32, ptr %2, align 4
   %4 = zext i32 %3 to i64
+; CHECK: %1 = zext i32 0 to i64
   ret i64 %4
 }
 
+; CHECK: define weak_odr dso_local i64 @_ZTS15common_function_with_offset(ptr %0) {  
+; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %3 = load i32, ptr %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
+
 define weak_odr dso_local i64 @_ZTS14first_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS14first_function(ptr %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS14first_function() {
   %1 = call i64 @_ZTS15common_function()
-; CHECK: %2 = call i64 @_ZTS15common_function(ptr %0)
+; CHECK: %1 = call i64 @_ZTS15common_function()
   ret i64 %1
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS14first_function_with_offset(ptr %0) {
+; CHECK: %2 = call i64 @_ZTS15common_function_with_offset(ptr %0)
+; CHECK: ret i64 %2
 
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS12first_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4
-; CHECK: call void @llvm.memset.p0.i64(ptr nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr %0, i32 0, i32 0
   %0 = call i64 @_ZTS14first_function()
-; CHECK: %2 = call i64 @_ZTS14first_function(ptr %1)
+; CHECK: %0 = call i64 @_ZTS14first_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS12first_kernel_with_offset(ptr byval([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14first_function(ptr %0)
+; CHECK:   %1 = call i64 @_ZTS14first_function_with_offset(ptr %0)
 ; CHECK:   ret void
 ; CHECK: }
 
 define weak_odr dso_local i64 @_ZTS15second_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS15second_function(ptr %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS15second_function() {
   %1 = call i64 @_ZTS15common_function()
-; CHECK: %2 = call i64 @_ZTS15common_function(ptr %0)
+; CHECK: %1 = call i64 @_ZTS15common_function()
   ret i64 %1
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS15second_function_with_offset(ptr %0) { 
+; CHECK: %2 = call i64 @_ZTS15common_function_with_offset(ptr %0)
+; CHECK: ret i64 %2
 
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS13second_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4
-; CHECK: call void @llvm.memset.p0.i64(ptr nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr %0, i32 0, i32 0
   %0 = call i64 @_ZTS15second_function()
-; CHECK: %2 = call i64 @_ZTS15second_function(ptr %1)
+; CHECK: %0 = call i64 @_ZTS15second_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS13second_kernel_with_offset(ptr byval([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS15second_function(ptr %0)
+; CHECK:   %1 = call i64 @_ZTS15second_function_with_offset(ptr %0)
 ; CHECK:   ret void
 ; CHECK: }
 
 ; This function doesn't get called by a kernel entry point.
 define weak_odr dso_local i64 @_ZTS15no_entry_point() {
-; CHECK: define weak_odr dso_local i64 @_ZTS15no_entry_point(ptr %0) {
+; CHECK: define weak_odr dso_local i64 @_ZTS15no_entry_point() {
   %1 = tail call ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
   %2 = getelementptr inbounds i32, ptr %1, i64 2
-; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
   %3 = load i32, ptr %2, align 4
   %4 = zext i32 %3 to i64
+; CHECK: %1 = zext i32 0 to i64
   ret i64 %4
 }
+
+; CHECK: define weak_odr dso_local i64 @_ZTS15no_entry_point_with_offset(ptr %0) {
+; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %3 = load i32, ptr %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
 
 !nvvm.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5, !6}
 ; CHECK: !nvvm.annotations = !{!0, !1, !2, !1, !3, !3, !3, !3, !4, !4, !3, !5, !6, !7, !8}

--- a/llvm/test/CodeGen/NVPTX/global-offset-simple.ll
+++ b/llvm/test/CodeGen/NVPTX/global-offset-simple.ll
@@ -10,8 +10,7 @@ declare ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: llvm.nvvm.implicit.offset
 
 define weak_odr dso_local i64 @_ZTS14other_function() {
-; CHECK: define weak_odr dso_local i64 @_ZTS14other_function(ptr %0) {
-; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function() {
   %1 = tail call ptr @llvm.nvvm.implicit.offset()
 ; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
   %2 = getelementptr inbounds i32, ptr %1, i64 2
@@ -20,20 +19,25 @@ define weak_odr dso_local i64 @_ZTS14other_function() {
   ret i64 %4
 }
 
+; CHECK: define weak_odr dso_local i64 @_ZTS14other_function_with_offset(ptr %0) {
+; CHECK-NOT: tail call ptr @llvm.nvvm.implicit.offset()
+; CHECK: %2 = getelementptr inbounds i32, ptr %0, i64 2
+; CHECK: %3 = load i32, ptr %2, align 4
+; CHECK: %4 = zext i32 %3 to i64
+; CHECK: ret i64 %4
+; CHECK: }
+
 ; Function Attrs: noinline
 define weak_odr dso_local void @_ZTS14example_kernel() {
 entry:
-; CHECK: %0 = alloca [3 x i32], align 4
-; CHECK: call void @llvm.memset.p0.i64(ptr nonnull align 4 dereferenceable(12) %0, i8 0, i64 12, i1 false)
-; CHECK: %1 = getelementptr inbounds [3 x i32], ptr %0, i32 0, i32 0
   %0 = call i64 @_ZTS14other_function()
-; CHECK: %2 = call i64 @_ZTS14other_function(ptr %1)
+; CHECK: %0 = call i64 @_ZTS14other_function()
   ret void
 }
 
 ; CHECK: define weak_odr dso_local void @_ZTS14example_kernel_with_offset(ptr byval([3 x i32]) %0) {
 ; CHECK: entry:
-; CHECK:   %1 = call i64 @_ZTS14other_function(ptr %0)
+; CHECK:   %1 = call i64 @_ZTS14other_function_with_offset(ptr %0)
 ; CHECK:   ret void
 ; CHECK: }
 


### PR DESCRIPTION
Extend #11674 by modifying the globaloffset optimization pass to always
replace uses of Loads from the `llvm.nvvm.implicit.offset` and
`llvm.amdgcn.implicit.offset intrinsics` with constant zeros in the
original non-offset kernel.
Hence, perform the optimization even when
`-enable-global-offset=true` (default).
Duplicate recursively functions containing calls to the implicit offset
intrinsic and let the implicit offset kernel entry point only call
the original functions (i.e. do not call the functions with added offset
arguments).
Remove zero allocations for the original kernel entry points.