### PR TITLE
[SYCL-MLIR] Attach fast math flags to codegened operations

### DIFF
--- a/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMathOps.td
+++ b/mlir-sycl/include/mlir/Dialect/SYCL/IR/SYCLMathOps.td
@@ -14,6 +14,7 @@
 #define SYCL_MATH_OPS
 
 include "mlir/Dialect/Arith/IR/ArithBase.td"
+include "mlir/Dialect/Arith/IR/ArithOpsInterfaces.td"
 include "mlir/Interfaces/InferTypeOpInterface.td"
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -40,7 +41,10 @@ def SYCLMathFunc : SYCLOpTrait<"SYCLMathFunc">;
 // TODO: Support marrarys.
 // TODO: Consider VectorUnrollOpInterface, ElementwiseMappable.
 class SYCL_MathOp<string mnemonic, list<Trait> traits = []> :
-    SYCL_Op<"math." # mnemonic, traits # [SYCLMathFunc, Pure]>;
+    SYCL_Op<"math." # mnemonic,
+            traits # [SYCLMathFunc,
+                      DeclareOpInterfaceMethods<ArithFastMathInterface>,
+                      Pure]>;
 
 class SYCL_FloatUnaryOp<string mnemonic, string synopsis = "",
                         list<Trait> traits = []> :

--- a/mlir-sycl/lib/Conversion/SYCLToMath/SYCLToMath.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToMath/SYCLToMath.cpp
@@ -44,7 +44,7 @@ struct OneToOneMappingPattern : public OpConversionPattern<SYCLOpT> {
     // `op` has a native MLIR type, hence we can just replace it with its
     // counterpart in the `math` dialect.
     NamedAttribute fastmath = rewriter.getNamedAttr(
-        MathOpT::getFastMathAttrName(), adaptor.getFastmathAttr());
+        SYCLOpT::getFastMathAttrName(), adaptor.getFastmathAttr());
     rewriter.replaceOpWithNewOp<MathOpT>(op, adaptor.getOperands(), fastmath);
   }
 };

--- a/polygeist/tools/cgeist/Lib/CGExpr.cc
+++ b/polygeist/tools/cgeist/Lib/CGExpr.cc
@@ -1205,9 +1205,10 @@ MLIRScanner::createSYCLMethodOp(llvm::StringRef FunctionName,
   return cast<sycl::SYCLMethodOpInterface>(op);
 }
 
