### PR TITLE
Last fp-accuracy option wins.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -65,10 +65,10 @@ def err_drv_no_cuda_libdevice : Error<
   "via '--cuda-path', or pass '-nocudalib' to build without linking with "
   "libdevice">;
 
-def warn_function_fp_accuracy_already_set : Warning <
-  "floating point accuracy value of '%0' has already been assigned to "
-  "function '%1'">,
-  InGroup<DiagGroup<"fp-accuracy-already-set">>;
+def warn_drv_fp_accuracy_override : Warning <
+  "'-ffp-accuracy=%0' overrides '-ffp-accuracy=%1' for the function '%2'">,
+  InGroup<FPAccOverride>;
+
 def err_drv_no_rocm_device_lib : Error<
   "cannot find ROCm device library%select{| for %1|for ABI version %1}0; provide its path via "
   "'--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build "

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -793,6 +793,7 @@ def UnusedCommandLineArgument : DiagGroup<"unused-command-line-argument">;
 def IgnoredOptimizationArgument : DiagGroup<"ignored-optimization-argument">;
 def InvalidCommandLineArgument : DiagGroup<"invalid-command-line-argument",
                                            [IgnoredOptimizationArgument]>;
+def FPAccOverride : DiagGroup<"fp-accuracy-override">;
 def UnusedComparison : DiagGroup<"unused-comparison">;
 def UnusedExceptionParameter : DiagGroup<"unused-exception-parameter">;
 def UnneededInternalDecl : DiagGroup<"unneeded-internal-declaration">;

--- a/clang/test/Driver/fp-accuracy.c
+++ b/clang/test/Driver/fp-accuracy.c
@@ -38,7 +38,11 @@
 
 // RUN: not %clang -fno-math-errno -ffp-accuracy=low:[sin,cos] \
 // RUN: -ffp-accuracy=high %s 2>&1  \
-// RUN: | FileCheck %s --check-prefix=WARN
+// RUN: | FileCheck %s --check-prefix=WARN1
+
+// RUN: not %clang -fno-math-errno -ffp-accuracy=low:[sin,cos] \
+// RUN: -ffp-accuracy=high:[cos,tan] %s 2>&1  \
+// RUN: | FileCheck %s --check-prefix=WARN2
 
 // RUN: not %clang -Xclang -verify -ffp-accuracy=low:[sin,cos] \
 // RUN: -ffp-accuracy=high -fmath-errno %s 2>&1  \
@@ -58,7 +62,8 @@
 // ERR: (frontend): unsupported argument 'foo' to option '-ffp-accuracy'
 // ERR-1: (frontend): unsupported argument 'foo' to option '-ffp-accuracy'
 // ERR-2: (frontend): unsupported argument 'high=[sin]' to option '-ffp-accuracy'
-// WARN: floating point accuracy value of 'low' has already been assigned to function 'cos'
-// WARN: floating point accuracy value of 'low' has already been assigned to function 'sin'
+// WARN1: '-ffp-accuracy=high' overrides '-ffp-accuracy=low:[sin,cos]' for the function 'cos'
+// WARN1: '-ffp-accuracy=high' overrides '-ffp-accuracy=low:[sin,cos]' for the function 'sin'
+// WARN2: '-ffp-accuracy=high:[cos,tan]' overrides '-ffp-accuracy=low:[sin,cos]' for the function 'cos'
 
 // ERR-3: (frontend): floating point accuracy requirements cannot be guaranteed when '-fmath-errno' is enabled; use '-fno-math-errno' to enable floating point accuracy control


### PR DESCRIPTION
This implements a new request to make the last fp-accuracy option on the command line wins.
A warning is generated to warn the user.