### PR TITLE
[ESIMD] Implement property-based gather(usm, ...)

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -22,6 +22,7 @@
 #include "llvm/ADT/DenseSet.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringSwitch.h"
+#include "llvm/CodeGen/ValueTypes.h"
 #include "llvm/Demangle/Demangle.h"
 #include "llvm/Demangle/ItaniumDemangle.h"
 #include "llvm/GenXIntrinsics/GenXIntrinsics.h"
@@ -352,7 +353,6 @@ public:
           nk(-1)}},
         {"vload", {"vload", {l(0)}}},
         {"vstore", {"vstore", {a(1), a(0)}}},
-        {"svm_gather", {"svm.gather", {ai1(1), t(3), a(0), u(-1)}}},
         {"svm_gather4_scaled",
          {"svm.gather4.scaled", {ai1(1), t(2), c16(0), c64(0), a(0), u(-1)}}},
         {"svm_scatter", {"svm.scatter", {ai1(2), t(3), a(0), a(1)}}},
@@ -968,6 +968,38 @@ static void translateBlockStore(CallInst &CI, bool IsSLM) {
 
   auto SI = Builder.CreateAlignedStore(Op1, Op0, Align);
   SI->setDebugLoc(CI.getDebugLoc());
+}
+
+static void translateGatherLoad(CallInst &CI, bool IsSLM) {
+  IRBuilder<> Builder(&CI);
+  constexpr int AlignmentTemplateArgIdx = 2;
+  APInt Val = parseTemplateArg(CI, AlignmentTemplateArgIdx,
+                               ESIMDIntrinDesc::GenXArgConversion::TO_I64);
+  Align AlignValue(Val.getZExtValue());
+
+  auto OffsetsOp = CI.getArgOperand(0);
+  auto MaskOp = CI.getArgOperand(1);
+  auto PassThroughOp = CI.getArgOperand(2);
+  auto DataType = CI.getType();
+
+  // Convert the mask from <N x i16> to <N x i1>.
+  Value *Zero = ConstantInt::get(MaskOp->getType(), 0);
+  MaskOp = Builder.CreateICmp(ICmpInst::ICMP_NE, MaskOp, Zero);
+
+  // The address space may be 3-SLM, 1-global or private.
+  // At the moment of calling 'gather()' operation the pointer passed to it
+  // is already 4-generic. Thus, simply use 4-generic for global and private
+  // and let GPU BE deduce the actual address space from the use-def graph.
+  unsigned AS = IsSLM ? 3 : 4;
+  auto ElemType = DataType->getScalarType();
+  auto NumElems = (cast<VectorType>(DataType))->getElementCount();
+  auto VPtrType = VectorType::get(PointerType::get(ElemType, AS), NumElems);
+  auto VPtrOp = Builder.CreateIntToPtr(OffsetsOp, VPtrType);
+
+  auto LI = Builder.CreateMaskedGather(DataType, VPtrOp, AlignValue, MaskOp,
+                                       PassThroughOp);
+  LI->setDebugLoc(CI.getDebugLoc());
+  CI.replaceAllUsesWith(LI);
 }
 
 // TODO Specify document behavior for slm_init and nbarrier_init when:
@@ -1910,6 +1942,13 @@ size_t SYCLLowerESIMDPass::runOnFunction(Function &F,
         ToErase.push_back(CI);
         continue;
       }
