### PR TITLE
[Driver][SYCL] Fix issue with coverage and profile options for device

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1088,7 +1088,8 @@ SYCLToolChain::TranslateArgs(const llvm::opt::DerivedArgList &Args,
     bool Unsupported = false;
     for (OptSpecifier UnsupportedOpt : getUnsupportedOpts()) {
       if (Opt.matches(UnsupportedOpt)) {
-        if (A->getValues().size() == 1) {
+        if (Opt.getID() == options::OPT_fsanitize_EQ &&
+            A->getValues().size() == 1) {
           std::string SanitizeVal = A->getValue();
           if (SanitizeVal == "address") {
             if (IsNewDAL)

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -35,6 +35,12 @@
 // RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 // RUN: %clangxx -fsycl -forder-file-instrumentation -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-forder-file-instrumentation
+// Check to make sure our '-fsanitize=address' exception isn't triggered by a
+// different option
+// RUN: %clangxx -fsycl -fprofile-instr-generate=address -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-fprofile-instr-generate=address \
+// RUN:    -DOPT_CC1=-fprofile-instrument=clang \
+// RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 
 // CHECK: ignoring '[[OPT]]' option as it is not currently supported for target '[[ARCH]]{{.*}}' [-Woption-ignored]
 // CHECK-NOT: clang{{.*}} "-fsycl-is-device"{{.*}} "[[OPT]]{{.*}}"


### PR DESCRIPTION
The changes which prevent coverage and profile options from being used for device compilations had a problem with -fsanitize=address logic.  We were allowing _any_ option that happened to have 'address' as an argument as a legal pass through.  Adjust this exception to be specific to -fsanitize.