### PR TITLE
[Driver][SYCL][clang-linker-wrapper] Fix sycl device library arguments

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10692,7 +10692,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
 
   // Add any SYCL offloading specific options to the clang-linker-wrapper
   if (C.hasOffloadToolChain<Action::OFK_SYCL>()) {
-    // --sycl-device-libraries=<comma separated list> contains all of the SYCL
+    // -sycl-device-libraries=<comma separated list> contains all of the SYCL
     // device specific libraries that are needed.  This provides the list of
     // files file only.
     // TODO: This generic list will be populated with only device binaries
@@ -10720,14 +10720,14 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
         LibList += ",";
       LibList += AddLib;
     }
-    // --sycl-device-libraries=<libs> provides a comma separate list of
+    // -sycl-device-libraries=<libs> provides a comma separate list of
     // libraries to add to the device linking step.
     // SYCL device libraries can be found.
     if (LibList.size())
       CmdArgs.push_back(
-          Args.MakeArgString(Twine("--sycl-device-libraries=") + LibList));
+          Args.MakeArgString(Twine("-sycl-device-libraries=") + LibList));
 
-    // --sycl-device-library-location=<dir> provides the location in which the
+    // -sycl-device-library-location=<dir> provides the location in which the
     // SYCL device libraries can be found.
     SmallString<128> DeviceLibDir(D.Dir);
     llvm::sys::path::append(DeviceLibDir, "..", "lib");
@@ -10749,7 +10749,7 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       }
     }
     CmdArgs.push_back(Args.MakeArgString(
-        Twine("--sycl-device-library-location=") + DeviceLibDir));
+        Twine("-sycl-device-library-location=") + DeviceLibDir));
   }
 
   auto appendOption = [](SmallString<128> &OptString, StringRef AddOpt) {

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -38,8 +38,8 @@
 // RUN:          --sysroot=%S/Inputs/SYCL -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS %s
 // WRAPPER_OPTIONS: clang-linker-wrapper{{.*}} "--triple=spir64"
-// WRAPPER_OPTIONS-SAME: "--sycl-device-libraries=libsycl-crt.o,libsycl-complex.o,libsycl-complex-fp64.o,libsycl-cmath.o,libsycl-cmath-fp64.o,libsycl-imf.o,libsycl-imf-fp64.o,libsycl-imf-bf16.o,libsycl-itt-user-wrappers.o,libsycl-itt-compiler-wrappers.o,libsycl-itt-stubs.o"
-// WRAPPER_OPTIONS-SAME: "--sycl-device-library-location={{.*}}/lib"
+// WRAPPER_OPTIONS-SAME: "-sycl-device-libraries=libsycl-crt.o,libsycl-complex.o,libsycl-complex-fp64.o,libsycl-cmath.o,libsycl-cmath-fp64.o,libsycl-imf.o,libsycl-imf-fp64.o,libsycl-imf-bf16.o,libsycl-itt-user-wrappers.o,libsycl-itt-compiler-wrappers.o,libsycl-itt-stubs.o"
+// WRAPPER_OPTIONS-SAME: "-sycl-device-library-location={{.*}}/lib"
 
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
 // RUN:          -Xspirv-translator -translator-opt -### %s 2>&1 \


### PR DESCRIPTION
Right now we use `--`, but in `clang-linker-wrapper` we use the clang Arg infrastructure to match them, and that requires `-`.

At least for me every invocation of SYCL with the new offload model hits this problem. After this, at least `clang-linker-wrapper` gets further and we get some `sycl-post-link` error which I'll look at next.