### PR TITLE
[ESIMD] Add non-experimental version of fence() for DG2 and PVC

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -384,6 +384,62 @@ enum class cache_hint : uint8_t {
   const_cached = 7
 };
 
+/// The scope that fence() operation should apply to.
+/// Supported platforms: DG2, PVC
+enum class fence_scope : uint8_t {
+  /// Wait until all previous memory transactions from this thread are observed
+  /// within the local thread-group.
+  group = 0,
+
+  /// Wait until all previous memory transactions from this thread are observed
+  /// within the local sub-slice.
+  local = 1,
+
+  /// Wait until all previous memory transactions from this thread are observed
+  /// in the local tile.
+  tile = 2,
+
+  /// Wait until all previous memory transactions from this thread are observed
+  /// in the local GPU.
+  gpu = 3,
+
+  /// Wait until all previous memory transactions from this thread are observed
+  /// across all GPUs in the system.
+  gpus = 4,
+
+  /// Global memory data-port only: wait until all previous memory transactions
+  /// from this thread are observed at the "system" level.
+  system = 5,
+
+  /// Global memory data-port only: for GPUs that do not follow
+  /// PCIe Write ordering for downstream writes targeting device memory,
+  /// this op will commit to device memory all downstream and peer writes that
+  /// have reached the device.
+  system_acquire = 6
+};
+
+/// The cache flush operation to apply to caches after fence() is complete.
+/// Supported platforms: DG2, PVC
+enum class fence_flush_op : uint8_t {
+  none = 0,       /// no operation;
+  evict = 1,      /// R/W: evict dirty lines; R/W and RO: invalidate clean lines
+  invalidate = 2, /// R/W and RO: invalidate all clean lines;
+
+  // enum with the value 4 is reserved;
+
+  clean = 4 /// R/W: dirty lines are written to memory, but retained in
+            /// cache in clean state; RO: no effect.
+};
+
+/// The target memory kind for fence() operation.
+/// Supported platforms: DG2, PVC
+enum class memory_kind : uint8_t {
+  global = 0, /// untyped global memory
+  // enum with the value 1 is reserved;
+  image = 2, /// image (also known as typed global memory)
+  local = 3, /// shared local memory
+};
+
 /// L1, L2 or L3 cache hint levels. L3 is reserved for future use.
 enum class cache_level : uint8_t { L1 = 1, L2 = 2, L3 = 3 };
 

--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -425,7 +425,7 @@ enum class fence_flush_op : uint8_t {
   evict = 1,      /// R/W: evict dirty lines; R/W and RO: invalidate clean lines
   invalidate = 2, /// R/W and RO: invalidate all clean lines;
 
-  // enum with the value 4 is reserved;
+  // enum with the value 3 is reserved;
 
   clean = 4 /// R/W: dirty lines are written to memory, but retained in
             /// cache in clean state; RO: no effect.

--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -641,6 +641,24 @@ __ESIMD_INTRIN void __esimd_fence(uint8_t cntl)
 }
 #endif // __SYCL_DEVICE_ONLY__
 
+/// Memory fence.
+/// Supported platforms: DG2, PVC
+///
+/// @tparam Kind is the Sfid shaded function.
+/// @tparam FenceOp is the fence operation.
+/// @tparam Scope is the operation scope.
+/// @tparam N is the SIMD size of operation (the number of addresses to access)
+/// @param pred is predicates.
+template <uint8_t Kind, uint8_t FenceOp, uint8_t Scope, int N>
+__ESIMD_INTRIN void __esimd_lsc_fence(__ESIMD_DNS::simd_mask_storage_t<N> pred)
+#ifdef __SYCL_DEVICE_ONLY__
+    ;
+#else  // __SYCL_DEVICE_ONLY__
+{
+  __ESIMD_UNSUPPORTED_ON_HOST;
+}
+#endif // __SYCL_DEVICE_ONLY__
+
 // Predicated (masked) scaled gather from a surface.
 //
 // Template (compile-time constant) parameters:

