### PR TITLE
[SYCL][ESIMD][E2E] Fix Arc postcommit

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc.cpp
@@ -6,7 +6,7 @@
 //
 //==----------------------------------------------------------==//
 // TODO: Enable after driver bug is fixed
-// XFAIL: gpu-intel-dg2
+// UNSUPPORTED: gpu-intel-dg2
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc_dg2.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc_dg2.cpp
@@ -6,7 +6,7 @@
 //
 //==------------------------------------------------------------==//
 // TODO: Enable after driver bug is fixed
-// XFAIL: *
+// UNSUPPORTED: gpu-intel-dg2
 
 // REQUIRES: gpu-intel-dg2
 


### PR DESCRIPTION
The tests will fail if they actually run, but the driver used in CI is old enough to hit the runtime driver check so they return as passed before actually doing anything. Just mark them as unsupported for now to simplify things. We already have an internal tracker for the root issue.