### PR TITLE
[SYCL][Graph] Change property test to unsupported on CUDA

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
@@ -5,10 +5,8 @@
 //
 // CHECK-NOT: LEAK
 
-// Temporarily disabled for CUDA.
-// XFAIL: cuda
-// Note: failing negative test with HIP in the original test
-// TODO: disable hip when HIP backend will be supported by Graph
+// Note: failing negative test with CUDA & HIP in the original test
+// UNSUPPORTED: cuda, hip
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
@@ -5,11 +5,8 @@
 //
 // CHECK-NOT: LEAK
 
-// Temporarily disabled for CUDA.
-// XFAIL: cuda
-
-// Note: failing negative test with HIP in the original test
-// TODO: disable hip when HIP backend will be supported by Graph
+// Note: failing negative test with CUDA & HIP in the original test
+// UNSUPPORTED: cuda, hip
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
The CI E2E tests are failing because these tests are passing rather than expectedly failing

* UR nightly CI - https://github.com/oneapi-src/unified-runtime/actions/runs/7160854862/job/19495692574
* intel/llvm CI - https://github.com/intel/llvm/actions/runs/7168248741/job/19516014849

Change the tests to be skipped rather than XFAIL while we investigate