### PR TITLE
[SYCL][ESIMD] Implement unified memory API - atomic_update(acc,...) with one operand

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -3675,18 +3675,18 @@ atomic_update_impl(AccessorTy acc, simd<Toffset, N> offsets, simd<T, N> src0,
   check_lsc_data_size<T, DS>();
   check_atomic<Op, T, N, 1, /*IsLSC*/ true>();
   check_cache_hint<cache_action::atomic, L1H, L2H>();
-  constexpr uint16_t _AddressScale = 1;
-  constexpr int _ImmOffset = 0;
-  constexpr lsc_data_size _DS = expand_data_size(finalize_data_size<T, DS>());
-  constexpr lsc_vector_size _VS = to_lsc_vector_size<1>();
-  constexpr lsc_data_order _Transposed = lsc_data_order::nontranspose;
+  constexpr uint16_t AddressScale = 1;
+  constexpr int ImmOffset = 0;
+  constexpr lsc_data_size EDS = expand_data_size(finalize_data_size<T, DS>());
+  constexpr lsc_vector_size VS = to_lsc_vector_size<1>();
+  constexpr lsc_data_order Transposed = lsc_data_order::nontranspose;
   using MsgT = typename lsc_expand_type<T>::type;
   constexpr int IOp = lsc_to_internal_atomic_op<T, Op>();
   simd<MsgT, N> Msg_data = lsc_format_input<MsgT>(src0);
   auto si = get_surface_index(acc);
   simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_bti_1<MsgT, IOp, L1H, L2H, _AddressScale, _ImmOffset,
-                                _DS, _VS, _Transposed, N>(
+      __esimd_lsc_xatomic_bti_1<MsgT, IOp, L1H, L2H, AddressScale, ImmOffset,
+                                EDS, VS, Transposed, N>(
           pred.data(), offsets.data(), Msg_data.data(), si);
   return lsc_format_ret<T>(Tmp);
 #endif

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -5497,7 +5497,7 @@ atomic_update(AccessorTy acc, simd<Toffset, N> byte_offset, simd<T, N> src0,
 ///               simd_view<T, RegionTy> src0,
 ///               simd_mask<N> mask, props = {});                // (acc-au1-3)
 ///
-/// A variation of \c atomic_update API with src0 represented as
+/// A variation of \c atomic_update API with \c src0 represented as
 /// \c simd_view object.
 ///
 /// Atomically updates \c N memory locations represented by an accessor and
@@ -5547,7 +5547,7 @@ atomic_update(AccessorTy acc, simd<Toffset, N> byte_offset,
 ///               simd_view<T, RegionTy> src0,
 ///               props = {});                                   // (acc-au1-4)
 ///
-/// A variation of \c atomic_update API with src0 represented as
+/// A variation of \c atomic_update API with \c src0 represented as
 /// \c simd_view object and no mask operand.
 ///
 /// Atomically updates \c N memory locations represented by an accessor and
@@ -5731,8 +5731,8 @@ atomic_update(AccessorTy acc, simd_view<Toffset, RegionTy> byte_offset,
 ///               simd_view<T, RegionTy> src0,
 ///               simd_mask<N> mask, props = {});                // (acc-au1-7)
 ///
-/// A variation of \c atomic_update API with byte_offset and src0 represented as
-/// \c simd_view objects.
+/// A variation of \c atomic_update API with \c byte_offset and \c src0
+/// represented as \c simd_view objects.
 ///
 /// @tparam Op The atomic operation - can be one of the following:
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c
@@ -5779,8 +5779,8 @@ atomic_update(AccessorTy acc, simd_view<Toffset, OffsetRegionTy> byte_offset,
 ///               simd_view<T, RegionTy> src0,
 ///               props = {});                                   // (acc-au1-8)
 ///
-/// A variation of \c atomic_update API with byte_offset and src0 represented as
-/// \c simd_view objects and no mask operand.
+/// A variation of \c atomic_update API with \c byte_offset and \c src0
+/// represented as \c simd_view objects and no mask operand.
 ///
 /// @tparam Op The atomic operation - can be one of the following:
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -3955,7 +3955,8 @@ atomic_update(T *p, Toffset byte_offset, simd_mask<N> mask = 1) {
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4035,7 +4036,8 @@ atomic_update(T *p, simd<Toffset, N> byte_offset, simd<T, N> src0,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4072,7 +4074,8 @@ atomic_update(T *p, simd<Toffset, N> byte_offset, simd<T, N> src0,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4111,7 +4114,8 @@ atomic_update(T *p, simd<Toffset, N> byte_offset, simd_view<T, RegionTy> src0,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4150,7 +4154,7 @@ atomic_update(T *p, simd<Toffset, N> byte_offset, simd_view<T, RegionTy> src0,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4190,7 +4194,7 @@ atomic_update(T *p, simd_view<Toffset, RegionTy> offsets, simd<T, N> src0,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4229,7 +4233,7 @@ atomic_update(T *p, simd_view<Toffset, RegionTy> offsets, simd<T, N> src0,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -4271,7 +4275,7 @@ atomic_update(T *p, simd_view<Toffset, OffsetRegionTy> offsets,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @param p The USM pointer.
@@ -5370,7 +5374,8 @@ atomic_update(AccessorTy acc, Toffset byte_offset, simd_mask<N> mask) {
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5461,7 +5466,8 @@ atomic_update(AccessorTy acc, simd<Toffset, N> byte_offset, simd<T, N> src0,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5509,7 +5515,8 @@ atomic_update(AccessorTy acc, simd<Toffset, N> byte_offset, simd<T, N> src0,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5559,7 +5566,8 @@ atomic_update(AccessorTy acc, simd<Toffset, N> byte_offset,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5600,7 +5608,8 @@ atomic_update(AccessorTy acc, simd<Toffset, N> byte_offset,
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c atomic_op::max,
 /// \c atomic_op::xchg, \c atomic_op::bit_and, \c atomic_op::bit_or,
 /// \c atomic_op::bit_xor, \c atomic_op::minsint, \c atomic_op::maxsint,
-/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::store.
+/// \c atomic_op::fmax, \c atomic_op::fmin, \c atomic_op::fadd, \c
+/// atomic_op::fsub, \c atomic_op::store.
 /// @tparam Tx The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5652,7 +5661,7 @@ atomic_update(AccessorTy acc, simd<uint32_t, N> offset, simd<Tx, N> src0,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5696,7 +5705,7 @@ atomic_update(AccessorTy acc, simd_view<Toffset, RegionTy> byte_offset,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5739,7 +5748,7 @@ atomic_update(AccessorTy acc, simd_view<Toffset, RegionTy> byte_offset,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.
@@ -5787,7 +5796,7 @@ atomic_update(AccessorTy acc, simd_view<Toffset, OffsetRegionTy> byte_offset,
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c
 /// atomic_op::bit_or, \c atomic_op::bit_xor, \c atomic_op::minsint, \c
 /// atomic_op::maxsint, \c atomic_op::fmax, \c atomic_op::fmin, \c
-/// atomic_op::store.
+/// atomic_op::fadd, \c atomic_op::fsub, \c atomic_op::store.
 /// @tparam T The vector element type.
 /// @tparam N The number of memory locations to update.
 /// @tparam AccessorTy type of the SYCL accessor.

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -5733,6 +5733,7 @@ atomic_update(AccessorTy acc, simd_view<Toffset, RegionTy> byte_offset,
 ///
 /// A variation of \c atomic_update API with byte_offset and src0 represented as
 /// \c simd_view objects.
+///
 /// @tparam Op The atomic operation - can be one of the following:
 /// \c atomic_op::add, \c atomic_op::sub, \c atomic_op::min, \c
 /// atomic_op::max, \c atomic_op::xchg, \c atomic_op::bit_and, \c

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2698,7 +2698,7 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size (unused/obsolete).
+/// @tparam DS is the data size.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @param p is the base pointer.
@@ -2736,7 +2736,7 @@ lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd_mask<N> pred = 1) {
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size (unused/obsolete).
+/// @tparam DS is the data size.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @param p is the base pointer.
@@ -2850,7 +2850,7 @@ lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd<T, N> src0,
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size (unused/obsolete).
+/// @tparam DS is the data size.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AccessorTy is the \ref sycl::accessor type.
@@ -2909,7 +2909,7 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size (unused/obsolete).
+/// @tparam DS is the data size.
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AccessorTy is the \ref sycl::accessor type.

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -2698,7 +2698,7 @@ lsc_slm_atomic_update(__ESIMD_NS::simd<uint32_t, N> offsets,
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size.
+/// @tparam DS is the data size (unused/obsolete).
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @param p is the base pointer.
@@ -2736,7 +2736,7 @@ lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd_mask<N> pred = 1) {
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size.
+/// @tparam DS is the data size (unused/obsolete).
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @param p is the base pointer.
@@ -2850,7 +2850,7 @@ lsc_atomic_update(T *p, Toffset offset, __ESIMD_NS::simd<T, N> src0,
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size.
+/// @tparam DS is the data size (unused/obsolete).
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AccessorTy is the \ref sycl::accessor type.
@@ -2909,7 +2909,7 @@ lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<uint32_t, N> offsets,
 /// @tparam Op is operation type.
 /// @tparam T is element type.
 /// @tparam N is the number of channels (platform dependent).
-/// @tparam DS is the data size.
+/// @tparam DS is the data size (unused/obsolete).
 /// @tparam L1H is L1 cache hint.
 /// @tparam L3H is L3 cache hint.
 /// @tparam AccessorTy is the \ref sycl::accessor type.
@@ -2930,34 +2930,8 @@ __ESIMD_API std::enable_if_t<
     __ESIMD_NS::simd<T, N>>
 lsc_atomic_update(AccessorTy acc, __ESIMD_NS::simd<Toffset, N> offsets,
                   __ESIMD_NS::simd<T, N> src0, __ESIMD_NS::simd_mask<N> pred) {
-#ifdef __ESIMD_FORCE_STATELESS_MEM
-  return lsc_atomic_update<Op, T, N, DS, L1H, L3H>(
-      __ESIMD_DNS::accessorToPointer<T>(acc), offsets, src0, pred);
-#else
-  static_assert(sizeof(T) > 1, "Unsupported data type");
-  static_assert(std::is_integral_v<Toffset> && sizeof(Toffset) == 4,
-                "Unsupported offset type");
-  detail::check_lsc_vector_size<1>();
-  detail::check_lsc_data_size<T, DS>();
-  __ESIMD_DNS::check_atomic<Op, T, N, 1>();
-  detail::check_lsc_cache_hint<detail::lsc_action::atomic, L1H, L3H>();
-  constexpr uint16_t _AddressScale = 1;
-  constexpr int _ImmOffset = 0;
-  constexpr lsc_data_size _DS =
-      detail::expand_data_size(detail::finalize_data_size<T, DS>());
-  constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<1>();
-  constexpr detail::lsc_data_order _Transposed =
-      detail::lsc_data_order::nontranspose;
-  using MsgT = typename detail::lsc_expand_type<T>::type;
-  constexpr int IOp = detail::lsc_to_internal_atomic_op<T, Op>();
-  __ESIMD_NS::simd<MsgT, N> Msg_data = detail::lsc_format_input<MsgT>(src0);
-  auto si = __ESIMD_NS::get_surface_index(acc);
-  __ESIMD_NS::simd<MsgT, N> Tmp =
-      __esimd_lsc_xatomic_bti_1<MsgT, IOp, L1H, L3H, _AddressScale, _ImmOffset,
-                                _DS, _VS, _Transposed, N>(
-          pred.data(), offsets.data(), Msg_data.data(), si);
-  return detail::lsc_format_ret<T>(Tmp);
-#endif
+  return __ESIMD_DNS::atomic_update_impl<Op, T, N, DS, L1H, L3H>(acc, offsets,
+                                                                 src0, pred);
 }
 
 /// Variant of \c lsc_atomic_update that uses \c local_accessor as a parameter.

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
@@ -264,10 +264,9 @@ bool test_acc(queue q, const Config &cfg) {
       return true;
     } else {
 
-      std::cout << "Accessor Testing "
-                << "op=" << to_string(op) << " n_args=" << n_args
-                << " T=" << esimd_test::type_name<T>() << " N=" << N
-                << " UseMask=" << (UseMask ? "true" : "false")
+      std::cout << "Accessor Testing " << "op=" << to_string(op)
+                << " n_args=" << n_args << " T=" << esimd_test::type_name<T>()
+                << " N=" << N << " UseMask=" << (UseMask ? "true" : "false")
                 << " UseProperties=" << (UseProperties ? "true" : "false")
                 << "\n\t" << cfg << "...";
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
@@ -260,90 +260,93 @@ bool test_acc(queue q, const Config &cfg) {
     return true;
   } else {
     // Remove once 1 and 2 are supported
-    if constexpr (n_args == 2)
+    if constexpr (n_args == 2) {
       return true;
+    } else {
 
-    std::cout << "Accessor Testing " << "op=" << to_string(op)
-              << " n_args=" << n_args << " T=" << esimd_test::type_name<T>()
-              << " N=" << N << " UseMask=" << (UseMask ? "true" : "false")
-              << " UseProperties=" << (UseProperties ? "true" : "false")
-              << "\n\t" << cfg << "...";
+      std::cout << "Accessor Testing "
+                << "op=" << to_string(op) << " n_args=" << n_args
+                << " T=" << esimd_test::type_name<T>() << " N=" << N
+                << " UseMask=" << (UseMask ? "true" : "false")
+                << " UseProperties=" << (UseProperties ? "true" : "false")
+                << "\n\t" << cfg << "...";
 
-    size_t size = cfg.start_ind + (N - 1) * cfg.stride + 1;
-    T *arr = malloc_shared<T>(size, q);
-    int n_threads = cfg.threads_per_group * cfg.n_groups;
+      size_t size = cfg.start_ind + (N - 1) * cfg.stride + 1;
+      T *arr = malloc_shared<T>(size, q);
+      int n_threads = cfg.threads_per_group * cfg.n_groups;
 
-    for (int i = 0; i < size; ++i) {
-      arr[i] = ImplF<T, N>::init(i, cfg);
-    }
+      for (int i = 0; i < size; ++i) {
+        arr[i] = ImplF<T, N>::init(i, cfg);
+      }
 
-    range<1> glob_rng(n_threads);
-    range<1> loc_rng(cfg.threads_per_group);
-    nd_range<1> rng(glob_rng, loc_rng);
+      range<1> glob_rng(n_threads);
+      range<1> loc_rng(cfg.threads_per_group);
+      nd_range<1> rng(glob_rng, loc_rng);
 
-    properties props{cache_hint_L1<cache_hint::uncached>,
-                     cache_hint_L2<cache_hint::write_back>};
+      properties props{cache_hint_L1<cache_hint::uncached>,
+                       cache_hint_L2<cache_hint::write_back>};
 
-    try {
-      buffer<T, 1> arr_buf(arr, range<1>(size));
-      auto e = q.submit([&](handler &cgh) {
-        auto arr_acc =
-            arr_buf.template get_access<access::mode::read_write>(cgh);
-        cgh.parallel_for(rng, [=](id<1> ii) SYCL_ESIMD_KERNEL {
-          int i = ii;
-          simd<Toffset, N> offsets(cfg.start_ind * sizeof(T),
-                                   cfg.stride * sizeof(T));
-          simd_mask<N> m = 1;
-          if constexpr (UseMask) {
-            if (cfg.masked_lane < N)
-              m[cfg.masked_lane] = 0;
-          }
-          // barrier to achieve better contention:
-          // Intra-work group barrier.
-          barrier();
+      try {
+        buffer<T, 1> arr_buf(arr, range<1>(size));
+        auto e = q.submit([&](handler &cgh) {
+          auto arr_acc =
+              arr_buf.template get_access<access::mode::read_write>(cgh);
+          cgh.parallel_for(rng, [=](id<1> ii) SYCL_ESIMD_KERNEL {
+            int i = ii;
+            simd<Toffset, N> offsets(cfg.start_ind * sizeof(T),
+                                     cfg.stride * sizeof(T));
+            simd_mask<N> m = 1;
+            if constexpr (UseMask) {
+              if (cfg.masked_lane < N)
+                m[cfg.masked_lane] = 0;
+            }
+            // barrier to achieve better contention:
+            // Intra-work group barrier.
+            barrier();
 
-          // the atomic operation itself applied in a loop:
-          for (int cnt = 0; cnt < cfg.repeat; ++cnt) {
-            if constexpr (n_args == 0) {
-              if constexpr (UseMask) {
-                if constexpr (UseProperties)
-                  atomic_update<op, T>(arr_acc, offsets, m, props);
-                else
-                  atomic_update<op, T>(arr_acc, offsets, m);
-              } else {
-                if constexpr (UseProperties)
-                  atomic_update<op, T>(arr_acc, offsets, props);
-                else
-                  atomic_update<op, T>(arr_acc, offsets);
-              }
-            } else if constexpr (n_args == 1) {
-              simd<T, N> v0 = ImplF<T, N>::arg0(i);
-              if constexpr (UseMask) {
-                if constexpr (UseProperties)
-                  atomic_update<op>(arr_acc, offsets, v0, m, props);
-                else
-                  atomic_update<op>(arr_acc, offsets, v0, m);
-              } else {
-                if constexpr (UseProperties)
-                  atomic_update<op>(arr_acc, offsets, v0, props);
-                else
-                  atomic_update<op>(arr_acc, offsets, v0);
+            // the atomic operation itself applied in a loop:
+            for (int cnt = 0; cnt < cfg.repeat; ++cnt) {
+              if constexpr (n_args == 0) {
+                if constexpr (UseMask) {
+                  if constexpr (UseProperties)
+                    atomic_update<op, T>(arr_acc, offsets, m, props);
+                  else
+                    atomic_update<op, T>(arr_acc, offsets, m);
+                } else {
+                  if constexpr (UseProperties)
+                    atomic_update<op, T>(arr_acc, offsets, props);
+                  else
+                    atomic_update<op, T>(arr_acc, offsets);
+                }
+              } else if constexpr (n_args == 1) {
+                simd<T, N> v0 = ImplF<T, N>::arg0(i);
+                if constexpr (UseMask) {
+                  if constexpr (UseProperties)
+                    atomic_update<op>(arr_acc, offsets, v0, m, props);
+                  else
+                    atomic_update<op>(arr_acc, offsets, v0, m);
+                } else {
+                  if constexpr (UseProperties)
+                    atomic_update<op>(arr_acc, offsets, v0, props);
+                  else
+                    atomic_update<op>(arr_acc, offsets, v0);
+                }
               }
             }
-          }
+          });
         });
-      });
-      e.wait();
-    } catch (sycl::exception const &e) {
-      std::cout << "SYCL exception caught: " << e.what() << '\n';
+        e.wait();
+      } catch (sycl::exception const &e) {
+        std::cout << "SYCL exception caught: " << e.what() << '\n';
+        free(arr, q);
+        return false;
+      }
+
+      bool passed = verify<T, N, ImplF>(arr, cfg, size);
+
       free(arr, q);
-      return false;
+      return passed;
     }
-
-    bool passed = verify<T, N, ImplF>(arr, cfg, size);
-
-    free(arr, q);
-    return passed;
   }
 }
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
@@ -260,7 +260,7 @@ bool test_acc(queue q, const Config &cfg) {
     return true;
   } else {
     // Remove once 1 and 2 are supported
-    if constexpr (n_args != 0)
+    if constexpr (n_args == 2)
       return true;
 
     std::cout << "Accessor Testing " << "op=" << to_string(op)
@@ -315,6 +315,19 @@ bool test_acc(queue q, const Config &cfg) {
                   atomic_update<op, T>(arr_acc, offsets, props);
                 else
                   atomic_update<op, T>(arr_acc, offsets);
+              }
+            } else if constexpr (n_args == 1) {
+              simd<T, N> v0 = ImplF<T, N>::arg0(i);
+              if constexpr (UseMask) {
+                if constexpr (UseProperties)
+                  atomic_update<op>(arr_acc, offsets, v0, m, props);
+                else
+                  atomic_update<op>(arr_acc, offsets, v0, m);
+              } else {
+                if constexpr (UseProperties)
+                  atomic_update<op>(arr_acc, offsets, v0, props);
+                else
+                  atomic_update<op>(arr_acc, offsets, v0);
               }
             }
           }

--- a/sycl/test/esimd/memory_properties.cpp
+++ b/sycl/test/esimd/memory_properties.cpp
@@ -373,35 +373,28 @@ test_atomic_update(AccType &acc, float *ptrf, int byte_offset32,
 
     // Accessors
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    // CHECK-COUNT-8: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_9 =
         atomic_update<atomic_op::add, int>(acc, offsets, add, pred, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_10 =
         atomic_update<atomic_op::add, int>(acc, offsets, add, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_11 = atomic_update<atomic_op::add, int, VL>(
         acc, offsets, add_view, pred, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_12 =
         atomic_update<atomic_op::add, int, VL>(acc, offsets, add_view, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_13 = atomic_update<atomic_op::add, int, VL>(
         acc, offsets_view, add, pred, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_14 =
         atomic_update<atomic_op::add, int, VL>(acc, offsets_view, add, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_15 = atomic_update<atomic_op::add, int, VL>(
         acc, offsets_view, add_view, pred, props_a);
 
-    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_16 = atomic_update<atomic_op::add, int, VL>(
         acc, offsets_view, add_view, props_a);
 

--- a/sycl/test/esimd/memory_properties.cpp
+++ b/sycl/test/esimd/memory_properties.cpp
@@ -332,6 +332,8 @@ test_atomic_update(AccType &acc, float *ptrf, int byte_offset32,
 
   // Test atomic update with one operand.
   {
+    // USM
+
     // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 0, <4 x i32> undef)
     auto res_atomic_0 =
         atomic_update<atomic_op::add, int>(ptr, offsets, add, pred, props_a);
@@ -364,13 +366,52 @@ test_atomic_update(AccType &acc, float *ptrf, int byte_offset32,
     auto res_atomic_7 = atomic_update<atomic_op::add, int, VL>(
         ptr, offsets_view, add_view, props_a);
 
-    // atomic_upate without cache hints:
+    // atomic_update without cache hints:
     // CHECK: call <4 x i32> @llvm.genx.svm.atomic.add.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, <4 x i64> {{[^)]+}}, <4 x i32> undef)
     auto res_atomic_8 =
         atomic_update<atomic_op::add, int>(ptr, offsets, add, pred);
+
+    // Accessors
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_9 =
+        atomic_update<atomic_op::add, int>(acc, offsets, add, pred, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_10 =
+        atomic_update<atomic_op::add, int>(acc, offsets, add, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_11 = atomic_update<atomic_op::add, int, VL>(
+        acc, offsets, add_view, pred, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_12 =
+        atomic_update<atomic_op::add, int, VL>(acc, offsets, add_view, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_13 = atomic_update<atomic_op::add, int, VL>(
+        acc, offsets_view, add, pred, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_14 =
+        atomic_update<atomic_op::add, int, VL>(acc, offsets_view, add, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_15 = atomic_update<atomic_op::add, int, VL>(
+        acc, offsets_view, add_view, pred, props_a);
+
+    // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.bti.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i8 12, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef, i32 {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_16 = atomic_update<atomic_op::add, int, VL>(
+        acc, offsets_view, add_view, props_a);
+
+    // atomic_update without cache hints:
+    // CHECK: call <4 x i32> @llvm.genx.dword.atomic.add.v4i32.v4i1.v4i32(<4 x i1> {{[^)]+}}, i32 {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> undef)
+    auto res_atomic_17 =
+        atomic_update<atomic_op::add, int>(acc, offsets, add, pred);
   }
 
-  // Test atomic update with one operand.
+  // Test atomic update with two operands.
   {
     // CHECK: call <4 x i32> @llvm.genx.lsc.xatomic.stateless.v4i32.v4i1.v4i64(<4 x i1> {{[^)]+}}, i8 18, i8 1, i8 3, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <4 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0, <4 x i32> undef)
     auto res_atomic_1 = atomic_update<atomic_op::cmpxchg, int>(
@@ -493,7 +534,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_block_store(AccType &acc,
   // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4f32(<1 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x float> {{[^)]+}}, i32 0)
   block_store(ptrf, vals, mask, store_props_a);
 
-  // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> %{{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
+  // CHECK: call void @llvm.genx.lsc.store.stateless.v1i1.v1i64.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 3, i8 3, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i64> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store(ptri, byte_offset64, valsi, mask, store_props_c);
 
   // Test SVM/legacy USM block store


### PR DESCRIPTION
atomic_update API with accessors and one operand. Next is two operands.

I also fixed a problem where we weren't passing props down, it should be noop right now but maybe in the future it will matter.