### PR TITLE
[NFC][SYCL][Bindless] Don't use double type in e2e tests

### DIFF
--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
@@ -94,7 +94,7 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
 
       cgh.parallel_for<kernel<DType, CType>>(N, [=](sycl::id<1> id) {
         DType sum = 0;
-        float x = float(id[0] + 0.5) / (float)N;
+        float x = float(id[0] + 0.5f) / (float)N;
         // Extension: read mipmap level 0 with anisotropic filtering and level 1
         // with LOD
         VecType px1 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
@@ -107,8 +107,8 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
             size_t dim1 = it.get_local_id(1);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
 
             // Extension: read mipmap level 1 with LOD
             VecType px2 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
@@ -95,9 +95,9 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
             size_t dim2 = it.get_local_id(2);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
-            float fdim2 = float(dim2 + 0.5) / (float)depth;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
+            float fdim2 = float(dim2 + 0.5f) / (float)depth;
 
             // Extension: read mipmap with anisotropic filtering with zero
             // viewing gradients

--- a/sycl/test-e2e/bindless_images/sampling_1D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_1D.cpp
@@ -67,7 +67,7 @@ int main() {
 
       cgh.parallel_for<image_addition>(N, [=](sycl::id<1> id) {
         // Normalize coordinate -- +0.5 to look towards centre of pixel
-        float x = float(id[0] + 0.5) / (float)N;
+        float x = float(id[0] + 0.5f) / (float)N;
         // Extension: read image data from handle
         float px1 =
             sycl::ext::oneapi::experimental::read_image<float>(imgHandle, x);

--- a/sycl/test-e2e/bindless_images/sampling_2D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D.cpp
@@ -95,8 +95,8 @@ int main() {
             size_t dim1 = it.get_local_id(1);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
 
             // Extension: read image data from handle
             sycl::float4 px1 =

--- a/sycl/test-e2e/bindless_images/sampling_2D_USM_shared.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_USM_shared.cpp
@@ -94,8 +94,8 @@ int main() {
             size_t dim1 = it.get_local_id(1);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
 
             // Extension: read image data from handle
             float px = sycl::ext::oneapi::experimental::read_image<float>(

--- a/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
@@ -79,8 +79,8 @@ int main() {
             size_t dim1 = it.get_local_id(1);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
 
             // Extension: read image data from handle
             sycl::half4 px1 =

--- a/sycl/test-e2e/bindless_images/sampling_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_3D.cpp
@@ -73,9 +73,9 @@ int main() {
             size_t dim2 = it.get_local_id(2);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
-            float fdim2 = float(dim2 + 0.5) / (float)depth;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
+            float fdim2 = float(dim2 + 0.5f) / (float)depth;
 
             // Extension: read image data from handle
             sycl::float4 px1 =

--- a/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
@@ -116,8 +116,8 @@ bool run_test() {
             size_t dim1 = it.get_local_id(1);
 
             // Normalize coordinates -- +0.5 to look towards centre of pixel
-            float fdim0 = float(dim0 + 0.5) / (float)width;
-            float fdim1 = float(dim1 + 0.5) / (float)height;
+            float fdim0 = float(dim0 + 0.5f) / (float)width;
+            float fdim1 = float(dim1 + 0.5f) / (float)height;
 
             // Extension: read mipmap level 1 with LOD
             MyType pixel =

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
@@ -143,9 +143,9 @@ bool run_sycl(sycl::range<NDims> globalSize, sycl::range<NDims> localSize,
               size_t dim2 = it.get_global_id(2);
 
               // Normalize coordinates -- +0.5 to look towards centre of pixel
-              float fdim0 = float(dim0 + 0.5) / (float)width;
-              float fdim1 = float(dim1 + 0.5) / (float)height;
-              float fdim2 = float(dim2 + 0.5) / (float)depth;
+              float fdim0 = float(dim0 + 0.5f) / (float)width;
+              float fdim1 = float(dim1 + 0.5f) / (float)height;
+              float fdim2 = float(dim2 + 0.5f) / (float)depth;
 
               // Extension: read image data from handle (Vulkan imported)
               VecType pixel;
@@ -160,8 +160,8 @@ bool run_sycl(sycl::range<NDims> globalSize, sycl::range<NDims> localSize,
               size_t dim1 = it.get_global_id(1);
 
               // Normalize coordinates -- +0.5 to look towards centre of pixel
-              float fdim0 = float(dim0 + 0.5) / (float)width;
-              float fdim1 = float(dim1 + 0.5) / (float)height;
+              float fdim0 = float(dim0 + 0.5f) / (float)width;
+              float fdim1 = float(dim1 + 0.5f) / (float)height;
 
               // Extension: read image data from handle (Vulkan imported)
               VecType pixel = syclexp::read_image<


### PR DESCRIPTION
double type needs -ze-fp64-gen-emu compile flag on DG2. Adding the flag each time is inconvenient for testing.