+      if (Name.startswith("__esimd_gather_ld") ||
+          Name.startswith("__esimd_slm_gather_ld")) {
+        translateGatherLoad(*CI, Name.startswith("__esimd_slm_gather_ld"));
+        ToErase.push_back(CI);
+        continue;
+      }
+
       if (Name.startswith("__esimd_nbarrier_init")) {
         translateNbarrierInit(*CI);
         ToErase.push_back(CI);

--- a/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
@@ -64,8 +64,8 @@
 //
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth = 0>
-__ESIMD_INTRIN __ESIMD_INTRIN std::enable_if_t<(Width > 0) && M % Width == 0,
-                                               __ESIMD_DNS::vector_type_t<T, M>>
+__ESIMD_INTRIN std::enable_if_t<(Width > 0) && M % Width == 0,
+                                __ESIMD_DNS::vector_type_t<T, M>>
 __esimd_rdregion(__ESIMD_DNS::vector_type_t<T, N> Input, uint16_t Offset);
 
 template <typename T, int N, int M, int ParentWidth = 0>
@@ -263,8 +263,8 @@ __ESIMD_INTRIN uint16_t __esimd_all(__ESIMD_DNS::vector_type_t<T, N> src)
 // Implementations of ESIMD intrinsics for the SYCL host device
 template <typename T, int N, int M, int VStride, int Width, int Stride,
           int ParentWidth>
-__ESIMD_INTRIN __ESIMD_INTRIN std::enable_if_t<(Width > 0) && M % Width == 0,
-                                               __ESIMD_DNS::vector_type_t<T, M>>
+__ESIMD_INTRIN std::enable_if_t<(Width > 0) && M % Width == 0,
+                                __ESIMD_DNS::vector_type_t<T, M>>
 __esimd_rdregion(__ESIMD_DNS::vector_type_t<T, N> Input, uint16_t Offset) {
   uint16_t EltOffset = Offset / sizeof(T);
   assert(Offset % sizeof(T) == 0);

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -67,65 +67,483 @@ __ESIMD_API SurfaceIndex get_surface_index(AccessorTy acc) {
   }
 }
 
-/// Loads ("gathers") elements from different memory locations and returns a
-/// vector of them. Each memory location is base address plus an offset - a
-/// value of the corresponding element in the input offset vector. Access to
-/// any element's memory location can be disabled via the input vector of
-/// predicates (mask).
-/// @tparam Tx Element type, must be of size 4 or less.
-/// @tparam N Number of elements to read; can be \c 1, \c 2, \c 4, \c 8, \c 16
-///   or \c 32.
-/// @param p The base address.
-/// @param offsets the vector of 32-bit or 64-bit offsets in bytes. For each
-/// lane \c i,   ((byte*)p + offsets[i]) must be element size aligned.
-/// @param mask The access mask, defaults to all 1s.
-/// @return A vector of elements read. Elements in masked out lanes are
-///   undefined.
-///
-template <typename Tx, int N, typename Toffset>
-__ESIMD_API simd<Tx, N> gather(const Tx *p, simd<Toffset, N> offsets,
-                               simd_mask<N> mask = 1) {
-  using T = detail::__raw_t<Tx>;
-  static_assert(std::is_integral_v<Toffset>, "Unsupported offset type");
-  static_assert(detail::isPowerOf2(N, 32), "Unsupported value of N");
-  simd<uint64_t, N> offsets_i = convert<uint64_t>(offsets);
-  simd<uint64_t, N> addrs(reinterpret_cast<uint64_t>(p));
-  addrs = addrs + offsets_i;
+namespace detail {
 
+// Format u8 and u16 to u8u32 and u16u32 by doing garbage-extension.
+template <typename RT, typename T, int N>
+ESIMD_INLINE simd<RT, N> lsc_format_input(simd<T, N> Vals) {
   if constexpr (sizeof(T) == 1) {
-    auto Ret = __esimd_svm_gather<T, N, detail::ElemsPerAddrEncoding<4>(),
-                                  detail::ElemsPerAddrEncoding<1>()>(
-        addrs.data(), mask.data());
-    return __esimd_rdregion<T, N * 4, N, /*VS*/ 0, N, 4>(Ret, 0);
+    // Extend bytes to RT.
+    return Vals.template bit_cast_view<uint8_t>();
   } else if constexpr (sizeof(T) == 2) {
-    auto Ret = __esimd_svm_gather<T, N, detail::ElemsPerAddrEncoding<2>(),
-                                  detail::ElemsPerAddrEncoding<2>()>(
-        addrs.data(), mask.data());
-    return __esimd_rdregion<T, N * 2, N, /*VS*/ 0, N, 2>(Ret, 0);
-  } else
-    return __esimd_svm_gather<T, N, detail::ElemsPerAddrEncoding<1>(),
-                              detail::ElemsPerAddrEncoding<1>()>(addrs.data(),
-                                                                 mask.data());
+    // Extend words to RT.
+    return Vals.template bit_cast_view<uint16_t>();
+  } else {
+    return Vals.template bit_cast_view<RT>();
+  }
 }
 
-/// A variation of \c gather API with \c offsets represented as \c simd_view
-/// object.
+// Format u8u32 and u16u32 back to u8 and u16.
+template <typename T, typename T1, int N>
+ESIMD_INLINE simd<T, N> lsc_format_ret(simd<T1, N> Vals) {
+  auto Formatted = Vals.template bit_cast_view<T>();
+  if constexpr (sizeof(T) == sizeof(T1)) {
+    return Formatted;
+  } else {
+    constexpr int Stride = Formatted.length / N;
+    return Formatted.template select<N, Stride>(0);
+  }
+}
+
+/// USM pointer gather.
+/// Supported platforms: DG2, PVC
+/// VISA instruction: lsc_load.ugm
 ///
-/// @tparam Tx Element type, must be of size 4 or less.
-/// @tparam N Number of elements to read; can be \c 1, \c 2, \c 4, \c 8, \c 16
-///   or \c 32.
+/// Collects elements located at specified address and returns them
+/// as a single \ref simd object.
+///
+/// @tparam T is element type.
+/// @tparam NElts is the number of elements to load per address.
+/// @tparam DS is the data size.
+/// @tparam L1H is L1 cache hint.
+/// @tparam L2H is L2 cache hint.
+/// @tparam N is the number of channels (platform dependent).
+/// @param p is the base pointer.
+/// @param offsets is the zero-based offsets in bytes.
+/// @param pred is predicates.
+/// @return is a vector of type T and size N * NElts
+template <typename T, int NElts, lsc_data_size DS, cache_hint L1H,
+          cache_hint L2H, int N, typename OffsetT>
+__ESIMD_API simd<T, N * NElts> gather_impl(const T *p, simd<OffsetT, N> offsets,
+                                           simd_mask<N> pred) {
+  static_assert(std::is_integral_v<OffsetT>, "Unsupported offset type");
+  check_lsc_vector_size<NElts>();
+  check_lsc_data_size<T, DS>();
+  check_cache_hint<cache_action::load, L1H, L2H>();
+  constexpr uint16_t AddressScale = 1;
+  constexpr int ImmOffset = 0;
+  constexpr lsc_data_size EDS = expand_data_size(finalize_data_size<T, DS>());
+  constexpr lsc_vector_size VS = to_lsc_vector_size<NElts>();
+  constexpr auto Transposed = lsc_data_order::nontranspose;
+  using MsgT = typename lsc_expand_type<T>::type;
+  simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
+  addrs += convert<uintptr_t>(offsets);
+  simd<MsgT, N * NElts> Tmp =
+      __esimd_lsc_load_stateless<MsgT, L1H, L2H, AddressScale, ImmOffset, EDS,
+                                 VS, Transposed, N>(pred.data(), addrs.data());
+  return lsc_format_ret<T>(Tmp);
+}
+
+/// USM pointer gather.
+/// Supported platforms: DG2, PVC
+/// VISA instruction: lsc_load.ugm
+///
+/// Collects elements located at specified address and returns them
+/// as a single \ref simd object.
+///
+/// @tparam T is element type.
+/// @tparam NElts is the number of elements to load per address.
+/// @tparam DS is the data size.
+/// @tparam L1H is L1 cache hint.
+/// @tparam L2H is L2 cache hint.
+/// @tparam N is the number of channels (platform dependent).
+/// @param p is the base pointer.
+/// @param offsets is the zero-based offsets in bytes.
+/// @param pred is predicates.
+/// @param pass_thru contains the vector which elements are copied
+/// to the returned result when the corresponding element of \p pred is 0.
+/// @return is a vector of type T and size N * NElts
+///
+template <typename T, int NElts, lsc_data_size DS, cache_hint L1H,
+          cache_hint L2H, int N, typename OffsetT>
+__ESIMD_API simd<T, N * NElts> gather_impl(const T *p, simd<OffsetT, N> offsets,
+                                           simd_mask<N> pred,
+                                           simd<T, N * NElts> pass_thru) {
+  static_assert(std::is_integral_v<OffsetT>, "Unsupported offset type");
+  check_lsc_vector_size<NElts>();
+  check_lsc_data_size<T, DS>();
+  check_cache_hint<cache_action::load, L1H, L2H>();
+  constexpr uint16_t AddressScale = 1;
+  constexpr int ImmOffset = 0;
+  constexpr lsc_data_size EDS = expand_data_size(finalize_data_size<T, DS>());
+  constexpr lsc_vector_size VS = to_lsc_vector_size<NElts>();
+  constexpr auto Transposed = lsc_data_order::nontranspose;
+  using MsgT = typename lsc_expand_type<T>::type;
+  simd<uintptr_t, N> Addrs = reinterpret_cast<uintptr_t>(p);
+  Addrs += convert<uintptr_t>(offsets);
+  simd<MsgT, N * NElts> PassThruExpanded = lsc_format_input<MsgT>(pass_thru);
+  simd<MsgT, N * NElts> Result =
+      __esimd_lsc_load_merge_stateless<MsgT, L1H, L2H, AddressScale, ImmOffset,
+                                       EDS, VS, Transposed, N>(
+          pred.data(), Addrs.data(), PassThruExpanded.data());
+  return lsc_format_ret<T>(Result);
+}
+} // namespace detail
+
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});                   // (usm-ga-1)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask,
+///                   PropertyListT props = {});                   // (usm-ga-2)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-ga-3)
+///
+/// The next 3 functions are similar to the above and added for convenience.
+/// They assume the VS parameter is set to 1 and do not require specifying
+/// the template parameters <T, N, VS> at function calls.
+/// template <typename T, int N, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});                   // (usm-ga-4)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask, PropertyListT props = {});// (usm-ga-5)
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-ga-6)
+///
+/// The next 5 functions are variations of the first 3 above (usm-ga-1,2,3)
+/// and added only to support simd_view instead of simd for byte_offsets
+/// and/or pass_thru operands.
+/// template <typename T, int N, int VS = 1, typename OffsetObjT,
+///           typename OffsetRegionT, typename PropertyListT = empty_props_t>
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///             PropertyListT props = {});                         // (usm-ga-7)
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-ga-8)
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             PropertyListT props = {});                         // (usm-ga-9)
+
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});                   // (usm-ga-1)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element from
+/// \p pass_thru operand is returned.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
 /// @param p The base address.
