### PR TITLE
[SYCL] Fix invalid input handling in ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_BE_error.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_BE_error.cpp
@@ -1,7 +1,0 @@
-
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
-// RUN: env ONEAPI_DEVICE_SELECTOR="macaroni:*" %{run-unfiltered-devices} %t.out
-// XFAIL: *
-
-// Calling ONEAPI_DEVICE_SELECTOR with an illegal backend should result in an
-// error.

--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_input.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_input.cpp
@@ -1,0 +1,15 @@
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="macaroni:*" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=":" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:." %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="macaroni_level_zero:." %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:macaroni_gpu" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:0..0" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:::gpu" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:.1" %{run-unfiltered-devices} %t.out
+// XFAIL: *
+
+// Calling ONEAPI_DEVICE_SELECTOR with an illegal input should result in an
+// error.

--- a/sycl/test/Unit/lit.cfg.py
+++ b/sycl/test/Unit/lit.cfg.py
@@ -79,7 +79,7 @@ else:
 # The mock plugin currently appears as an opencl plugin, but could be changed in
 # the future. To avoid it being filtered out we set the filter to use the *
 # wildcard.
-config.environment['ONEAPI_DEVICE_SELECTOR'] = "'*:*'"
+config.environment['ONEAPI_DEVICE_SELECTOR'] = "*:*"
 lit_config.note("Using Mock Plugin.")
 
 config.environment['SYCL_CACHE_DIR'] = config.llvm_obj_root + "/sycl_cache"


### PR DESCRIPTION
Cover cases when backend and/or devices are not specified, when backend or device name is a substring (we expect exact match according to documentation) etc.