### PR TITLE
[SYCL][Matrix][E2E] Add element_wise_all_sizes_no_split.cpp test

### DIFF
--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
@@ -5,11 +5,14 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// This is a version of element_wise_all_sizes test with disabled device code
+// split to test against fixed bug in IGC
+
 // REQUIRES: matrix-xmx8
 
 // TODO: Currently fails and regularly times out on DG2. Re-enable when this has
 //       been addressed.
-// XFAIL: gpu-intel-dg2
+// UNSUPPORTED: gpu-intel-dg2
 
 // RUN: %{build} -fsycl-device-code-split=off -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
@@ -9,7 +9,7 @@
 
 // TODO: Currently fails and regularly times out on DG2. Re-enable when this has
 //       been addressed.
-// UNSUPPORTED: gpu-intel-dg2
+// XFAIL: gpu-intel-dg2
 
 // RUN: %{build} -fsycl-device-code-split=off -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
@@ -1,0 +1,28 @@
+//==-------- element_wise_all_sizes_no_split.cpp  - DPC++ joint_matrix------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: matrix-xmx8
+
+// TODO: Currently fails and regularly times out on DG2. Re-enable when this has
+//       been addressed.
+// UNSUPPORTED: gpu-intel-dg2
+
+// RUN: %{build} -fsycl-device-code-split=off -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <random>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental::matrix;
+using bfloat16 = sycl::ext::oneapi::bfloat16;
+
+#define SG_SZ 8
+constexpr size_t TN = 8;
+
+#include "../element_wise_all_sizes_impl.hpp"


### PR DESCRIPTION
This patch adds version of element_wise_all_sizes.cpp test with disabled device code split. It is known that the code with disabled device code split fails on GPU due to a bug in IGC. We need to test such case.