### PR TITLE
[SYCL][NFC] Optimize `vector_byte.cpp` E2E test

### DIFF
--- a/sycl/test-e2e/Basic/vector_byte.cpp
+++ b/sycl/test-e2e/Basic/vector_byte.cpp
@@ -12,8 +12,10 @@
 //
 //===----------------------------------------------------------------------===//
 
-#define SYCL_SIMPLE_SWIZZLES
 #include <sycl/sycl.hpp>
+
+#include <cstddef> // std::byte
+#include <tuple> // std::ignore
 
 int main() {
   std::byte bt{7};
@@ -30,7 +32,7 @@ int main() {
     // operator[]
     assert(vb16[3] == std::byte{2});
     // explicit conversion
-    std::byte(vb1.x());
+    std::ignore = std::byte(vb1.x());
     std::byte b = vb1;
 
     // operator=


### PR DESCRIPTION
Removed `SYCL_SIMPLE_SWIZZLES` macro definition, because those swizzles are not used by the test.

Defining `SYCL_SIMPLE_SWIZZLES` has significant impact on compilation time: the test compiles about twice faster without it on my local machine.

Also fixed warnings about unused variable.