### PR TITLE
[SYCL][E2E] Add sycl::half_precision math functions to marray_math.cpp

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_math.cpp
@@ -5,7 +5,27 @@
 // RUN: %if preview-breaking-changes-supported %{ %{build} %{mathflags} -fpreview-breaking-changes -o %t_preview.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}
 
+#include <cmath>
 #include <sycl/sycl.hpp>
+
+template <typename T> T get_ulp_sycl(T x) {
+  const T inf = std::numeric_limits<T>::infinity();
+  const T negative = sycl::fabs(sycl::nextafter(x, -inf) - x);
+  const T positive = sycl::fabs(sycl::nextafter(x, inf) - x);
+  return sycl::fmin(negative, positive);
+}
+
+template <> inline sycl::half get_ulp_sycl<sycl::half>(sycl::half x) {
+  const auto ulp = get_ulp_sycl<float>(x);
+  const float multiplier = 8192.0f;
+  return static_cast<sycl::half>(ulp * multiplier);
+}
+
+template <typename T> bool compare_floats(T actual, T expected) {
+  const T difference = static_cast<T>(std::fabs(actual - expected));
+  const T difference_expected = get_ulp_sycl(expected);
+  return difference <= difference_expected;
+}
 
 #define TEST(FUNC, MARRAY_ELEM_TYPE, DIM, EXPECTED, DELTA, ...)                \
   {                                                                            \
@@ -76,6 +96,26 @@
     }                                                                          \
   }
 
