### PR TITLE
[SYCL] [NATIVECPU] Avoid passing -emit-only-kernels-as-entry-point on native cpu

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10283,7 +10283,8 @@ void SYCLPostLink::ConstructJob(Compilation &C, const JobAction &JA,
   // TODO: Try to extend this feature for non-Intel GPUs.
   if (!TCArgs.hasFlag(options::OPT_fno_sycl_remove_unused_external_funcs,
                       options::OPT_fsycl_remove_unused_external_funcs, false) &&
-      !T.isNVPTX() && !T.isAMDGPU())
+      !T.isNVPTX() && !T.isAMDGPU() &&
+      !isSYCLNativeCPU(getToolChain(), C.getDefaultToolChain()))
     addArgs(CmdArgs, TCArgs, {"-emit-only-kernels-as-entry-points"});
 
   // OPT_fsycl_device_code_split is not checked as it is an alias to

--- a/clang/test/Driver/sycl-native-cpu-fsycl.cpp
+++ b/clang/test/Driver/sycl-native-cpu-fsycl.cpp
@@ -39,6 +39,7 @@
 
 //CHECK_INVO:{{.*}}clang{{.*}}-fsycl-is-device{{.*}}"-fsycl-is-native-cpu" "-D" "__SYCL_NATIVE_CPU__" 
 //CHECK_INVO:{{.*}}clang{{.*}}"-x" "ir"
+//CHECK_INVO-NOT:{{.*}}sycl-post-link{{.*}}-emit-only-kernels-as-entry-points
 //CHECK_INVO:{{.*}}clang{{.*}}"-fsycl-is-host"{{.*}}
 
 // checks that the device and host triple is correct in the generated actions when it is set explicitly


### PR DESCRIPTION
Similarly to NVPTX and AMD, Native CPU needs to not set ` -emit-only-kernels-as-entry-point` since kernels for this target are not identified by the calling convention.