### PR TITLE
[SYCL][NFC] Cleanup warnings in E2E tests

### DIFF
--- a/sycl/test-e2e/Basic/aspects.cpp
+++ b/sycl/test-e2e/Basic/aspects.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build} -o %t.out -DSYCL_DISABLE_IMAGE_ASPECT_WARNING
 // RUN: %{run-unfiltered-devices} %t.out
 //
 // Hip is missing some of the parameters tested here so it fails with NVIDIA

--- a/sycl/test-e2e/Basic/device-selectors.cpp
+++ b/sycl/test-e2e/Basic/device-selectors.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build} -o %t.out -DSYCL_DISABLE_IMAGE_ASPECT_WARNING
 // RUN: %{run-unfiltered-devices} %t.out
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/Basic/exceptions-SYCL-2020.cpp
+++ b/sycl/test-e2e/Basic/exceptions-SYCL-2020.cpp
@@ -88,9 +88,6 @@ int main() {
       someL0ErrCode{EC};
   sycl::errc_for<sycl::backend::ext_oneapi_level_zero> anotherL0ErrCode{EC};
   assert(someL0ErrCode == anotherL0ErrCode);
-  sycl::backend_traits<sycl::backend::host>::errc someHOSTErrCode{EC};
-  sycl::errc_for<sycl::backend::host> anotherHOSTErrCode{EC};
-  assert(someHOSTErrCode == anotherHOSTErrCode);
   sycl::backend_traits<sycl::backend::ext_oneapi_cuda>::errc someCUDAErrCode{
       EC};
   sycl::errc_for<sycl::backend::ext_oneapi_cuda> anotherCUDAErrCode{EC};

--- a/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
@@ -22,7 +22,7 @@ void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
     auto DstA = Dst.template get_access<mode::write>(CGH);
 
     CGH.host_task([=]() {
-      for (size_t Idx = 0; Idx < SrcA.get_count(); ++Idx)
+      for (size_t Idx = 0; Idx < SrcA.size(); ++Idx)
         DstA[Idx] = SrcA[Idx];
     });
   });

