### PR TITLE
[SYCL] Last fp-accuracy command line wins.

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -65,10 +65,10 @@ def err_drv_no_cuda_libdevice : Error<
   "via '--cuda-path', or pass '-nocudalib' to build without linking with "
   "libdevice">;
 
-def warn_function_fp_accuracy_already_set : Warning <
-  "floating point accuracy value of '%0' has already been assigned to "
-  "function '%1'">,
-  InGroup<DiagGroup<"fp-accuracy-already-set">>;
+def warn_drv_fp_accuracy_override : Warning <
+  "'-ffp-accuracy=%0' overrides '-ffp-accuracy=%1' for the function '%2'">,
+  InGroup<FPAccOverride>;
+
 def err_drv_no_rocm_device_lib : Error<
   "cannot find ROCm device library%select{| for %1|for ABI version %1}0; provide its path via "
   "'--rocm-path' or '--rocm-device-lib-path', or pass '-nogpulib' to build "

--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -850,6 +850,7 @@ def DeallocInCategory:DiagGroup<"dealloc-in-category">;
 def SelectorTypeMismatch : DiagGroup<"selector-type-mismatch">;
 def Selector : DiagGroup<"selector", [SelectorTypeMismatch]>;
 def Protocol : DiagGroup<"protocol">;
+def FPAccOverride : DiagGroup<"fp-accuracy-override">;
 // No longer in use, preserve for backwards compatibility.
 def : DiagGroup<"at-protocol">;
 def PropertyAccessDotSyntax: DiagGroup<"property-access-dot-syntax">;

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3745,14 +3745,14 @@ void CompilerInvocation::ParseFpAccuracyArgs(LangOptions &Opts, ArgList &Args,
               FuncName = FuncName.drop_front(1);
             if (FuncName.back() == ']')
               FuncName = FuncName.drop_back(1);
-            auto FuncMap = Opts.FPAccuracyFuncMap.find(FuncName.str());
             checkFPAccuracyIsValid(ValElement[0], Diags);
             // No need to fill the map if the FPaccuracy is 'default'.
             // The default builtin will be generated.
             if (!ValElement[0].equals("default")) {
-              // if FPAccuracyFuncMap of this function has been prviously set
+              // if FPAccuracyFuncMap of this function has been previously set
               // update its value; the last fp-accuracy option in the command
               // line wins.
+              auto FuncMap = Opts.FPAccuracyFuncMap.find(FuncName.str());
               if (FuncMap != Opts.FPAccuracyFuncMap.end()) {
                 diagnoseFPAccuracyHasVal(Diags, ValElement[0], ValuesArr[1],
                                          ValuesArr[0], FuncMap->first.c_str());

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -600,12 +600,6 @@ static bool FixupInvocation(CompilerInvocation &Invocation,
     LangOpts.NewAlignOverride = 0;
   }
 
-  // Diagnose FPAccuracy option validity.
-  if (!LangOpts.FPAccuracyVal.empty())
-    for (const auto &F : LangOpts.FPAccuracyFuncMap)
-      Diags.Report(diag::warn_function_fp_accuracy_already_set)
-          << F.second << F.first;
-
   // Prevent the user from specifying both -fsycl-is-device and -fsycl-is-host.
   if (LangOpts.SYCLIsDevice && LangOpts.SYCLIsHost)
     Diags.Report(diag::err_drv_argument_not_allowed_with) << "-fsycl-is-device"
@@ -3712,6 +3706,12 @@ static void checkFPAccuracyIsValid(StringRef ValElement,
         << "-ffp-accuracy" << ValElement;
 }
 
+static void diagnoseFPAccuracyHasVal(DiagnosticsEngine &Diags,
+                                     StringRef ValElement, StringRef Opt1,
+                                     StringRef Opt2, const std::string Func) {
+  Diags.Report(diag::warn_drv_fp_accuracy_override) << Opt1 << Opt2 << Func;
+}
+
 void CompilerInvocation::ParseFpAccuracyArgs(LangOptions &Opts, ArgList &Args,
                                              DiagnosticsEngine &Diags) {
   for (StringRef Values : Args.getAllArgValues(OPT_ffp_builtin_accuracy_EQ)) {
@@ -3727,6 +3727,14 @@ void CompilerInvocation::ParseFpAccuracyArgs(LangOptions &Opts, ArgList &Args,
         if (ValElement.size() == 1) {
           checkFPAccuracyIsValid(ValElement[0], Diags);
           Opts.FPAccuracyVal = ValElement[0].str();
+          // if FPAccuracyFuncMap is not empty, visit it and update
+          // the values of the FPAccuracy of each function in the map;
+          // last fp-accuracy option in the command line wins.
+          for (auto &F : Opts.FPAccuracyFuncMap) {
+            diagnoseFPAccuracyHasVal(Diags, ValElement[0], ValuesArr[1],
+                                     ValuesArr[0], F.first);
+            F.second = ValElement[0];
+          }
         }
         // The option is of the form -ffp-accuracy=value:[f1, ... fn].
         if (ValElement.size() == 2) {
@@ -3741,9 +3749,19 @@ void CompilerInvocation::ParseFpAccuracyArgs(LangOptions &Opts, ArgList &Args,
             checkFPAccuracyIsValid(ValElement[0], Diags);
             // No need to fill the map if the FPaccuracy is 'default'.
             // The default builtin will be generated.
-            if (!ValElement[0].equals("default"))
-              Opts.FPAccuracyFuncMap.insert(
-                  {FuncName.str(), ValElement[0].str()});
+            if (!ValElement[0].equals("default")) {
+              // if FPAccuracyFuncMap of this function has been prviously set
+              // update its value; the last fp-accuracy option in the command
+              // line wins.
+              if (FuncMap != Opts.FPAccuracyFuncMap.end()) {
+                diagnoseFPAccuracyHasVal(Diags, ValElement[0], ValuesArr[1],
+                                         ValuesArr[0], FuncMap->first.c_str());
+                FuncMap->second = ValElement[0].str();
+              } else {
+                Opts.FPAccuracyFuncMap.insert(
+                    {FuncName.str(), ValElement[0].str()});
+              }
+            }
           }
         }
       }

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -3,8 +3,8 @@
 // RUN: | FileCheck --check-prefixes=CHECK %s
 
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown \
-// RUN: "-ffp-builtin-accuracy=high:[acosf,cos,pow] low:[tan] \
-// medium:[sincos,log10]" -Wno-return-type -Wno-implicit-function-declaration \
+// RUN: "-ffp-builtin-accuracy=high:[acosf,cos,pow] low:[tan] medium:[sincos,log10]" \
+// RUN:  -Wno-return-type -Wno-implicit-function-declaration \
 // RUN: -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-F1 %s
 
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown \

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -12,7 +12,7 @@
 // RUN: -Wno-return-type -Wno-implicit-function-declaration -emit-llvm -o - %s \
 // RUN: | FileCheck --check-prefix=CHECK-F2 %s
 
-// RUN: %clang_cc1 -triple x86_64-unknown-unknown		     \
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown \
 // RUN: "-ffp-builtin-accuracy=high low:[tan] medium:[sincos,log10]" \
 // RUN: -Wno-return-type -Wno-implicit-function-declaration -emit-llvm -o - %s \
 // RUN: | FileCheck --check-prefix=CHECK-F3 %s
@@ -21,6 +21,16 @@
 // RUN: "-ffp-builtin-accuracy=high:sin medium" -Wno-return-type \
 // RUN: -Wno-implicit-function-declaration -emit-llvm -o - %s \
 // RUN: | FileCheck --check-prefixes=CHECK-F4 %s
+
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown \
+// RUN: "-ffp-builtin-accuracy=medium:[sin,cos] high:[sin,tan]" \
+// RUN: -Wno-return-type -Wno-implicit-function-declaration \
+// RUN: -emit-llvm -o - %s | FileCheck --check-prefixes=CHECK-F5 %s
+
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown \
+// RUN: "-ffp-builtin-accuracy=medium high:[sin,atan]" \
+// RUN: -Wno-return-type -Wno-implicit-function-declaration \
+// RUN: -emit-llvm -o - %s | FileCheck --check-prefixes=CHECK-F6 %s
 
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -ffp-builtin-accuracy=sycl \
 // RUN: -D SPIR -Wno-implicit-function-declaration -emit-llvm -o - %s \
@@ -232,7 +242,80 @@ double rsqrt(double);
 // CHECK-F4: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call double @llvm.fpbuiltin.tanh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
-
+//
+// CHECK-F5-LABEL: define dso_local void @f1(
+// CHECK-F5: call double @acos(double noundef {{.*}})
+// CHECK-F5: call double @acosh(double noundef {{.*}})
+// CHECK-F5: call double @asin(double noundef {{.*}})
+// CHECK-F5: call double @asinh(double noundef {{.*}})
+// CHECK-F5: call double @atan(double noundef {{.*}})
+// CHECK-F5: call double @atan2(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call double @atanh(double noundef {{.*}})
+// CHECK-F5: call double @llvm.fpbuiltin.cos.f64(double {{.*}}) #[[ATTR_F5_MEDIUM:[0-9]+]]
+// CHECK-F5: call double @cosh(double noundef {{.*}})
+// CHECK-F5: call double @erf(double noundef {{.*}})
+// CHECK-F5: call double @erfc(double noundef {{.*}})
+// CHECK-F5: call double @llvm.exp.f64(double {{.*}})
+// CHECK-F5: call i32 (double, ...) @exp10(double noundef {{.*}})
+// CHECK-F5: call double @llvm.exp2.f64(double {{.*}})
+// CHECK-F5: call double @expm1(double noundef {{.*}})
+// CHECK-F5: call i32 (double, double, ...) @fadd(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call i32 (double, double, ...) @fdiv(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call i32 (double, double, ...) @fmul(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call i32 (double, double, ...) @frem(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call i32 (double, double, ...) @fsub(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call double @hypot(double noundef {{.*}}, double noundef {{.*}})
+// CHECK-F5: call double @ldexp(double noundef {{.*}}, i32 noundef {{.*}})
+// CHECK-F5: call double @llvm.log.f64(double {{.*}})
+// CHECK-F5: call double @llvm.log10.f64(double {{.*}})
+// CHECK-F5: call double @log1p(double noundef {{.*}})
+// CHECK-F5: call double @llvm.log2.f64(double {{.*}})
+// CHECK-F5: call double @llvm.pow.f64(double {{.*}}, double {{.*}})
+// CHECK-F5: call i32 (double, ...) @rsqrt(double noundef {{.*}})
+// CHECK-F5: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F5_HIGH:[0-9]+]]
+// CHECK-F5: call i32 (double, ptr, ptr, ...) @sincos(double noundef {{.*}}, ptr noundef {{.*}}, ptr noundef {{.*}})
+// CHECK-F5: call double @sinh(double noundef {{.*}})
+// CHECK-F5: call double @llvm.sqrt.f64(double {{.*}})
+// CHECK-F5: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F5_HIGH]]
+// CHECK-F5: call double @tanh(double noundef {{.*}})
+//
+//
+// CHECK-F6-LABEL: define dso_local void @f1(
+// CHECK-F6: call double @llvm.fpbuiltin.acos.f64(double {{.*}}) #[[ATTR_F6_MEDIUM:[0-9]+]]
+// CHECK-F6: call double @llvm.fpbuiltin.acosh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.asin.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.asinh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.atan.f64(double {{.*}}) #[[ATTR_F6_HIGH:[0-9]+]]
+// CHECK-F6: call double @llvm.fpbuiltin.atan2.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.atanh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.cos.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.cosh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.erf.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.erfc.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.exp.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.exp10.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.exp2.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.expm1.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.fadd.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.fdiv.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.fmul.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.frem.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.fsub.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.hypot.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.ldexp.f64(double {{.*}}, i32 {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.log.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.log1p.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.log2.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F6_HIGH]]
+// CHECK-F6: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.tanh.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+//
 // CHECK-SPIR-LABEL: define dso_local spir_func void @f1
 // CHECK-SPIR: call double @llvm.fpbuiltin.acos.f64(double {{.*}}) #[[ATTR_SYCL1:[0-9]+]]
 // CHECK-SPIR: call double @llvm.fpbuiltin.acosh.f64(double {{.*}}) #[[ATTR_SYCL1]]
@@ -339,6 +422,28 @@ void f1(float a, float b) {
 // CHECK-F4: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F4_MEDIUM]]
 // CHECK-F4: call float @tanf(float {{.*}})
 //
+// CHECK-F5-LABEL: define dso_local void @f2(
+// CHECK-F5: call float @llvm.cos.f32(float {{.*}})
+// CHECK-F5: call float @llvm.sin.f32(float {{.*}})
+// CHECK-F5: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F5_HIGH]]
+// CHECK-F5: call double @llvm.log10.f64(double {{.*}})
+// CHECK-F5: call i32 (double, ptr, ptr, ...) @sincos(double noundef {{.*}}, ptr noundef {{.*}}, ptr noundef {{.*}})
+// CHECK-F5: call float @tanf(float noundef {{.*}})
+//
+// CHECK-F5: attributes #[[ATTR_F5_MEDIUM]] = {{.*}}"fpbuiltin-max-error"="4.0"
+// CHECK-F5: attributes #[[ATTR_F5_HIGH]] = {{.*}}"fpbuiltin-max-error"="1.0"
+//
+// CHECK-F6-LABEL: define dso_local void @f2(
+// CHECK-F6: call float @llvm.fpbuiltin.cos.f32(float {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F6_MEDIUM]]
+// CHECK-F6: call float @tanf(float noundef {{.*}}) #[[ATTR8:[0-9]+]]
+//
+// CHECK-F6: attributes #[[ATTR_F6_MEDIUM]] = {{.*}}"fpbuiltin-max-error"="4.0"
+// CHECK-F6: attributes #[[ATTR_F6_HIGH]] = {{.*}}"fpbuiltin-max-error"="1.0"
+//
 // CHECK-SPIR-LABEL: define dso_local spir_func void @f2
 // CHECK-SPIR: call float @llvm.fpbuiltin.cos.f32(float {{.*}}) #[[ATTR_SYCL1]]
 // CHECK-SPIR: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_SYCL1]]
@@ -351,6 +456,7 @@ void f1(float a, float b) {
 // CHECK: call float @fake_exp10(float {{.*}})
 // CHECK-F1: call float @fake_exp10(float {{.*}})
 // CHECK-F2: call float @fake_exp10(float {{.*}})
+
 // CHECK-SPIR-LABEL: define dso_local spir_func void @f3
 // CHECK-SPIR: call spir_func float @fake_exp10(float {{.*}})
 

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -17,6 +17,11 @@
 // RUN: -Wno-return-type -Wno-implicit-function-declaration -emit-llvm -o - %s \
 // RUN: | FileCheck --check-prefix=CHECK-F3 %s
 
+// RUN: %clang_cc1 -triple x86_64-unknown-unknown \
+// RUN: "-ffp-builtin-accuracy=high:sin medium" -Wno-return-type \
+// RUN: -Wno-implicit-function-declaration -emit-llvm -o - %s \
+// RUN: | FileCheck --check-prefixes=CHECK-F4 %s
+
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -ffp-builtin-accuracy=sycl \
 // RUN: -D SPIR -Wno-implicit-function-declaration -emit-llvm -o - %s \
 // RUN: | FileCheck --check-prefix=CHECK-SPIR %s
@@ -192,6 +197,42 @@ double rsqrt(double);
 // CHECK-F3: attributes #[[ATTR_F3_MEDIUM]] = {{.*}}"fpbuiltin-max-error"="4.0"
 // CHECK-F3: attributes #[[ATTR_F3_LOW]] = {{.*}}"fpbuiltin-max-error"="67108864.0"
 //
+// CHECK-LABEL-F4: define dso_local void @f1
+// CHECK-F4: call double @llvm.fpbuiltin.acos.f64(double %conv) #[[ATTR_F4_MEDIUM:[0-9]+]]
+// CHECK-F4: call double @llvm.fpbuiltin.acosh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.asin.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.asinh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.atan.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.atan2.f64(double {{.*}}, double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.atanh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.cos.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.cosh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.erf.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.erfc.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.exp.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.exp10.f64(double {{.*}})
+// CHECK-F4: call double @llvm.fpbuiltin.exp2.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.expm1.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.fadd.f64(double {{.*}}, double {{.*}})
+// CHECK-F4: call double @llvm.fpbuiltin.fdiv.f64(double {{.*}}, double {{.*}})
+// CHECK-F4: call double @llvm.fpbuiltin.fmul.f64(double {{.*}}, double {{.*}})
+// CHECK-F4: call double @llvm.fpbuiltin.frem.f64(double {{.*}}, double {{.*}})
+// CHECK-F4: call double @llvm.fpbuiltin.fsub.f64(double {{.*}}, double {{.*}})
+// CHECK-F4: call double @llvm.fpbuiltin.hypot.f64(double {{.*}}, double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.ldexp.f64(double {{.*}}, i32 {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.log.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.log1p.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.log2.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.pow.f64(double {{.*}}, double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.rsqrt.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.sin.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr %p1, ptr %p2)
+// CHECK-F4: call double @llvm.fpbuiltin.sinh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.sqrt.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.tanh.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+
 // CHECK-SPIR-LABEL: define dso_local spir_func void @f1
 // CHECK-SPIR: call double @llvm.fpbuiltin.acos.f64(double {{.*}}) #[[ATTR_SYCL1:[0-9]+]]
 // CHECK-SPIR: call double @llvm.fpbuiltin.acosh.f64(double {{.*}}) #[[ATTR_SYCL1]]
@@ -289,6 +330,14 @@ void f1(float a, float b) {
 // CHECK-F2: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F2_MEDIUM]]
 // CHECK-F2: call float @tanf(float noundef {{.*}})
+//
+// CHECK-LABEL-F4: define dso_local void @f2
+// CHECK-F4: call float @llvm.fpbuiltin.cos.f32(float {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call float @llvm.fpbuiltin.sin.f32(float {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.tan.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call double @llvm.fpbuiltin.log10.f64(double {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call void @llvm.fpbuiltin.sincos.f64(double {{.*}}, ptr {{.*}}, ptr {{.*}}) #[[ATTR_F4_MEDIUM]]
+// CHECK-F4: call float @tanf(float {{.*}})
 //
 // CHECK-SPIR-LABEL: define dso_local spir_func void @f2
 // CHECK-SPIR: call float @llvm.fpbuiltin.cos.f32(float {{.*}}) #[[ATTR_SYCL1]]

--- a/clang/test/CodeGen/fp-accuracy.c
+++ b/clang/test/CodeGen/fp-accuracy.c
@@ -3,9 +3,9 @@
 // RUN: | FileCheck --check-prefixes=CHECK %s
 
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown \
-// RUN: "-ffp-builtin-accuracy=high:[acosf,cos,pow] low:[tan] medium:[sincos,log10]" \
-// RUN: -Wno-return-type -Wno-implicit-function-declaration -emit-llvm -o - %s \
-// RUN: | FileCheck --check-prefix=CHECK-F1 %s
+// RUN: "-ffp-builtin-accuracy=high:[acosf,cos,pow] low:[tan] \
+// medium:[sincos,log10]" -Wno-return-type -Wno-implicit-function-declaration \
+// RUN: -emit-llvm -o - %s | FileCheck --check-prefix=CHECK-F1 %s
 
 // RUN: %clang_cc1 -triple x86_64-unknown-unknown \
 // RUN: "-ffp-builtin-accuracy=medium high:[tan] cuda:[cos]" \

--- a/clang/test/Driver/fp-accuracy.c
+++ b/clang/test/Driver/fp-accuracy.c
@@ -38,7 +38,11 @@
 
 // RUN: not %clang -fno-math-errno -ffp-accuracy=low:[sin,cos] \
 // RUN: -ffp-accuracy=high %s 2>&1  \
-// RUN: | FileCheck %s --check-prefix=WARN
+// RUN: | FileCheck %s --check-prefix=WARN1
+
+// RUN: not %clang -fno-math-errno -ffp-accuracy=low:[sin,cos] \
+// RUN: -ffp-accuracy=high:[cos,tan] %s 2>&1  \
+// RUN: | FileCheck %s --check-prefix=WARN2
 
 // RUN: not %clang -Xclang -verify -ffp-accuracy=low:[sin,cos] \
 // RUN: -ffp-accuracy=high -fmath-errno %s 2>&1  \
@@ -58,7 +62,9 @@
 // ERR: (frontend): unsupported argument 'foo' to option '-ffp-accuracy'
 // ERR-1: (frontend): unsupported argument 'foo' to option '-ffp-accuracy'
 // ERR-2: (frontend): unsupported argument 'high=[sin]' to option '-ffp-accuracy'
-// WARN: floating point accuracy value of 'low' has already been assigned to function 'cos'
-// WARN: floating point accuracy value of 'low' has already been assigned to function 'sin'
+// WARN1: '-ffp-accuracy=high' overrides '-ffp-accuracy=low:[sin,cos]' for the function 'cos'
+// WARN1: '-ffp-accuracy=high' overrides '-ffp-accuracy=low:[sin,cos]' for the function 'sin'
+// WARN2: '-ffp-accuracy=high:[cos,tan]' overrides '-ffp-accuracy=low:[sin,cos]' for the function 'cos'
+
 
 // ERR-3: (frontend): floating point accuracy requirements cannot be guaranteed when '-fmath-errno' is enabled; use '-fno-math-errno' to enable floating point accuracy control


### PR DESCRIPTION
This implements a new request to make the last fp-accuracy option on the command line wins.
A warning is generated to warn the user.