### PR TITLE
[SYCL] revisit sycl::bit_cast constexpr 

### DIFF
--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -33,7 +33,7 @@
 #elif __SYCL_HAS_BUILTIN_BIT_CAST
 // second choice __builtin_bit_cast
 #define __SYCL_BC_CONSTEXPR constexpr
-#elif
+#else
 // fallback memcpy
 #include <sycl/detail/memcpy.hpp>
 #define __SYCL_BC_CONSTEXPR

--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -14,7 +14,7 @@
 // no fallback.
 
 // MSVC 2019 Update 9 or later (aka Visual Studio 2019 v 16.8.1)
-#if defined(_MSC_VER) && _MSC_VER >= 1928 
+#if defined(_MSC_VER) && _MSC_VER >= 1928
 #define __SYCL_HAS_BUILTIN_BIT_CAST 1
 #elif defined(__has_builtin)
 #define __SYCL_HAS_BUILTIN_BIT_CAST __has_builtin(__builtin_bit_cast)

--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -20,6 +20,9 @@
 #define __SYCL_HAS_BUILTIN_BIT_CAST __has_builtin(__builtin_bit_cast)
 #elif defined(__GNUC__)
 #define __SYCL_HAS_BUILTIN_BIT_CAST 1 // available in GCC
+#elif (__GXX__ > 6) || (__GXX__ == 6 && __GXX_MINOR__ >= 1)
+// Built-in available in G++ 6.1 or later
+#define __SYCL_HAS_BUILTIN_BIT_CAST 1
 #else
 #define __SYCL_HAS_BUILTIN_BIT_CAST 0
 #endif

