### PR TITLE
Avoid sema error in test case

### DIFF
--- a/sycl/test/basic_tests/marray/marray.cpp
+++ b/sycl/test/basic_tests/marray/marray.cpp
@@ -44,10 +44,10 @@ struct NotDefaultConstructible {
 };
 
 template <typename T> void CheckBinOps() {
-  sycl::marray<T, 3> ref_arr0{0};
-  sycl::marray<T, 3> ref_arr1{1};
-  sycl::marray<T, 3> ref_arr2{2};
-  sycl::marray<T, 3> ref_arr3{3};
+  sycl::marray<T, 3> ref_arr0{T(0)};
+  sycl::marray<T, 3> ref_arr1{T(1)};
+  sycl::marray<T, 3> ref_arr2{T(2)};
+  sycl::marray<T, 3> ref_arr3{T(3)};
 
   CHECK_BINOP(+, ref_arr1, ref_arr2)
   CHECK_BINOP(-, ref_arr1, ref_arr2)


### PR DESCRIPTION
This patch https://github.com/llvm/llvm-project/pull/75332 would report narrowing conversions with const references, which could lead to "error: constant expression evaluates to 2 which cannot be narrowed to type 'bool'".