### PR TITLE
[SYCL][E2E] Remove Basic/query_emulate_subdevice.cpp

### DIFF
--- a/sycl/test-e2e/Basic/query_emulate_subdevice.cpp
+++ b/sycl/test-e2e/Basic/query_emulate_subdevice.cpp
@@ -1,9 +1,0 @@
-// RUN: %{build} -o %t.out
-// RUN: env CreateMultipleSubDevices=2 EnableTimestampPacket=1 \
-// RUN: NEOReadDebugKeys=1 ONEAPI_DEVICE_SELECTOR="*:gpu" %{run-unfiltered-devices} %t.out
-
-// UNSUPPORTED: gpu-intel-dg1
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero
-
-#include "query.hpp"


### PR DESCRIPTION
Remove outdated and unstable test Basic/query_emulate_subdevice.cpp. It uses untested, unsupported and partially working debug features of NEO RT. Instead, Basic/query.cpp is using to query real subdevices of discrete graphics cards.