### PR TITLE
[SYCL] Change return type of abs_diff

### DIFF
--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -542,7 +542,7 @@ def : ConstOCLSPVBuiltin<"rotate", [AIGenTypeN, AIGenTypeN, AIGenTypeN]>;
 
 def : ConstOCLSPVBuiltin<"s_abs", [AUIGenTypeN, ASIGenTypeN]>;
 
-def : ConstOCLSPVBuiltin<"s_abs_diff", [AUIGenTypeN, ASIGenTypeN, ASIGenTypeN]>;
+def : ConstOCLSPVBuiltin<"s_abs_diff", [ASIGenTypeN, ASIGenTypeN, ASIGenTypeN]>;
 
 foreach name = ["s_add_sat",
                 "s_hadd", "s_rhadd",

--- a/libclc/generic/include/clc/integer/abs_diff.inc
+++ b/libclc/generic/include/clc/integer/abs_diff.inc
@@ -1,1 +1,2 @@
-_CLC_OVERLOAD _CLC_DECL __CLC_U_GENTYPE abs_diff(__CLC_GENTYPE x, __CLC_GENTYPE y);
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE abs_diff(__CLC_GENTYPE x,
+                                               __CLC_GENTYPE y);

--- a/libclc/generic/include/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/include/core/integer/clc_abs_diff.inc
@@ -6,5 +6,5 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DECL __CLC_U_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
-                                                       __CLC_GENTYPE y);
+_CLC_OVERLOAD _CLC_DECL __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
+                                                     __CLC_GENTYPE y);

