### PR TITLE
[SYCL-MLIR] Drop pointer to pointer `llvm.bitcast` operations

### DIFF
--- a/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/DialectBuilder.h
+++ b/mlir-sycl/include/mlir/Conversion/SYCLToLLVM/DialectBuilder.h
@@ -74,7 +74,6 @@ public:
 
   LLVM::AllocaOp genAlloca(Type type, Type elemType, Value size,
                            int64_t align) const;
-  LLVM::BitcastOp genBitcast(Type type, Value val) const;
   LLVM::ExtractValueOp genExtractValue(Type type, Value container,
                                        ArrayRef<int64_t> pos) const;
   LLVM::CallOp genCall(FlatSymbolRefAttr funcSym, TypeRange resTypes,

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DPCPP.cpp
@@ -1005,7 +1005,7 @@ public:
   }
 
 private:
-  /// Rewrite sycl.cast() to a LLVM bitcast operation.
+  /// Rewrite sycl.cast() to a NOP.
   LogicalResult rewriteCast(SYCLCastOp op, OpAdaptor opAdaptor,
                             ConversionPatternRewriter &rewriter) const {
     LLVM_DEBUG(llvm::dbgs() << "CastPattern: Rewriting op: "; op.dump();

--- a/mlir-sycl/lib/Conversion/SYCLToLLVM/DialectBuilder.cpp
+++ b/mlir-sycl/lib/Conversion/SYCLToLLVM/DialectBuilder.cpp
@@ -108,10 +108,6 @@ LLVM::AllocaOp LLVMBuilder::genAlloca(Type type, Type elemType, Value size,
   return create<LLVM::AllocaOp>(type, elemType, size, align);
 }
 
-LLVM::BitcastOp LLVMBuilder::genBitcast(Type type, Value val) const {
-  return create<LLVM::BitcastOp>(type, val);
-}
-
 LLVM::ExtractValueOp
 LLVMBuilder::genExtractValue(Type type, Value container,
                              ArrayRef<int64_t> position) const {

--- a/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/Mem2Reg.cpp
@@ -1137,10 +1137,6 @@ bool Mem2Reg::forwardStoreToLoad(
         list.emplace_back((Value)co, true);
         continue;
       }
-      if (auto co = dyn_cast<mlir::LLVM::BitcastOp>(user)) {
-        list.emplace_back((Value)co, modified);
-        continue;
-      }
       if (auto co = dyn_cast<mlir::LLVM::AddrSpaceCastOp>(user)) {
         list.emplace_back((Value)co, modified);
         continue;
@@ -1315,8 +1311,6 @@ bool Mem2Reg::forwardStoreToLoad(
                   else if (auto co =
                                val.getDefiningOp<polygeist::Pointer2MemrefOp>())
                     val = co.getSource();
-                  else if (auto co = val.getDefiningOp<LLVM::BitcastOp>())
-                    val = co.getArg();
                   else if (auto co = val.getDefiningOp<LLVM::AddrSpaceCastOp>())
                     val = co.getArg();
                   else if (auto co = val.getDefiningOp<LLVM::GEPOp>())

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ParallelLoopDistribute.cpp
@@ -726,8 +726,6 @@ static LogicalResult distributeAroundBarrier(T op, BarrierOp barrier,
     } else if (auto ao = dyn_cast<LLVM::AllocaOp>(o)) {
       Value sz = ao.getArraySize();
       rewriter.setInsertionPointAfter(alloc.getDefiningOp());
-      alloc =
-          rewriter.create<LLVM::BitcastOp>(ao.getLoc(), ao.getType(), alloc);
       for (auto &u : llvm::make_early_inc_range(ao.getResult().getUses())) {
         rewriter.setInsertionPoint(u.getOwner());
         Value idx = nullptr;

--- a/polygeist/tools/cgeist/Lib/CGCall.cc
+++ b/polygeist/tools/cgeist/Lib/CGCall.cc
@@ -792,8 +792,7 @@ ValueCategory MLIRScanner::VisitCallExpr(clang::CallExpr *Expr) {
                    cast<LLVM::LLVMPointerType>(T).getAddressSpace() &&
                "val does not have the same memory space as T");
         Val = Builder.create<polygeist::Memref2PointerOp>(Loc, T, Val);
-      } else if (T != Val.getType())
-        Val = Builder.create<LLVM::BitcastOp>(Loc, T, Val);
+      }
       return ValueCategory(Val, /*isRef*/ false);
     }
     assert(isa<MemRefType>(T));

--- a/polygeist/tools/cgeist/Lib/ValueCategory.cc
+++ b/polygeist/tools/cgeist/Lib/ValueCategory.cc
@@ -526,8 +526,9 @@ ValueCategory ValueCategory::BitCast(OpBuilder &Builder, Location Loc,
   assert((!isa<mlir::VectorType>(DestTy) ||
           cast<mlir::VectorType>(DestTy).getNumElements() == 1) &&
          "Expecting single-element vector");
-
-  return Cast<LLVM::BitcastOp>(Builder, Loc, DestTy, ElemTy);
+  // No operation is needed in an opaque pointer world, so we simply change the
+  // element type.
+  return {val, isReference, ElemTy};
 }
 
 ValueCategory ValueCategory::MemRef2Ptr(OpBuilder &Builder,


### PR DESCRIPTION
With opaque pointers, pointer to pointer `llvm.bitcast` operations will be either illegal (cannot bitcast between pointer types with different address spaces) or will be folded-away as source and result pointer types will be the same and the operation a NOP. Drop `llvm.bitcast` creation in the frontend and passes code handling these operations, as they should not be receiving these if the code is canonicalized.