### PR TITLE
[SYCL] Don't print vendor in sycl-ls' output

### DIFF
--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -65,5 +65,28 @@ inline std::ostream &operator<<(std::ostream &Out, backend be) {
   return Out;
 }
 
+namespace detail {
+inline std::string_view get_backend_name_no_vendor(backend Backend) {
+  switch (Backend) {
+  case backend::host:
+    return "host";
+  case backend::opencl:
+    return "opencl";
+  case backend::ext_oneapi_level_zero:
+    return "level_zero";
+  case backend::ext_oneapi_cuda:
+    return "cuda";
+  case backend::ext_intel_esimd_emulator:
+    return "esimd_emulator";
+  case backend::ext_oneapi_hip:
+    return "hip";
+  case backend::ext_oneapi_native_cpu:
+    return "native_cpu";
+  case backend::all:
+    return "all";
+  }
+}
+} // namespace detail
+
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/backend_types.hpp
+++ b/sycl/include/sycl/backend_types.hpp
@@ -85,6 +85,8 @@ inline std::string_view get_backend_name_no_vendor(backend Backend) {
   case backend::all:
     return "all";
   }
+
+  return "";
 }
 } // namespace detail
 

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -155,8 +155,9 @@ int main(int argc, char **argv) {
       // plugin.
 
       for (const auto &Device : Devices) {
-        std::cout << "[" << Backend << ":" << getDeviceTypeName(Device) << ":"
-                  << DeviceNums[Backend] << "] ";
+        std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
+                  << getDeviceTypeName(Device) << ":" << DeviceNums[Backend]
+                  << "] ";
         ++DeviceNums[Backend];
         // Verbose parameter is set to false to print regular devices output
         // first


### PR DESCRIPTION
This is to align with the default/recommended usage of `ONEAPI_DEVICE_SELECTOR`. Addresses one part of
https://github.com/intel/llvm/issues/12048.