### PR TITLE
[SYCL] Remove WA for L0 for not immediate context usage

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1388,8 +1388,6 @@ void UnMapMemObject::emitInstrumentationData() {
 #endif
 }
 
-bool UnMapMemObject::producesPiEvent() const { return true; }
-
 pi_int32 UnMapMemObject::enqueueImp() {
   waitForPreparedHostEvents();
   std::vector<EventImplPtr> EventImpls = MPreparedDepsEvents;
@@ -1475,8 +1473,6 @@ void MemCpyCommand::emitInstrumentationData() {
 const ContextImplPtr &MemCpyCommand::getWorkerContext() const {
   return getWorkerQueue()->getContextImplPtr();
 }
-
-bool MemCpyCommand::producesPiEvent() const { return true; }
 
 pi_int32 MemCpyCommand::enqueueImp() {
   waitForPreparedHostEvents();

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -558,7 +558,6 @@ public:
   void printDot(std::ostream &Stream) const final;
   const Requirement *getRequirement() const final { return &MDstReq; }
   void emitInstrumentationData() override;
-  bool producesPiEvent() const final;
 
 private:
   pi_int32 enqueueImp() final;
@@ -580,7 +579,6 @@ public:
   const Requirement *getRequirement() const final { return &MDstReq; }
   void emitInstrumentationData() final;
   const ContextImplPtr &getWorkerContext() const final;
-  bool producesPiEvent() const final;
 
 private:
   pi_int32 enqueueImp() final;


### PR DESCRIPTION
This WA removal should not be critical since now immediate command list is used by default. For immediate command list this WA is not applicable/needed.
needed for https://github.com/intel/llvm/pull/11758 to make producesPiEvent() runtime independent. It is also needed for existing impl of non blocking enqueue with host task dependency since now it produces wrong values if depEvent command was not enqueued yet (processDepEvent).