### PR TITLE
[SYCL] Flush queue on memory operations

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -170,6 +170,7 @@ event_impl::event_impl(const QueueImplPtr &Queue)
     }
     return;
   }
+
   MState.store(HES_Complete);
 }
 
@@ -414,7 +415,7 @@ std::vector<EventImplPtr> event_impl::getWaitList() {
   return Result;
 }
 
-void event_impl::flushIfNeeded(const QueueImplPtr &UserQueue) {
+void event_impl::flushIfNeeded() {
   // Some events might not have a native handle underneath even at this point,
   // e.g. those produced by memset with 0 size (no PI call is made).
   if (MIsFlushed || !MEvent)
@@ -427,8 +428,6 @@ void event_impl::flushIfNeeded(const QueueImplPtr &UserQueue) {
     MIsFlushed = true;
     return;
   }
-  if (Queue == UserQueue)
-    return;
 
   // Check if the task for this event has already been submitted.
   pi_event_status Status = PI_EVENT_QUEUED;

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -188,10 +188,9 @@ public:
   /// @return a vector of "immediate" dependencies for this event_impl.
   std::vector<EventImplPtr> getWaitList();
 
-  /// Performs a flush on the queue associated with this event if the user queue
-  /// is different and the task associated with this event hasn't been submitted
-  /// to the device yet.
-  void flushIfNeeded(const QueueImplPtr &UserQueue);
+  /// Performs a flush on the queue associated with this event if the task
+  /// associated with this event hasn't been submitted to the device yet.
+  void flushIfNeeded();
 
   /// Cleans dependencies of this event_impl.
   void cleanupDependencyEvents();
@@ -203,6 +202,11 @@ public:
   ///
   /// \return true if this event is discarded.
   bool isDiscarded() const { return MState == HES_Discarded; }
+
+  /// Returns the queue associated with this event.
+  ///
+  /// @return shared_ptr to MQueue, please be aware it can be empty pointer
+  QueueImplPtr getQueue() { return MQueue.lock(); }
 
   /// Returns worker queue for command.
   ///

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -112,6 +112,7 @@ event queue_impl::memset(const std::shared_ptr<detail::queue_impl> &Self,
     MemoryManager::fill_usm(Ptr, Self, Count, Value,
                             getOrWaitEvents(DepEvents, MContext),
                             &EventImpl->getHandleRef(), EventImpl);
+    EventImpl->flushIfNeeded();
 
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
@@ -205,6 +206,7 @@ event queue_impl::memcpy(const std::shared_ptr<detail::queue_impl> &Self,
     MemoryManager::copy_usm(Src, Self, Count, Dest,
                             getOrWaitEvents(DepEvents, MContext),
                             &EventImpl->getHandleRef(), EventImpl);
+    EventImpl->flushIfNeeded();
 
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
@@ -248,6 +250,7 @@ event queue_impl::mem_advise(const std::shared_ptr<detail::queue_impl> &Self,
     MemoryManager::advise_usm(Ptr, Self, Length, Advice,
                               getOrWaitEvents(DepEvents, MContext),
                               &EventImpl->getHandleRef(), EventImpl);
+    EventImpl->flushIfNeeded();
 
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
@@ -293,6 +296,7 @@ event queue_impl::memcpyToDeviceGlobal(
                                          Self, NumBytes, Offset, Src,
                                          getOrWaitEvents(DepEvents, MContext),
                                          &EventImpl->getHandleRef(), EventImpl);
+    EventImpl->flushIfNeeded();
 
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
@@ -338,6 +342,7 @@ event queue_impl::memcpyFromDeviceGlobal(
         DeviceGlobalPtr, IsDeviceImageScope, Self, NumBytes, Offset, Dest,
         getOrWaitEvents(DepEvents, MContext), &EventImpl->getHandleRef(),
         EventImpl);
+    EventImpl->flushIfNeeded();
 
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -299,10 +299,15 @@ bool Command::isHostTask() const {
           CG::CGTYPE::CodeplayHostTask);
 }
 
-static void flushCrossQueueDeps(const std::vector<EventImplPtr> &EventImpls,
-                                const QueueImplPtr &Queue) {
+/// Performs a flush on the queue associated with the event if it is different
+/// from the WorkerQueue.
+void Command::flushCrossQueueDeps(const std::vector<EventImplPtr> &EventImpls,
+                                  const QueueImplPtr &WorkerQueue) {
+
   for (auto &EventImpl : EventImpls) {
-    EventImpl->flushIfNeeded(Queue);
+    if (WorkerQueue != EventImpl->getQueue()) {
+      EventImpl->flushIfNeeded();
+    }
   }
 }
 

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -244,6 +244,9 @@ public:
 
   bool isHostTask() const;
 
+  void flushCrossQueueDeps(const std::vector<EventImplPtr> &EventImpls,
+                           const QueueImplPtr &Queue);
+
 protected:
   QueueImplPtr MQueue;
   EventImplPtr MEvent;

--- a/sycl/test-e2e/Plugin/level_zero_batch_test_copy_with_compute.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_batch_test_copy_with_compute.cpp
@@ -296,7 +296,6 @@ int main(int argc, char *argv[]) {
                                           Z1[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X1, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy2>(sycl::range<2>{M, N},
@@ -306,7 +305,6 @@ int main(int argc, char *argv[]) {
                                           Z2[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X2, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy3>(sycl::range<2>{M, N},
@@ -316,7 +314,6 @@ int main(int argc, char *argv[]) {
                                           Z3[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X3, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy4>(sycl::range<2>{M, N},
@@ -326,7 +323,6 @@ int main(int argc, char *argv[]) {
                                           Z4[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X4, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy5>(sycl::range<2>{M, N},
@@ -336,7 +332,6 @@ int main(int argc, char *argv[]) {
                                           Z5[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X5, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy6>(sycl::range<2>{M, N},
@@ -346,7 +341,6 @@ int main(int argc, char *argv[]) {
                                           Z6[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X6, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy7>(sycl::range<2>{M, N},
@@ -356,7 +350,6 @@ int main(int argc, char *argv[]) {
                                           Z7[m * N + n] = Y1[m * N + n];
                                         });
       });
-      q.memcpy(X7, Y1, sizeof(uint32_t) * M * N);
 
       q.submit([&](sycl::handler &h) {
         h.parallel_for<class u32_copy8>(sycl::range<2>{M, N},
@@ -366,6 +359,16 @@ int main(int argc, char *argv[]) {
                                           Z8[m * N + n] = Y1[m * N + n];
                                         });
       });
+
+      q.wait();
+
+      q.memcpy(X1, Y1, sizeof(uint32_t) * M * N);
+      q.memcpy(X2, Y1, sizeof(uint32_t) * M * N);
+      q.memcpy(X3, Y1, sizeof(uint32_t) * M * N);
+      q.memcpy(X4, Y1, sizeof(uint32_t) * M * N);
+      q.memcpy(X5, Y1, sizeof(uint32_t) * M * N);
+      q.memcpy(X6, Y1, sizeof(uint32_t) * M * N);
+      q.memcpy(X7, Y1, sizeof(uint32_t) * M * N);
       q.memcpy(X8, Y1, sizeof(uint32_t) * M * N);
 
       q.wait();

--- a/sycl/test-e2e/XPTI/basic_event_collection_linux.cpp
+++ b/sycl/test-e2e/XPTI/basic_event_collection_linux.cpp
@@ -74,7 +74,7 @@
 // CHECK-DAG:    src_memory_ptr : {{.*}}
 // CHECK-DAG:    sycl_device : {{.*}}
 // CHECK-NEXT: PI Call Begin : piextUSMEnqueueMemcpy
-// CHECK-NEXT: Task end
+// CHECK: Task end
 // CHECK-DAG:    memory_size : {{.*}}
 // CHECK-DAG:    dest_memory_ptr : {{.*}}
 // CHECK-DAG:    src_memory_ptr : {{.*}}

--- a/sycl/unittests/event/CMakeLists.txt
+++ b/sycl/unittests/event/CMakeLists.txt
@@ -1,4 +1,4 @@
 add_sycl_unittest(EventTests OBJECT
   EventDestruction.cpp
-        EventGetInfo.cpp
+  EventGetInfo.cpp
 )

--- a/sycl/unittests/event/CMakeLists.txt
+++ b/sycl/unittests/event/CMakeLists.txt
@@ -1,3 +1,4 @@
 add_sycl_unittest(EventTests OBJECT
   EventDestruction.cpp
+        EventGetInfo.cpp
 )

--- a/sycl/unittests/event/EventGetInfo.cpp
+++ b/sycl/unittests/event/EventGetInfo.cpp
@@ -24,8 +24,6 @@ pi_result redefinedEventGetInfoAfter(pi_event event, pi_event_info param_name,
   if (events.find(event) == events.end()) {
     *Result = PI_EVENT_QUEUED;
     events.insert({event, true});
-  } else {
-    *Result = PI_EVENT_SUBMITTED;
   }
 
   return PI_SUCCESS;

--- a/sycl/unittests/event/EventGetInfo.cpp
+++ b/sycl/unittests/event/EventGetInfo.cpp
@@ -1,0 +1,58 @@
+//==------------------ EventGetInfo.cpp --- event unit tests ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <detail/context_impl.hpp>
+#include <gtest/gtest.h>
+#include <helpers/PiMock.hpp>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+pi_result redefinedEventGetInfoAfter(pi_event event, pi_event_info param_name,
+                                     size_t param_value_size, void *param_value,
+                                     size_t *param_value_size_ret) {
+  EXPECT_EQ(param_name, PI_EVENT_INFO_COMMAND_EXECUTION_STATUS)
+      << "Unexpected event info requested";
+  static std::unordered_map<pi_event, bool> events;
+
+  auto *Result = reinterpret_cast<pi_event_status *>(param_value);
+  if (events.find(event) == events.end()) {
+    *Result = PI_EVENT_QUEUED;
+    events.insert({event, true});
+  } else {
+    *Result = PI_EVENT_SUBMITTED;
+  }
+
+  return PI_SUCCESS;
+}
+
+void preparePiMock(unittest::PiMock &Mock) {
+  Mock.redefineAfter<detail::PiApiKind::piEventGetInfo>(
+      redefinedEventGetInfoAfter);
+}
+
+// Check that events that are in queued status are handled properly.
+TEST(EventGetInfo, EventQueuedStatus) {
+  sycl::unittest::PiMock Mock;
+  sycl::platform Plt = Mock.getPlatform();
+  preparePiMock(Mock);
+
+  context Ctx{Plt.get_devices()[0]};
+  queue Q{Ctx, default_selector()};
+
+  auto DeviceAlloc = sycl::malloc_device<char>(1, Q);
+
+  auto event = Q.memset(DeviceAlloc, 42, 1);
+  auto info = event.get_info<sycl::info::event::command_execution_status>();
+
+  ASSERT_TRUE(info == sycl::info::event_command_status::complete ||
+              info == sycl::info::event_command_status::running ||
+              info == sycl::info::event_command_status::submitted);
+
+  sycl::free(DeviceAlloc, Q);
+}

--- a/sycl/unittests/queue/EventClear.cpp
+++ b/sycl/unittests/queue/EventClear.cpp
@@ -53,11 +53,21 @@ pi_result redefinedEventGetInfoAfter(pi_event event, pi_event_info param_name,
   // This is important, because removal algorithm assumes that
   // events are likely to be removed oldest first, and stops removing
   // at the first non-completed event.
+  // There might be multiple calls to get info on the same event. So we need to
+  // keep track of the submitted events.
+  static std::unordered_map<pi_event, pi_event_status> events;
   static int Counter = 0;
   auto *Result = reinterpret_cast<pi_event_status *>(param_value);
-  *Result = (Counter < (ExpectedEventThreshold / 2)) ? PI_EVENT_COMPLETE
-                                                     : PI_EVENT_RUNNING;
-  Counter++;
+  if (events.find(event) == events.end()) {
+
+    pi_event_status status = (Counter < (ExpectedEventThreshold / 2))
+                                 ? PI_EVENT_COMPLETE
+                                 : PI_EVENT_RUNNING;
+    events.insert({event, status});
+    Counter++;
+  }
+
+  *Result = events[event];
   return PI_SUCCESS;
 }
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/9944 introduced a hack in the OpenCL PI plugin which maps PI_EVENT_QUEUED to PI_EVENT_SUBMITTED. This hack is problematic because it will make SYCL-RT assume that an event has been flushed when it might not have been. At the moment, this could result in buggy behaviour on the OpenCL backend when using multiple queues. The OpenCL specification states:

> "To use event objects that refer to commands enqueued in a command-queue as event objects to wait on by commands enqueued in a different command-queue, the application must call a clFlush or any blocking commands that perform an implicit flush of the command-queue where the commands that refer to these event objects are enqueued."

This PR, changes SYCL-RT to properly flush user events if they are in the PI_EVENT_QUEUED status. This will allow the hack to be removed from unified runtime.

There was also a couple of tests that had to be updated because they made assumptions about the ordering of calls to the PI plugin layers.