### PR TITLE
[NFC][Driver] Remove inadvertent append for the host link

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5868,8 +5868,6 @@ class OffloadingActionBuilder final {
       return NumOfDeviceLibLinked != 0;
     }
 
-    Action *appendLinkHostActions(ActionList &AL) override { return AL.back(); }
-
     void appendLinkDependences(OffloadAction::DeviceDependences &DA) override {
       // DeviceLinkerInputs holds binaries per ToolChain (TC) / bound-arch pair
       // The following will loop link and post process for each TC / bound-arch


### PR DESCRIPTION
When performing the task involving early-AOT behaviors, an additional virtual function override of appendLinkHostActions was added, which was returning the end of the action list.  This did not have an overall impact on the SYCL compilation flow, so it was unnoticed.  When combining with the OpenMP interop offloading steps, this was causing an additional invalid object/device to be added to the host link.

This can only be tested with the old offloading model, which only exists with the SYCL toolchain on the intel/llvm branch.