### PR TITLE
[SYCL][Doc] Fix formatting in extension template

### DIFF
--- a/sycl/doc/extensions/template.asciidoc
+++ b/sycl/doc/extensions/template.asciidoc
@@ -135,16 +135,16 @@ _It is also appropriate to give an indication of who the target audience is for
 the extension.  For example, if the extension is intended only for ninja
 programmers, we might say something like:_
 
-> The properties described in this extension are advanced features that most
-> applications should not need to use.  In most cases, applications get the
-> best performance without using these properties.
+The properties described in this extension are advanced features that most
+applications should not need to use.  In most cases, applications get the best
+performance without using these properties.
 
 _Occasionally, we might add an extension as a stopgap measure for a limited
 audience.  When this happens, it's best to discourage general usage with a
 statement like:_
 
-> This extension exists to solve a specific problem, and a general solution is
-> still being evaluated.  It is not recommended for general usage.
+This extension exists to solve a specific problem, and a general solution is
+still being evaluated.  It is not recommended for general usage.
 
 _Note that text should be wrapped at 80 columns as shown in this template.
 Extensions use AsciiDoc markup language (like this template).  If you need help


### PR DESCRIPTION
Commit b32db9a4cdd7ffd9ca4874e495d06766e10c8889 added some new suggested text to the extension specification template, which was formatted as a quote.  This formatting is inconsistent with the other suggested text, which is not formatted as a quote.  Fix this.