### PR TITLE
[SYCL][Graph] Fix bug with debug print graph feature

### DIFF
--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -246,8 +246,8 @@ public:
     printDotCG(Stream, Verbose);
     for (const auto &Dep : MPredecessors) {
       auto NodeDep = Dep.lock();
-      Stream << "  \"" << NodeDep->MCommandGroup.get() << "\" -> \""
-             << MCommandGroup.get() << "\"" << std::endl;
+      Stream << "  \"" << NodeDep.get() << "\" -> \"" << this << "\""
+             << std::endl;
     }
 
     for (std::weak_ptr<node_impl> Succ : MSuccessors) {
@@ -261,14 +261,12 @@ private:
   /// @param Verbose If true, print additional information about the nodes such
   /// as kernel args or memory access where applicable.
   void printDotCG(std::ostream &Stream, bool Verbose) {
-    sycl::detail::CG::CGTYPE CGType = MCommandGroup->getType();
+    Stream << "\"" << this << "\" [style=bold, label=\"";
 
-    Stream << "\"" << MCommandGroup.get() << "\" [style=bold, label=\"";
-
-    Stream << "ID = " << MCommandGroup.get() << "\\n";
+    Stream << "ID = " << this << "\\n";
     Stream << "TYPE = ";
 
-    switch (CGType) {
+    switch (MCGType) {
     case sycl::detail::CG::CGTYPE::None:
       Stream << "None \\n";
       break;

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
@@ -50,7 +50,7 @@ int main() {
       CGH.copy(AccA, DataB2D.data());
     });
 
-    add_node(Graph, Queue, [&](handler &CGH) { /* empty node */ });
+    add_empty_node(Graph, Queue);
 
     Graph.print_graph("graph.dot");
 


### PR DESCRIPTION
Some nodes may not have any associated CommandGroup, e.g. empty nodes. 
This PR therefore changes the way node IDs are assigned in the printed graph. 
Node IDs are now based on the Node address instead of the CommandGroup address. 
The test has been update to generate a node without a CommandGroup.