### PR TITLE
[SYCL] Initialize error code in sycl::exception

### DIFF
--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -105,7 +105,7 @@ private:
   // Exceptions must be noexcept copy constructible, so cannot use std::string
   // directly.
   std::shared_ptr<std::string> MMsg;
-  pi_int32 MPIErr;
+  pi_int32 MPIErr = 0;
   std::shared_ptr<context> MContext;
   std::error_code MErrC = make_error_code(sycl::errc::invalid);
 


### PR DESCRIPTION
If there is no backend specific error code associated with the sycl::exception then error code must be 0, so initialize with 0 by default, otherwise static analyzer complains about unitialized data member.