### PR TITLE
[SYCL-MLIR][sycl] Add `fastmath` attribute to `sycl.math.*` operations

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMathOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMathOps.td
@@ -13,6 +13,7 @@
 #ifndef SYCL_MATH_OPS
 #define SYCL_MATH_OPS
 
+include "mlir/Dialect/Arith/IR/ArithBase.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -38,7 +39,6 @@ def SYCLMathFunc : SYCLOpTrait<"SYCLMathFunc">;
 // can be applied to scalars and vectors.
 // TODO: Support marrarys.
 // TODO: Consider VectorUnrollOpInterface, ElementwiseMappable.
-// TODO: Consider arith::FastMathFlags.
 class SYCL_MathOp<string mnemonic, list<Trait> traits = []> :
     SYCL_Op<"math." # mnemonic, traits # [SYCLMathFunc, Pure]>;
 
@@ -46,27 +46,39 @@ class SYCL_FloatUnaryOp<string mnemonic, string synopsis = "",
                         list<Trait> traits = []> :
     SYCL_MathOp<mnemonic, traits # [AllTypesMatch<["x", "result"]>]> {
   let summary = synopsis # ".";
-  let arguments = (ins SYCL_Genfloat:$x);
+  let arguments = (ins SYCL_Genfloat:$x,
+                       DefaultValuedAttr<
+                           Arith_FastMathAttr,
+                           "::mlir::arith::FastMathFlags::none">:$fastmath);
   let results = (outs SYCL_Genfloat:$result);
-  let assemblyFormat = [{ $x attr-dict `:` type($result) }];
+  let assemblyFormat = [{ $x (`fastmath` `` $fastmath^)?
+                             attr-dict `:` type($result) }];
 }
 
 class SYCL_FloatBinaryOp<string mnemonic, string synopsis = "",
                          list<Trait> traits = []> :
     SYCL_MathOp<mnemonic, traits # [AllTypesMatch<["x", "y", "result"]>]> {
   let summary = synopsis # ".";
-  let arguments = (ins SYCL_Genfloat:$x, SYCL_Genfloat:$y);
+  let arguments = (ins SYCL_Genfloat:$x, SYCL_Genfloat:$y,
+                       DefaultValuedAttr<
+                           Arith_FastMathAttr,
+                           "::mlir::arith::FastMathFlags::none">:$fastmath);
   let results = (outs SYCL_Genfloat:$result);
-  let assemblyFormat = [{ $x `,` $y attr-dict `:` type($result) }];
+  let assemblyFormat = [{ $x `,` $y (`fastmath` `` $fastmath^)?
+                             attr-dict `:` type($result) }];
 }
 
 class SYCL_FloatTernaryOp<string mnemonic, string synopsis = "",
                           list<Trait> traits = []> :
     SYCL_MathOp<mnemonic, traits # [AllTypesMatch<["a", "b", "c", "result"]>]> {
   let summary = synopsis # ".";
-  let arguments = (ins SYCL_Genfloat:$a, SYCL_Genfloat:$b, SYCL_Genfloat:$c);
+  let arguments = (ins SYCL_Genfloat:$a, SYCL_Genfloat:$b, SYCL_Genfloat:$c,
+                       DefaultValuedAttr<
+                           Arith_FastMathAttr,
+                           "::mlir::arith::FastMathFlags::none">:$fastmath);
   let results = (outs SYCL_Genfloat:$result);
-  let assemblyFormat = [{ $a `,` $b `,` $c attr-dict `:` type($result) }];
+  let assemblyFormat = [{ $a `,` $b `,` $c (`fastmath` `` $fastmath^)?
+                             attr-dict `:` type($result) }];
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/mlir-sycl/lib/Conversion/SYCLToMath/SYCLToMath.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToMath/SYCLToMath.cpp
@@ -43,7 +43,9 @@ struct OneToOneMappingPattern : public OpConversionPattern<SYCLOpT> {
                ConversionPatternRewriter &rewriter) const override {
     // `op` has a native MLIR type, hence we can just replace it with its
     // counterpart in the `math` dialect.
-    rewriter.replaceOpWithNewOp<MathOpT>(op, adaptor.getOperands());
+    NamedAttribute fastmath = rewriter.getNamedAttr(
+        MathOpT::getFastMathAttrName(), adaptor.getFastmathAttr());
+    rewriter.replaceOpWithNewOp<MathOpT>(op, adaptor.getOperands(), fastmath);
   }
 };
 

--- a/mlir-sycl/test/Conversion/SYCLToMath/math-ops.mlir
+++ b/mlir-sycl/test/Conversion/SYCLToMath/math-ops.mlir
@@ -491,3 +491,19 @@ func.func @test_math_ops_vector_of_half(%arg0 : !sycl_vec_sycl_half_2_, %arg1 : 
   
   return
 }
+
+// CHECK-LABEL: test_fastmath
+func.func @test_fastmath(%arg0 : f32, %arg1 : f32, %arg2 : f32) {
+  // CHECK: %{{.*}} = math.ceil %arg0 fastmath<fast>  : f32
+  %c0 = sycl.math.ceil %arg0 fastmath<fast> : f32
+  // CHECK: %{{.*}} = math.copysign %arg0, %arg1 fastmath<fast> : f32
+  %c1 = sycl.math.copysign %arg0, %arg1 fastmath<reassoc,nnan,ninf,nsz,arcp,contract,afn>  : f32
+  // CHECK: %{{.*}} = math.cos  %arg0 : f32
+  %c2 = sycl.math.cos %arg0 fastmath<none>  : f32
+  // CHECK: %{{.*}} = math.exp %arg0 fastmath<ninf> : f32
+  %e2 = sycl.math.exp %arg0 fastmath<ninf> : f32
+  // CHECK: %{{.*}} = math.exp2 %arg0 fastmath<fast> : f32
+  %e0 = sycl.math.exp2 %arg0 fastmath<fast> : f32
+
+  return
+}

--- a/mlir-sycl/test/Dialect/SYCL/math-ops.mlir
+++ b/mlir-sycl/test/Dialect/SYCL/math-ops.mlir
@@ -260,3 +260,19 @@ func.func @test_math_ops_vector_of_half(%arg0 : !sycl_vec_sycl_half_2_, %arg1 : 
 
   return
 }
+
+// CHECK-LABEL: test_fastmath
+func.func @test_fastmath(%arg0 : f32, %arg1 : f32, %arg2 : f32) {
+  // CHECK: %{{.*}} = sycl.math.ceil %arg0 fastmath<fast>  : f32
+  %c0 = sycl.math.ceil %arg0 fastmath<fast> : f32
+  // CHECK: %{{.*}} = sycl.math.copysign %arg0, %arg1 fastmath<fast> : f32
+  %c1 = sycl.math.copysign %arg0, %arg1 fastmath<reassoc,nnan,ninf,nsz,arcp,contract,afn>  : f32
+  // CHECK: %{{.*}} = sycl.math.cos  %arg0 : f32
+  %c2 = sycl.math.cos %arg0 fastmath<none>  : f32
+  // CHECK: %{{.*}} = sycl.math.exp %arg0 fastmath<ninf> : f32
+  %e2 = sycl.math.exp %arg0 fastmath<ninf> : f32
+  // CHECK: %{{.*}} = sycl.math.exp2 %arg0 fastmath<fast> : f32
+  %e0 = sycl.math.exp2 %arg0 fastmath<fast> : f32
+
+  return
+}


### PR DESCRIPTION
Add support for `fastmath` flags to the math operations in the `sycl` dialect.