### PR TITLE
[SYCL][Matrix tests]make multi_ptr access direct inside the kernel

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_annotated_ptr_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_annotated_ptr_impl.hpp
@@ -6,18 +6,21 @@ template <typename T1, typename T2, size_t M, size_t N, size_t K,
 void matrix_multiply(T1 *C, T2 *A, T2 *B, queue &q) {
   size_t NDRangeM = M / TM;
   size_t NDRangeN = N / TN;
-  auto pA = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(A);
-  auto pB = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(B);
-  auto pC = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(C);
   q.submit([&](handler &cgh) {
      cgh.parallel_for(
          nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
          [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
 
          {
+           auto pA =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(A);
+           auto pB =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(B);
+           auto pC =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(C);
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
@@ -76,14 +76,6 @@ double joint_matmul(TOperand *A, TOperand *B, TResult *C, queue &q, int i) {
   assert(rowsA % tM == 0);
   assert(colsA % tK == 0);
   assert(colsB % tN == 0);
-
-  auto pA = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(A);
-  auto pB = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(B);
-  auto pC = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(C);
-
   // submit main kernel
   std::chrono::high_resolution_clock::time_point start =
       std::chrono::high_resolution_clock::now();
@@ -94,6 +86,15 @@ double joint_matmul(TOperand *A, TOperand *B, TResult *C, queue &q, int i) {
         // loop global
         // loop localrange
         [=](nd_item<2> it) [[intel::reqd_sub_group_size(sgSize)]] {
+          auto pA =
+              address_space_cast<sycl::access::address_space::global_space,
+                                 sycl::access::decorated::no>(A);
+          auto pB =
+              address_space_cast<sycl::access::address_space::global_space,
+                                 sycl::access::decorated::no>(B);
+          auto pC =
+              address_space_cast<sycl::access::address_space::global_space,
+                                 sycl::access::decorated::no>(C);
           auto m2 = it.get_group(0);
           auto n2 = it.get_group(1);
           auto m1 = it.get_local_id(0);

--- a/sycl/test-e2e/Matrix/joint_matrix_colA_rowB_colC_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_colA_rowB_colC_impl.hpp
@@ -19,19 +19,22 @@ void matrix_multiply(T1 *C, T2 *A, T2 *B, queue q) {
   size_t NDRangeM = M / TM;
   size_t NDRangeN = N / TN;
 
-  auto pA = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(A);
-  auto pB = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(B);
-  auto pC = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(C);
-
   q.submit([&](handler &cgh) {
      cgh.parallel_for(
          nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
          [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
 
          {
+           auto pA =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(A);
+           auto pB =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(B);
+           auto pC =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(C);
+
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems

--- a/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
@@ -18,20 +18,21 @@ void matrix_multiply(T1 *C, T2 *A, T2 *B, queue q, unsigned int vnniFactor) {
   // Add one iteration for the out of bounds dpas instruction
   size_t NDRangeM = M / TM + (((M % TM) != 0) ? 1 : 0);
   size_t NDRangeN = N / TN;
-
-  auto pA = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(A);
-  auto pB = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(B);
-  auto pC = address_space_cast<sycl::access::address_space::global_space,
-                               sycl::access::decorated::no>(C);
-
   q.submit([&](handler &cgh) {
      cgh.parallel_for(
          nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
          [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]]
 
          {
+           auto pA =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(A);
+           auto pB =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(B);
+           auto pC =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(C);
            // The submatrix API has to be accessed by all the workitems in a
            // subgroup these functions will be called once by the subgroup no
            // code divergence between the workitems

--- a/sycl/test-e2e/Matrix/joint_matrix_transposeC_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_transposeC_impl.hpp
@@ -13,20 +13,21 @@ void matrix_load_and_store(T1 *input, T1 *out_col_major, T1 *out_row_major,
   size_t NDRangeM = M / TM;
   size_t NDRangeN = N / TN;
 
-  auto p_input = address_space_cast<sycl::access::address_space::global_space,
-                                    sycl::access::decorated::no>(input);
-
-  auto p_out_col_major =
-      address_space_cast<sycl::access::address_space::global_space,
-                         sycl::access::decorated::no>(out_col_major);
-  auto p_out_row_major =
-      address_space_cast<sycl::access::address_space::global_space,
-                         sycl::access::decorated::no>(out_row_major);
-
   q.submit([&](handler &cgh) {
      cgh.parallel_for(
          nd_range<2>({NDRangeM, NDRangeN * SG_SZ}, {1, 1 * SG_SZ}),
          [=](nd_item<2> spmd_item) [[intel::reqd_sub_group_size(SG_SZ)]] {
+           auto p_input =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(input);
+
+           auto p_out_col_major =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(out_col_major);
+           auto p_out_row_major =
+               address_space_cast<sycl::access::address_space::global_space,
+                                  sycl::access::decorated::no>(out_row_major);
+
            const auto global_idx = spmd_item.get_global_id(0);
            const auto global_idy = spmd_item.get_global_id(1);
            const auto sg_startx = global_idx - spmd_item.get_local_id(0);


### PR DESCRIPTION
This change explicitly defines multi_ptr inside the kernel instead of outside the kernel.  Before, we rely on the runtime to correctly treat the lambda capture clause and create correct private copies for each of these variables.  With this change, we are making sure that these variables are correctly captured (private copies) inside the kernel.