### PR TITLE
[SYCL] Fix maybe-uninitialized warning

### DIFF
--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -238,7 +238,7 @@ void event_impl::wait(std::shared_ptr<sycl::detail::event_impl> Self) {
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   void *TelemetryEvent = nullptr;
-  uint64_t IId;
+  uint64_t IId = 0;
   std::string Name;
   int32_t StreamID = xptiRegisterStream(SYCL_STREAM_NAME);
   TelemetryEvent = instrumentationProlog(Name, StreamID, IId);


### PR DESCRIPTION
sycl/source/detail/event_impl.cpp:223:24: error: ‘IId’ may be used
uninitialized in this function [-Werror=maybe-uninitialized