--- a/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/common.hpp
@@ -27,7 +27,8 @@ namespace ext::intel::experimental::esimd {
 
 /// The scope that lsc_fence operation should apply to
 /// Supported platforms: DG2, PVC
-enum class lsc_scope : uint8_t {
+enum class __SYCL_DEPRECATED(
+    "use sycl::ext::intel::esimd::fence_scope") lsc_scope : uint8_t {
   group = 0,  /// flush out to the threadgroup's scope
   local = 1,  /// flush out to the local scope
   tile = 2,   /// tile, flush out to several DSSs
@@ -39,24 +40,26 @@ enum class lsc_scope : uint8_t {
 
 /// The lsc_fence operation to apply to caches
 /// Supported platforms: DG2, PVC
-enum class lsc_fence_op : uint8_t {
-  none = 0,       /// no operation
-  evict = 1,      /// dirty lines evicted and invalidated from L1
-  invalidate = 2, /// invalidate all clean lines
-  discard = 3,    /// direct and clean lines are discarded w/o eviction
-  clean = 4,      /// dirty lines are written to memory, but retained in cache
-                  /// in clean state
-  flushl3 = 5,    /// flush only L3
-};
+enum class __SYCL_DEPRECATED("use sycl::ext::intel::esimd::fence_flush_op")
+    lsc_fence_op : uint8_t {
+      none = 0,       /// no operation
+      evict = 1,      /// dirty lines evicted and invalidated from L1
+      invalidate = 2, /// invalidate all clean lines
+      discard = 3,    /// direct and clean lines are discarded w/o eviction
+      clean = 4,   /// dirty lines are written to memory, but retained in cache
+                   /// in clean state
+      flushl3 = 5, /// flush only L3
+    };
 
 /// The specific LSC shared function to fence with lsc_fence
 /// Supported platforms: DG2, PVC
-enum class lsc_memory_kind : uint8_t {
-  untyped_global = 0,         /// untyped global memory
-  untyped_global_low_pri = 1, /// low-priority untyped global memory
-  typed_global = 2,           /// typed global memory
-  shared_local = 3,           /// shared local memory
-};
+enum class __SYCL_DEPRECATED("use sycl::ext::intel::esimd::memory_kind")
+    lsc_memory_kind : uint8_t {
+      untyped_global = 0,         /// untyped global memory
+      untyped_global_low_pri = 1, /// low-priority untyped global memory
+      typed_global = 2,           /// typed global memory
+      shared_local = 3,           /// shared local memory
+    };
 
 using lsc_data_size = __ESIMD_DNS::lsc_data_size;
 

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -416,25 +416,6 @@ __esimd_lsc_xatomic_slm_2(
 }
 #endif // __SYCL_DEVICE_ONLY__
 
-/// Memory fence.
-/// Supported platforms: DG2, PVC
-///
-/// @tparam Kind is the Sfid shaded function.
-/// @tparam FenceOp is the fence operation.
-/// @tparam Scope is the operation scope.
-/// @tparam N is the SIMD size of operation (the number of addresses to access)
-/// @param pred is predicates.
-template <__ESIMD_ENS::lsc_memory_kind Kind, __ESIMD_ENS::lsc_fence_op FenceOp,
-          __ESIMD_ENS::lsc_scope Scope, int N>
-__ESIMD_INTRIN void __esimd_lsc_fence(__ESIMD_DNS::simd_mask_storage_t<N> pred)
-#ifdef __SYCL_DEVICE_ONLY__
-    ;
-#else  // __SYCL_DEVICE_ONLY__
-{
-  __ESIMD_UNSUPPORTED_ON_HOST;
-}
-#endif // __SYCL_DEVICE_ONLY__
-
 __ESIMD_INTRIN uint32_t __esimd_slm_alloc(uint32_t size)
 #ifdef __SYCL_DEVICE_ONLY__
     ;

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -3091,12 +3091,17 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 template <lsc_memory_kind Kind = lsc_memory_kind::untyped_global,
           lsc_fence_op FenceOp = lsc_fence_op::none,
           lsc_scope Scope = lsc_scope::group, int N = 16>
+__SYCL_DEPRECATED("use sycl::ext::intel::esimd::fence<Kind, FenceOp, Scope>()")
 __ESIMD_API void lsc_fence(__ESIMD_NS::simd_mask<N> pred = 1) {
   static_assert(
       Kind != lsc_memory_kind::shared_local ||
           (FenceOp == lsc_fence_op::none && Scope == lsc_scope::group),
       "SLM fence must have 'none' lsc_fence_op and 'group' scope");
-  __esimd_lsc_fence<Kind, FenceOp, Scope, N>(pred.data());
+  static_assert(Kind != lsc_memory_kind::untyped_global_low_pri,
+                "lsc_memory_kind::untyped_global_low_pri is not supported in HW"
+                " and/or GPU drivers");
+  __esimd_lsc_fence<static_cast<uint8_t>(Kind), static_cast<uint8_t>(FenceOp),
+                    static_cast<uint8_t>(Scope), N>(pred.data());
 }
 
 /// @} sycl_esimd_memory_lsc

--- a/sycl/test-e2e/ESIMD/fence.cpp
+++ b/sycl/test-e2e/ESIMD/fence.cpp
@@ -1,0 +1,197 @@
+//==------------ fence.cpp - DPC++ ESIMD on-device test --------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: gpu-intel-dg2 || gpu-intel-pvc
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// This test verifies the intrinsic fence.
+// It is based on https://en.wikipedia.org/wiki/Memory_barrier#Example
+
+#include <algorithm>
+#include <cmath>
+#include <iostream>
+#include <numeric>
+#include <sycl/ext/intel/esimd.hpp>
+#include <sycl/sycl.hpp>
+
+#include "esimd_test_utils.hpp"
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+// Returns 'true' if the test passes.
+bool testGlobal(queue &Q, int OddOrEven /*0 - Even, 1 - Odd*/) {
+  constexpr size_t LocalSize = 16;
+  constexpr unsigned int SIMDSize = 8;
+  constexpr size_t Size = LocalSize * SIMDSize * 64;
+
+  int NumErrors = 0;
+  std::cout << "Running testGlobal() with OddOrEven = " << OddOrEven << "...";
+
+  int *A = aligned_alloc_shared<int>(128, Size, Q);
+  int *B = aligned_alloc_shared<int>(128, Size, Q);
+  int *ResA = aligned_alloc_shared<int>(128, Size, Q);
+  int *ResB = aligned_alloc_shared<int>(128, Size, Q);
+  std::fill(A, A + Size, 0);
+  std::fill(B, B + Size, 0);
+  std::fill(ResA, ResA + Size, 0);
+  std::fill(ResB, ResB + Size, 0);
+
+  try {
+    Q.submit([&](handler &h) {
+       range<1> GlobalRange(Size / SIMDSize);
+       range<1> LocalRange(LocalSize);
+       // There are many pairs of threads.
+       // 0-th thread:
+       //     A = 5;
+       //     fence;
+       //     B = 1;
+       // 1-st thread:
+       //     BB = B; // Don't use infinite loop 'while(B == 0) {}' as
+       //             // it was in the original example at wiki-page.
+       //             // That loop had incorrect assumption about compiler
+       //             // would keep the load inside the loop.
+       //     fence;
+       //     AA = A; // If B is 1, then A must be equal to 5.
+       h.parallel_for(nd_range<1>{GlobalRange, LocalRange},
+                      [=](nd_item<1> NdId) SYCL_ESIMD_KERNEL {
+                        auto GID = NdId.get_global_linear_id();
+                        auto Offset = GID / 2 * SIMDSize;
+                        auto ByteOffset = Offset * sizeof(int);
+
+                        if (NdId.get_local_linear_id() % 2 == OddOrEven) {
+                          // First thread: write data and condition
+                          // and provoke gpu to reorder instructions
+                          block_store(A + Offset, simd<int, SIMDSize>{5});
+
+                          // Protect from reordering the writes to A and B.
+                          fence<memory_kind::global>();
+
+                          block_store(B + Offset, simd<int, SIMDSize>{1});
+                        } else {
+                          auto BVec = block_load<int, SIMDSize>(B + Offset);
+
+                          // Protect from reordering the reads from B and A.
+                          fence<memory_kind::global>();
+
+                          auto AVec = block_load<int, SIMDSize>(A + Offset);
+
+                          AVec.copy_to(ResA + Offset);
+                          BVec.copy_to(ResB + Offset);
+                        }
+                      });
+     }).wait();
+  } catch (sycl::exception e) {
+    std::cout << "\nSYCL exception caught: " << e.what();
+    NumErrors = 1000;
+  }
+
+  for (int I = 0; I < Size / 2 && NumErrors < 10; I++) {
+    if (ResB[I] != 0 && ResA[I] == 0) {
+      NumErrors++;
+      std::cout << I << ": Error - B was written before A: A = " << ResA[I]
+                << ", B = " << ResB[I] << std::endl;
+    }
+  }
+
+  free(A, Q);
+  free(B, Q);
+  free(ResA, Q);
+  free(ResB, Q);
+  std::cout << " Done" << (NumErrors ? " with ERRORS" : "") << std::endl;
+  return NumErrors == 0;
+}
+
+bool testLocal(queue &Q) {
+  constexpr size_t LocalSize = 16;
+  constexpr unsigned int SIMDSize = 8;
+  constexpr size_t Size = LocalSize * SIMDSize * 64;
+
+  std::cout << "Running testLocal()...";
+
+  int NumErrors = 0;
+  int *ResA = aligned_alloc_shared<int>(128, Size, Q);
+  int *ResB = aligned_alloc_shared<int>(128, Size, Q);
+  std::fill(ResA, ResA + Size, 0);
+  std::fill(ResB, ResB + Size, 0);
+
+  try {
+    Q.submit([&](handler &h) {
+       range<2> GlobalRange(Size / SIMDSize, 2);
+       range<2> LocalRange(LocalSize, 2);
+       // There are many pairs of threads.
+       // 0-th thread:
+       //     A_SLM = 5;
+       //     mem_fence
+       //     B_SLM = 1;
+       // 1-st thread:
+       //     BB = B_SLM;
+       //     mem_fence
+       //     AA = A_SLM; // If BB is 1, then AA must be 5.
+       h.parallel_for(
+           nd_range<2>{GlobalRange, LocalRange},
+           [=](nd_item<2> NdId) SYCL_ESIMD_KERNEL {
+             constexpr int SLMSize = LocalSize * SIMDSize * 2 * sizeof(int);
+             // Allocate SLM memory and initialize it with zeroes.
+             slm_init<SLMSize>();
+             if (NdId.get_local_linear_id() == 0) {
+               for (int I = 0; I < SLMSize; I += SIMDSize * sizeof(int))
+                 slm_block_store(I, simd<int, SIMDSize>(0));
+             }
+             barrier();
+
+             auto Offset = NdId.get_local_id(0) * SIMDSize;
+             auto ByteOffsetA = Offset * sizeof(int);
+             auto ByteOffsetB = SLMSize / 2 + ByteOffsetA;
+             if (NdId.get_local_id(1) == 0) {
+               slm_block_store(ByteOffsetA, simd<int, SIMDSize>(5));
+               fence<memory_kind::local>();
+               slm_block_store(ByteOffsetB, simd<int, SIMDSize>(1));
+             } else {
+               auto BVec = slm_block_load<int, SIMDSize>(ByteOffsetB);
+               fence<memory_kind::local>();
+               auto AVec = slm_block_load<int, SIMDSize>(ByteOffsetA);
+
+               AVec.copy_to(ResA + Offset);
+               BVec.copy_to(ResB + Offset);
+             }
+           });
+     }).wait();
+  } catch (sycl::exception e) {
+    std::cout << "\nSYCL exception caught: " << e.what();
+    NumErrors = 1000;
+  }
+
+  for (int I = 0; I < Size && NumErrors < 10; I++) {
+    if (ResB[I] != 0 && ResA[I] == 0) {
+      NumErrors++;
+      std::cout << I << ": Error - B was written before A: A = " << ResA[I]
+                << ", B = " << ResB[I] << std::endl;
+    }
+  }
+
+  std::cout << " Done" << (NumErrors ? " with ERRORS" : "") << std::endl;
+
+  free(ResA, Q);
+  free(ResB, Q);
+  return NumErrors == 0;
+}
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  bool Passed = true;
+  Passed &= testGlobal(Q, 0);
+  Passed &= testGlobal(Q, 1);
+
+  Passed &= testLocal(Q);
+
+  std::cout << (Passed != 0 ? "PASSED" : "FAILED") << std::endl;
+  return Passed ? 0 : 1;
+}


### PR DESCRIPTION
The new esimd::fence() accepts 3 template enum parameters and is usable only on DG2 and PVC.
It implements the subset of functionality supported by experimental::esimd::lsc_fence(). The functionality that was not included into the public version is a) not supported by hardware and/or GPU drivers
b) too specific and is too risky to use now.