### PR TITLE
[SYCL] Don't zero-initialize MImageObj in 1.2.1 image

### DIFF
--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -924,7 +924,7 @@ public:
 
 #ifdef __SYCL_DEVICE_ONLY__
   // Default constructor for objects later initialized with __init member.
-  image_accessor() : MImageObj() {}
+  image_accessor() {}
 #endif
 
   // Available only when: accessTarget == access::target::host_image


### PR DESCRIPTION
image_accessor constructor was generating following IR in O0 mode:
```
store target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) zeroinitializer, ptr addrspace(4) %MImageObj, align 8
```
As a target extension type, spirv.Image currently allows zeroinit.
However, OpConstantNull in spirv spec doesn't allow image type.
Therefore, we're not able to get sycl 1.2.1 image working in O0 mode.

This PR solves the issue by not initializing MImageObj.