### PR TITLE
[GENX]: Add `genx.conv.fptofp` operation

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -191,6 +191,49 @@ def GENX_SubGroupShuffleOp : GENX_Op<"sub_group_shuffle", [
 }
 
 //===----------------------------------------------------------------------===//
+// Type Conversions
+//===----------------------------------------------------------------------===//
+
+/// Enum attribute of the different floating-point rounding modes.
+def RoundingMode : I32EnumAttr<"RoundingMode", "GENX floating-point rounding mode",
+  [
+    I32EnumAttrCase<"UNUSED", 0>,
+    I32EnumAttrCase<"RTE",    1>, ///< Round to nearest, ties to even
+    I32EnumAttrCase<"RTN",    2>, ///< Round toward negative
+    I32EnumAttrCase<"RTP",    3>, ///< Round toward positive
+    I32EnumAttrCase<"RTZ",    4>, ///< Round toward zero
+  ]> {
+  let genSpecializedAttr = 0;
+  let cppNamespace = "::mlir::GENX";
+}
+def RoundingModeAttr : EnumAttr<GENX_Dialect, RoundingMode, "rounding_mode"> {
+  let assemblyFormat = "`<` $value `>`";
+}
+
+def GENX_FpToFpOp : GENX_Op<"conv.fptofp">,
+  Results<(outs AnyFloat:$res)>,
+  Arguments<(ins
+    AnyFloat:$arg,
+    RoundingModeAttr:$roundingMode
+  )> {
+
+  let summary = "Convert between floating point types";
+
+  string baseDescription = [{
+    Convert `$arg` to the type of the result `$res`. If necessary, round the 
+    result according to `$roundingMode`.
+  }];
+
+  string llvmBuilder = [{
+    $res = createGenISAFpToFp(op, builder, moduleTranslation);
+  }];
+
+  let assemblyFormat = [{
+    $arg attr-dict `:` type($arg) `to` type($res)
+  }];
+}
+
+//===----------------------------------------------------------------------===//
 // Matrix operations
 //===----------------------------------------------------------------------===//
 

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -46,7 +46,6 @@ static llvm::CallInst *createDeviceFunctionCall(llvm::IRBuilderBase &builder,
 // Synchronization
 //===----------------------------------------------------------------------===//
 
-// Create a call to SPIR a "sub_group_shuffle" function.
 static llvm::CallInst *createSubGroupShuffle(llvm::IRBuilderBase &builder,
                                              llvm::Value *value,
                                              llvm::Value *mask,
@@ -98,7 +97,6 @@ static llvm::CallInst *createSubGroupShuffle(llvm::IRBuilderBase &builder,
 // Type Conversions
 //===----------------------------------------------------------------------===//
 
-// Create a call to GenISA_dpas for matrix multiply-add.
 static llvm::CallInst *
 createGenISAFpToFp(GENX::FpToFpOp op, llvm::IRBuilderBase &builder,
                    LLVM::ModuleTranslation &moduleTranslation) {
@@ -139,7 +137,6 @@ createGenISAFpToFp(GENX::FpToFpOp op, llvm::IRBuilderBase &builder,
 // Matrix operations
 //===----------------------------------------------------------------------===//
 
-// Create a call to GenISA_dpas for matrix multiply-add.
 static llvm::CallInst *
 createGenISADPAS(GENX::MatrixDPASOp op, llvm::IRBuilderBase &builder,
                  LLVM::ModuleTranslation &moduleTranslation) {
@@ -178,7 +175,6 @@ createGenISADPAS(GENX::MatrixDPASOp op, llvm::IRBuilderBase &builder,
   return builder.CreateCall(fn, args);
 }
 
-// Create a call to GenISA_LSC2DBlockRead for loading a 2D submatrix.
 static llvm::CallInst *
 createGenISA2DBlockRead(GENX::Matrix2DBlockLoadOp op,
                         llvm::IRBuilderBase &builder,
@@ -209,7 +205,6 @@ createGenISA2DBlockRead(GENX::Matrix2DBlockLoadOp op,
   return builder.CreateCall(fn, args);
 }
 
-// Create a call to GenISA_LSC2DBlockWrite for storing to a 2D submatrix.
 static llvm::CallInst *
 createGenISA2DBlockWrite(GENX::Matrix2DBlockStoreOp op,
                          llvm::IRBuilderBase &builder,

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -1,5 +1,13 @@
 // RUN: mlir-opt -split-input-file -verify-diagnostics %s
 
+func.func @genx.fptofp(%a : i32) {
+  // expected-error @+1 {{custom op 'genx.conv.fptofp' invalid kind of type specified}}
+  %0 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTE>} : i32 to i16
+  llvm.return
+}
+
+// -----
+
 func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>) {
   // expected-error @+1 {{'genx.matrix.dpas' op expecting repeat count to be 1, 2, 4, or 8}}
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=6:i32} : (vector<8xi32>, vector<16xi8>, vector<32xi8>) -> vector<8xi32>

--- a/mlir/test/Dialect/LLVMIR/genx.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx.mlir
@@ -68,6 +68,26 @@ func.func @genx.sub_group_shuffle() {
   llvm.return
 }
 
+llvm.func @genx.fptofp(%a: f32, %b: f16) {
+  // CHECK: %0 = genx.conv.fptofp %arg0 {roundingMode = #genx.rounding_mode<RTE>} : f32 to f16
+  // CHECK-NEXT: %1 = genx.conv.fptofp %arg0 {roundingMode = #genx.rounding_mode<RTN>} : f32 to f16
+  // CHECK-NEXT: %2 = genx.conv.fptofp %arg0 {roundingMode = #genx.rounding_mode<RTP>} : f32 to f16
+  // CHECK-NEXT: %3 = genx.conv.fptofp %arg0 {roundingMode = #genx.rounding_mode<RTZ>} : f32 to f16
+  // CHECK-NEXT: %4 = genx.conv.fptofp %arg1 {roundingMode = #genx.rounding_mode<RTE>} : f16 to f32
+  // CHECK-NEXT: %5 = genx.conv.fptofp %arg1 {roundingMode = #genx.rounding_mode<RTN>} : f16 to f32
+  // CHECK-NEXT: %6 = genx.conv.fptofp %arg1 {roundingMode = #genx.rounding_mode<RTP>} : f16 to f32
+  // CHECK-NEXT: %7 = genx.conv.fptofp %arg1 {roundingMode = #genx.rounding_mode<RTZ>} : f16 to f32
+  %0 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTE>} : f32 to f16
+  %1 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTN>} : f32 to f16
+  %2 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTP>} : f32 to f16
+  %3 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTZ>} : f32 to f16    
+  %4 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTE>} : f16 to f32
+  %5 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTN>} : f16 to f32
+  %6 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTP>} : f16 to f32
+  %7 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTZ>} : f16 to f32
+  llvm.return
+}
+
 llvm.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>) {
   // CHECK: %0 = genx.matrix.dpas %arg0, %arg1, %arg2 {pa = #genx.precision_type<S8>, pb = #genx.precision_type<S8>, rc = 8 : i32} : (vector<8xi32>, vector<16xi8>, vector<32xi8>) -> vector<8xi32>
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi32>, vector<16xi8>, vector<32xi8>) -> vector<8xi32>

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -42,7 +42,6 @@ llvm.func @genx.barrier() {
 
 // -----
 
-
 llvm.func @genx.sub_group_shuffle() {
   // CHECK-LABEL: genx.sub_group_shuffle
   %0 = llvm.mlir.constant(0 : i32) : i32
@@ -72,6 +71,29 @@ llvm.func @genx.sub_group_shuffle() {
   %15 = llvm.mlir.constant(0.0 : f64) : f64
   // CHECK: %10 = call double @_Z21sub_group_shuffle_xordj(double 0.000000e+00, i32 0)
   %16 = genx.sub_group_shuffle XOR %15, %0 : f64 -> f64
+  llvm.return
+}
+
+// -----
+
+llvm.func @genx.fptofp(%a: f32, %b: f16) {
+  // CHECK-LABEL: genx.fptofp
+  // CHECK: call half @llvm.genx.GenISA.ftof.rte.f16.f32(float %0)
+  // CHECK-NEXT: call half @llvm.genx.GenISA.ftof.rtn.f16.f32(float %0)
+  // CHECK-NEXT: call half @llvm.genx.GenISA.ftof.rtp.f16.f32(float %0)
+  // CHECK-NEXT: call half @llvm.genx.GenISA.ftof.rtz.f16.f32(float %0)
+  // CHECK-NEXT: call float @llvm.genx.GenISA.ftof.rte.f32.f16(half %1)
+  // CHECK-NEXT: call float @llvm.genx.GenISA.ftof.rtn.f32.f16(half %1)
+  // CHECK-NEXT: call float @llvm.genx.GenISA.ftof.rtp.f32.f16(half %1)
+  // CHECK-NEXT: call float @llvm.genx.GenISA.ftof.rtz.f32.f16(half %1)
+  %0 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTE>} : f32 to f16
+  %1 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTN>} : f32 to f16
+  %2 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTP>} : f32 to f16
+  %3 = genx.conv.fptofp %a {roundingMode=#genx.rounding_mode<RTZ>} : f32 to f16
+  %4 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTE>} : f16 to f32
+  %5 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTN>} : f16 to f32
+  %6 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTP>} : f16 to f32
+  %7 = genx.conv.fptofp %b {roundingMode=#genx.rounding_mode<RTZ>} : f16 to f32
   llvm.return
 }
 


### PR DESCRIPTION
Add a new operation to the GENX dialect to handle floating point to floating point conversion. 
This operation exposes the following IGC intrinsic functions:
  - GenISA_ftof_rte   // round to nearest
  - GenISA_ftof_rtn   // round toward negative
  - GenISA_ftof_rtp   // round toward positive
  - GenISA_ftof_rtz   // round toward zero