-mlir::Operation *MLIRScanner::createSYCLMathOp(llvm::StringRef FunctionName,
-                                               mlir::ValueRange Operands,
-                                               mlir::Type ReturnType) {
+mlir::Operation *
+MLIRScanner::createSYCLMathOp(llvm::StringRef FunctionName,
+                              mlir::ValueRange Operands, mlir::Type ReturnType,
+                              mlir::arith::FastMathFlagsAttr FMF) {
   constexpr std::size_t NumMathFuncs{18};
   // Sorted array
   // clang-format off
@@ -1261,8 +1262,13 @@ mlir::Operation *MLIRScanner::createSYCLMathOp(llvm::StringRef FunctionName,
   }
 
   StringRef OpName(Iter->second);
+  // We need a placeholder sycl.math operation type to get the attribute name
+  using PlaceholderMathOp = sycl::SYCLCeilOp;
+  NamedAttribute FastMathAttr =
+      Builder.getNamedAttr(PlaceholderMathOp::getFastMathAttrName(), FMF);
   return tryToCreateOperation(Builder, Loc, Builder.getStringAttr(OpName),
-                              MathFuncOperands, /*types=*/ReturnType);
+                              MathFuncOperands, /*types=*/ReturnType,
+                              FastMathAttr);
 }
 
 Operation *MLIRScanner::createSYCLBuiltinOp(const clang::FunctionDecl *Callee,
@@ -1440,8 +1446,9 @@ MLIRScanner::emitSYCLOps(const clang::Expr *Expr,
                  .value_or(nullptr);
 
       if (!Op && OptRetType.has_value())
-        Op =
-            createSYCLMathOp(Func->getNameAsString(), Args, OptRetType.value());
+        Op = createSYCLMathOp(Func->getNameAsString(), Args, OptRetType.value(),
+                              getFastMathFlags(Expr->getFPFeaturesInEffect(
+                                  Glob.getCGM().getLangOpts())));
 
       if (!Op)
         Op = Builder.create<mlir::sycl::SYCLCallOp>(
@@ -1532,7 +1539,10 @@ ValueCategory MLIRScanner::VisitAtomicExpr(clang::AtomicExpr *BO) {
     if (isa<mlir::IntegerType>(Ty))
       V = Builder.create<arith::AddIOp>(Loc, V, A1);
     else
-      V = Builder.create<arith::AddFOp>(Loc, V, A1);
+      V = Builder.create<arith::AddFOp>(
+          Loc, V, A1,
+          getFastMathFlags(
+              BO->getFPFeaturesInEffect(Glob.getCGM().getLangOpts())));
 
     return ValueCategory(V, false);
   }
@@ -2130,10 +2140,9 @@ private:
 // op and if so, build the fmuladd.
 //
 // Checks that (a) the operation is fusable, and (b) -ffp-contract=on.
-static std::optional<ValueCategory> tryEmitFMulAdd(const BinOpInfo &Op,
-                                                   OpBuilder &Builder,
-                                                   Location Loc,
-                                                   bool IsSub = false) {
+static std::optional<ValueCategory>
+tryEmitFMulAdd(const BinOpInfo &Op, OpBuilder &Builder, Location Loc,
+               arith::FastMathFlagsAttr FMF, bool IsSub = false) {
   const BinaryOperator::Opcode Opcode = Op.getOpcode();
 
   assert((Opcode == BO_Add || Opcode == BO_AddAssign || Opcode == BO_Sub ||
@@ -2164,17 +2173,18 @@ static std::optional<ValueCategory> tryEmitFMulAdd(const BinOpInfo &Op,
   // there's no point creating a muladd operation.
   constexpr auto tryEmit = [](OpBuilder &Builder, Location Loc,
                               ValueCategory Original, ValueCategory LHS,
-                              ValueCategory RHS, bool NegLHS, bool NegMul,
+                              ValueCategory RHS, arith::FastMathFlagsAttr FMF,
+                              bool NegLHS, bool NegMul,
                               bool NegAdd) -> std::optional<ValueCategory> {
     auto LHSOp = LHS.val.getDefiningOp<arith::MulFOp>();
     if (LHSOp && (LHS.val.use_empty() || NegLHS))
-      return LHS.FMA(Builder, Loc, RHS, NegMul, NegAdd);
+      return LHS.FMA(Builder, Loc, RHS, FMF, NegMul, NegAdd);
     return {};
   };
   std::optional<ValueCategory> Res =
-      tryEmit(Builder, Loc, Op.getLHS(), LHS, RHS, NegLHS, NegLHS, IsSub);
+      tryEmit(Builder, Loc, Op.getLHS(), LHS, RHS, FMF, NegLHS, NegLHS, IsSub);
   return Res ? Res
-             : tryEmit(Builder, Loc, Op.getRHS(), RHS, LHS, NegRHS,
+             : tryEmit(Builder, Loc, Op.getRHS(), RHS, LHS, FMF, NegRHS,
                        IsSub ^ NegRHS, false);
 }
 
@@ -2763,7 +2773,7 @@ ValueCategory MLIRScanner::EmitBinMul(const BinOpInfo &Info) {
   assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
 
   if (mlirclang::isFPOrFPVectorTy(LHS.val.getType()))
-    return LHS.FMul(Builder, Loc, RHS);
+    return LHS.FMul(Builder, Loc, RHS, getFastMathFlags(Info.getFPFeatures()));
   return LHS.Mul(Builder, Loc, RHS);
 }
 
@@ -2793,7 +2803,7 @@ ValueCategory MLIRScanner::EmitBinDiv(const BinOpInfo &Info) {
             << "Not applying OpenCL/HIP precision options.\n";
       }
     });
-    return LHS.FDiv(Builder, Loc, RHS);
+    return LHS.FDiv(Builder, Loc, RHS, getFastMathFlags(Info.getFPFeatures()));
   }
   if (Info.getType()->hasUnsignedIntegerRepresentation())
     return LHS.UDiv(Builder, Loc, RHS);
@@ -2968,8 +2978,11 @@ ValueCategory MLIRScanner::EmitBinAdd(const BinOpInfo &Info) {
   assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
 
   if (mlirclang::isFPOrFPVectorTy(LHS.val.getType())) {
-    std::optional<ValueCategory> FMulAdd = tryEmitFMulAdd(Info, Builder, Loc);
-    return FMulAdd ? *FMulAdd : LHS.FAdd(Builder, Loc, RHS.val);
+    std::optional<ValueCategory> FMulAdd = tryEmitFMulAdd(
+        Info, Builder, Loc, getFastMathFlags(Info.getFPFeatures()));
+    return FMulAdd ? *FMulAdd
+                   : LHS.FAdd(Builder, Loc, RHS.val,
+                              getFastMathFlags(Info.getFPFeatures()));
   }
 
   return LHS.Add(Builder, Loc, RHS.val);
@@ -2989,9 +3002,12 @@ ValueCategory MLIRScanner::EmitBinSub(const BinOpInfo &Info) {
     }
     assert(!Info.getType()->isConstantMatrixType() && "Not yet implemented");
     if (mlirclang::isFPOrFPVectorTy(LHS.val.getType())) {
-      std::optional<ValueCategory> FMulAdd =
-          tryEmitFMulAdd(Info, Builder, Loc, /*IsSub=*/true);
-      return FMulAdd ? *FMulAdd : LHS.FSub(Builder, Loc, RHS.val);
+      std::optional<ValueCategory> FMulAdd = tryEmitFMulAdd(
+          Info, Builder, Loc, getFastMathFlags(Info.getFPFeatures()),
+          /*IsSub=*/true);
+      return FMulAdd ? *FMulAdd
+                     : LHS.FSub(Builder, Loc, RHS.val,
+                                getFastMathFlags(Info.getFPFeatures()));
     }
     return LHS.Sub(Builder, Loc, RHS.val);
   }
@@ -3167,16 +3183,17 @@ ValueCategory MLIRScanner::VisitMinus(UnaryOperator *E,
   else
     Op = Visit(E->getSubExpr());
 
+  clang::FPOptions FPO = E->getFPFeaturesInEffect(Glob.getCGM().getLangOpts());
+
   // Generate a unary FNeg for FP ops.
   if (mlirclang::isFPOrFPVectorTy(Op.val.getType()))
-    return Op.FNeg(Builder, Loc);
+    return Op.FNeg(Builder, Loc, getFastMathFlags(FPO));
 
   // Emit unary minus with EmitBinSub so we handle overflow cases etc.
   const ValueCategory Zero =
       ValueCategory::getNullValue(Builder, Loc, Op.val.getType());
-  return EmitBinSub(
-      BinOpInfo{Zero, Op, E->getType(), BinaryOperator::Opcode::BO_Sub,
-                E->getFPFeaturesInEffect(Glob.getCGM().getLangOpts()), E});
+  return EmitBinSub(BinOpInfo{Zero, Op, E->getType(),
+                              BinaryOperator::Opcode::BO_Sub, FPO, E});
 }
 
 ValueCategory MLIRScanner::VisitImag(UnaryOperator *E, QualType PromotionType) {

--- a/polygeist/tools/cgeist/Lib/ValueCategory.h
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.h
@@ -143,7 +143,7 @@ public:
                     mlir::Value RHS, bool HasNUW = false,
                     bool HasNSW = false) const;
   ValueCategory FMul(mlir::OpBuilder &Builder, mlir::Location Loc,
-                     mlir::Value RHS) const;
+                     mlir::Value RHS, mlir::arith::FastMathFlagsAttr FMF) const;
   ValueCategory CMul(mlir::OpBuilder &Builder, mlir::Location Loc,
                      mlir::Value RHS) const;
 
@@ -157,7 +157,7 @@ public:
   ValueCategory ExactUDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
                           mlir::Value RHS) const;
   ValueCategory FDiv(mlir::OpBuilder &Builder, mlir::Location Loc,
-                     mlir::Value RHS) const;
+                     mlir::Value RHS, mlir::arith::FastMathFlagsAttr FMF) const;
 
   ValueCategory URem(mlir::OpBuilder &Builder, mlir::Location Loc,
                      mlir::Value RHS) const;
@@ -172,21 +172,23 @@ public:
                     mlir::Value RHS, bool HasNUW = false,
                     bool HasNSW = false) const;
 
-  ValueCategory FNeg(mlir::OpBuilder &Builder, mlir::Location Loc) const;
+  ValueCategory FNeg(mlir::OpBuilder &Builder, mlir::Location Loc,
+                     mlir::arith::FastMathFlagsAttr FMF) const;
   ValueCategory Neg(mlir::OpBuilder &Builder, mlir::Location Loc,
                     bool HasNUW = false, bool HasNSW = false) const;
   ValueCategory Add(mlir::OpBuilder &Builder, mlir::Location Loc,
                     mlir::Value RHS, bool HasNUW = false,
                     bool HasNSW = false) const;
   ValueCategory FAdd(mlir::OpBuilder &Builder, mlir::Location Loc,
-                     mlir::Value RHS) const;
+                     mlir::Value RHS, mlir::arith::FastMathFlagsAttr FMF) const;
   ValueCategory FMA(mlir::OpBuilder &Builder, mlir::Location Loc,
-                    ValueCategory Addend, bool NegMul, bool NegAdd) const;
+                    ValueCategory Addend, mlir::arith::FastMathFlagsAttr FMF,
+                    bool NegMul, bool NegAdd) const;
   ValueCategory Sub(mlir::OpBuilder &Builder, mlir::Location Loc,
                     mlir::Value RHS, bool HasNUW = false,
                     bool HasNSW = false) const;
   ValueCategory FSub(mlir::OpBuilder &Builder, mlir::Location Loc,
-                     mlir::Value RHS) const;
+                     mlir::Value RHS, mlir::arith::FastMathFlagsAttr FMF) const;
   ValueCategory CAdd(mlir::OpBuilder &Builder, mlir::Location Loc,
                      mlir::Value RHS) const;
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -65,28 +65,6 @@ static llvm::cl::opt<bool>
 /*                               MLIRScanner                                  */
 /******************************************************************************/
 
