### PR TITLE
[SYCL][E2E] Mark get_backend.cpp as XFAIL on DG2

### DIFF
--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,3 +1,5 @@
+// Failing due to old driver
+// XFAIL: gpu-intel-dg2
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 //


### PR DESCRIPTION
It seems to fail always as reported in the below bug.

Just XFAIL it for now until we get a new driver, I locally reproduced the issue with the current syclos driver and saw it passing with a newer driver.

Closes: https://github.com/intel/llvm/issues/12117