### PR TITLE
[SYCL] kernel_compiler and device lists.

### DIFF
--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -372,11 +372,15 @@ public:
 
     Plugin->call<PiApiKind::piProgramRetain>(PiProgram);
 
+    std::vector<pi::PiDevice> DeviceVec;
+    DeviceVec.reserve(Devices.size());
     for (const auto &SyclDev : Devices) {
       pi::PiDevice Dev = getSyclObjImpl(SyclDev)->getHandleRef();
-      Plugin->call<errc::build, PiApiKind::piProgramBuild>(
-          PiProgram, 1, &Dev, nullptr, nullptr, nullptr);
+      DeviceVec.push_back(Dev);
     }
+    Plugin->call<errc::build, PiApiKind::piProgramBuild>(
+        PiProgram, DeviceVec.size(), DeviceVec.data(), nullptr, nullptr,
+        nullptr);
 
     // Get the number of kernels in the program.
     size_t NumKernels;

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler.cpp
@@ -8,10 +8,6 @@
 
 // REQUIRES: ocloc
 
-// UNSUPPORTED: (gpu-intel-dg2 && level_zero) || (gpu-intel-pvc && level_zero)
-// Seems to be an incompatibility with the KernelCompiler on L0 with DG2 and
-// PVC.
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -82,8 +78,11 @@ void test_build_and_run() {
   using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
   using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
 
-  sycl::queue q;
-  sycl::context ctx = q.get_context();
+  // only one device is supported at this time, so we limit the queue and
+  // context to that
+  sycl::device d{sycl::default_selector_v};
+  sycl::context ctx{d};
+  sycl::queue q{ctx, d};
 
   bool ok = syclex::is_source_kernel_bundle_supported(
       ctx.get_backend(), syclex::source_language::opencl);
@@ -135,8 +134,11 @@ void test_error() {
   using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
   using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
 
-  sycl::queue q;
-  sycl::context ctx = q.get_context();
+  // only one device is supported at this time, so we limit the queue and
+  // context to that
+  sycl::device d{sycl::default_selector_v};
+  sycl::context ctx{d};
+  sycl::queue q{ctx, d};
 
   bool ok = syclex::is_source_kernel_bundle_supported(
       ctx.get_backend(), syclex::source_language::opencl);

--- a/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
@@ -8,15 +8,14 @@
 
 // REQUIRES: ocloc
 
-// UNSUPPORTED: (gpu-intel-dg2 && level_zero) || (gpu-intel-pvc && level_zero)
-// Seems to be an incompatibility with the KernelCompiler on L0 with DG2 and
-// PVC.
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Here we are testing some of the various args that SYCL can and cannot
 // pass to an OpenCL kernel that is compiled with the kernel_compiler.
+
+// no backend supports compiling for multiple devices yet, so we limit
+// the queue and context to just one.
 
 // IMPORTANT: LevelZero YES!
 // Even though this test is covering which OpenCL capabilities
@@ -51,9 +50,9 @@ auto constexpr LocalAccCLSource = R"===(
 )===";
 
 void test_local_accessor() {
-
-  sycl::queue q;
-  sycl::context ctx = q.get_context();
+  sycl::device d{sycl::default_selector_v};
+  sycl::context ctx{d};
+  sycl::queue q{ctx, d};
 
   source_kb kbSrc = syclex::create_kernel_bundle_from_source(
       ctx, syclex::source_language::opencl, LocalAccCLSource);
@@ -93,8 +92,9 @@ __kernel void usm_kernel(__global int *usmPtr, int multiplier,  float added) {
 )===";
 
 void test_usm_pointer_and_scalar() {
-  sycl::queue q;
-  sycl::context ctx = q.get_context();
+  sycl::device d{sycl::default_selector_v};
+  sycl::context ctx{d};
+  sycl::queue q{ctx, d};
 
   source_kb kbSrc = syclex::create_kernel_bundle_from_source(
       ctx, syclex::source_language::opencl, USMCLSource);
@@ -146,8 +146,9 @@ struct pair {
 };
 
 void test_struct() {
-  sycl::queue q;
-  sycl::context ctx = q.get_context();
+  sycl::device d{sycl::default_selector_v};
+  sycl::context ctx{d};
+  sycl::queue q{ctx, d};
 
   source_kb kbSrc = syclex::create_kernel_bundle_from_source(
       ctx, syclex::source_language::opencl, StructSrc);


### PR DESCRIPTION
piProgramBuild must be called with a device list, not individually. BUT no backend presently supports kernel compilation across multiple devices, so the test ensures that any queue/context instantiated is limited to just one device.