### PR TITLE
[SYCL] Fix `operator||` and `operator&&` in `vec`

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1074,7 +1074,7 @@ public:
 // by SYCL device compiler only.
 #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_RELLOGOP(RELLOGOP)                                              \
-  vec<rel_t, NumElements> operator RELLOGOP(const vec &Rhs) const {            \
+  vec<rel_t, NumElements> operator RELLOGOP(const vec & Rhs) const {           \
     vec<rel_t, NumElements> Ret{};                                             \
     /* This special case is needed since there are no standard operator||   */ \
     /* or operator&& functions for std::array.                              */ \
@@ -1100,7 +1100,7 @@ public:
                                 (std::is_fundamental_v<vec_data_t<T>> ||       \
                                  std::is_same_v<T, half>),                     \
                             vec<rel_t, NumElements>>                           \
-  operator RELLOGOP(const T &Rhs) const {                                      \
+  operator RELLOGOP(const T & Rhs) const {                                     \
     return *this RELLOGOP vec(static_cast<const DataT &>(Rhs));                \
   }
 #else

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1074,12 +1074,25 @@ public:
 // by SYCL device compiler only.
 #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_RELLOGOP(RELLOGOP)                                              \
-  vec<rel_t, NumElements> operator RELLOGOP(const vec & Rhs) const {           \
-    auto Ret =                                                                 \
-        vec<rel_t, NumElements>((typename vec<rel_t, NumElements>::vector_t)(  \
-            m_Data RELLOGOP Rhs.m_Data));                                      \
-    if (NumElements == 1) /*Scalar 0/1 logic was applied, invert*/             \
-      Ret *= -1;                                                               \
+  vec<rel_t, NumElements> operator RELLOGOP(const vec &Rhs) const {            \
+    vec<rel_t, NumElements> Ret{};                                             \
+    /* This special case is needed since there are no standard operator||   */ \
+    /* or operator&& functions for std::array.                              */ \
+    if constexpr (IsUsingArrayOnDevice &&                                      \
+                  (std::string_view(#RELLOGOP) == "||" ||                      \
+                   std::string_view(#RELLOGOP) == "&&")) {                     \
+      for (size_t I = 0; I < NumElements; ++I) {                               \
+        Ret.setValue(I,                                                        \
+                     -(vec_data<DataT>::get(getValue(I))                       \
+                           RELLOGOP vec_data<DataT>::get(Rhs.getValue(I))));   \
+      }                                                                        \
+    } else {                                                                   \
+      Ret = vec<rel_t, NumElements>(                                           \
+          (typename vec<rel_t, NumElements>::vector_t)(                        \
+              m_Data RELLOGOP Rhs.m_Data));                                    \
+      if (NumElements == 1) /*Scalar 0/1 logic was applied, invert*/           \
+        Ret *= -1;                                                             \
+    }                                                                          \
     return Ret;                                                                \
   }                                                                            \
   template <typename T>                                                        \
@@ -1087,7 +1100,7 @@ public:
                                 (std::is_fundamental_v<vec_data_t<T>> ||       \
                                  std::is_same_v<T, half>),                     \
                             vec<rel_t, NumElements>>                           \
-  operator RELLOGOP(const T & Rhs) const {                                     \
+  operator RELLOGOP(const T &Rhs) const {                                      \
     return *this RELLOGOP vec(static_cast<const DataT &>(Rhs));                \
   }
 #else

--- a/sycl/test-e2e/Regression/vec_logical_ops.cpp
+++ b/sycl/test-e2e/Regression/vec_logical_ops.cpp
@@ -1,0 +1,15 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes && ./%t.out %}
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue q;
+  q.single_task([=]() {
+    auto testVec1 = sycl::vec<double, 16>(static_cast<double>(1));
+    auto testVec2 = sycl::vec<double, 16>(static_cast<double>(2));
+    sycl::vec<std::int64_t, 16> resVec1 = testVec1 || testVec2;
+    sycl::vec<std::int64_t, 16> resVec2 = testVec1 && testVec2;
+  });
+}


### PR DESCRIPTION
Adds a special case logical operator implementation for device code using `std::array`. Fixes #11903.