### PR TITLE
[SYCL][Fusion] Require feature for all fusion tests

### DIFF
--- a/sycl/test-e2e/KernelFusion/abort_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_fusion.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/KernelFusion/abort_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -O2 -fsycl-embed-ir -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 SYCL_ENABLE_FUSION_CACHING=0 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/KernelFusion/abort_internalization_stored_ptr.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization_stored_ptr.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "Computation error" --implicit-check-not "Internalized" --check-prefix=CHECK %if hip %{ --check-prefix=CHECK-HIP %} %else %{ --check-prefix=CHECK-NON-HIP %}
 

--- a/sycl/test-e2e/KernelFusion/barrier_local_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/barrier_local_internalization.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/buffer_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/buffer_internalization.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/cached_ndrange.cpp
+++ b/sycl/test-e2e/KernelFusion/cached_ndrange.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "COMPUTATION ERROR"
 // UNSUPPORTED: hip

--- a/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/complete_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/complete_fusion.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/device_info_descriptor.cpp
+++ b/sycl/test-e2e/KernelFusion/device_info_descriptor.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/diamond_shape.cpp
+++ b/sycl/test-e2e/KernelFusion/diamond_shape.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/diamond_shape_local.cpp
+++ b/sycl/test-e2e/KernelFusion/diamond_shape_local.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/different_nd_ranges.cpp
+++ b/sycl/test-e2e/KernelFusion/different_nd_ranges.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelFusion/event_wait_complete.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_complete.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelFusion/existing_local_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/existing_local_accessor.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
+++ b/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelFusion/internalize_array_wrapper.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_array_wrapper.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/internalize_array_wrapper_local.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_array_wrapper_local.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/internalize_deep.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_deep.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/internalize_multi_ptr.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_multi_ptr.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/internalize_vec.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vec.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/jit_caching.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "COMPUTATION ERROR" --implicit-check-not "WRONG INTERNALIZATION"
 

--- a/sycl/test-e2e/KernelFusion/jit_caching_multispirv.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multispirv.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: fusion, gpu, (opencl || level_zero)
+// REQUIRES: gpu, (opencl || level_zero)
 // RUN: %{build} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 

--- a/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: fusion, gpu, (hip || cuda)
+// REQUIRES: gpu, (hip || cuda)
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 // XFAIL: *

--- a/sycl/test-e2e/KernelFusion/lit.local.cfg
+++ b/sycl/test-e2e/KernelFusion/lit.local.cfg
@@ -1,5 +1,6 @@
 import platform
 
+config.required_features += ['fusion']
 config.unsupported_features += ['accelerator']
 
 # TODO: enable on Windows once kernel fusion is supported on Windows.

--- a/sycl/test-e2e/KernelFusion/local_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/local_internalization.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/math_function.cpp
+++ b/sycl/test-e2e/KernelFusion/math_function.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
+++ b/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/pointer_arg_function.cpp
+++ b/sycl/test-e2e/KernelFusion/pointer_arg_function.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
 // This test currently fails because InferAddressSpace is not able to remove all

--- a/sycl/test-e2e/KernelFusion/private_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/private_internalization.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/ranged_offset_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/ranged_offset_accessor.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/struct_with_array.cpp
+++ b/sycl/test-e2e/KernelFusion/struct_with_array.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/sync_two_queues_event_dep.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_two_queues_event_dep.cpp
@@ -1,5 +1,4 @@
 // For this test, complete_fusion must be supported.
-// REQUIRES: fusion
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
@@ -1,5 +1,4 @@
 // For this test, complete_fusion must be supported.
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/KernelFusion/three_dimensional.cpp
+++ b/sycl/test-e2e/KernelFusion/three_dimensional.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/two_dimensional.cpp
+++ b/sycl/test-e2e/KernelFusion/two_dimensional.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
+++ b/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
+++ b/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: fusion
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
Even fusion end-to-end tests that do not require `complete_fusion` would fail if the tests are executed on a device that supports fusion in principle (e.g., CPU), but the build has fusion disabled.

This change simply replaces the `REQUIRES: fusion` in individual test files with the equivalent in the `lit.local.cfg` to require the `fusion` feature for all tests in the directory.