### PR TITLE
[SYCL][SPIRV Backend][Driver] Add option to enable use of SPIRV backend for SYCL offload

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -181,6 +181,7 @@ def do_configure(args):
         "-DSYCL_ENABLE_KERNEL_FUSION={}".format(sycl_enable_fusion),
         "-DSYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB={}".format(sycl_preview_lib),
         "-DBUG_REPORT_URL=https://github.com/intel/llvm/issues",
+        "-DLLVM_EXPERIMENTAL_TARGETS_TO_BUILD=SPIRV",
     ]
 
     if args.l0_headers and args.l0_loader:

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -1179,6 +1179,12 @@ def offload_new_driver : Flag<["--"], "offload-new-driver">,
 def no_offload_new_driver : Flag<["--"], "no-offload-new-driver">,
   Visibility<[ClangOption, CC1Option]>, Group<f_Group>,
   HelpText<"Don't Use the new driver for offloading compilation.">;
+def use_spirv_backend : Flag<["--"], "use-spirv-backend">,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Use the new SPIRV backend for offloading compilation.">;
+def no_use_spirv_backend : Flag<["--"], "no-use-spirv-backend">,
+  Visibility<[ClangOption, CC1Option]>,
+  HelpText<"Don't use the new SPIRV backend for offloading compilation.">;
 
 def offload_device_only : Flag<["--"], "offload-device-only">,
   Visibility<[ClangOption, FlangOption]>,

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10130,9 +10130,9 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
     if (ShouldPreserveMetadata)
       TranslatorArgs.push_back("--spirv-preserve-auxdata");
 
-    // Use SPIRV backend for LLVm to SPIRV Translation
+    // Use SPIRV backend for LLVM to SPIRV Translation
     if (TCArgs.hasFlag(options::OPT_use_spirv_backend,
-                   options::OPT_no_use_spirv_backend, true))
+                       options::OPT_no_use_spirv_backend, true))
       TranslatorArgs.push_back("--spirv-backend");
     // Disable all the extensions by default
     std::string ExtArg("-spirv-ext=-all");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10132,7 +10132,7 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
 
     // Use SPIRV backend for LLVM to SPIRV Translation
     if (TCArgs.hasFlag(options::OPT_use_spirv_backend,
-                       options::OPT_no_use_spirv_backend, true))
+                       options::OPT_no_use_spirv_backend, false))
       TranslatorArgs.push_back("--spirv-backend");
     // Disable all the extensions by default
     std::string ExtArg("-spirv-ext=-all");

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10130,6 +10130,10 @@ void SPIRVTranslator::ConstructJob(Compilation &C, const JobAction &JA,
     if (ShouldPreserveMetadata)
       TranslatorArgs.push_back("--spirv-preserve-auxdata");
 
+    // Use SPIRV backend for LLVm to SPIRV Translation
+    if (TCArgs.hasFlag(options::OPT_use_spirv_backend,
+                   options::OPT_no_use_spirv_backend, true))
+      TranslatorArgs.push_back("--spirv-backend");
     // Disable all the extensions by default
     std::string ExtArg("-spirv-ext=-all");
     std::string DefaultExtArg =


### PR DESCRIPTION
This is a prototype model to enable testing of SPIRV backend that is being upstreamed in the llorg community for SYCL offload compilation. 
SPIRV backend is used for translating LLVM IR to SPIR-V IR. This use is enabled by passing a flag '--use-spirv-backend' to the clang driver. This flag is not passed by default.

Thanks
Sincerely
