### PR TITLE
[SYCL] compute kernel hash only once

### DIFF
--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -236,7 +236,7 @@ private:
 struct SYCLKernelInfo {
 
   std::string Name;
-  std::size_t KenelNameStringHash;
+  std::size_t KernelNameStringHash;
   SYCLArgumentDescriptor Args;
 
   AttributeList Attributes;
@@ -249,10 +249,10 @@ struct SYCLKernelInfo {
   SYCLKernelInfo() : Name{}, Args{}, Attributes{}, NDR{}, BinaryInfo{} {}
 
   SYCLKernelInfo(const std::string &KernelName,
-                 std::size_t &KenelNameStringHash,
+                 std::size_t &KernelNameStringHash,
                  const SYCLArgumentDescriptor &ArgDesc, const NDRange &NDR,
                  const SYCLKernelBinaryInfo &BinInfo)
-      : Name{KernelName}, KenelNameStringHash{KenelNameStringHash},
+      : Name{KernelName}, KernelNameStringHash{KernelNameStringHash},
         Args{ArgDesc}, Attributes{}, NDR{NDR}, BinaryInfo{BinInfo} {}
 
   explicit SYCLKernelInfo(const std::string &KernelName)

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -236,7 +236,7 @@ private:
 struct SYCLKernelInfo {
 
   std::string Name;
-
+  std::size_t KenelNameStringHash;
   SYCLArgumentDescriptor Args;
 
   AttributeList Attributes;
@@ -249,10 +249,11 @@ struct SYCLKernelInfo {
   SYCLKernelInfo() : Name{}, Args{}, Attributes{}, NDR{}, BinaryInfo{} {}
 
   SYCLKernelInfo(const std::string &KernelName,
+                 std::size_t &KenelNameStringHash,
                  const SYCLArgumentDescriptor &ArgDesc, const NDRange &NDR,
                  const SYCLKernelBinaryInfo &BinInfo)
-      : Name{KernelName}, Args{ArgDesc}, Attributes{}, NDR{NDR}, BinaryInfo{
-                                                                     BinInfo} {}
+      : Name{KernelName}, KenelNameStringHash{KenelNameStringHash},
+        Args{ArgDesc}, Attributes{}, NDR{NDR}, BinaryInfo{BinInfo} {}
 
   explicit SYCLKernelInfo(const std::string &KernelName)
       : Name{KernelName}, Args{}, Attributes{}, NDR{}, BinaryInfo{} {}

--- a/sycl/include/sycl/detail/cg.hpp
+++ b/sycl/include/sycl/detail/cg.hpp
@@ -169,7 +169,7 @@ public:
   std::shared_ptr<detail::kernel_bundle_impl> MKernelBundle;
   std::vector<ArgDesc> MArgs;
   std::string MKernelName;
-  std::size_t MKenelNameStringHash;
+  std::size_t MKernelNameStringHash;
   std::vector<std::shared_ptr<detail::stream_impl>> MStreams;
   std::vector<std::shared_ptr<const void>> MAuxiliaryResources;
   sycl::detail::pi::PiKernelCacheConfig MKernelCacheConfig;
@@ -178,7 +178,7 @@ public:
                std::shared_ptr<detail::kernel_impl> SyclKernel,
                std::shared_ptr<detail::kernel_bundle_impl> KernelBundle,
                CG::StorageInitHelper CGData, std::vector<ArgDesc> Args,
-               std::string KernelName, std::size_t KenelNameStringHash,
+               std::string KernelName, std::size_t KernelNameStringHash,
                std::vector<std::shared_ptr<detail::stream_impl>> Streams,
                std::vector<std::shared_ptr<const void>> AuxiliaryResources,
                CGTYPE Type,
@@ -189,7 +189,7 @@ public:
         MSyclKernel(std::move(SyclKernel)),
         MKernelBundle(std::move(KernelBundle)), MArgs(std::move(Args)),
         MKernelName(std::move(KernelName)),
-        MKenelNameStringHash(std::move(KenelNameStringHash)),
+        MKernelNameStringHash(std::move(KernelNameStringHash)),
         MStreams(std::move(Streams)),
         MAuxiliaryResources(std::move(AuxiliaryResources)),
         MKernelCacheConfig(std::move(KernelCacheConfig)) {
@@ -200,7 +200,7 @@ public:
 
   std::vector<ArgDesc> getArguments() const { return MArgs; }
   std::string getKernelName() const { return MKernelName; }
-  std::size_t getKenelNameStringHash() { return MKenelNameStringHash; }
+  std::size_t getKernelNameStringHash() { return MKernelNameStringHash; }
 
   std::vector<std::shared_ptr<detail::stream_impl>> getStreams() const {
     return MStreams;

--- a/sycl/include/sycl/detail/cg.hpp
+++ b/sycl/include/sycl/detail/cg.hpp
@@ -169,6 +169,7 @@ public:
   std::shared_ptr<detail::kernel_bundle_impl> MKernelBundle;
   std::vector<ArgDesc> MArgs;
   std::string MKernelName;
+  std::size_t MKenelNameStringHash;
   std::vector<std::shared_ptr<detail::stream_impl>> MStreams;
   std::vector<std::shared_ptr<const void>> MAuxiliaryResources;
   sycl::detail::pi::PiKernelCacheConfig MKernelCacheConfig;
@@ -177,7 +178,7 @@ public:
                std::shared_ptr<detail::kernel_impl> SyclKernel,
                std::shared_ptr<detail::kernel_bundle_impl> KernelBundle,
                CG::StorageInitHelper CGData, std::vector<ArgDesc> Args,
-               std::string KernelName,
+               std::string KernelName, std::size_t KenelNameStringHash,
                std::vector<std::shared_ptr<detail::stream_impl>> Streams,
                std::vector<std::shared_ptr<const void>> AuxiliaryResources,
                CGTYPE Type,
@@ -187,7 +188,9 @@ public:
         MNDRDesc(std::move(NDRDesc)), MHostKernel(std::move(HKernel)),
         MSyclKernel(std::move(SyclKernel)),
         MKernelBundle(std::move(KernelBundle)), MArgs(std::move(Args)),
-        MKernelName(std::move(KernelName)), MStreams(std::move(Streams)),
+        MKernelName(std::move(KernelName)),
+        MKenelNameStringHash(std::move(KenelNameStringHash)),
+        MStreams(std::move(Streams)),
         MAuxiliaryResources(std::move(AuxiliaryResources)),
         MKernelCacheConfig(std::move(KernelCacheConfig)) {
     assert(getType() == Kernel && "Wrong type of exec kernel CG.");
@@ -197,6 +200,8 @@ public:
 
   std::vector<ArgDesc> getArguments() const { return MArgs; }
   std::string getKernelName() const { return MKernelName; }
+  std::size_t getKenelNameStringHash() { return MKenelNameStringHash; }
+
   std::vector<std::shared_ptr<detail::stream_impl>> getStreams() const {
     return MStreams;
   }

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -3369,7 +3369,6 @@ private:
   // Make stream class friend to be able to keep the list of associated streams
   friend class stream;
   friend class detail::stream_impl;
-
   // Make reduction friends to store buffers and arrays created for it
   // in handler from reduction methods.
   template <typename T, class BinaryOperation, int Dims, size_t Extent,

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1830,7 +1830,7 @@ public:
                KernelBundleImplPtr)
         .get_specialization_constant<SpecName>();
   }
-  std::size_t getKenelNameStringHash() { return MKernelNameStringHash; }
+  std::size_t getKernelNameStringHash() { return MKernelNameStringHash; }
   void
   use_kernel_bundle(const kernel_bundle<bundle_state::executable> &ExecBundle);
 

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -908,7 +908,7 @@ private:
                                    KI::isESIMD());
       MKernelName = KI::getName();
       using NameT =
-        typename detail::get_kernel_name_t<KernelName, KernelType>::name;
+          typename detail::get_kernel_name_t<KernelName, KernelType>::name;
       MKenelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
     } else {
       // In case w/o the integration header it is necessary to process

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -909,7 +909,7 @@ private:
       MKernelName = KI::getName();
       using NameT =
           typename detail::get_kernel_name_t<KernelName, KernelType>::name;
-      MKenelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
+      MKernelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
     } else {
       // In case w/o the integration header it is necessary to process
       // accessors from the list(which are associated with this handler) as
@@ -1830,7 +1830,7 @@ public:
                KernelBundleImplPtr)
         .get_specialization_constant<SpecName>();
   }
-  std::size_t getKenelNameStringHash() { return MKenelNameStringHash; }
+  std::size_t getKenelNameStringHash() { return MKernelNameStringHash; }
   void
   use_kernel_bundle(const kernel_bundle<bundle_state::executable> &ExecBundle);
 
@@ -2129,7 +2129,7 @@ public:
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
-      MKenelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
+      MKernelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
     } else
       StoreLambda<NameT, KernelType, /*Dims*/ 1, void>(std::move(KernelFunc));
 #else
@@ -2166,7 +2166,7 @@ public:
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
-      MKenelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
+      MKernelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
     } else
       StoreLambda<NameT, KernelType, Dims, LambdaArgType>(
           std::move(KernelFunc));
