### PR TITLE
[SYCL] Fix device handling during interop L0 context creation

### DIFF
--- a/sycl/source/backend/level_zero.cpp
+++ b/sycl/source/backend/level_zero.cpp
@@ -55,8 +55,9 @@ __SYCL_EXPORT context make_context(const std::vector<device> &DeviceList,
       NativeHandle, DeviceHandles.size(), DeviceHandles.data(), !KeepOwnership,
       &PiContext);
   // Construct the SYCL context from PI context.
-  return detail::createSyclObjFromImpl<context>(std::make_shared<context_impl>(
-      PiContext, detail::defaultAsyncHandler, Plugin, !KeepOwnership));
+  return detail::createSyclObjFromImpl<context>(
+      std::make_shared<context_impl>(PiContext, detail::defaultAsyncHandler,
+                                     Plugin, DeviceList, !KeepOwnership));
 }
 
 //----------------------------------------------------------------------------

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -71,6 +71,7 @@ public:
   /// transferred to runtime
   context_impl(sycl::detail::pi::PiContext PiContext,
                async_handler AsyncHandler, const PluginPtr &Plugin,
+               const std::vector<sycl::device> &DeviceList = {},
                bool OwnedByRuntime = true);
 
   ~context_impl();

--- a/sycl/test-e2e/Basic/interop/ze_context_device.cpp
+++ b/sycl/test-e2e/Basic/interop/ze_context_device.cpp
@@ -1,0 +1,60 @@
+// REQUIRES: level_zero, level_zero_dev_kit
+// RUN: %{build} -o %t.out %level_zero_options
+// RUN: %{run} %t.out
+
+// This test checks that an interop Level Zero device is properly handled during
+// interop context construction.
+#include <sycl/ext/oneapi/backend/level_zero.hpp>
+#include <sycl/sycl.hpp>
+
+#include <level_zero/ze_api.h>
+
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+int main(int argc, char *argv[]) {
+  int level0DriverIndex = 0;
+  int level0DeviceIndex = 0;
+
+  zeInit(0);
+  uint32_t level0NumDrivers = 0;
+  zeDriverGet(&level0NumDrivers, nullptr);
+
+  assert(level0NumDrivers > 0);
+
+  std::vector<ze_driver_handle_t> level0Drivers(level0NumDrivers);
+  zeDriverGet(&level0NumDrivers, level0Drivers.data());
+
+  ze_driver_handle_t level0Driver = level0Drivers[level0DriverIndex];
+  uint32_t level0NumDevices = 0;
+  zeDeviceGet(level0Driver, &level0NumDevices, nullptr);
+
+  assert(level0NumDevices > 0);
+
+  std::vector<ze_device_handle_t> level0Devices(level0NumDevices);
+  zeDeviceGet(level0Driver, &level0NumDevices, level0Devices.data());
+
+  ze_device_handle_t level0Device = level0Devices[level0DeviceIndex];
+  ze_context_handle_t level0Context = nullptr;
+  ze_context_desc_t level0ContextDesc = {};
+  level0ContextDesc.stype = ZE_STRUCTURE_TYPE_CONTEXT_DESC;
+  zeContextCreateEx(level0Driver, &level0ContextDesc, 1, &level0Device,
+                    &level0Context);
+
+  sycl::device dev;
+  sycl::device interopDev =
+      sycl::make_device<sycl::backend::ext_oneapi_level_zero>(level0Device);
+  sycl::context interopCtx =
+      sycl::make_context<sycl::backend::ext_oneapi_level_zero>(
+          {level0Context,
+           {interopDev},
+           sycl::ext::oneapi::level_zero::ownership::keep});
+
+  assert(interopCtx.get_devices().size() == 1);
+  assert(interopCtx.get_devices()[0] == interopDev);
+  sycl::queue q{interopCtx, interopDev};
+
+  zeContextDestroy(level0Context);
+  return 0;
+}


### PR DESCRIPTION
The Level Zero make_context accepts a vector of SYCL devices. Those devices were not being propagated to the created context, which led to an error during queue creation.

This patch fixes the problem by forwarding those devices to the context constructor.