### PR TITLE
[SYCL] Missing C++ cstdint include

### DIFF
--- a/clang/test/Driver/clang-offload-wrapper-exe.cpp
+++ b/clang/test/Driver/clang-offload-wrapper-exe.cpp
@@ -32,7 +32,8 @@
 // RUN: %t.batch.exe > %t.batch.exe.out
 // RUN: diff -b %t.batch.exe.out %t.all
 
-#include <assert.h>
+#include <cassert>
+#include <cstdint>
 #include <cstring>
 #include <iostream>
 #include <string>


### PR DESCRIPTION
Fix a test compilation error with g++ 13 on Ubuntu 23.10. Replace also a C header include with the official C++ one.

Bug context:
```
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:55:3: error: unknown type name 'uint32_t'
   55 |   uint32_t Type;    // pi_property_type
      |   ^
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:56:3: error: unknown type name 'uint64_t'
   56 |   uint64_t ValSize; // size of property value in bytes
      |   ^
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:70:3: error: unknown type name 'uint16_t'
   70 |   uint16_t Version;
      |   ^
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:71:3: error: unknown type name 'uint8_t'
   71 |   uint8_t Kind;   // 4 for SYCL
      |   ^
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:72:3: error: unknown type name 'uint8_t'
   72 |   uint8_t Format; // 1 for native
      |   ^
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:88:3: error: unknown type name 'uint16_t'
   88 |   uint16_t Version;
      |   ^
/home/rkeryell/Xilinx/Projects/LLVM/worktrees/intel/llvm/clang/test/Driver/clang-offload-wrapper-exe.cpp:89:3: error: unknown type name 'uint16_t'
   89 |   uint16_t NumDeviceBinaries;
      |   ^
7 errors generated.
```