### PR TITLE
[SYCL-MLIR][NFC] Fix warnings in `polygeist`

### DIFF
--- a/polygeist/lib/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/MemoryAccessAnalysis.cpp
@@ -1406,7 +1406,7 @@ bool MemoryAccessAnalysis::hasZeroIndex(const MemRefAccess &access) const {
   if (accessValueMap.getNumDims() != 0)
     return false;
 
-  auto index = accessValueMap.getResult(0).dyn_cast<AffineConstantExpr>();
+  auto index = dyn_cast<AffineConstantExpr>(accessValueMap.getResult(0));
   return (index && index.getValue() == 0);
 }
 

--- a/polygeist/lib/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Analysis/ReachingDefinitionAnalysis.cpp
@@ -91,8 +91,10 @@ ReachingDefinition::ReachingDefinition(ProgramPoint p)
       return;
     if (auto funcOp = dyn_cast<FunctionOpInterface>(block->getParentOp())) {
       for (Value arg : funcOp.getArguments()) {
-        if (isa<MemRefType, LLVM::LLVMPointerType>(arg.getType()))
-          setModifier(arg, Definition());
+        if (isa<MemRefType, LLVM::LLVMPointerType>(arg.getType())) {
+          ChangeResult modified = setModifier(arg, Definition());
+          assert(modified == ChangeResult::Change);
+        }
       }
     }
   }