-arith::FastMathFlagsAttr
-MLIRScanner::getFastMathFlags(clang::FPOptions FPFeatures) {
-  arith::FastMathFlags FMF =
-      arith::FastMathFlags::none |
-      (FPFeatures.getAllowFPReassociate() ? arith::FastMathFlags::reassoc
-                                          : arith::FastMathFlags::none) |
-      (FPFeatures.getNoHonorNaNs() ? arith::FastMathFlags::nnan
-                                   : arith::FastMathFlags::none) |
-      (FPFeatures.getNoHonorInfs() ? arith::FastMathFlags::ninf
-                                   : arith::FastMathFlags::none) |
-      (FPFeatures.getNoSignedZero() ? arith::FastMathFlags::nsz
-                                    : arith::FastMathFlags::none) |
-      (FPFeatures.getAllowReciprocal() ? arith::FastMathFlags::arcp
-                                       : arith::FastMathFlags::none) |
-      (FPFeatures.getAllowApproxFunc() ? arith::FastMathFlags::afn
-                                       : arith::FastMathFlags::none) |
-      (FPFeatures.allowFPContractAcrossStatement()
-           ? arith::FastMathFlags::contract
-           : arith::FastMathFlags::none);
-  return Builder.getAttr<arith::FastMathFlagsAttr>(FMF);
-}
-
 MLIRScanner::MLIRScanner(MLIRASTConsumer &Glob, OwningOpRef<ModuleOp> &Module,
                          LowerToInfo &LTInfo, InsertionContext FuncContext)
     : Glob(Glob), Function(), FuncContext(FuncContext), Module(Module),
