### PR TITLE
[SYCL][Fusion][NoSTL] Encode argument descriptor using fixed-size arrays

### DIFF
--- a/sycl-fusion/common/include/DynArray.h
+++ b/sycl-fusion/common/include/DynArray.h
@@ -1,0 +1,89 @@
+//==------------ DynArray.h - Non-STL replacement for std::array -----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_COMMON_DYNARRAY_H
+#define SYCL_FUSION_COMMON_DYNARRAY_H
+
+#include <algorithm>
+
+namespace jit_compiler {
+
+///
+/// A fixed-size, dynamically-allocated array, with an interface that is a
+/// subset of `std::array`.
+template <typename T> class DynArray {
+public:
+  DynArray() = default;
+
+  explicit DynArray(size_t Size) { init(Size); }
+
+  ~DynArray() { deinit(); }
+
+  DynArray(const DynArray &Other) {
+    init(Other.Size);
+    std::copy(Other.begin(), Other.end(), begin());
+  }
+
+  DynArray &operator=(const DynArray &Other) {
+    deinit();
+    init(Other.Size);
+    std::copy(Other.begin(), Other.end(), begin());
+    return *this;
+  }
+
+  DynArray(DynArray &&Other) { moveFrom(std::move(Other)); }
+
+  DynArray &operator=(DynArray &&Other) {
+    deinit();
+    moveFrom(std::move(Other));
+    return *this;
+  }
+
+  size_t size() const { return Size; }
+  bool empty() const { return Size == 0; }
+
+  const T *begin() const { return Values; }
+  const T *end() const { return Values + Size; }
+  T *begin() { return Values; }
+  T *end() { return Values + Size; }
+
+  const T &operator[](int Idx) const { return Values[Idx]; }
+  T &operator[](int Idx) { return Values[Idx]; }
+
+private:
+  T *Values = nullptr;
+  size_t Size = 0;
+
+  void init(size_t NewSize) {
+    if (NewSize == 0)
+      return;
+
+    Values = new T[NewSize];
+    Size = NewSize;
+  }
+
+  void deinit() {
+    if (!Values)
+      return;
+
+    delete[] Values;
+    Values = nullptr;
+    Size = 0;
+  }
+
+  void moveFrom(DynArray &&Other) {
+    Values = Other.Values;
+    Other.Values = nullptr;
+    Size = Other.Size;
+    Other.Size = 0;
+  }
+};
+
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_COMMON_DYNARRAY_H

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -9,6 +9,8 @@
 #ifndef SYCL_FUSION_COMMON_KERNEL_H
 #define SYCL_FUSION_COMMON_KERNEL_H
 
+#include "DynArray.h"
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -118,6 +120,8 @@ struct SYCLKernelAttribute {
   AttributeValueList Values;
 };
 
+///
+/// Encode usage of parameters for the actual kernel function.
 enum ArgUsage : uint8_t {
   // Used to indicate that an argument is not used by the kernel
   Unused = 0,
@@ -132,15 +136,17 @@ enum ArgUsage : uint8_t {
 };
 
 ///
-/// Encode usage of parameters for the actual kernel function.
-using ArgUsageMask = std::vector<std::underlying_type_t<ArgUsage>>;
+/// Expose the enum's underlying type because it simplifies bitwise operations.
+using ArgUsageUT = std::underlying_type_t<ArgUsage>;
 
 ///
-/// Describe the list of arguments by their kind.
+/// Describe the list of arguments by their kind and usage.
 struct SYCLArgumentDescriptor {
-  std::vector<ParameterKind> Kinds;
+  explicit SYCLArgumentDescriptor(size_t NumArgs)
+      : Kinds(NumArgs), UsageMask(NumArgs){};
 
-  ArgUsageMask UsageMask;
+  DynArray<ParameterKind> Kinds;
+  DynArray<ArgUsageUT> UsageMask;
 };
 
 ///
@@ -312,8 +318,8 @@ struct SYCLKernelInfo {
       : Name{KernelName}, Args{ArgDesc}, Attributes{}, NDR{NDR}, BinaryInfo{
                                                                      BinInfo} {}
 
-  explicit SYCLKernelInfo(const std::string &KernelName)
-      : Name{KernelName}, Args{}, Attributes{}, NDR{}, BinaryInfo{} {}
+  SYCLKernelInfo(const std::string &KernelName, size_t NumArgs)
+      : Name{KernelName}, Args{NumArgs}, Attributes{}, NDR{}, BinaryInfo{} {}
 };
 
 ///

--- a/sycl-fusion/passes/cleanup/Cleanup.cpp
+++ b/sycl-fusion/passes/cleanup/Cleanup.cpp
@@ -86,10 +86,8 @@ static Function *createMaskedFunction(const BitVector &Mask, Function *F,
 }
 
 static void updateArgUsageMask(jit_compiler::SYCLKernelInfo *Info,
-                               const jit_compiler::ArgUsageMask &NewArgInfo) {
-  // Masks iterator.
-  jit_compiler::ArgUsageMask &KernelMask = Info->Args.UsageMask;
-
+                               ArrayRef<jit_compiler::ArgUsageUT> NewArgInfo) {
+  auto &KernelMask = Info->Args.UsageMask;
   auto New = NewArgInfo.begin();
   for (auto &C : KernelMask) {
     if (C & jit_compiler::ArgUsage::Used) {
@@ -105,7 +103,7 @@ static void updateArgUsageMask(jit_compiler::SYCLKernelInfo *Info,
   }
 }
 
-static void applyArgMask(const jit_compiler::ArgUsageMask &NewArgInfo,
+static void applyArgMask(ArrayRef<jit_compiler::ArgUsageUT> NewArgInfo,
                          const BitVector &Mask, Function *F,
                          ModuleAnalysisManager &AM, TargetFusionInfo &TFI) {
   // Create the function without the masked-out args.
@@ -143,7 +141,7 @@ static void maskMD(const BitVector &Mask, Function *F) {
   }
 }
 
-void llvm::fullCleanup(const jit_compiler::ArgUsageMask &ArgUsageInfo,
+void llvm::fullCleanup(ArrayRef<jit_compiler::ArgUsageUT> ArgUsageInfo,
                        Function *F, ModuleAnalysisManager &AM,
                        TargetFusionInfo &TFI, ArrayRef<StringRef> MDToErase) {
   // Erase metadata.

--- a/sycl-fusion/passes/cleanup/Cleanup.h
+++ b/sycl-fusion/passes/cleanup/Cleanup.h
@@ -25,7 +25,7 @@ namespace llvm {
 /// @param[in] F Function to be cleaned.
 /// @param[in] AM Module analysis manager.
 /// @param[in] EraseMD Keys of metadata to remove.
-void fullCleanup(const jit_compiler::ArgUsageMask &ArgUsageInfo, Function *F,
+void fullCleanup(ArrayRef<::jit_compiler::ArgUsageUT> ArgUsageInfo, Function *F,
                  ModuleAnalysisManager &AM, TargetFusionInfo &TFI,
                  ArrayRef<StringRef> EraseMD);
 } // namespace llvm

--- a/sycl-fusion/passes/internalization/Internalization.cpp
+++ b/sycl-fusion/passes/internalization/Internalization.cpp
@@ -664,7 +664,7 @@ static void moduleCleanup(Module &M, ModuleAnalysisManager &AM,
     // Use the argument usage mask to provide feedback to the runtime which
     // arguments have been promoted to private or local memory and which have
     // been eliminated in the process (private promotion).
-    jit_compiler::ArgUsageMask NewArgInfo;
+    SmallVector<jit_compiler::ArgUsageUT> NewArgInfo;
     for (auto I : enumerate(MD->operands())) {
       const auto &MDS = cast<MDString>(I.value().get())->getString();
       if (MDS == PrivatePromotion) {

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
@@ -129,19 +129,24 @@ private:
                           llvm::Function *FusedFunction,
                           jit_compiler::SYCLKernelInfo &FusedKernelInfo) const;
 
-  void appendKernelInfo(jit_compiler::SYCLKernelInfo &FusedInfo,
+  using MutableParamKindList = llvm::SmallVector<jit_compiler::ParameterKind>;
+  using MutableArgUsageMask = llvm::SmallVector<jit_compiler::ArgUsageUT>;
+  using MutableAttributeList =
+      llvm::SmallVector<jit_compiler::SYCLKernelAttribute>;
+
+  void appendKernelInfo(MutableParamKindList &FusedParamKinds,
+                        MutableArgUsageMask &FusedArgUsageMask,
+                        MutableAttributeList &FusedAttributes,
                         jit_compiler::SYCLKernelInfo &InputInfo,
                         const llvm::ArrayRef<bool> ParamUseMask) const;
 
-  void updateArgUsageMask(jit_compiler::ArgUsageMask &NewMask,
+  void updateArgUsageMask(MutableArgUsageMask &NewMask,
                           jit_compiler::SYCLArgumentDescriptor &InputDef,
                           const llvm::ArrayRef<bool> ParamUseMask) const;
 
   using KernelAttributeList = jit_compiler::AttributeList;
 
   using KernelAttr = jit_compiler::SYCLKernelAttribute;
-
-  using KernelAttrIterator = KernelAttributeList::iterator;
 
   ///
   /// Indicates the result of merging two attributes of the same kind.
@@ -161,7 +166,7 @@ private:
   ///
   /// Merge the content of Other into Attributes, adding, removing or updating
   /// attributes as needed.
-  void mergeKernelAttributes(KernelAttributeList &Attributes,
+  void mergeKernelAttributes(MutableAttributeList &Attributes,
                              const KernelAttributeList &Other) const;
 
   ///
@@ -184,24 +189,24 @@ private:
   ///
   /// Get the attribute with the specified name from the list or return nullptr
   /// in case no such attribute is present.
-  KernelAttr *getAttribute(KernelAttributeList &Attributes,
+  KernelAttr *getAttribute(MutableAttributeList &Attributes,
                            llvm::StringRef AttrName) const;
 
   ///
   /// Add the attribute to the list.
-  void addAttribute(KernelAttributeList &Attributes,
+  void addAttribute(MutableAttributeList &Attributes,
                     const KernelAttr &Attr) const;
 
   ///
   /// Remove the attribute with the specified name from the list, if present.
-  void removeAttribute(KernelAttributeList &Attributes,
+  void removeAttribute(MutableAttributeList &Attributes,
                        llvm::StringRef AttrName) const;
 
   ///
   /// Find the attribute with the specified name in the list, or return the
   /// end() iterator if no such attribute is present.
-  KernelAttrIterator findAttribute(KernelAttributeList &Attributes,
-                                   llvm::StringRef AttrName) const;
+  MutableAttributeList::iterator findAttribute(MutableAttributeList &Attributes,
+                                               llvm::StringRef AttrName) const;
 
   ///
   /// Retrieve the attribute value at the given index as unsigned integer.

--- a/sycl-fusion/passes/syclcp/SYCLCP.cpp
+++ b/sycl-fusion/passes/syclcp/SYCLCP.cpp
@@ -215,7 +215,7 @@ static void moduleCleanup(Module &M, ModuleAnalysisManager &AM,
   }
   for (auto *F : ToProcess) {
     auto *MD = F->getMetadata(SYCLCP::Key);
-    jit_compiler::ArgUsageMask NewArgInfo;
+    SmallVector<jit_compiler::ArgUsageUT> NewArgInfo;
     for (auto I : enumerate(MD->operands())) {
       if (const auto *MDS = dyn_cast<MDString>(I.value().get())) {
         // A value is masked-out if it has a non-empty MDString

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -19,7 +19,8 @@ enum class BinaryFormat : uint32_t;
 class JITContext;
 struct SYCLKernelInfo;
 struct SYCLKernelAttribute;
-using ArgUsageMask = std::vector<unsigned char>;
+template <typename T> class DynArray;
+using ArgUsageMask = DynArray<uint8_t>;
 } // namespace jit_compiler
 
 struct pi_device_binaries_struct;


### PR DESCRIPTION
Introduces the `jit_compiler::DynArray` template to represent a fixed-sized-but-dynamically allocated array with an `std::array`-compatible interface. `DynArray` is then used to replace the uses of `std::vector` in the `SYCLArgumentDescriptor` struct. Client code was updated to either determine the number of arguments beforehand, or use dynamically-growable containers to collect the relevant info locally and then copy it over to a `DynArray` instance.

*This PR is part of a series of changes to remove uses of STL classes in the kernel fusion interface to prevent ABI issues in the future.*