### PR TITLE
[SYCL][FPGA] Update LLVM IR Metadata with IVdep attribute

### DIFF
--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -499,9 +499,10 @@ static void EmitLegacyIVDepLoopMetadata(
     return;
   }
 
-  Metadata *SafelenMDs[] = {MDString::get(Ctx, "llvm.loop.parallel_accesses_safelen"),
-                            ConstantAsMetadata::get(ConstantInt::get(
-                                llvm::Type::getInt32Ty(Ctx), I.SafeLen))};
+  Metadata *SafelenMDs[] = {
+      MDString::get(Ctx, "llvm.loop.parallel_accesses_safelen"),
+      ConstantAsMetadata::get(
+          ConstantInt::get(llvm::Type::getInt32Ty(Ctx), I.SafeLen))};
   LoopProperties.push_back(MDNode::get(Ctx, SafelenMDs));
 }
 
@@ -1222,7 +1223,8 @@ void LoopInfo::addIVDepMetadata(const ValueDecl *Array,
   if (MD.size() == 1)
     GEP->setMetadata("llvm.access.group", cast<llvm::MDNode>(MD.front()));
   else if (!MD.empty())
-    GEP->setMetadata("llvm.access.group", MDNode::get(Header->getContext(), MD));
+    GEP->setMetadata("llvm.access.group",
+                     MDNode::get(Header->getContext(), MD));
 }
 
 void LoopInfoStack::addIVDepMetadata(const ValueDecl *Array,

--- a/clang/lib/CodeGen/CGLoopInfo.cpp
+++ b/clang/lib/CodeGen/CGLoopInfo.cpp
@@ -499,7 +499,7 @@ static void EmitLegacyIVDepLoopMetadata(
     return;
   }
 
-  Metadata *SafelenMDs[] = {MDString::get(Ctx, "llvm.loop.ivdep.safelen"),
+  Metadata *SafelenMDs[] = {MDString::get(Ctx, "llvm.loop.parallel_accesses_safelen"),
                             ConstantAsMetadata::get(ConstantInt::get(
                                 llvm::Type::getInt32Ty(Ctx), I.SafeLen))};
   LoopProperties.push_back(MDNode::get(Ctx, SafelenMDs));
@@ -1220,9 +1220,9 @@ void LoopInfo::addIVDepMetadata(const ValueDecl *Array,
   collectIVDepMetadata(Array, MD);
 
   if (MD.size() == 1)
-    GEP->setMetadata("llvm.index.group", cast<llvm::MDNode>(MD.front()));
+    GEP->setMetadata("llvm.access.group", cast<llvm::MDNode>(MD.front()));
   else if (!MD.empty())
-    GEP->setMetadata("llvm.index.group", MDNode::get(Header->getContext(), MD));
+    GEP->setMetadata("llvm.access.group", MDNode::get(Header->getContext(), MD));
 }
 
 void LoopInfoStack::addIVDepMetadata(const ValueDecl *Array,

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-array.cpp
@@ -9,7 +9,7 @@ void ivdep_array_no_safelen() {
   // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
   int b[10];
   [[intel::ivdep(a)]] for (int i = 0; i != 10; ++i) {
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_ARR:[0-9]+]]
     a[i] = 0;
     // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
     b[i] = 0;
@@ -25,7 +25,7 @@ void ivdep_array_with_safelen() {
   // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
   int b[10];
   [[intel::ivdep(a, 5)]] for (int i = 0; i != 10; ++i) {
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_ARR_SAFELEN:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_ARR_SAFELEN:[0-9]+]]
     a[i] = 0;
     // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
     b[i] = 0;
@@ -49,13 +49,13 @@ void ivdep_multiple_arrays() {
   [[intel::ivdep(b, 5)]]
   [[intel::ivdep(c)]]
   [[intel::ivdep(d)]] for (int i = 0; i != 10; ++i) {
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_MUL_ARR:[0-9]+]]
     a[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_MUL_ARR:[0-9]+]]
     b[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_C]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_C_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_C]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_C_MUL_ARR:[0-9]+]]
     c[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_D]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_D_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_D]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_D_MUL_ARR:[0-9]+]]
     d[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_ARR:[0-9]+]]
   }