-/// @param offsets the simd_view of 32-bit or 64-bit offsets in bytes. For each
-/// lane \c i,   ((byte*)p + offsets[i]) must be element size aligned.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
 /// @param mask The access mask, defaults to all 1s.
+/// @param pass_thru The vector pass through values.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
+template <typename T, int N, int VS, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd<OffsetT, N / VS> byte_offsets, simd_mask<N / VS> mask,
+       simd<T, N> pass_thru, PropertyListT props = {}) {
+  static_assert(std::is_integral_v<OffsetT>, "Unsupported offset type");
+  static_assert(N / VS >= 1 && N % VS == 0, "N must be divisible by VS");
+
+  constexpr size_t Alignment =
+      detail::getPropertyValue<PropertyListT, alignment_key>(sizeof(T));
+  static_assert(Alignment >= sizeof(T),
+                "slm_gather() requires at least element-size alignment");
+  constexpr auto L1Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L1_key>(
+          cache_hint::none);
+  constexpr auto L2Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L2_key>(
+          cache_hint::none);
+  if constexpr (L1Hint != cache_hint::none || L2Hint != cache_hint::none ||
+                VS > 1) {
+    static_assert(VS == 1 || sizeof(T) >= 4,
+                  "VS > 1 is supprted only for 4- and 8-byte elements");
+    return detail::gather_impl<T, VS, detail::lsc_data_size::default_size,
+                               L1Hint, L2Hint>(p, byte_offsets, mask,
+                                               pass_thru);
+  } else {
+    simd<uint64_t, N> Addrs(reinterpret_cast<uint64_t>(p));
+    Addrs = Addrs + convert<uint64_t>(byte_offsets);
+
+    using MsgT = detail::__raw_t<T>;
+    return __esimd_gather_ld<MsgT, N, Alignment>(
+        Addrs.data(), mask.data(),
+        sycl::bit_cast<__ESIMD_DNS::vector_type_t<MsgT, N>>(pass_thru.data()));
+  }
+}
+
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   simd_mask<N / VS> mask,
+///                   PropertyListT props = {});                   // (usm-ga-2)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element of the
+/// returned vector is undefined.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param mask The access mask, defaults to all 1s.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
 /// @return A vector of elements read. Elements in masked out lanes are
 ///   undefined.
-///
-template <typename Tx, int N, typename OffsetObjT, typename RegionTy>
-__ESIMD_API simd<Tx, N> gather(const Tx *p,
-                               simd_view<OffsetObjT, RegionTy> offsets,
-                               simd_mask<N> mask = 1) {
-  return gather<Tx, N>(p, offsets.read(), mask);
+template <typename T, int N, int VS, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd<OffsetT, N / VS> byte_offsets, simd_mask<N / VS> mask,
+       PropertyListT props = {}) {
+  simd<T, N> PassThru; // it is intentionally undefined
+  return gather<T, N, VS>(p, byte_offsets, mask, PassThru, props);
+}
+
+/// template <typename T, int N, int VS, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-ga-3)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
+template <typename T, int N, int VS, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd<OffsetT, N / VS> byte_offsets,
+       PropertyListT props = {}) {
+  simd<T, N> PassThru; // it is intentionally undefined
+  simd_mask<N / VS> Mask = 1;
+  return gather<T, N, VS>(p, byte_offsets, Mask, PassThru, props);
+}
+
+/// template <typename T, int N, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask, simd<T, N> pass_thru,
+///                   PropertyListT props = {});                   // (usm-ga-4)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element from
+/// \p pass_thru operand is returned.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param mask The access mask, defaults to all 1s.
+/// @param pass_thru The vector pass through values.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
+template <typename T, int N, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd<OffsetT, N> byte_offsets, simd_mask<N> mask,
+       simd<T, N> pass_thru, PropertyListT props = {}) {
+  constexpr int VS = 1;
+  return gather<T, N, VS>(p, byte_offsets, mask, pass_thru, props);
+}
+
+/// template <typename T, int N, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   simd_mask<N> mask, PropertyListT props = {});// (usm-ga-5)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element of the
+/// returned vector is undefined.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param mask The access mask, defaults to all 1s.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read. Elements in masked out lanes are
+///   undefined.
+template <typename T, int N, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd<OffsetT, N> byte_offsets, simd_mask<N> mask,
+       PropertyListT props = {}) {
+  constexpr int VS = 1;
+  return gather<T, N, VS>(p, byte_offsets, mask, props);
+}
+
+/// template <typename T, int N, typename OffsetT,
+///           typename PropertyListT = empty_properties_t>
+/// simd<T, N> gather(const T *p, simd<OffsetT, N> byte_offsets,
+///                   PropertyListT props = {});                   // (usm-ga-6)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
+template <typename T, int N, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd<OffsetT, N> byte_offsets, PropertyListT props = {}) {
+  constexpr int VS = 1;
+  return gather<T, N, VS>(p, byte_offsets, props);
+}
+
+/// template <typename T, int N, int VS = 1, typename OffsetObjT,
+///           typename OffsetRegionT, typename PropertyListT = empty_props_t>
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             simd_mask<N / VS> mask, simd<T, N> pass_thru,
+///             PropertyListT props = {});                         // (usm-ga-7)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element from
+/// \p pass_thru operand is returned.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param mask The access mask, defaults to all 1s.
+/// @param pass_thru The vector pass through values.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
+template <typename T, int N, int VS = 1, typename OffsetObjT,
+          typename OffsetRegionT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+       simd_mask<N / VS> mask, simd<T, N> pass_thru, PropertyListT props = {}) {
+  static_assert(std::is_integral_v<typename OffsetRegionT::element_type>,
+                "Unsupported offset type");
+  return gather<T, N, VS>(p, byte_offsets.read(), mask, pass_thru, props);
+}
+
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             simd_mask<N / VS> mask, PropertyListT props = {}); // (usm-ga-8)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the load from
+/// (p + byte_offsets[i]) is skipped and the corresponding i-th element of the
+/// returned vector is undefined.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param mask The access mask, defaults to all 1s.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read. Elements in masked out lanes are
+///   undefined.
+template <typename T, int N, int VS = 1, typename OffsetObjT,
+          typename OffsetRegionT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+       simd_mask<N / VS> mask, PropertyListT props = {}) {
+  return gather<T, N, VS>(p, byte_offsets.read(), mask, props);
+}
+
+/// simd <T, N> gather(const T *p,
+///             simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+///             PropertyListT props = {});                         // (usm-ga-9)
+/// Loads ("gathers") elements ov the type 'T' from memory locations addressed
+/// by the base pointer \p p and byte offsets \p byte_offsets, and returns
+/// the loaded elements.
+/// @tparam T Element type.
+/// @tparam N Number of elements to read.
+/// @tparam VS Vector size. It can also be read as the number of reads per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC.
+/// @param p The base address.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+/// @return A vector of elements read.
+template <typename T, int N, int VS = 1, typename OffsetObjT,
+          typename OffsetRegionT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+gather(const T *p, simd_view<OffsetObjT, OffsetRegionT> byte_offsets,
+       PropertyListT props = {}) {
+  return gather<T, N, VS>(p, byte_offsets.read(), props);
 }
 
 /// A variation of \c gather API with \c offsets represented as scalar.