+#define TEST4(FUNC, MARRAY_ELEM_TYPE, DIM, EXPECTED, ...)                      \
+  {                                                                            \
+    {                                                                          \
+      MARRAY_ELEM_TYPE result[DIM];                                            \
+      {                                                                        \
+        sycl::buffer<MARRAY_ELEM_TYPE> b(result, sycl::range{DIM});            \
+        deviceQueue.submit([&](sycl::handler &cgh) {                           \
+          sycl::accessor res_access{b, cgh};                                   \
+          cgh.single_task([=]() {                                              \
+            sycl::marray<MARRAY_ELEM_TYPE, DIM> res = FUNC(__VA_ARGS__);       \
+            for (int i = 0; i < DIM; i++)                                      \
+              res_access[i] = res[i];                                          \
+          });                                                                  \
+        });                                                                    \
+      }                                                                        \
+      for (int i = 0; i < DIM; i++)                                            \
+        assert(compare_floats(result[i], EXPECTED[i]));                        \
+    }                                                                          \
+  }
+
 #define EXPECTED(TYPE, ...) ((TYPE[]){__VA_ARGS__})
 
 int main() {
@@ -118,32 +158,34 @@ int main() {
   if (deviceQueue.get_device().has(sycl::aspect::fp64))
     TEST3(sycl::nan, double, 3, ma8);
 
-  TEST(sycl::half_precision::sin, float, 3,
-       EXPECTED(float, 0.98545f, -0.871576f, -0.832267f), 0.001, ma6);
-  TEST(sycl::half_precision::cos, float, 3,
-       EXPECTED(float, 0.169967, -0.490261, 0.554375), 0.001, ma6);
-  TEST(sycl::half_precision::tan, float, 3,
-       EXPECTED(float, 5.797, 1.777, -1.501), 0.001, ma6);
-  TEST(sycl::half_precision::divide, float, 2, EXPECTED(float, 3.0f, 1.0f), 0,
-       ma2, ma1);
-  TEST(sycl::half_precision::log, float, 2, EXPECTED(float, 0.0f, 0.693f),
-       0.001, ma1);
-  TEST(sycl::half_precision::log2, float, 2, EXPECTED(float, 0.0f, 1.f), 0,
-       ma1);
-  TEST(sycl::half_precision::log10, float, 2, EXPECTED(float, 0.0f, 0.301f),
-       0.001, ma1);
-  TEST(sycl::half_precision::powr, float, 2, EXPECTED(float, 3.0f, 4.0f), 0,
-       ma2, ma1);
-  TEST(sycl::half_precision::recip, float, 2, EXPECTED(float, 0.333f, 0.5f),
-       0.001, ma2);
-  TEST(sycl::half_precision::sqrt, float, 2, EXPECTED(float, 1.0f, 1.414f),
-       0.001, ma1);
-  TEST(sycl::half_precision::rsqrt, float, 2, EXPECTED(float, 1.0f, 0.707f),
-       0.001, ma1);
-  TEST(sycl::half_precision::exp, float, 2, EXPECTED(float, 2.718f, 7.389f),
-       0.001, ma1);
-  TEST(sycl::half_precision::exp2, float, 2, EXPECTED(float, 2, 4), 0, ma1);
-  TEST(sycl::half_precision::exp10, float, 2, EXPECTED(float, 10, 100), 0, ma1);
+  TEST4(sycl::half_precision::sin, sycl::half, 3,
+        EXPECTED(sycl::half, 0.98545f, -0.871576f, -0.832267f), ma6);
+  TEST4(sycl::half_precision::cos, sycl::half, 3,
+        EXPECTED(sycl::half, 0.169967f, -0.490261f, 0.554375f), ma6);
+  TEST4(sycl::half_precision::tan, sycl::half, 3,
+        EXPECTED(sycl::half, 5.797f, 1.777f, -1.501f), ma6);
+  TEST4(sycl::half_precision::divide, sycl::half, 2,
+        EXPECTED(sycl::half, 3.0f, 1.0f), ma2, ma1);
+  TEST4(sycl::half_precision::log, sycl::half, 2,
+        EXPECTED(sycl::half, 0.0f, 0.693f), ma1);
+  TEST4(sycl::half_precision::log2, sycl::half, 2,
+        EXPECTED(sycl::half, 0.0f, 1.f), ma1);
+  TEST4(sycl::half_precision::log10, sycl::half, 2,
+        EXPECTED(sycl::half, 0.0f, 0.301f), ma1);
+  TEST4(sycl::half_precision::powr, sycl::half, 2,
+        EXPECTED(sycl::half, 3.0f, 4.0f), ma2, ma1);
+  TEST4(sycl::half_precision::recip, sycl::half, 2,
+        EXPECTED(sycl::half, 0.333f, 0.5f), ma2);
+  TEST4(sycl::half_precision::sqrt, sycl::half, 2,
+        EXPECTED(sycl::half, 1.0f, 1.414f), ma1);
+  TEST4(sycl::half_precision::rsqrt, sycl::half, 2,
+        EXPECTED(sycl::half, 1.0f, 0.707f), ma1);
+  TEST4(sycl::half_precision::exp, sycl::half, 2,
+        EXPECTED(sycl::half, 2.718f, 7.389f), ma1);
+  TEST4(sycl::half_precision::exp2, sycl::half, 2, EXPECTED(sycl::half, 2, 4),
+        ma1);
+  TEST4(sycl::half_precision::exp10, sycl::half, 2,
+        EXPECTED(sycl::half, 10, 100), ma1);
 
   return 0;
 }

--- a/sycl/test-e2e/Basic/built-ins/marray_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_math.cpp
@@ -2,6 +2,8 @@
 
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if preview-breaking-changes-supported %{ %{build} %{mathflags} -fpreview-breaking-changes -o %t_preview.out %}
+// RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}
 
 #include <sycl/sycl.hpp>
 
@@ -115,8 +117,33 @@ int main() {
   TEST3(sycl::nan, float, 3, ma7);
   if (deviceQueue.get_device().has(sycl::aspect::fp64))
     TEST3(sycl::nan, double, 3, ma8);
-  TEST(sycl::half_precision::exp10, float, 2, EXPECTED(float, 10, 100), 0.1,
+
+  TEST(sycl::half_precision::sin, float, 3,
+       EXPECTED(float, 0.98545f, -0.871576f, -0.832267f), 0.001, ma6);
+  TEST(sycl::half_precision::cos, float, 3,
+       EXPECTED(float, 0.169967, -0.490261, 0.554375), 0.001, ma6);
+  TEST(sycl::half_precision::tan, float, 3,
+       EXPECTED(float, 5.797, 1.777, -1.501), 0.001, ma6);
+  TEST(sycl::half_precision::divide, float, 2, EXPECTED(float, 3.0f, 1.0f), 0,
+       ma2, ma1);
+  TEST(sycl::half_precision::log, float, 2, EXPECTED(float, 0.0f, 0.693f),
+       0.001, ma1);
+  TEST(sycl::half_precision::log2, float, 2, EXPECTED(float, 0.0f, 1.f), 0,
        ma1);
+  TEST(sycl::half_precision::log10, float, 2, EXPECTED(float, 0.0f, 0.301f),
+       0.001, ma1);
+  TEST(sycl::half_precision::powr, float, 2, EXPECTED(float, 3.0f, 4.0f), 0,
+       ma2, ma1);
+  TEST(sycl::half_precision::recip, float, 2, EXPECTED(float, 0.333f, 0.5f),
+       0.001, ma2);
+  TEST(sycl::half_precision::sqrt, float, 2, EXPECTED(float, 1.0f, 1.414f),
+       0.001, ma1);
+  TEST(sycl::half_precision::rsqrt, float, 2, EXPECTED(float, 1.0f, 0.707f),
+       0.001, ma1);
+  TEST(sycl::half_precision::exp, float, 2, EXPECTED(float, 2.718f, 7.389f),
+       0.001, ma1);
+  TEST(sycl::half_precision::exp2, float, 2, EXPECTED(float, 2, 4), 0, ma1);
+  TEST(sycl::half_precision::exp10, float, 2, EXPECTED(float, 10, 100), 0, ma1);
 
   return 0;
 }


### PR DESCRIPTION
Add missing math functions defined in the sycl::half_precision namespace. Thank you for your review.