@@ -2206,7 +2206,7 @@ public:
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
-      MKenelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
+      MKernelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
     } else
       StoreLambda<NameT, KernelType, Dims, LambdaArgType>(
           std::move(KernelFunc));
@@ -2245,7 +2245,7 @@ public:
     if (!MIsHost && !lambdaAndKernelHaveEqualName<NameT>()) {
       extractArgsAndReqs();
       MKernelName = getKernelName();
-      MKenelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
+      MKernelNameStringHash = KernelNameHash<NameT>::get(MKernelName);
     } else
       StoreLambda<NameT, KernelType, Dims, LambdaArgType>(
           std::move(KernelFunc));
@@ -3314,7 +3314,7 @@ private:
   /// Struct that encodes global size, local size, ...
   detail::NDRDescT MNDRDesc;
   std::string MKernelName;
-  std::size_t MKenelNameStringHash;
+  std::size_t MKernelNameStringHash;
   /// Storage for a sycl::kernel object.
   std::shared_ptr<detail::kernel_impl> MKernel;
   /// Type of the command group, e.g. kernel, fill. Can also encode version.

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -876,7 +876,7 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
           auto OutEvent = CreateNewEvent();
           pi_int32 Res = sycl::detail::enqueueImpKernel(
               Queue, CG->MNDRDesc, CG->MArgs, CG->MKernelBundle,
-              CG->MSyclKernel, CG->MKernelName, CG->MKenelNameStringHash,
+              CG->MSyclKernel, CG->MKernelName, CG->MKernelNameStringHash,
               RawEvents, OutEvent,
               // TODO: Pass accessor mem allocations
               nullptr,

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -876,7 +876,8 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
           auto OutEvent = CreateNewEvent();
           pi_int32 Res = sycl::detail::enqueueImpKernel(
               Queue, CG->MNDRDesc, CG->MArgs, CG->MKernelBundle,
-              CG->MSyclKernel, CG->MKernelName, RawEvents, OutEvent,
+              CG->MSyclKernel, CG->MKernelName, CG->MKenelNameStringHash,
+              RawEvents, OutEvent,
               // TODO: Pass accessor mem allocations
               nullptr,
               // TODO: Extract from handler

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -749,8 +749,8 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
         SYCLTypeToIndices(CurrentNDR.GlobalOffset)};
 
     Ranges.push_back(JITCompilerNDR);
-    InputKernelInfo.emplace_back(KernelName, KernelNameStringHash, ArgDescriptor,
-                                 JITCompilerNDR, BinInfo);
+    InputKernelInfo.emplace_back(KernelName, KernelNameStringHash,
+                                 ArgDescriptor, JITCompilerNDR, BinInfo);
     InputKernelNames.push_back(KernelName);
 
     // Collect information for the fused kernel

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -662,6 +662,7 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
     auto *KernelCG = static_cast<CGExecKernel *>(&CG);
 
     auto KernelName = KernelCG->MKernelName;
+    auto KenelNameStringHash = KernelCG->MKenelNameStringHash;
     if (KernelName.empty()) {
       printPerformanceWarning(
           "Cannot fuse kernel with invalid kernel function name");
@@ -748,8 +749,8 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
         SYCLTypeToIndices(CurrentNDR.GlobalOffset)};
 
     Ranges.push_back(JITCompilerNDR);
-    InputKernelInfo.emplace_back(KernelName, ArgDescriptor, JITCompilerNDR,
-                                 BinInfo);
+    InputKernelInfo.emplace_back(KernelName, KenelNameStringHash, ArgDescriptor,
+                                 JITCompilerNDR, BinInfo);
     InputKernelNames.push_back(KernelName);
 
     // Collect information for the fused kernel
@@ -889,8 +890,9 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   std::unique_ptr<detail::CG> FusedCG;
   FusedCG.reset(new detail::CGExecKernel(
       NDRDesc, nullptr, nullptr, std::move(KernelBundleImplPtr),
-      std::move(CGData), std::move(FusedArgs), FusedKernelInfo.Name, {}, {},
-      CG::CGTYPE::Kernel, KernelCacheConfig));
+      std::move(CGData), std::move(FusedArgs), FusedKernelInfo.Name,
+      FusedKernelInfo.KenelNameStringHash, {}, {}, CG::CGTYPE::Kernel,
+      KernelCacheConfig));
   return FusedCG;
 }
 

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -662,7 +662,7 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
     auto *KernelCG = static_cast<CGExecKernel *>(&CG);
 
     auto KernelName = KernelCG->MKernelName;
