### PR TITLE
[CUDA][HIP][L0][NATIVECPU][OpenCL] Remove usage of die/terminate throughout adapters

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,14 +56,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/martygrant/unified-runtime.git")
   # commit fe5bc760d0a9fa28247d3f0b57c20114f02eda49
   # Merge: 47af3ee2 3e1f1636
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
   # Date:   Fri Dec 1 11:21:41 2023 +0000
   #     Merge pull request #1102 from hdelan/adapter-batch1
   #     [HIP] Adapter PR batch
-  set(UNIFIED_RUNTIME_TAG fe5bc760d0a9fa28247d3f0b57c20114f02eda49)
+  set(UNIFIED_RUNTIME_TAG martin/removeDieTermination)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
For UR https://github.com/oneapi-src/unified-runtime/pull/1127