### PR TITLE
[SYCL][ESIMD][E2E] Fix driver check in slm_init_no_inline.cpp

### DIFF
--- a/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
+++ b/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
@@ -1,5 +1,5 @@
 // TODO: Investigate fail of this test on Gen12 platform
-// REQUIRES-INTEL-DRIVER: lin: 26516, win: 101.4827
+// REQUIRES-INTEL-DRIVER: lin: 27427, win: 101.4827
 // REQUIRES: gpu-intel-pvc
 // TODO: Support ze_debug once GPU hang introduced in new GPU driver is solved
 // UNSUPPORTED: ze_debug


### PR DESCRIPTION
We actually need a later driver, I manually verified this.