### PR TITLE
[SYCL][NFC] Drop output from FilterSelector E2E tests

### DIFF
--- a/sycl/test-e2e/FilterSelector/reuse.cpp
+++ b/sycl/test-e2e/FilterSelector/reuse.cpp
@@ -20,8 +20,6 @@ int main() {
 
   Devs = device::get_devices();
 
-  std::cout << "# Devices found: " << Devs.size() << std::endl;
-
   if (Devs.size() > 1) {
     filter_selector filter("1");
 

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -26,11 +26,6 @@ int main() {
   Accels = device::get_devices(sycl::info::device_type::accelerator);
   Devs = device::get_devices();
 
-  std::cout << "# CPU Devices found: " << CPUs.size() << std::endl;
-  std::cout << "# GPU Devices found: " << GPUs.size() << std::endl;
-  std::cout << "# Accelerators found: " << Accels.size() << std::endl;
-  std::cout << "# Devices found: " << Devs.size() << std::endl;
-
   bool HasLevelZeroDevices = false;
   bool HasOpenCLDevices = false;
   bool HasCUDADevices = false;
@@ -60,159 +55,128 @@ int main() {
     }
   }
 
-  std::cout << "HasLevelZeroDevices = " << HasLevelZeroDevices << std::endl;
-  std::cout << "HasOpenCLDevices    = " << HasOpenCLDevices << std::endl;
-  std::cout << "HasCUDADevices      = " << HasCUDADevices << std::endl;
-  std::cout << "HasHIPDevices       = " << HasHIPDevices << std::endl;
-  std::cout << "HasOpenCLGPU        = " << HasOpenCLGPU << std::endl;
-  std::cout << "HasLevelZeroGPU     = " << HasLevelZeroGPU << std::endl;
-
   if (!CPUs.empty()) {
-    std::cout << "Test 'cpu'";
     device d1(filter_selector("cpu"));
-    assert(d1.is_cpu());
-    std::cout << "...PASS" << std::endl;
+    assert(d1.is_cpu() && "filter_selector(\"cpu\") failed");
   }
 
   if (!GPUs.empty()) {
-    std::cout << "Test 'gpu'";
     device d2(filter_selector("gpu"));
-    assert(d2.is_gpu());
-    std::cout << "...PASS" << std::endl;
+    assert(d2.is_gpu() && "filter_selector(\"gpu\") failed");
   }
 
   if (!CPUs.empty() || !GPUs.empty()) {
-    std::cout << "Test 'cpu,gpu'";
     device d3(filter_selector("cpu,gpu"));
-    assert((d3.is_gpu() || d3.is_cpu()));
-    std::cout << "...PASS" << std::endl;
+    assert((d3.is_gpu() || d3.is_cpu()) &&
+           "filter_selector(\"cpu,gpu\") failed");
   }
 
   if (HasOpenCLDevices) {
-    std::cout << "Test 'opencl'";
     device d4(filter_selector("opencl"));
-    assert(d4.get_platform().get_backend() == backend::opencl);
-    std::cout << "...PASS" << std::endl;
+    assert(d4.get_platform().get_backend() == backend::opencl &&
+           "filter_selector(\"opencl\") failed");
 
     if (!CPUs.empty()) {
-      std::cout << "Test 'opencl:cpu'";
       device d5(filter_selector("opencl:cpu"));
-      assert(d5.is_cpu() && d5.get_platform().get_backend() == backend::opencl);
-      std::cout << "...PASS" << std::endl;
+      assert(d5.is_cpu() &&
+             d5.get_platform().get_backend() == backend::opencl &&
+             "filter_selector(\"opencl:cpu\") failed");
 
-      std::cout << "Test 'opencl:cpu:0'";
       device d6(filter_selector("opencl:cpu:0"));
-      assert(d6.is_cpu() && d6.get_platform().get_backend() == backend::opencl);
-      std::cout << "...PASS" << std::endl;
+      assert(d6.is_cpu() &&
+             d6.get_platform().get_backend() == backend::opencl &&
+             "filter_selector(\"opencl:cpu:0\") failed");
     }
 
     if (HasOpenCLGPU) {
-      std::cout << "Test 'opencl:gpu'" << std::endl;
       device d7(filter_selector("opencl:gpu"));
-      assert(d7.is_gpu() && d7.get_platform().get_backend() == backend::opencl);
+      assert(d7.is_gpu() &&
+             d7.get_platform().get_backend() == backend::opencl &&
+             "filter_selector(\"opencl:gpu\") failed");
     }
   }
 
-  std::cout << "Test '0'";
   device d8(filter_selector("0"));
-  std::cout << "...PASS" << std::endl;
 
   try {
     // pick something crazy
     device d9(filter_selector("gpu:999"));
-    std::cout << "d9 = " << d9.get_info<sycl::info::device::name>()
-              << std::endl;
   } catch (const sycl::runtime_error &e) {
     const char *ErrorMesg =
         "Could not find a device that matches the specified filter(s)!";
-    assert(std::string{e.what()}.find(ErrorMesg) == 0);
-    std::cout << "Selector failed as expected! OK" << std::endl;
+    assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
+           "filter_selector(\"gpu:999\") unexpectedly selected a device");
   }
 
   try {
     // pick something crazy
     device d10(filter_selector("bob:gpu"));
-    std::cout << "d10 = " << d10.get_info<sycl::info::device::name>()
-              << std::endl;
   } catch (const sycl::runtime_error &e) {
     const char *ErrorMesg = "Invalid filter string!";
-    assert(std::string{e.what()}.find(ErrorMesg) == 0);
-    std::cout << "Selector failed as expected! OK" << std::endl;
+    assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
+           "filter_selector(\"bob:gpu\") unexpectedly selected a device");
   }
 
   try {
     // pick something crazy
     device d11(filter_selector("opencl:bob"));
-    std::cout << "d11 = " << d11.get_info<sycl::info::device::name>()
-              << std::endl;
   } catch (const sycl::runtime_error &e) {
     const char *ErrorMesg = "Invalid filter string!";
-    assert(std::string{e.what()}.find(ErrorMesg) == 0);
-    std::cout << "Selector failed as expected! OK" << std::endl;
+    assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
+           "filter_selector(\"opencl:bob\") unexpectedly selected a device");
   }
 
   if (HasLevelZeroDevices && HasLevelZeroGPU) {
-    std::cout << "Test 'level_zero'";
     device d12(filter_selector("level_zero"));
-    assert(d12.get_platform().get_backend() == backend::ext_oneapi_level_zero);
-    std::cout << "...PASS" << std::endl;
+    assert(d12.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
+           "filter_selector(\"level_zero\") failed");
 
-    std::cout << "Test 'level_zero:gpu'";
     device d13(filter_selector("level_zero:gpu"));
     assert(d13.is_gpu() &&
-           d13.get_platform().get_backend() == backend::ext_oneapi_level_zero);
-    std::cout << "...PASS" << std::endl;
+           d13.get_platform().get_backend() == backend::ext_oneapi_level_zero &&
+           "filter_selector(\"level_zero:gpu\") failed");
 
     if (HasOpenCLDevices && !CPUs.empty()) {
-      std::cout << "Test 'level_zero:gpu,cpu'";
       device d14(filter_selector("level_zero:gpu,cpu"));
-      assert((d14.is_gpu() || d14.is_cpu()));
-      std::cout << "...PASS 1/2" << std::endl;
+      assert((d14.is_gpu() || d14.is_cpu()) &&
+             "filter_selector(\"level_zero:gpu,cpu\") failed");
       if (d14.is_gpu()) {
         assert(d14.get_platform().get_backend() ==
-               backend::ext_oneapi_level_zero);
-        std::cout << "...PASS 2/2" << std::endl;
+                   backend::ext_oneapi_level_zero &&
+               "filter_selector(\"level_zero:gpu,cpu\") failed");
       }
     }
   }
 
   if (Devs.size() > 1) {
-    std::cout << "Test '1'";
     device d15(filter_selector("1"));
-    std::cout << "...PASS" << std::endl;
   }
 
   if (HasCUDADevices) {
-    std::cout << "Test 'cuda'";
     device d16(filter_selector("cuda"));
-    assert(d16.get_platform().get_backend() == backend::ext_oneapi_cuda);
-    std::cout << "...PASS" << std::endl;
+    assert(d16.get_platform().get_backend() == backend::ext_oneapi_cuda &&
+           "filter_selector(\"cuda\") failed");
 
-    std::cout << "Test 'cuda:gpu'";
     device d17(filter_selector("cuda:gpu"));
     assert(d17.is_gpu() &&
-           d17.get_platform().get_backend() == backend::ext_oneapi_cuda);
-    std::cout << "...PASS" << std::endl;
+           d17.get_platform().get_backend() == backend::ext_oneapi_cuda &&
+           "filter_selector(\"cuda:gpu\") failed");
   }
 
   if (!Accels.empty()) {
-    std::cout << "Test 'accelerator'";
     device d18(filter_selector("accelerator"));
-    assert(d18.is_accelerator());
-    std::cout << "...PASS" << std::endl;
+    assert(d18.is_accelerator() && "filter_selector(\"accelerator\") failed");
   }
 
   if (HasHIPDevices) {
-    std::cout << "Test 'hip'";
     device d19(ext::oneapi::filter_selector("hip"));
-    assert(d19.get_platform().get_backend() == backend::ext_oneapi_hip);
-    std::cout << "...PASS" << std::endl;
+    assert(d19.get_platform().get_backend() == backend::ext_oneapi_hip &&
+           "filter_selector(\"hip\") failed");
 
-    std::cout << "test 'hip:gpu'";
     device d20(ext::oneapi::filter_selector("hip:gpu"));
     assert(d20.is_gpu() &&
-           d20.get_platform().get_backend() == backend::ext_oneapi_hip);
-    std::cout << "...PASS" << std::endl;
+           d20.get_platform().get_backend() == backend::ext_oneapi_hip &&
+           "filter_selector(\"hip:gpu\") failed");
   }
 
   return 0;

