### PR TITLE
[opencl-aot] Fix regression in error reporting

### DIFF
--- a/opencl/opencl-aot/source/main.cpp
+++ b/opencl/opencl-aot/source/main.cpp
@@ -604,9 +604,13 @@ int main(int Argc, char *Argv[]) {
   }
 
   if (!CompilerBuildLog.empty()) {
-    logs() << "\n"
-           << CmdToCmdInfoMap[OptCommand].first << " log:\n"
-           << CompilerBuildLog << '\n';
+    std::string CompilerBuildLogMessage = "\n" +
+                                          CmdToCmdInfoMap[OptCommand].first +
+                                          " log:\n" + CompilerBuildLog + '\n';
+    if (!ErrorMessage.empty())
+      std::cerr << CompilerBuildLogMessage;
+    else
+      logs() << CompilerBuildLogMessage;
   }
 
   if (clFailed(CLErr)) {


### PR DESCRIPTION
This patch fixes a regression in error reporting, previously compiler build log was printed to `std::cerr`, but now it doesn't print by default. It makes it difficult for developers to understand what's going on. So now the compiler build log is printed to `std::cerr` if there is an error message, and to verbose logs if compilation was successful but there is something in the compiler build logs.