### PR TITLE
[SYCL][UR] Fix include for COMGR

### DIFF
--- a/sycl/plugins/hip/CMakeLists.txt
+++ b/sycl/plugins/hip/CMakeLists.txt
@@ -134,6 +134,21 @@ if("${SYCL_BUILD_PI_HIP_PLATFORM}" STREQUAL "AMD")
   target_link_libraries(pi_hip PUBLIC rocmdrv)
 
   if(SYCL_ENABLE_COMGR)
+    set(PI_COMGR_VERSION5_HEADER "${PI_HIP_INCLUDE_DIR}/amd_comgr/amd_comgr.h")
+    set(PI_COMGR_VERSION4_HEADER "${PI_HIP_INCLUDE_DIR}/amd_comgr.h")
+    # The COMGR header changed location between ROCm version 4 and 5.
+    # Check for the existence in the version 5 location or fallback to version 4
+    if(NOT EXISTS "${PI_COMGR_VERSION5_HEADER}")
+      if(NOT EXISTS "${PI_COMGR_VERSION4_HEADER}")
+        message(FATAL_ERROR "Could not find AMD COMGR header at "
+                            "${PI_COMGR_VERSION5_HEADER} or "
+                            "${PI_COMGR_VERSION4_HEADER}, "
+                            "check ROCm installation")
+      else()
+        target_compile_definitions(pi_hip PRIVATE UR_COMGR_VERSION4_INCLUDE)
+      endif()
+    endif()  
+
     add_library(amd_comgr SHARED IMPORTED GLOBAL)
     set_target_properties(
       amd_comgr PROPERTIES

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -63,7 +63,7 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   # Date:   Wed Jan 3 13:27:16 2024 +0000
   #     Merge pull request #1198 from al42and/aa-rocm6
   #     [HIP] Fix build with ROCm 6.0.0
-  set(UNIFIED_RUNTIME_TAG lukas/comgr-include-rocm4)
+  set(UNIFIED_RUNTIME_TAG d398d4aec1f9c2397433dc5a4619d5c30269c622)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,14 +56,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 1d7863601e9ecfffadf0617236a472a3b00fddbe
-  # Merge: cf87428c 3ee71a71
+  set(UNIFIED_RUNTIME_REPO "https://github.com/sommerlukas/unified-runtime.git")
+  # commit 749d8e51ea8e56726a9fb57949d7a3f81b47b15c
+  # Merge: 810a5774 34831f4b
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Thu Jan 4 11:03:26 2024 +0000
-  #     Merge pull request #938 from Bensuo/cmdbuf-fill-memset-l0
-  #     [EXP][CMDBUF] Implement Fill commands for L0 adapter
-  set(UNIFIED_RUNTIME_TAG 1d7863601e9ecfffadf0617236a472a3b00fddbe)
+  # Date:   Wed Jan 3 13:27:16 2024 +0000
+  #     Merge pull request #1198 from al42and/aa-rocm6
+  #     [HIP] Fix build with ROCm 6.0.0
+  set(UNIFIED_RUNTIME_TAG lukas/comgr-include-rocm4)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,14 +56,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/sommerlukas/unified-runtime.git")
-  # commit 749d8e51ea8e56726a9fb57949d7a3f81b47b15c
-  # Merge: 810a5774 34831f4b
+  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  # commit c311fe82256a7bc7f6ddd19cb86c8d555ce401bc
+  # Merge: eee75a29 d398d4ae
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Wed Jan 3 13:27:16 2024 +0000
-  #     Merge pull request #1198 from al42and/aa-rocm6
-  #     [HIP] Fix build with ROCm 6.0.0
-  set(UNIFIED_RUNTIME_TAG d398d4aec1f9c2397433dc5a4619d5c30269c622)
+  # Date:   Thu Jan 4 15:12:54 2024 +0000
+  #     Merge pull request #1222 from sommerlukas/lukas/comgr-include-rocm4
+  #     [UR][HIP] Fix include for AMD COMGR
+  set(UNIFIED_RUNTIME_TAG c311fe82256a7bc7f6ddd19cb86c8d555ce401bc)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
The code object finalization for kernel fusion uses the AMD COMGR. The location of the corresponding header changed between ROCm version 4 and 5.

This PR fixes the include for ROCm version 4.
