### PR TITLE
[SYCL][E2E] Fix preview flag testing for non-HIP and non-CUDA devices

### DIFF
--- a/sycl/test-e2e/Basic/vector/int-convert.cpp
+++ b/sycl/test-e2e/Basic/vector/int-convert.cpp
@@ -10,8 +10,8 @@
 // RUN: %{build} -o %t.out -DSYCL2020_DISABLE_DEPRECATION_WARNINGS
 // RUN: %{run} %t.out
 //
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -DSYCL2020_DISABLE_DEPRECATION_WARNINGS %s -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{  %{run} %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Basic/vector/int-convert.cpp
+++ b/sycl/test-e2e/Basic/vector/int-convert.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out -DSYCL2020_DISABLE_DEPRECATION_WARNINGS
 // RUN: %{run} %t.out
 //
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes -DSYCL2020_DISABLE_DEPRECATION_WARNINGS %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/DeviceLib/built-ins/scalar_integer.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/scalar_integer.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/PreviewBreakingChanges/preview_lib_marker.cpp
+++ b/sycl/test-e2e/PreviewBreakingChanges/preview_lib_marker.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: preview-breaking-changes-supported
 
-// RUN: %clangxx -fsycl -fpreview-breaking-changes %s -o %t
+// RUN: %clangxx -fsycl -fpreview-breaking-changes %s -o %t.out
 // RUN: %{run} %t.out
 
 // Test to help identify that E2E testing correctly detects and uses the preview

--- a/sycl/test-e2e/Regression/vec_logical_ops.cpp
+++ b/sycl/test-e2e/Regression/vec_logical_ops.cpp
@@ -1,6 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes && ./%t.out %}
+
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Regression/vec_logical_ops.cpp
+++ b/sycl/test-e2e/Regression/vec_logical_ops.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/USM/math.cpp
+++ b/sycl/test-e2e/USM/math.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -183,8 +183,8 @@ class SYCLEndToEndTest(lit.formats.ShTest):
 
 
         # Temporary fix due to failures in CUDA and HIP behind preview flag.
-        if (('ext_oneapi_cuda:gpu' not in devices_for_test) and
-            ('ext_oneapi_hip:gpu' not in devices_for_test) and
+        if ((('ext_oneapi_cuda:gpu' in devices_for_test) or
+            ('ext_oneapi_hip:gpu' in devices_for_test)) and
             ('preview-breaking-changes-supported' in test.config.available_features)):
             test.config.available_features.remove('preview-breaking-changes-supported')
 

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -207,6 +207,12 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                     if op_sys in test.config.available_features:
                         conditions[op_sys] = True
 
+                # Temporary fix due to failures in CUDA and HIP behind preview flag.
+                if (('ext_oneapi_cuda:gpu' not in devices_for_test) and
+                    ('ext_oneapi_hip:gpu' not in devices_for_test) and
+                    ('preview-breaking-changes-supported' in test.config.available_features)):
+                    conditions['preview-breaking-changes-supported'] = True
+
                 tmp_script = lit.TestRunner.applySubstitutions(
                     tmp_script, [], conditions, recursion_limit=test.config.recursiveExpansionLimit)
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -177,11 +177,11 @@ else:
 # Check for sycl-preview library
 check_preview_breaking_changes_file='preview_breaking_changes_link.cpp'
 with open(check_preview_breaking_changes_file, 'w') as fp:
-    fp.write('#include <sycl/sycl.hpp>')
-    fp.write('namespace sycl { inline namespace _V1 { namespace detail {')
-    fp.write('extern void PreviewMajorReleaseMarker();')
-    fp.write('}}}')
-    fp.write('int main() { sycl::detail::PreviewMajorReleaseMarker(); return 0; }')
+    fp.write('#include <sycl/sycl.hpp>\n')
+    fp.write('namespace sycl { inline namespace _V1 { namespace detail {\n')
+    fp.write('extern void PreviewMajorReleaseMarker();\n')
+    fp.write('}}}\n')
+    fp.write('int main() { sycl::detail::PreviewMajorReleaseMarker(); return 0; }\n')
 
 sp = subprocess.getstatusoutput(config.dpcpp_compiler+' -fsycl -fpreview-breaking-changes ' + check_preview_breaking_changes_file)
 if sp[0] == 0:


### PR DESCRIPTION
The preview flag testing for E2E testing is currently broken. https://github.com/intel/llvm/pull/11929 attempts to fix it but has shown that some breakages in CUDA and HIP have been hidden behind the broken testing. To allow for proper testing while these failures are being investigated, this PR implements the fixes from https://github.com/intel/llvm/pull/11929 with the caveat that they do not apply when HIP and CUDA devices are part of the testing. This is a temporary solution and does *not* replace https://github.com/intel/llvm/pull/11929.