@@ -836,8 +814,8 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
           Loc, Prev,
           Builder.create<arith::ConstantFloatOp>(
               Loc, APFloat(FT.getFloatSemantics(), "1"), FT),
-          getFastMathFlags(
-              U->getFPFeaturesInEffect(Glob.getCGM().getLangOpts())));
+          mlirclang::getFastMathFlags(
+              Builder, U->getFPFeaturesInEffect(Glob.getCGM().getLangOpts())));
     } else if (auto MT = dyn_cast<MemRefType>(Ty)) {
       auto Shape = std::vector<int64_t>(MT.getShape());
       Shape[0] = ShapedType::kDynamic;
@@ -885,8 +863,8 @@ ValueCategory MLIRScanner::VisitUnaryOperator(clang::UnaryOperator *U) {
           Loc, Prev,
           Builder.create<arith::ConstantFloatOp>(
               Loc, APFloat(FT.getFloatSemantics(), "1"), FT),
-          getFastMathFlags(
-              U->getFPFeaturesInEffect(Glob.getCGM().getLangOpts())));
+          mlirclang::getFastMathFlags(
+              Builder, U->getFPFeaturesInEffect(Glob.getCGM().getLangOpts())));
     } else if (auto PT = dyn_cast<LLVM::LLVMPointerType>(Ty)) {
       auto ITy = IntegerType::get(Builder.getContext(), 64);
       Next = Builder.create<LLVM::GEPOp>(

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -349,7 +349,8 @@ private:
   /// `sycl` dialect.
   mlir::Operation *createSYCLMathOp(llvm::StringRef FunctionName,
                                     mlir::ValueRange Operands,
-                                    mlir::Type ReturnType);
+                                    mlir::Type ReturnType,
+                                    mlir::arith::FastMathFlagsAttr FMF);
 
   /// Creates an instance of a SYCL grid operation replacing a call to \param
   /// Callee.
@@ -401,6 +402,9 @@ private:
                                        mlir::ValueRange Args);
 
 public:
