### PR TITLE
[SYCL] Limit the directories that are searched when loading dependencies of the plugins

### DIFF
--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -133,23 +133,21 @@ void preloadLibraries() {
 
   MapT &dllMap = getDllMap();
 
+  // When searching for dependencies of the OpenCL and Level Zero plugins
+  // (including ICD loader and the Level Zero loader respectively) limit the
+  // list of directories to %windows%\system32 and the directory that contains
+  // the loaded DLL (the plugin). ICD loader is located in the same directory as
+  // OpenCL plugin, the Level Zero loader is in the system directory. Standard
+  // library dependencies are in the system directory.
   auto ocl_path = LibSYCLDir / __SYCL_OPENCL_PLUGIN_NAME;
-  // When searching for dependencies of the OpenCL plugin (which includes ICD
-  // loader) limit the list of directories to %windows%\system32 and the
-  // directory that contains the loaded DLL (OpenCL plugin). ICD loader is
-  // located in the same directory as OpenCL plugin. Standard library
-  // dependencies are in the system directory.
   dllMap.emplace(ocl_path, LoadLibraryEx(ocl_path.wstring().c_str(), NULL,
                                          LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
                                              LOAD_LIBRARY_SEARCH_SYSTEM32));
 
-  // When searching for dependencies of the Level Zero plugin (which includes
-  // level zero loader) limit the list of directories to %windows%\system32.
-  // In this case we know that the Level Zero Loader is located in the system
-  // directory. Standard library dependencies are in the system directory.
   auto l0_path = LibSYCLDir / __SYCL_LEVEL_ZERO_PLUGIN_NAME;
   dllMap.emplace(l0_path, LoadLibraryEx(l0_path.wstring().c_str(), NULL,
-                                        LOAD_LIBRARY_SEARCH_SYSTEM32));
+                                        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                            LOAD_LIBRARY_SEARCH_SYSTEM32));
 
   auto cuda_path = LibSYCLDir / __SYCL_CUDA_PLUGIN_NAME;
   dllMap.emplace(cuda_path,

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -139,7 +139,7 @@ void preloadLibraries() {
   // current directory and some other directories which are considered unsafe.
   auto flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32;
 
-  auto loadPlugin = [&](auto pluginName, DWORD flags = NULL) {
+  auto loadPlugin = [&](auto pluginName, DWORD flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32) {
     auto path = LibSYCLDir / pluginName;
     dllMap.emplace(path, LoadLibraryEx(path.wstring().c_str(), NULL, flags));
   };

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -133,25 +133,23 @@ void preloadLibraries() {
 
   MapT &dllMap = getDllMap();
 
-  // When searching for dependencies of the OpenCL and Level Zero plugins
-  // (including ICD loader and the Level Zero loader respectively) limit the
+  // When searching for dependencies of the plugins limit the
   // list of directories to %windows%\system32 and the directory that contains
-  // the loaded DLL (the plugin). ICD loader is located in the same directory as
-  // OpenCL plugin, the Level Zero loader is in the system directory. Standard
-  // library dependencies are in the system directory.
+  // the loaded DLL (the plugin). This is necessary to avoid loading dlls from
+  // current directory and some other directories which are considered unsafe.
   auto flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32;
 
-  auto loadPlugin = [&](auto plugin_name, DWORD flags = NULL) {
-    auto path = LibSYCLDir / plugin_name;
+  auto loadPlugin = [&](auto pluginName, DWORD flags = NULL) {
+    auto path = LibSYCLDir / pluginName;
     dllMap.emplace(path, LoadLibraryEx(path.wstring().c_str(), NULL, flags));
   };
   loadPlugin(__SYCL_OPENCL_PLUGIN_NAME, flags);
   loadPlugin(__SYCL_LEVEL_ZERO_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_CUDA_PLUGIN_NAME);
-  loadPlugin(__SYCL_ESIMD_EMULATOR_PLUGIN_NAME);
-  loadPlugin(__SYCL_HIP_PLUGIN_NAME);
-  loadPlugin(__SYCL_UNIFIED_RUNTIME_PLUGIN_NAME);
-  loadPlugin(__SYCL_NATIVE_CPU_PLUGIN_NAME);
+  loadPlugin(__SYCL_CUDA_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_ESIMD_EMULATOR_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_HIP_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_UNIFIED_RUNTIME_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_NATIVE_CPU_PLUGIN_NAME, flags);
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -134,11 +134,22 @@ void preloadLibraries() {
   MapT &dllMap = getDllMap();
 
   auto ocl_path = LibSYCLDir / __SYCL_OPENCL_PLUGIN_NAME;
-  dllMap.emplace(ocl_path,
-                 LoadLibraryEx(ocl_path.wstring().c_str(), NULL, NULL));
+  // When searching for dependencies of the OpenCL plugin (which includes ICD
+  // loader) limit the list of directories to %windows%\system32 and the
+  // directory that contains the loaded DLL (OpenCL plugin). ICD loader is
+  // located in the same directory as OpenCL plugin. Standard library
+  // dependencies are in the system directory.
+  dllMap.emplace(ocl_path, LoadLibraryEx(ocl_path.wstring().c_str(), NULL,
+                                         LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                             LOAD_LIBRARY_SEARCH_SYSTEM32));
 
+  // When searching for dependencies of the Level Zero plugin (which includes
+  // level zero loader) limit the list of directories to %windows%\system32.
+  // In this case we know that the Level Zero Loader is located in the system
+  // directory. Standard library dependencies are in the system directory.
   auto l0_path = LibSYCLDir / __SYCL_LEVEL_ZERO_PLUGIN_NAME;
-  dllMap.emplace(l0_path, LoadLibraryEx(l0_path.wstring().c_str(), NULL, NULL));
+  dllMap.emplace(l0_path, LoadLibraryEx(l0_path.wstring().c_str(), NULL,
+                                        LOAD_LIBRARY_SEARCH_SYSTEM32));
 
   auto cuda_path = LibSYCLDir / __SYCL_CUDA_PLUGIN_NAME;
   dllMap.emplace(cuda_path,

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -137,19 +137,17 @@ void preloadLibraries() {
   // list of directories to %windows%\system32 and the directory that contains
   // the loaded DLL (the plugin). This is necessary to avoid loading dlls from
   // current directory and some other directories which are considered unsafe.
-  auto flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32;
-
   auto loadPlugin = [&](auto pluginName, DWORD flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32) {
     auto path = LibSYCLDir / pluginName;
     dllMap.emplace(path, LoadLibraryEx(path.wstring().c_str(), NULL, flags));
   };
-  loadPlugin(__SYCL_OPENCL_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_LEVEL_ZERO_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_CUDA_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_ESIMD_EMULATOR_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_HIP_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_UNIFIED_RUNTIME_PLUGIN_NAME, flags);
-  loadPlugin(__SYCL_NATIVE_CPU_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_OPENCL_PLUGIN_NAME);
+  loadPlugin(__SYCL_LEVEL_ZERO_PLUGIN_NAME);
+  loadPlugin(__SYCL_CUDA_PLUGIN_NAME);
+  loadPlugin(__SYCL_ESIMD_EMULATOR_PLUGIN_NAME);
+  loadPlugin(__SYCL_HIP_PLUGIN_NAME);
+  loadPlugin(__SYCL_UNIFIED_RUNTIME_PLUGIN_NAME);
+  loadPlugin(__SYCL_NATIVE_CPU_PLUGIN_NAME);
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -137,7 +137,9 @@ void preloadLibraries() {
   // list of directories to %windows%\system32 and the directory that contains
   // the loaded DLL (the plugin). This is necessary to avoid loading dlls from
   // current directory and some other directories which are considered unsafe.
-  auto loadPlugin = [&](auto pluginName, DWORD flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32) {
+  auto loadPlugin = [&](auto pluginName,
+                        DWORD flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
+                                      LOAD_LIBRARY_SEARCH_SYSTEM32) {
     auto path = LibSYCLDir / pluginName;
     dllMap.emplace(path, LoadLibraryEx(path.wstring().c_str(), NULL, flags));
   };

--- a/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
+++ b/sycl/pi_win_proxy_loader/pi_win_proxy_loader.cpp
@@ -139,34 +139,19 @@ void preloadLibraries() {
   // the loaded DLL (the plugin). ICD loader is located in the same directory as
   // OpenCL plugin, the Level Zero loader is in the system directory. Standard
   // library dependencies are in the system directory.
-  auto ocl_path = LibSYCLDir / __SYCL_OPENCL_PLUGIN_NAME;
-  dllMap.emplace(ocl_path, LoadLibraryEx(ocl_path.wstring().c_str(), NULL,
-                                         LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
-                                             LOAD_LIBRARY_SEARCH_SYSTEM32));
+  auto flags = LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR | LOAD_LIBRARY_SEARCH_SYSTEM32;
 
-  auto l0_path = LibSYCLDir / __SYCL_LEVEL_ZERO_PLUGIN_NAME;
-  dllMap.emplace(l0_path, LoadLibraryEx(l0_path.wstring().c_str(), NULL,
-                                        LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR |
-                                            LOAD_LIBRARY_SEARCH_SYSTEM32));
-
-  auto cuda_path = LibSYCLDir / __SYCL_CUDA_PLUGIN_NAME;
-  dllMap.emplace(cuda_path,
-                 LoadLibraryEx(cuda_path.wstring().c_str(), NULL, NULL));
-
-  auto esimd_path = LibSYCLDir / __SYCL_ESIMD_EMULATOR_PLUGIN_NAME;
-  dllMap.emplace(esimd_path,
-                 LoadLibraryEx(esimd_path.wstring().c_str(), NULL, NULL));
-
-  auto hip_path = LibSYCLDir / __SYCL_HIP_PLUGIN_NAME;
-  dllMap.emplace(hip_path,
-                 LoadLibraryEx(hip_path.wstring().c_str(), NULL, NULL));
-
-  auto ur_path = LibSYCLDir / __SYCL_UNIFIED_RUNTIME_PLUGIN_NAME;
-  dllMap.emplace(ur_path, LoadLibraryEx(ur_path.wstring().c_str(), NULL, NULL));
-
-  auto nativecpu_path = LibSYCLDir / __SYCL_NATIVE_CPU_PLUGIN_NAME;
-  dllMap.emplace(nativecpu_path,
-                 LoadLibraryEx(nativecpu_path.wstring().c_str(), NULL, NULL));
+  auto loadPlugin = [&](auto plugin_name, DWORD flags = NULL) {
+    auto path = LibSYCLDir / plugin_name;
+    dllMap.emplace(path, LoadLibraryEx(path.wstring().c_str(), NULL, flags));
+  };
+  loadPlugin(__SYCL_OPENCL_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_LEVEL_ZERO_PLUGIN_NAME, flags);
+  loadPlugin(__SYCL_CUDA_PLUGIN_NAME);
+  loadPlugin(__SYCL_ESIMD_EMULATOR_PLUGIN_NAME);
+  loadPlugin(__SYCL_HIP_PLUGIN_NAME);
+  loadPlugin(__SYCL_UNIFIED_RUNTIME_PLUGIN_NAME);
+  loadPlugin(__SYCL_NATIVE_CPU_PLUGIN_NAME);
 
   // Restore system error handling.
   (void)SetErrorMode(SavedMode);


### PR DESCRIPTION
Currently the default search order is used when loading dependencies of the plugins (these dependencies include the Level Zero loader and the ICD loader for opencl and level zero plugins respectively) and that list includes current directory and some other directories which are not considered safe. This patch limits the list of directories when loading the dependencies of the plugins. See: https://learn.microsoft.com/en-us/windows/win32/api/libloaderapi/nf-libloaderapi-loadlibraryexa for reference.