### PR TITLE
[SYCL] making sycl::bit_cast constexpr in all cases

### DIFF
--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <algorithm>   // max
 #include <type_traits> // for is_trivially_copyable, enable_if_t
 
 #if __cplusplus >= 202002L
@@ -24,15 +25,11 @@ namespace sycl {
 inline namespace _V1 {
 
 template <typename To, typename From>
-#if __cpp_lib_bit_cast ||                                                      \
-    (defined(__has_builtin) && __has_builtin(__builtin_bit_cast))
-constexpr
-#endif
-    std::enable_if_t<sizeof(To) == sizeof(From) &&
-                         std::is_trivially_copyable<From>::value &&
-                         std::is_trivially_copyable<To>::value,
-                     To>
-    bit_cast(const From &from) noexcept {
+constexpr std::enable_if_t<sizeof(To) == sizeof(From) &&
+                               std::is_trivially_copyable<From>::value &&
+                               std::is_trivially_copyable<To>::value,
+                           To>
+bit_cast(const From &from) noexcept {
 #if __cpp_lib_bit_cast
   return std::bit_cast<To>(from);
 #else // __cpp_lib_bit_cast
@@ -40,11 +37,22 @@ constexpr
 #if defined(__has_builtin) && __has_builtin(__builtin_bit_cast)
   return __builtin_bit_cast(To, from);
 #else // __has_builtin(__builtin_bit_cast)
-  static_assert(std::is_trivially_default_constructible<To>::value,
+  // When building the SYCL library on Windows we may end up here.
+  // By asserting constructible and aligning the union we should be
+  // as close to free of UB as is possible without using memcpy (which is not
+  // constexpr).
+  static_assert(std::is_trivially_default_constructible_v<To>,
                 "To must be trivially default constructible");
-  To to;
-  sycl::detail::memcpy(&to, &from, sizeof(To));
-  return to;
+  static_assert(std::is_trivially_default_constructible_v<From>,
+                "From  must be trivially default constructible");
+  constexpr std::size_t max_alignment =
+      std::max(std::alignment_of_v<To>, std::alignment_of_v<From>);
+  union alignas(max_alignment) {
+    From from;
+    To to;
+  } result = {};
+  result.from = from;
+  return result.to;
 #endif // __has_builtin(__builtin_bit_cast)
 
 #endif // __cpp_lib_bit_cast

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -53,7 +53,15 @@ int test(sycl::queue Queue, const From &Value) {
   return 0;
 }
 
+template <typename T> constexpr bool is_constexpr_evaluable(T value) {
+  return value != T{};
+}
+
 int main() {
+  constexpr float pi = 3.14159f;
+  static_assert(is_constexpr_evaluable(sycl::bit_cast<uint32_t>(pi)),
+                "not constexpr");
+
   sycl::queue Queue;
   int ReturnCode = 0;
 


### PR DESCRIPTION
Presently `sycl::bit_cast`  uses `std::bit_cast` when available, and falls back to the clang builtin otherwise. If that is not available, we currenty use memcpy, but that is not constexpr.  
In this PR we are switching that last fallback case to use a union instead of memcpy. This case is normally only encountered when building the SYCL library itself with MSVC.  End user code is never exposed to this fallback ( unless using `-fsycl-host-compiler=cl.exe`  )