### PR TITLE
[SYCL] Enable Auto GRF by default on PVC on Linux

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -9765,7 +9765,8 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     if (TC.getTriple().getSubArch() == llvm::Triple::NoSubArch) {
       // Only store compile/link opts in the image descriptor for the SPIR-V
       // target; AOT compilation has already been performed otherwise.
-      TC.AddImpliedTargetArgs(TT, TCArgs, BuildArgs, JA);
+      const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
+      TC.AddImpliedTargetArgs(TT, TCArgs, BuildArgs, JA, *HostTC);
       TC.TranslateBackendTargetArgs(TT, TCArgs, BuildArgs);
       createArgString("-compile-opts=");
       BuildArgs.clear();

--- a/clang/lib/Driver/ToolChains/SYCL.h
+++ b/clang/lib/Driver/ToolChains/SYCL.h
@@ -173,7 +173,7 @@ public:
   void AddImpliedTargetArgs(const llvm::Triple &Triple,
                             const llvm::opt::ArgList &Args,
                             llvm::opt::ArgStringList &CmdArgs,
-                            const JobAction &JA) const;
+                            const JobAction &JA, const ToolChain &HostTC) const;
   void TranslateBackendTargetArgs(const llvm::Triple &Triple,
                                   const llvm::opt::ArgList &Args,
                                   llvm::opt::ArgStringList &CmdArgs,

--- a/clang/test/Driver/ftarget-compile-fast.cpp
+++ b/clang/test/Driver/ftarget-compile-fast.cpp
@@ -17,4 +17,4 @@
 // RUN:     -ftarget-compile-fast %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=TARGET_COMPILE_FAST_JIT %s
 
-// TARGET_COMPILE_FAST_JIT: clang-offload-wrapper{{.*}} "-compile-opts=-ftarget-compile-fast
+// TARGET_COMPILE_FAST_JIT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-ftarget-compile-fast

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
@@ -17,6 +17,10 @@
 // RUN:   | FileCheck -check-prefix=DEFAULT_AOT %s
 
 // RUN: %clang -### -fsycl \
+// RUN:    -fsycl-targets=spir64_gen %s 2>&1 \
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+
+// RUN: %clang -### -fsycl \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:small,pvc:large %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=MULTIPLE_ARGS_AOT %s
 
@@ -35,6 +39,9 @@
 // RUN: %clang -### -fsycl \
 // RUN:   -ftarget-register-alloc-mode=pvc:default %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=DEFAULT_JIT %s
+
+// RUN: %clang -### -fsycl %s 2>&1 \
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_JIT %} %else %{ -check-prefix=AUTO_JIT %} %s
 
 // RUN: %clang -### -fsycl \
 // RUN:   -ftarget-register-alloc-mode=pvc:small,pvc:large %s 2>&1 \

--- a/clang/test/Driver/sycl-offload-static-lib-2.cpp
+++ b/clang/test/Driver/sycl-offload-static-lib-2.cpp
@@ -240,6 +240,6 @@
 // STATIC_LIB_NOSRC-CUDA: llvm-foreach{{.*}}ptxas{{.*}} "--output-file" "[[CUBINLIST:.+]]"{{.*}}  "[[PTXLIST]]"
 // STATIC_LIB_NOSRC-CUDA: llvm-foreach{{.*}}fatbin{{.*}} "--create" "[[OBJLIST:.+]]"{{.*}} "--image={{.*}}[[PTXLIST]]" "--image={{.*}}[[CUBINLIST]]"
 // STATIC_LIB_NOSRC: file-table-tform{{.*}} "-o" "[[TABLE1:.+\.table]]" "[[TABLE]]" "[[OBJLIST]]"
-// STATIC_LIB_NOSRC: clang-offload-wrapper{{.*}} "-o=[[BCFILE2:.+\.bc]]" "-host=x86_64-unknown-linux-gnu" "-target=[[TARGET]]" "-kind=sycl" "-batch" "[[TABLE1]]"
+// STATIC_LIB_NOSRC: clang-offload-wrapper{{.*}} "-o=[[BCFILE2:.+\.bc]]" "-host=x86_64-unknown-linux-gnu"{{.*}}"-target=[[TARGET]]" "-kind=sycl" "-batch" "[[TABLE1]]"
 // STATIC_LIB_NOSRC: llc{{.*}} "-filetype=obj" "-o" "[[FINALOBJ:.+\.o]]" "[[BCFILE2]]"
 // STATIC_LIB_NOSRC: ld{{.*}} "-L/dummy/dir" {{.*}} "{{.*}}_lib.{{(a|lo)}}" "[[FINALOBJ]]"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -405,14 +405,14 @@
 
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-OPTS %s
-// CHK-TOOLS-OPTS: clang-offload-wrapper{{.*}} "-compile-opts=-DFOO1 -DFOO2"
+// CHK-TOOLS-OPTS: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-DFOO1 -DFOO2"
 
 /// Check for implied options (-g -O0)
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64-unknown-unknown -g -O0 -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
 // RUN:   %clang_cl -### -fsycl -fsycl-targets=spir64-unknown-unknown -Zi -Od -Xsycl-target-backend "-DFOO1 -DFOO2" %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-TOOLS-IMPLIED-OPTS %s