--- a/polygeist/lib/Dialect/Polygeist/Transforms/AffineCFG.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/AffineCFG.cpp
@@ -519,8 +519,7 @@ AffineDimExpr AffineApplyNormalizer::renumberOneDim(Value v) {
   if (inserted) {
     reorderedDims.push_back(v);
   }
-  return getAffineDimExpr(iterPos->second, v.getContext())
-      .cast<AffineDimExpr>();
+  return cast<AffineDimExpr>(getAffineDimExpr(iterPos->second, v.getContext()));
 }
 
 static void composeAffineMapAndOperands(AffineMap *map,

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -497,7 +497,7 @@ bool hasZeroIndex(const affine::MemRefAccess &access) {
   if (accessValueMap.getNumDims() != 0)
     return false;
 
-  auto index = accessValueMap.getResult(0).dyn_cast<AffineConstantExpr>();
+  auto index = dyn_cast<AffineConstantExpr>(accessValueMap.getResult(0));
   return (index && index.getValue() == 0);
 }
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
@@ -99,17 +99,17 @@ public:
   }
   Offset(AffineExpr op, unsigned numDims, unsigned numSymbols,
          mlir::OperandRange vals) {
-    if (auto opc = op.dyn_cast<AffineConstantExpr>()) {
+    if (auto opc = dyn_cast<AffineConstantExpr>(op)) {
       idx = opc.getValue();
       type = Type::Index;
       return;
     }
-    if (auto opd = op.dyn_cast<AffineDimExpr>()) {
+    if (auto opd = dyn_cast<AffineDimExpr>(op)) {
       val = vals[opd.getPosition()];
       type = Type::Value;
       return;
     }
-    if (auto ops = op.dyn_cast<AffineSymbolExpr>()) {
+    if (auto ops = dyn_cast<AffineSymbolExpr>(op)) {
       val = vals[numDims + ops.getPosition()];
       type = Type::Value;
       return;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
@@ -456,7 +456,7 @@ struct NormalizeLoop : public OpRewritePattern<scf::ForOp> {
 
 static bool isNormalized(affine::AffineParallelOp op) {
   auto isZero = [](AffineExpr v) {
-    if (auto ce = v.dyn_cast<AffineConstantExpr>())
+    if (auto ce = dyn_cast<AffineConstantExpr>(v))
       return ce.getValue() == 0;
     return false;
   };

--- a/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/SYCLRaiseHost.cpp
@@ -717,7 +717,7 @@ public:
 
     StringRef declContext = static_cast<StringRef>(*demangled);
     // Can't use `isMemberFunction` because `sycl::buffer` is a template.
-    return declContext.startswith("sycl::_V1::buffer") &&
+    return declContext.starts_with("sycl::_V1::buffer") &&
            functionNameMatches(demangler, "get_access");
   }
 };

--- a/polygeist/tools/cgeist/Lib/clang-mlir.cc
+++ b/polygeist/tools/cgeist/Lib/clang-mlir.cc
@@ -1969,13 +1969,13 @@ void MLIRASTConsumer::HandleDeclContext(clang::DeclContext *DC) {
     std::string Name = MLIRScanner::getMangledFuncName(*FD, CGM);
 
     // Don't create std functions unless necessary
-    if (StringRef(Name).startswith("_ZNKSt"))
+    if (StringRef(Name).starts_with("_ZNKSt"))
       continue;
-    if (StringRef(Name).startswith("_ZSt"))
+    if (StringRef(Name).starts_with("_ZSt"))
       continue;
-    if (StringRef(Name).startswith("_ZNSt"))
+    if (StringRef(Name).starts_with("_ZNSt"))
       continue;
-    if (StringRef(Name).startswith("_ZN9__gnu"))
+    if (StringRef(Name).starts_with("_ZN9__gnu"))
       continue;
     if (Name == "cudaGetDevice" || Name == "cudaMalloc")
       continue;
@@ -2028,13 +2028,13 @@ bool MLIRASTConsumer::HandleTopLevelDecl(clang::DeclGroupRef DG) {
     std::string Name = MLIRScanner::getMangledFuncName(*FD, CGM);
 
     // Don't create std functions unless necessary
-    if (StringRef(Name).startswith("_ZNKSt"))
+    if (StringRef(Name).starts_with("_ZNKSt"))
       continue;
-    if (StringRef(Name).startswith("_ZSt"))
+    if (StringRef(Name).starts_with("_ZSt"))
       continue;
-    if (StringRef(Name).startswith("_ZNSt"))
+    if (StringRef(Name).starts_with("_ZNSt"))
       continue;
-    if (StringRef(Name).startswith("_ZN9__gnu"))
+    if (StringRef(Name).starts_with("_ZN9__gnu"))
       continue;
     if (Name == "cudaGetDevice" || Name == "cudaMalloc")
       continue;

--- a/polygeist/tools/cgeist/Lib/utils.cc
+++ b/polygeist/tools/cgeist/Lib/utils.cc
@@ -47,7 +47,7 @@ Operation *replaceFuncByOperation(func::FuncOp F, llvm::StringRef OpName,
   assert(Ctx->isOperationRegistered(OpName) &&
          "Provided lower_to opName should be registered.");
 
-  if (OpName.startswith("memref"))
+  if (OpName.starts_with("memref"))
     return buildLinalgOp(OpName, B, Input, Output);
 
   // NOTE: The attributes of the provided FuncOp is ignored.

--- a/polygeist/tools/cgeist/driver.cc
+++ b/polygeist/tools/cgeist/driver.cc
@@ -1094,7 +1094,7 @@ parseOptimizationLevel(llvm::StringRef Arg) {
     return llvm::OptimizationLevel::O1;
   }
 
-  if (Arg.startswith("fast")) {
+  if (Arg.starts_with("fast")) {
     // We handle -Ofast like -O3.
     return llvm::OptimizationLevel::O3;
   }
@@ -1158,23 +1158,23 @@ void Options::splitCommandLineOptions(int argc, char **argv) {
       continue;
     }
 
-    if (Ref == "-fPIC" || Ref == "-c" || Ref.startswith("-fsanitize"))
+    if (Ref == "-fPIC" || Ref == "-c" || Ref.starts_with("-fsanitize"))
       LinkOpts.push_back(argv[I]);
     else if (Ref == "-L" || Ref == "-l") {
       LinkOpts.push_back(argv[I]);
       I++;
       LinkOpts.push_back(argv[I]);
-    } else if (Ref.startswith("-L") || Ref.startswith("-l") ||
-               Ref.startswith("-Wl"))
+    } else if (Ref.starts_with("-L") || Ref.starts_with("-l") ||
+               Ref.starts_with("-Wl"))
       LinkOpts.push_back(argv[I]);
     else if (Ref == "-D" || Ref == "-I") {
       MLIROpts.push_back(argv[I]);
       I++;
       MLIROpts.push_back(argv[I]);
-    } else if (Ref.startswith("-D")) {
+    } else if (Ref.starts_with("-D")) {
       MLIROpts.push_back("-D");
       MLIROpts.push_back(&argv[I][2]);
-    } else if (Ref.startswith("-I")) {
+    } else if (Ref.starts_with("-I")) {
       MLIROpts.push_back("-I");
       MLIROpts.push_back(&argv[I][2]);
     } else if (Ref == "-fsycl-is-device") {


### PR DESCRIPTION
- Replace deprecated member function cast-like calls with free
  function calls
- Replace `startswith` member function call with `starts_with`
- Use `nodiscard` `ChangeResult` value returned by `setModifier`.

Signed-off-by: Victor Perez <victor.perez@codeplay.com>