### PR TITLE
[SYCL-MLIR][NFC] Adapt `IntegerRangeAnalysis` changes for upstreaming

### DIFF
--- a/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
+++ b/mlir/lib/Analysis/DataFlow/IntegerRangeAnalysis.cpp
@@ -14,22 +14,10 @@
 
 #include "mlir/Analysis/DataFlow/IntegerRangeAnalysis.h"
 #include "mlir/Analysis/DataFlow/ConstantPropagationAnalysis.h"
-#include "mlir/Analysis/DataFlow/SparseAnalysis.h"
-#include "mlir/Analysis/DataFlowFramework.h"
-#include "mlir/IR/BuiltinAttributes.h"
-#include "mlir/IR/Dialect.h"
-#include "mlir/IR/OpDefinition.h"
-#include "mlir/IR/Value.h"
-#include "mlir/Interfaces/ControlFlowInterfaces.h"
 #include "mlir/Interfaces/InferIntRangeInterface.h"
 #include "mlir/Interfaces/LoopLikeInterface.h"
-#include "mlir/Support/LLVM.h"
-#include "llvm/ADT/STLExtras.h"
-#include "llvm/Support/Casting.h"
 #include "llvm/Support/Debug.h"
-#include <cassert>
 #include <optional>
-#include <utility>
 
 #define DEBUG_TYPE "int-range-analysis"
 

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -731,18 +731,23 @@ func.func @extui_uses_unsigned(%arg0 : i32) -> i1 {
     func.return %4 : i1
 }
 
-/// Catch a bug that crash in getLoopBoundFromFold when
-/// SparseConstantPropagation loaded in the solver.
+/// Catch a bug that caused a crash in getLoopBoundFromFold when
+// SparseConstantPropagation is loaded in the solver.
 
-// CHECK-LABEL: func.func @caller(%[[ARG0:.*]]
-// CHECK: call @callee(%[[ARG0]])
-// CHECK-LABEL: func.func @callee(%[[ARG0]]
-// CHECK: %[[LOAD:.*]] = affine.load %[[ARG0]]
-// CHECK: scf.for {{.*}} to %[[LOAD]] 
+// CHECK-LABEL:   func.func @caller(
+// CHECK-SAME:                      %[[VAL_0:.*]]: memref<?xindex, 4>) {
+// CHECK:           call @callee(%[[VAL_0]]) : (memref<?xindex, 4>) -> ()
+// CHECK:           return
+// CHECK:         }
 func.func @caller(%arg0: memref<?xindex, 4>) {
   call @callee(%arg0) : (memref<?xindex, 4>) -> ()
   return
 }
+
+// CHECK-LABEL:   func.func private @callee(
+// CHECK-SAME:                              %[[VAL_0:.*]]: memref<?xindex, 4>) {
+// CHECK:           return
+// CHECK:         }
 func.func private @callee(%arg0: memref<?xindex, 4>) {
   %c1 = arith.constant 1 : index
   %c0 = arith.constant 0 : index

--- a/mlir/test/Dialect/Arith/int-range-interface.mlir
+++ b/mlir/test/Dialect/Arith/int-range-interface.mlir
@@ -732,7 +732,7 @@ func.func @extui_uses_unsigned(%arg0 : i32) -> i1 {
 }
 
 /// Catch a bug that caused a crash in getLoopBoundFromFold when
-// SparseConstantPropagation is loaded in the solver.
+/// SparseConstantPropagation is loaded in the solver.
 
 // CHECK-LABEL:   func.func @caller(
 // CHECK-SAME:                      %[[VAL_0:.*]]: memref<?xindex, 4>) {


### PR DESCRIPTION
- Remove not needed headers being included
- Fix `check-mlir` due to variable being used in label in test