### PR TITLE
[SYCL][Graph] Kernel property bugfix

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -724,11 +724,6 @@ void exec_graph_impl::createCommandBuffers(
 }
 
 exec_graph_impl::~exec_graph_impl() {
-  WriteLock LockImpl(MGraphImpl->MMutex);
-
-  // clear all recording queue if not done before (no call to end_recording)
-  MGraphImpl->clearQueues();
-
   const sycl::detail::PluginPtr &Plugin =
       sycl::detail::getSyclObjImpl(MContext)->getPlugin();
   MSchedule.clear();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2488,8 +2488,9 @@ pi_int32 enqueueImpCommandBufferKernel(
   }
 
   if (Res != pi_result::PI_SUCCESS) {
-    throw sycl::exception(errc::invalid,
-                          "Failed to add kernel to PI command-buffer");
+    const device_impl &DeviceImplem = *(DeviceImpl);
+    detail::enqueue_kernel_launch::handleErrorOrWarning(Res, DeviceImplem,
+                                                        PiKernel, NDRDesc);
   }
 
   return Res;

--- a/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
@@ -5,8 +5,10 @@
 //
 // CHECK-NOT: LEAK
 
-// Note: failing negative test with CUDA & HIP in the original test
-// UNSUPPORTED: cuda, hip
+// Temporarily disabled for CUDA.
+// XFAIL: cuda
+// Note: failing negative test with HIP in the original test
+// TODO: disable hip when HIP backend will be supported by Graph
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Inputs/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Inputs/work_group_size_prop.cpp
@@ -85,8 +85,6 @@ int test(queue &Queue, PropertiesT Props, KernelType KernelFunc) {
     return 1;
   }
 
-  return 0;
-
   // Negative test case: Specify local size that does not match required size.
   exp_ext::command_graph GraphN{Queue.get_context(), Queue.get_device()};
   try {

--- a/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
@@ -5,8 +5,10 @@
 //
 // CHECK-NOT: LEAK
 
-// Note: failing negative test with CUDA & HIP in the original test
-// UNSUPPORTED: cuda, hip
+// Temporarily disabled for CUDA.
+// XFAIL: cuda
+// Note: failing negative test with HIP in the original test
+// TODO: disable hip when HIP backend will be supported by Graph
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
Fixes kernel property tests.
Improves PI exception messages.
Removes queue clearing in the executable graph destructor as this is already done by the modifiable graph destructor.
Fixes the temporary disabling of kernel prop test performed by https://github.com/intel/llvm/pull/12137