### PR TITLE
[SYCL][ESIMD][E2E] Split atomic_update_acc_pvc.cpp into two tests

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_pvc.cpp
@@ -10,8 +10,6 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
-// RUN: %{run} %t.out
 
 #include "Inputs/atomic_update.hpp"
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_pvc_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_pvc_stateless.cpp
@@ -1,0 +1,14 @@
+//==-- atomic_update_acc_pvc_stateless.cpp - DPC++ ESIMD on-device test --==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===-------------------------------------------------------------------===//
+
+// REQUIRES: gpu-intel-pvc
+
+// RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
+// RUN: %{run} %t.out
+
+#include "atomic_update_acc_pvc.cpp"


### PR DESCRIPTION
It's slow so let's at least split the stateless/stateful into separate tests.