@@ -76,13 +76,13 @@ void ivdep_multiple_arrays_template() {
   [[intel::ivdep(b, 5)]]
   [[intel::ivdep(c)]]
   [[intel::ivdep(d)]] for (int i = 0; i != 10; ++i) {
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_MUL_ARR:[0-9]+]]
     a[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_MUL_ARR:[0-9]+]]
     b[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_C]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_C_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_C]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_C_MUL_ARR:[0-9]+]]
     c[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_D]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_D_MUL_ARR:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_D]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_D_MUL_ARR:[0-9]+]]
     d[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_ARR:[0-9]+]]
   }
@@ -98,9 +98,9 @@ void ivdep_array_and_global() {
   int b[10];
   [[intel::ivdep]]
   [[intel::ivdep(a)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_ARR_AND_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_ARR_AND_GLOB:[0-9]+]]
     a[i] = 0;
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_ARR_AND_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_ARR_AND_GLOB:[0-9]+]]
     b[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_AND_GLOB:[0-9]+]]
   }
@@ -116,9 +116,9 @@ void ivdep_array_and_inf_global() {
   int b[10];
   [[intel::ivdep]]
   [[intel::ivdep(a, 8)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_ARR_AND_INF_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_ARR_AND_INF_GLOB:[0-9]+]]
     a[i] = 0;
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_ARR_AND_INF_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_ARR_AND_INF_GLOB:[0-9]+]]
     b[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_AND_INF_GLOB:[0-9]+]]
   }
@@ -134,9 +134,9 @@ void ivdep_array_and_greater_global() {
   int b[10];
   [[intel::ivdep(9)]]
   [[intel::ivdep(a, 8)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB:[0-9]+]]
     a[i] = 0;
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB:[0-9]+]]
     b[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_ARR_AND_GREAT_GLOB:[0-9]+]]
   }
@@ -155,11 +155,11 @@ void ivdep_mul_arrays_and_global() {
   [[intel::ivdep(5)]]
   [[intel::ivdep(b, 6)]]
   [[intel::ivdep(c)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_ARR_AND_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_MUL_ARR_AND_GLOB:[0-9]+]]
     a[i] = 0;
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_ARR_AND_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_MUL_ARR_AND_GLOB:[0-9]+]]
     b[i] = 0;
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_C]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_C_MUL_ARR_AND_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_C]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_C_MUL_ARR_AND_GLOB:[0-9]+]]
     c[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_ARR_AND_GLOB:[0-9]+]]
   }
@@ -172,7 +172,7 @@ void ivdep_ptr() {
   [[intel::ivdep(ptr, 5)]] for (int i = 0; i != 10; ++i)
       ptr[i] = 0;
   // CHECK: %[[PTR_LOAD:[0-9a-z]+]] = load ptr addrspace(4), ptr addrspace(4) %[[PTR]]
-  // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds i32, ptr addrspace(4) %[[PTR_LOAD]], i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_PTR:[0-9]+]]
+  // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds i32, ptr addrspace(4) %[[PTR_LOAD]], i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_PTR:[0-9]+]]
   // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_PTR:[0-9]+]]
 }
 
@@ -186,14 +186,14 @@ void ivdep_struct() {
   [[intel::ivdep(s.arr, 5)]] for (int i = 0; i != 10; ++i)
       s.arr[i] = 0;
   // CHECK: %[[STRUCT_ARR:[0-9a-z]+]] = getelementptr inbounds %struct.S, ptr addrspace(4) %[[STRUCT]].ascast, i32 0, i32 1
-  // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[STRUCT_ARR]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_STRUCT_ARR:[0-9]+]]
+  // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[STRUCT_ARR]], i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_STRUCT_ARR:[0-9]+]]
   // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_STRUCT_ARR:[0-9]+]]
 
   [[intel::ivdep(s.ptr, 5)]] for (int i = 0; i != 10; ++i)
       s.ptr[i] = 0;
   // CHECK: %[[STRUCT_PTR:[0-9a-z]+]] = getelementptr inbounds %struct.S, ptr addrspace(4) %[[STRUCT]].ascast, i32 0, i32 0
   // CHECK: %[[LOAD_STRUCT_PTR:[0-9a-z]+]] = load ptr addrspace(4), ptr addrspace(4) %[[STRUCT_PTR]]
-  // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds i32, ptr addrspace(4) %[[LOAD_STRUCT_PTR]], i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_STRUCT_PTR:[0-9]+]]
+  // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds i32, ptr addrspace(4) %[[LOAD_STRUCT_PTR]], i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_STRUCT_PTR:[0-9]+]]
   // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_STRUCT_PTR:[0-9]+]]
 }
 
