### PR TITLE
[SYCL][E2E] Move XFAIL to driver check in get_backend.cpp

### DIFF
--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,5 +1,5 @@
 // Failing due to old driver
-// XFAIL: gpu-intel-dg2
+// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 //


### PR DESCRIPTION
It passes with a newer driver so just check for that.