### PR TITLE
[SYCL][Graph] Exception if profiling is called on an event returned from a queue in record mode.

### DIFF
--- a/sycl/source/event.cpp
+++ b/sycl/source/event.cpp
@@ -81,6 +81,13 @@ event::get_info() const {
 template <typename Param>
 typename detail::is_event_profiling_info_desc<Param>::return_type
 event::get_profiling_info() const {
+  if (impl->getCommandGraph()) {
+    throw sycl::exception(make_error_code(errc::invalid),
+                          "Profiling information is unavailable for events "
+                          "returned from a submission to a queue in the "
+                          "recording state.");
+  }
+
   if constexpr (!std::is_same_v<Param, info::event_profiling::command_submit>) {
     impl->wait(impl);
   }

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1941,6 +1941,25 @@ TEST_F(CommandGraphTest, GraphPartitionsMerging) {
   ASSERT_FALSE(PartitionsList[4]->isHostTask());
 }
 
+TEST_F(CommandGraphTest, ProfilingException) {
+  Graph.begin_recording(Queue);
+  auto Event1 = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto Event2 = Queue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  Graph.end_recording(Queue);
+
+  try {
+    Event1.get_profiling_info<sycl::info::event_profiling::command_start>();
+  } catch (exception &Exception) {
+    ASSERT_FALSE(
+        std::string(Exception.what())
+            .find("Profiling information is unavailable for events returned "
+                  "from a submission to a queue in the recording state.") ==
+        std::string::npos);
+  }
+}
+
 class MultiThreadGraphTest : public CommandGraphTest {
 public:
   MultiThreadGraphTest()


### PR DESCRIPTION
Throws an appropriate message if profiling is called on an event returned from a queue in record mode. 
Adds a test to check the exception message thrown.