### PR TITLE
[GHA] Uplift Linux GPU RT version to 23.35.27191.9

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "23.30.26918.9",
-      "version": "23.30.26918.9",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/23.30.26918.9",
+      "github_tag": "23.35.27191.9",
+      "version": "23.35.27191.9",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/23.35.27191.9",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.14828.8",
-      "version": "1.0.14828.8",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.14828.8",
+      "github_tag": "igc-1.0.15136.4",
+      "version": "1.0.15136.4",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.15136.4",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.14.0",
-      "version": "v1.14.0",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.14.0",
+      "github_tag": "v1.15.1",
+      "version": "v1.15.1",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.15.1",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Scheduled drivers uplift