-    auto KenelNameStringHash = KernelCG->MKenelNameStringHash;
+    auto KernelNameStringHash = KernelCG->MKernelNameStringHash;
     if (KernelName.empty()) {
       printPerformanceWarning(
           "Cannot fuse kernel with invalid kernel function name");
@@ -749,7 +749,7 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
         SYCLTypeToIndices(CurrentNDR.GlobalOffset)};
 
     Ranges.push_back(JITCompilerNDR);
-    InputKernelInfo.emplace_back(KernelName, KenelNameStringHash, ArgDescriptor,
+    InputKernelInfo.emplace_back(KernelName, KernelNameStringHash, ArgDescriptor,
                                  JITCompilerNDR, BinInfo);
     InputKernelNames.push_back(KernelName);
 
@@ -891,7 +891,7 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   FusedCG.reset(new detail::CGExecKernel(
       NDRDesc, nullptr, nullptr, std::move(KernelBundleImplPtr),
       std::move(CGData), std::move(FusedArgs), FusedKernelInfo.Name,
-      FusedKernelInfo.KenelNameStringHash, {}, {}, CG::CGTYPE::Kernel,
+      FusedKernelInfo.KernelNameStringHash, {}, {}, CG::CGTYPE::Kernel,
       KernelCacheConfig));
   return FusedCG;
 }

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -531,7 +531,7 @@ public:
 
     auto [Kernel, CacheMutex, ArgMask] =
         detail::ProgramManager::getInstance().getOrCreateKernel(
-            MContext, KernelID.get_name(), /*PropList=*/{},
+            MContext, KernelID.get_name(), 0, /*PropList=*/{},
             SelectedImage->get_program_ref());
 
     std::shared_ptr<kernel_impl> KernelImpl =

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <type_traits>
 
