### PR TITLE
[SYCL][Bindless][Exp] Fix free_image_mem declaration

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bindless_images.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images.hpp
@@ -90,7 +90,7 @@ void free_image_mem(image_mem_handle handle, const sycl::device &syclDevice,
  */
 __SYCL_EXPORT_DEPRECATED("Distinct image frees are deprecated. "
                          "Instead use overload that accepts image_type.")
-void free_image_mem(image_mem_handle handle, const sycl::device &syclQueue);
+void free_image_mem(image_mem_handle handle, const sycl::queue &syclQueue);
 
 /**
  *  @brief   Free image memory


### PR DESCRIPTION
- A declaration of `free_image_mem` incorrectly took `sycl::device` as a parameter, which should have been a `sycl::queue`. This is now fixed.