### PR TITLE
[SYCL][E2E] Limit driver version filtering to Intel GPUs

### DIFF
--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,5 +1,5 @@
 // Failing due to old driver
-// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27202, win: 101.4677
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 //

--- a/sycl/test-e2e/ESIMD/accessor_local.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_local.cpp
@@ -1,4 +1,4 @@
-// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27202, win: 101.4677
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // This test verifies usage of local_accessor methods operator[]

--- a/sycl/test-e2e/ESIMD/api/slm_gather_scatter_heavy.cpp
+++ b/sycl/test-e2e/ESIMD/api/slm_gather_scatter_heavy.cpp
@@ -12,7 +12,7 @@
 // GPU driver had an error in handling of SLM aligned block_loads/stores,
 // which has been fixed only in "1.3.26816", and in win/opencl version going
 // _after_ 101.4575.
-// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26816, win: 101.4576
 //
 // The test checks functionality of the slm gather/scatter ESIMD intrinsics.
 // It varies element type, vector length and stride of gather/scatter operation.

--- a/sycl/test-e2e/ESIMD/assert.cpp
+++ b/sycl/test-e2e/ESIMD/assert.cpp
@@ -1,4 +1,4 @@
-// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26816, win: 101.4576
 // REQUIRES: linux && level_zero
 
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -o %t.out

--- a/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // This test checks DWORD local accessor atomic operations.
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke_cmpxchg.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // This test checks DWORD local accessor cmpxchg atomic operations.
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke_cmpxchg_scalar_off.cpp
+++ b/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke_cmpxchg_scalar_off.cpp
@@ -9,7 +9,7 @@
 // This test checks DWORD local accessor cmpxchg atomic operations with scalar
 // offset.
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke_scalar_off.cpp
+++ b/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke_scalar_off.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // This test checks DWORD local accessor atomic operations with scalar offset.
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 27012, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27012, win: 101.4576
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/ext_math_saturate.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_saturate.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 27012, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27012, win: 101.4576
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/local_accessor_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_block_load_store.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27202, win: 101.4677
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // This test verifies usage of block_load/block_store for local_accessor.

--- a/sycl/test-e2e/ESIMD/local_accessor_copy_to_from.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_copy_to_from.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27202, win: 101.4677
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/local_accessor_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_gather_scatter.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/local_accessor_gather_scatter_rgba.cpp
+++ b/sycl/test-e2e/ESIMD/local_accessor_gather_scatter_rgba.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // The test checks functionality of the gather_rgba/scatter_rgba local
 // accessor-based ESIMD intrinsics.
 

--- a/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke.cpp
@@ -8,7 +8,7 @@
 // This test checks local accessor atomic operations.
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc || gpu-intel-dg2
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_block_load_store.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc || gpu-intel-dg2
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_gather_scatter.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_local_accessor_gather_scatter.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc || gpu-intel-dg2
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/slm_block_load_store.cpp
+++ b/sycl/test-e2e/ESIMD/slm_block_load_store.cpp
@@ -10,7 +10,7 @@
 //
 //
 // Note: "lin" format below is used for Win L0 as well.
-// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26816, win: 101.4576
 //
 // https://github.com/intel/llvm/issues/11358
 // UNSUPPORTED: linux

--- a/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
+++ b/sycl/test-e2e/ESIMD/slm_init_no_inline.cpp
@@ -1,5 +1,5 @@
 // TODO: Investigate fail of this test on Gen12 platform
-// REQUIRES-INTEL-DRIVER: lin: 27427, win: 101.4827
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27427, win: 101.4827
 // REQUIRES: gpu-intel-pvc
 // TODO: Support ze_debug once GPU hang introduced in new GPU driver is solved
 // UNSUPPORTED: ze_debug