@@ -267,7 +267,7 @@ int main() {
 // CHECK-DAG: ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB]] = distinct !{}
 // CHECK-DAG: ![[MD_LOOP_ARR_AND_GREAT_GLOB]] = distinct !{![[MD_LOOP_ARR_AND_GREAT_GLOB]], ![[MP]], ![[IVDEP_ARR_AND_GREAT_GLOB:[0-9]+]], ![[IVDEP_LEGACY_ARR_AND_GREAT_GLOB:[0-9]+]]}
-// CHECK-DAG: ![[IVDEP_LEGACY_ARR_AND_GREAT_GLOB]] = !{!"llvm.loop.ivdep.safelen", i32 9}
+// CHECK-DAG: ![[IVDEP_LEGACY_ARR_AND_GREAT_GLOB]] = !{!"llvm.loop.parallel_accesses_safelen", i32 9}
 // CHECK-DAG: ![[IVDEP_ARR_AND_GREAT_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_ARR_AND_GREAT_GLOB]], ![[IDX_GROUP_B_ARR_AND_GREAT_GLOB]], i32 9}
 
 /// Multiple arrays with specific safelens and lesser global safelen
@@ -277,7 +277,7 @@ int main() {
 // CHECK-DAG: ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]] = distinct !{}
 // CHECK-DAG: ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]] = distinct !{}
 // CHECK-DAG: ![[MD_LOOP_MUL_ARR_AND_GLOB]] = distinct !{![[MD_LOOP_MUL_ARR_AND_GLOB]], ![[MP]], ![[IVDEP_A_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_LEGACY_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_B_MUL_ARR_AND_GLOB:[0-9]+]], ![[IVDEP_C_MUL_ARR_AND_GLOB:[0-9]+]]}
-// CHECK-DAG: ![[IVDEP_LEGACY_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.ivdep.safelen", i32 5}
+// CHECK-DAG: ![[IVDEP_LEGACY_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_accesses_safelen", i32 5}
 // CHECK-DAG: ![[IVDEP_A_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_A_MUL_ARR_AND_GLOB]], i32 5}
 // CHECK-DAG: ![[IVDEP_B_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_B_MUL_ARR_AND_GLOB]], i32 6}
 // CHECK-DAG: ![[IVDEP_C_MUL_ARR_AND_GLOB]] = !{!"llvm.loop.parallel_access_indices", ![[IDX_GROUP_C_MUL_ARR_AND_GLOB]]}

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-embedded-loops.cpp
@@ -8,8 +8,8 @@ void ivdep_inner_loop_access() {
   int a[10];
   [[intel::ivdep]] for (int i = 0; i != 10; ++i) {
     [[intel::ivdep(3)]] for (int j = 0; j != 10; ++j) {
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_ACCESS:[0-9]+]]
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_ACCESS]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_INNER_ACCESS:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_INNER_ACCESS]]
       a[i] = a[(i + j) % 10];
       // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_INNER_LOOP_INNER_ACCESS:[0-9]+]]
     }
@@ -24,12 +24,12 @@ void ivdep_embedded_global_safelen() {
   // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
   int a[10];
   [[intel::ivdep]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_GLOB_SFLN:[0-9]+]]
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_GLOB_SFLN]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_OUTER_GLOB_SFLN:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_OUTER_GLOB_SFLN]]
     a[i] = a[i % 2];
     [[intel::ivdep]] for (int j = 0; j != 10; ++j) {
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_GLOB_SFLN:[0-9]+]]
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_GLOB_SFLN]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_INNER_GLOB_SFLN:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_INNER_GLOB_SFLN]]
       a[i] = a[(i + j) % 10];
       // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_GLOB_SFLN:[0-9]+]]
     }
