### PR TITLE
[SYCL][NFC] Disable int-convert.cpp on Windows

### DIFF
--- a/sycl/test-e2e/Basic/vector/int-convert.cpp
+++ b/sycl/test-e2e/Basic/vector/int-convert.cpp
@@ -6,6 +6,8 @@
 //
 // XFAIL: cuda
 // FIXME: un-xfail the test once intel/llvm#11840 is resolved
+// UNSUPPORTED: windows
+// FIXME: re-enable the test on windows once intel/llvm#12011 is resolved
 //
 // RUN: %{build} -o %t.out -DSYCL2020_DISABLE_DEPRECATION_WARNINGS
 // RUN: %{run} %t.out


### PR DESCRIPTION
The test sporadically timeouts on Windows which is reported in intel/llvm#12011. This commit temporarily disables it in there to avoid annoying noise in CI.