### PR TITLE
Remove key_t

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
@@ -152,19 +152,16 @@ struct device_has_key {
 
 template <size_t... Dims>
 struct property_value<work_group_size_key, std::integral_constant<size_t, Dims>...> {
-  using key_t = work_group_size_key;
   constexpr size_t operator[](int dim) const;
 };
 
 template <size_t... Dims>
 struct property_value<work_group_size_hint_key, std::integral_constant<size_t, Dims>...> {
-  using key_t = work_group_size_hint_key;
   constexpr size_t operator[](int dim) const;
 };
 
 template <sycl::aspect... Aspects>
 struct property_value<device_has_key, std::integral_constant<sycl::aspect, Aspects>...> {
-  using key_t = device_has_key;
   static constexpr std::array<sycl::aspect, sizeof...(Aspects)> value;
 };
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -155,7 +155,6 @@ struct foo_key {
 // The name of the property value class is the the name of the property without any suffix.
 using foo = property_value<foo_key>;
 template <> struct property_value<foo_key> {
-  using key_t = foo_key;
   constexpr property_value(int v) : value(v) {}
   int value;
 };
@@ -233,10 +232,10 @@ template<typename V, typename O, typename=void> struct is_property_value_of;
 template<typename V> struct is_property_value<V, std::enable_if_t<(sizeof(V)>0)>> : is_property_key<V> {};
 template<typename V, typename O> struct is_property_value_of<V, O, std::enable_if_t<(sizeof(V)>0)>> : is_property_key_of<V,O> {};
 // Specialization for compile-time-constant properties
-template<typename V> struct is_property_value<V, std::void_t<typename V::key_t>> :
-  is_property_key<typename V::key_t> {};
-template<typename V, typename O> struct is_property_value_of<V, O, std::void_t<typename V::key_t>> :
-  is_property_key_of<typename V::key_t, O> {};
+template<typename V> struct is_property_value<V, std::void_t<key_from_value<V>>> : //key_from_value is exposition only
+  is_property_key<key_from_value<V>> {};
+template<typename V, typename O> struct is_property_value_of<V, O, std::void_t<key_from_value<V>>> :
+  is_property_key_of<key_from_value<V>, O> {};
 
 } // namespace experimental::oneapi::ext::sycl
 ```
@@ -255,9 +254,6 @@ namespace sycl::ext::oneapi::experimental {
 
 template<typename Property, typename First, typename...Others>
 struct property_value {
-  // Alias of the property key type
-  using key_t = Property;
-
   // Each property with multi-parameter property_value must define template 
   // specializations for accessing the parameters.
 
@@ -290,11 +286,6 @@ using value_t = First;
 | Available only when there is exactly one parameter.  When the parameter's value is a type, `value_t`
 is that type.  When the parameter's value is a non-type, `value_t` is an implementation-defined type
 with a member constant `value` equal to the value.
-a|
-```c++
-using key_t = property;
-```
-| The property key type.
 |===
 --
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -99,8 +99,7 @@ The intention is to provide a robust mechanism with which to pass compile-time-c
 property:: A property is represented by a key and value. Properties can be used to provide extra values to classes or functions.
 
 property value:: An object of the property value class. A property value has zero or more property parameters.
-For runtime properties the value type is the same as the key type.
-For compile time properties the value type is given by the `value_t` type alias of the key type.
+The value type is given by the `value_t` type alias of the key type.
 
 property key:: A class representing the property key. It is used to query properties.
 
@@ -138,27 +137,33 @@ value to determine which of the extension's APIs the implementation supports.
 
 Properties have a value and key type,
 and by convention, these classes are declared in the root of the
-`sycl::ext::oneapi::experimental` namespace. For a runtime property the key and value types are the same and the name of the property value
-class has no suffix. A runtime property value typically has a constructor
+`sycl::ext::oneapi::experimental` namespace. 
+The value type is a template specialization of `property_value`. 
+The property key class contains a `value_t` alias which is templated on the property parameters.
+
+A runtime property value typically has a constructor
 which takes the value(s) of the properties and member function(s) which return those values. 
 
 ```c++
 namespace sycl::ext::oneapi::experimental {
 
+// The runtime property key
+struct foo_key {
+  using value_t = property_value<foo_key>;
+};
 // This is a runtime property value with one integer parameter.
 // The name of the property value class is the the name of the property without any suffix.
-struct foo {
-  foo(int);
+using foo = property_value<foo_key>;
+template <> struct property_value<foo_key> {
+  using key_t = foo_key;
+  constexpr property_value(int v) : value(v) {}
   int value;
 };
-// A runtime property key is an alias to the value type.
-using foo_key = foo;
 
 } // namespace experimental::oneapi::ext::sycl
 ```
 
-For compile-time constant parameters the value type is a template specialization of `property_value`. 
-The property key class contains a `value_t` alias which is templated on the property parameters. The `property_value` class holds the
+For compile-time constant parameters the `property_value` class holds the
 values of the compile-time parameters as template arguments. The parameters to a compile-
 time-constant property can be either types or non-type values.
 The implementation provides a variable with the property value type. The variable has the name of the property without a suffix.

--- a/sycl/include/sycl/ext/intel/esimd/memory_properties.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory_properties.hpp
@@ -132,21 +132,18 @@ namespace ext::oneapi::experimental {
 template <__ESIMD_NS::cache_hint Hint>
 struct property_value<__ESIMD_NS::cache_hint_L1_key,
                       std::integral_constant<__ESIMD_NS::cache_hint, Hint>> {
-  using key_t = __ESIMD_NS::cache_hint_L1_key;
   static constexpr __ESIMD_NS::cache_level level = __ESIMD_NS::cache_level::L1;
   static constexpr __ESIMD_NS::cache_hint hint = Hint;
 };
 template <__ESIMD_NS::cache_hint Hint>
 struct property_value<__ESIMD_NS::cache_hint_L2_key,
                       std::integral_constant<__ESIMD_NS::cache_hint, Hint>> {
-  using key_t = __ESIMD_NS::cache_hint_L2_key;
   static constexpr __ESIMD_NS::cache_level level = __ESIMD_NS::cache_level::L2;
   static constexpr __ESIMD_NS::cache_hint hint = Hint;
 };
 template <__ESIMD_NS::cache_hint Hint>
 struct property_value<__ESIMD_NS::cache_hint_L3_key,
                       std::integral_constant<__ESIMD_NS::cache_hint, Hint>> {
-  using key_t = __ESIMD_NS::cache_hint_L3_key;
   static constexpr __ESIMD_NS::cache_level level = __ESIMD_NS::cache_level::L3;
   static constexpr __ESIMD_NS::cache_hint hint = Hint;
 };

--- a/sycl/include/sycl/ext/intel/experimental/kernel_execution_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/kernel_execution_properties.hpp
@@ -26,12 +26,19 @@ inline constexpr cache_config_enum large_slm =
 inline constexpr cache_config_enum large_data =
     cache_config_enum::large_data;
 
-struct cache_config {
-  cache_config(cache_config_enum v) : value(v) {}
-  cache_config_enum value;
+struct cache_config_key {
+  using value_t = oneapi::experimental::property_value<cache_config_key>;
 };
-
-using cache_config_key = cache_config;
+using cache_config = cache_config_key::value_t;
+} // namespace ext::intel::experimental
+namespace ext::oneapi::experimental {
+template <> struct property_value<intel::experimental::cache_config_key> {
+  using key_t = intel::experimental::cache_config_key;
+  property_value(intel::experimental::cache_config_enum v) : value(v) {}
+  intel::experimental::cache_config_enum value;
+};
+} // namespace ext::oneapi::experimental
+namespace ext::intel::experimental {
 
 inline bool operator==(const cache_config &lhs,
                        const cache_config &rhs) {

--- a/sycl/include/sycl/ext/intel/experimental/kernel_execution_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/kernel_execution_properties.hpp
@@ -33,7 +33,6 @@ using cache_config = cache_config_key::value_t;
 } // namespace ext::intel::experimental
 namespace ext::oneapi::experimental {
 template <> struct property_value<intel::experimental::cache_config_key> {
-  using key_t = intel::experimental::cache_config_key;
   property_value(intel::experimental::cache_config_enum v) : value(v) {}
   intel::experimental::cache_config_enum value;
 };

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_util.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_util.hpp
@@ -106,8 +106,8 @@ struct ValidAllocPropertyList<T, detail::properties_t<Prop, Props...>>
                     is_valid_property<T *, Prop>::value,
                 "Found invalid compile-time property in the property list.");
   // check if a runtime property is valid for malloc
-  static_assert(!detail::IsRuntimeProperty<Prop>::value ||
-                    IsRuntimePropertyValid<Prop>::value,
+  static_assert(!detail::IsRuntimePropertyValue<Prop>::value ||
+                    IsRuntimePropertyValid<typename Prop::key_t>::value,
                 "Found invalid runtime property in the property list.");
 };
 

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_util.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_util.hpp
@@ -107,7 +107,7 @@ struct ValidAllocPropertyList<T, detail::properties_t<Prop, Props...>>
                 "Found invalid compile-time property in the property list.");
   // check if a runtime property is valid for malloc
   static_assert(!detail::IsRuntimePropertyValue<Prop>::value ||
-                    IsRuntimePropertyValid<typename Prop::key_t>::value,
+                    IsRuntimePropertyValid<key_from_value<Prop>>::value,
                 "Found invalid runtime property in the property list.");
 };
 

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -67,8 +67,6 @@ struct property_value<work_group_size_key, std::integral_constant<size_t, Dim0>,
   static_assert(detail::AllNonZero<Dim0, Dims...>::value,
                 "work_group_size property must only contain non-zero values.");
 
-  using key_t = work_group_size_key;
-
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
@@ -85,8 +83,6 @@ struct property_value<work_group_size_hint_key,
       detail::AllNonZero<Dim0, Dims...>::value,
       "work_group_size_hint property must only contain non-zero values.");
 
-  using key_t = work_group_size_hint_key;
-
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
@@ -98,7 +94,6 @@ struct property_value<sub_group_size_key,
   static_assert(Size != 0,
                 "sub_group_size_key property must contain a non-zero value.");
 
-  using key_t = sub_group_size_key;
   using value_t = std::integral_constant<uint32_t, Size>;
   static constexpr uint32_t value = Size;
 };
@@ -106,7 +101,6 @@ struct property_value<sub_group_size_key,
 template <aspect... Aspects>
 struct property_value<device_has_key,
                       std::integral_constant<aspect, Aspects>...> {
-  using key_t = device_has_key;
   static constexpr std::array<aspect, sizeof...(Aspects)> value{Aspects...};
 };
 

--- a/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
@@ -55,7 +55,6 @@ struct property_value<
     std::integral_constant<int, Target>,
     std::integral_constant<intel::experimental::latency_control_type, Type>,
     std::integral_constant<int, Cycle>> {
-  using key_t = intel::experimental::latency_constraint_key;
   static constexpr int target = Target;
   static constexpr intel::experimental::latency_control_type type = Type;
   static constexpr int cycle = Cycle;

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -248,20 +248,20 @@ struct all_props_are_keys_of : std::true_type {};
 
 template <typename SyclT>
 struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::detail::empty_properties_t>
+    SyclT, empty_properties_t>
     : std::true_type {};
 
 template <typename SyclT, typename PropT>
 struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::properties<std::tuple<PropT>>>
-    : std::bool_constant<ext::oneapi::experimental::is_property_key_of<
-          typename PropT::key_t, SyclT>::value> {};
+    SyclT, properties<std::tuple<PropT>>>
+    : std::bool_constant<is_property_key_of<
+          key_from_value<PropT>, SyclT>::value> {};
 
 template <typename SyclT, typename PropT, typename... PropTs>
 struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::properties<std::tuple<PropT, PropTs...>>>
-    : std::bool_constant<ext::oneapi::experimental::is_property_key_of<
-                             typename PropT::key_t, SyclT>::value &&
+    SyclT, properties<std::tuple<PropT, PropTs...>>>
+    : std::bool_constant<is_property_key_of<
+                             key_from_value<PropT>, SyclT>::value &&
                          all_props_are_keys_of<SyclT, PropTs...>()> {};
 
 } // namespace detail

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -77,7 +77,7 @@ template <typename... Ts> struct RuntimePropertyStorage<std::tuple<Ts...>> {
 };
 template <typename T, typename... Ts>
 struct RuntimePropertyStorage<std::tuple<T, Ts...>>
-    : std::conditional_t<IsRuntimeProperty<T>::value,
+    : std::conditional_t<IsRuntimePropertyValue<T>::value,
                          PrependTuple<T, typename RuntimePropertyStorage<
                                              std::tuple<Ts...>>::type>,
                          RuntimePropertyStorage<std::tuple<Ts...>>> {};
@@ -149,9 +149,9 @@ public:
   template <typename PropertyT>
   typename std::enable_if_t<detail::IsRuntimeProperty<PropertyT>::value &&
                                 has_property<PropertyT>(),
-                            PropertyT>
+                            typename PropertyT::value_t>
   get_property() const {
-    return std::get<PropertyT>(Storage);
+    return std::get<typename PropertyT::value_t>(Storage);
   }
 
   template <typename PropertyT>
@@ -254,16 +254,15 @@ struct all_props_are_keys_of<
 template <typename SyclT, typename PropT>
 struct all_props_are_keys_of<
     SyclT, ext::oneapi::experimental::properties<std::tuple<PropT>>>
-    : std::bool_constant<
-          ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value> {
-};
+    : std::bool_constant<ext::oneapi::experimental::is_property_key_of<
+          typename PropT::key_t, SyclT>::value> {};
 
 template <typename SyclT, typename PropT, typename... PropTs>
 struct all_props_are_keys_of<
     SyclT, ext::oneapi::experimental::properties<std::tuple<PropT, PropTs...>>>
-    : std::bool_constant<
-          ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value &&
-          all_props_are_keys_of<SyclT, PropTs...>()> {};
+    : std::bool_constant<ext::oneapi::experimental::is_property_key_of<
+                             typename PropT::key_t, SyclT>::value &&
+                         all_props_are_keys_of<SyclT, PropTs...>()> {};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -247,22 +247,18 @@ template <typename SyclT, typename PropertiesT>
 struct all_props_are_keys_of : std::true_type {};
 
 template <typename SyclT>
-struct all_props_are_keys_of<
-    SyclT, empty_properties_t>
-    : std::true_type {};
+struct all_props_are_keys_of<SyclT, empty_properties_t> : std::true_type {};
 
 template <typename SyclT, typename PropT>
-struct all_props_are_keys_of<
-    SyclT, properties<std::tuple<PropT>>>
-    : std::bool_constant<is_property_key_of<
-          key_from_value<PropT>, SyclT>::value> {};
+struct all_props_are_keys_of<SyclT, properties<std::tuple<PropT>>>
+    : std::bool_constant<
+          is_property_key_of<key_from_value<PropT>, SyclT>::value> {};
 
 template <typename SyclT, typename PropT, typename... PropTs>
-struct all_props_are_keys_of<
-    SyclT, properties<std::tuple<PropT, PropTs...>>>
-    : std::bool_constant<is_property_key_of<
-                             key_from_value<PropT>, SyclT>::value &&
-                         all_props_are_keys_of<SyclT, PropTs...>()> {};
+struct all_props_are_keys_of<SyclT, properties<std::tuple<PropT, PropTs...>>>
+    : std::bool_constant<
+          is_property_key_of<key_from_value<PropT>, SyclT>::value &&
+          all_props_are_keys_of<SyclT, PropTs...>()> {};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -62,6 +62,8 @@ struct HasValue<T, decltype((void)T::value, 0)> : std::true_type {};
 template <typename PropertyT>
 struct IsCompileTimePropertyValue : std::false_type {};
 
+template <typename PropertyT>
+struct IsRuntimePropertyValue : std::false_type {};
 // Checks if a type is either a runtime property or if it is a compile-time
 // property
 template <typename T> struct IsProperty {
@@ -73,7 +75,7 @@ template <typename T> struct IsProperty {
 // property_value with a valid compile-time property
 template <typename T> struct IsPropertyValue {
   static constexpr bool value =
-      IsRuntimeProperty<T>::value || IsCompileTimePropertyValue<T>::value;
+      IsRuntimePropertyValue<T>::value || IsCompileTimePropertyValue<T>::value;
 };
 
 // Checks that all types in a tuple are valid properties.

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -70,7 +70,8 @@ template <typename V>
 using is_property_value = is_property_key<detail::key_from_value_or_void<V>>;
 
 template <typename V, typename O>
-using is_property_value_of = is_property_key_of<detail::key_from_value_or_void<V>, O>;
+using is_property_value_of =
+    is_property_key_of<detail::key_from_value_or_void<V>, O>;
 
 namespace detail {
 

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -57,15 +57,11 @@ operator!=(const property_value<PropertyT, A...> &,
   return (!std::is_same<A, B>::value || ...);
 }
 
-template <typename V, typename = void> struct is_property_value {
-  static constexpr bool value =
-      detail::IsRuntimeProperty<V>::value && is_property_key<V>::value;
-};
-template <typename V, typename O, typename = void> struct is_property_value_of {
-  static constexpr bool value =
-      detail::IsRuntimeProperty<V>::value && is_property_key_of<V, O>::value;
-};
-// Specialization for compile-time-constant properties
+template <typename V, typename = void>
+struct is_property_value : std::false_type {};
+template <typename V, typename O, typename = void>
+struct is_property_value_of : std::false_type {};
+// Specialization for properties
 template <typename V>
 struct is_property_value<V, std::void_t<typename V::key_t>>
     : is_property_key<typename V::key_t> {};
@@ -84,6 +80,10 @@ struct PropertyID<property_value<PropertyT, PropertyValueTs...>>
 template <typename PropertyT, typename... PropertyValueTs>
 struct IsCompileTimePropertyValue<property_value<PropertyT, PropertyValueTs...>>
     : IsCompileTimeProperty<PropertyT> {};
+
+template <typename PropertyT, typename... PropertyValueTs>
+struct IsRuntimePropertyValue<property_value<PropertyT, PropertyValueTs...>>
+    : IsRuntimeProperty<PropertyT> {};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -818,7 +818,6 @@ struct build_options_key {
 };
 using build_options = property_value<build_options_key>;
 template <> struct property_value<build_options_key> {
-  using key_t = build_options_key;
   std::vector<std::string> opts;
   property_value(const std::string &optsArg) : opts{optsArg} {}
   property_value(const std::vector<std::string> &optsArg) : opts(optsArg) {}
@@ -856,7 +855,6 @@ struct save_log_key {
 };
 using save_log = property_value<save_log_key>;
 template <> struct property_value<save_log_key> {
-  using key_t = save_log_key;
   std::string *log;
   property_value(std::string *logArg) : log(logArg) {}
 };

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -813,12 +813,16 @@ namespace ext::oneapi::experimental {
 /////////////////////////
 // PropertyT syclex::build_options
 /////////////////////////
-struct build_options {
-  std::vector<std::string> opts;
-  build_options(const std::string &optsArg) : opts{optsArg} {}
-  build_options(const std::vector<std::string> &optsArg) : opts(optsArg) {}
+struct build_options_key {
+  using value_t = property_value<build_options_key>;
 };
-using build_options_key = build_options;
+using build_options = property_value<build_options_key>;
+template <> struct property_value<build_options_key> {
+  using key_t = build_options_key;
+  std::vector<std::string> opts;
+  property_value(const std::string &optsArg) : opts{optsArg} {}
+  property_value(const std::vector<std::string> &optsArg) : opts(optsArg) {}
+};
 
 template <> struct is_property_key<build_options_key> : std::true_type {};
 
@@ -847,12 +851,15 @@ struct IsCompileTimeProperty<sycl::ext::oneapi::experimental::build_options_key>
 /////////////////////////
 // PropertyT syclex::save_log
 /////////////////////////
-struct save_log {
-  std::string *log;
-  save_log(std::string *logArg) : log(logArg) {}
+struct save_log_key {
+  using value_t = property_value<save_log_key>;
 };
-using save_log_key = save_log;
-
+using save_log = property_value<save_log_key>;
+template <> struct property_value<save_log_key> {
+  using key_t = save_log_key;
+  std::string *log;
+  property_value(std::string *logArg) : log(logArg) {}
+};
 template <> struct is_property_key<save_log_key> : std::true_type {};
 
 template <>
@@ -917,11 +924,11 @@ build(kernel_bundle<bundle_state::ext_oneapi_source> &SourceKB,
       const std::vector<device> &Devices, PropertyListT props = {}) {
   std::vector<std::string> BuildOptionsVec;
   std::string *LogPtr = nullptr;
-  if constexpr (props.template has_property<build_options>()) {
-    BuildOptionsVec = props.template get_property<build_options>().opts;
+  if constexpr (props.template has_property<build_options_key>()) {
+    BuildOptionsVec = props.template get_property<build_options_key>().opts;
   }
-  if constexpr (props.template has_property<save_log>()) {
-    LogPtr = props.template get_property<save_log>().log;
+  if constexpr (props.template has_property<save_log_key>()) {
+    LogPtr = props.template get_property<save_log_key>().log;
   }
   return detail::build_from_source(SourceKB, Devices, BuildOptionsVec, LogPtr);
 }

--- a/sycl/test/extensions/annotated_usm/fake_properties.hpp
+++ b/sycl/test/extensions/annotated_usm/fake_properties.hpp
@@ -92,8 +92,7 @@ template <> struct property_value<foz_key> {
     using value_t = property_value<rt_prop##N##_key>;                          \
   };                                                                           \
   using rt_prop##N = property_value<rt_prop##N##_key>;                         \
-  template <> struct property_value<rt_prop##N##_key> {                        \
-  }
+  template <> struct property_value<rt_prop##N##_key> {}
 
 rt_prop(1);
 rt_prop(2);

--- a/sycl/test/extensions/annotated_usm/fake_properties.hpp
+++ b/sycl/test/extensions/annotated_usm/fake_properties.hpp
@@ -89,14 +89,14 @@ template <> struct property_value<foz_key> {
   bool value2;
 };
 
-#define rt_prop(N) \
-struct rt_prop ## N ## _key { \
-  using value_t = property_value<rt_prop ## N ## _key>; \
-}; \
-using rt_prop ## N = property_value<rt_prop ## N ## _key>; \
-template <> struct property_value<rt_prop ## N ## _key> { \
-using key_t = rt_prop ## N ## _key; \
-}
+#define rt_prop(N)                                                             \
+  struct rt_prop##N##_key {                                                    \
+    using value_t = property_value<rt_prop##N##_key>;                          \
+  };                                                                           \
+  using rt_prop##N = property_value<rt_prop##N##_key>;                         \
+  template <> struct property_value<rt_prop##N##_key> {                        \
+    using key_t = rt_prop##N##_key;                                            \
+  }
 
 rt_prop(1);
 rt_prop(2);

--- a/sycl/test/extensions/annotated_usm/fake_properties.hpp
+++ b/sycl/test/extensions/annotated_usm/fake_properties.hpp
@@ -74,7 +74,6 @@ struct foo_key {
 };
 using foo = property_value<foo_key>;
 template <> struct property_value<foo_key> {
-  using key_t = foo_key;
   constexpr property_value(foo_enum v) : value(v) {}
   foo_enum value;
 };
@@ -84,7 +83,6 @@ struct foz_key {
 };
 using foz = property_value<foz_key>;
 template <> struct property_value<foz_key> {
-  using key_t = foz_key;
   float value1;
   bool value2;
 };
@@ -95,7 +93,6 @@ template <> struct property_value<foz_key> {
   };                                                                           \
   using rt_prop##N = property_value<rt_prop##N##_key>;                         \
   template <> struct property_value<rt_prop##N##_key> {                        \
-    using key_t = rt_prop##N##_key;                                            \
   }
 
 rt_prop(1);

--- a/sycl/test/extensions/annotated_usm/fake_properties.hpp
+++ b/sycl/test/extensions/annotated_usm/fake_properties.hpp
@@ -69,85 +69,70 @@ template <> struct IsCompileTimeProperty<boo_key> : std::true_type {};
 
 // Runtime properties
 enum foo_enum : unsigned { a, b, c };
-struct foo {
-  constexpr foo(foo_enum v) : value(v) {}
+struct foo_key {
+  using value_t = property_value<foo_key>;
+};
+using foo = property_value<foo_key>;
+template <> struct property_value<foo_key> {
+  using key_t = foo_key;
+  constexpr property_value(foo_enum v) : value(v) {}
   foo_enum value;
 };
 
-struct foz {
+struct foz_key {
+  using value_t = property_value<foz_key>;
+};
+using foz = property_value<foz_key>;
+template <> struct property_value<foz_key> {
+  using key_t = foz_key;
   float value1;
   bool value2;
 };
 
-struct rt_prop1 {};
-struct rt_prop2 {};
-struct rt_prop3 {};
-struct rt_prop4 {};
-struct rt_prop5 {};
-struct rt_prop6 {};
-struct rt_prop7 {};
-struct rt_prop8 {};
-struct rt_prop9 {};
-struct rt_prop10 {};
-struct rt_prop11 {};
-struct rt_prop12 {};
-struct rt_prop13 {};
-struct rt_prop14 {};
-struct rt_prop15 {};
-struct rt_prop16 {};
-struct rt_prop17 {};
-struct rt_prop18 {};
-struct rt_prop19 {};
-struct rt_prop20 {};
-struct rt_prop21 {};
-struct rt_prop22 {};
-struct rt_prop23 {};
-struct rt_prop24 {};
-struct rt_prop25 {};
-struct rt_prop26 {};
-struct rt_prop27 {};
-struct rt_prop28 {};
-struct rt_prop29 {};
-struct rt_prop30 {};
-struct rt_prop31 {};
-struct rt_prop32 {};
-struct rt_prop33 {};
+#define rt_prop(N) \
+struct rt_prop ## N ## _key { \
+  using value_t = property_value<rt_prop ## N ## _key>; \
+}; \
+using rt_prop ## N = property_value<rt_prop ## N ## _key>; \
+template <> struct property_value<rt_prop ## N ## _key> { \
+using key_t = rt_prop ## N ## _key; \
+}
 
-using foo_key = foo;
-using foz_key = foz;
-using rt_prop1_key = rt_prop1;
-using rt_prop2_key = rt_prop2;
-using rt_prop3_key = rt_prop3;
-using rt_prop4_key = rt_prop4;
-using rt_prop5_key = rt_prop5;
-using rt_prop6_key = rt_prop6;
-using rt_prop7_key = rt_prop7;
-using rt_prop8_key = rt_prop8;
-using rt_prop9_key = rt_prop9;
-using rt_prop10_key = rt_prop10;
-using rt_prop11_key = rt_prop11;
-using rt_prop12_key = rt_prop12;
-using rt_prop13_key = rt_prop13;
-using rt_prop14_key = rt_prop14;
-using rt_prop15_key = rt_prop15;
-using rt_prop16_key = rt_prop16;
-using rt_prop17_key = rt_prop17;
-using rt_prop18_key = rt_prop18;
-using rt_prop19_key = rt_prop19;
-using rt_prop20_key = rt_prop20;
-using rt_prop21_key = rt_prop21;
-using rt_prop22_key = rt_prop22;
-using rt_prop23_key = rt_prop23;
-using rt_prop24_key = rt_prop24;
-using rt_prop25_key = rt_prop25;
-using rt_prop26_key = rt_prop26;
-using rt_prop27_key = rt_prop27;
-using rt_prop28_key = rt_prop28;
-using rt_prop29_key = rt_prop29;
-using rt_prop30_key = rt_prop30;
-using rt_prop31_key = rt_prop31;
-using rt_prop32_key = rt_prop32;
-using rt_prop33_key = rt_prop33;
+rt_prop(1);
+rt_prop(2);
+rt_prop(3);
+rt_prop(4);
+rt_prop(5);
+rt_prop(6);
+rt_prop(7);
+rt_prop(8);
+rt_prop(9);
+rt_prop(10);
+rt_prop(11);
+rt_prop(12);
+rt_prop(13);
+rt_prop(14);
+rt_prop(15);
+rt_prop(16);
+rt_prop(17);
+rt_prop(18);
+rt_prop(19);
+rt_prop(20);
+rt_prop(21);
+rt_prop(22);
+rt_prop(23);
+rt_prop(24);
+rt_prop(25);
+rt_prop(26);
+rt_prop(27);
+rt_prop(28);
+rt_prop(29);
+rt_prop(30);
+rt_prop(31);
+rt_prop(32);
+rt_prop(33);
+
+#undef rt_prop
 
 template <> struct is_property_key<foo_key> : std::true_type {};
 template <> struct is_property_key<foz_key> : std::true_type {};

--- a/sycl/test/extensions/properties/mock_compile_time_properties.hpp
+++ b/sycl/test/extensions/properties/mock_compile_time_properties.hpp
@@ -12,6 +12,8 @@
 
 #pragma once
 
+#include <sycl/sycl.hpp>
+
 namespace sycl {
 namespace ext {
 namespace oneapi {
@@ -30,8 +32,13 @@ struct boo_key {
   template <typename... Ts> using value_t = property_value<boo_key, Ts...>;
 };
 
-struct foo {
-  constexpr foo(int v) : value(v) {}
+struct foo_key {
+  using value_t = property_value<foo_key>;
+};
+using foo = property_value<foo_key>;
+template <> struct property_value<foo_key> {
+  using key_t = foo_key;
+  constexpr property_value(int v) : value(v) {}
   int value;
 };
 
@@ -40,13 +47,15 @@ inline bool operator==(const foo &lhs, const foo &rhs) {
 }
 inline bool operator!=(const foo &lhs, const foo &rhs) { return !(lhs == rhs); }
 
-struct foz {
-  constexpr foz(float v1, bool v2) : value1(v1), value2(v2) {}
+struct foz_key {
+  using value_t = property_value<foz_key>;
+};
+using foz = property_value<foz_key>;
+template <> struct property_value<foz_key> {
+  using key_t = foz_key;
+  constexpr property_value(float v1, bool v2) : value1(v1), value2(v2) {}
   // Define copy constructor to make foz non-trivially copyable
-  constexpr foz(const foz &f) {
-    value1 = f.value1;
-    value2 = f.value2;
-  }
+  constexpr property_value(const foz &f) : value1(f.value1), value2(f.value2) {}
   float value1;
   bool value2;
 };
@@ -56,11 +65,16 @@ inline bool operator==(const foz &lhs, const foz &rhs) {
 }
 inline bool operator!=(const foz &lhs, const foz &rhs) { return !(lhs == rhs); }
 
-struct fir {
+struct fir_key {
+  using value_t = property_value<fir_key>;
+};
+using fir = property_value<fir_key>;
+template <> struct property_value<fir_key> {
+  using key_t = fir_key;
   // Intentionally not constexpr to test for properties that cannot be constexpr
-  fir(float v1, bool v2) : value1(v1), value2(v2) {}
+  property_value(float v1, bool v2) : value1(v1), value2(v2) {}
   // Define copy constructor to make foz non-trivially copyable
-  fir(const foz &f) {
+  property_value(const foz &f) {
     value1 = f.value1;
     value2 = f.value2;
   }
@@ -76,10 +90,6 @@ inline bool operator!=(const fir &lhs, const fir &rhs) { return !(lhs == rhs); }
 inline constexpr bar_key::value_t bar;
 template <int K> inline constexpr baz_key::value_t<K> baz;
 template <typename... Ts> inline constexpr boo_key::value_t<Ts...> boo;
-
-using foo_key = foo;
-using foz_key = foz;
-using fir_key = fir;
 
 template <> struct is_property_key<bar_key> : std::true_type {};
 template <> struct is_property_key<baz_key> : std::true_type {};

--- a/sycl/test/extensions/properties/mock_compile_time_properties.hpp
+++ b/sycl/test/extensions/properties/mock_compile_time_properties.hpp
@@ -37,7 +37,6 @@ struct foo_key {
 };
 using foo = property_value<foo_key>;
 template <> struct property_value<foo_key> {
-  using key_t = foo_key;
   constexpr property_value(int v) : value(v) {}
   int value;
 };
@@ -52,7 +51,6 @@ struct foz_key {
 };
 using foz = property_value<foz_key>;
 template <> struct property_value<foz_key> {
-  using key_t = foz_key;
   constexpr property_value(float v1, bool v2) : value1(v1), value2(v2) {}
   // Define copy constructor to make foz non-trivially copyable
   constexpr property_value(const foz &f) : value1(f.value1), value2(f.value2) {}
@@ -70,7 +68,6 @@ struct fir_key {
 };
 using fir = property_value<fir_key>;
 template <> struct property_value<fir_key> {
-  using key_t = fir_key;
   // Intentionally not constexpr to test for properties that cannot be constexpr
   property_value(float v1, bool v2) : value1(v1), value2(v2) {}
   // Define copy constructor to make foz non-trivially copyable

--- a/sycl/test/extensions/properties/properties_equality.cpp
+++ b/sycl/test/extensions/properties/properties_equality.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify %s
 // expected-no-diagnostics
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/extensions/properties/properties_is_property_key.cpp
+++ b/sycl/test/extensions/properties/properties_is_property_key.cpp
@@ -33,13 +33,6 @@ int main() {
       !sycl::ext::oneapi::experimental::is_property_key<
           decltype(sycl::ext::oneapi::experimental::boo<bool, float>)>::value);
 
-  // Check is_property_key for runtime property values.
-  // NOTE: For runtime properties the key is an alias of the value.
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::foo>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::foz>::value);
-
   // Check is_property_key for non-property-key types.
   static_assert(!sycl::ext::oneapi::experimental::is_property_key<int>::value);
   static_assert(!sycl::ext::oneapi::experimental::is_property_key<
@@ -73,11 +66,10 @@ int main() {
                 sycl::queue>::value);
 
   // Check is_property_key_of for runtime property keys.
-  // NOTE: For runtime properties the key is an alias of the value.
   static_assert(sycl::ext::oneapi::experimental::is_property_key_of<
-                sycl::ext::oneapi::experimental::foo, sycl::queue>::value);
+                sycl::ext::oneapi::experimental::foo_key, sycl::queue>::value);
   static_assert(sycl::ext::oneapi::experimental::is_property_key_of<
-                sycl::ext::oneapi::experimental::foz, sycl::queue>::value);
+                sycl::ext::oneapi::experimental::foz_key, sycl::queue>::value);
 
   // Check is_property_key_of for non-property-key types.
   static_assert(

--- a/sycl/test/extensions/properties/properties_is_property_value.cpp
+++ b/sycl/test/extensions/properties/properties_is_property_value.cpp
@@ -33,13 +33,6 @@ int main() {
   static_assert(!sycl::ext::oneapi::experimental::is_property_value<
                 sycl::ext::oneapi::experimental::boo_key>::value);
 
-  // Check is_property_value for runtime property keys.
-  // NOTE: For runtime properties the key is an alias of the value.
-  static_assert(sycl::ext::oneapi::experimental::is_property_value<
-                sycl::ext::oneapi::experimental::foo_key>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_value<
-                sycl::ext::oneapi::experimental::foz_key>::value);
-
   // Check is_property_value for non-property-key types.
   static_assert(
       !sycl::ext::oneapi::experimental::is_property_value<int>::value);
@@ -72,13 +65,6 @@ int main() {
                 sycl::ext::oneapi::experimental::baz_key, sycl::queue>::value);
   static_assert(!sycl::ext::oneapi::experimental::is_property_value_of<
                 sycl::ext::oneapi::experimental::boo_key, sycl::queue>::value);
-
-  // Check is_property_value_of for runtime property keys.
-  // NOTE: For runtime properties the key is an alias of the value.
-  static_assert(sycl::ext::oneapi::experimental::is_property_value_of<
-                sycl::ext::oneapi::experimental::foo_key, sycl::queue>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_value_of<
-                sycl::ext::oneapi::experimental::foz_key, sycl::queue>::value);
 
   // Check is_property_value_of for non-property-key types.
   static_assert(!sycl::ext::oneapi::experimental::is_property_value_of<

--- a/sycl/test/extensions/properties/properties_kernel.cpp
+++ b/sycl/test/extensions/properties/properties_kernel.cpp
@@ -31,8 +31,6 @@ using device_has_all =
 
 template <aspect Aspect> inline void singleAspectDeviceHasChecks() {
   static_assert(is_property_value<decltype(device_has<Aspect>)>::value);
-  static_assert(std::is_same_v<device_has_key,
-                               typename decltype(device_has<Aspect>)::key_t>);
   static_assert(decltype(device_has<Aspect>)::value.size() == 1);
   static_assert(decltype(device_has<Aspect>)::value[0] == Aspect);
 }
@@ -51,22 +49,6 @@ int main() {
   static_assert(
       is_property_value<decltype(work_group_size_hint<6, 6, 6>)>::value);
   static_assert(is_property_value<decltype(sub_group_size<7>)>::value);
-
-  static_assert(
-      std::is_same_v<work_group_size_key, decltype(work_group_size<8>)::key_t>);
-  static_assert(std::is_same_v<work_group_size_key,
-                               decltype(work_group_size<9, 9>)::key_t>);
-  static_assert(std::is_same_v<work_group_size_key,
-                               decltype(work_group_size<10, 10, 10>)::key_t>);
-  static_assert(std::is_same_v<work_group_size_hint_key,
-                               decltype(work_group_size_hint<11>)::key_t>);
-  static_assert(std::is_same_v<work_group_size_hint_key,
-                               decltype(work_group_size_hint<12, 12>)::key_t>);
-  static_assert(
-      std::is_same_v<work_group_size_hint_key,
-                     decltype(work_group_size_hint<13, 13, 13>)::key_t>);
-  static_assert(
-      std::is_same_v<sub_group_size_key, decltype(sub_group_size<14>)::key_t>);
 
   static_assert(work_group_size<15>[0] == 15);
   static_assert(work_group_size<16, 17>[0] == 16);
@@ -123,11 +105,9 @@ int main() {
   singleAspectDeviceHasChecks<aspect::ext_intel_memory_bus_width>();
 
   static_assert(is_property_value<decltype(device_has<>)>::value);
-  static_assert(std::is_same_v<device_has_key, decltype(device_has<>)::key_t>);
   static_assert(decltype(device_has<>)::value.size() == 0);
 
   static_assert(is_property_value<device_has_all>::value);
-  static_assert(std::is_same_v<device_has_key, device_has_all::key_t>);
   static_assert(device_has_all::value.size() == 36);
   static_assert(device_has_all::value[0] == aspect::cpu);
   static_assert(device_has_all::value[1] == aspect::gpu);

--- a/sycl/test/extensions/properties/properties_kernel_cache_config.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_cache_config.cpp
@@ -20,15 +20,15 @@ int main() {
       cache_config{large_slm});
   using PS = decltype(Props1);
   static_assert(sycl::ext::oneapi::experimental::is_property_list_v<PS>);
-  static_assert(PS::has_property<cache_config>());
-  assert(Props1.get_property<cache_config>() == large_slm);
+  static_assert(PS::has_property<cache_config_key>());
+  assert(Props1.get_property<cache_config_key>() == large_slm);
 
   sycl::ext::oneapi::experimental::properties Props2(
       cache_config{large_data});
   using PS = decltype(Props2);
   static_assert(sycl::ext::oneapi::experimental::is_property_list_v<PS>);
-  static_assert(PS::has_property<cache_config>());
-  assert(Props2.get_property<cache_config>() == large_data);
+  static_assert(PS::has_property<cache_config_key>());
+  assert(Props2.get_property<cache_config_key>() == large_data);
 
   // Check that duplicate cache_config can't be specified.
   // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: Duplicate properties in property list.}}


### PR DESCRIPTION
Unnecessary. Simplifies defining properties.
Part 2 of simplifying properties.