### PR TITLE
[SYCL][NATIVECPU]Rename ext_native_cpu to ext_oneapi_native_cpu

### DIFF
--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -24,7 +24,7 @@ enum class backend : char {
   ext_intel_esimd_emulator __SYCL_DEPRECATED(
       "esimd emulator is no longer supported") = 5,
   ext_oneapi_hip = 6,
-  ext_native_cpu = 7,
+  ext_oneapi_native_cpu = 7,
 };
 
 template <backend Backend> class backend_traits;
@@ -56,7 +56,7 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
   case backend::ext_oneapi_hip:
     Out << "ext_oneapi_hip";
     break;
-  case backend::ext_native_cpu:
+  case backend::ext_oneapi_native_cpu:
     Out << "ext_native_cpu";
     break;
   case backend::all:

--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -57,7 +57,7 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
     Out << "ext_oneapi_hip";
     break;
   case backend::ext_oneapi_native_cpu:
-    Out << "ext_native_cpu";
+    Out << "ext_oneapi_native_cpu";
     break;
   case backend::all:
     Out << "all";

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -61,7 +61,7 @@ backend convertBackend(pi_platform_backend PiBackend) {
   case PI_EXT_PLATFORM_BACKEND_ESIMD:
     return backend::ext_intel_esimd_emulator;
   case PI_EXT_PLATFORM_BACKEND_NATIVE_CPU:
-    return backend::ext_native_cpu;
+    return backend::ext_oneapi_native_cpu;
   }
   throw sycl::runtime_error{"convertBackend: Unsupported backend",
                             PI_ERROR_INVALID_OPERATION};

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -185,7 +185,7 @@ const std::array<std::pair<std::string, backend>, 8> &getSyclBeMap() {
        {"cuda", backend::ext_oneapi_cuda},
        {"hip", backend::ext_oneapi_hip},
        {"esimd_emulator", backend::ext_intel_esimd_emulator},
-       {"native_cpu", backend::ext_native_cpu},
+       {"native_cpu", backend::ext_oneapi_native_cpu},
        {"*", backend::all}}};
   return SyclBeMap;
 }

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -348,8 +348,8 @@ std::vector<std::pair<std::string, backend>> findPlugins() {
                                  backend::ext_oneapi_hip);
         HIPFound = true;
       }
-      if (!NativeCPUFound &&
-          (Backend == backend::ext_oneapi_native_cpu || Backend == backend::all)) {
+      if (!NativeCPUFound && (Backend == backend::ext_oneapi_native_cpu ||
+                              Backend == backend::all)) {
         PluginNames.emplace_back(__SYCL_NATIVE_CPU_PLUGIN_NAME,
                                  backend::ext_oneapi_native_cpu);
       }

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -309,7 +309,7 @@ std::vector<std::pair<std::string, backend>> findPlugins() {
     PluginNames.emplace_back(__SYCL_HIP_PLUGIN_NAME, backend::ext_oneapi_hip);
     PluginNames.emplace_back(__SYCL_UR_PLUGIN_NAME, backend::all);
     PluginNames.emplace_back(__SYCL_NATIVE_CPU_PLUGIN_NAME,
-                             backend::ext_native_cpu);
+                             backend::ext_oneapi_native_cpu);
   } else if (FilterList) {
     std::vector<device_filter> Filters = FilterList->get();
     bool OpenCLFound = false;
@@ -349,9 +349,9 @@ std::vector<std::pair<std::string, backend>> findPlugins() {
         HIPFound = true;
       }
       if (!NativeCPUFound &&
-          (Backend == backend::ext_native_cpu || Backend == backend::all)) {
+          (Backend == backend::ext_oneapi_native_cpu || Backend == backend::all)) {
         PluginNames.emplace_back(__SYCL_NATIVE_CPU_PLUGIN_NAME,
-                                 backend::ext_native_cpu);
+                                 backend::ext_oneapi_native_cpu);
       }
       PluginNames.emplace_back(__SYCL_UR_PLUGIN_NAME, backend::all);
     }
@@ -375,9 +375,9 @@ std::vector<std::pair<std::string, backend>> findPlugins() {
     if (list.backendCompatible(backend::ext_oneapi_hip)) {
       PluginNames.emplace_back(__SYCL_HIP_PLUGIN_NAME, backend::ext_oneapi_hip);
     }
-    if (list.backendCompatible(backend::ext_native_cpu)) {
+    if (list.backendCompatible(backend::ext_oneapi_native_cpu)) {
       PluginNames.emplace_back(__SYCL_NATIVE_CPU_PLUGIN_NAME,
-                               backend::ext_native_cpu);
+                               backend::ext_oneapi_native_cpu);
     }
     PluginNames.emplace_back(__SYCL_UR_PLUGIN_NAME, backend::all);
   }

--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -21,7 +21,7 @@ bool check(backend be) {
   case backend::ext_oneapi_level_zero:
   case backend::ext_oneapi_cuda:
   case backend::ext_oneapi_hip:
-  case backend::ext_native_cpu:
+  case backend::ext_oneapi_native_cpu:
     return true;
   default:
     return false;

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -26,7 +26,7 @@ const std::map<backend, std::string> BackendStringMap = {
     {backend::ext_oneapi_level_zero, "ext_oneapi_level_zero"},
     {backend::ext_oneapi_cuda, "ext_oneapi_cuda"},
     {backend::ext_oneapi_hip, "ext_oneapi_hip"},
-    {backend::ext_oneapi_native_cpu, "ext_native_cpu"}};
+    {backend::ext_oneapi_native_cpu, "ext_oneapi_native_cpu"}};
 
 std::string getDeviceTypeName(const device &d) {
   auto DeviceType = d.get_info<info::device::device_type>();

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -26,7 +26,7 @@ const std::map<backend, std::string> BackendStringMap = {
     {backend::ext_oneapi_level_zero, "ext_oneapi_level_zero"},
     {backend::ext_oneapi_cuda, "ext_oneapi_cuda"},
     {backend::ext_oneapi_hip, "ext_oneapi_hip"},
-    {backend::ext_native_cpu, "ext_native_cpu"}};
+    {backend::ext_oneapi_native_cpu, "ext_native_cpu"}};
 
 std::string getDeviceTypeName(const device &d) {
   auto DeviceType = d.get_info<info::device::device_type>();


### PR DESCRIPTION
Renames the `ext_native_cpu` backend type to `ext_oneapi_native_cpu`, making it conformant to the SYCL specification. 