### PR TITLE
[SYCL][NFC] Silence some warnings in ESIMD E2E tests

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
@@ -110,7 +110,6 @@ const char *to_string(DWORDAtomicOp op) {
     return "smin";
   case DWORDAtomicOp::smax:
     return "smax";
-#ifndef USE_DWORD_ATOMICS
   case DWORDAtomicOp::fmax:
     return "fmax";
   case DWORDAtomicOp::fmin:
@@ -119,7 +118,6 @@ const char *to_string(DWORDAtomicOp op) {
     return "fadd";
   case DWORDAtomicOp::fsub:
     return "fsub";
-#endif // !USE_DWORD_ATOMICS
   case DWORDAtomicOp::fcmpxchg:
     return "fcmpxchg";
   case DWORDAtomicOp::load:

--- a/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke.cpp
@@ -77,12 +77,14 @@ const char *to_string(DWORDAtomicOp op) {
     return "smin";
   case DWORDAtomicOp::smax:
     return "smax";
-#ifndef USE_DWORD_ATOMICS
   case DWORDAtomicOp::fmax:
     return "fmax";
   case DWORDAtomicOp::fmin:
     return "fmin";
-#endif // !USE_DWORD_ATOMICS
+  case DWORDAtomicOp::fadd:
+    return "fadd";
+  case DWORDAtomicOp::fsub:
+    return "fsub";
   case DWORDAtomicOp::fcmpxchg:
     return "fcmpxchg";
   case DWORDAtomicOp::load:
@@ -125,6 +127,10 @@ const char *to_string(LSCAtomicOp op) {
     return "lsc::fmax";
   case LSCAtomicOp::fmin:
     return "lsc::fmin";
+  case LSCAtomicOp::fadd:
+    return "lsc::fadd";
+  case LSCAtomicOp::fsub:
+    return "lsc::fsub";
   case LSCAtomicOp::fcmpxchg:
     return "lsc::fcmpxchg";
   case LSCAtomicOp::load:


### PR DESCRIPTION
`to_string` helper using in several ESIMD tests didn't cover some of enumerations fully, thus causing warnings in tests.