### PR TITLE
[SYCL][E2E] Enable device_architecture test back on Windows OpenCL

### DIFF
--- a/sycl/test-e2e/DeviceArchitecture/device_architecture_on_device_aot.cpp
+++ b/sycl/test-e2e/DeviceArchitecture/device_architecture_on_device_aot.cpp
@@ -1,8 +1,4 @@
 // REQUIRES: opencl-aot, cpu
-// TODO: Test is failing on Windows with OpenCL, enable back when the issue
-// fixed.
-// UNSUPPORTED: windows && opencl
-
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %s -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Problem was fixed, so enable test back.