### PR TITLE
[SYCL][Fusion] Stop fusion attempt early if nothing is enqueued

### DIFF
--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -630,6 +630,11 @@ std::unique_ptr<detail::CG>
 jit_compiler::fuseKernels(QueueImplPtr Queue,
                           std::vector<ExecCGCommand *> &InputKernels,
                           const property_list &PropList) {
+  if (InputKernels.empty()) {
+    printPerformanceWarning("Fusion list is empty");
+    return nullptr;
+  }
+
   // Retrieve the device binary from each of the input
   // kernels to hand them over to the JIT compiler.
   std::vector<::jit_compiler::SYCLKernelInfo> InputKernelInfo;

--- a/sycl/test-e2e/KernelFusion/abort_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_fusion.cpp
@@ -74,6 +74,15 @@ void performFusion(queue &q, range<Kernel1Dim> k1Global,
   assert(numErrors == 0);
 }
 
+static void emptyFusionList(queue &q) {
+  ext::codeplay::experimental::fusion_wrapper fw(q);
+  fw.start_fusion();
+  assert(fw.is_in_fusion_mode() && "Queue should be in fusion mode");
+  fw.complete_fusion();
+  assert(!fw.is_in_fusion_mode() &&
+         "Queue should not be in fusion mode anymore");
+}
+
 int main() {
 
   queue q{ext::codeplay::experimental::property::queue::enable_fusion{}};
@@ -85,6 +94,12 @@ int main() {
   // CHECK: ERROR: JIT compilation for kernel fusion failed with message:
   // CHECK-NEXT: Cannot fuse kernels with different offsets or local sizes
   // CHECK: COMPUTATION OK
+
+  // Scenario: An empty fusion list should not be classified as having
+  // incompatible ND ranges.
+  emptyFusionList(q);
+  // CHECK-NOT: Cannot fuse kernels with different offsets or local sizes
+  // CHECK: WARNING: Fusion list is empty
 
   return 0;
 }


### PR DESCRIPTION
Previously, fusion would fail because an empty list of ND ranges is determined to be incompatible.