### PR TITLE
[SYCL-MLIR][CI] Run relevant tests on changes

### DIFF
--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -47,15 +47,30 @@ jobs:
               - *libclc
               - 'sycl/*'
               - 'sycl/!(test-e2e|doc)/**'
-            mlir_sycl: &mlir_sycl
+            mlir: &mlir
+              - *llvm
               - 'mlir/**'
-              - 'mlir-sycl/**'
-              - 'polygeist/**'
+            polygeist_dialect: &polygeist_dialect
+              - *mlir
+              - 'polygeist/include/**'
+              - 'polygeist/lib/**'
+            sycl_dialect: &sycl_dialect
+              - *mlir
+              - 'mlir-sycl/include/**'
+              - 'mlir-sycl/lib/**'
             polygeist: &polygeist
-              - *mlir_sycl
+              - *polygeist_dialect
+              - *sycl_dialect
+              - 'polygeist/test/**'
+              - 'polygeist/unittests/**'
+            mlir_sycl: &mlir_sycl
+              - *sycl_dialect
+              - *polygeist_dialect
+              - 'mlir-sycl/**'
             cgeist: &cgeist
-              - *polygeist
+              - *mlir_sycl
               - *sycl
+              - 'polygeist/tools/cgeist/**'
             ci:
               - .github/workflows/**
               # devops/* contains config files, including drivers versions.
@@ -76,6 +91,6 @@ jobs:
               return '${{ steps.changes.outputs.changes }}';
             }
             // Treat everything as changed for huge PRs.
-            return ["llvm", "llvm_spirv", "clang", "sycl_fusion", "xptifw", "libclc", "sycl", "mlir_sycl", "polygeist", "cgeist", "ci"];
+            return ["llvm", "llvm_spirv", "clang", "sycl_fusion", "xptifw", "libclc", "sycl", "mlir", "mlir_sycl", "polygeist", "cgeist", "ci"];
 
       - run: echo '${{ steps.result.outputs.result }}'

--- a/.github/workflows/sycl_detect_changes.yml
+++ b/.github/workflows/sycl_detect_changes.yml
@@ -51,19 +51,19 @@ jobs:
               - *llvm
               - 'mlir/**'
             polygeist_dialect: &polygeist_dialect
-              - *mlir
               - 'polygeist/include/**'
               - 'polygeist/lib/**'
             sycl_dialect: &sycl_dialect
-              - *mlir
               - 'mlir-sycl/include/**'
               - 'mlir-sycl/lib/**'
             polygeist: &polygeist
+              - *mlir
               - *polygeist_dialect
               - *sycl_dialect
               - 'polygeist/test/**'
               - 'polygeist/unittests/**'
             mlir_sycl: &mlir_sycl
+              - *mlir
               - *sycl_dialect
               - *polygeist_dialect
               - 'mlir-sycl/**'

--- a/.github/workflows/sycl_linux_build.yml
+++ b/.github/workflows/sycl_linux_build.yml
@@ -38,7 +38,7 @@ on:
       changes:
         type: string
         description: 'Filter matches for the changed files in the PR'
-        default: '[mlir_sycl, polygeist, cgeist, clang]'
+        default: '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice, mlir, polygeist, mlir_sycl, cgeist]'
         required: false
       merge_ref:
         description: |
@@ -66,7 +66,7 @@ on:
         type: choice
         options:
           - "[]"
-          - '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice]'
+          - '[llvm, clang, sycl, llvm_spirv, xptifw, libclc, libdevice, mlir, polygeist, mlir_sycl, cgeist]'
       build_image:
         type: choice
         options:
@@ -180,6 +180,11 @@ jobs:
       run: |
         cmake --build $GITHUB_WORKSPACE/build --target polygeist-doc
     # TODO allow to optionally disable in-tree checks
+    - name: check-mlir
+      shell: bash
+      if: always() && !cancelled() && contains(inputs.changes, 'mlir')
+      run: |
+        cmake --build $GITHUB_WORKSPACE/build --target check-mlir
     - name: check-mlir-sycl
       shell: bash
       if: always() && !cancelled() && contains(inputs.changes, 'mlir_sycl')


### PR DESCRIPTION
- Run `check-mlir` when `mlir` or `llvm` change;
- Run `check-mlir-sycl` on `polygeist` or `sycl` dialect changes, SYCL-MLIR test changes, or when `check-mlir` needs to be run;
- Run `check-polygeist` on `polygeist` or `sycl` dialect changes, polygeist test changes, or when `check-mlir` needs to be run;
- Run `check-cgeist` when any of the above needs to be run or the cgeist frontend changes.