### PR TITLE
Handle unreachable default in llvm::SwitchIns.

### DIFF
--- a/llvm/test/CodeGen/NVPTX/unreachable-switch-case.ll
+++ b/llvm/test/CodeGen/NVPTX/unreachable-switch-case.ll
@@ -1,0 +1,31 @@
+; RUN: llc < %s -march=nvptx -mcpu=sm_20 -verify-machineinstrs | FileCheck %s  
+
+declare noundef i32 @llvm.nvvm.read.ptx.sreg.tid.x() #1
+
+define void @kernel_func() {
+
+  %1 = tail call i32 @llvm.nvvm.read.ptx.sreg.tid.x()
+
+  switch i32 %1, label %unreachabledefault [
+    i32 0, label %bb0
+    i32 1, label %bb1
+    i32 2, label %bb1
+    i32 3, label %bb2
+  ]
+
+  bb0:
+    ret void
+
+  bb1:
+    ret void
+
+  bb2:
+    ret void
+
+  unreachabledefault:
+    unreachable
+
+; CHECK:  @kernel_func
+; CHECK-NOT: unreachabledefault
+; CHECK:  -- End function
+}


### PR DESCRIPTION
Addressing [Lower unreachable to exit to allow ptxas to accurately reconstruct the CFG](https://reviews.llvm.org/D152789) resulted in  performance regression In scenarios where a `Switch Instruction` has an unreachable default successor. Substituting the unreachable instruction with an exit instruction introduces an additional block in the Control Flow Graph (CFG), thereby negatively impacting performance. To mitigate this undesirable impact, we refrain from processing blocks that serve as successors to the unreachable default in the switch instruction.These blocks are subsequently optimized out by other passes in the optimization pipeline.