@@ -2664,13 +3082,31 @@ __ESIMD_API void slm_init(uint32_t size) { __esimd_slm_init(size); }
 /// This API has almost the same interface as the @ref accessor_gather
 /// "accessor-based gather", except that it does not have the accessor and the
 /// global offset parameters.
-///
-template <typename T, int N>
-__ESIMD_API
-    std::enable_if_t<(N == 1 || N == 8 || N == 16 || N == 32), simd<T, N>>
-    slm_gather(simd<uint32_t, N> offsets, simd_mask<N> mask = 1) {
-  detail::LocalAccessorMarker acc;
-  return detail::gather_impl<T, N>(acc, offsets, 0, mask);
+template <typename T, int N,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+slm_gather(simd<uint32_t, N> byte_offsets, simd_mask<N> mask,
+           PropertyListT props = {}) {
+  using MsgT = detail::__raw_t<T>;
+  constexpr size_t Alignment =
+      detail::getPropertyValue<PropertyListT, alignment_key>(sizeof(T));
+  static_assert(Alignment >= sizeof(T),
+                "slm_gather() requires at least element-size alignment");
+  simd<MsgT, N> PassThru; // it is intentionally undefined
+  return __esimd_slm_gather_ld<MsgT, N, Alignment>(
+      byte_offsets.data(), mask.data(), PassThru.data());
+}
+
+template <typename T, int N,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>, simd<T, N>>
+slm_gather(simd<uint32_t, N> byte_offsets, PropertyListT props = {}) {
+  simd_mask<N> Mask = 1;
+  return slm_gather<T, N>(byte_offsets, Mask, props);
 }
 
 /// Load a scalar value from the Shared Local Memory.
@@ -3543,19 +3979,6 @@ constexpr int lsc_to_internal_atomic_op() {
   return static_cast<int>(LSCOp);
 }
 
-// Format u8u32 and u16u32 back to u8 and u16.
-template <typename T, typename T1, int N>
-ESIMD_INLINE __ESIMD_NS::simd<T, N>
-lsc_format_ret(__ESIMD_NS::simd<T1, N> Vals) {
-  auto Formatted = Vals.template bit_cast_view<T>();
-  if constexpr (sizeof(T) == sizeof(T1)) {
-    return Formatted;
-  } else {
-    constexpr int Stride = Formatted.length / N;
-    return Formatted.template select<N, Stride>(0);
-  }
-}
-
 /// SLM atomic.
 /// Supported platforms: DG2, PVC
 /// VISA instruction: lsc_atomic_<OP>.slm
@@ -3911,20 +4334,6 @@ atomic_update(AccessorT lacc, simd<uint32_t, N> byte_offset, simd<T, N> src0,
 /// @} sycl_esimd_memory_slm
 
 namespace detail {
-
-// Format u8 and u16 to u8u32 and u16u32 by doing garbage-extension.
-template <typename RT, typename T, int N>
-ESIMD_INLINE simd<RT, N> lsc_format_input(simd<T, N> Vals) {
-  if constexpr (sizeof(T) == 1) {
-    // Extend bytes to RT.
-    return Vals.template bit_cast_view<uint8_t>();
-  } else if constexpr (sizeof(T) == 2) {
-    // Extend words to RT.
-    return Vals.template bit_cast_view<uint16_t>();
-  } else {
-    return Vals.template bit_cast_view<RT>();
-  }
-}
 
 /// USM pointer atomic.
 /// Supported platforms: DG2, PVC

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -462,13 +462,7 @@ lsc_format_input(__ESIMD_NS::simd<T, N> Vals) {
 template <typename T, typename T1, int N>
 ESIMD_INLINE __ESIMD_NS::simd<T, N>
 lsc_format_ret(__ESIMD_NS::simd<T1, N> Vals) {
-  auto Formatted = Vals.template bit_cast_view<T>();
-  if constexpr (sizeof(T) == sizeof(T1)) {
-    return Formatted;
-  } else {
-    constexpr int Stride = Formatted.length / N;
-    return Formatted.template select<N, Stride>(0);
-  }
+  return __ESIMD_DNS::lsc_format_ret<T, T1, N>(Vals);
 }
 
 template <typename T> constexpr uint32_t get_lsc_data_size() {
@@ -695,24 +689,7 @@ template <typename T, int NElts = 1,
 __ESIMD_API __ESIMD_NS::simd<T, N * NElts>
 lsc_gather(const T *p, __ESIMD_NS::simd<Toffset, N> offsets,
            __ESIMD_NS::simd_mask<N> pred = 1) {
-  static_assert(std::is_integral_v<Toffset>, "Unsupported offset type");
-  detail::check_lsc_vector_size<NElts>();
-  detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_cache_hint<detail::lsc_action::load, L1H, L3H>();
-  constexpr uint16_t _AddressScale = 1;
-  constexpr int _ImmOffset = 0;
-  constexpr lsc_data_size _DS =
-      detail::expand_data_size(detail::finalize_data_size<T, DS>());
-  constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<NElts>();
-  constexpr auto _Transposed = detail::lsc_data_order::nontranspose;
-  using MsgT = typename detail::lsc_expand_type<T>::type;
-  __ESIMD_NS::simd<uintptr_t, N> addrs = reinterpret_cast<uintptr_t>(p);
-  addrs += convert<uintptr_t>(offsets);
-  __ESIMD_NS::simd<MsgT, N * NElts> Tmp =
-      __esimd_lsc_load_stateless<MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS,
-                                 _VS, _Transposed, N>(pred.data(),
-                                                      addrs.data());
-  return detail::lsc_format_ret<T>(Tmp);
+  return __ESIMD_DNS::gather_impl<T, NElts, DS, L1H, L3H>(p, offsets, pred);
 }
 
 /// USM pointer gather.
@@ -743,26 +720,8 @@ __ESIMD_API __ESIMD_NS::simd<T, N * NElts>
 lsc_gather(const T *p, __ESIMD_NS::simd<Toffset, N> offsets,
            __ESIMD_NS::simd_mask<N> pred,
            __ESIMD_NS::simd<T, N * NElts> pass_thru) {
-  static_assert(std::is_integral_v<Toffset>, "Unsupported offset type");
-  detail::check_lsc_vector_size<NElts>();
-  detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_cache_hint<detail::lsc_action::load, L1H, L3H>();
-  constexpr uint16_t _AddressScale = 1;
-  constexpr int _ImmOffset = 0;
-  constexpr lsc_data_size _DS =
-      detail::expand_data_size(detail::finalize_data_size<T, DS>());
-  constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<NElts>();
-  constexpr auto _Transposed = detail::lsc_data_order::nontranspose;
-  using MsgT = typename detail::lsc_expand_type<T>::type;
-  __ESIMD_NS::simd<uintptr_t, N> Addrs = reinterpret_cast<uintptr_t>(p);
-  Addrs += convert<uintptr_t>(offsets);
-  __ESIMD_NS::simd<MsgT, N * NElts> PassThruExpanded =
-      detail::lsc_format_input<MsgT>(pass_thru);
-  __ESIMD_NS::simd<MsgT, N * NElts> Result =
-      __esimd_lsc_load_merge_stateless<MsgT, L1H, L3H, _AddressScale,
-                                       _ImmOffset, _DS, _VS, _Transposed, N>(
-          pred.data(), Addrs.data(), PassThruExpanded.data());
-  return detail::lsc_format_ret<T>(Result);
+  return __ESIMD_DNS::gather_impl<T, NElts, DS, L1H, L3H>(p, offsets, pred,
+                                                          pass_thru);
 }
 
 template <typename T, int NElts = 1,

--- a/sycl/test-e2e/ESIMD/api/svm_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/api/svm_gather_scatter.cpp
@@ -54,7 +54,7 @@ template <typename T, int N> bool test(queue &Q) {
   T *Dst = Ptr2.get();
 
   for (int I = 0; I < N; ++I) {
-    Src[I] = I + 1;
+    Src[I] = I + 1 + 0.5;
     Dst[I] = 0;
   }
 
@@ -123,6 +123,7 @@ int main(void) {
   Pass &= test<int32_t, 16>(Q);
   Pass &= test<int32_t, 32>(Q);
 #endif
+
   if (Dev.has(aspect::fp16)) {
     Pass &= test<half, 1>(Q);
 #ifndef USE_SCALAR_OFFSET
@@ -133,7 +134,6 @@ int main(void) {
     Pass &= test<half, 32>(Q);
 #endif
   }
-
   Pass &= test<bfloat16, 1>(Q);
 #ifndef USE_SCALAR_OFFSET
   Pass &= test<bfloat16, 2>(Q);
@@ -152,7 +152,6 @@ int main(void) {
   Pass &= test<tfloat32, 32>(Q);
 #endif
 #endif
-
   std::cout << (Pass ? "Test Passed\n" : "Test FAILED\n");
   return Pass ? 0 : 1;
 }

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/gather.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/gather.hpp
@@ -1,0 +1,286 @@
+//==------------- gather.hpp - DPC++ ESIMD on-device test ------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "common.hpp"
+
+using namespace sycl;
+using namespace sycl::ext::intel::esimd;
+
+#ifdef USE_64_BIT_OFFSET
+typedef uint64_t OffsetT;
+#else
+typedef uint32_t OffsetT;
+#endif
+
+template <typename T>
+bool verify(const T *In, const T *Out, int N, int Size, int VS,
+            uint32_t MaskStride, bool UseMask, bool UsePassThru) {
+  using Tuint = esimd_test::uint_type_t<sizeof(T)>;
+  const Tuint *InI = reinterpret_cast<const Tuint *>(In);
+  const Tuint *OutI = reinterpret_cast<const Tuint *>(Out);
+
+  int NOffsets = N / VS;
+  int NumErrors = 0;
+
+  for (uint32_t I = 0; I < Size; I += N) { // Verify by 1 vector at once
+    for (int VSI = 0; VSI < VS; VSI++) {
+      for (int OffsetI = 0; OffsetI < NOffsets; OffsetI++) {
+        int Offset = OffsetI * VS;
+        Tuint ExpectedI = InI[I + Offset + VSI];
+        size_t OutIndex = I + VSI * NOffsets + OffsetI;
+        Tuint ComputedI = OutI[OutIndex];
+
+        bool IsMaskSet = UseMask ? ((OffsetI % MaskStride) == 0 ? 1 : 0) : true;
+        if (!IsMaskSet) {
+          if (!UsePassThru)
+            continue; // Value is undefined;
+          ExpectedI = OutIndex;
+        }
+
+        if (ExpectedI != ComputedI && ++NumErrors < 16) {
+          std::cerr << "Error at index=" << OutIndex
+                    << ": Expected=" << ExpectedI << ", Computed=" << ComputedI
+                    << ", IsMaskSet=" << IsMaskSet << std::endl;
+        }
+      }
+    }
+  }
+  return NumErrors == 0;
+}
+
+template <typename T, uint16_t N, uint16_t VS, bool UseMask, bool UsePassThru,
+          bool UseProperties, typename PropertiesT>
+bool testUSM(queue Q, uint32_t MaskStride, PropertiesT) {
+
+  static_assert(VS > 0 && N % VS == 0,
+                "Incorrect VS parameter. N must be divisible by VS.");
+  constexpr int NOffsets = N / VS;
+  static_assert(!UsePassThru || UseMask,
+                "PassThru cannot be used without using mask");
+
+  uint32_t Groups = 8;
+  uint32_t Threads = 16;
+
+  std::cout << "Running case: T=" << esimd_test::type_name<T>() << ", N=" << N
+            << ", VS=" << VS << ", MaskStride=" << MaskStride
+            << ", Groups=" << Groups << ", Threads=" << Threads
+            << ", use_mask=" << UseMask << ", use_pass_thru=" << UsePassThru
+            << ", use_properties=" << UseProperties << std::endl;
+
+  uint16_t Size = Groups * Threads * N;
+  using Tuint = esimd_test::uint_type_t<sizeof(T)>;
+
+  sycl::range<1> GlobalRange{Groups};
+  sycl::range<1> LocalRange{Threads};
+  sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
+
+  T *Out = sycl::malloc_shared<T>(Size, Q);
+  std::memset(Out, 0, Size * sizeof(T));
+
+  T *In = sycl::malloc_shared<T>(Size * 2, Q);
+  for (int I = 0; I < Size; I++)
+    In[I] = esimd_test::getRandomValue<T>();
+
+  try {
+    Q.parallel_for(Range, [=](sycl::nd_item<1> NDI) SYCL_ESIMD_KERNEL {
+       int GlobalID = NDI.get_global_id(0);
+       PropertiesT Props{};
+
+       simd<OffsetT, NOffsets> ByteOffsets(GlobalID * N * sizeof(T),
+                                           VS * sizeof(T));
+       simd_view ByteOffsetsView = ByteOffsets.template select<NOffsets, 1>();
+
+       simd_mask<NOffsets> Pred;
+       for (int I = 0; I < NOffsets; I++)
+         Pred[I] = (I % MaskStride == 0) ? 1 : 0;
+
+       using Tuint = esimd_test::uint_type_t<sizeof(T)>;
+       simd<Tuint, N> PassThruInt(GlobalID * N, 1);
+       simd<T, N> PassThru = PassThruInt.template bit_cast_view<T>();
+       auto PassThruView = PassThru.template select<N, 1>(0);
+
+       simd<T, N> Vals;
+       if constexpr (VS > 1) { // VS > 1 requires specifying <T, N, VS>
+         if constexpr (UsePassThru) {
+           if constexpr (UseProperties) {
+             if (GlobalID % 4 == 0) // ByteOffset - simd, PassThru - simd
+               Vals = gather<T, N, VS>(In, ByteOffsets, Pred, PassThru, Props);
+             else if (GlobalID % 4 == 1) // ByteOffset - simd, PassThru - view
+               Vals =
+                   gather<T, N, VS>(In, ByteOffsets, Pred, PassThruView, Props);
+             else if (GlobalID % 4 == 2) // ByteOffset - view, PassThru - simd
+               Vals =
+                   gather<T, N, VS>(In, ByteOffsetsView, Pred, PassThru, Props);
+             else // ByteOffset - view, PassThru - view
+               Vals = gather<T, N, VS>(In, ByteOffsetsView, Pred, PassThruView,
+                                       Props);
+           } else {                 // UseProperties is false
+             if (GlobalID % 4 == 0) // ByteOffset - simd, PassThru - simd
+               Vals = gather<T, N, VS>(In, ByteOffsets, Pred, PassThru);
+             else if (GlobalID % 4 == 1) // ByteOffset - simd, PassThru - view
+               Vals = gather<T, N, VS>(In, ByteOffsets, Pred, PassThruView);
+             else if (GlobalID % 4 == 2) // ByteOffset - view, PassThru - simd
+               Vals = gather<T, N, VS>(In, ByteOffsetsView, Pred, PassThru);
+             else // ByteOffset - view, PassThru - view
+               Vals = gather<T, N, VS>(In, ByteOffsetsView, Pred, PassThruView);
+           }
+         } else if constexpr (UseMask) { // UsePassThru is false
+           if constexpr (UseProperties) {
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather<T, N, VS>(In, ByteOffsets, Pred, Props);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N, VS>(In, ByteOffsetsView, Pred, Props);
+           } else {                 // UseProperties is false
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather<T, N, VS>(In, ByteOffsets, Pred);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N, VS>(In, ByteOffsetsView, Pred);
+           }
+         } else { // UseMask is false, UsePassThru is false
+           if constexpr (UseProperties) {
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather<T, N, VS>(In, ByteOffsets, Props);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N, VS>(In, ByteOffsetsView, Props);
+           } else {                 // UseProperties is false
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather<T, N, VS>(In, ByteOffsets);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N, VS>(In, ByteOffsetsView);
+           }
+         }
+       } else {
+         // if (VS == 1) then <T, N, VS> can often be omitted - test it here.
+         // The variants accepting simd_view for 'PassThru' operand though
+         // still require <T, N> to be specified explicitly to help
+         // C++ FE do simd to simd_view matching.
+         if constexpr (UsePassThru) {
+           if constexpr (UseProperties) {
+             if (GlobalID % 4 == 0) // ByteOffset - simd, PassThru - simd
+               Vals = gather(In, ByteOffsets, Pred, PassThru, Props);
+             else if (GlobalID % 4 == 1) // ByteOffset - simd, PassThru - view
+               Vals = gather<T, N>(In, ByteOffsets, Pred, PassThruView, Props);
+             else if (GlobalID % 4 == 2) // ByteOffset - view, PassThru - simd
+               Vals = gather(In, ByteOffsetsView, Pred, PassThru, Props);
+             else // ByteOffset - view, PassThru - view
+               Vals =
+                   gather<T, N>(In, ByteOffsetsView, Pred, PassThruView, Props);
+           } else {                 // UseProperties is false
+             if (GlobalID % 4 == 0) // ByteOffset - simd, PassThru - simd
+               Vals = gather(In, ByteOffsets, Pred, PassThru);
+             else if (GlobalID % 4 == 1) // ByteOffset - simd, PassThru - view
+               Vals = gather<T, N>(In, ByteOffsets, Pred, PassThruView);
+             else if (GlobalID % 4 == 2) // ByteOffset - view, PassThru - simd
+               Vals = gather<T, N>(In, ByteOffsetsView, Pred, PassThru);
+             else // ByteOffset - view, PassThru - view
+               Vals = gather<T, N>(In, ByteOffsetsView, Pred, PassThruView);
+           }
+         } else if constexpr (UseMask) { // UsePassThru is false
+           if constexpr (UseProperties) {
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather(In, ByteOffsets, Pred, Props);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N>(In, ByteOffsetsView, Pred, Props);
+           } else {                 // UseProperties is false
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather(In, ByteOffsets, Pred);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N>(In, ByteOffsetsView, Pred);
+           }
+         } else { // UsePassThru is false, UseMask is false
+           if constexpr (UseProperties) {
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather(In, ByteOffsets, Props);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N>(In, ByteOffsetsView, Props);
+           } else {
+             if (GlobalID % 2 == 0) // ByteOffset - simd
+               Vals = gather(In, ByteOffsets);
+             else // ByteOffset - simd_view
+               Vals = gather<T, N>(In, ByteOffsetsView);
+           }
+         }
+       } // end if (VS == 1)
+       Vals.copy_to(Out + GlobalID * N);
+       // scatter(Out, ByteOffsets.template select<NOffsets, 1>(), Vals);
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    sycl::free(In, Q);
+    sycl::free(Out, Q);
+    return false;
+  }
+
+  bool Passed = verify(In, Out, N, Size, VS, MaskStride, UseMask, UsePassThru);
+  if (!Passed)
+    std::cout << "Case FAILED" << std::endl;
+
+  sycl::free(In, Q);
+  sycl::free(Out, Q);
+  return Passed;
+}
+
+template <typename T, TestFeatures Features> bool testUSM(queue Q) {
+  constexpr bool UseMask = true;
+  constexpr bool UsePassThru = true;
+  constexpr bool UseProperties = true;
+
+  properties AlignElemProps{alignment<sizeof(T)>};
+
+  bool Passed = true;
+  Passed &= testUSM<T, 1, 1, !UseMask, !UsePassThru, !UseProperties>(
+      Q, 2, AlignElemProps);
+  Passed &= testUSM<T, 2, 1, UseMask, !UsePassThru, !UseProperties>(
+      Q, 2, AlignElemProps);
+  Passed &= testUSM<T, 4, 1, UseMask, UsePassThru, !UseProperties>(
+      Q, 2, AlignElemProps);
+  Passed &= testUSM<T, 8, 1, UseMask, UsePassThru, UseProperties>(
+      Q, 3, AlignElemProps);
+  Passed &= testUSM<T, 16, 1, UseMask, UsePassThru, UseProperties>(
+      Q, 2, AlignElemProps);
+  Passed &= testUSM<T, 32, 1, UseMask, UsePassThru, !UseProperties>(
+      Q, 3, AlignElemProps);
+
+  // TODO: test non-power-of-2 N
+  // Such cases were promised to be supported, but in fact they fail.
+  // Create some test cases here after the issue in GPU driver is resolved.
+
+  if constexpr (Features == TestFeatures::PVC ||
+                Features == TestFeatures::DG2) {
+    properties LSCProps{cache_hint_L1<cache_hint::streaming>,
+                        cache_hint_L2<cache_hint::cached>,
+                        alignment<sizeof(T)>};
+    Passed &=
+        testUSM<T, 1, 1, !UseMask, !UsePassThru, UseProperties>(Q, 2, LSCProps);
+    Passed &=
+        testUSM<T, 2, 1, UseMask, !UsePassThru, UseProperties>(Q, 2, LSCProps);
+    Passed &=
+        testUSM<T, 4, 1, UseMask, UsePassThru, UseProperties>(Q, 2, LSCProps);
+    Passed &=
+        testUSM<T, 8, 1, UseMask, UsePassThru, UseProperties>(Q, 3, LSCProps);
+
+    Passed &=
+        testUSM<T, 32, 1, UseMask, UsePassThru, UseProperties>(Q, 2, LSCProps);
+
+    // Check VS > 1. GPU supports only dwords and qwords in this mode.
+    if constexpr (sizeof(T) >= 4) {
+      // TODO: This test case causes flaky fail. Enable it after the issue
+      // in GPU driver is fixed.
+      // Passed &= testUSM<T, 16, 2, UseMask, !UsePassThru, UseProperties>(
+      //    Q, 3, AlignElemProps);
+
+      Passed &= testUSM<T, 32, 2, !UseMask, !UsePassThru, UseProperties>(
+          Q, 3, AlignElemProps);
+      Passed &= testUSM<T, 32, 2, UseMask, !UsePassThru, UseProperties>(
+          Q, 3, AlignElemProps);
+      Passed &= testUSM<T, 32, 2, UseMask, UsePassThru, UseProperties>(
+          Q, 3, AlignElemProps);
+    }
+  }
+  return Passed;
+}

--- a/sycl/test-e2e/ESIMD/unified_memory_api/gather_usm.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/gather_usm.cpp
@@ -1,0 +1,37 @@
+//==------- gather_usm.cpp - DPC++ ESIMD on-device test --------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies esimd::gather() functions accepting USM pointer
+// and optional compile-time esimd::properties.
+// The gather() calls in this test do not use cache-hint properties
+// or VS > 1 (number of loads per offset) to not impose using PVC features.
+
+#include "Inputs/gather.hpp"
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  constexpr auto TestFeatures = TestFeatures::Generic;
+  bool Passed = true;
+
+  Passed &= testUSM<int8_t, TestFeatures>(Q);
+  Passed &= testUSM<int16_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp16))
+    Passed &= testUSM<sycl::half, TestFeatures>(Q);
+  Passed &= testUSM<uint32_t, TestFeatures>(Q);
+  Passed &= testUSM<float, TestFeatures>(Q);
+  Passed &= testUSM<ext::intel::experimental::esimd::tfloat32, TestFeatures>(Q);
+  Passed &= testUSM<int64_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp64))
+    Passed &= testUSM<double, TestFeatures>(Q);
+  std::cout << (Passed ? "Passed\n" : "FAILED\n");
+  return Passed ? 0 : 1;
+}

--- a/sycl/test-e2e/ESIMD/unified_memory_api/gather_usm_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/gather_usm_pvc.cpp
@@ -1,0 +1,39 @@
+//==------- gather_usm_pvc.cpp - DPC++ ESIMD on-device test ----------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies esimd::gather() functions accepting USM pointer
+// and optional compile-time esimd::properties.
+// The gather() calls in this test use either cache-hint properties
+// or VS > 1 (number of loads per offset) and require PVC to run.
+
+#include "Inputs/gather.hpp"
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  constexpr auto TestFeatures = TestFeatures::PVC;
+  bool Passed = true;
+
+  Passed &= testUSM<int8_t, TestFeatures>(Q);
+  Passed &= testUSM<int16_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp16))
+    Passed &= testUSM<sycl::half, TestFeatures>(Q);
+  Passed &= testUSM<uint32_t, TestFeatures>(Q);
+  Passed &= testUSM<float, TestFeatures>(Q);
+  Passed &= testUSM<ext::intel::experimental::esimd::tfloat32, TestFeatures>(Q);
+  Passed &= testUSM<int64_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp64))
+    Passed &= testUSM<double, TestFeatures>(Q);
+
+  std::cout << (Passed ? "Passed\n" : "FAILED\n");
+  return Passed ? 0 : 1;
+}