@@ -44,12 +44,12 @@ void ivdep_embedded_various_safelens() {
   // CHECK: %[[ARRAY_A:[0-9a-z]+]] = alloca [10 x i32]
   int a[10];
   [[intel::ivdep(a, 4)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_VAR_SFLN:[0-9]+]]
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_OUTER_VAR_SFLN]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_OUTER_VAR_SFLN:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_OUTER_VAR_SFLN]]
     a[i] = a[i % 2];
     [[intel::ivdep(a, 2)]] for (int j = 0; j != 10; ++j) {
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_VAR_SFLN:[0-9]+]]
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_INNER_VAR_SFLN]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_INNER_VAR_SFLN:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_INNER_VAR_SFLN]]
       a[i] = a[(i + j) % 10];
       // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_VAR_SFLN:[0-9]+]]
     }
@@ -68,15 +68,15 @@ void ivdep_embedded_multiple_arrays() {
   // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
   int b[10];
   [[intel::ivdep(a, 3), intel::ivdep(b, 4)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS:[0-9]+]]
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_OUTER_MUL_ARRS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_OUTER_MUL_ARRS]]
     a[i] = a[i % 2];
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_OUTER_MUL_ARRS:[0-9]+]]
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_OUTER_MUL_ARRS]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_OUTER_MUL_ARRS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_OUTER_MUL_ARRS]]
     b[i] = b[i % 2];
     [[intel::ivdep(2)]] for (int j = 0; j != 10; ++j) {
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_INNER_MUL_ARRS:[0-9]+]]
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_INNER_MUL_ARRS:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_INNER_MUL_ARRS:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_INNER_MUL_ARRS:[0-9]+]]
       a[i] = b[(i + j) % 10];
       // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_MUL_ARRS:[0-9]+]]
     }
@@ -97,15 +97,15 @@ void ivdep_embedded_multiple_arrays_global() {
   // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
   int b[10];
   [[intel::ivdep(a)]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB:[0-9]+]]
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_OUTER_MUL_ARRS_GLOB]]
     a[i] = a[i % 2];
     // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
     // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}{{[[:space:]]}}
     b[i] = b[i % 2];
     [[intel::ivdep]] for (int j = 0; j != 10; ++j) {
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB:[0-9]+]]
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_INNER_MUL_ARRS_GLOB:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_INNER_MUL_ARRS_GLOB:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_INNER_MUL_ARRS_GLOB:[0-9]+]]
       a[i] = b[(i + j) % 10];
       // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_INNER_MUL_ARRS_GLOB:[0-9]+]]
     }
@@ -118,13 +118,13 @@ void ivdep_embedded_multiple_arrays_global() {
 void ivdep_embedded_multiple_dimensions() {
   int a[10];
   [[intel::ivdep]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_DIM_1_MUL_DIMS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_DIM_1_MUL_DIMS:[0-9]+]]
     a[i] = i;
     [[intel::ivdep]] for (int j = 0; j != 10; ++j) {
-      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_DIM_2_MUL_DIMS:[0-9]+]]
+      // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_DIM_2_MUL_DIMS:[0-9]+]]
       a[j] += j;
       [[intel::ivdep]] for (int k = 0; k != 10; ++k) {
-        // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_DIM_3_MUL_DIMS:[0-9]+]]
+        // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_DIM_3_MUL_DIMS:[0-9]+]]
         a[k] += k;
         // CHECK: br label %for.cond{{[0-9]*}}, !llvm.loop ![[MD_LOOP_DIM_3_MUL_DIMS:[0-9]+]]
       }