--- a/sycl/test-e2e/HostInteropTask/host-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task.cpp
@@ -44,7 +44,7 @@ void test2(queue &Q) {
     auto Acc = Buffer1.template get_access<mode::write>(CGH);
 
     auto Kernel = [=](item<1> Id) { Acc[Id] = 123; };
-    CGH.parallel_for<NameGen<class Test6Init, true>>(Acc.get_count(), Kernel);
+    CGH.parallel_for<NameGen<class Test6Init, true>>(Acc.size(), Kernel);
   });
 
   Q.submit([&](handler &CGH) {
@@ -52,7 +52,7 @@ void test2(queue &Q) {
     auto AccDst = Buffer2.template get_access<mode::write>(CGH);
 
     auto Func = [=] {
-      for (size_t Idx = 0; Idx < AccDst.get_count(); ++Idx)
+      for (size_t Idx = 0; Idx < AccDst.size(); ++Idx)
         AccDst[Idx] = AccSrc[Idx];
     };
     CGH.host_task(Func);
@@ -61,7 +61,7 @@ void test2(queue &Q) {
   {
     auto Acc = Buffer2.get_host_access();
 
-    for (size_t Idx = 0; Idx < Acc.get_count(); ++Idx) {
+    for (size_t Idx = 0; Idx < Acc.size(); ++Idx) {
       std::cout << "Second buffer [" << Idx << "] = " << Acc[Idx] << std::endl;
       assert(Acc[Idx] == 123);
     }

--- a/sycl/test-e2e/Plugin/enqueue-arg-order-buffer.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-buffer.cpp
@@ -124,21 +124,21 @@ void testGetLinearIndex() {
     buffer<float, 2> buffer_2D(data_2D.data(), range<2>(height, width));
     buffer<float, 3> buffer_3D(data_3D.data(), range<3>(depth, height, width));
 
-    auto acc_1D = buffer_1D.get_access<access::mode::read_write>();
+    auto acc_1D = buffer_1D.get_host_access();
     auto accTest_1D = AccTest<float, 1>(acc_1D);
     size_t linear_1D = accTest_1D.gLI(id<1>(x)); // s.b. 4
     std::cout << "linear_1D: " << linear_1D << "  target_1D: " << target_1D
               << std::endl;
     assert(linear_1D == target_1D && "linear_1D s.b. 4");
 
-    auto acc_2D = buffer_2D.get_access<access::mode::read_write>();
+    auto acc_2D = buffer_2D.get_host_access();
     auto accTest_2D = AccTest<float, 2>(acc_2D);
     size_t linear_2D = accTest_2D.gLI(id<2>(y, x));
     std::cout << "linear_2D: " << linear_2D << "  target_2D: " << target_2D
               << std::endl;
     assert(linear_2D == target_2D && "linear_2D s.b. 52");
 
-    auto acc_3D = buffer_3D.get_access<access::mode::read_write>();
+    auto acc_3D = buffer_3D.get_host_access();
     auto accTest_3D = AccTest<float, 3>(acc_3D);
     size_t linear_3D = accTest_3D.gLI(id<3>(z, y, x));
     std::cout << "linear_3D: " << linear_3D << "  target_3D: " << target_3D

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -19,12 +19,10 @@ using namespace std;
 const std::map<info::device_type, std::string> DeviceTypeStringMap = {
     {info::device_type::cpu, "cpu"},
     {info::device_type::gpu, "gpu"},
-    {info::device_type::host, "host"},
     {info::device_type::accelerator, "acc"}};
 
 const std::map<backend, std::string> BackendStringMap = {
     {backend::opencl, "opencl"},
-    {backend::host, "host"},
     {backend::ext_oneapi_level_zero, "ext_oneapi_level_zero"},
     {backend::ext_oneapi_cuda, "ext_oneapi_cuda"},
     {backend::ext_oneapi_hip, "ext_oneapi_hip"},
@@ -111,8 +109,7 @@ int GetPreferredDeviceIndex(const std::vector<device> &devices,
   const std::map<info::device_type, int> scoreByType = {
       {info::device_type::cpu, 300},
       {info::device_type::gpu, 500},
-      {info::device_type::accelerator, 75},
-      {info::device_type::host, 100}};
+      {info::device_type::accelerator, 75}};
   int score = -1;
   int index = -1;
   int devCount = devices.size();

--- a/sycl/test-e2e/Regression/group.cpp
+++ b/sycl/test-e2e/Regression/group.cpp
@@ -189,7 +189,7 @@ bool group__async_work_group_copy() {
         cgh.parallel_for<class group__async_work_group_copy>(
             nd_range<2>{GlobalRange, LocalRange}, [=](nd_item<DIMS> I) {
               const auto Group = I.get_group();
-              const auto NumElem = AccLocal.get_count();
+              const auto NumElem = AccLocal.size();
               const auto Off = Group[0] * I.get_group_range(1) * NumElem +
                                Group[1] * I.get_local_range(1);
               auto PtrGlobal =

--- a/sycl/test-e2e/Sampler/basic-rw-float.cpp
+++ b/sycl/test-e2e/Sampler/basic-rw-float.cpp
@@ -73,7 +73,7 @@ void test_rw(image_channel_order ChanOrder, image_channel_type ChanType) {
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels, no sampler" << std::endl;
     check_pixels(test_acc, ref, offset);
   } // ~image / ~buffer

--- a/sycl/test-e2e/Sampler/basic-rw.cpp
+++ b/sycl/test-e2e/Sampler/basic-rw.cpp
@@ -87,7 +87,7 @@ void test_rw(image_channel_order ChanOrder, image_channel_type ChanType) {
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels, no sampler" << std::endl;
     check_pixels(test_acc, ref, offset);
   } // ~image / ~buffer

--- a/sycl/test-e2e/Sampler/normalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clamp-linear-float.cpp
@@ -128,7 +128,7 @@ void test_normalized_clamp_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read seven pixels at 'boundary' locations, starting out of "
                  "bounds,  sample:   Normalized +  Clamp  + Linear"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-clamp-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clamp-nearest.cpp
@@ -106,7 +106,7 @@ void test_normalized_clamp_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels at low-boundary locations,  sample:   "
                  "Normalized +  Clamp  + Nearest"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-clampedge-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clampedge-linear-float.cpp
@@ -117,7 +117,7 @@ void test_normalized_clampedge_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read three pixels at inner boundary locations,  sample:  "
                  " Normalized +  ClampEdge  + Linear"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-clampedge-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-clampedge-nearest.cpp
@@ -111,7 +111,7 @@ void test_normalized_clampedge_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels at low-boundary locations,  sample:   "
                  "Normalized +  Clamp To Edge  + Nearest"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-mirror-linear-float.cpp
@@ -130,7 +130,7 @@ void test_normalized_mirrored_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read three pixels at inner boundary locations,  sample:  "
                  " Normalized +  Mirrored  + Linear"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-mirror-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-mirror-nearest.cpp
@@ -128,7 +128,7 @@ void test_normalized_mirrored_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels at low-boundary locations,  sample:   "
                  "Normalized + Mirrored Repeat  + Nearest"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-none-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-none-linear-float.cpp
@@ -117,7 +117,7 @@ void test_normalized_none_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read three pixels at inner boundary locations,  sample:  "
                  " Normalized +  None  + Linear"
               << std::endl;

--- a/sycl/test-e2e/Sampler/normalized-none-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-none-nearest.cpp
@@ -122,7 +122,7 @@ void test_normalized_none_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
 
     std::cout << "read four pixels at low-boundary locations,  sample:   "
                  "Normalized +  None  + Nearest"

--- a/sycl/test-e2e/Sampler/normalized-repeat-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/normalized-repeat-linear-float.cpp
@@ -129,7 +129,7 @@ void test_normalized_repeat_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
 
     std::cout << "read three pixels at inner boundary locations,  sample:  "
                  " Normalized +  Repeat  + Linear"

--- a/sycl/test-e2e/Sampler/normalized-repeat-nearest.cpp
+++ b/sycl/test-e2e/Sampler/normalized-repeat-nearest.cpp
@@ -125,7 +125,7 @@ void test_normalized_repeat_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
 
     std::cout << "read four pixels at low-boundary locations,  sample:   "
                  "Normalized +  Repeat  + Nearest"

--- a/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clamp-linear-float.cpp
@@ -109,7 +109,7 @@ void test_unnormalized_clamp_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
 
     std::cout << "read six pixels, float coordinates,   sample:   "
                  "NonNormalized + Clamp + Linear"

--- a/sycl/test-e2e/Sampler/unnormalized-clamp-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clamp-nearest.cpp
@@ -90,7 +90,7 @@ void test_unnormalized_clamp_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read six pixels,   sampler:   UnNormalized + Clamp + Nearest"
               << std::endl;
     check_pixels(test_acc, ref, offset);

--- a/sycl/test-e2e/Sampler/unnormalized-clampedge-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clampedge-linear-float.cpp
@@ -110,7 +110,7 @@ void test_unnormalized_clampedge_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
 
     std::cout << "read six pixels, float coordinates,   sample:   "
                  "NonNormalized + ClampEDGE + Linear"

--- a/sycl/test-e2e/Sampler/unnormalized-clampedge-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-clampedge-nearest.cpp
@@ -92,7 +92,7 @@ void test_unnormalized_clampedge_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read six pixels,   sampler:   UnNormalized + ClampEdge + "
                  "Nearest"
               << std::endl;

--- a/sycl/test-e2e/Sampler/unnormalized-none-linear-float.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-none-linear-float.cpp
@@ -148,7 +148,7 @@ void test_unnormalized_none_linear_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels. no sampler" << std::endl;
     check_pixels(test_acc, ref_pixel, offset);
 

--- a/sycl/test-e2e/Sampler/unnormalized-none-nearest.cpp
+++ b/sycl/test-e2e/Sampler/unnormalized-none-nearest.cpp
@@ -86,7 +86,7 @@ void test_unnormalized_none_nearest_sampler(image_channel_order ChanOrder,
 
     // REPORT RESULTS
     size_t offset = 0;
-    auto test_acc = testResults.get_access<access::mode::read>();
+    auto test_acc = testResults.get_host_access();
     std::cout << "read four pixels,  sample:   NonNormalized +  None  + Nearest"
               << std::endl;
     check_pixels(test_acc, ref, offset);

--- a/sycl/test-e2e/Scheduler/BasicSchedulerTests.cpp
+++ b/sycl/test-e2e/Scheduler/BasicSchedulerTests.cpp
@@ -59,8 +59,8 @@ int main() {
             BufSize, [=](sycl::id<1> Id) { Buf1Acc[Id] = Buf2Acc[Id]; });
       });
 
-      auto Buf1HostAcc = Buf1.get_access<sycl_access_mode::read>();
-      auto Buf2HostAcc = Buf2.get_access<sycl_access_mode::read>();
+      auto Buf1HostAcc = Buf1.get_host_access();
+      auto Buf2HostAcc = Buf2.get_host_access();
     });
 
   } catch (...) {

--- a/sycl/test-e2e/Scheduler/HostAccDestruction.cpp
+++ b/sycl/test-e2e/Scheduler/HostAccDestruction.cpp
@@ -21,7 +21,7 @@ int main() {
   sycl::buffer<int, 1> buf(size);
   {
     sycl::queue q;
-    auto host_acc = buf.get_access<sycl::access::mode::read_write>();
+    auto host_acc = buf.get_host_access();
     q.submit([&](sycl::handler &cgh) {
       auto acc = buf.get_access<sycl::access::mode::read_write>(cgh);
       cgh.parallel_for<class SingleTask>(

--- a/sycl/test-e2e/Scheduler/MultipleDevices.cpp
+++ b/sycl/test-e2e/Scheduler/MultipleDevices.cpp
@@ -62,7 +62,7 @@ int multidevice_test(queue MyQueue1, queue MyQueue2) {
     });
   });
 
-  auto FinalD = BufD.get_access<access::mode::read>();
+  auto FinalD = BufD.get_host_access();
   std::cout << "Result:" << std::endl;
   for (size_t i = 0; i < N; i++) {
 

--- a/sycl/test-e2e/Scheduler/ReleaseResourcesTest.cpp
+++ b/sycl/test-e2e/Scheduler/ReleaseResourcesTest.cpp
@@ -33,7 +33,7 @@ int main() {
                                      [=](sycl::id<1> Id) { (void)BufAcc[Id]; });
     });
 
-    auto BufHostAcc = Buf.get_access<sycl_access_mode::read>();
+    auto BufHostAcc = Buf.get_host_access();
 
     Queue.wait_and_throw();
 


### PR DESCRIPTION
Main changes:
- dropped uses of deprecated APIs where this is not a direct goal of the test (`get_count` -> `size`)
- defined `SYCL_DISABLE_IMAGE_ASPECT_WARNING` for some tests
- `get_access` -> `get_host_access` (for simple cases)
- removed uses of host backend