+  /// Return `arith.fastmath` attribute corresponding to input \p FPFeatures.
+  mlir::arith::FastMathFlagsAttr getFastMathFlags(clang::FPOptions FPFeatures);
+
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,
               LowerToInfo &LTInfo, InsertionContext FuncContext);
 

--- a/polygeist/tools/cgeist/Lib/clang-mlir.h
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.h
@@ -402,9 +402,6 @@ private:
                                        mlir::ValueRange Args);
 
 public:
-  /// Return `arith.fastmath` attribute corresponding to input \p FPFeatures.
-  mlir::arith::FastMathFlagsAttr getFastMathFlags(clang::FPOptions FPFeatures);
-
   MLIRScanner(MLIRASTConsumer &Glob, mlir::OwningOpRef<mlir::ModuleOp> &Module,
               LowerToInfo &LTInfo, InsertionContext FuncContext);
 

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -95,4 +95,26 @@ void setInsertionPoint(OpBuilder &Builder, InsertionContext FuncContext,
   }
 }
 
+arith::FastMathFlagsAttr getFastMathFlags(mlir::Builder &Builder,
+                                          clang::FPOptions FPFeatures) {
+  arith::FastMathFlags FMF =
+      arith::FastMathFlags::none |
+      (FPFeatures.getAllowFPReassociate() ? arith::FastMathFlags::reassoc
+                                          : arith::FastMathFlags::none) |
+      (FPFeatures.getNoHonorNaNs() ? arith::FastMathFlags::nnan
+                                   : arith::FastMathFlags::none) |
+      (FPFeatures.getNoHonorInfs() ? arith::FastMathFlags::ninf
+                                   : arith::FastMathFlags::none) |
+      (FPFeatures.getNoSignedZero() ? arith::FastMathFlags::nsz
+                                    : arith::FastMathFlags::none) |
+      (FPFeatures.getAllowReciprocal() ? arith::FastMathFlags::arcp
+                                       : arith::FastMathFlags::none) |
+      (FPFeatures.getAllowApproxFunc() ? arith::FastMathFlags::afn
+                                       : arith::FastMathFlags::none) |
+      (FPFeatures.allowFPContractAcrossStatement()
+           ? arith::FastMathFlags::contract
+           : arith::FastMathFlags::none);
+  return Builder.getAttr<arith::FastMathFlagsAttr>(FMF);
+}
+
 } // namespace mlirclang

--- a/polygeist/tools/cgeist/Lib/utils.h
+++ b/polygeist/tools/cgeist/Lib/utils.h
@@ -9,6 +9,8 @@
 #ifndef MLIR_TOOLS_MLIRCLANG_UTILS_H
 #define MLIR_TOOLS_MLIRCLANG_UTILS_H
 
+#include "mlir/Dialect/Arith/IR/Arith.h"
+#include "clang/Basic/LangOptions.h"
 #include "llvm/Support/CommandLine.h"
 
 extern llvm::cl::opt<bool> SuppressWarnings;
@@ -76,6 +78,9 @@ mlir::gpu::GPUModuleOp getDeviceModule(mlir::ModuleOp Module);
 /// InsertionContext \p FuncContext.
 void setInsertionPoint(mlir::OpBuilder &Builder, InsertionContext FuncContext,
                        mlir::ModuleOp Module);
