### PR TITLE
[SYCL-MLIR] Add `mlir-translate` to `deploy-sycl-toolchain`

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -456,6 +456,7 @@ set( SYCL_TOOLCHAIN_DEPLOY_COMPONENTS
      sycl
      libsycldevice
      level-zero-sycl-dev
+     mlir-translate
      ${XPTIFW_LIBS}
      ${SYCL_TOOLCHAIN_DEPS}
 )


### PR DESCRIPTION
`mlir-translate` is needed to perform SYCL host code raising. Add to `deploy-sycl-toolchain`.