### PR TITLE
[SYCL][E2E] Fix floating point division precision test on MSVC

### DIFF
--- a/sycl/test-e2e/Basic/float_division_precise.cpp
+++ b/sycl/test-e2e/Basic/float_division_precise.cpp
@@ -1,4 +1,6 @@
-// RUN: %{build} -ffp-model=precise -o %t.out
+// DEFINE: %{preciseflag} = %if cl_options %{/fp:precise%} %else %{-ffp-model=precise%}
+
+// RUN: %{build} %{preciseflag} -o %t.out
 // RUN: %{run} %t.out
 
 // Tests that -ffp-model=precise causes floating point division to be the same


### PR DESCRIPTION
This commit fixes the flag passed to the compiler when using the MSVC-compatible compiler options.