### PR TITLE
[sycl-post-link][Driver] Pass in -emit-only-kernels-as-entry-point option by default

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3929,6 +3929,8 @@ def foperator_arrow_depth_EQ : Joined<["-"], "foperator-arrow-depth=">, Group<f_
   Visibility<[ClangOption, CC1Option]>,
   HelpText<"Maximum number of 'operator->'s to call for a member access">,
   MarshallingInfoInt<LangOpts<"ArrowDepth">, "256">;
+def femit_sycl_external_funcs_as_entry_points : Flag<["-"], "femit-sycl-external-funcs-as-entry-points">,
+  Group<sycl_Group>, HelpText<"Treat `SYCL_EXTERNAL` functions as entry point in sycl-post-link tool">;
 
 def fsave_optimization_record : Flag<["-"], "fsave-optimization-record">,
   Visibility<[ClangOption, FlangOption]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10324,7 +10324,8 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
   // On FPGA target we don't need non-kernel functions as entry points, because
   // it only increases amount of code for device compiler to handle, without any
   // actual benefits.
-  if (T.getArchName() == "spir64_fpga")
+  if ((T.getArchName() == "spir64_fpga") ||
+      !TCArgs.getLastArg(options::OPT_femit_sycl_external_funcs_as_entry_points))
     addArgs(CmdArgs, TCArgs, {"-emit-only-kernels-as-entry-points"});
 
   // OPT_fsycl_device_code_split is not checked as it is an alias to

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -170,3 +170,11 @@
 /// Check if the clang with fsycl adds C++ libraries to the link line
 //  RUN:  %clang -### -target x86_64-unknown-linux-gnu -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK-FSYCL-WITH-CLANG %s
 // CHECK-FSYCL-WITH-CLANG: "-lstdc++"
+
+/// Check selective passing of -emit-only-kernels-as-entry-points to sycl-post-link tool
+// RUN: %clang -### -target spir64_fpga -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_OPT_PASS %s
+// RUN: %clang -### -target spir64_gen -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_OPT_PASS %s
+// CHECK_SYCL_POST_LINK_OPT_PASS: sycl-post-link{{.*}}emit-only-kernels-as-entry-points
+// RUN: %clang -### -target spir64_gen -femit-sycl-external-funcs-as-entry-points -fsycl %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_OPT_NO_PASS %s
+// CHECK_SYCL_POST_LINK_OPT_NO_PASS-NOT: sycl-post-link{{.*}}emit-only-kernels-as-entry-points
+


### PR DESCRIPTION
sycl-post-link is one of the tools invoked during compilation of SYCL device code. One of the options passed to this tool is ‘emit-only-kernels-as-entry-points’. This option was introduced to stop treating `SYCL_EXTERNAL` functions as entry points. However, it was turned on by default only for FPGAs and turned off for other backends. We are noticing that there are no tangible benefits to treating `SYCL_EXTERNAL` functions as entry points and that treating them as entry points results in unnecessary device code bloating. We propose to turn on ` emit-only-kernels-as-entry-points` by default. However, we want to expose this option to users and allow them to turn it off if required. Hence we propose the following command line option to be added into compiler:
  -femit-sycl-external-funcs-as-entry-points // Linux and Windows
This option takes no arguments

Thanks