--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -35,12 +35,11 @@ namespace sycl {
 inline namespace _V1 {
 
 template <typename To, typename From>
-constexpr
-    std::enable_if_t<sizeof(To) == sizeof(From) &&
-                         std::is_trivially_copyable<From>::value &&
-                         std::is_trivially_copyable<To>::value,
-                     To>
-    bit_cast(const From &from) noexcept {
+constexpr std::enable_if_t<sizeof(To) == sizeof(From) &&
+                               std::is_trivially_copyable<From>::value &&
+                               std::is_trivially_copyable<To>::value,
+                           To>
+bit_cast(const From &from) noexcept {
 #if __cpp_lib_bit_cast
   // first choice std::bit_cast
   return std::bit_cast<To>(from);

--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -18,6 +18,8 @@
 #define __SYCL_HAS_BUILTIN_BIT_CAST 1
 #elif defined(__has_builtin)
 #define __SYCL_HAS_BUILTIN_BIT_CAST __has_builtin(__builtin_bit_cast)
+#elif defined(__GNUC__)
+#define __SYCL_HAS_BUILTIN_BIT_CAST 1 // available in GCC
 #else
 #define __SYCL_HAS_BUILTIN_BIT_CAST 0
 #endif

--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -10,44 +10,59 @@
 
 #include <type_traits> // for is_trivially_copyable, enable_if_t
 
+// std::bit_cast is first choice, __builtin_bit_cast second.
+// memcpy fallback of last resort, not constexpr :-(
+
+#if defined(_MSC_VER) && _MSC_VER >= 1928 // MSVC 2019 Update 9 or later
+#define __SYCL_HAS_BUILTIN_BIT_CAST 1
+#elif defined(__has_builtin)
+#define __SYCL_HAS_BUILTIN_BIT_CAST __has_builtin(__builtin_bit_cast)
+#else
+#define __SYCL_HAS_BUILTIN_BIT_CAST 0
+#endif
+
 #if __cplusplus >= 202002L
 #include <version> // defines __cpp_lib_bit_cast
 #endif
 
 #if __cpp_lib_bit_cast
+// first choice std::bit_cast
 #include <bit>
-#elif !defined(__has_builtin) || !__has_builtin(__builtin_bit_cast)
+#define __SYCL_BC_CONSTEXPR constexpr
+#elif __SYCL_HAS_BUILTIN_BIT_CAST
+// second choice __builtin_bit_cast
+#define __SYCL_BC_CONSTEXPR constexpr
+#elif
+// fallback memcpy
 #include <sycl/detail/memcpy.hpp>
+#define __SYCL_BC_CONSTEXPR
 #endif
 
 namespace sycl {
 inline namespace _V1 {
 
 template <typename To, typename From>
-#if __cpp_lib_bit_cast ||                                                      \
-    (defined(__has_builtin) && __has_builtin(__builtin_bit_cast))
-constexpr
-#endif
+__SYCL_BC_CONSTEXPR
     std::enable_if_t<sizeof(To) == sizeof(From) &&
                          std::is_trivially_copyable<From>::value &&
                          std::is_trivially_copyable<To>::value,
                      To>
     bit_cast(const From &from) noexcept {
 #if __cpp_lib_bit_cast
+  // first choice std::bit_cast
   return std::bit_cast<To>(from);
-#else // __cpp_lib_bit_cast
-
-#if defined(__has_builtin) && __has_builtin(__builtin_bit_cast)
+#elif __SYCL_HAS_BUILTIN_BIT_CAST
+  // second choice __builtin_bit_cast
   return __builtin_bit_cast(To, from);
-#else // __has_builtin(__builtin_bit_cast)
+#else
+  // fallback memcpy
   static_assert(std::is_trivially_default_constructible<To>::value,
                 "To must be trivially default constructible");
   To to;
   sycl::detail::memcpy(&to, &from, sizeof(To));
   return to;
-#endif // __has_builtin(__builtin_bit_cast)
-
-#endif // __cpp_lib_bit_cast
+#endif
 }
+
 } // namespace _V1
 } // namespace sycl

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
-
-// This test is a dependency of its neighbor 'win_host_compile.cpp'
+// RUN: %if windows %{  %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus'  -o %t2.out  %s  %}
+// RUN: %if windows %{  %{run} %t2.out  %}
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -55,15 +55,7 @@ int test(sycl::queue Queue, const From &Value) {
   return 0;
 }
 
-template <typename T> constexpr bool is_constexpr_evaluable(T value) {
-  return value != T{};
-}
-
 int main() {
-  constexpr float pi = 3.14159f;
-  static_assert(is_constexpr_evaluable(sycl::bit_cast<uint32_t>(pi)),
-                "not constexpr");
-
   sycl::queue Queue;
   int ReturnCode = 0;
 

--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -1,6 +1,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
+// This test is a dependency of its neighbor 'win_host_compile.cpp'
+
 #include <sycl/sycl.hpp>
 
 #include <iostream>
@@ -53,7 +55,15 @@ int test(sycl::queue Queue, const From &Value) {
   return 0;
 }
 
+template <typename T> constexpr bool is_constexpr_evaluable(T value) {
+  return value != T{};
+}
+
 int main() {
+  constexpr float pi = 3.14159f;
+  static_assert(is_constexpr_evaluable(sycl::bit_cast<uint32_t>(pi)),
+                "not constexpr");
+
   sycl::queue Queue;
   int ReturnCode = 0;
 

--- a/sycl/test-e2e/Basic/bit_cast/win_host_compile.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/win_host_compile.cpp
@@ -1,7 +1,7 @@
 
 // REQUIRES: windows
 
-// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus'  -o %t.out  bit_cast.cpp
+// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus'  -o %t.out  %p/bit_cast.cpp
 // RUN: %{run} %t.out
 
 // This test depends on its neighbor 'bit_cast.cpp'.

--- a/sycl/test-e2e/Basic/bit_cast/win_host_compile.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/win_host_compile.cpp
@@ -1,0 +1,7 @@
+
+// REQUIRES: windows
+
+// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus'  -o %t.out  bit_cast.cpp
+// RUN: %{run} %t.out
+
+// This test depends on its neighbor 'bit_cast.cpp'.

--- a/sycl/test-e2e/Basic/bit_cast/win_host_compile.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/win_host_compile.cpp
@@ -1,7 +1,0 @@
-
-// REQUIRES: windows
-
-// RUN: %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus'  -o %t.out  %p/bit_cast.cpp
-// RUN: %{run} %t.out
-
-// This test depends on its neighbor 'bit_cast.cpp'.


### PR DESCRIPTION
We were attempting to detect the presence of the builtins using the `__has_builtin` macro, but that's only present in Clang and GCC. For MSVC, one simply checks that that version is later than 1928,.

But older versions of GCC don't have the bit_cast builtin, so the non constexpr fallback remains for now. 