### PR TITLE
[SYCL][Doc]Remove APIs to get kernel by type-name

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -397,24 +397,6 @@ Therefore, the function `kernel_bundle::get_kernel_ids` returns an empty vector
 of `kernel_id` objects if the kernel bundle was created from a bundle of state
 `bundle_state::ext_oneapi_source`.
 
-Depending on the source language, the following kernel bundle functions may be
-used to query for a kernel when the kernel bundle was created from a bundle of
-state `bundle_state::ext_oneapi_source`.
-
-```
-template <typename KernelName>
-bool has_kernel() const noexcept;
-
-template <typename KernelName>
-bool has_kernel(const device& dev) const noexcept;
-
-template <typename KernelName>
-kernel get_kernel() const;
-```
-
-The specification for each source language tells how these functions behave and
-how the `KernelName` is interpreted.
-
 === New kernel bundle member functions
 
 This extensions adds the following new `kernel_bundle` member functions:

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
@@ -137,10 +137,6 @@ sycl::kernel_bundle<sycl::bundle_state::executable> kb = /*...*/;
 sycl::kernel k = kb.ext_oneapi_get_kernel("foo");
 ```
 
-There is no mechanism to decorate an OpenCL C kernel with a type-name, so the
-forms of `kernel_bundle::has_kernel` or `kernel_bundle::get_kernel` that take a
-type-name are not useful for kernels defined in OpenCL C.
-
 === Kernel argument restrictions
 
 When a kernel is defined in OpenCL C and invoked from SYCL via a `kernel`


### PR DESCRIPTION
In #11861 we decided to remove the ability to get the `kernel` object for a free-function kernel using a type-name.  Therefore, we don't need this ability in online-compiled kernels either.  Remove the associated wording from the kernel compiler specs.