@@ -161,7 +161,7 @@ int main() {
 // CHECK-DAG: ![[IDX_GROUP_INNER_ACCESS]] = !{![[OUTER_NODE_INNER_ACCESS:[0-9]+]], ![[INNER_NODE_INNER_ACCESS:[0-9]+]]}
 // CHECK-DAG: ![[INNER_NODE_INNER_ACCESS]] = distinct !{}
 // CHECK-DAG: ![[MD_INNER_LOOP_INNER_ACCESS]] = distinct !{![[MD_INNER_LOOP_INNER_ACCESS]], ![[#]], ![[IVDEP_INNER_INNER_ACCESS:[0-9]+]], ![[IVDEP_LEGACY_INNER_INNER_ACCESS:[0-9]+]]}
-// CHECK-DAG: ![[IVDEP_LEGACY_INNER_INNER_ACCESS]] = !{!"llvm.loop.ivdep.safelen", i32 3}
+// CHECK-DAG: ![[IVDEP_LEGACY_INNER_INNER_ACCESS]] = !{!"llvm.loop.parallel_accesses_safelen", i32 3}
 // CHECK-DAG: ![[IVDEP_INNER_INNER_ACCESS]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_INNER_ACCESS]], i32 3}
 //
 // Outer loop
@@ -206,7 +206,7 @@ int main() {
 // CHECK-DAG: ![[IDX_GROUP_B_INNER_MUL_ARRS]] = !{![[IDX_GROUP_B_OUTER_MUL_ARRS]], ![[INNER_NODE_B_MUL_ARRS:[0-9]+]]}
 // CHECK-DAG: ![[INNER_NODE_B_MUL_ARRS]] = distinct !{}
 // CHECK-DAG: ![[MD_LOOP_INNER_MUL_ARRS]] = distinct !{![[MD_LOOP_INNER_MUL_ARRS]], ![[#]], ![[IVDEP_INNER_A_B_MUL_ARRS:[0-9]+]], ![[IVDEP_LEGACY_INNER_MUL_ARRS:[0-9]+]]}
-// CHECK-DAG: ![[IVDEP_LEGACY_INNER_MUL_ARRS]] = !{!"llvm.loop.ivdep.safelen", i32 2}
+// CHECK-DAG: ![[IVDEP_LEGACY_INNER_MUL_ARRS]] = !{!"llvm.loop.parallel_accesses_safelen", i32 2}
 // CHECK-DAG: ![[IVDEP_INNER_A_B_MUL_ARRS]] = !{!"llvm.loop.parallel_access_indices", ![[INNER_NODE_B_MUL_ARRS]], ![[INNER_NODE_A_MUL_ARRS]], i32 2}
 //
 // Outer loop

--- a/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-ivdep-global.cpp
@@ -9,9 +9,9 @@ void ivdep_no_param() {
   // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
   int b[10];
   [[intel::ivdep]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_NO_PARAM:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_NO_PARAM:[0-9]+]]
     a[i] = 0;
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_NO_PARAM:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_NO_PARAM:[0-9]+]]
     b[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_NO_PARAM:[0-9]+]]
   }
@@ -29,12 +29,12 @@ void ivdep_no_param_multiple_geps() {
   // CHECK: %[[TMP:[0-9a-z]+]] = alloca i32
   int t;
   [[intel::ivdep]] for (int i = 0; i != 10; ++i) {
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_GEPS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_MUL_GEPS:[0-9]+]]
     t = a[i];
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_GEPS:[0-9]+]]
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_MUL_GEPS]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_MUL_GEPS:[0-9]+]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_MUL_GEPS]]
     a[i] = b[i];
-    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_MUL_GEPS]]
+    // CHECK: %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_MUL_GEPS]]
     b[i] = t;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_MUL_GEPS:[0-9]+]]
   }
@@ -49,9 +49,9 @@ void ivdep_safelen() {
   // CHECK: %[[ARRAY_B:[0-9a-z]+]] = alloca [10 x i32]
   int b[10];
   [[intel::ivdep(5)]] for (int i = 0; i != 10; ++i) {
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_SAFELEN:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_SAFELEN:[0-9]+]]
     a[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_SAFELEN:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_SAFELEN:[0-9]+]]
     b[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_SAFELEN:[0-9]+]]
   }