-// CHK-TOOLS-IMPLIED-OPTS: clang-offload-wrapper{{.*}} "-compile-opts=-g -DFOO1 -DFOO2"
+// CHK-TOOLS-IMPLIED-OPTS: clang-offload-wrapper{{.*}} "-compile-opts=-g{{.*}}-DFOO1 -DFOO2"
 
 /// Check for implied options (-O0)
 // RUN:   %clang -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64 -O0 %s 2>&1 \

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -120,7 +120,7 @@
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -Xsycl-target-backend=spir64 -DFOO -Xsycl-target-linker=spir64 -DFOO2 %S/Inputs/SYCL/objlin64.o 2>&1 \
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT %s
-// SYCL_TARGET_OPT: clang-offload-wrapper{{.*}} "-compile-opts=-DFOO" "-link-opts=-DFOO2"
+// SYCL_TARGET_OPT: clang-offload-wrapper{{.*}} "-compile-opts={{.*}}-DFOO" "-link-opts=-DFOO2"
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_x86_64 -Xsycl-target-backend -DFOO %S/Inputs/SYCL/objlin64.o 2>&1 \
 // RUN:    | FileCheck -check-prefixes=SYCL_TARGET_OPT_AOT %s
 // RUN:  %clangxx -### -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend -DFOO %S/Inputs/SYCL/objlin64.o 2>&1 \

--- a/clang/test/Driver/sycl-oneapi-gpu.cpp
+++ b/clang/test/Driver/sycl-oneapi-gpu.cpp
@@ -403,9 +403,9 @@
 // RUN:   -fno-sycl-device-lib=all -fno-sycl-instrument-device-code \
 // RUN:   -target x86_64-unknown-linux-gnu -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK_TOOLS_BEOPTS
-// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "dg1" "-DDG1"
-// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl" "-DSKL"
-// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl" "-DSKL2"
+// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "dg1"{{.*}}"-DDG1"
+// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl"{{.*}}"-DSKL"
+// CHECK_TOOLS_BEOPTS: ocloc{{.*}} "-device" "skl"{{.*}}"-DSKL2"
 
 /// Check that ocloc backend option settings only occur for the expected
 /// toolchains when mixing intel_gpu and non-spir64_gen targets
@@ -416,7 +416,7 @@
 // RUN:   -fno-sycl-device-lib=all -fno-sycl-instrument-device-code \
 // RUN:   -target x86_64-unknown-linux-gnu -### %s 2>&1 | \
 // RUN:   FileCheck %s --check-prefix=CHECK_TOOLS_BEOPTS_MIX
-// CHECK_TOOLS_BEOPTS_MIX: ocloc{{.*}} "-device" "dg1" "-DDG1"
+// CHECK_TOOLS_BEOPTS_MIX: ocloc{{.*}} "-device" "dg1"{{.*}}"-DDG1"
 // CHECK_TOOLS_BEOPTS_MIX: opencl-aot{{.*}} "-DCPU"
 // CHECK_TOOLS_BEOPTS_MIX-NOT: "-DDG1"
-// CHECK_TOOLS_BEOPTS_MIX: ocloc{{.*}} "-device" "skl" "-DSKL2"
+// CHECK_TOOLS_BEOPTS_MIX: ocloc{{.*}} "-device" "skl"{{.*}}"-DSKL2"

--- a/sycl/test-e2e/KernelAndProgram/target_register_alloc_mode.cpp
+++ b/sycl/test-e2e/KernelAndProgram/target_register_alloc_mode.cpp
@@ -2,12 +2,14 @@
 
 // RUN: %{build} -ftarget-register-alloc-mode=pvc:auto -o %t_with.out
 // RUN: %{build} -o %t_without.out
+// RUN: %{build} -ftarget-register-alloc-mode=pvc:default -o %t_default.out
 
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t_with.out 2>&1 | FileCheck --check-prefix=CHECK-WITH %s
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t_without.out 2>&1 | FileCheck --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %s
+// RUN: env SYCL_PI_TRACE=-1 %{run} %t_with.out 2>&1 | FileCheck --check-prefix=CHECK-OPT %s
+// RUN: env SYCL_PI_TRACE=-1 %{run} %t_without.out 2>&1 | FileCheck %if system-windows %{ --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %} %else %{ --check-prefix=CHECK-OPT %} %s
+// RUN: env SYCL_PI_TRACE=-1 %{run} %t_default.out 2>&1 | FileCheck --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %s
 
-// CHECK-WITH: ---> piProgramBuild(
-// CHECK-WITH: -ze-intel-enable-auto-large-GRF-mode
+// CHECK-OPT: ---> piProgramBuild(
+// CHECK-OPT: -ze-intel-enable-auto-large-GRF-mode
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
Enable auto GRF mode by default on PVC on Linux. We are not doing this for Windows because the driver doesn't support it.

We have run extensive internal testing and are convinced this will not cause performance regressions, and will improve performance in some cases.

You can revert to the previous behavior with `-ftarget-register-alloc-mode=pvc:default`, and we will monitor performance tracking after this and react as necessary. 