### PR TITLE
[SYCL][ESIMD][E2E] Add Linux driver version requirement to block_store_slm_acc.cpp

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/block_store.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/block_store.hpp
@@ -682,9 +682,9 @@ bool test_block_store_local_acc_slm(queue Q) {
 
   bool Passed = true;
 
-  // Many cases currently fail on Windows before this driver version.
-  if (!esimd_test::isGPUDriverGE(Q, esimd_test::GPUDriverOS::Windows, "26957",
-                                 "101.4824", false))
+  // Many cases currently fail before this driver version.
+  if (!esimd_test::isGPUDriverGE(Q, esimd_test::GPUDriverOS::LinuxAndWindows,
+                                 "26957", "101.4824", false))
     return Passed;
 
   // Test block_store() from SLM that doesn't use the mask is implemented


### PR DESCRIPTION
Originally it seemed the problem was only on Windows, but it seems it happens on Linux too, see [here](https://github.com/intel/llvm/pull/11921#issuecomment-1836638347).

I manually verified it fails consistently before this version and passes consistently after this version.