### PR TITLE
Update cryptography version in requirements.txt

### DIFF
--- a/llvm/utils/git/requirements.txt
+++ b/llvm/utils/git/requirements.txt
@@ -14,7 +14,7 @@ cffi==1.15.1
     #   pynacl
 charset-normalizer==2.1.1
     # via requests
-cryptography==41.0.4
+cryptography==41.0.6
     # via pyjwt
 deprecated==1.2.13
     # via pygithub


### PR DESCRIPTION
This fixes https://github.com/intel/llvm/security/dependabot/39