### PR TITLE
[SYCL][ESIMD][E2E] Re-enable unified memory bsycl/tlock_store tests on DG2

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc.cpp
@@ -5,9 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //==----------------------------------------------------------==//
-// TODO: Enable after driver bug is fixed
-// UNSUPPORTED: gpu-intel-dg2
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc_dg2.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm_acc_dg2.cpp
@@ -5,9 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //==------------------------------------------------------------==//
-// TODO: Enable after driver bug is fixed
-// UNSUPPORTED: gpu-intel-dg2
-
 // REQUIRES: gpu-intel-dg2
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
I should have done this in https://github.com/intel/llvm/commit/a8d6290ef7358257f68317f26981fe086d19bfd2, with the test fixed these pass on DG2 now.