### PR TITLE
[SYCL-MLIR][polygeist] Use `sycl.kernel_func_obj` attribute in `FunctionKernelInfo`

### DIFF
--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -111,11 +111,11 @@ class FunctionKernelInfo {
 public:
   explicit FunctionKernelInfo(gpu::GPUModuleOp module) : ST(module) {}
 
-  /// Returns true if the given function is potentially a SYCL kernel body
+  /// Returns true if the given function is a SYCL kernel body
   /// function. The SYCL kernel body function is created by SemaSYCL in clang
   /// for the body of the SYCL kernel, e.g., code in parallel_for. The cgeist
   /// frontend attaches a `sycl.kernel_func_obj` attribute to these functions.
-  bool isKernelFuncObjFunction(FunctionOpInterface func);
+  bool isKernelFuncObjFunction(FunctionOpInterface func) const;
 
   llvm::SmallSet<FunctionOpInterface, 4>
   getKernelFuncObjFunctions(gpu::GPUFuncOp kernel);

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -115,14 +115,14 @@ public:
   /// function. The SYCL kernel body function is created by SemaSYCL in clang
   /// for the body of the SYCL kernel, e.g., code in parallel_for. The cgeist
   /// frontend attaches a `sycl.kernel_func_obj` attribute to these functions.
-  bool isKernelFuncObjFunction(FunctionOpInterface func) const;
+  static bool isKernelFuncObjFunction(FunctionOpInterface func);
 
-  llvm::SmallSet<FunctionOpInterface, 4>
+  static llvm::SmallSet<FunctionOpInterface, 4>
   getKernelFuncObjFunctions(gpu::GPUFuncOp kernel);
 
   /// Populates \p kernels with GPU kernels that can reach \p func.
   void getKernelCallers(FunctionOpInterface func,
-                        SmallVectorImpl<gpu::GPUFuncOp> &kernels);
+                        SmallVectorImpl<gpu::GPUFuncOp> &kernels) const;
 
 private:
   SymbolTable ST;

--- a/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
+++ b/polygeist/include/mlir/Dialect/Polygeist/Utils/TransformUtils.h
@@ -124,10 +124,6 @@ public:
   void getKernelCallers(FunctionOpInterface func,
                         SmallVectorImpl<gpu::GPUFuncOp> &kernels);
 
-  /// Returns whether \p CallableOp is a KernelFuncObj function called from the
-  /// body of a SYCL kernel.
-  bool isCalledDirectlyFromKernel(CallableOpInterface callableOp);
-
 private:
   SymbolTable ST;
 };

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
@@ -616,17 +616,6 @@ bool ArgumentPromotionPass::isCandidateCallable(
     return false;
   }
 
-  // Ensure all the call sites for this function are either in a GPU kernel or
-  // in a function that is called directly by a GPU kernel.
-  // TODO: Could generalize by checking that the call chain from the GPU kernel
-  // are all candidates.
-  if (!funcKernelInfo.isCalledDirectlyFromKernel(callableOp)) {
-    LLVM_DEBUG(llvm::dbgs().indent(2)
-               << "not a candidate: found call site that is called by a GPU "
-                  "kernel with depth more than 2.\n");
-    return false;
-  }
-
   return true;
 }
 

--- a/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/ArgumentPromotion.cpp
@@ -215,8 +215,7 @@ private:
   bool isCandidateCall(CallOpInterface callOp) const;
 
   /// Return true is the callee is a candidate, and false otherwise.
-  bool isCandidateCallable(CallableOpInterface callableOp,
-                           polygeist::FunctionKernelInfo &funcKernelInfo);
+  bool isCandidateCallable(CallableOpInterface callableOp);
 
   /// Return true if the call \p callOp operand at position \p pos is a
   /// candidate for peeling, and false otherwise.
@@ -458,7 +457,6 @@ void ArgumentPromotionPass::collectCandidates(
       module->getRegion(0).front().getOperations().front());
   if (!gpuModule)
     return;
