### PR TITLE
[SYCL][CodeGen] Attach fpmath metadata for single precision fdiv/sqrt

### DIFF
--- a/clang/lib/CodeGen/CGExpr.cpp
+++ b/clang/lib/CodeGen/CGExpr.cpp
@@ -5821,7 +5821,7 @@ void CodeGenFunction::SetSqrtFPAccuracy(llvm::Value *Val) {
   if (!EltTy->isFloatTy())
     return;
 
-  if ((getLangOpts().OpenCL &&
+  if (((getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) &&
        !CGM.getCodeGenOpts().OpenCLCorrectlyRoundedDivSqrt) ||
       (getLangOpts().HIP && getLangOpts().CUDAIsDevice &&
        !CGM.getCodeGenOpts().HIPCorrectlyRoundedDivSqrt)) {
@@ -5842,7 +5842,7 @@ void CodeGenFunction::SetDivFPAccuracy(llvm::Value *Val) {
   if (!EltTy->isFloatTy())
     return;
 
-  if ((getLangOpts().OpenCL &&
+  if (((getLangOpts().OpenCL || getLangOpts().SYCLIsDevice) &&
        !CGM.getCodeGenOpts().OpenCLCorrectlyRoundedDivSqrt) ||
       (getLangOpts().HIP && getLangOpts().CUDAIsDevice &&
        !CGM.getCodeGenOpts().HIPCorrectlyRoundedDivSqrt)) {

--- a/clang/test/CodeGenSYCL/fpmath.cpp
+++ b/clang/test/CodeGenSYCL/fpmath.cpp
@@ -1,0 +1,41 @@
+// RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-device -emit-llvm %s -o - | FileCheck --check-prefix=CHECK-FPMATH %s
+// RUN: %clang_cc1 -cl-fp32-correctly-rounded-divide-sqrt -triple spir64-unknown-unknown -fsycl-is-device -emit-llvm %s -o - | FileCheck %s --implicit-check-not='!fpmath'
+
+#include "Inputs/sycl.hpp"
+
+using namespace sycl;
+
+SYCL_EXTERNAL float sqrt(float);
+SYCL_EXTERNAL double sqrt(double);
+
+int main() {
+  queue q;
+  range<1> numOfItems{1};
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for<class Kernel0>(numOfItems,[=](id<1> wiID) {
+    float a = 0;
+    float b = 1;
+    // CHECK-FPMATH: fdiv float {{[^)]+}}, {{[^)]+}}, !fpmath ![[#DivMD:]]
+    float c = a/b;
+    (void) c;
+    double d = (double)a/b;
+    // CHECK-FPMATH-NOT: fdiv double{{.*}}!fpmath
+    (void) d;
+    });
+  });
+
+   q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for<class Kernel1>(numOfItems,[=](id<1> wiID) {
+
+    float a = 1;
+    // CHECK-FPMATH: call spir_func noundef float @_Z4sqrtf(float noundef {{[^)]+}}) #{{[0-9]+}}, !fpmath ![[#SqrtMD:]]
+    float b = sqrt(a);
+    (void) b;
+    // CHECK-FPMATH-NOT: call spir_func noundef double @_Z4sqrtd{{.*}}!fpmath
+    sqrt((double)a);
+    });
+  });
+}
+
+// CHECK-FPMATH: ![[#DivMD]] = !{float 2.500000e+00}
+// CHECK-FPMATH: ![[#SqrtMD]] = !{float 3.000000e+00}


### PR DESCRIPTION
The OpenCL spec (and thus SYCL spec) allows error for single precision float division and sqrt. For OpenCL, the maximum allowed error is captured today using the `fpmath` metadata. In the long term we want to use the `fpbuiltin` intrinsics, but not all backends are ready for that yet.

Emit the fpmath metadata for SYCL too.

Right now the SPIR-V translator drops the `fpmath` metadata, but I have an [open PR](https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2266) to keep it around so that backends can take advantage of it.