### PR TITLE
[SYCL] Stop using legacy `feature_not_supported` exception

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -982,9 +982,9 @@ public:
 
     device Device = getDeviceFromHandler(CommandGroupHandlerRef);
     if (!Device.has(aspect::ext_intel_legacy_image))
-      throw feature_not_supported(
-          "SYCL 1.2.1 images are not supported by this device.",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(
+          sycl::errc::feature_not_supported,
+          "SYCL 1.2.1 images are not supported by this device.");
   }
 #endif
 

--- a/sycl/include/sycl/ext/oneapi/group_local_memory.hpp
+++ b/sycl/include/sycl/ext/oneapi/group_local_memory.hpp
@@ -11,7 +11,7 @@
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_ALWAYS_INLINE
 #include <sycl/detail/pi.h>                   // for PI_ERROR_INVALID_OPERA...
 #include <sycl/detail/type_traits.hpp>        // for is_group
-#include <sycl/exception.hpp>                 // for feature_not_supported
+#include <sycl/exception.hpp>                 // for exception
 #include <sycl/ext/intel/usm_pointers.hpp>    // for multi_ptr
 
 #include <type_traits> // for enable_if_t
@@ -42,9 +42,9 @@ std::enable_if_t<
   }
   return reinterpret_cast<__attribute__((opencl_local)) T *>(AllocatedMem);
 #else
-  throw feature_not_supported(
-      "sycl_ext_oneapi_local_memory extension is not supported on host device",
-      PI_ERROR_INVALID_OPERATION);
+  throw sycl::exception(
+      sycl::errc::feature_not_supported,
+      "sycl_ext_oneapi_local_memory extension is not supported on host");
 #endif
 }
 
@@ -64,9 +64,9 @@ std::enable_if_t<
   // Silence unused variable warning
   (void)g;
   [&args...] {}();
-  throw feature_not_supported(
-      "sycl_ext_oneapi_local_memory extension is not supported on host device",
-      PI_ERROR_INVALID_OPERATION);
+  throw sycl::exception(
+      sycl::errc::feature_not_supported,
+      "sycl_ext_oneapi_local_memory extension is not supported on host");
 #endif
 }
 } // namespace ext::oneapi

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -464,11 +464,13 @@ void event_impl::setSubmissionTime() {
     if (QueueImplPtr Queue = MQueue.lock()) {
       try {
         MSubmitTime = Queue->getDeviceImplPtr()->getCurrentDeviceTime();
-      } catch (feature_not_supported &e) {
-        throw sycl::exception(
-            make_error_code(errc::profiling),
-            std::string("Unable to get command group submission time: ") +
-                e.what());
+      } catch (sycl::exception &e) {
+        if (e.code() == sycl::errc::feature_not_supported)
+          throw sycl::exception(
+              make_error_code(errc::profiling),
+              std::string("Unable to get command group submission time: ") +
+                  e.what());
+        std::rethrow_exception(std::current_exception());
       }
     }
   } else {

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -36,10 +36,10 @@ program_impl::program_impl(ContextImplPtr Context,
                            const property_list &PropList)
     : MContext(Context), MDevices(DeviceList), MPropList(PropList) {
   if (Context->getDevices().size() > 1) {
-    throw feature_not_supported(
+    throw sycl::exception(
+        sycl::errc::feature_not_supported,
         "multiple devices within a context are not supported with "
-        "sycl::program and sycl::kernel",
-        PI_ERROR_INVALID_OPERATION);
+        "sycl::program and sycl::kernel");
   }
 }
 
@@ -65,10 +65,10 @@ program_impl::program_impl(
 
   MContext = ProgramList[0]->MContext;
   if (MContext->getDevices().size() > 1) {
-    throw feature_not_supported(
+    throw sycl::exception(
+        sycl::errc::feature_not_supported,
         "multiple devices within a context are not supported with "
-        "sycl::program and sycl::kernel",
-        PI_ERROR_INVALID_OPERATION);
+        "sycl::program and sycl::kernel");
   }
   MDevices = ProgramList[0]->MDevices;
   std::vector<device> DevicesSorted;

--- a/sycl/source/detail/program_impl.hpp
+++ b/sycl/source/detail/program_impl.hpp
@@ -315,9 +315,9 @@ private:
   void check_device_feature_support(const std::vector<device> &Devices) {
     for (const auto &Device : Devices) {
       if (!Device.get_info<Param>()) {
-        throw feature_not_supported(
-            "Online compilation is not supported by this device",
-            PI_ERROR_COMPILER_NOT_AVAILABLE);
+        throw sycl::exception(
+            sycl::errc::feature_not_supported,
+            "Online compilation is not supported by this device");
       }
     }
   }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -300,9 +300,9 @@ ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
   // assert(Format != PI_DEVICE_BINARY_TYPE_NONE && "Image format not set");
 
   if (!isDeviceBinaryTypeSupported(Context, Format))
-    throw feature_not_supported(
-        "SPIR-V online compilation is not supported in this context",
-        PI_ERROR_INVALID_OPERATION);
+    throw sycl::exception(
+        sycl::errc::feature_not_supported,
+        "SPIR-V online compilation is not supported in this context");
 
   // Get program metadata from properties
   auto ProgMetadata = Img.getProgramMetadata();
@@ -1040,8 +1040,8 @@ void CheckJITCompilationForImage(const RTDeviceBinaryImage *const &Image,
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64_GEN) == 0) ||
       (strcmp(RawImg.DeviceTargetSpec,
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64_FPGA) == 0)) {
-    throw feature_not_supported("Recompiling AOT image is not supported",
-                                PI_ERROR_INVALID_OPERATION);
+    throw sycl::exception(sycl::errc::feature_not_supported,
+                          "Recompiling AOT image is not supported");
   }
 }
 

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -74,8 +74,8 @@ sampler_impl::getOrCreateSampler(const context &Context) {
       getSyclObjImpl(Context)->getHandleRef(), sprops, &resultSampler);
 
   if (errcode_ret == PI_ERROR_INVALID_OPERATION)