--- a/sycl/test-e2e/FilterSelector/select_device.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device.cpp
@@ -23,7 +23,6 @@ int main() {
   const char *envVal = std::getenv("ONEAPI_DEVICE_SELECTOR");
   std::string forcedPIs;
   if (envVal) {
-    std::cout << "ONEAPI_DEVICE_SELECTOR=" << envVal << std::endl;
     forcedPIs = envVal;
   }
   if (!envVal || forcedPIs == "*" ||
@@ -32,8 +31,6 @@ int main() {
     device d = ds.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("Level-Zero") != string::npos);
-    std::cout << "Level-zero GPU Device is found: " << std::boolalpha
-              << d.is_gpu() << std::endl;
   }
   if (envVal && forcedPIs != "*" &&
       forcedPIs.find("opencl:gpu") != std::string::npos) {
@@ -41,20 +38,16 @@ int main() {
     device d = gs.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("OpenCL") != string::npos);
-    std::cout << "OpenCL GPU Device is found: " << std::boolalpha << d.is_gpu()
-              << std::endl;
   }
   if (!envVal || forcedPIs == "*" ||
       forcedPIs.find("cpu") != std::string::npos) {
     cpu_selector cs;
     device d = cs.select_device();
-    std::cout << "CPU device is found: " << d.is_cpu() << std::endl;
   }
   if (!envVal || forcedPIs == "*" ||
       forcedPIs.find("acc") != std::string::npos) {
     accelerator_selector as;
     device d = as.select_device();
-    std::cout << "ACC device is found: " << d.is_accelerator() << std::endl;
   }
   if (envVal && (forcedPIs.find("cpu") == std::string::npos &&
                  forcedPIs.find("opencl") == std::string::npos &&
@@ -63,10 +56,10 @@ int main() {
       cpu_selector cs;
       device d = cs.select_device();
     } catch (...) {
-      std::cout << "Expectedly, CPU device is not found." << std::endl;
       return 0; // expected
     }
-    std::cerr << "Error: CPU device is found" << std::endl;
+    std::cerr << "Error: CPU device is found, even though it shouldn't be"
+              << std::endl;
     return -1;
   }
 

--- a/sycl/test-e2e/FilterSelector/select_device_acc.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_acc.cpp
@@ -18,16 +18,14 @@ int main() {
   const char *envVal = std::getenv("ONEAPI_DEVICE_SELECTOR");
   std::string forcedPIs;
   if (envVal) {
-    std::cout << "ONEAPI_DEVICE_SELECTOR=" << envVal << std::endl;
     forcedPIs = envVal;
   }
   {
     default_selector ds;
     device d = ds.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
-    assert(name.find("OpenCL") != string::npos);
-    std::cout << "ACC Device is found: " << std::boolalpha << d.is_accelerator()
-              << std::endl;
+    assert(name.find("OpenCL") != string::npos &&
+           "default selector failed to find acc device");
   }
   {
     gpu_selector gs;
@@ -37,7 +35,6 @@ int main() {
                 << d.is_gpu() << std::endl;
       return -1;
     } catch (...) {
-      std::cout << "Expectedly, GPU device is not found." << std::endl;
     }
   }
   {
@@ -48,15 +45,14 @@ int main() {
                 << d.is_cpu() << std::endl;
       return -1;
     } catch (...) {
-      std::cout << "Expectedly, CPU device is not found." << std::endl;
     }
   }
   {
     accelerator_selector as;
     device d = as.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
-    assert(name.find("OpenCL") != string::npos);
-    std::cout << "ACC device is found: " << d.is_accelerator() << std::endl;
+    assert(name.find("OpenCL") != string::npos &&
+           "accelerator_selector failed to find acc device");
   }
 
   return 0;

--- a/sycl/test-e2e/FilterSelector/select_device_cpu.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_cpu.cpp
@@ -18,16 +18,14 @@ int main() {
   const char *envVal = std::getenv("ONEAPI_DEVICE_SELECTOR");
   std::string forcedPIs;
   if (envVal) {
-    std::cout << "ONEAPI_DEVICE_SELECTOR=" << envVal << std::endl;
     forcedPIs = envVal;
   }
   {
     default_selector ds;
     device d = ds.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
-    assert(name.find("OpenCL") != string::npos);
-    std::cout << "CPU Device is found: " << std::boolalpha << d.is_cpu()
-              << std::endl;
+    assert(name.find("OpenCL") != string::npos &&
+           "default_selector failed to find cpu device");
   }
   {
     gpu_selector gs;
@@ -37,13 +35,11 @@ int main() {
                 << std::endl;
       return -1;
     } catch (...) {
-      std::cout << "Expectedly, GPU device is not found." << std::endl;
     }
   }
   {
     cpu_selector cs;
     device d = cs.select_device();
-    std::cout << "CPU device is found: " << d.is_cpu() << std::endl;
   }
   {
     accelerator_selector as;
@@ -53,7 +49,6 @@ int main() {
                 << std::endl;
       return -1;
     } catch (...) {
-      std::cout << "Expectedly, ACC device is not found." << std::endl;
     }
   }
 

--- a/sycl/test-e2e/FilterSelector/select_device_cuda.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_cuda.cpp
@@ -18,7 +18,6 @@ int main() {
   const char *envVal = getenv("ONEAPI_DEVICE_SELECTOR");
   string forcedPIs;
   if (envVal) {
-    cout << "ONEAPI_DEVICE_SELECTOR=" << envVal << std::endl;
     forcedPIs = envVal;
   }
 
@@ -27,15 +26,12 @@ int main() {
     device d = ds.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("CUDA") != string::npos);
-    cout << "CUDA GPU Device is found: " << boolalpha << d.is_gpu()
-         << std::endl;
   }
   {
     gpu_selector gs;
     device d = gs.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("CUDA") != string::npos);
-    cout << name << " is found: " << boolalpha << d.is_gpu() << std::endl;
   }
   {
     cpu_selector cs;
@@ -44,7 +40,6 @@ int main() {
       cerr << "CPU device is found in error: " << d.is_cpu() << std::endl;
       return -1;
     } catch (...) {
-      cout << "Expectedly, cpu device is not found." << std::endl;
     }
   }
   {
@@ -54,7 +49,6 @@ int main() {
       cerr << "ACC device is found in error: " << d.is_accelerator()
            << std::endl;
     } catch (...) {
-      cout << "Expectedly, ACC device is not found." << std::endl;
     }
   }
 

--- a/sycl/test-e2e/FilterSelector/select_device_level_zero.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_level_zero.cpp
@@ -18,7 +18,6 @@ int main() {
   const char *envVal = getenv("ONEAPI_DEVICE_SELECTOR");
   string forcedPIs;
   if (envVal) {
-    cout << "ONEAPI_DEVICE_SELECTOR=" << envVal << std::endl;
     forcedPIs = envVal;
   }
 
@@ -27,15 +26,12 @@ int main() {
     device d = ds.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("Level-Zero") != string::npos);
-    cout << "Level-Zero GPU Device is found: " << boolalpha << d.is_gpu()
-         << std::endl;
   }
   {
     gpu_selector gs;
     device d = gs.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("Level-Zero") != string::npos);
-    cout << name << " is found: " << boolalpha << d.is_gpu() << std::endl;
   }
   {
     cpu_selector cs;
@@ -44,7 +40,6 @@ int main() {
       cerr << "CPU device is found in error: " << d.is_cpu() << std::endl;
       return -1;
     } catch (...) {
-      cout << "Expectedly, cpu device is not found." << std::endl;
     }
   }
   {
@@ -54,7 +49,6 @@ int main() {
       cerr << "ACC device is found in error: " << d.is_accelerator()
            << std::endl;
     } catch (...) {
-      cout << "Expectedly, ACC device is not found." << std::endl;
     }
   }
 

--- a/sycl/test-e2e/FilterSelector/select_device_opencl.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_opencl.cpp
@@ -18,7 +18,6 @@ int main() {
   const char *envVal = getenv("ONEAPI_DEVICE_SELECTOR");
   string forcedPIs;
   if (envVal) {
-    cout << "ONEAPI_DEVICE_SELECTOR=" << envVal << std::endl;
     forcedPIs = envVal;
   }
 
@@ -26,26 +25,23 @@ int main() {
     default_selector ds;
     device d = ds.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
-    assert(name.find("OpenCL") != string::npos);
-    cout << "OpenCL GPU Device is found: " << boolalpha << d.is_gpu()
-         << std::endl;
+    assert(name.find("OpenCL") != string::npos &&
+           "default_selector failed to find an opencl device");
   }
   {
     gpu_selector gs;
     device d = gs.select_device();
     string name = d.get_platform().get_info<info::platform::name>();
-    assert(name.find("OpenCL") != string::npos);
-    cout << name << " is found: " << boolalpha << d.is_gpu() << std::endl;
+    assert(name.find("OpenCL") != string::npos &&
+           "gpu_selector failed to find an opencl device");
   }
   {
     cpu_selector cs;
     device d = cs.select_device();
-    cout << "CPU device is found : " << d.is_cpu() << std::endl;
   }
   {
     accelerator_selector as;
     device d = as.select_device();
-    cout << "ACC device is found : " << d.is_accelerator() << std::endl;
   }
 
   return 0;


### PR DESCRIPTION
Removed most uses of `std::cout` from `FilterSelector` E2E tests.

There is no need in positive or informational output in those tests: it is not displayed in CI logs when tests pass, it is not checked by tools like `FileCheck`, etc. Expectation is that less I/O will allow tests to pass quicker