### PR TITLE
[SYCL][E2E] Disable Matrix/XMX8/element_wise_all_sizes.cpp on DG2

### DIFF
--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
@@ -6,7 +6,10 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: matrix-xmx8
-// XFAIL: gpu-intel-dg2
+
+// TODO: Currently fails and regularly times out on DG2. Re-enable when this has
+//       been addressed. 
+// UNSUPPORTED: gpu-intel-dg2
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
@@ -8,7 +8,7 @@
 // REQUIRES: matrix-xmx8
 
 // TODO: Currently fails and regularly times out on DG2. Re-enable when this has
-//       been addressed. 
+//       been addressed.
 // UNSUPPORTED: gpu-intel-dg2
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
This commit disables the Matrix/XMX8/element_wise_all_sizes.cpp on DG2. It was already known to fail, but has also been seen to regularly time out in CI.