-    throw feature_not_supported("Images are not supported by this device.",
-                                errcode_ret);
+    throw sycl::exception(sycl::errc::feature_not_supported,
+                          "Images are not supported by this device.");
 
   Plugin->checkPiResult(errcode_ret);
   std::lock_guard<std::mutex> Lock(MMutex);

--- a/sycl/source/esimd_emulator_device_interface.cpp
+++ b/sycl/source/esimd_emulator_device_interface.cpp
@@ -35,7 +35,7 @@ __SYCL_EXPORT ESIMDDeviceInterface *getESIMDDeviceInterface() {
     std::cerr << "ESIMD EMU plugin error or not loaded - try setting "
                  "SYCL_DEVICE_FILTER=esimd_emulator:gpu environment variable"
               << std::endl;
-    throw sycl::feature_not_supported();
+    throw sycl::exception(sycl::errc::feature_not_supported);
   }
 
   ESIMDEmuPluginOpaqueData *OpaqueData =
@@ -53,7 +53,7 @@ __SYCL_EXPORT ESIMDDeviceInterface *getESIMDDeviceInterface() {
               << "Returned version : " << OpaqueData->version << std::endl
               << "Required version : "
               << ESIMD_EMULATOR_PLUGIN_OPAQUE_DATA_VERSION << std::endl;
-    throw feature_not_supported();
+    throw sycl::exception(sycl::errc::feature_not_supported);
   }
   // Opaque data version is OK, can cast the 'data' field.
   ESIMDDeviceInterface *Interface =
@@ -68,7 +68,7 @@ __SYCL_EXPORT ESIMDDeviceInterface *getESIMDDeviceInterface() {
               << "Found version : " << Interface->version << std::endl
               << "Required version :" << ESIMD_DEVICE_INTERFACE_VERSION
               << std::endl;
-    throw feature_not_supported();
+    throw sycl::exception(sycl::errc::feature_not_supported);
   }
   return Interface;
 }

--- a/sycl/test-e2e/Basic/subdevice.cpp
+++ b/sycl/test-e2e/Basic/subdevice.cpp
@@ -47,8 +47,10 @@ int main() {
         assert(sycl::get_native<sycl::backend::opencl>(
                    SubDevicesEq[0].get_info<info::device::parent_device>()) ==
                sycl::get_native<sycl::backend::opencl>(dev));
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -64,8 +66,10 @@ int main() {
         assert(SubDevicesByCount[0]
                    .get_info<info::device::partition_type_property>() ==
                info::partition_property::partition_by_counts);
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -76,8 +80,10 @@ int main() {
             << "Created " << SubDevicesDomainNuma.size()
             << " subdevices using partition by numa affinity domain scheme."
             << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -87,8 +93,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL4.size()
                   << " subdevices using partition by L4 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -98,8 +106,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL3.size()
                   << " subdevices using partition by L3 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -109,8 +119,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL2.size()
                   << " subdevices using partition by L2 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -120,8 +132,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL1.size()
                   << " subdevices using partition by L1 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -132,8 +146,10 @@ int main() {
                   << " subdevices using partition by next partitionable "
                      "domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       // test exception

--- a/sycl/test-e2e/Basic/subsubdevice.cpp
+++ b/sycl/test-e2e/Basic/subsubdevice.cpp
@@ -48,8 +48,10 @@ int main() {
         assert(sycl::get_native<sycl::backend::opencl>(
                    SubDevicesEq[0].get_info<info::device::parent_device>()) ==
                sycl::get_native<sycl::backend::opencl>(dev));
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -65,8 +67,10 @@ int main() {
         assert(SubDevicesByCount[0]
                    .get_info<info::device::partition_type_property>() ==
                info::partition_property::partition_by_counts);
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -88,8 +92,10 @@ int main() {
                   << " sub-subdevices from subdevice 0 using partition by numa "
                      "affinity domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -99,8 +105,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL4.size()
                   << " subdevices using partition by L4 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -110,8 +118,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL3.size()
                   << " subdevices using partition by L3 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -121,8 +131,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL2.size()
                   << " subdevices using partition by L2 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -132,8 +144,10 @@ int main() {
         std::cout << "Created " << SubDevicesDomainL1.size()
                   << " subdevices using partition by L1 cache domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
 
       try {
@@ -154,8 +168,10 @@ int main() {
                   << " sub-subdevices from subdevice 0 using partition by next "
                      "partitionable domain scheme."
                   << std::endl;
-      } catch (feature_not_supported) {
-        // okay skip it
+      } catch (const sycl::exception &e) {
+        if (e.code() != sycl::errc::feature_not_supported)
+          std::rethrow_exception(std::current_exception());
+        // otherwise okay skip it
       }
     }
   } catch (exception e) {


### PR DESCRIPTION
Cleaned up both SYCL RT and tests to remove use of legacy SYCL 1.2.1 `feature_not_supported` exception and replaced its uses with `sycl::exception` with `feature_not_supported` error code