+#include <boost/container_hash/hash.hpp>
 #include <boost/unordered/unordered_flat_map.hpp>
 #include <boost/unordered_map.hpp>
 
@@ -136,10 +137,36 @@ public:
       ::boost::unordered_map<std::string, KernelBuildResultPtr>;
   using KernelCacheT =
       ::boost::unordered_map<sycl::detail::pi::PiProgram, KernelByNameT>;
-
   using KernelFastCacheKeyT =
-      std::tuple<SerializedObj, sycl::detail::pi::PiDevice, std::string,
-                 std::string>;
+      std::tuple<SerializedObj, sycl::detail::pi::PiDevice, std::string>;
+
+  // Wrapper for the cache key tuple with precomputed hash
+  struct CachedKernelKey {
+    KernelFastCacheKeyT originalKey;
+    std::size_t precomputedHash;
+
+    // Constructor to initialize both the key and the hash
+    CachedKernelKey(const KernelFastCacheKeyT &key)
+        : originalKey(key), precomputedHash(0) {}
+
+    bool operator==(const CachedKernelKey &other) const { return true; }
+    // Setter function to update precomputedHash
+    void setPrecomputedHash(std::size_t hash) { precomputedHash = hash; }
+  };
+
+  struct KeyHasher {
+    std::size_t operator()(const CachedKernelKey &k) const {
+      std::size_t combinedHash = k.precomputedHash;
+      ::boost::hash_combine(combinedHash,
+                            ::boost::hash_value((std::get<0>(
+                                k.originalKey)))); // hash of SerializedObj
+      ::boost::hash_combine(
+          combinedHash, ::boost::hash_value(
+                            (std::get<1>(k.originalKey)))); // hash of PiDevice
+      return combinedHash;
+    }
+  };
+
   using KernelFastCacheValT =
       std::tuple<sycl::detail::pi::PiKernel, std::mutex *,
                  const KernelArgMask *, sycl::detail::pi::PiProgram>;
@@ -149,7 +176,8 @@ public:
   // higher overhead of insertion that comes with unordered_flat_map is more
   // of an issue there. For that reason, those use regular unordered maps.
   using KernelFastCacheT =
-      ::boost::unordered_flat_map<KernelFastCacheKeyT, KernelFastCacheValT>;
+      ::boost::unordered_flat_map<CachedKernelKey, KernelFastCacheValT,
+                                  KeyHasher>;
 
   ~KernelProgramCache() = default;
 

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -149,7 +149,9 @@ public:
     CachedKernelKey(const KernelFastCacheKeyT &key)
         : originalKey(key), precomputedHash(0) {}
 
-    bool operator==(const CachedKernelKey &other) const { return originalKey == other.originalKey; }
+    bool operator==(const CachedKernelKey &other) const {
+      return originalKey == other.originalKey;
+    }
     // Setter function to update precomputedHash
     void setPrecomputedHash(std::size_t hash) { precomputedHash = hash; }
   };

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -149,7 +149,7 @@ public:
     CachedKernelKey(const KernelFastCacheKeyT &key)
         : originalKey(key), precomputedHash(0) {}
 
