### PR TITLE
[SYCL][NFC] Silence deprecated API warnings in tests

### DIFF
--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t.out
 // RUN: %{run} %t.out
 
 //==----------------accessor.cpp - SYCL accessor basic test ----------------==//

--- a/sycl/test-e2e/Basic/multi_ptr_legacy.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_legacy.cpp
@@ -1,6 +1,6 @@
-// RUN: %{build} -fsycl-dead-args-optimization -o %t.out
+// RUN: %{build} -fsycl-dead-args-optimization -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -DRESTRICT_WRITE_ACCESS_TO_CONSTANT_PTR -fsycl-dead-args-optimization -o %t1.out
+// RUN: %{build} -DRESTRICT_WRITE_ACCESS_TO_CONSTANT_PTR -fsycl-dead-args-optimization -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t1.out
 // RUN: %{run} %t1.out
 
 //==-------- multi_ptr_legacy.cpp - SYCL multi_ptr legacy test -------------==//

--- a/sycl/test-e2e/Basic/parallel_for_offset_integral_t.cpp
+++ b/sycl/test-e2e/Basic/parallel_for_offset_integral_t.cpp
@@ -1,6 +1,6 @@
-// RUN: %{build} -DLAMBDA_KERNEL=1 -o %t1.out
+// RUN: %{build} -DLAMBDA_KERNEL=1 -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t1.out
 // RUN: %{run} %t1.out
-// RUN: %{build} -DLAMBDA_KERNEL=0 -o %t2.out
+// RUN: %{build} -DLAMBDA_KERNEL=0 -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t2.out
 // RUN: %{run} %t2.out
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/vector_operators.cpp
+++ b/sycl/test-e2e/Basic/vector_operators.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t.out
 // RUN: %{run} %t.out
 
 //==---------- vector_operators.cpp - SYCL vec<> operators test ------------==//


### PR DESCRIPTION
Some tests check APIs which are deprecated and it is by design, because those APIs should still work. However, they produce a lot of noise by deprecation warnings.

Added corresponding macro to some of E2E tests to silence those warnings.