### PR TITLE
[SYCL][Graph] Fix post-commit CI after PR #11472

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -1692,6 +1692,7 @@ void MemoryManager::ext_oneapi_fill_cmd_buffer(
     unsigned int ElementSize,
     std::vector<sycl::detail::pi::PiExtSyncPoint> Deps,
     sycl::detail::pi::PiExtSyncPoint *OutSyncPoint) {
+  (void)Size;
   assert(SYCLMemObj && "The SYCLMemObj is nullptr");
 
   const PluginPtr &Plugin = Context->getPlugin();


### PR DESCRIPTION
Ignore unused `Size` parameter from `memory_manager::ext_oneapi_fill_cmd_buffer`.

This was introduced in PR https://github.com/intel/llvm/pull/11472 and passed as `Req->MMemoryRange` from the command-group requirement but not used for calling the underlying UR function, leading to a
`-Wunused-parameter` error.

It may be that this is needed to support buffers of dimension greater than 1, which there are currently no graphs tests for. This will be investigated as a follow-up once post-commit CI is unblocked with this PR.