### PR TITLE
[CI] Add support for sycl-rel-** branches to CI

### DIFF
--- a/.github/workflows/sycl_linux_precommit.yml
+++ b/.github/workflows/sycl_linux_precommit.yml
@@ -8,6 +8,7 @@ on:
     branches:
     - sycl
     - sycl-devops-pr/**
+    - sycl-rel-**
     # Do not run builds if changes are only in the following locations
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'

--- a/.github/workflows/sycl_post_commit.yml
+++ b/.github/workflows/sycl_post_commit.yml
@@ -5,6 +5,7 @@ on:
     branches:
     - sycl
     - sycl-devops-pr/**
+    - sycl-rel-**
 
   pull_request:
     branches:

--- a/.github/workflows/sycl_windows_precommit.yml
+++ b/.github/workflows/sycl_windows_precommit.yml
@@ -6,6 +6,7 @@ on:
     - sycl
     - sycl-devops-pr/**
     - llvmspirv_pulldown
+    - sycl-rel-**
     # Do not run builds if changes are only in the following locations
     paths-ignore:
     - '.github/ISSUE_TEMPLATE/**'


### PR DESCRIPTION
add sycl-rel-** to the pre-commit/post-commit workflow supported branches