-    bool operator==(const CachedKernelKey &other) const { return true; }
+    bool operator==(const CachedKernelKey &other) const { return originalKey == other.originalKey; }
     // Setter function to update precomputedHash
     void setPrecomputedHash(std::size_t hash) { precomputedHash = hash; }
   };

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -650,7 +650,7 @@ std::tuple<sycl::detail::pi::PiKernel, std::mutex *, const KernelArgMask *,
 ProgramManager::getOrCreateKernel(const ContextImplPtr &ContextImpl,
                                   const DeviceImplPtr &DeviceImpl,
                                   const std::string &KernelName,
-                                  std::size_t KenelNameStringHash) {
+                                  std::size_t KernelNameStringHash) {
   if (DbgProgMgr > 0) {
     std::cerr << ">>> ProgramManager::getOrCreateKernel(" << ContextImpl.get()
               << ", " << DeviceImpl.get() << ", " << KernelName << ")\n";
@@ -670,7 +670,7 @@ ProgramManager::getOrCreateKernel(const ContextImplPtr &ContextImpl,
 
   auto key = std::make_tuple(std::move(SpecConsts), PiDevice, KernelName);
   KernelProgramCache::CachedKernelKey k(key);
-  k.setPrecomputedHash(KenelNameStringHash);
+  k.setPrecomputedHash(KernelNameStringHash);
   if (SYCLConfig<SYCL_CACHE_IN_MEM>::get()) {
     auto ret_tuple = Cache.tryToGetKernelFast(k);
     constexpr size_t Kernel = 0;  // see KernelFastCacheValT tuple
@@ -689,7 +689,7 @@ ProgramManager::getOrCreateKernel(const ContextImplPtr &ContextImpl,
   sycl::detail::pi::PiProgram Program =
       getBuiltPIProgram(ContextImpl, DeviceImpl, KernelName);
 
-  auto BuildF = [this, &Program, &KernelName, KenelNameStringHash,
+  auto BuildF = [this, &Program, &KernelName, KernelNameStringHash,
                  &ContextImpl] {
     sycl::detail::pi::PiKernel Kernel = nullptr;
 
@@ -2353,7 +2353,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 std::tuple<sycl::detail::pi::PiKernel, std::mutex *, const KernelArgMask *>
 ProgramManager::getOrCreateKernel(const context &Context,
                                   const std::string &KernelName,
-                                  std::size_t KenelNameStringHash,
+                                  std::size_t KernelNameStringHash,
                                   const property_list &PropList,
                                   sycl::detail::pi::PiProgram Program) {
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -149,7 +149,8 @@ public:
              sycl::detail::pi::PiProgram>
   getOrCreateKernel(const ContextImplPtr &ContextImpl,
                     const DeviceImplPtr &DeviceImpl,
-                    const std::string &KernelName);
+                    const std::string &KernelName,
+                    std::size_t KenelNameStringHash);
 
   sycl::detail::pi::PiProgram
   getPiProgramFromPiKernel(sycl::detail::pi::PiKernel Kernel,
@@ -283,6 +284,7 @@ public:
 
   std::tuple<sycl::detail::pi::PiKernel, std::mutex *, const KernelArgMask *>
   getOrCreateKernel(const context &Context, const std::string &KernelName,
+                    std::size_t KenelNameStringHash,
                     const property_list &PropList,
                     sycl::detail::pi::PiProgram Program);
 

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -150,7 +150,7 @@ public:
   getOrCreateKernel(const ContextImplPtr &ContextImpl,
                     const DeviceImplPtr &DeviceImpl,
                     const std::string &KernelName,
-                    std::size_t KenelNameStringHash);
+                    std::size_t KernelNameStringHash);
 
   sycl::detail::pi::PiProgram
   getPiProgramFromPiKernel(sycl::detail::pi::PiKernel Kernel,
@@ -284,7 +284,7 @@ public:
 
   std::tuple<sycl::detail::pi::PiKernel, std::mutex *, const KernelArgMask *>
   getOrCreateKernel(const context &Context, const std::string &KernelName,
-                    std::size_t KenelNameStringHash,
+                    std::size_t KernelNameStringHash,
                     const property_list &PropList,
                     sycl::detail::pi::PiProgram Program);
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1919,7 +1919,7 @@ std::string instrumentationGetKernelName(
 void instrumentationAddExtraKernelMetadata(
     xpti_td *&CmdTraceEvent, const NDRDescT &NDRDesc,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
-    const std::string &KernelName,
+    const std::string &KernelName, std::size_t KenelNameStringHash,
     const std::shared_ptr<detail::kernel_impl> &SyclKernel,
     const QueueImplPtr &Queue,
     std::vector<ArgDesc> &CGArgs) // CGArgs are not const since they could be
@@ -1961,7 +1961,8 @@ void instrumentationAddExtraKernelMetadata(
   } else {
     std::tie(Kernel, KernelMutex, EliminatedArgMask, Program) =
         detail::ProgramManager::getInstance().getOrCreateKernel(
-            Queue->getContextImplPtr(), Queue->getDeviceImplPtr(), KernelName);
+            Queue->getContextImplPtr(), Queue->getDeviceImplPtr(), KernelName,
+            KenelNameStringHash);
   }
 
   applyFuncOnFilteredArgs(EliminatedArgMask, CGArgs, FilterArgs);
@@ -2077,7 +2078,7 @@ std::pair<xpti_td *, uint64_t> emitKernelInstrumentationData(
   if (CmdTraceEvent) {
     instrumentationAddExtraKernelMetadata(CmdTraceEvent, NDRDesc,
                                           KernelBundleImplPtr, SyclKernelName,
-                                          SyclKernel, Queue, CGArgs);
+                                          0, SyclKernel, Queue, CGArgs);
 
     xptiNotifySubscribers(
         StreamID, NotificationTraceType, detail::GSYCLGraphEvent, CmdTraceEvent,
@@ -2124,8 +2125,8 @@ void ExecCGCommand::emitInstrumentationData() {
           reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
       instrumentationAddExtraKernelMetadata(
           CmdTraceEvent, KernelCG->MNDRDesc, KernelCG->getKernelBundle(),
-          KernelCG->MKernelName, KernelCG->MSyclKernel, MQueue,
-          KernelCG->MArgs);
+          KernelCG->MKernelName, KernelCG->MKenelNameStringHash,
+          KernelCG->MSyclKernel, MQueue, KernelCG->MArgs);
     }
 
     xptiNotifySubscribers(
@@ -2435,7 +2436,8 @@ pi_int32 enqueueImpCommandBufferKernel(
   } else {
     std::tie(PiKernel, std::ignore, EliminatedArgMask, PiProgram) =
         sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
-            ContextImpl, DeviceImpl, CommandGroup.MKernelName);
+            ContextImpl, DeviceImpl, CommandGroup.MKernelName,
+            CommandGroup.MKenelNameStringHash);
   }
 
   auto SetFunc = [&Plugin, &PiKernel, &DeviceImageImpl, &Ctx,
@@ -2500,7 +2502,7 @@ pi_int32 enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
-    const std::string &KernelName,
+    const std::string &KernelName, std::size_t KenelNameStringHash,
     std::vector<sycl::detail::pi::PiEvent> &RawEvents,
     const detail::EventImplPtr &OutEventImpl,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
@@ -2554,7 +2556,7 @@ pi_int32 enqueueImpKernel(
   } else {
     std::tie(Kernel, KernelMutex, EliminatedArgMask, Program) =
         detail::ProgramManager::getInstance().getOrCreateKernel(
-            ContextImpl, DeviceImpl, KernelName);
+            ContextImpl, DeviceImpl, KernelName, KenelNameStringHash);
   }
 
   // We may need more events for the launch, so we make another reference.
@@ -2913,7 +2915,7 @@ pi_int32 ExecCGCommand::enqueueImpQueue() {
     const std::shared_ptr<detail::kernel_impl> &SyclKernel =
         ExecKernel->MSyclKernel;
     const std::string &KernelName = ExecKernel->MKernelName;
-
+    std::size_t KenelNameStringHash = ExecKernel->MKenelNameStringHash;
     if (!EventImpl) {
       // Kernel only uses assert if it's non interop one
       bool KernelUsesAssert =
@@ -2926,8 +2928,8 @@ pi_int32 ExecCGCommand::enqueueImpQueue() {
 
     return enqueueImpKernel(
         MQueue, NDRDesc, Args, ExecKernel->getKernelBundle(), SyclKernel,
-        KernelName, RawEvents, EventImpl, getMemAllocationFunc,
-        ExecKernel->MKernelCacheConfig);
+        KernelName, KenelNameStringHash, RawEvents, EventImpl,
+        getMemAllocationFunc, ExecKernel->MKernelCacheConfig);
   }
   case CG::CGTYPE::CopyUSM: {
     CGCopyUSM *Copy = (CGCopyUSM *)MCommandGroup.get();

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -1919,7 +1919,7 @@ std::string instrumentationGetKernelName(
 void instrumentationAddExtraKernelMetadata(
     xpti_td *&CmdTraceEvent, const NDRDescT &NDRDesc,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
-    const std::string &KernelName, std::size_t KenelNameStringHash,
+    const std::string &KernelName, std::size_t KernelNameStringHash,
     const std::shared_ptr<detail::kernel_impl> &SyclKernel,
     const QueueImplPtr &Queue,
     std::vector<ArgDesc> &CGArgs) // CGArgs are not const since they could be
@@ -1962,7 +1962,7 @@ void instrumentationAddExtraKernelMetadata(
     std::tie(Kernel, KernelMutex, EliminatedArgMask, Program) =
         detail::ProgramManager::getInstance().getOrCreateKernel(
             Queue->getContextImplPtr(), Queue->getDeviceImplPtr(), KernelName,
-            KenelNameStringHash);
+            KernelNameStringHash);
   }
 
   applyFuncOnFilteredArgs(EliminatedArgMask, CGArgs, FilterArgs);
@@ -2125,7 +2125,7 @@ void ExecCGCommand::emitInstrumentationData() {
           reinterpret_cast<detail::CGExecKernel *>(MCommandGroup.get());
       instrumentationAddExtraKernelMetadata(
           CmdTraceEvent, KernelCG->MNDRDesc, KernelCG->getKernelBundle(),
-          KernelCG->MKernelName, KernelCG->MKenelNameStringHash,
+          KernelCG->MKernelName, KernelCG->MKernelNameStringHash,
           KernelCG->MSyclKernel, MQueue, KernelCG->MArgs);
     }
 
@@ -2437,7 +2437,7 @@ pi_int32 enqueueImpCommandBufferKernel(
     std::tie(PiKernel, std::ignore, EliminatedArgMask, PiProgram) =
         sycl::detail::ProgramManager::getInstance().getOrCreateKernel(
             ContextImpl, DeviceImpl, CommandGroup.MKernelName,
-            CommandGroup.MKenelNameStringHash);
+            CommandGroup.MKernelNameStringHash);
   }
 
   auto SetFunc = [&Plugin, &PiKernel, &DeviceImageImpl, &Ctx,
@@ -2502,7 +2502,7 @@ pi_int32 enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
-    const std::string &KernelName, std::size_t KenelNameStringHash,
+    const std::string &KernelName, std::size_t KernelNameStringHash,
     std::vector<sycl::detail::pi::PiEvent> &RawEvents,
     const detail::EventImplPtr &OutEventImpl,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,
@@ -2556,7 +2556,7 @@ pi_int32 enqueueImpKernel(
   } else {
     std::tie(Kernel, KernelMutex, EliminatedArgMask, Program) =
         detail::ProgramManager::getInstance().getOrCreateKernel(
-            ContextImpl, DeviceImpl, KernelName, KenelNameStringHash);
+            ContextImpl, DeviceImpl, KernelName, KernelNameStringHash);
   }
 
   // We may need more events for the launch, so we make another reference.
@@ -2915,7 +2915,7 @@ pi_int32 ExecCGCommand::enqueueImpQueue() {
     const std::shared_ptr<detail::kernel_impl> &SyclKernel =
         ExecKernel->MSyclKernel;
     const std::string &KernelName = ExecKernel->MKernelName;
-    std::size_t KenelNameStringHash = ExecKernel->MKenelNameStringHash;
+    std::size_t KernelNameStringHash = ExecKernel->MKernelNameStringHash;
     if (!EventImpl) {
       // Kernel only uses assert if it's non interop one
       bool KernelUsesAssert =
@@ -2928,7 +2928,7 @@ pi_int32 ExecCGCommand::enqueueImpQueue() {
 
     return enqueueImpKernel(
         MQueue, NDRDesc, Args, ExecKernel->getKernelBundle(), SyclKernel,
-        KernelName, KenelNameStringHash, RawEvents, EventImpl,
+        KernelName, KernelNameStringHash, RawEvents, EventImpl,
         getMemAllocationFunc, ExecKernel->MKernelCacheConfig);
   }
   case CG::CGTYPE::CopyUSM: {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -625,7 +625,7 @@ pi_int32 enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
-    const std::string &KernelName, std::size_t KenelNameStringHash,
+    const std::string &KernelName, std::size_t KernelNameStringHash,
     std::vector<sycl::detail::pi::PiEvent> &RawEvents,
     const detail::EventImplPtr &Event,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -625,7 +625,7 @@ pi_int32 enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
-    const std::string &KernelName,
+    const std::string &KernelName, std::size_t KenelNameStringHash,
     std::vector<sycl::detail::pi::PiEvent> &RawEvents,
     const detail::EventImplPtr &Event,
     const std::function<void *(Requirement *Req)> &getMemAllocationFunc,

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -272,10 +272,10 @@ event handler::finalize() {
                 nullptr);
             Result = PI_SUCCESS;
           } else {
-            Result =
-                enqueueImpKernel(MQueue, MNDRDesc, MArgs, KernelBundleImpPtr,
-                                 MKernel, MKernelName, RawEvents, NewEvent,
-                                 nullptr, MImpl->MKernelCacheConfig);
+            Result = enqueueImpKernel(MQueue, MNDRDesc, MArgs,
+                                      KernelBundleImpPtr, MKernel, MKernelName,
+                                      MKenelNameStringHash, RawEvents, NewEvent,
+                                      nullptr, MImpl->MKernelCacheConfig);
           }
         }
 #ifdef XPTI_ENABLE_INSTRUMENTATION
@@ -325,7 +325,7 @@ event handler::finalize() {
     CommandGroup.reset(new detail::CGExecKernel(
         std::move(MNDRDesc), std::move(MHostKernel), std::move(MKernel),
         std::move(MImpl->MKernelBundle), std::move(CGData), std::move(MArgs),
-        MKernelName, std::move(MStreamStorage),
+        MKernelName, MKenelNameStringHash, std::move(MStreamStorage),
         std::move(MImpl->MAuxiliaryResources), MCGType,
         MImpl->MKernelCacheConfig, MCodeLoc));
     break;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -272,10 +272,10 @@ event handler::finalize() {
                 nullptr);
             Result = PI_SUCCESS;
           } else {
-            Result = enqueueImpKernel(MQueue, MNDRDesc, MArgs,
-                                      KernelBundleImpPtr, MKernel, MKernelName,
-                                      MKernelNameStringHash, RawEvents, NewEvent,
-                                      nullptr, MImpl->MKernelCacheConfig);
+            Result = enqueueImpKernel(
+                MQueue, MNDRDesc, MArgs, KernelBundleImpPtr, MKernel,
+                MKernelName, MKernelNameStringHash, RawEvents, NewEvent,
+                nullptr, MImpl->MKernelCacheConfig);
           }
         }
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -274,7 +274,7 @@ event handler::finalize() {
           } else {
             Result = enqueueImpKernel(MQueue, MNDRDesc, MArgs,
                                       KernelBundleImpPtr, MKernel, MKernelName,
-                                      MKenelNameStringHash, RawEvents, NewEvent,
+                                      MKernelNameStringHash, RawEvents, NewEvent,
                                       nullptr, MImpl->MKernelCacheConfig);
           }
         }
@@ -325,7 +325,7 @@ event handler::finalize() {
     CommandGroup.reset(new detail::CGExecKernel(
         std::move(MNDRDesc), std::move(MHostKernel), std::move(MKernel),
         std::move(MImpl->MKernelBundle), std::move(CGData), std::move(MArgs),
-        MKernelName, MKenelNameStringHash, std::move(MStreamStorage),
+        MKernelName, MKernelNameStringHash, std::move(MStreamStorage),
         std::move(MImpl->MAuxiliaryResources), MCGType,
         MImpl->MKernelCacheConfig, MCodeLoc));
     break;

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -122,9 +122,9 @@ public:
           std::move(CGH->MNDRDesc), std::move(CGH->MHostKernel),
           std::move(CGH->MKernel), std::move(MImpl->MKernelBundle),
           std::move(CGH->CGData), std::move(CGH->MArgs),
-          std::move(CGH->MKernelName), std::move(CGH->MStreamStorage),
-          std::move(MImpl->MAuxiliaryResources), CGH->MCGType, {},
-          CGH->MCodeLoc));
+          std::move(CGH->MKernelName), std::move(CGH->MKenelNameStringHash),
+          std::move(CGH->MStreamStorage), std::move(MImpl->MAuxiliaryResources),
+          CGH->MCGType, {}, CGH->MCodeLoc));
       break;
     }
     default:

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -122,7 +122,7 @@ public:
           std::move(CGH->MNDRDesc), std::move(CGH->MHostKernel),
           std::move(CGH->MKernel), std::move(MImpl->MKernelBundle),
           std::move(CGH->CGData), std::move(CGH->MArgs),
-          std::move(CGH->MKernelName), std::move(CGH->MKenelNameStringHash),
+          std::move(CGH->MKernelName), std::move(CGH->MKernelNameStringHash),
           std::move(CGH->MStreamStorage), std::move(MImpl->MAuxiliaryResources),
           CGH->MCGType, {}, CGH->MCodeLoc));
       break;

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -306,7 +306,7 @@ public:
       CommandGroup.reset(new sycl::detail::CGExecKernel(
           getNDRDesc(), std::move(getHostKernel()), getKernel(),
           std::move(MImpl->MKernelBundle), std::move(CGData), getArgs(),
-          getKernelName(), getKenelNameStringHash(), getStreamStorage(),
+          getKernelName(), getKernelNameStringHash(), getStreamStorage(),
           MImpl->MAuxiliaryResources, getCGType(), {}, getCodeLoc()));
       break;
     }

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -306,8 +306,8 @@ public:
       CommandGroup.reset(new sycl::detail::CGExecKernel(
           getNDRDesc(), std::move(getHostKernel()), getKernel(),
           std::move(MImpl->MKernelBundle), std::move(CGData), getArgs(),
-          getKernelName(), getStreamStorage(), MImpl->MAuxiliaryResources,
-          getCGType(), {}, getCodeLoc()));
+          getKernelName(), getKenelNameStringHash(), getStreamStorage(),
+          MImpl->MAuxiliaryResources, getCGType(), {}, getCodeLoc()));
       break;
     }
     case sycl::detail::CG::CodeplayHostTask: {

--- a/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
+++ b/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
@@ -32,9 +32,9 @@ public:
           detail::CG::StorageInitHelper(getArgsStorage(), getAccStorage(),
                                         getSharedPtrStorage(),
                                         getRequirements(), getEvents()),
-          getArgs(), getKernelName(), getStreamStorage(),
-          std::move(MImpl->MAuxiliaryResources), getCGType(), {},
-          getCodeLoc()));
+          getArgs(), getKernelName(), getKenelNameStringHash(),
+          getStreamStorage(), std::move(MImpl->MAuxiliaryResources),
+          getCGType(), {}, getCodeLoc()));
       break;
     }
     default:

--- a/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
+++ b/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
@@ -32,7 +32,7 @@ public:
           detail::CG::StorageInitHelper(getArgsStorage(), getAccStorage(),
                                         getSharedPtrStorage(),
                                         getRequirements(), getEvents()),
-          getArgs(), getKernelName(), getKenelNameStringHash(),
+          getArgs(), getKernelName(), getKernelNameStringHash(),
           getStreamStorage(), std::move(MImpl->MAuxiliaryResources),
           getCGType(), {}, getCodeLoc()));
       break;


### PR DESCRIPTION
We currently compute the hash from scratch each time a kernel is submitted. The most expensive part of that is the hashing of the kernel name string. This patch intends to compute and store the kernel name hash once in the headers to reduce this overhead. In this implementation we create a wrapper over the current cache key tuple that has the precomputed string hash. We can now use this wrapper as the map key to only recompute hashes for the other parts.