--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_slm_acc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_slm_acc.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26918, win: 101.4953
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26918, win: 101.4953
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_slm_acc_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_slm_acc_cmpxchg.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26918, win: 101.4953
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26918, win: 101.4953
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_slm_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_slm_cmpxchg.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 26918, win: 101.4953
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26918, win: 101.4953
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_load_slm.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_load_slm.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: win: 101.4887
+// REQUIRES-INTEL-GPU-DRIVER: win: 101.4887
 // Somehow the driver version check above does not work, i.e. Windows CI runs
 // the test with 31.0.101.4502 (if opencl:gpu) and 1.3.26370 (if level-zero:gpu)
 // It seems the driver check infrastructure may need some fix/tuning.

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_load_slm_acc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_load_slm_acc.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// REQUIRES-INTEL-GPU-DRIVER: lin: 27202, win: 101.4677
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/block_store_slm.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //==------------------------------------------------------------------------==//
-// REQUIRES-INTEL-DRIVER: win: 101.4887
+// REQUIRES-INTEL-GPU-DRIVER: win: 101.4887
 // Somehow the driver version check above does not work, i.e. Windows CI runs
 // the test with 31.0.101.4502 (if opencl:gpu) and 1.3.26370 (if level-zero:gpu)
 // It seems the driver check infrastructure may need some fix/tuning.

--- a/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/ImplicitSubgroup/slm_load_store.cpp
@@ -1,7 +1,7 @@
 // GPU driver had an error in handling of SLM aligned block_loads/stores,
 // which has been fixed only in "1.3.26816", and in win/opencl version going
 // _after_ 101.4575.
-// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26816, win: 101.4576
 //
 // RUN: %clangxx -DIMPL_SUBGROUP -fsycl -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr %S/../slm_load_store.cpp -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out

--- a/sycl/test-e2e/InvokeSimd/Regression/slm_gather_scatter.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/slm_gather_scatter.cpp
@@ -1,7 +1,7 @@
 // GPU driver had an error in handling of SLM aligned block_loads/stores,
 // which has been fixed only in "1.3.26816", and in win/opencl version going
 // _after_ 101.4575.
-// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26816, win: 101.4576
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out

--- a/sycl/test-e2e/InvokeSimd/Regression/slm_load_store.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/slm_load_store.cpp
@@ -1,7 +1,7 @@
 // GPU driver had an error in handling of SLM aligned block_loads/stores,
 // which has been fixed only in "1.3.26816", and in win/opencl version going
 // _after_ 101.4575.
-// REQUIRES-INTEL-DRIVER: lin: 26816, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26816, win: 101.4576
 //
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8.cpp
@@ -1,7 +1,7 @@
 // Test not intended to run on PVC
 // UNSUPPORTED: gpu-intel-pvc
 //
-// REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES-INTEL-GPU-DRIVER: lin: 26690, win: 101.4576
 //
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -109,7 +109,11 @@ class SYCLEndToEndTest(lit.formats.ShTest):
 
             driver_ok = True
             (backend, dev) = d.split(":")
