### PR TITLE
[SYCL][Tests] Fix preview flags in testing

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/host_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/host_math.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out %}
 
 #include <cmath>
 #include <iomanip>

--- a/sycl/test-e2e/Basic/built-ins/host_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/host_math.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <cmath>

--- a/sycl/test-e2e/Basic/built-ins/host_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/host_math.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <cmath>

--- a/sycl/test-e2e/Basic/built-ins/marray_common.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_common.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #ifdef _WIN32

--- a/sycl/test-e2e/Basic/built-ins/marray_common.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_common.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #ifdef _WIN32

--- a/sycl/test-e2e/Basic/built-ins/marray_common.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_common.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}
 
 #ifdef _WIN32
 #define _USE_MATH_DEFINES // To use math constants

--- a/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <CL/sycl.hpp>

--- a/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out %}
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <CL/sycl.hpp>

--- a/sycl/test-e2e/Basic/built-ins/marray_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_math.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} %{mathflags} -o -fpreview-breaking-changes %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} %{mathflags} -fpreview-breaking-changes -o %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/built-ins/marray_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_math.cpp
@@ -2,8 +2,8 @@
 
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} %{mathflags} -fpreview-breaking-changes -o %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{ %{build} %{mathflags} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Basic/built-ins/marray_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_math.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} %{mathflags} -o -fpreview %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} %{mathflags} -o -fpreview-breaking-changes %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/built-ins/marray_relational.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_relational.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <CL/sycl.hpp>

--- a/sycl/test-e2e/Basic/built-ins/marray_relational.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_relational.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}
 
 #include <CL/sycl.hpp>
 

--- a/sycl/test-e2e/Basic/built-ins/marray_relational.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_relational.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview-breaking-changes %t_preview.out%}
+// RUN: %if preview-breaking-changes-supported %{%{build} -fpreview-breaking-changes -o %t_preview.out%}
 // RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
 
 #include <CL/sycl.hpp>

--- a/sycl/test-e2e/Basic/built-ins/vec_common.cpp
+++ b/sycl/test-e2e/Basic/built-ins/vec_common.cpp
@@ -1,10 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
-
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{  %{run} %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #ifdef _WIN32
 #define _USE_MATH_DEFINES // To use math constants

--- a/sycl/test-e2e/Basic/built-ins/vec_geometric.cpp
+++ b/sycl/test-e2e/Basic/built-ins/vec_geometric.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
-
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{  %{run} %t2.out %}
 

--- a/sycl/test-e2e/Basic/built-ins/vec_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/vec_math.cpp
@@ -2,11 +2,8 @@
 
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} %{mathflags} -o -fpreview %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
-
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %{mathflags} %s -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{  %{run} %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Basic/built-ins/vec_relational.cpp
+++ b/sycl/test-e2e/Basic/built-ins/vec_relational.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{%{build} -o -fpreview %t_preview.out%}
-// RUN: %if preview-breaking-changes-supported %{%{run} %t_preview.out%}
-
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{  %{run} %t2.out %}
 

--- a/sycl/test-e2e/DeviceLib/built-ins/nan.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/nan.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fsycl-device-code-split=per_kernel -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -fsycl-device-code-split=per_kernel -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <iostream>

--- a/sycl/test-e2e/DeviceLib/built-ins/scalar_integer.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/scalar_integer.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %{build} -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/USM/math.cpp
+++ b/sycl/test-e2e/USM/math.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %{build} -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/relational_builtins.cpp
+++ b/sycl/test/basic_tests/relational_builtins.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl %s -o %t.out
-// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl %s -o %t.out %}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t.out %}
 
 // NOTE: Compile the test fully to ensure the library exports the right host
 // symbols.

--- a/sycl/test/basic_tests/types.cpp
+++ b/sycl/test/basic_tests/types.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -fsyntax-only
-// RUN: %if preview-breaking-changes-supported %{%clangxx -fsycl -fpreview-breaking-changes -fsycl-targets=%sycl_triple %s -fsyntax-only%}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes -fsycl-targets=%sycl_triple %s -fsyntax-only %}
 
 //==--------------- types.cpp - SYCL types test ----------------------------==//
 //

--- a/sycl/test/basic_tests/valid_kernel_args.cpp
+++ b/sycl/test/basic_tests/valid_kernel_args.cpp
@@ -8,7 +8,7 @@
 
 // The test checks that the types can be used to pass kernel parameters by value
 // RUN: %clangxx -fsycl -fsyntax-only %s -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning
-// RUN: %if preview-breaking-changes-supported %{%clangxx -fsycl -fsyntax-only -fpreview-breaking-changes %s -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning%}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fsyntax-only -fpreview-breaking-changes %s -Wno-sycl-strict -Xclang -verify-ignore-unexpected=note,warning %}
 
 // Check that the test can be compiled with device compiler as well.
 // RUN: %clangxx -fsycl-device-only -fsyntax-only %s -Wno-sycl-strict

--- a/sycl/test/regression/abs_diff_host.cpp
+++ b/sycl/test/regression/abs_diff_host.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %t.out
-// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl %s -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %t2.out %}
 
 // Test checks that sycl::abs_diff correctly handles signed operations that


### PR DESCRIPTION
The preview flag was intended to be used in a number of builtins tests but were not correctly added to the build steps. This commit amends these tests.