### PR TITLE
[SYCL][E2E] Enable string_test.cpp on DG2

### DIFF
--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -8,9 +8,6 @@
 // FIXME: enable opaque pointers support on CPU.
 // UNSUPPORTED: cpu
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #include <cassert>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
It's passing now so the XFAIL is causing every postcommit run to fail.