### PR TITLE
[hip] Fix HSA headers lookup

### DIFF
--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -24,7 +24,14 @@ else()
 endif()
 
 if("${SYCL_BUILD_PI_HIP_HSA_INCLUDE_DIR}" STREQUAL "")
-  set(PI_HIP_HSA_INCLUDE_DIR "${SYCL_BUILD_PI_HIP_ROCM_DIR}/hsa/include")
+  # pre v6 versions of ROCM prefix their include directory with /hsa but this
+  # was fixed in v6 to act like a well-behaved package
+  foreach (SUF hsa/include include)
+    if (EXISTS "${SYCL_BUILD_PI_HIP_ROCM_DIR}/${SUF}")
+      set(PI_HIP_HSA_INCLUDE_DIR "${SYCL_BUILD_PI_HIP_ROCM_DIR}/${SUF}")
+      break()
+    endif()
+  endforeach()
 else()
   set(PI_HIP_HSA_INCLUDE_DIR "${SYCL_BUILD_PI_HIP_INCLUDE_DIR}")
 endif()


### PR DESCRIPTION
ROCm installations prior to v6 don't respect the traditional installation layout and install the HSA headers to `$PREFIX/hsa/include/hsa` whereas in rocm6 it looks like they're putting it in the right place at `$PREFIX/include/hsa`.

That cleanup from AMD is good news, but it means that our workarounds now break and we need to check both places.

This is a companion to
https://github.com/oneapi-src/unified-runtime/pull/1208