### PR TITLE
[CI] Enable pr-code-format workflow for intel/llvm repo

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   code_formatter:
     runs-on: ubuntu-latest
-    if: github.repository == 'llvm/llvm-project'
+    if: github.repository == 'llvm/llvm-project' || github.repository == 'intel/llvm'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4


### PR DESCRIPTION
To experiment with the suggestion in https://github.com/intel/llvm/discussions/12085.
Note that `pull_request_target` means we cannot test this before we merge it.