### PR TITLE
[SYCL] Throw exception for unsupported UR features

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -234,8 +234,6 @@ make_kernel_bundle(pi_native_handle NativeHandle, const context &TargetContext,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
   ProgramDevices.resize(NumDevices);
 
@@ -246,8 +244,6 @@ make_kernel_bundle(pi_native_handle NativeHandle, const context &TargetContext,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   for (const auto &Dev : ProgramDevices) {
@@ -259,8 +255,6 @@ make_kernel_bundle(pi_native_handle NativeHandle, const context &TargetContext,
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Program get build info command not supported by backend.");
-    } else {
-      Plugin->checkPiResult(Result);
     }
 
     switch (BinaryType) {

--- a/sycl/source/backend/opencl.cpp
+++ b/sycl/source/backend/opencl.cpp
@@ -67,16 +67,31 @@ __SYCL_EXPORT bool has_extension(const sycl::platform &SyclPlatform,
   // Manual invocation of plugin API to avoid using deprecated
   // info::platform::extensions call.
   size_t ResultSize = 0;
-  Plugin->call<PiApiKind::piPlatformGetInfo>(
-      PluginPlatform, PI_PLATFORM_INFO_EXTENSIONS, /*param_value_size=*/0,
-      /*param_value_size=*/nullptr, &ResultSize);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piPlatformGetInfo>(
+          PluginPlatform, PI_PLATFORM_INFO_EXTENSIONS, /*param_value_size=*/0,
+          /*param_value_size=*/nullptr, &ResultSize);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Platform get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   if (ResultSize == 0)
     return false;
 
   std::unique_ptr<char[]> Result(new char[ResultSize]);
-  Plugin->call<PiApiKind::piPlatformGetInfo>(PluginPlatform,
-                                             PI_PLATFORM_INFO_EXTENSIONS,
-                                             ResultSize, Result.get(), nullptr);
+  PiResult = Plugin->call_nocheck<PiApiKind::piPlatformGetInfo>(
+      PluginPlatform, PI_PLATFORM_INFO_EXTENSIONS, ResultSize, Result.get(),
+      nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Platform get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
 
   std::string_view ExtensionsString(Result.get());
   return ExtensionsString.find(Extension) != std::string::npos;
@@ -98,16 +113,28 @@ __SYCL_EXPORT bool has_extension(const sycl::device &SyclDevice,
   // Manual invocation of plugin API to avoid using deprecated
   // info::device::extensions call.
   size_t ResultSize = 0;
-  Plugin->call<PiApiKind::piDeviceGetInfo>(
-      PluginDevice, PI_DEVICE_INFO_EXTENSIONS, /*param_value_size=*/0,
-      /*param_value_size=*/nullptr, &ResultSize);
-  if (ResultSize == 0)
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piDeviceGetInfo>(
+          PluginDevice, PI_DEVICE_INFO_EXTENSIONS, /*param_value_size=*/0,
+          /*param_value_size=*/nullptr, &ResultSize);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Device get info command not supported by backend.");
+  }
+  if (ResultSize == 0) {
     return false;
+  }
 
   std::unique_ptr<char[]> Result(new char[ResultSize]);
-  Plugin->call<PiApiKind::piDeviceGetInfo>(PluginDevice,
-                                           PI_DEVICE_INFO_EXTENSIONS,
-                                           ResultSize, Result.get(), nullptr);
+  PiResult = Plugin->call_nocheck<PiApiKind::piDeviceGetInfo>(
+      PluginDevice, PI_DEVICE_INFO_EXTENSIONS, ResultSize, Result.get(),
+      nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Device get info command not supported by backend.");
+  }
 
   std::string_view ExtensionsString(Result.get());
   return ExtensionsString.find(Extension) != std::string::npos;

--- a/sycl/source/backend/opencl.cpp
+++ b/sycl/source/backend/opencl.cpp
@@ -75,8 +75,6 @@ __SYCL_EXPORT bool has_extension(const sycl::platform &SyclPlatform,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Platform get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
   if (ResultSize == 0)
     return false;
@@ -89,8 +87,6 @@ __SYCL_EXPORT bool has_extension(const sycl::platform &SyclPlatform,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Platform get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   std::string_view ExtensionsString(Result.get());

--- a/sycl/source/detail/buffer_impl.cpp
+++ b/sycl/source/detail/buffer_impl.cpp
@@ -88,8 +88,8 @@ buffer_impl::getNativeVector(backend BackendName) const {
     // resident on, so pass nullptr for Device param. Buffer interop may not be
     // supported by all backends.
     sycl::detail::pi::PiResult Result =
-        Plugin->call_nocheck<PiApiKind::piextMemGetNativeHandle>(NativeMem,
-                                                                 &Handle);
+        Plugin->call_nocheck<PiApiKind::piextMemGetNativeHandle>(
+            NativeMem, /*Dev*/ nullptr, &Handle);
     if (Result == PI_ERROR_INVALID_OPERATION) {
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),

--- a/sycl/source/detail/error_handling/error_handling.cpp
+++ b/sycl/source/detail/error_handling/error_handling.cpp
@@ -210,8 +210,6 @@ void handleInvalidWorkGroupSize(const device_impl &DeviceImpl, pi_kernel Kernel,
             throw sycl::exception(
                 sycl::make_error_code(sycl::errc::feature_not_supported),
                 "Kernel get info command not supported by backend.");
-          } else {
-            Plugin->checkPiResult(Result);
           }
           size_t OptsSize = 0;
 
@@ -222,8 +220,6 @@ void handleInvalidWorkGroupSize(const device_impl &DeviceImpl, pi_kernel Kernel,
             throw sycl::exception(
                 sycl::make_error_code(sycl::errc::feature_not_supported),
                 "Program get build info command not supported by backend.");
-          } else {
-            Plugin->checkPiResult(Result);
           }
 
           std::string Opts(OptsSize, '\0');
@@ -234,8 +230,6 @@ void handleInvalidWorkGroupSize(const device_impl &DeviceImpl, pi_kernel Kernel,
             throw sycl::exception(
                 sycl::make_error_code(sycl::errc::feature_not_supported),
                 "Program get build info command not supported by backend.");
-          } else {
-            Plugin->checkPiResult(Result);
           }
 
           const bool HasStd20 = Opts.find("-cl-std=CL2.0") != std::string::npos;

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -77,7 +77,7 @@ void event_impl::waitInternal(bool *Success) {
         (Error == PI_ERROR_UNKNOWN ||
          Error == PI_ERROR_EXEC_STATUS_ERROR_FOR_EVENTS_IN_WAIT_LIST)) {
       *Success = false;
-    } else if (Success == PI_ERROR_INVALID_OPERATION) {
+    } else if (Error == PI_ERROR_INVALID_OPERATION) {
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Event wait command not supported by backend.");

--- a/sycl/source/detail/event_info.hpp
+++ b/sycl/source/detail/event_info.hpp
@@ -26,8 +26,16 @@ get_event_profiling_info(sycl::detail::pi::PiEvent Event,
                 "Unexpected event profiling info descriptor");
   typename Param::return_type Result{0};
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piEventGetProfilingInfo>(
-      Event, PiInfoCode<Param>::value, sizeof(Result), &Result, nullptr);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piEventGetProfilingInfo>(
+          Event, PiInfoCode<Param>::value, sizeof(Result), &Result, nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Event get info not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   return Result;
 }
 
@@ -38,8 +46,16 @@ typename Param::return_type get_event_info(sycl::detail::pi::PiEvent Event,
                 "Unexpected event info descriptor");
   typename Param::return_type Result{0};
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piEventGetInfo>(Event, PiInfoCode<Param>::value,
-                                          sizeof(Result), &Result, nullptr);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piEventGetInfo>(
+          Event, PiInfoCode<Param>::value, sizeof(Result), &Result, nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Event get info not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   return Result;
 }
 

--- a/sycl/source/detail/image_impl.cpp
+++ b/sycl/source/detail/image_impl.cpp
@@ -273,8 +273,6 @@ static void getImageInfo(const ContextImplPtr Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Mem image get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 }
 
@@ -296,8 +294,6 @@ image_impl::image_impl(cl_mem MemObject, const context &SyclContext,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Mem get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   sycl::detail::pi::PiMemImageFormat Format;

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -421,8 +421,6 @@ public:
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Program get info command not supported by backend.");
-    } else {
-      Plugin->checkPiResult(Result);
     }
 
     // Get the kernel names.
@@ -433,8 +431,6 @@ public:
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Program get info command not supported by backend.");
-    } else {
-      Plugin->checkPiResult(Result);
     }
 
     // semi-colon delimited list of kernel names.
@@ -446,8 +442,6 @@ public:
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Program get info command not supported by backend.");
-    } else {
-      Plugin->checkPiResult(Result);
     }
     std::vector<std::string> KernelNames =
         detail::split_string(KernelNamesStr, ';');

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -413,20 +413,42 @@ public:
 
     // Get the number of kernels in the program.
     size_t NumKernels;
-    Plugin->call<PiApiKind::piProgramGetInfo>(
-        PiProgram, PI_PROGRAM_INFO_NUM_KERNELS, sizeof(size_t), &NumKernels,
-        nullptr);
+    sycl::detail::pi::PiResult Result =
+        Plugin->call_nocheck<PiApiKind::piProgramGetInfo>(
+            PiProgram, PI_PROGRAM_INFO_NUM_KERNELS, sizeof(size_t), &NumKernels,
+            nullptr);
+    if (Result == PI_ERROR_INVALID_OPERATION) {
+      throw sycl::exception(
+          sycl::make_error_code(sycl::errc::feature_not_supported),
+          "Program get info command not supported by backend.");
+    } else {
+      Plugin->checkPiResult(Result);
+    }
 
     // Get the kernel names.
     size_t KernelNamesSize;
-    Plugin->call<PiApiKind::piProgramGetInfo>(
+    Result = Plugin->call_nocheck<PiApiKind::piProgramGetInfo>(
         PiProgram, PI_PROGRAM_INFO_KERNEL_NAMES, 0, nullptr, &KernelNamesSize);
+    if (Result == PI_ERROR_INVALID_OPERATION) {
+      throw sycl::exception(
+          sycl::make_error_code(sycl::errc::feature_not_supported),
+          "Program get info command not supported by backend.");
+    } else {
+      Plugin->checkPiResult(Result);
+    }
 
     // semi-colon delimited list of kernel names.
     std::string KernelNamesStr(KernelNamesSize, ' ');
-    Plugin->call<PiApiKind::piProgramGetInfo>(
+    Result = Plugin->call_nocheck<PiApiKind::piProgramGetInfo>(
         PiProgram, PI_PROGRAM_INFO_KERNEL_NAMES, KernelNamesStr.size(),
         &KernelNamesStr[0], nullptr);
+    if (Result == PI_ERROR_INVALID_OPERATION) {
+      throw sycl::exception(
+          sycl::make_error_code(sycl::errc::feature_not_supported),
+          "Program get info command not supported by backend.");
+    } else {
+      Plugin->checkPiResult(Result);
+    }
     std::vector<std::string> KernelNames =
         detail::split_string(KernelNamesStr, ';');
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -55,8 +55,6 @@ kernel_impl::kernel_impl(sycl::detail::pi::PiKernel Kernel,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get info command not supported by backend.");
-  } else {
-    getPlugin()->checkPiResult(Result);
   }
 
   if (ContextImpl->getHandleRef() != Context) {

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -38,8 +38,6 @@ get_kernel_info(sycl::detail::pi::PiKernel Kernel, const PluginPtr &Plugin) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
   if (ResultSize == 0) {
     return "";
@@ -52,8 +50,6 @@ get_kernel_info(sycl::detail::pi::PiKernel Kernel, const PluginPtr &Plugin) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
   return std::string(Result.data());
 }
@@ -72,8 +68,6 @@ get_kernel_info(sycl::detail::pi::PiKernel Kernel, const PluginPtr &Plugin) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
   return Result;
 }
@@ -93,8 +87,6 @@ get_kernel_device_specific_info_helper(sycl::detail::pi::PiKernel Kernel,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get sub group info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 }
 
@@ -169,8 +161,6 @@ uint32_t get_kernel_device_specific_info_with_input(
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get sub group info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   return Result;

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -31,15 +31,30 @@ get_kernel_info(sycl::detail::pi::PiKernel Kernel, const PluginPtr &Plugin) {
   size_t ResultSize = 0;
 
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piKernelGetInfo>(Kernel, PiInfoCode<Param>::value, 0,
-                                           nullptr, &ResultSize);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piKernelGetInfo>(
+          Kernel, PiInfoCode<Param>::value, 0, nullptr, &ResultSize);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Kernel get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   if (ResultSize == 0) {
     return "";
   }
   std::vector<char> Result(ResultSize);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piKernelGetInfo>(Kernel, PiInfoCode<Param>::value,
-                                           ResultSize, Result.data(), nullptr);
+  PiResult = Plugin->call_nocheck<PiApiKind::piKernelGetInfo>(
+      Kernel, PiInfoCode<Param>::value, ResultSize, Result.data(), nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Kernel get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   return std::string(Result.data());
 }
 
@@ -50,8 +65,16 @@ get_kernel_info(sycl::detail::pi::PiKernel Kernel, const PluginPtr &Plugin) {
   uint32_t Result = 0;
 
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piKernelGetInfo>(Kernel, PiInfoCode<Param>::value,
-                                           sizeof(uint32_t), &Result, nullptr);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piKernelGetInfo>(
+          Kernel, PiInfoCode<Param>::value, sizeof(uint32_t), &Result, nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Kernel get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   return Result;
 }
 
@@ -62,9 +85,17 @@ get_kernel_device_specific_info_helper(sycl::detail::pi::PiKernel Kernel,
                                        sycl::detail::pi::PiDevice Device,
                                        const PluginPtr &Plugin, void *Result,
                                        size_t Size) {
-  Plugin->call<PiApiKind::piKernelGetSubGroupInfo>(
-      Kernel, Device, PiInfoCode<Param>::value, 0, nullptr, Size, Result,
-      nullptr);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piKernelGetSubGroupInfo>(
+          Kernel, Device, PiInfoCode<Param>::value, 0, nullptr, Size, Result,
+          nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Kernel get sub group info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
 }
 
 template <typename Param>
@@ -130,9 +161,17 @@ uint32_t get_kernel_device_specific_info_with_input(
   size_t Input[3] = {In[0], In[1], In[2]};
   uint32_t Result = 0;
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piKernelGetSubGroupInfo>(
-      Kernel, Device, PiInfoCode<Param>::value, sizeof(size_t) * 3, Input,
-      sizeof(uint32_t), &Result, nullptr);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piKernelGetSubGroupInfo>(
+          Kernel, Device, PiInfoCode<Param>::value, sizeof(size_t) * 3, Input,
+          sizeof(uint32_t), &Result, nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Kernel get sub group info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
 
   return Result;
 }

--- a/sycl/source/detail/persistent_device_code_cache.cpp
+++ b/sycl/source/detail/persistent_device_code_cache.cpp
@@ -114,8 +114,6 @@ void PersistentDeviceCodeCache::putItemToDisc(
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   std::vector<size_t> BinarySizes(DeviceNum);
@@ -126,8 +124,6 @@ void PersistentDeviceCodeCache::putItemToDisc(
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   std::vector<std::vector<char>> Result;
@@ -137,15 +133,13 @@ void PersistentDeviceCodeCache::putItemToDisc(
     Pointers.push_back(Result[I].data());
   }
 
-  PiResult = Plugin->call<PiApiKind::piProgramGetInfo>(
+  PiResult = Plugin->call_nocheck<PiApiKind::piProgramGetInfo>(
       NativePrg, PI_PROGRAM_INFO_BINARIES, sizeof(char *) * Pointers.size(),
       Pointers.data(), nullptr);
   if (PiResult == PI_ERROR_INVALID_OPERATION) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   size_t i = 0;

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -196,8 +196,16 @@ void contextSetExtendedDeleter(const sycl::context &context,
   auto impl = getSyclObjImpl(context);
   auto contextHandle = reinterpret_cast<pi_context>(impl->getHandleRef());
   const auto &Plugin = impl->getPlugin();
-  Plugin->call<PiApiKind::piextContextSetExtendedDeleter>(contextHandle, func,
-                                                          user_data);
+  sycl::detail::pi::PiResult Result =
+      Plugin->call_nocheck<PiApiKind::piextContextSetExtendedDeleter>(
+          contextHandle, func, user_data);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Context set extended deleter command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
 }
 
 std::string platformInfoToString(pi_platform_info info) {

--- a/sycl/source/detail/pi_utils.hpp
+++ b/sycl/source/detail/pi_utils.hpp
@@ -32,8 +32,15 @@ struct OwnedPiEvent {
   }
   ~OwnedPiEvent() {
     // Release the event if the ownership was not transferred.
-    if (MEvent.has_value())
-      MPlugin->call<PiApiKind::piEventRelease>(*MEvent);
+    if (MEvent.has_value()) {
+      sycl::detail::pi::PiResult Result =
+          MPlugin->call_nocheck<PiApiKind::piEventRelease>(*MEvent);
+      if (Result == PI_ERROR_INVALID_OPERATION) {
+        assert(!"Event release command not supported by backend.");
+      } else {
+        MPlugin->checkPiResult(Result);
+      }
+    }
   }
 
   OwnedPiEvent(OwnedPiEvent &&Other)

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -258,8 +258,6 @@ std::vector<int> platform_impl::filterDeviceFilter(
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Platform get info command not supported by backend.");
-  } else {
-    MPlugin->checkPiResult(Result);
   }
   backend Backend = convertBackend(PiBackend);
 

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -54,8 +54,6 @@ public:
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Platform get info command not supported by backend.");
-    } else {
-      APlugin->checkPiResult(Result);
     }
     MBackend = convertBackend(PiBackend);
   }

--- a/sycl/source/detail/platform_info.hpp
+++ b/sycl/source/detail/platform_info.hpp
@@ -25,15 +25,31 @@ get_platform_info_string_impl(sycl::detail::pi::PiPlatform Plt,
                               pi_platform_info PiCode) {
   size_t ResultSize;
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piPlatformGetInfo>(Plt, PiCode, 0, nullptr,
-                                             &ResultSize);
+  sycl::detail::pi::PiResult PiResult =
+      Plugin->call_nocheck<PiApiKind::piPlatformGetInfo>(Plt, PiCode, 0,
+                                                         nullptr, &ResultSize);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Platform get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   if (ResultSize == 0) {
     return "";
   }
+
   std::unique_ptr<char[]> Result(new char[ResultSize]);
   // TODO catch an exception and put it to list of asynchronous exceptions
-  Plugin->call<PiApiKind::piPlatformGetInfo>(Plt, PiCode, ResultSize,
-                                             Result.get(), nullptr);
+  PiResult = Plugin->call_nocheck<PiApiKind::piPlatformGetInfo>(
+      Plt, PiCode, ResultSize, Result.get(), nullptr);
+  if (PiResult == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Platform get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(PiResult);
+  }
   return Result.get();
 }
 // The platform information methods

--- a/sycl/source/detail/platform_info.hpp
+++ b/sycl/source/detail/platform_info.hpp
@@ -32,8 +32,6 @@ get_platform_info_string_impl(sycl::detail::pi::PiPlatform Plt,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Platform get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
   if (ResultSize == 0) {
     return "";
@@ -47,8 +45,6 @@ get_platform_info_string_impl(sycl::detail::pi::PiPlatform Plt,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Platform get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
   return Result.get();
 }

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -156,8 +156,6 @@ program_impl::program_impl(ContextImplPtr Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   std::vector<sycl::detail::pi::PiDevice> PiDevices(NumDevices);
@@ -169,8 +167,6 @@ program_impl::program_impl(ContextImplPtr Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   std::vector<device> PlatformDevices =
@@ -199,8 +195,6 @@ program_impl::program_impl(ContextImplPtr Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get build info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
   if (BinaryType == PI_PROGRAM_BINARY_TYPE_NONE) {
     throw invalid_object_error(
@@ -216,8 +210,6 @@ program_impl::program_impl(ContextImplPtr Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get build info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   std::vector<char> OptionsVector(Size);
@@ -228,8 +220,6 @@ program_impl::program_impl(ContextImplPtr Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get build info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   std::string Options(OptionsVector.begin(), OptionsVector.end());
@@ -389,8 +379,6 @@ std::vector<std::vector<char>> program_impl::get_binaries() const {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   std::vector<char *> Pointers;
@@ -406,8 +394,6 @@ std::vector<std::vector<char>> program_impl::get_binaries() const {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(PiResult);
   }
 
   return Result;
@@ -480,10 +466,10 @@ program_impl::get_pi_kernel_arg_mask_pair(const std::string &KernelName) const {
   // Some PI Plugins (like OpenCL) require this call to enable USM
   // For others, PI will turn this into a NOP.
   if (getContextImplPtr()->getPlatformImpl()->supports_usm()) {
-  Plugin->call<PiApiKind::piKernelSetExecInfo>(
-      Result.first, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
+    Plugin->call<PiApiKind::piKernelSetExecInfo>(
+        Result.first, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
   }
-  
+
   return Result;
 }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -768,8 +768,6 @@ ProgramManager::getPiProgramFromPiKernel(sycl::detail::pi::PiKernel Kernel,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Kernel get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   return Program;
@@ -787,8 +785,6 @@ ProgramManager::getProgramBuildLog(const sycl::detail::pi::PiProgram &Program,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   std::vector<sycl::detail::pi::PiDevice> PIDevices(
@@ -800,8 +796,6 @@ ProgramManager::getProgramBuildLog(const sycl::detail::pi::PiProgram &Program,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Program get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   std::string Log = "The program was built for " +
@@ -818,8 +812,6 @@ ProgramManager::getProgramBuildLog(const sycl::detail::pi::PiProgram &Program,
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Program get build info command not supported by backend.");
-    } else {
-      Plugin->checkPiResult(Result);
     }
 
     if (DeviceBuildInfoStrSize > 0) {
@@ -833,8 +825,6 @@ ProgramManager::getProgramBuildLog(const sycl::detail::pi::PiProgram &Program,
         throw sycl::exception(
             sycl::make_error_code(sycl::errc::feature_not_supported),
             "Program get build info command not supported by backend.");
-      } else {
-        Plugin->checkPiResult(Result);
       }
       DeviceBuildInfoString = std::string(DeviceBuildInfo.data());
     }

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -51,8 +51,6 @@ uint32_t queue_impl::get_info<info::queue::reference_count>() const {
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Queue get info command not supported by backend.");
-    } else {
-      getPlugin()->checkPiResult(Result);
     }
   }
   return result;
@@ -622,8 +620,6 @@ bool queue_impl::ext_oneapi_empty() const {
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Queue get info command not supported by backend.");
-    } else {
-      getPlugin()->checkPiResult(Result);
     }
     if (!IsReady) {
       return false;

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -238,8 +238,6 @@ private:
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::feature_not_supported),
           "Queue get info command not supported by backend.");
-    } else {
-      Plugin->checkPiResult(Result);
     }
 
     MDevice = MContext->findMatchingDeviceImpl(DevicePI);

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -44,8 +44,6 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Sampler get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   Result = Plugin->call_nocheck<PiApiKind::piSamplerGetInfo>(
@@ -55,8 +53,6 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Sampler get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   Result = Plugin->call_nocheck<PiApiKind::piSamplerGetInfo>(
@@ -66,8 +62,6 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Sampler get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 }
 

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2445,7 +2445,7 @@ static pi_result SetKernelParamsAndLaunch(
   }
   if (OutEventImpl != nullptr)
     OutEventImpl->setHostEnqueueTime();
-  pi_result Error =
+  pi_result Result =
       [&](auto... Args) {
         if (IsCooperative) {
           return Plugin
@@ -2466,7 +2466,7 @@ static pi_result SetKernelParamsAndLaunch(
     Plugin->checkPiResult(Result);
   }
 
-  return Error;
+  return Result;
 }
 
 // The function initialize accessors and calls lambda.

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -42,16 +42,38 @@ SYCLMemObjT::SYCLMemObjT(pi_native_handle MemObject, const context &SyclContext,
   sycl::detail::pi::PiContext Context = nullptr;
   const PluginPtr &Plugin = getPlugin();
 
-  Plugin->call<detail::PiApiKind::piextMemCreateWithNativeHandle>(
-      MemObject, MInteropContext->getHandleRef(), OwnNativeHandle,
-      &MInteropMemObject);
+  sycl::detail::pi::PiResult Result =
+      Plugin->call_nocheck<detail::PiApiKind::piextMemCreateWithNativeHandle>(
+          MemObject, MInteropContext->getHandleRef(), OwnNativeHandle,
+          &MInteropMemObject);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem create with native handle command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
 
   // Get the size of the buffer in bytes
-  Plugin->call<detail::PiApiKind::piMemGetInfo>(
+  Result = Plugin->call_nocheck<detail::PiApiKind::piMemGetInfo>(
       MInteropMemObject, PI_MEM_SIZE, sizeof(size_t), &MSizeInBytes, nullptr);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
 
-  Plugin->call<PiApiKind::piMemGetInfo>(MInteropMemObject, PI_MEM_CONTEXT,
-                                        sizeof(Context), &Context, nullptr);
+  Result = Plugin->call_nocheck<PiApiKind::piMemGetInfo>(
+      MInteropMemObject, PI_MEM_CONTEXT, sizeof(Context), &Context, nullptr);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
 
   if (MInteropContext->getHandleRef() != Context)
     throw sycl::invalid_parameter_error(
@@ -106,12 +128,28 @@ SYCLMemObjT::SYCLMemObjT(pi_native_handle MemObject, const context &SyclContext,
   Desc.num_samples = 0;
   Desc.buffer = nullptr;
 
-  Plugin->call<detail::PiApiKind::piextMemImageCreateWithNativeHandle>(
+  sycl::detail::pi::PiResult Result = Plugin->call_nocheck<
+      detail::PiApiKind::piextMemImageCreateWithNativeHandle>(
       MemObject, MInteropContext->getHandleRef(), OwnNativeHandle, &Format,
       &Desc, &MInteropMemObject);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem image create with native handle command not supported by "
+        "backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
 
-  Plugin->call<PiApiKind::piMemGetInfo>(MInteropMemObject, PI_MEM_CONTEXT,
-                                        sizeof(Context), &Context, nullptr);
+  Result = Plugin->call_nocheck<PiApiKind::piMemGetInfo>(
+      MInteropMemObject, PI_MEM_CONTEXT, sizeof(Context), &Context, nullptr);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
 
   if (MInteropContext->getHandleRef() != Context)
     throw sycl::invalid_parameter_error(
@@ -177,9 +215,17 @@ size_t SYCLMemObjT::getBufSizeForContext(const ContextImplPtr &Context,
   size_t BufSize = 0;
   const PluginPtr &Plugin = Context->getPlugin();
   // TODO is there something required to support non-OpenCL backends?
-  Plugin->call<detail::PiApiKind::piMemGetInfo>(
-      detail::pi::cast<sycl::detail::pi::PiMem>(MemObject), PI_MEM_SIZE,
-      sizeof(size_t), &BufSize, nullptr);
+  sycl::detail::pi::PiResult Result =
+      Plugin->call_nocheck<detail::PiApiKind::piMemGetInfo>(
+          detail::pi::cast<sycl::detail::pi::PiMem>(MemObject), PI_MEM_SIZE,
+          sizeof(size_t), &BufSize, nullptr);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem get info command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
   return BufSize;
 }
 

--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -61,8 +61,6 @@ SYCLMemObjT::SYCLMemObjT(pi_native_handle MemObject, const context &SyclContext,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Mem get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   Result = Plugin->call_nocheck<PiApiKind::piMemGetInfo>(
@@ -71,8 +69,6 @@ SYCLMemObjT::SYCLMemObjT(pi_native_handle MemObject, const context &SyclContext,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Mem get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   if (MInteropContext->getHandleRef() != Context)
@@ -147,8 +143,6 @@ SYCLMemObjT::SYCLMemObjT(pi_native_handle MemObject, const context &SyclContext,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Mem get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   if (MInteropContext->getHandleRef() != Context)
@@ -223,8 +217,6 @@ size_t SYCLMemObjT::getBufSizeForContext(const ContextImplPtr &Context,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Mem get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
   return BufSize;
 }

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -661,8 +661,6 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "USM get mem alloc info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   // The device is not necessarily a member of the context, it could be a

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -295,8 +295,6 @@ bool device::ext_oneapi_can_access_peer(const device &peer,
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),
         "Peer access get info command not supported by backend.");
-  } else {
-    Plugin->checkPiResult(Result);
   }
 
   return value == 1;

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -279,17 +279,20 @@ event handler::finalize() {
           if (MQueue->getDeviceImplPtr()->getBackend() ==
               backend::ext_intel_esimd_emulator) {
             // Capture the host timestamp for profiling (queue time)
-            if (NewEvent != nullptr) {
+            if (NewEvent != nullptr)
               NewEvent->setHostEnqueueTime();
             [&](auto... Args) {
               if (MImpl->MKernelIsCooperative) {
-                Result = MQueue->getPlugin()
-                    ->call_nocheck<
-                        detail::PiApiKind::piextEnqueueCooperativeKernelLaunch>(
-                        Args...);
+                Result =
+                    MQueue->getPlugin()
+                        ->call_nocheck<detail::PiApiKind::
+                                           piextEnqueueCooperativeKernelLaunch>(
+                            Args...);
               } else {
-                Result =  MQueue->getPlugin()
-                    ->call_nocheck<detail::PiApiKind::piEnqueueKernelLaunch>(Args...);
+                Result =
+                    MQueue->getPlugin()
+                        ->call_nocheck<
+                            detail::PiApiKind::piEnqueueKernelLaunch>(Args...);
               }
             }(/* queue */
               nullptr,

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -36,7 +36,7 @@ pi_native_handle interop_handle::getNativeMem(detail::Requirement *Req) const {
   pi_native_handle Handle;
   sycl::detail::pi::PiResult Result =
       Plugin->call_nocheck<detail::PiApiKind::piextMemGetNativeHandle>(
-          Iter->second, &Handle);
+          Iter->second, MDevice->getHandleRef(), &Handle);
   if (Result == PI_ERROR_INVALID_OPERATION) {
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::feature_not_supported),

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -34,8 +34,16 @@ pi_native_handle interop_handle::getNativeMem(detail::Requirement *Req) const {
 
   auto Plugin = MQueue->getPlugin();
   pi_native_handle Handle;
-  Plugin->call<detail::PiApiKind::piextMemGetNativeHandle>(
-      Iter->second, MDevice->getHandleRef(), &Handle);
+  sycl::detail::pi::PiResult Result =
+      Plugin->call_nocheck<detail::PiApiKind::piextMemGetNativeHandle>(
+          Iter->second, &Handle);
+  if (Result == PI_ERROR_INVALID_OPERATION) {
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::feature_not_supported),
+        "Mem get native handle command not supported by backend.");
+  } else {
+    Plugin->checkPiResult(Result);
+  }
   return Handle;
 }
 

--- a/sycl/test-e2e/Plugin/ur_unsupported_feature.cpp
+++ b/sycl/test-e2e/Plugin/ur_unsupported_feature.cpp
@@ -1,0 +1,41 @@
+// REQUIRES: opencl
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests that the Unified Runtime "UR_RESULT_ERROR_UNSUPPORTED_FEATURE" error
+// code is passed up to the SYCL runtime and is handled appropriately, when an
+// entry-point is not implemented in a given adapter.
+// IMPORTANT: This test should be updated if the feature used for testing later
+// receives support - use another unsupported feature instead
+// Currently using "piextMemImageAllocate"
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  sycl::device Device;
+  sycl::queue Queue(Device);
+  sycl::context Context = Queue.get_context();
+
+  sycl::ext::oneapi::experimental::image_descriptor Descriptor(
+      {0}, sycl::image_channel_order::rgba, sycl::image_channel_type::fp32);
+
+  bool Success = false;
+
+  try {
+    sycl::ext::oneapi::experimental::image_mem imgMem0(Descriptor, Device,
+                                                       Context);
+  } catch (sycl::exception &e) {
+    if (e.code() == sycl::errc::feature_not_supported) {
+      Success = true;
+    }
+  }
+
+  // We want this test to succeed by "failing" and specifically catching a
+  // "sycl::errc::feature_not_supported" exception.
+  assert(Success);
+
+  return 0;
+}


### PR DESCRIPTION
Stemming from removing `die` calls in unsupported UR entry points (https://github.com/oneapi-src/unified-runtime/pull/1127) and a spin-out issue discussing how to handle these errors in intel-llvm (https://github.com/oneapi-src/unified-runtime/issues/1161).

This PR changes various PI entry points to interpret `PI_ERROR_INVALID_OPERATION` as receiving `UR_RESULT_ERROR_UNSUPPORTED_FEATURE` and will throw a SYCL exception with error code `sycl::errc::feature_not_supported`.

A new e2e test has been added (`Plugin/ur_unsupported_feature.cpp`) which is meant to purposely call an unsupported UR entry point and will assert that an exception is thrown specifically with code `sycl::errc::feature_not_supported` to ensure we are handling unsupported features from UR in intel-llvm appropriately.