### PR TITLE
[SYCL][E2E] Improve debugability of user_defined_reductions.cpp test

### DIFF
--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
@@ -65,11 +65,10 @@ inline custom_type operator+(const custom_type &lhs, const custom_type &rhs) {
   return custom_type(lhs.n.i + rhs.n.i, lhs.n.f + rhs.n.f, lhs.ull + rhs.ull);
 }
 
-inline std::ostream& operator<<(std::ostream &os, const custom_type &v) {
+inline std::ostream &operator<<(std::ostream &os, const custom_type &v) {
   os << "custom_type { .n = " << v.n << ", .ull = " << v.ull << "}";
   return os;
 }
-
 
 struct custom_type_wo_default_ctor {
   static constexpr unsigned long long default_ull_value = 42;
@@ -100,8 +99,10 @@ constexpr std::array<T, sizeof...(Is)> init_array(T value,
   return {{(static_cast<void>(Is), value)...}};
 }
 
-inline std::ostream& operator<<(std::ostream &os, const custom_type_wo_default_ctor &v) {
-  os << "custom_type_wo_default_ctor { .n = " << v.n << ", .ull = " << v.ull << "}";
+inline std::ostream &operator<<(std::ostream &os,
+                                const custom_type_wo_default_ctor &v) {
+  os << "custom_type_wo_default_ctor { .n = " << v.n << ", .ull = " << v.ull
+     << "}";
   return os;
 }
 

--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
@@ -65,6 +65,12 @@ inline custom_type operator+(const custom_type &lhs, const custom_type &rhs) {
   return custom_type(lhs.n.i + rhs.n.i, lhs.n.f + rhs.n.f, lhs.ull + rhs.ull);
 }
 
+inline std::ostream& operator<<(std::ostream &os, const custom_type &v) {
+  os << "custom_type { .n = " << v.n << ", .ull = " << v.ull << "}";
+  return os;
+}
+
+
 struct custom_type_wo_default_ctor {
   static constexpr unsigned long long default_ull_value = 42;
 
@@ -92,6 +98,11 @@ template <typename T, std::size_t... Is>
 constexpr std::array<T, sizeof...(Is)> init_array(T value,
                                                   std::index_sequence<Is...>) {
   return {{(static_cast<void>(Is), value)...}};
+}
+
+inline std::ostream& operator<<(std::ostream &os, const custom_type_wo_default_ctor &v) {
+  os << "custom_type_wo_default_ctor { .n = " << v.n << ", .ull = " << v.ull << "}";
+  return os;
 }
 
 using namespace sycl;


### PR DESCRIPTION
... by providing additional `std::ostream operator<<` overloads for custom types used in the test.`