-  polygeist::FunctionKernelInfo funcKernelInfo(gpuModule);
 
   // Search for candidate call operations in GPU kernels.
   gpuModule->walk([&](gpu::GPUFuncOp gpuFuncOp) {
@@ -483,7 +481,7 @@ void ArgumentPromotionPass::collectCandidates(
       });
 
       // Perform basic checks to ensure the callable is OK.
-      if (!isCandidateCallable(callableOp, funcKernelInfo))
+      if (!isCandidateCallable(callableOp))
         return;
 
       // Perform basic checks to ensure all calls to the callable are OK.
@@ -590,8 +588,7 @@ bool ArgumentPromotionPass::isCandidateOperand(
 }
 
 bool ArgumentPromotionPass::isCandidateCallable(
-    CallableOpInterface callableOp,
-    polygeist::FunctionKernelInfo &funcKernelInfo) {
+    CallableOpInterface callableOp) {
   Operation *op = callableOp;
   auto funcOp = cast<FunctionOpInterface>(op);
   // The function must be defined, and private or with linkonce_odr linkage.
@@ -610,7 +607,7 @@ bool ArgumentPromotionPass::isCandidateCallable(
   }
 
   // Check candidate is a SYCL KernelObjFunction.
-  if (!funcKernelInfo.isKernelFuncObjFunction(funcOp)) {
+  if (!polygeist::FunctionKernelInfo::isKernelFuncObjFunction(funcOp)) {
     LLVM_DEBUG(llvm::dbgs().indent(2)
                << "not a candidate: not a SYCL KernelObjFunction\n");
     return false;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
@@ -116,8 +116,7 @@ public:
 
 private:
   /// Returns true if \p func is a candidate.
-  bool isCandidateFunction(FunctionOpInterface func,
-                           polygeist::FunctionKernelInfo &funcKernelInfo) const;
+  bool isCandidateFunction(FunctionOpInterface func) const;
   /// Returns true if \p acc1 and \p acc2 need to be checked for no overlap. For
   /// example, under strict aliasing rule, accessors with different element
   /// types are not alias, so return false.
@@ -143,13 +142,12 @@ void KernelDisjointSpecializationPass::runOnOperation() {
       getOperation()->getRegion(0).front().getOperations().front());
   if (!gpuModule)
     return;
-  polygeist::FunctionKernelInfo funcKernelInfo(gpuModule);
 
   SmallVector<FunctionOpInterface> candidates;
   gpuModule->walk([&](FunctionOpInterface func) {
     LLVM_DEBUG(llvm::dbgs()
                << "Processing function \"" << func.getName() << "\"\n");
-    if (isCandidateFunction(func, funcKernelInfo))
+    if (isCandidateFunction(func))
       candidates.push_back(func);
   });
 
@@ -174,9 +172,8 @@ void KernelDisjointSpecializationPass::runOnOperation() {
 }
 
 bool KernelDisjointSpecializationPass::isCandidateFunction(
-    FunctionOpInterface func,
-    polygeist::FunctionKernelInfo &funcKernelInfo) const {
-  if (!funcKernelInfo.isKernelFuncObjFunction(func)) {
+    FunctionOpInterface func) const {
+  if (!polygeist::FunctionKernelInfo::isKernelFuncObjFunction(func)) {
     LLVM_DEBUG(llvm::dbgs().indent(2)
                << "not a candidate: not a potential kernel body function\n");
     return false;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/KernelDisjointSpecialization.cpp
@@ -116,9 +116,8 @@ public:
 
 private:
   /// Returns true if \p func is a candidate.
-  bool isCandidateFunction(
-      FunctionOpInterface func,
-      const polygeist::FunctionKernelInfo &funcKernelInfo) const;
+  bool isCandidateFunction(FunctionOpInterface func,
+                           polygeist::FunctionKernelInfo &funcKernelInfo) const;
   /// Returns true if \p acc1 and \p acc2 need to be checked for no overlap. For
   /// example, under strict aliasing rule, accessors with different element
   /// types are not alias, so return false.
@@ -176,8 +175,8 @@ void KernelDisjointSpecializationPass::runOnOperation() {
 
 bool KernelDisjointSpecializationPass::isCandidateFunction(
     FunctionOpInterface func,
-    const polygeist::FunctionKernelInfo &funcKernelInfo) const {
-  if (!funcKernelInfo.isPotentialKernelBodyFunction(func)) {
+    polygeist::FunctionKernelInfo &funcKernelInfo) const {
+  if (!funcKernelInfo.isKernelFuncObjFunction(func)) {
     LLVM_DEBUG(llvm::dbgs().indent(2)
                << "not a candidate: not a potential kernel body function\n");
     return false;

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -1027,7 +1027,8 @@ private:
                     DataFlowSolver &solver) const;
 
   /// Transform a candidate kernel body function.
-  void transform(FunctionOpInterface func, FunctionKernelInfo &funcKernelInfo,
+  void transform(FunctionOpInterface func,
+                 const FunctionKernelInfo &funcKernelInfo,
                  const unsigned sharedMemoryRemaining, DataFlowSolver &solver);
 
   /// Transform a candidate loop.
@@ -1081,7 +1082,7 @@ void LoopInternalization::runOnGPUModule(gpu::GPUModuleOp gpuModule) {
       return;
 
     llvm::SmallSet<FunctionOpInterface, 4> bodyFuncs =
-        funcKernelInfo.getKernelFuncObjFunctions(kernel);
+        FunctionKernelInfo::getKernelFuncObjFunctions(kernel);
     kernelBodyFuncs.insert(bodyFuncs.begin(), bodyFuncs.end());
   });
 
@@ -1275,7 +1276,7 @@ Value LoopInternalization::getTileSize(LoopLikeOpInterface loop,
 }
 
 void LoopInternalization::transform(FunctionOpInterface func,
-                                    FunctionKernelInfo &funcKernelInfo,
+                                    const FunctionKernelInfo &funcKernelInfo,
                                     const unsigned sharedMemoryRemaining,
                                     DataFlowSolver &solver) {
   // Calculate the total amount of shared memory needed to promote the memory

--- a/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Transforms/LoopInternalization.cpp
@@ -1027,8 +1027,7 @@ private:
                     DataFlowSolver &solver) const;
 
   /// Transform a candidate kernel body function.
-  void transform(FunctionOpInterface func,
-                 const FunctionKernelInfo &funcKernelInfo,
+  void transform(FunctionOpInterface func, FunctionKernelInfo &funcKernelInfo,
                  const unsigned sharedMemoryRemaining, DataFlowSolver &solver);
 
   /// Transform a candidate loop.
@@ -1082,7 +1081,7 @@ void LoopInternalization::runOnGPUModule(gpu::GPUModuleOp gpuModule) {
       return;
 
     llvm::SmallSet<FunctionOpInterface, 4> bodyFuncs =
-        funcKernelInfo.getPotentialKernelBodyFunctions(kernel);
+        funcKernelInfo.getKernelFuncObjFunctions(kernel);
     kernelBodyFuncs.insert(bodyFuncs.begin(), bodyFuncs.end());
   });
 
@@ -1276,7 +1275,7 @@ Value LoopInternalization::getTileSize(LoopLikeOpInterface loop,
 }
 
 void LoopInternalization::transform(FunctionOpInterface func,
-                                    const FunctionKernelInfo &funcKernelInfo,
+                                    FunctionKernelInfo &funcKernelInfo,
                                     const unsigned sharedMemoryRemaining,
                                     DataFlowSolver &solver) {
   // Calculate the total amount of shared memory needed to promote the memory

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -258,13 +258,12 @@ namespace polygeist {
 // FunctionKernelInfo
 //===----------------------------------------------------------------------===//
 
-bool FunctionKernelInfo::isKernelFuncObjFunction(
-    FunctionOpInterface func) const {
+bool FunctionKernelInfo::isKernelFuncObjFunction(FunctionOpInterface func) {
   return func->hasAttr(sycl::SYCLDialect::getKernelFuncObjAttrName());
 }
 
 void FunctionKernelInfo::getKernelCallers(
-    FunctionOpInterface func, SmallVectorImpl<gpu::GPUFuncOp> &kernels) {
+    FunctionOpInterface func, SmallVectorImpl<gpu::GPUFuncOp> &kernels) const {
   auto callers = func->getAttrOfType<ArrayAttr>(
       sycl::SYCLDialect::getKernelFuncObjAttrName());
   if (!callers)
@@ -282,7 +281,8 @@ FunctionKernelInfo::getKernelFuncObjFunctions(gpu::GPUFuncOp kernel) {
 
   StringRef kernelName = kernel.getName();
   llvm::SmallSet<FunctionOpInterface, 4> kernelBodyFunctions;
-  for (auto func : cast<gpu::GPUModuleOp>(ST.getOp()).getOps<func::FuncOp>()) {
+  auto gpuModule = kernel->getParentOfType<gpu::GPUModuleOp>();
+  for (auto func : gpuModule.getOps<func::FuncOp>()) {
     if (auto attr = func->getAttrOfType<ArrayAttr>(
             sycl::SYCLDialect::getKernelFuncObjAttrName())) {
       if (llvm::any_of(attr.getAsRange<FlatSymbolRefAttr>(),

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -258,7 +258,8 @@ namespace polygeist {
 // FunctionKernelInfo
 //===----------------------------------------------------------------------===//
 
-bool FunctionKernelInfo::isKernelFuncObjFunction(FunctionOpInterface func) {
+bool FunctionKernelInfo::isKernelFuncObjFunction(
+    FunctionOpInterface func) const {
   return func->hasAttr(sycl::SYCLDialect::getKernelFuncObjAttrName());
 }
 

--- a/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
+++ b/polygeist/lib/Dialect/Polygeist/Utils/TransformUtils.cpp
@@ -296,21 +296,6 @@ FunctionKernelInfo::getKernelFuncObjFunctions(gpu::GPUFuncOp kernel) {
   return kernelBodyFunctions;
 }
 
-bool FunctionKernelInfo::isCalledDirectlyFromKernel(
-    CallableOpInterface callableOp) {
-  // Early exit if this is not a KernelFuncObj function
-  if (!isKernelFuncObjFunction(static_cast<FunctionOpInterface>(callableOp))) {
-    return false;
-  }
-  std::optional<SymbolTable::UseRange> optUses =
-      ST.getSymbolUses(callableOp, ST.getOp());
-  assert(optUses && "Expecting valid symbol table");
-  SymbolTable::UseRange uses = *optUses;
-  return llvm::any_of(uses, [](SymbolTable::SymbolUse use) {
-    return use.getUser()->getParentOfType<gpu::GPUFuncOp>();
-  });
-}
-
 namespace {
 
 struct SCFIfBuilder {

--- a/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
+++ b/polygeist/test/polygeist-opt/sycl/argpromotion.mlir
@@ -2,9 +2,10 @@
 
 gpu.module @device_func {
   // COM: This function is a candidate, check that it is transformed correctly.
-  func.func private @callee1(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 {
+  func.func private @callee1(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 attributes {sycl.kernel_func_obj = [@test1, @test2]} {
     // CHECK-LABEL: func.func private @callee1
-    // CHECK-SAME:    (%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?xi64> {llvm.noalias}) -> i64 {
+    // CHECK-SAME:    (%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?xi64> {llvm.noalias}) -> i64
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@test1, @test2]}
     // CHECK-NOT:     {{.*}} = "polygeist.subindex"
     // CHECK:         {{.*}} = affine.load %arg0[0] : memref<?xi32>
     // CHECK-NEXT:    {{.*}} = affine.load %arg1[0] : memref<?xi64>
@@ -65,9 +66,10 @@ gpu.module @device_func {
   }
 
   // COM: Test that multiple peelable arguments are peeled correctly.
-  func.func private @callee3(%arg0: memref<?x!llvm.struct<(i32)>>, %arg1: memref<?x!llvm.struct<(f32)>>) {
+  func.func private @callee3(%arg0: memref<?x!llvm.struct<(i32)>>, %arg1: memref<?x!llvm.struct<(f32)>>) attributes {sycl.kernel_func_obj = [@test3]} {
     // CHECK-LABEL: func.func private @callee3
-    // CHECK-SAME:    (%arg0: memref<?xi32>, %arg1: memref<?xf32>) {
+    // CHECK-SAME:    (%arg0: memref<?xi32>, %arg1: memref<?xf32>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@test3]}
     // CHECK-NOT:     {{.*}} = "polygeist.subindex"
     // CHECK:         {{.*}} = affine.load %arg0[0] : memref<?xi32>
     // CHECK-NEXT:    {{.*}} = affine.load %arg1[0] : memref<?xf32>
@@ -97,9 +99,10 @@ gpu.module @device_func {
   // COM: Test that a peelable argument can be peeled when another argument with the expected type 
   // COM: cannot be peeled (because used in the callee by an invalid instruction).
   // COM: The first argument in this function can be peeled but the second cannot.
-  func.func private @callee4(%arg0: memref<?x!llvm.struct<(i32)>>, %arg1: memref<?x!llvm.struct<(f32)>>) {
+  func.func private @callee4(%arg0: memref<?x!llvm.struct<(i32)>>, %arg1: memref<?x!llvm.struct<(f32)>>) attributes {sycl.kernel_func_obj = [@test4]} {
     // CHECK-LABEL: func.func private @callee4
-    // CHECK-SAME:    (%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?x!llvm.struct<(f32)>>) {
+    // CHECK-SAME:    (%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?x!llvm.struct<(f32)>>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@test4]}
     // CHECK-NOT:     {{.*}} = "polygeist.subindex"
     // CHECK:         {{.*}} = memref.memory_space_cast %arg1 : memref<?x!llvm.struct<(f32)>> to memref<?x!llvm.struct<(f32)>, 4>
     // CHECK-NEXT:    {{.*}} = affine.load %arg0[0] : memref<?xi32>
@@ -123,9 +126,10 @@ gpu.module @device_func {
   }
 
   // COM: The second argument in this function can be peeled but the first cannot.
-  func.func private @callee5(%arg0: memref<?x!llvm.struct<(f32)>>, %arg1: memref<?x!llvm.struct<(i32)>>) {
+  func.func private @callee5(%arg0: memref<?x!llvm.struct<(f32)>>, %arg1: memref<?x!llvm.struct<(i32)>>) attributes {sycl.kernel_func_obj = [@test5]} {
     // CHECK-LABEL: func.func private @callee5
-    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(f32)>>, %arg1: memref<?xi32> {llvm.noalias}) {
+    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(f32)>>, %arg1: memref<?xi32> {llvm.noalias})
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@test5]}
     // CHECK-NOT:     {{.*}} = "polygeist.subindex"
     // CHECK:         {{.*}} = memref.memory_space_cast %arg0 : memref<?x!llvm.struct<(f32)>> to memref<?x!llvm.struct<(f32)>, 4>
     // CHECK-NEXT:    {{.*}} = affine.load %arg1[0] : memref<?xi32>
@@ -150,10 +154,10 @@ gpu.module @device_func {
 
   // COM: Test that the a call to a linkonce_odr function is modified.
   // COM: This function is a candidate, check that it is transformed correctly.
-  func.func @callee6(%arg0: memref<?x!llvm.struct<(i32, i64)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+  func.func @callee6(%arg0: memref<?x!llvm.struct<(i32, i64)>>) attributes {llvm.linkage = #llvm.linkage<linkonce_odr>, sycl.kernel_func_obj = [@test6]} {
     // CHECK-LABEL: func.func private @callee6
     // CHECK-SAME:    (%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?xi64> {llvm.noalias})
-    // CHECK-SAME:    attributes {llvm.linkage = #llvm.linkage<private>} {
+    // CHECK-SAME:    attributes {llvm.linkage = #llvm.linkage<private>, sycl.kernel_func_obj = [@test6]} {
     func.return
   }
   gpu.func @test6() kernel {

--- a/polygeist/test/polygeist-opt/sycl/argpromotion_invalid.mlir
+++ b/polygeist/test/polygeist-opt/sycl/argpromotion_invalid.mlir
@@ -3,7 +3,7 @@
 #map = affine_map<(s0) -> (s0 - 1)>  
 gpu.module @device_func {
   // COM: This function is not a candidate because it is not defined.
-  func.func private @callee1(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> ()
+  func.func private @callee1(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> () attributes {sycl.kernel_func_obj = [@caller1]}
     //CHECK-LABEL: func.func private @callee1
   gpu.func @caller1() kernel {  
     // CHECK-LABEL: gpu.func @caller1() kernel
@@ -15,7 +15,7 @@ gpu.module @device_func {
   }
 
   // COM: This function is not a candidate because it doesn't have any argument.
-  func.func private @callee2() -> () {
+  func.func private @callee2() -> () attributes {sycl.kernel_func_obj = [@caller2]} {
     // CHECK-LABEL: func.func private @callee2
     func.return 
   }
@@ -28,9 +28,10 @@ gpu.module @device_func {
 
   // COM: This function is not a candidate because the argument doesn't have the
   // COM: expected type.
-  func.func private @callee3(%arg0: memref<?xi32>) -> () {
+  func.func private @callee3(%arg0: memref<?xi32>) -> () attributes {sycl.kernel_func_obj = [@caller3]} {
     // CHECK-LABEL: func.func private @callee3
-    // CHECK-SAME:    (%arg0: memref<?xi32>) {
+    // CHECK-SAME:    (%arg0: memref<?xi32>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@caller3]}
     func.return
   }
   gpu.func @caller3() kernel {
@@ -43,9 +44,10 @@ gpu.module @device_func {
   }
 
   // COM: Should not peel the argument because it is a multidimentional memref.
-  func.func private @callee4(%arg0: memref<?x1x!llvm.struct<(i32)>>) {
+  func.func private @callee4(%arg0: memref<?x1x!llvm.struct<(i32)>>) attributes {sycl.kernel_func_obj = [@caller4]} {
     // CHECK-LABEL: func.func private @callee4
-    // CHECK-SAME:    (%arg0: memref<?x1x!llvm.struct<(i32)>>) {
+    // CHECK-SAME:    (%arg0: memref<?x1x!llvm.struct<(i32)>>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@caller4]}
     func.return
   }
   gpu.func @caller4() kernel {
@@ -59,9 +61,10 @@ gpu.module @device_func {
 
   // COM: Should not peel the argument because it is memref with non-identity
   // COM: layout.
-  func.func private @callee5(%arg0: memref<?x!llvm.struct<(i32)>, #map>) {
+  func.func private @callee5(%arg0: memref<?x!llvm.struct<(i32)>, #map>) attributes {sycl.kernel_func_obj = [@caller5]} {
     // CHECK-LABEL: func.func private @callee5
-    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32)>, #map>) {
+    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32)>, #map>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@caller5]}
     func.return
   }
   gpu.func @caller5() kernel {
@@ -75,9 +78,10 @@ gpu.module @device_func {
 
   // COM: Test that an argument that is a memref with element type
   // COM: 'struct<(struct<(...)>)>' is not peeled.
-  func.func private @callee6(%arg0: memref<?x!llvm.struct<(struct<(i32)>)>>) {
+  func.func private @callee6(%arg0: memref<?x!llvm.struct<(struct<(i32)>)>>) attributes {sycl.kernel_func_obj = [@caller6]} {
     // CHECK-LABEL: func.func private @callee6
-    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(struct<(i32)>)>>) {
+    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(struct<(i32)>)>>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@caller6]}
     func.return
   }
   gpu.func @caller6() kernel {
@@ -91,9 +95,10 @@ gpu.module @device_func {
 
   // COM: This function is not a candidate because one call site uses the
   // COM: argument after the call.
-  func.func private @callee7(%arg0: memref<?x!llvm.struct<(i32, i64)>>) {  
+  func.func private @callee7(%arg0: memref<?x!llvm.struct<(i32, i64)>>) attributes {sycl.kernel_func_obj = [@caller7]} {  
     // CHECK-LABEL: func.func private @callee7
-    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32, i64)>>) {      
+    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32, i64)>>)
+    // CHECK-SAME:    attributes {sycl.kernel_func_obj = [@caller7]}
     func.return
   }  
   gpu.func @caller7() kernel {
@@ -104,6 +109,32 @@ gpu.module @device_func {
     func.call @callee7(%cast) : (memref<?x!llvm.struct<(i32, i64)>>) -> ()
     %i = arith.constant 0 : index
     %0 = memref.load %cast[%i] : memref<?x!llvm.struct<(i32, i64)>>
+    gpu.return
+  }
+
+  // COM: This function is not a candidate because it does not have the sycl.kernel_func_obj attribute
+  func.func private @callee8(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 {
+    // CHECK-LABEL: func.func private @callee8
+    // CHECK-SAME:    (%arg0: memref<?x!llvm.struct<(i32, i64)>>)
+    %c0 = arith.constant 0 : index
+    %c1 = arith.constant 1 : index
+    %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(i32, i64)>>, index) -> memref<?xi32>
+    %1 = "polygeist.subindex"(%arg0, %c1) : (memref<?x!llvm.struct<(i32, i64)>>, index) -> memref<?xi64>
+    %2 = affine.load %0[0] : memref<?xi32>
+    %3 = affine.load %1[0] : memref<?xi64>
+    %4 = arith.extsi %2 : i32 to i64
+    %5 = arith.addi %3, %4 : i64
+    return %5 : i64
+  }
+
+  gpu.func @test8() kernel {
+    // CHECK-LABEL: gpu.func @test8() kernel
+    // CHECK:         %{{.*}} = func.call @callee8(%{{.*}}) : (memref<?x!llvm.struct<(i32, i64)>>) -> i64
+    %alloca_1 = memref.alloca() : memref<1x!llvm.struct<(i32, i64)>>
+    %cast_1 = memref.cast %alloca_1 : memref<1x!llvm.struct<(i32, i64)>> to memref<?x!llvm.struct<(i32, i64)>>
+    %alloca_2 = memref.alloca() : memref<1xi32>
+    %cast_2 = memref.cast %alloca_2 : memref<1xi32> to memref<?xi32>
+    func.call @callee8(%cast_1) : (memref<?x!llvm.struct<(i32, i64)>>) -> i64
     gpu.return
   }
 }

--- a/polygeist/test/polygeist-opt/sycl/argpromotion_privatize.mlir
+++ b/polygeist/test/polygeist-opt/sycl/argpromotion_privatize.mlir
@@ -3,10 +3,10 @@
 gpu.module @device_func {
 
   // COM: Test that both @callee and @wrapper are privatized.
-  // CHECK-DAG: func.func private @callee(%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?xi64> {llvm.noalias}) -> i64 attributes {llvm.linkage = #llvm.linkage<private>}
+  // CHECK-DAG: func.func private @callee(%arg0: memref<?xi32> {llvm.noalias}, %arg1: memref<?xi64> {llvm.noalias}) -> i64 attributes {llvm.linkage = #llvm.linkage<private>, sycl.kernel_func_obj = [@caller1, @caller2]}
   // CHECK-DAG: func.func private @wrapper(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 attributes {llvm.linkage = #llvm.linkage<private>}
 
-  func.func @callee(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>} {
+  func.func @callee(%arg0: memref<?x!llvm.struct<(i32, i64)>>) -> i64 attributes {llvm.linkage = #llvm.linkage<linkonce_odr>, sycl.kernel_func_obj = [@caller1, @caller2]} {
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index
     %0 = "polygeist.subindex"(%arg0, %c0) : (memref<?x!llvm.struct<(i32, i64)>>, index) -> memref<?xi32>

--- a/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/kernel_disjoint_specialization.mlir
@@ -23,9 +23,11 @@ gpu.module @device_func {
   // CHECK-LABEL: func.func private @callee1.specialized(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev> {sycl.inner.disjoint},
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint})
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller1]
   // CHECK-LABEL: func.func private @callee1(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev>,
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>)
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller1]
   // CHECK-LABEL: gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
 
   // COM: Obtain a pointer to the beginning of the first accessor.
@@ -59,7 +61,7 @@ gpu.module @device_func {
   // CHECK-NEXT:    } else {
   // CHECK-NEXT:      func.call @callee1(%arg0, %arg1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  func.func private @callee1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
+  func.func private @callee1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) attributes {sycl.kernel_func_obj = [@caller1]} {
     return
   }
   gpu.func @caller1(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
@@ -70,15 +72,17 @@ gpu.module @device_func {
   // COM: No need to version as the accessor types are different.
   // CHECK-LABEL: func.func private @callee2.specialized(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_r_dev> {sycl.inner.disjoint}, 
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint}) attributes {llvm.linkage = #llvm.linkage<private>} {
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint})
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller2]
   // CHECK-LABEL: func.func private @callee2(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_i32_r_dev>, 
-  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
+  // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>)
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller2]
   // CHECK-LABEL: gpu.func @caller2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
   // CHECK-NEXT:    func.call @callee2.specialized(%arg0, %arg1) : (memref<?x!sycl_accessor_1_i32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
   // CHECK-NEXT:    gpu.return
   // CHECK-NEXT:  }
-  func.func private @callee2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
+  func.func private @callee2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) attributes {sycl.kernel_func_obj = [@caller2]} {
     return
   }
   gpu.func @caller2(%arg0: memref<?x!sycl_accessor_1_i32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) kernel {
@@ -90,9 +94,11 @@ gpu.module @device_func {
   // CHECK-LABEL: func.func private @callee3.specialized(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_2_f32_r_dev> {sycl.inner.disjoint}, 
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_2_f32_w_dev> {sycl.inner.disjoint})
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller3]
   // CHECK-LABEL: func.func private @callee3(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_2_f32_r_dev>, 
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_2_f32_w_dev>)
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller3]
   // CHECK-LABEL: gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) kernel {
 
   // COM: Obtain a pointer to the beginning of the first accessor.
@@ -129,7 +135,7 @@ gpu.module @device_func {
   // CHECK-NEXT:    } else {
   // CHECK-NEXT:      func.call @callee3(%arg0, %arg1) : (memref<?x!sycl_accessor_2_f32_r_dev>, memref<?x!sycl_accessor_2_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  func.func private @callee3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) {
+  func.func private @callee3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) attributes {sycl.kernel_func_obj = [@caller3]} {
     return
   }
   gpu.func @caller3(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_accessor_2_f32_w_dev>) kernel {
@@ -141,9 +147,11 @@ gpu.module @device_func {
   // CHECK-LABEL: func.func private @callee4.specialized(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev> {sycl.inner.disjoint},
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev> {sycl.inner.disjoint})
+  // CHECK-SAME:    sycl.kernel_func_obj = [@wrapper4]
   // CHECK-LABEL: func.func private @callee4(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_1_f32_r_dev>,
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_1_f32_w_dev>)
+  // CHECK-SAME:    sycl.kernel_func_obj = [@wrapper4]
   // CHECK-LABEL: func.func @caller4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) {
   // CHECK:         scf.if %{{.*}} {
   // CHECK-NEXT:      func.call @callee4.specialized(%0, %1) : (memref<?x!sycl_accessor_1_f32_r_dev>, memref<?x!sycl_accessor_1_f32_w_dev>) -> ()
@@ -152,7 +160,7 @@ gpu.module @device_func {
   // CHECK-NEXT:    }
   // CHECK-LABEL: gpu.func @wrapper4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) kernel {
   // CHECK-NEXT:    sycl.call @caller4(%arg0)
-  func.func private @callee4(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) {
+  func.func private @callee4(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_accessor_1_f32_w_dev>) attributes {sycl.kernel_func_obj = [@wrapper4]} {
     return
   }
   func.func @caller4(%arg0: memref<?x!llvm.struct<(!sycl_accessor_1_f32_r_dev, !sycl_accessor_1_f32_w_dev)>>) {
@@ -172,9 +180,11 @@ gpu.module @device_func {
   // CHECK-LABEL: func.func private @callee5.specialized(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_dev> {sycl.inner.disjoint},
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_dev> {sycl.inner.disjoint})
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller5]
   // CHECK-LABEL: func.func private @callee5(
   // CHECK-SAME:    %arg0: memref<?x!sycl_accessor_0_f32_r_dev>,
   // CHECK-SAME:    %arg1: memref<?x!sycl_accessor_0_f32_w_dev>)
+  // CHECK-SAME:    sycl.kernel_func_obj = [@caller5]
   // CHECK-LABEL: gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) kernel {
   // CHECK-NEXT:    [[ARG0_BEGIN:%.*]] = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_dev>) -> memref<?xf32, 1>
   // CHECK-NEXT:    %1 = sycl.accessor.get_pointer(%arg0) : (memref<?x!sycl_accessor_0_f32_r_dev>) -> memref<?xf32, 1>
@@ -196,7 +206,7 @@ gpu.module @device_func {
   // CHECK-NEXT:    } else {
   // CHECK-NEXT:      func.call @callee5(%arg0, %arg1) : (memref<?x!sycl_accessor_0_f32_r_dev>, memref<?x!sycl_accessor_0_f32_w_dev>) -> ()
   // CHECK-NEXT:    }
-  func.func private @callee5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) {
+  func.func private @callee5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) attributes {sycl.kernel_func_obj = [@caller5]} {
     return
   }
   gpu.func @caller5(%arg0: memref<?x!sycl_accessor_0_f32_r_dev>, %arg1: memref<?x!sycl_accessor_0_f32_w_dev>) kernel {

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization.mlir
@@ -15,7 +15,8 @@
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0 + s0, 256)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<64xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine_2d(
-// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_item_2_>) {
+// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_item_2_>)
+// CHECK-SAME:      sycl.kernel_func_obj = [@kernel]
 
 // COM: Get local ids:
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.local_id : !sycl_id_2_1
@@ -89,7 +90,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_item_2>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -128,7 +129,8 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!s
 // CHECK-DAG:   [[MAP3:#map.*]] = affine_map<(d0)[s0] -> ((d0 - 1) * s0 + s0 + 1, 512)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL:  func.func private @affine_3d(
-// CHECK-SAME:       %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
+// CHECK-SAME:       %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>)
+// CHECK-SAME:       sycl.kernel_func_obj = [@kernel]
 
 // COM: Get work group sizes:
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_3_1
@@ -235,7 +237,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!s
 // CHECK-NEXT:  }
 // CHECK-NEXT:  return
 gpu.module @device_func {
-func.func private @affine_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) {
+func.func private @affine_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_3>
   %id = memref.cast %alloca : memref<1x!sycl_id_3> to memref<?x!sycl_id_3>
   %c0_i32 = arith.constant 0 : i32
@@ -282,7 +284,8 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!s
 
 // CHECK:           memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL:     func.func private @scf_2d(
-// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_2_>) {
+// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_2_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_2_>)
+// CHECK-SAME:          sycl.kernel_func_obj = [@kernel]
 
 // COM: Get work group sizes:
 // CHECK-NEXT:        %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_2_1
@@ -409,7 +412,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!s
 // CHECK-NEXT:        return
 // CHECK-NEXT:      }
 gpu.module @device_func {
-func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @scf_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0 = arith.constant 0 : index
@@ -451,7 +454,8 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!s
 
 // CHECK:           memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL:     func.func private @scf_3d(
-// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>) {
+// CHECK-SAME:          %[[VAL_0:.*]]: memref<?x!sycl_accessor_3_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_nd_item_3_>)
+// CHECK-SAME:          sycl.kernel_func_obj = [@kernel]
 
 // COM: Get work group sizes:
 // CHECK-NEXT:        %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_3_1
@@ -556,7 +560,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!s
 // CHECK-NEXT:      }
 // CHECK-NEXT:      return
 gpu.module @device_func {
-func.func private @scf_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) {
+func.func private @scf_3d(%arg0: memref<?x!sycl_accessor_3_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_3>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_3>
   %id = memref.cast %alloca : memref<1x!sycl_id_3> to memref<?x!sycl_id_3>
   %c0 = arith.constant 0 : index

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization_invalid.mlir
@@ -16,7 +16,7 @@
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 gpu.module @device_func {
-func.func private @callee1(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @callee1(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) attributes {sycl.kernel_func_obj = [@caller1]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -35,7 +35,7 @@ gpu.func @caller1(%arg0: memref<?xi32, #sycl.access.address_space<local>>, %arg1
   gpu.return
 }
 
-func.func private @callee2(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @callee2(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) attributes {sycl.kernel_func_obj = [@caller2]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -74,7 +74,7 @@ gpu.func @caller2(%arg0: memref<?xi32, 3>, %arg1: memref<?x!sycl_accessor_2_f32_
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -118,7 +118,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!s
 !sycl_nd_item_2 = !sycl.nd_item<[2], (!sycl_item_2, !sycl_item_2, !sycl_group_2)>
 
 gpu.module @device_func {
-func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) {
+func.func private @affine_2d(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!sycl_nd_item_2>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_2>
   %id = memref.cast %alloca : memref<1x!sycl_id_2> to memref<?x!sycl_id_2>
   %c0_i32 = arith.constant 0 : i32
@@ -162,7 +162,7 @@ gpu.func @kernel(%arg0: memref<?x!sycl_accessor_2_f32_r_dev>, %arg1: memref<?x!s
 !sycl_item_1_ = !sycl.item<[1, true], (!sycl_item_base_1_)>
 
 gpu.module @device_func {
-func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) {
+func.func private @affine(%alloca_cond: memref<1xi1>, %arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   %id = memref.cast %alloca : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
   %c0_i32 = arith.constant 0 : i32

--- a/polygeist/test/polygeist-opt/sycl/loop_internalization_unroll.mlir
+++ b/polygeist/test/polygeist-opt/sycl/loop_internalization_unroll.mlir
@@ -15,7 +15,8 @@
 // CHECK-DAG:   [[MAP2:#map.*]] = affine_map<(d0)[s0] -> (d0 * s0)>
 // CHECK:       memref.global "private" @WGLocalMem : memref<32000xi8, #sycl.access.address_space<local>>
 // CHECK-LABEL: func.func private @affine(
-// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_1_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_item_1_>) {
+// CHECK-SAME:      %[[VAL_0:.*]]: memref<?x!sycl_accessor_1_f32_r_dev>, %[[VAL_1:.*]]: memref<?x!sycl_item_1_>)
+// CEHCK-SAME:      sycl.kernel_func_obj = [@kernel]
 // CHECK-NEXT:    %[[VAL_2:.*]] = sycl.work_group_size : !sycl_range_1_1
 // CHECK-NEXT:    %[[VAL_3:.*]] = memref.alloca() : memref<1x!sycl_range_1_1>
 // CHECK-NEXT:    %[[VAL_4:.*]] = arith.constant 0 : index
@@ -114,7 +115,7 @@
 // CHECK-NEXT:    return
 // CHECK-NEXT:  }
 gpu.module @device_func {
-func.func private @affine(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) {
+func.func private @affine(%arg0: memref<?x!sycl_accessor_1_f32_r_dev>, %arg1: memref<?x!sycl_item_1_>) attributes {sycl.kernel_func_obj = [@kernel]} {
   %alloca = memref.alloca() : memref<1x!sycl_id_1_>
   %id = memref.cast %alloca : memref<1x!sycl_id_1_> to memref<?x!sycl_id_1_>
   %c0_i32 = arith.constant 0 : i32

--- a/polygeist/test/polygeist-opt/sycl/matrix_multiply_reduction.mlir
+++ b/polygeist/test/polygeist-opt/sycl/matrix_multiply_reduction.mlir
@@ -4,7 +4,8 @@
 // CHECK-SAME:    (%arg0: memref<?x!sycl_accessor_1_f32_w_dev, 4> {llvm.noalias, sycl.inner.disjoint},
 // CHECK-SAME:     %arg1: memref<?x!sycl_accessor_1_f32_r_dev, 4> {llvm.noalias, sycl.inner.disjoint},
 // CHECK-SAME:     %arg2: memref<?x!sycl_accessor_1_f32_r_dev, 4> {llvm.noalias, sycl.inner.disjoint},
-// CHECK-SAME:     %arg3: i32) attributes {llvm.linkage = #llvm.linkage<private>} {
+// CHECK-SAME:     %arg3: i32)
+// CHECK-SAME:     sycl.kernel_func_obj = [@caller]
 // CHECK-DAG: [[ALLOCA:%.*]] = memref.alloca()
 // CHECK-DAG: [[CAST:%.*]] = memref.cast [[ALLOCA]]
 // CHECK-DAG: [[ALLOCA1:%.*]] = memref.alloca()
@@ -39,7 +40,7 @@ gpu.module @device_func {
     gpu.return
   }
 
-  func.func private @matrix_multiply_reduction(%arg0: memref<?x!llvm.struct<(!sycl_accessor_write_1_, !sycl_accessor_read_1_, !sycl_accessor_read_1_)>, 4>, %arg1: i32) {
+  func.func private @matrix_multiply_reduction(%arg0: memref<?x!llvm.struct<(!sycl_accessor_write_1_, !sycl_accessor_read_1_, !sycl_accessor_read_1_)>, 4>, %arg1: i32) attributes {sycl.kernel_func_obj = [@caller]} {
     %c2048 = arith.constant 2048 : index
     %c0 = arith.constant 0 : index
     %c1 = arith.constant 1 : index


### PR DESCRIPTION
Use this attribute in `FunctionKernelInfo` instead of obtaining the list of kernel body functions by traversing the call-graph.