### PR TITLE
[SYCL] Fix device selector bug introduced in #12288

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -266,15 +266,23 @@ std::vector<int> platform_impl::filterDeviceFilter(
     MPlugin->call<PiApiKind::piDeviceGetInfo>(
         Device, PI_DEVICE_INFO_TYPE, sizeof(sycl::detail::pi::PiDeviceType),
         &PiDevType, nullptr);
+    // Assumption here is that there is 1-to-1 mapping between PiDevType and
+    // Sycl device type for GPU, CPU, and ACC.
+    info::device_type DeviceType = pi::cast<info::device_type>(PiDevType);
 
     for (const FilterT &Filter : FilterList->get()) {
       backend FilterBackend = Filter.Backend.value_or(backend::all);
       // First, match the backend entry.
       if (FilterBackend != Backend && FilterBackend != backend::all)
         continue;
+      info::device_type FilterDevType =
+          Filter.DeviceType.value_or(info::device_type::all);
 
       // Match the device_num entry.
       if (Filter.DeviceNum && DeviceNum != Filter.DeviceNum.value())
+        continue;
+
+      if (FilterDevType != info::device_type::all && FilterDevType != DeviceType)
         continue;
 
       if constexpr (is_ods_target) {

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -282,7 +282,8 @@ std::vector<int> platform_impl::filterDeviceFilter(
       if (Filter.DeviceNum && DeviceNum != Filter.DeviceNum.value())
         continue;
 
-      if (FilterDevType != info::device_type::all && FilterDevType != DeviceType)
+      if (FilterDevType != info::device_type::all &&
+          FilterDevType != DeviceType)
         continue;
 
       if constexpr (is_ods_target) {

--- a/sycl/test-e2e/DeprecatedFeatures/sycl_device_filter.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/sycl_device_filter.cpp
@@ -1,0 +1,35 @@
+// RUN: %{build} -o %t.out
+// RUN: %if any-device-is-cpu %{ env SYCL_DEVICE_FILTER=cpu %{run-unfiltered-devices} %t.out %}
+// RUN: %if any-device-is-gpu %{ env SYCL_DEVICE_FILTER=gpu %{run-unfiltered-devices} %t.out %}
+// RUN: %if any-device-is-acc %{ env SYCL_DEVICE_FILTER=acc %{run-unfiltered-devices} %t.out %}
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  namespace dev_info = sycl::info::device;
+
+  auto device_type = [](sycl::device d) -> std::string_view {
+    switch (d.get_info<dev_info::device_type>()) {
+    case sycl::info::device_type::cpu:
+      return "cpu";
+    case sycl::info::device_type::gpu:
+      return "gpu";
+    case sycl::info::device_type::accelerator:
+      return "acc";
+    default:
+      return "unknown";
+    }
+  };
+
+  auto devices = sycl::device::get_devices();
+  for (sycl::device d : devices) {
+    std::cout << device_type(d) << " " << d.get_info<dev_info::name>()
+              << std::endl;
+  }
+  assert(!devices.empty());
+  auto expected_type = std::getenv("SYCL_DEVICE_FILTER");
+  assert(std::all_of(devices.begin(), devices.end(), [=](auto d) {
+    return expected_type == device_type(d);
+  }));
+  return 0;
+}

--- a/sycl/test-e2e/DeprecatedFeatures/sycl_device_filter.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/sycl_device_filter.cpp
@@ -28,8 +28,7 @@ int main() {
   }
   assert(!devices.empty());
   auto expected_type = std::getenv("SYCL_DEVICE_FILTER");
-  assert(std::all_of(devices.begin(), devices.end(), [=](auto d) {
-    return expected_type == device_type(d);
-  }));
+  assert(std::all_of(devices.begin(), devices.end(),
+                     [=](auto d) { return expected_type == device_type(d); }));
   return 0;
 }


### PR DESCRIPTION
The very last commit in #12288
(https://github.com/intel/llvm/pull/12288/commits/f9a1377f835f86ab71fb6886e07f5e201a0f085b) accidentally removed one condition needed to add the device into allowed devices list. Restore it here.