### PR TITLE
[SYCL][NFC] Remove item dependency on reduction.

### DIFF
--- a/sycl/include/sycl/detail/reduction_forward.hpp
+++ b/sycl/include/sycl/detail/reduction_forward.hpp
@@ -9,8 +9,9 @@
 #pragma once
 
 #include <sycl/detail/item_base.hpp> // for range
+#include <sycl/detail/helpers.hpp>   // for Builder
 #include <sycl/id.hpp>               // for id
-#include <sycl/item.hpp>             // for getDelinearizedItem, item
+#include <sycl/item.hpp>             // for item
 #include <sycl/nd_range.hpp>         // for nd_range
 #include <sycl/range.hpp>            // for range
 
@@ -51,7 +52,7 @@ template <class FunctorTy> void withAuxHandler(handler &CGH, FunctorTy Func);
 
 template <int Dims>
 item<Dims, false> getDelinearizedItem(range<Dims> Range, id<Dims> Id) {
-  return {Range, Id};
+  return Builder::createItem<Dims,false>(Range, Id);
 }
 } // namespace reduction
 

--- a/sycl/include/sycl/item.hpp
+++ b/sycl/include/sycl/item.hpp
@@ -21,17 +21,13 @@
 
 namespace sycl {
 inline namespace _V1 {
+
 namespace detail {
 class Builder;
 template <typename TransformedArgType, int Dims, typename KernelType>
 class RoundedRangeKernel;
 template <typename TransformedArgType, int Dims, typename KernelType>
 class RoundedRangeKernelWithKH;
-
-namespace reduction {
-template <int Dims>
-item<Dims, false> getDelinearizedItem(range<Dims> Range, id<Dims> Id);
-} // namespace reduction
 } // namespace detail
 
 /// Identifies an instance of the function object executing at each point
@@ -133,10 +129,6 @@ protected:
   friend class detail::Builder;
 
 private:
-  template <int Dims>
-  friend item<Dims, false>
-  detail::reduction::getDelinearizedItem(range<Dims> Range, id<Dims> Id);
-
   detail::ItemBase<Dimensions, with_offset> MImpl;
 };
 


### PR DESCRIPTION
Use Builder::createItem help function to create `item` object instead of
adding one helper function in reduction namespace.
