### PR TITLE
[SYCL][Bindless][Exp] Add default constructors to image handle structs

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
@@ -506,6 +506,7 @@ namespace sycl::ext::oneapi::experimental {
 struct unsampled_image_handle {
   using raw_image_handle_type = /* Implementation defined */;
 
+  unsampled_image_handle();
   unsampled_image_handle(raw_image_handle_type raw_handle);
 
   raw_image_handle_type raw_handle;
@@ -515,6 +516,7 @@ struct unsampled_image_handle {
 struct sampled_image_handle {
   using raw_image_handle_type = /* Implementation defined */;
 
+  sampled_image_handle();
   sampled_image_handle(raw_image_handle_type raw_image_handle);
 
   raw_image_handle_type raw_handle;
@@ -618,7 +620,10 @@ If the creation of an image fails, `create_image` will throw a `sycl::exception`
 with error code `sycl::errc::runtime`.
 
 The `unsampled_image_handle` and `sampled_image_handle` types shall be 
-default-constructible, copy-constructible, and device-copyable.
+default-constructible, copy-constructible, and device-copyable. When default 
+constructed, image handles are not valid until a user manually assigns a valid 
+`raw_image_handle_type` to the `raw_handle` field of the handle struct. The 
+default value of the `raw_handle` is implementation defined.
 
 The `unsampled_image_handle` and `sampled_image_handle` types have a 
 constructor to allow creation of the types from a `raw_image_handle_type`

--- a/sycl/include/sycl/ext/oneapi/bindless_images.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images.hpp
@@ -32,6 +32,8 @@ namespace ext::oneapi::experimental {
 struct unsampled_image_handle {
   using raw_image_handle_type = pi_uint64;
 
+  unsampled_image_handle() : raw_handle(~0) {}
+
   unsampled_image_handle(raw_image_handle_type raw_image_handle)
       : raw_handle(raw_image_handle) {}
 
@@ -41,6 +43,8 @@ struct unsampled_image_handle {
 /// Opaque sampled image handle type.
 struct sampled_image_handle {
   using raw_image_handle_type = pi_uint64;
+
+  sampled_image_handle() : raw_handle(~0) {}
 
   sampled_image_handle(raw_image_handle_type raw_image_handle)
       : raw_handle(raw_image_handle) {}

--- a/sycl/test-e2e/bindless_images/read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/read_1D.cpp
@@ -66,13 +66,20 @@ int main() {
     assert(imgMem0MoveAssign != imgMem1CopyAssign);
     assert(imgMem1 == imgMem1CopyAssign);
 
+    // We can default construct image handles
+    sycl::ext::oneapi::experimental::unsampled_image_handle imgHandle1;
+
     // Extension: create the image and return the handle
-    sycl::ext::oneapi::experimental::unsampled_image_handle imgHandle1 =
+    sycl::ext::oneapi::experimental::unsampled_image_handle tmpHandle =
         sycl::ext::oneapi::experimental::create_image(imgMem0MoveAssign, desc,
                                                       dev, ctxt);
     sycl::ext::oneapi::experimental::unsampled_image_handle imgHandle2 =
         sycl::ext::oneapi::experimental::create_image(imgMem1CopyAssign, desc,
                                                       dev, ctxt);
+
+    // Default constructed image handles are not valid until we assign a valid
+    // raw handle to the struct
+    imgHandle1.raw_handle = tmpHandle.raw_handle;
 
     // Extension: copy over data to device
     q.ext_oneapi_copy(dataIn1.data(), imgMem0MoveAssign.get_handle(), desc);


### PR DESCRIPTION
The image handle structs now have default constructors. Default constructed image handles are not valid until the `raw_handle` field of the struct is populated with a previously created and valid image handle.