### PR TITLE
[SYCL-MLIR][clang] Attach `SYCLKernelObjFunc` to kernel body functions

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1499,6 +1499,16 @@ def SYCLAccessorReadonly : Attr {
   let Documentation = [InternalOnly];
 }
 
+// Used to mark SYCL kernel object functions implementing SYCL kernels.
+// The Kernels arguments corresponds to the kernels this function implements.
+def SYCLKernelObjFunc : Attr {
+  // This attribute has no spellings as it is only ever created implicitly.
+  let Spellings = [];
+  let Args = [VariadicStringArgument<"Kernels">];
+  let SemaHandler = 0;
+  let Documentation = [InternalOnly];
+}
+
 // The attribute denotes that it is a function written in a scalar fashion, which
 // is used in ESIMD context and needs to be vectorized by a vector backend compiler.
 // For now, this attribute will be used only in internal implementation of

--- a/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
+++ b/clang/test/SemaSYCL/basic-kernel-wrapper.cpp
@@ -18,6 +18,12 @@ int main() {
   });
 }
 
+// Check kernel body function has SYCLKernelObjFuncAttr attribute attached
+
+// CHECK: CXXMethodDecl {{.*}} used constexpr operator() 'void () const'
+// CHECK: SYCLKernelObjFuncAttr
+// CHECK-SAME: Implicit _ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E14kernel_wrapper
+
 // Check declaration of the kernel
 
 // CHECK: FunctionDecl {{.*}}kernel_wrapper{{.*}} 'void (__global int *, sycl::range<1>, sycl::range<1>, sycl::id<1>)'


### PR DESCRIPTION
`SemaSYCL` introduces kernels calling user-provided kernel body functions to avoid OpenCL limitations on kernel arguments. Mark the original kernel body functions with a new `SYCLKernelObjFunc` attribute to handle them in codegen.