@@ -67,9 +67,9 @@ void ivdep_conflicting_safelen() {
   int b[10];
   [[intel::ivdep(5)]]
   [[intel::ivdep(4)]] for (int i = 0; i != 10; ++i) {
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_A_CONFL_SAFELEN:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_A_CONFL_SAFELEN:[0-9]+]]
     a[i] = 0;
-    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.index.group ![[IDX_GROUP_B_CONFL_SAFELEN:[0-9]+]]
+    // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_B]].ascast, i64 0, i64 %{{[0-9a-z]+}}, !llvm.access.group ![[IDX_GROUP_B_CONFL_SAFELEN:[0-9]+]]
     b[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_LOOP_CONFL_SAFELEN:[0-9]+]]
   }
@@ -83,7 +83,7 @@ void ivdep_safelen_one() {
   int a[10];
   [[intel::ivdep(1)]] for (int i = 0; i != 10; ++i) {
     // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}
-    // CHECK-NOT: !llvm.index.group
+    // CHECK-NOT: !llvm.access.group
     a[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_NO_LOOP_SAFELEN1:[0-9]+]]
   }
@@ -97,7 +97,7 @@ void ivdep_safelen_zero() {
   int a[10];
   [[intel::ivdep(0)]] for (int i = 0; i != 10; ++i) {
     // CHECK:  %{{[0-9a-z]+}} = getelementptr inbounds [10 x i32], ptr addrspace(4) %[[ARRAY_A]].ascast, i64 0, i64 %{{[0-9a-z]+}}
-    // CHECK-NOT: !llvm.index.group
+    // CHECK-NOT: !llvm.access.group
     a[i] = 0;
     // CHECK: br label %for.cond, !llvm.loop ![[MD_NO_LOOP_SAFELEN2:[0-9]+]]
   }
@@ -122,7 +122,7 @@ int main() {
 
 // Find recurring instances of legacy "IVDep enable/safelen" MD nodes.
 // CHECK-DAG: ![[IVDEP_LEGACY_ENABLE:[0-9]+]] = !{!"llvm.loop.ivdep.enable"}
-// CHECK-DAG: ![[IVDEP_LEGACY_SAFELEN_5:[0-9]+]] = !{!"llvm.loop.ivdep.safelen", i32 5}
+// CHECK-DAG: ![[IVDEP_LEGACY_SAFELEN_5:[0-9]+]] = !{!"llvm.loop.parallel_accesses_safelen", i32 5}
 
 /// Global ivdep w/o safelen specified
 /// All arrays have the same INF safelen - put access groups into the same parallel_access_indices metadata
@@ -155,7 +155,7 @@ int main() {
 
 /// Global ivdep w/ safelen value of 1 has no effect. Attribute is ignored and no IR is generated with safelen value of 1.
 // CHECK-DAG: ![[MD_NO_LOOP_SAFELEN1]] = distinct !{![[MD_NO_LOOP_SAFELEN1]], ![[#]]}
-// CHECK-NOT: !{!"llvm.loop.ivdep.safelen", i32 1}
+// CHECK-NOT: !{!"llvm.loop.parallel_accesses_safelen", i32 1}
 
 /// Global ivdep w/ safelen value of 0 has no effect. Attribute is ignored and no IR is generated with safelen value of 0.
 // CHECK-DAG: ![[MD_NO_LOOP_SAFELEN2]] = distinct !{![[MD_NO_LOOP_SAFELEN2]], ![[#]]}


### PR DESCRIPTION
The approach of tying the "llvm.index.group" metadata with IVDep attribute to the GEP instructions would allow generation of incorrect hardware if the GEP or a load/store using that GEP was moved by the optimizer into or out of the loop.

This patch updates clang IR metadata (Based on new FPGA proposal - in conjunction with SPIR-V Translator work) to prevent this incorrect FPGA hardware from being generated if an optimizer moves llvm.index.group tagged GEPs (or load stores) into different blocks:

1. replaces "llvm.index.group" with "llvm.access.group" metadata for GEP instructions (or load stores) with IVDep attribute.
2. generates metadata "llvm.loop.parallel_accesses_safelen" with IVDep attribute for (SafeLen > 0) instead "llvm.loop.ivdep.safelen" (as compare to llvm.loop.parallel_accesses) for the accesses.