### PR TITLE
[SYCL][Graph] Fix OpenCL backend test fails with CPU device

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
@@ -5,8 +5,12 @@
 //
 // CHECK-NOT: LEAK
 
-// Temporarily disabled for CUDA.
-// XFAIL: cuda
+// Temporarily disabled for CUDA and OpenCL
+// The OpenCL emulation layer does not return `CL_INVALID_WORK_GROUP_SIZE` as it
+// should. So the Sycl graph support cannot correctly catch the error and throw
+// the approriate exception for negative test. An issue has been reported
+// https://github.com/bashbaug/SimpleOpenCLSamples/issues/95
+// XFAIL: cuda, opencl
 // Note: failing negative test with HIP in the original test
 // TODO: disable hip when HIP backend will be supported by Graph
 

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
@@ -22,6 +22,7 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   int *Dotp = malloc_device<int>(1, Queue);
+  Queue.memset(Dotp, 0, sizeof(int)).wait();
 
   const size_t N = 10;
   int *X = malloc_device<int>(N, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
@@ -24,6 +24,7 @@ int main() {
   exp_ext::command_graph Graph{Queue.get_context(), Queue.get_device()};
 
   int *Dotp = malloc_device<int>(1, Queue);
+  Queue.memset(Dotp, 0, sizeof(int)).wait();
 
   const size_t N = 10;
   int *X = malloc_device<int>(N, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -24,6 +24,7 @@ int main() {
   exp_ext::command_graph Graph{QueueA.get_context(), QueueA.get_device()};
 
   int *Dotp = malloc_device<int>(1, QueueA);
+  QueueA.memset(Dotp, 0, sizeof(int)).wait();
 
   const size_t N = 10;
   int *X = malloc_device<int>(N, QueueA);

--- a/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
@@ -5,8 +5,12 @@
 //
 // CHECK-NOT: LEAK
 
-// Temporarily disabled for CUDA.
-// XFAIL: cuda
+// Temporarily disabled for CUDA and OpenCL
+// The OpenCL emulation layer does not return `CL_INVALID_WORK_GROUP_SIZE` as it
+// should. So the Sycl graph support cannot correctly catch the error and throw
+// the approriate exception for negative test. An issue has been reported
+// https://github.com/bashbaug/SimpleOpenCLSamples/issues/95
+// XFAIL: cuda, opencl
 // Note: failing negative test with HIP in the original test
 // TODO: disable hip when HIP backend will be supported by Graph
 


### PR DESCRIPTION
Adds missing variable initializations.
Temporary disable `work_group_size_prop.cpp` because the failure results from a bug in the emulation layer.