--- a/libclc/generic/include/spirv/spirv_builtins.h
+++ b/libclc/generic/include/spirv/spirv_builtins.h
@@ -16905,53 +16905,53 @@ _CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_uint64_t
 _CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_uint64_t
     __spirv_ocl_s_abs(__clc_vec16_int64_t);
 
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_uint8_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_int8_t
     __spirv_ocl_s_abs_diff(__clc_int8_t, __clc_int8_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_uint8_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_int8_t
     __spirv_ocl_s_abs_diff(__clc_vec2_int8_t, __clc_vec2_int8_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_uint8_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_int8_t
     __spirv_ocl_s_abs_diff(__clc_vec3_int8_t, __clc_vec3_int8_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_uint8_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_int8_t
     __spirv_ocl_s_abs_diff(__clc_vec4_int8_t, __clc_vec4_int8_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_uint8_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_int8_t
     __spirv_ocl_s_abs_diff(__clc_vec8_int8_t, __clc_vec8_int8_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_uint8_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_int8_t
     __spirv_ocl_s_abs_diff(__clc_vec16_int8_t, __clc_vec16_int8_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_uint16_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_int16_t
     __spirv_ocl_s_abs_diff(__clc_int16_t, __clc_int16_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_uint16_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_int16_t
     __spirv_ocl_s_abs_diff(__clc_vec2_int16_t, __clc_vec2_int16_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_uint16_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_int16_t
     __spirv_ocl_s_abs_diff(__clc_vec3_int16_t, __clc_vec3_int16_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_uint16_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_int16_t
     __spirv_ocl_s_abs_diff(__clc_vec4_int16_t, __clc_vec4_int16_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_uint16_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_int16_t
     __spirv_ocl_s_abs_diff(__clc_vec8_int16_t, __clc_vec8_int16_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_uint16_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_int16_t
     __spirv_ocl_s_abs_diff(__clc_vec16_int16_t, __clc_vec16_int16_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_uint32_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_int32_t
     __spirv_ocl_s_abs_diff(__clc_int32_t, __clc_int32_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_uint32_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_int32_t
     __spirv_ocl_s_abs_diff(__clc_vec2_int32_t, __clc_vec2_int32_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_uint32_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_int32_t
     __spirv_ocl_s_abs_diff(__clc_vec3_int32_t, __clc_vec3_int32_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_uint32_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_int32_t
     __spirv_ocl_s_abs_diff(__clc_vec4_int32_t, __clc_vec4_int32_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_uint32_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_int32_t
     __spirv_ocl_s_abs_diff(__clc_vec8_int32_t, __clc_vec8_int32_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_uint32_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_int32_t
     __spirv_ocl_s_abs_diff(__clc_vec16_int32_t, __clc_vec16_int32_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_uint64_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_int64_t
     __spirv_ocl_s_abs_diff(__clc_int64_t, __clc_int64_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_uint64_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec2_int64_t
     __spirv_ocl_s_abs_diff(__clc_vec2_int64_t, __clc_vec2_int64_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_uint64_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec3_int64_t
     __spirv_ocl_s_abs_diff(__clc_vec3_int64_t, __clc_vec3_int64_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_uint64_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec4_int64_t
     __spirv_ocl_s_abs_diff(__clc_vec4_int64_t, __clc_vec4_int64_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_uint64_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec8_int64_t
     __spirv_ocl_s_abs_diff(__clc_vec8_int64_t, __clc_vec8_int64_t);
-_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_uint64_t
+_CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_vec16_int64_t
     __spirv_ocl_s_abs_diff(__clc_vec16_int64_t, __clc_vec16_int64_t);
 
 _CLC_OVERLOAD _CLC_DECL _CLC_CONSTFN __clc_int8_t

--- a/libclc/generic/lib/integer/abs_diff.inc
+++ b/libclc/generic/lib/integer/abs_diff.inc
@@ -1,3 +1,4 @@
-_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE abs_diff(__CLC_GENTYPE x, __CLC_GENTYPE y) {
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE abs_diff(__CLC_GENTYPE x,
+                                              __CLC_GENTYPE y) {
   return __clc_abs_diff(x, y);
 }

--- a/libclc/generic/lib/integer/abs_diff.inc
+++ b/libclc/generic/lib/integer/abs_diff.inc
@@ -1,3 +1,3 @@
-_CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE abs_diff(__CLC_GENTYPE x, __CLC_GENTYPE y) {
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE abs_diff(__CLC_GENTYPE x, __CLC_GENTYPE y) {
   return __clc_abs_diff(x, y);
 }

--- a/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
@@ -8,9 +8,10 @@
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
                                                     __CLC_GENTYPE y) {
-  if ((x < 0) == (y < 0))
+  __CLC_GENTYPE gentype_zero = 0;
+  if ((x < gentype_zero) == (y < gentype_zero))
     return (x > y) ? (x - y) : (y - x);
-  __CLC_GENTYPE ax = x < 0 ? -x : x;
-  __CLC_GENTYPE ay = y < 0 ? -y : y;
+  __CLC_GENTYPE ax = x < gentype_zero ? -x : x;
+  __CLC_GENTYPE ay = y < gentype_zero ? -y : y;
   return ax + ay;
 }

--- a/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
@@ -10,6 +10,6 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
                                                     __CLC_GENTYPE y) {
   __CLC_U_GENTYPE ux = __builtin_astype(x, __CLC_U_GENTYPE);
   __CLC_U_GENTYPE uy = __builtin_astype(y, __CLC_U_GENTYPE);
-  return x > y ? __builtin_astype(ux - uy, __CLC_GENTYPE)
-               : __builtin_astype(uy - ux, __CLC_GENTYPE);
+  __CLC_GENTYPE r = __builtin_astype(x > y ? ux - uy : uy - ux, __CLC_GENTYPE);
+  return r;
 }

--- a/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
@@ -9,9 +9,9 @@
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
                                                     __CLC_GENTYPE y) {
   __CLC_GENTYPE gentype_zero = 0;
-  if ((x < gentype_zero) == (y < gentype_zero))
-    return (x > y) ? (x - y) : (y - x);
   __CLC_GENTYPE ax = x < gentype_zero ? -x : x;
   __CLC_GENTYPE ay = y < gentype_zero ? -y : y;
-  return ax + ay;
+  return (x < gentype_zero) == (y < gentype_zero)
+      ? ((x > y) ? (x - y) : (y - x))
+      : (ax + ay);
 }

--- a/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
@@ -8,8 +8,9 @@
 
 _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
                                                     __CLC_GENTYPE y) {
-  __CLC_U_GENTYPE ux = __builtin_astype(x, __CLC_U_GENTYPE);
-  __CLC_U_GENTYPE uy = __builtin_astype(y, __CLC_U_GENTYPE);
-  __CLC_GENTYPE r = __builtin_astype(x > y ? ux - uy : uy - ux, __CLC_GENTYPE);
-  return r;
+  if ((x < 0) == (y < 0))
+    return (x > y) ? (x - y) : (y - x);
+  __CLC_GENTYPE ax = x < 0 ? -x : x;
+  __CLC_GENTYPE ay = y < 0 ? -y : y;
+  return ax + ay;
 }

--- a/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
@@ -12,6 +12,6 @@ _CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
   __CLC_GENTYPE ax = x < gentype_zero ? -x : x;
   __CLC_GENTYPE ay = y < gentype_zero ? -y : y;
   return (x < gentype_zero) == (y < gentype_zero)
-      ? ((x > y) ? (x - y) : (y - x))
-      : (ax + ay);
+             ? ((x > y) ? (x - y) : (y - x))
+             : (ax + ay);
 }

--- a/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
+++ b/libclc/generic/libspirv/core/integer/clc_abs_diff.inc
@@ -6,9 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-_CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
-                                                      __CLC_GENTYPE y) {
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE __clc_abs_diff(__CLC_GENTYPE x,
+                                                    __CLC_GENTYPE y) {
   __CLC_U_GENTYPE ux = __builtin_astype(x, __CLC_U_GENTYPE);
   __CLC_U_GENTYPE uy = __builtin_astype(y, __CLC_U_GENTYPE);
-  return x > y ? ux - uy : uy - ux;
+  return x > y ? __builtin_astype(ux - uy, __CLC_GENTYPE)
+               : __builtin_astype(uy - ux, __CLC_GENTYPE);
 }

--- a/libclc/generic/libspirv/integer/abs_diff.inc
+++ b/libclc/generic/libspirv/integer/abs_diff.inc
@@ -12,7 +12,7 @@
 #define DECL __spirv_ocl_u_abs_diff
 #endif
 
-_CLC_OVERLOAD _CLC_DEF __CLC_U_GENTYPE DECL(__CLC_GENTYPE x, __CLC_GENTYPE y) {
+_CLC_OVERLOAD _CLC_DEF __CLC_GENTYPE DECL(__CLC_GENTYPE x, __CLC_GENTYPE y) {
   return __clc_abs_diff(x, y);
 }
 

--- a/libclc/test/binding/ocl/s_abs_diff.cl
+++ b/libclc/test/binding/ocl/s_abs_diff.cl
@@ -15,141 +15,141 @@
 
 // CHECK-NOT: declare {{.*}} @_Z
 // CHECK-NOT: call {{[^ ]*}} bitcast
-__attribute__((overloadable)) __clc_uint8_t
+__attribute__((overloadable)) __clc_int8_t
 test___spirv_ocl_s_abs_diff(__clc_int8_t args_0, __clc_int8_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec2_uint8_t
+__attribute__((overloadable)) __clc_vec2_int8_t
 test___spirv_ocl_s_abs_diff(__clc_vec2_int8_t args_0,
                             __clc_vec2_int8_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec3_uint8_t
+__attribute__((overloadable)) __clc_vec3_int8_t
 test___spirv_ocl_s_abs_diff(__clc_vec3_int8_t args_0,
                             __clc_vec3_int8_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec4_uint8_t
+__attribute__((overloadable)) __clc_vec4_int8_t
 test___spirv_ocl_s_abs_diff(__clc_vec4_int8_t args_0,
                             __clc_vec4_int8_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec8_uint8_t
+__attribute__((overloadable)) __clc_vec8_int8_t
 test___spirv_ocl_s_abs_diff(__clc_vec8_int8_t args_0,
                             __clc_vec8_int8_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec16_uint8_t
+__attribute__((overloadable)) __clc_vec16_int8_t
 test___spirv_ocl_s_abs_diff(__clc_vec16_int8_t args_0,
                             __clc_vec16_int8_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_uint16_t
+__attribute__((overloadable)) __clc_int16_t
 test___spirv_ocl_s_abs_diff(__clc_int16_t args_0, __clc_int16_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec2_uint16_t
+__attribute__((overloadable)) __clc_vec2_int16_t
 test___spirv_ocl_s_abs_diff(__clc_vec2_int16_t args_0,
                             __clc_vec2_int16_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec3_uint16_t
+__attribute__((overloadable)) __clc_vec3_int16_t
 test___spirv_ocl_s_abs_diff(__clc_vec3_int16_t args_0,
                             __clc_vec3_int16_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec4_uint16_t
+__attribute__((overloadable)) __clc_vec4_int16_t
 test___spirv_ocl_s_abs_diff(__clc_vec4_int16_t args_0,
                             __clc_vec4_int16_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec8_uint16_t
+__attribute__((overloadable)) __clc_vec8_int16_t
 test___spirv_ocl_s_abs_diff(__clc_vec8_int16_t args_0,
                             __clc_vec8_int16_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec16_uint16_t
+__attribute__((overloadable)) __clc_vec16_int16_t
 test___spirv_ocl_s_abs_diff(__clc_vec16_int16_t args_0,
                             __clc_vec16_int16_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_uint32_t
+__attribute__((overloadable)) __clc_int32_t
 test___spirv_ocl_s_abs_diff(__clc_int32_t args_0, __clc_int32_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec2_uint32_t
+__attribute__((overloadable)) __clc_vec2_int32_t
 test___spirv_ocl_s_abs_diff(__clc_vec2_int32_t args_0,
                             __clc_vec2_int32_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec3_uint32_t
+__attribute__((overloadable)) __clc_vec3_int32_t
 test___spirv_ocl_s_abs_diff(__clc_vec3_int32_t args_0,
                             __clc_vec3_int32_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec4_uint32_t
+__attribute__((overloadable)) __clc_vec4_int32_t
 test___spirv_ocl_s_abs_diff(__clc_vec4_int32_t args_0,
                             __clc_vec4_int32_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec8_uint32_t
+__attribute__((overloadable)) __clc_vec8_int32_t
 test___spirv_ocl_s_abs_diff(__clc_vec8_int32_t args_0,
                             __clc_vec8_int32_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec16_uint32_t
+__attribute__((overloadable)) __clc_vec16_int32_t
 test___spirv_ocl_s_abs_diff(__clc_vec16_int32_t args_0,
                             __clc_vec16_int32_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_uint64_t
+__attribute__((overloadable)) __clc_int64_t
 test___spirv_ocl_s_abs_diff(__clc_int64_t args_0, __clc_int64_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec2_uint64_t
+__attribute__((overloadable)) __clc_vec2_int64_t
 test___spirv_ocl_s_abs_diff(__clc_vec2_int64_t args_0,
                             __clc_vec2_int64_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec3_uint64_t
+__attribute__((overloadable)) __clc_vec3_int64_t
 test___spirv_ocl_s_abs_diff(__clc_vec3_int64_t args_0,
                             __clc_vec3_int64_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec4_uint64_t
+__attribute__((overloadable)) __clc_vec4_int64_t
 test___spirv_ocl_s_abs_diff(__clc_vec4_int64_t args_0,
                             __clc_vec4_int64_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec8_uint64_t
+__attribute__((overloadable)) __clc_vec8_int64_t
 test___spirv_ocl_s_abs_diff(__clc_vec8_int64_t args_0,
                             __clc_vec8_int64_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);
 }
 
-__attribute__((overloadable)) __clc_vec16_uint64_t
+__attribute__((overloadable)) __clc_vec16_int64_t
 test___spirv_ocl_s_abs_diff(__clc_vec16_int64_t args_0,
                             __clc_vec16_int64_t args_1) {
   return __spirv_ocl_s_abs_diff(args_0, args_1);

--- a/sycl/include/sycl/builtins_legacy_scalar.hpp
+++ b/sycl/include/sycl/builtins_legacy_scalar.hpp
@@ -14,6 +14,7 @@
 
 #include <sycl/access/access.hpp>              // for address_space, decorated
 #include <sycl/aliases.hpp>                    // for half
+#include <sycl/bit_cast.hpp>                   // for bit_cast
 #include <sycl/detail/boolean.hpp>             // for Boolean
 #include <sycl/detail/builtins.hpp>            // for __invoke_select, __in...
 #include <sycl/detail/defines_elementary.hpp>  // for __SYCL_ALWAYS_INLINE
@@ -533,7 +534,7 @@ std::enable_if_t<detail::is_ugeninteger_v<T>, T> abs_diff(T x, T y) {
 template <typename T>
 std::enable_if_t<detail::is_igeninteger_v<T>, detail::make_unsigned_t<T>>
 abs_diff(T x, T y) {
-  return __sycl_std::__invoke_s_abs_diff<detail::make_unsigned_t<T>>(x, y);
+  return (detail::make_unsigned_t<T>)__sycl_std::__invoke_s_abs_diff<T>(x, y);
 }
 
 // geninteger add_sat (geninteger x, geninteger y)

--- a/sycl/source/builtins_generator.py
+++ b/sycl/source/builtins_generator.py
@@ -324,7 +324,6 @@ vint32ptr0 = [MultiPtr("int32_t", parent_idx=0), RawPtr(Vec(["int32_t"]))]
 # To help resolve template arguments, these are given the index of their parent
 # argument.
 elementtype0 = [ElementType(0)]
-unsignedtype0 = [ConversionTraitType("make_unsigned_t", 0)]
 samesizesignedint0 = [ConversionTraitType("same_size_signed_int_t", 0)]
 samesizeunsignedint0 = [ConversionTraitType("same_size_unsigned_int_t", 0)]
 intelements0 = [ConversionTraitType("int_elements_t", 0)]
@@ -400,7 +399,6 @@ builtin_types = {
   "intnptr0" : intnptr0,
   "vint32nptr0" : vint32ptr0,
   "elementtype0" : elementtype0,
-  "unsignedtype0" : unsignedtype0,
   "samesizesignedint0" : samesizesignedint0,
   "samesizeunsignedint0" : samesizeunsignedint0,
   "intelements0" : intelements0,
@@ -873,8 +871,8 @@ sycl_builtins = {# Math functions
                  "tgamma": [Def("genfloat", ["genfloat"])],
                  "trunc": [Def("genfloat", ["genfloat"])],
                  # Integer functions
-                 "abs_diff": [Def("unsignedtype0", ["igeninteger", "igeninteger"], invoke_prefix="s_", marray_use_loop=True, template_scalar_args=True),
-                              Def("unsignedtype0", ["ugeninteger", "ugeninteger"], invoke_prefix="u_", marray_use_loop=True, template_scalar_args=True)],
+                 "abs_diff": [Def("igeninteger", ["igeninteger", "igeninteger"], invoke_prefix="s_", marray_use_loop=True, template_scalar_args=True),
+                              Def("ugeninteger", ["ugeninteger", "ugeninteger"], invoke_prefix="u_", marray_use_loop=True, template_scalar_args=True)],
                  "add_sat": [Def("igeninteger", ["igeninteger", "igeninteger"], invoke_prefix="s_", marray_use_loop=True, template_scalar_args=True),
                              Def("ugeninteger", ["ugeninteger", "ugeninteger"], invoke_prefix="u_", marray_use_loop=True, template_scalar_args=True)],
                  "hadd": [Def("igeninteger", ["igeninteger", "igeninteger"], invoke_prefix="s_", marray_use_loop=True, template_scalar_args=True),

--- a/sycl/source/detail/builtins_integer.cpp
+++ b/sycl/source/detail/builtins_integer.cpp
@@ -21,10 +21,16 @@ namespace d = s::detail;
 namespace __host_std {
 namespace {
 
-template <typename T> inline std::make_unsigned_t<T> __abs_diff(T x, T y) {
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+template <typename T> using __abs_diff_return_t = T;
+#else  // __INTEL_PREVIEW_BREAKING_CHANGES
+template <typename T> using __abs_diff_return_t = std::make_unsigned_t<T>;
+#endif // __INTEL_PREVIEW_BREAKING_CHANGES
+
+template <typename T> inline __abs_diff_return_t<T> __abs_diff(T x, T y) {
   static_assert(std::is_integral<T>::value,
                 "Only integral types are supported");
-  using UT = std::make_unsigned_t<T>;
+  using UT = __abs_diff_return_t<T>;
 
   // We need to be careful to avoid undefined behavior from signed integer
   // overflow. That is, if only one of the operands are negative we can overflow
@@ -298,26 +304,25 @@ MAKE_1V_2V(sycl_host_u_abs_diff, s::cl_uint, s::cl_uint, s::cl_uint)
 MAKE_1V_2V(sycl_host_u_abs_diff, s::cl_ulong, s::cl_ulong, s::cl_ulong)
 
 // s_abs_diff
-__SYCL_EXPORT s::cl_uchar sycl_host_s_abs_diff(s::cl_char x,
-                                               s::cl_char y) __NOEXC {
+__SYCL_EXPORT s::cl_char sycl_host_s_abs_diff(s::cl_char x,
+                                              s::cl_char y) __NOEXC {
   return __abs_diff(x, y);
 }
-__SYCL_EXPORT s::cl_ushort sycl_host_s_abs_diff(s::cl_short x,
-                                                s::cl_short y) __NOEXC {
+__SYCL_EXPORT s::cl_short sycl_host_s_abs_diff(s::cl_short x,
+                                               s::cl_short y) __NOEXC {
   return __abs_diff(x, y);
 }
-__SYCL_EXPORT s::cl_uint sycl_host_s_abs_diff(s::cl_int x,
-                                              s::cl_int y) __NOEXC {
+__SYCL_EXPORT s::cl_int sycl_host_s_abs_diff(s::cl_int x, s::cl_int y) __NOEXC {
   return __abs_diff(x, y);
 }
-__SYCL_EXPORT s::cl_ulong sycl_host_s_abs_diff(s::cl_long x,
-                                               s::cl_long y) __NOEXC {
+__SYCL_EXPORT s::cl_long sycl_host_s_abs_diff(s::cl_long x,
+                                              s::cl_long y) __NOEXC {
   return __abs_diff(x, y);
 }
-MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_uchar, s::cl_char, s::cl_char)
-MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_ushort, s::cl_short, s::cl_short)
-MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_uint, s::cl_int, s::cl_int)
-MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_ulong, s::cl_long, s::cl_long)
+MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_char, s::cl_char, s::cl_char)
+MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_short, s::cl_short, s::cl_short)
+MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_int, s::cl_int, s::cl_int)
+MAKE_1V_2V(sycl_host_s_abs_diff, s::cl_long, s::cl_long, s::cl_long)
 
 // u_add_sat
 __SYCL_EXPORT s::cl_uchar sycl_host_u_add_sat(s::cl_uchar x,

--- a/sycl/test/regression/abs_diff_host.cpp
+++ b/sycl/test/regression/abs_diff_host.cpp
@@ -12,7 +12,12 @@
 #include <type_traits>
 
 template <typename T> void check() {
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  using UT = T;
+#else
   using UT = std::make_unsigned_t<T>;
+#endif
+
   constexpr T MaxVal = std::numeric_limits<T>::max();
   constexpr T MinVal = std::numeric_limits<T>::min();
   constexpr UT UMaxVal = MaxVal;


### PR DESCRIPTION
As of https://github.com/KhronosGroup/SYCL-Docs/pull/458 the return type of abs_diff has been changed to be the same as the input arguments, which in turn corresponds to how the extended OpenCL instruction set defines `s_abs_diff`. This commit changes the preview builtins to use the correct type as well as define `s_abs_diff` in accordance with the OpenCL extended instruction set.