### PR TITLE
[SYCL][UR][NFC] Update readme to the correct location of UR adapters

### DIFF
--- a/sycl/plugins/unified_runtime/ur/adapters/cuda/README.md
+++ b/sycl/plugins/unified_runtime/ur/adapters/cuda/README.md
@@ -1,6 +1,6 @@
 # Cuda adapter
 The source for the Cuda adapter has been moved to the
-[adapters](https://github.com/oneapi-src/unified-runtime/tree/adapters) branch
+[main](https://github.com/oneapi-src/unified-runtime/tree/main) branch
 of the [Unified Runtime](https://github.com/oneapi-src/unified-runtime/) repo.
 Changes can be made by opening pull requests against that branch, and updating
 the Unified Runtime commit in the parent

--- a/sycl/plugins/unified_runtime/ur/adapters/hip/README.md
+++ b/sycl/plugins/unified_runtime/ur/adapters/hip/README.md
@@ -1,6 +1,6 @@
 # HIP adapter
 The source for the HIP adapter has been moved to the
-[adapters](https://github.com/oneapi-src/unified-runtime/tree/adapters) branch
+[main](https://github.com/oneapi-src/unified-runtime/tree/main) branch
 of the [Unified Runtime](https://github.com/oneapi-src/unified-runtime/) repo. 
 Changes can be made by opening pull requests against that branch, and updating
 the Unified Runtime commit in the parent

--- a/sycl/plugins/unified_runtime/ur/adapters/level_zero/README.md
+++ b/sycl/plugins/unified_runtime/ur/adapters/level_zero/README.md
@@ -1,6 +1,6 @@
 # Level Zero adapter
 The source for the Level Zero adapter has been moved to the
-[adapters](https://github.com/oneapi-src/unified-runtime/tree/adapters) branch
+[main](https://github.com/oneapi-src/unified-runtime/tree/main) branch
 of the [Unified Runtime](https://github.com/oneapi-src/unified-runtime/) repo. 
 Changes can be made by opening pull requests against that branch, and updating
 the Unified Runtime commit in the parent

--- a/sycl/plugins/unified_runtime/ur/adapters/native_cpu/README.md
+++ b/sycl/plugins/unified_runtime/ur/adapters/native_cpu/README.md
@@ -1,6 +1,6 @@
 # Native CPU adapter
 The source for the SYCL Native CPU adapter has been moved to the
-[adapters](https://github.com/oneapi-src/unified-runtime/tree/adapters) branch
+[main](https://github.com/oneapi-src/unified-runtime/tree/main) branch
 of the [Unified Runtime](https://github.com/oneapi-src/unified-runtime/) repo.
 Changes can be made by opening pull requests against that branch, and updating
 the Unified Runtime commit in the parent

--- a/sycl/plugins/unified_runtime/ur/adapters/opencl/README.md
+++ b/sycl/plugins/unified_runtime/ur/adapters/opencl/README.md
@@ -1,6 +1,6 @@
 # OpenCL adapter
 The source for the OpenCL adapter has been moved to the
-[adapters](https://github.com/oneapi-src/unified-runtime/tree/adapters) branch
+[main](https://github.com/oneapi-src/unified-runtime/tree/main) branch
 of the [Unified Runtime](https://github.com/oneapi-src/unified-runtime/) repo. 
 Changes can be made by opening pull requests against that branch, and updating
 the Unified Runtime commit in the parent


### PR DESCRIPTION
Adapters branch of the oneapi-src/unified-runtime repo was merged with main branch, and was deprecated, and it will be removed soon. All development has moved to main branch.