--- a/sycl/test/esimd/memory_properties.cpp
+++ b/sycl/test/esimd/memory_properties.cpp
@@ -30,6 +30,10 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void
 test_block_store(AccType &, LocalAccType &local_acc, float *, int byte_offset32,
                  size_t byte_offset64);
 
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void
+test_gather_scatter(AccType &, float *, int byte_offset32,
+                    size_t byte_offset64);
+
 class EsimdFunctor {
 public:
   AccType acc;
@@ -42,6 +46,7 @@ public:
     test_block_load(acc, local_acc, ptr, byte_offset32, byte_offset64);
     test_atomic_update(acc, local_acc_int, ptr, byte_offset32, byte_offset64);
     test_block_store(acc, local_acc, ptr, byte_offset32, byte_offset64);
+    test_gather_scatter(acc, ptr, byte_offset32, byte_offset64);
   }
 };
 
@@ -927,4 +932,90 @@ test_block_store(AccType &acc, LocalAccType &local_acc, float *ptrf,
   // CHECK-COUNT-2: call void @llvm.genx.lsc.store.slm.v1i1.v1i32.v4i32(<1 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 4, i8 2, i8 0, <1 x i32> {{[^)]+}}, <4 x i32> {{[^)]+}}, i32 0)
   block_store<int, N>(local_acc, byte_offset32, valsi, mask, store_props_c);
   block_store<int, N>(local_acc, byte_offset32, viewi, mask, store_props_c);
+}
+
+// CHECK-LABEL: define {{.*}} @_Z19test_gather_scatter{{.*}}
+SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void
+test_gather_scatter(AccType &acc, float *ptrf, int byte_offset32,
+                    size_t byte_offset64) {
+  properties props_cache_load{cache_hint_L1<cache_hint::uncached>,
+                              cache_hint_L2<cache_hint::uncached>,
+                              alignment<8>};
+
+  properties props_align4{alignment<4>};
+  properties props_align8{alignment<8>};
+  properties props_align16{alignment<16>};
+
+  int *ptri = reinterpret_cast<int *>(ptrf);
+
+  simd<uint32_t, 32> ioffset_n32(byte_offset32, 8);
+  simd<uint64_t, 32> loffset_n32(byte_offset64, 16);
+  auto ioffset_n32_view = ioffset_n32.select<32, 1>();
+  auto loffset_n32_view = loffset_n32.select<32, 1>();
+
+  simd<uint32_t, 16> ioffset_n16(byte_offset32, 8);
+  simd<uint64_t, 16> loffset_n16(byte_offset64, 16);
+  auto ioffset_n16_view = ioffset_n16.select<16, 1>();
+  auto loffset_n16_view = loffset_n16.select<16, 1>();
+
+  simd_mask<32> mask_n32 = 1;
+  simd_mask<16> mask_n16 = 1;
+
+  simd<float, 32> usm;
+
+  // CHECK-COUNT-4: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
+  usm = gather(ptrf, ioffset_n32);
+  usm = gather<float, 32>(ptrf, ioffset_n32_view);
+
+  usm = gather(ptrf, loffset_n32);
+  usm = gather<float, 32>(ptrf, loffset_n32_view);
+
+  // CHECK-COUNT-4: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
+  usm = gather(ptrf, ioffset_n32, props_align8);
+  usm = gather<float, 32>(ptrf, ioffset_n32_view, props_align8);
+
+  usm = gather(ptrf, loffset_n32, props_align8);
+  usm = gather<float, 32>(ptrf, loffset_n32_view, props_align8);
+
+  // Same as above, but with 'mask' operand.
+  // CHECK-COUNT-4: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
+  usm = gather(ptrf, ioffset_n32, mask_n32);
+  usm = gather<float, 32>(ptrf, ioffset_n32_view, mask_n32);
+
+  usm = gather(ptrf, loffset_n32, mask_n32);
+  usm = gather<float, 32>(ptrf, loffset_n32_view, mask_n32);
+
+  // CHECK-COUNT-4: call <32 x float> @llvm.masked.gather.v32f32.v32p4(<32 x ptr addrspace(4)> {{[^)]+}}, i32 8, <32 x i1> {{[^)]+}}, <32 x float> {{[^)]+}})
+  usm = gather(ptrf, ioffset_n32, mask_n32, props_align8);
+  usm = gather<float, 32>(ptrf, ioffset_n32_view, mask_n32, props_align8);
+
+  usm = gather(ptrf, loffset_n32, mask_n32, props_align8);
+  usm = gather<float, 32>(ptrf, loffset_n32_view, mask_n32, props_align8);
+
+  // CHECK-COUNT-16: call <32 x i32> @llvm.genx.lsc.load.merge.stateless.v32i32.v16i1.v16i64(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, i32 0, <32 x i32> {{[^)]+}})
+  // check VS > 1. no 'mask' operand first.
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16);
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16_view);
+
+  usm = gather<float, 32, 2>(ptrf, loffset_n16);
+  usm = gather<float, 32, 2>(ptrf, loffset_n16_view);
+
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16, props_align4);
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16_view, props_align4);
+
+  usm = gather<float, 32, 2>(ptrf, loffset_n16, props_align4);
+  usm = gather<float, 32, 2>(ptrf, loffset_n16_view, props_align4);
+
+  // check VS > 1. Pass the 'mask' operand this time.
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16, mask_n16);
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16_view, mask_n16);
+
+  usm = gather<float, 32, 2>(ptrf, loffset_n16, mask_n16);
+  usm = gather<float, 32, 2>(ptrf, loffset_n16_view, mask_n16);
+
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16, mask_n16, props_align4);
+  usm = gather<float, 32, 2>(ptrf, ioffset_n16_view, mask_n16, props_align4);
+
+  usm = gather<float, 32, 2>(ptrf, loffset_n16, mask_n16, props_align4);
+  usm = gather<float, 32, 2>(ptrf, loffset_n16_view, mask_n16, props_align4);
 }


### PR DESCRIPTION
This patch also supports gather and masked-gather of any length N if it does not use L1/L2 hints of VS>1.

Additionally for gathers without L1/L2 vs VS>1 this patch uses LLVM IR instead of GenX SVM gather calls.