### PR TITLE
[SYCL][NFC] Do not test for internal libstdc++-13 allocator details

### DIFF
--- a/sycl/test/abi/layout_handler.cpp
+++ b/sycl/test/abi/layout_handler.cpp
@@ -33,7 +33,7 @@ void foo() {
 // CHECK-NEXT:  32 |       struct std::_Vector_base<class std::vector<char>, class std::allocator<class std::vector<char> > > (base)
 // CHECK-NEXT:  32 |         struct std::_Vector_base<class std::vector<char>, class std::allocator<class std::vector<char> > >::_Vector_impl _M_impl
 // CHECK-NEXT:  32 |           class std::allocator<class std::vector<char> > (base) (empty)
-// CHECK-NEXT:  32 |             class __gnu_cxx::new_allocator<class std::vector<char> > (base) (empty)
+// CHECK-NEXT:  32 |             class {{.+}}new_allocator<class std::vector<char> > (base) (empty)
 // CHECK:       32 |             pointer _M_start
 // CHECK-NEXT:  40 |             pointer _M_finish
 // CHECK-NEXT:  48 |             pointer _M_end_of_storage
@@ -41,7 +41,7 @@ void foo() {
 // CHECK-NEXT:  56 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::AccessorImplHost> > > (base)
 // CHECK-NEXT:  56 |         struct std::_Vector_base<class std::shared_ptr<class sycl::detail::AccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::AccessorImplHost> > >::_Vector_impl _M_impl
 // CHECK-NEXT:  56 |           class std::allocator<class std::shared_ptr<class sycl::detail::AccessorImplHost> > (base) (empty)
-// CHECK-NEXT:  56 |             class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::AccessorImplHost> > (base) (empty)
+// CHECK-NEXT:  56 |             class {{.+}}new_allocator<class std::shared_ptr<class sycl::detail::AccessorImplHost> > (base) (empty)
 // CHECK:       56 |             pointer _M_start
 // CHECK-NEXT:  64 |             pointer _M_finish
 // CHECK-NEXT:  72 |             pointer _M_end_of_storage
@@ -49,7 +49,7 @@ void foo() {
 // CHECK-NEXT:  80 |       struct std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > > (base)
 // CHECK-NEXT:  80 |         struct std::_Vector_base<class std::shared_ptr<const void>, class std::allocator<class std::shared_ptr<const void> > >::_Vector_impl _M_impl
 // CHECK-NEXT:  80 |           class std::allocator<class std::shared_ptr<const void> > (base) (empty)
-// CHECK-NEXT:  80 |             class __gnu_cxx::new_allocator<class std::shared_ptr<const void> > (base) (empty)
+// CHECK-NEXT:  80 |             class {{.+}}new_allocator<class std::shared_ptr<const void> > (base) (empty)
 // CHECK:       80 |             pointer _M_start
 // CHECK-NEXT:  88 |             pointer _M_finish
 // CHECK-NEXT:  96 |             pointer _M_end_of_storage
@@ -57,7 +57,7 @@ void foo() {
 // CHECK-NEXT: 104 |       struct std::_Vector_base<class sycl::detail::AccessorImplHost *, class std::allocator<class sycl::detail::AccessorImplHost *> > (base)
 // CHECK-NEXT: 104 |         struct std::_Vector_base<class sycl::detail::AccessorImplHost *, class std::allocator<class sycl::detail::AccessorImplHost *> >::_Vector_impl _M_impl
 // CHECK-NEXT: 104 |           class std::allocator<class sycl::detail::AccessorImplHost *> (base) (empty)
-// CHECK-NEXT: 104 |             class __gnu_cxx::new_allocator<class sycl::detail::AccessorImplHost *> (base) (empty)
+// CHECK-NEXT: 104 |             class {{.+}}new_allocator<class sycl::detail::AccessorImplHost *> (base) (empty)
 // CHECK:      104 |             pointer _M_start
 // CHECK-NEXT: 112 |             pointer _M_finish
 // CHECK-NEXT: 120 |             pointer _M_end_of_storage
@@ -65,7 +65,7 @@ void foo() {
 // CHECK-NEXT: 128 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::event_impl> > > (base)
 // CHECK-NEXT: 128 |         struct std::_Vector_base<class std::shared_ptr<class sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::event_impl> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 128 |           class std::allocator<class std::shared_ptr<class sycl::detail::event_impl> > (base) (empty)
-// CHECK-NEXT: 128 |             class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::event_impl> > (base) (empty)
+// CHECK-NEXT: 128 |             class {{.+}}new_allocator<class std::shared_ptr<class sycl::detail::event_impl> > (base) (empty)
 // CHECK:      128 |             pointer _M_start
 // CHECK-NEXT: 136 |             pointer _M_finish
 // CHECK-NEXT: 144 |             pointer _M_end_of_storage
@@ -73,7 +73,7 @@ void foo() {
 // CHECK-NEXT: 152 |     struct std::_Vector_base<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > > (base)
 // CHECK-NEXT: 152 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost>, class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 152 |         class std::allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > (base) (empty)
-// CHECK-NEXT: 152 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > (base) (empty)
+// CHECK-NEXT: 152 |           class {{.+}}new_allocator<class std::shared_ptr<class sycl::detail::LocalAccessorImplHost> > (base) (empty)
 // CHECK:      152 |           pointer _M_start
 // CHECK-NEXT: 160 |           pointer _M_finish
 // CHECK-NEXT: 168 |           pointer _M_end_of_storage
@@ -81,7 +81,7 @@ void foo() {
 // CHECK-NEXT: 176 |     struct std::_Vector_base<class std::shared_ptr<class sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > > (base)
 // CHECK-NEXT: 176 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::stream_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 176 |         class std::allocator<class std::shared_ptr<class sycl::detail::stream_impl> > (base) (empty)
-// CHECK-NEXT: 176 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::stream_impl> > (base) (empty)
+// CHECK-NEXT: 176 |           class {{.+}}new_allocator<class std::shared_ptr<class sycl::detail::stream_impl> > (base) (empty)
 // CHECK:      176 |           pointer _M_start
 // CHECK-NEXT: 184 |           pointer _M_finish
 // CHECK-NEXT: 192 |           pointer _M_end_of_storage
@@ -89,7 +89,7 @@ void foo() {
 // CHECK-NEXT: 200 |     struct std::_Vector_base<class sycl::detail::ArgDesc, class std::allocator<class sycl::detail::ArgDesc> > (base)
 // CHECK-NEXT: 200 |       struct std::_Vector_base<class sycl::detail::ArgDesc, class std::allocator<class sycl::detail::ArgDesc> >::_Vector_impl _M_impl
 // CHECK-NEXT: 200 |         class std::allocator<class sycl::detail::ArgDesc> (base) (empty)
-// CHECK-NEXT: 200 |           class __gnu_cxx::new_allocator<class sycl::detail::ArgDesc> (base) (empty)
+// CHECK-NEXT: 200 |           class {{.+}}new_allocator<class sycl::detail::ArgDesc> (base) (empty)
 // CHECK:      200 |           pointer _M_start
 // CHECK-NEXT: 208 |           pointer _M_finish
 // CHECK-NEXT: 216 |           pointer _M_end_of_storage
@@ -97,7 +97,7 @@ void foo() {
 // CHECK-NEXT: 224 |     struct std::_Vector_base<class sycl::detail::ArgDesc, class std::allocator<class sycl::detail::ArgDesc> > (base)
 // CHECK-NEXT: 224 |       struct std::_Vector_base<class sycl::detail::ArgDesc, class std::allocator<class sycl::detail::ArgDesc> >::_Vector_impl _M_impl
 // CHECK-NEXT: 224 |         class std::allocator<class sycl::detail::ArgDesc> (base) (empty)
-// CHECK-NEXT: 224 |           class __gnu_cxx::new_allocator<class sycl::detail::ArgDesc> (base) (empty)
+// CHECK-NEXT: 224 |           class {{.+}}new_allocator<class sycl::detail::ArgDesc> (base) (empty)
 // CHECK:      224 |           pointer _M_start
 // CHECK-NEXT: 232 |           pointer _M_finish
 // CHECK-NEXT: 240 |           pointer _M_end_of_storage
@@ -118,7 +118,7 @@ void foo() {
 // CHECK-NEXT: 352 |   class std::basic_string<char> MKernelName
 // CHECK-NEXT: 352 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
 // CHECK-NEXT: 352 |       class std::allocator<char> (base) (empty)
-// CHECK-NEXT: 352 |         class __gnu_cxx::new_allocator<char> (base) (empty)
+// CHECK-NEXT: 352 |         class {{.+}}new_allocator<char> (base) (empty)
 // CHECK-NEXT: 352 |       pointer _M_p
 // CHECK-NEXT: 360 |     size_type _M_string_length
 // CHECK-NEXT: 368 |     union std::basic_string<char>::(anonymous at {{.*}})
@@ -138,7 +138,7 @@ void foo() {
 // CHECK-NEXT: 432 |     struct std::_Vector_base<char, class std::allocator<char> > (base)
 // CHECK-NEXT: 432 |       struct std::_Vector_base<char, class std::allocator<char> >::_Vector_impl _M_impl
 // CHECK-NEXT: 432 |         class std::allocator<char> (base) (empty)
-// CHECK-NEXT: 432 |           class __gnu_cxx::new_allocator<char> (base) (empty)
+// CHECK-NEXT: 432 |           class {{.+}}new_allocator<char> (base) (empty)
 // CHECK:      432 |           pointer _M_start
 // CHECK-NEXT: 440 |           pointer _M_finish
 // CHECK-NEXT: 448 |           pointer _M_end_of_storage
@@ -160,7 +160,7 @@ void foo() {
 // CHECK-NEXT: 472 |     struct std::_Vector_base<class std::shared_ptr<class sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::event_impl> > > (base)
 // CHECK-NEXT: 472 |       struct std::_Vector_base<class std::shared_ptr<class sycl::detail::event_impl>, class std::allocator<class std::shared_ptr<class sycl::detail::event_impl> > >::_Vector_impl _M_impl
 // CHECK-NEXT: 472 |         class std::allocator<class std::shared_ptr<class sycl::detail::event_impl> > (base) (empty)
-// CHECK-NEXT: 472 |           class __gnu_cxx::new_allocator<class std::shared_ptr<class sycl::detail::event_impl> > (base) (empty)
+// CHECK-NEXT: 472 |           class {{.+}}new_allocator<class std::shared_ptr<class sycl::detail::event_impl> > (base) (empty)
 // CHECK:      472 |           pointer _M_start
 // CHECK-NEXT: 480 |           pointer _M_finish
 // CHECK-NEXT: 488 |           pointer _M_end_of_storage


### PR DESCRIPTION
Be more liberal to succeed also with g++13 STL.
The allocator used to be in this test:

  class __gnu_cxx::new_allocator<class std::vector<char> >

but is now with the libstdc++-13:

  class std::__new_allocator<class std::vector<char> >