### PR TITLE
Fix hip memadvise events regression

### DIFF
--- a/sycl/test-e2e/DiscardEvents/discard_events_usm.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_usm.cpp
@@ -5,6 +5,11 @@
 // The test checks that the last parameter is `nullptr` for all PI calls that
 // should discard events.
 // {{0|0000000000000000}} is required for various output on Linux and Windows.
+// NOTE: piextUSMEnqueuePrefetch and piextUSMEnqueueMemAdvise in the CUDA and
+//       HIP backends may return a warning result on Windows with error-code
+//       -996 (PI_ERROR_PLUGIN_SPECIFIC_ERROR) if USM managed memory is not
+//       supported or if unsupported advice flags are used for the latter API.
+//       Since it is a warning it is safe to ignore for this test.
 //
 // Everything that follows TestQueueOperations()
 // CHECK: ---> piextUSMEnqueueMemset(

--- a/sycl/test-e2e/DiscardEvents/discard_events_usm.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_usm.cpp
@@ -30,7 +30,7 @@
 // CHECK-NEXT:        pi_event * : {{0|0000000000000000}}[ nullptr ]
 //
 // CHECK: ---> piextUSMEnqueueMemAdvise(
-// CHECK: ) --->  pi_result : PI_SUCCESS
+// CHECK: ) --->  pi_result : {{PI_SUCCESS|-996}}
 // CHECK-NEXT:         [out]pi_event * : {{0|0000000000000000}}[ nullptr ]
 //
 // CHECK: ---> piEnqueueKernelLaunch(
@@ -75,7 +75,7 @@
 // CHECK-NEXT:        pi_event * : {{0|0000000000000000}}[ nullptr ]
 //
 // CHECK: ---> piextUSMEnqueueMemAdvise(
-// CHECK: ) --->  pi_result : PI_SUCCESS
+// CHECK: ) --->  pi_result : {{PI_SUCCESS|-996}}
 // CHECK-NEXT:         [out]pi_event * : {{0|0000000000000000}}[ nullptr ]
 //
 // CHECK: ---> piEnqueueKernelLaunch(

--- a/sycl/test-e2e/DiscardEvents/discard_events_usm_ooo_queue.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_usm_ooo_queue.cpp
@@ -5,10 +5,11 @@
 // The test checks that the last parameter is not `nullptr` for all PI calls
 // that should discard events.
 // {{0|0000000000000000}} is required for various output on Linux and Windows.
-// NOTE: piextUSMEnqueuePrefetch in the CUDA backend may return a warning
-//       result on Windows with error-code -996
-//       (PI_ERROR_PLUGIN_SPECIFIC_ERROR). Since it is a warning it is safe to
-//       ignore for this test.
+// NOTE: piextUSMEnqueuePrefetch and piextUSMEnqueueMemAdvise in the CUDA and
+//       HIP backends may return a warning result on Windows with error-code
+//       -996 (PI_ERROR_PLUGIN_SPECIFIC_ERROR) if USM managed memory is not
+//       supported or if unsupported advice flags are used for the latter API.
+//       Since it is a warning it is safe to ignore for this test.
 //
 // Everything that follows TestQueueOperations()
 // CHECK: ---> piextUSMEnqueueMemset(

--- a/sycl/test-e2e/DiscardEvents/discard_events_usm_ooo_queue.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_usm_ooo_queue.cpp
@@ -40,7 +40,7 @@
 //
 // CHECK: ---> piextUSMEnqueueMemAdvise(
 // CHECK-NOT:        pi_event * : {{0|0000000000000000}}[ nullptr ]
-// CHECK: --->  pi_result : PI_SUCCESS
+// CHECK: --->  pi_result : {{PI_SUCCESS|-996}}
 //
 // CHECK: ---> piEnqueueEventsWaitWithBarrier(
 // CHECK-NOT:        pi_event * : {{0|0000000000000000}}[ nullptr ]
@@ -97,7 +97,7 @@
 //
 // CHECK: ---> piextUSMEnqueueMemAdvise(
 // CHECK-NOT:        pi_event * : {{0|0000000000000000}}[ nullptr ]
-// CHECK: --->  pi_result : PI_SUCCESS
+// CHECK: --->  pi_result : {{PI_SUCCESS|-996}}
 //
 // CHECK: ---> piEnqueueEventsWaitWithBarrier(
 // CHECK-NOT:        pi_event * : {{0|0000000000000000}}[ nullptr ]


### PR DESCRIPTION
Updated the event discarding lit tests that check the `piextUSMEnqueueMemAdvise` entry point. The return code can also be `PI_ERROR_PLUGIN_SPECIFIC_ERROR` (-996) if the driver returns that managed memory is not supported for the device.