### PR TITLE
[SYCL][E2E] Enable string_test on DG2

### DIFF
--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -8,9 +8,6 @@
 // FIXME: enable opaque pointers support on CPU.
 // UNSUPPORTED: cpu
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 #include <cassert>
 #include <cstdint>
 #include <cstring>


### PR DESCRIPTION
string_test.cpp has started passing on DG2. This commit reenables the test.