### PR TITLE
[SYCL] Fix typo in DeviceLibExtension doc

### DIFF
--- a/sycl/doc/design/DeviceLibExtensions.rst
+++ b/sycl/doc/design/DeviceLibExtensions.rst
@@ -4,7 +4,7 @@ Device library extensions
 Device compiler that indicates support for a particular extension is
 supposed to support *all* the corresponding functions.
 
-cl_intel_devicelib_cassert
+cl_intel_devicelib_assert
 ==========================
 
 .. code:


### PR DESCRIPTION
This PR fixes typo in devicelib extension doc. In doc, we uses the term "cl_intel_devicelib_cassert" but we use "cl_intel_devicelib_assert" in sycl runtime and devicelib implementation. And for other cl_intel_devicelib_* extension aiming to support CXX std library such as math and complex functions, we use "cl_intel_devicelib_math", "cl_intel_devicelib_complex".
To align with other "cl_intel_devicelib_*" extension and sycl runtime& devicelib implementation, we change "cl_intel_devicelib_cassert" to "cl_intel_devicelib_assert".