### PR TITLE
[GENX] Allow cloning function with void return type

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/LLVMTypes.cpp
@@ -264,8 +264,9 @@ LLVMFunctionType::getChecked(function_ref<InFlightDiagnostic()> emitError,
 
 LLVMFunctionType LLVMFunctionType::clone(TypeRange inputs,
                                          TypeRange results) const {
-  assert(results.size() == 1 && "expected a single result type");
-  return get(results[0], llvm::to_vector(inputs), isVarArg());
+  assert(results.size() <= 1 && "expected no or a single result type");
+  Type resultTy = results.size() == 1 ? results[0] : LLVMVoidType::get(getContext());
+  return get(resultTy, llvm::to_vector(inputs), isVarArg());
 }
 
 ArrayRef<Type> LLVMFunctionType::getReturnTypes() const {


### PR DESCRIPTION
In https://github.com/intel/llvm/commit/d49d83e79ca0b59c3d68ff6c46eea69d848b0617, `getCallableResults`/`getResultTypes` changed to return `{}` instead of `LLVMVoidType` for functions that return `void`. 

When `insertArgument()` is invoked, `getTypeWithArgsAndResults()` is indirectly invoked, which then calls `LLVMFunctionType::clone()` with the result of `getResultTypes()` as result type. `LLVMFunctionType::clone()` expects exactly one result type. After d49d83e79ca0b59c3d68ff6c46eea69d848b0617, the number of result types becomes 0.

This PR modifies `LLVMFunctionType::clone()` to allow 0 result types.