+
+mlir::arith::FastMathFlagsAttr getFastMathFlags(mlir::Builder &B,
+                                                clang::FPOptions FPFeatures);
 
 } // namespace mlirclang
 

--- a/polygeist/tools/cgeist/Test/Verification/sycl/fastmath.cpp
+++ b/polygeist/tools/cgeist/Test/Verification/sycl/fastmath.cpp
@@ -1,0 +1,110 @@
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -S -emit-mlir -o - %s -fsycl-device-only -w -ffp-model=precise | FileCheck %s --check-prefixes="CHECK,CHECK-PRESTRICT,CHECK-PRECISE"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -S -emit-mlir -o - %s -fsycl-device-only -w -ffp-model=strict | FileCheck %s --check-prefixes="CHECK,CHECK-PRESTRICT,CHECK-STRICT"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -S -emit-mlir -o - %s -fsycl-device-only -w -ffp-model=fast | FileCheck %s --check-prefixes="CHECK,CHECK-FAST"
+// RUN: clang++ -fsycl -fsycl-targets=spir64-unknown-unknown-syclmlir -S -emit-mlir -o - %s -fsycl-device-only -w -fno-honor-nans -fno-honor-infinities | FileCheck %s --check-prefixes="CHECK,CHECK-NOHONOR"
+
+#include <sycl/sycl.hpp>
+
+// COM: Check fast math flags are propagated.
+
+template <typename T> SYCL_EXTERNAL T add(T a, T b) { return a + b; }
+template <typename T> SYCL_EXTERNAL T sub(T a, T b) { return a - b; }
+template <typename T> SYCL_EXTERNAL T mul(T a, T b) { return a * b; }
+template <typename T> SYCL_EXTERNAL T div(T a, T b) { return a / b; }
+template <typename T> SYCL_EXTERNAL T neg(T a) { return -a; }
+template <typename T> SYCL_EXTERNAL T pre_inc(T a) { return ++a; }
+template <typename T> SYCL_EXTERNAL T pre_dec(T a) { return --a; }
+template <typename T> SYCL_EXTERNAL T fma(T a, T b, T c) { return a * b + c; }
+template <typename T> SYCL_EXTERNAL T exp(T a) { return sycl::exp(a); }
+
+#define TEST_TYPE(type)                               \
+  template type add(type a, type b);                  \
+  template type sub(type a, type b);                  \
+  template type mul(type a, type b);                  \
+  template type div(type a, type b);                  \
+  template type neg(type a);                          \
+  template type pre_inc(type a);                      \
+  template type pre_dec(type a);                      \
+  template type fma(type a, type b, type c);          \
+  template type exp(type a);                          \
+
+// COM: No point in testing more than one fp type for now.
+
+TEST_TYPE(float)
+
+// CHECK-LABEL:     func.func @_Z3addIfET_S0_S0_(
+// CHECK-SAME:                                   %[[VAL_151:.*]]: f32 {llvm.noundef}, %[[VAL_152:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRESTRICT:   %[[VAL_153:.*]] = arith.addf %[[VAL_151]], %[[VAL_152]] : f32
+// CHECK-FAST:        %[[VAL_153:.*]] = arith.addf %[[VAL_151]], %[[VAL_152]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_153:.*]] = arith.addf %[[VAL_151]], %[[VAL_152]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_153]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z3subIfET_S0_S0_(
+// CHECK-SAME:                                   %[[VAL_154:.*]]: f32 {llvm.noundef}, %[[VAL_155:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRESTRICT:        %[[VAL_156:.*]] = arith.subf %[[VAL_154]], %[[VAL_155]] : f32
+// CHECK-FAST:             %[[VAL_156:.*]] = arith.subf %[[VAL_154]], %[[VAL_155]] fastmath<fast> : f32
+// CHECK-NOHONOR:          %[[VAL_156:.*]] = arith.subf %[[VAL_154]], %[[VAL_155]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_156]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z3mulIfET_S0_S0_(
+// CHECK-SAME:                                   %[[VAL_157:.*]]: f32 {llvm.noundef}, %[[VAL_158:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRESTRICT:   %[[VAL_159:.*]] = arith.mulf %[[VAL_157]], %[[VAL_158]] : f32
+// CHECK-FAST:        %[[VAL_159:.*]] = arith.mulf %[[VAL_157]], %[[VAL_158]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_159:.*]] = arith.mulf %[[VAL_157]], %[[VAL_158]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_159]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z3divIfET_S0_S0_(
+// CHECK-SAME:                                   %[[VAL_160:.*]]: f32 {llvm.noundef}, %[[VAL_161:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRESTRICT:   %[[VAL_162:.*]] = arith.divf %[[VAL_160]], %[[VAL_161]] : f32
+// CHECK-FAST:        %[[VAL_162:.*]] = arith.divf %[[VAL_160]], %[[VAL_161]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_162:.*]] = arith.divf %[[VAL_160]], %[[VAL_161]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_162]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z3negIfET_S0_(
+// CHECK-SAME:                                %[[VAL_163:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRESTRICT:   %[[VAL_164:.*]] = arith.negf %[[VAL_163]] : f32
+// CHECK-FAST:        %[[VAL_164:.*]] = arith.negf %[[VAL_163]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_164:.*]] = arith.negf %[[VAL_163]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_164]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z7pre_incIfET_S0_(
+// CHECK-SAME:                                    %[[VAL_165:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK:             %[[VAL_166:.*]] = arith.constant 1.000000e+00 : f32
+// CHECK-PRESTRICT:   %[[VAL_167:.*]] = arith.addf %[[VAL_165]], %[[VAL_166]] : f32
+// CHECK-FAST:        %[[VAL_167:.*]] = arith.addf %[[VAL_165]], %[[VAL_166]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_167:.*]] = arith.addf %[[VAL_165]], %[[VAL_166]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_167]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z7pre_decIfET_S0_(
+// CHECK-SAME:                                    %[[VAL_169:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK:             %[[VAL_170:.*]] = arith.constant 1.000000e+00 : f32
+// CHECK-PRESTRICT:   %[[VAL_171:.*]] = arith.subf %[[VAL_169]], %[[VAL_170]] : f32
+// CHECK-FAST:        %[[VAL_171:.*]] = arith.subf %[[VAL_169]], %[[VAL_170]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_171:.*]] = arith.subf %[[VAL_169]], %[[VAL_170]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_171]] : f32
+// CHECK:           }
+
+// CHECK:           func.func @_Z3fmaIfET_S0_S0_S0_(
+// CHECK-SAME:                                      %[[VAL_175:.*]]: f32 {llvm.noundef}, %[[VAL_176:.*]]: f32 {llvm.noundef}, %[[VAL_177:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRECISE:     %[[VAL_178:.*]] = math.fma %[[VAL_175]], %[[VAL_176]], %[[VAL_177]] : f32
+// CHECK-FAST:        %[[ADD:.*]] = arith.mulf %[[VAL_175]], %[[VAL_176]] fastmath<fast> : f32
+// CHECK-FAST:        %[[VAL_178:.*]] = arith.addf %[[ADD]], %[[VAL_177]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_178:.*]] = math.fma %[[VAL_175]], %[[VAL_176]], %[[VAL_177]] fastmath<nnan,ninf> : f32
+// CHECK-STRICT:      %[[ADD:.*]] = arith.mulf %[[VAL_175]], %[[VAL_176]] : f32
+// CHECK-STRICT:      %[[VAL_178:.*]] = arith.addf %[[ADD]], %[[VAL_177]] : f32
+// CHECK:             return %[[VAL_178]] : f32
+// CHECK:           }
+
+// CHECK-LABEL:     func.func @_Z3expIfET_S0_(
+// CHECK-SAME:                                %[[VAL_179:.*]]: f32 {llvm.noundef}) -> (f32 {llvm.noundef})
+// CHECK-PRESTRICT:   %[[VAL_180:.*]] = sycl.math.exp %[[VAL_179]] : f32
+// CHECK-FAST:        %[[VAL_180:.*]] = sycl.math.exp %[[VAL_179]] fastmath<fast> : f32
+// CHECK-NOHONOR:     %[[VAL_180:.*]] = sycl.math.exp %[[VAL_179]] fastmath<nnan,ninf> : f32
+// CHECK:             return %[[VAL_180]] : f32
+// CHECK:           }


### PR DESCRIPTION
Attach fast math flags to:
- Binary arithmetic operations
- Unary arithmetic operations
- `math.fma` operations
- `sycl.math.*` operations