-            if dev == "gpu" and backend not in ["cuda", "hip"] and test.intel_gpu_driver_req:
+            if (
+                dev == "gpu"
+                and backend not in ["cuda", "hip"]
+                and test.intel_gpu_driver_req
+            ):
                 for fmt in ["lin", "win"]:
                     if (
                         fmt in test.intel_gpu_driver_req

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -25,9 +25,9 @@ def get_triple(test, backend):
     return "spir64"
 
 
-def parse_min_intel_driver_req(line_number, line, output):
+def parse_min_intel_gpu_driver_req(line_number, line, output):
     """
-    Driver version looks like this for Intel devices:
+    Driver version looks like this for Intel GPU devices:
           Linux/L0:       [1.3.26370]
           Linux/opencl:   [23.22.26370.18]
           Windows/L0:     [1.3.26370]
@@ -66,9 +66,9 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 test.getSourcePath(),
                 additional_parsers=[
                     IntegratedTestKeywordParser(
-                        "REQUIRES-INTEL-DRIVER:",
+                        "REQUIRES-INTEL-GPU-DRIVER:",
                         ParserKind.CUSTOM,
-                        parse_min_intel_driver_req,
+                        parse_min_intel_gpu_driver_req,
                     )
                 ],
                 require_script=True,
@@ -85,7 +85,7 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         test.unsupported += test.config.unsupported_features
         test.unsupported += parsed["UNSUPPORTED:"] or []
 
-        test.intel_driver_req = parsed["REQUIRES-INTEL-DRIVER:"]
+        test.intel_gpu_driver_req = parsed["REQUIRES-INTEL-GPU-DRIVER:"]
 
         return script
 
@@ -108,13 +108,14 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 continue
 
             driver_ok = True
-            if test.intel_driver_req:
+            (backend, dev) = d.split(":")
+            if dev == "gpu" and backend not in ["cuda", "hip"] and test.intel_gpu_driver_req:
                 for fmt in ["lin", "win"]:
                     if (
-                        fmt in test.intel_driver_req
-                        and fmt in test.config.intel_driver_ver[d]
-                        and test.config.intel_driver_ver[d][fmt]
-                        < test.intel_driver_req[fmt]
+                        fmt in test.intel_gpu_driver_req
+                        and fmt in test.config.intel_gpu_driver_ver[d]
+                        and test.config.intel_gpu_driver_ver[d][fmt]
+                        < test.intel_gpu_driver_req[fmt]
                     ):
                         driver_ok = False
             if not driver_ok:

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -584,8 +584,8 @@ for sycl_device in config.sycl_devices:
 # discovered already.
 config.sycl_dev_features = {}
 
-# Version of the driver for a given device. Empty for non-Intel devices.
-config.intel_driver_ver = {}
+# Version of the Intel gpu driver for a given device. Empty for non-Intel non-gpu devices.
+config.intel_gpu_driver_ver = {}
 for sycl_device in config.sycl_devices:
     env = copy.copy(llvm_config.config.environment)
     env["ONEAPI_DEVICE_SELECTOR"] = sycl_device
@@ -613,7 +613,7 @@ for sycl_device in config.sycl_devices:
     dev_sg_sizes = []
     # See format.py's parse_min_intel_driver_req for explanation.
     is_intel_driver = False
-    intel_driver_ver = {}
+    intel_gpu_driver_ver = {}
     for line in sp.stdout.splitlines():
         if re.match(r" *Vendor *: Intel\(R\) Corporation", line):
             is_intel_driver = True
@@ -622,12 +622,12 @@ for sycl_device in config.sycl_devices:
             driver_str = driver_str.strip()
             lin = re.match(r"[0-9]{1,2}\.[0-9]{1,2}\.([0-9]{5})", driver_str)
             if lin:
-                intel_driver_ver["lin"] = int(lin.group(1))
+                intel_gpu_driver_ver["lin"] = int(lin.group(1))
             win = re.match(
                 r"[0-9]{1,2}\.[0-9]{1,2}\.([0-9]{3})\.([0-9]{4})", driver_str
             )
             if win:
-                intel_driver_ver["win"] = (int(win.group(1)), int(win.group(2)))
+                intel_gpu_driver_ver["win"] = (int(win.group(1)), int(win.group(2)))
         if re.match(r" *Aspects *:", line):
             _, aspects_str = line.split(":", 1)
             dev_aspects.append(aspects_str.strip().split(" "))
@@ -672,10 +672,10 @@ for sycl_device in config.sycl_devices:
     features.add(be)
 
     config.sycl_dev_features[sycl_device] = features.union(config.available_features)
-    if is_intel_driver:
-        config.intel_driver_ver[sycl_device] = intel_driver_ver
+    if is_intel_driver and sycl_device.split(":")[1] == "gpu":
+        config.intel_gpu_driver_ver[sycl_device] = intel_gpu_driver_ver
     else:
-        config.intel_driver_ver[sycl_device] = {}
+        config.intel_gpu_driver_ver[sycl_device] = {}
 
 # Set timeout for a single test
 try:


### PR DESCRIPTION
The driver filtering feature was implemented to work only for Intel GPU drivers.
So, if test is supposed to run on CPU and GPU or on GPUs from different vendors,
filter should be applied only for Intel GPUs and not impact other devices