### PR TITLE
[SYCL][Graph] Add missing exception for USM memset

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -85,6 +85,12 @@ event queue_impl::memset(const std::shared_ptr<detail::queue_impl> &Self,
   // Emit a begin/end scope for this call
   PrepareNotify.scopedNotify((uint16_t)xpti::trace_point_type_t::task_begin);
 #endif
+  if (MGraph.lock()) {
+    throw sycl::exception(make_error_code(errc::invalid),
+                          "The memset feature is not yet available "
+                          "for use with the SYCL Graph extension.");
+  }
+
   if (MHasDiscardEventsSupport) {
     MemoryManager::fill_usm(Ptr, Self, Count, Value,
                             getOrWaitEvents(DepEvents, MContext), nullptr);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1720,6 +1720,25 @@ TEST_F(CommandGraphTest, KernelPropertiesExceptionCheck) {
                                                         KernelFunction);
 }
 
+TEST_F(CommandGraphTest, USMMemsetShortcutExceptionCheck) {
+
+  const size_t N = 10;
+  unsigned char *Arr = malloc_device<unsigned char>(N, Queue);
+  int Value = 77;
+
+  Graph.begin_recording(Queue);
+
+  std::error_code ExceptionCode = make_error_code(sycl::errc::success);
+  try {
+    Queue.memset(Arr, Value, N);
+  } catch (exception &Exception) {
+    ExceptionCode = Exception.code();
+  }
+  ASSERT_EQ(ExceptionCode, sycl::errc::invalid);
+
+  Graph.end_recording(Queue);
+}
+
 TEST_F(CommandGraphTest, Memcpy2DExceptionCheck) {
   constexpr size_t RECT_WIDTH = 30;
   constexpr size_t RECT_HEIGHT = 21;


### PR DESCRIPTION
Throws a invalid exception when memset queue shortcut is used during graph recording since memset is not supported by the current graph implementation. 
Adds a unitest checking that the exception is correctly thrown.

Addresses issue #11940