### PR TITLE
[CI] Respect disable-lint in pr-code-format workflow

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   code_formatter:
     runs-on: ubuntu-latest
-    if: github.repository == 'llvm/llvm-project' || github.repository == 'intel/llvm'
+    if: (github.repository == 'llvm/llvm-project' || github.repository == 'intel/llvm') && !contains(github.event.pull_request.labels.*.name, 'disable-lint')
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4


### PR DESCRIPTION
There is bug in this workflow, it fails if we have too many changed files.
eg:
https://github.com/intel/llvm/actions/runs/7291149287/job/19869497941?pr=12226

We also want it to respect the label.
