### PR TITLE
[SYCL][E2E] Fix preview testing of vec_rel_swizzle_ops

### DIFF
--- a/sycl/test-e2e/Regression/vec_rel_swizzle_ops.cpp
+++ b/sycl/test-e2e/Regression/vec_rel_swizzle_ops.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fpreview-breaking-changes %s -o %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t2.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
 
 #include <cstdlib>


### PR DESCRIPTION
The commit introducing vec_rel_swizzle_ops missed testing with the preview options due to a fix happening in the interrim. It is supposed to build with the %{build} tag to ensure CUDA and HIP are built with the correct target binaries. This commit fixes this issue.