### PR TITLE
[SYCL] Align sycl-ls output with ONEAPI_DEVICE_SELECTOR syntax

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -413,7 +413,7 @@ if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
             config.available_features.add("gpu-amd-gfx90a")
         if not line.startswith("["):
             continue
-        (backend, device) = line[1:].split(']')[0].split(":")
+        (backend, device) = line[1:].split("]")[0].split(":")
         devices.add("{}:{}".format(backend, device))
     config.sycl_devices = list(devices)
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -413,7 +413,7 @@ if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
             config.available_features.add("gpu-amd-gfx90a")
         if not line.startswith("["):
             continue
-        (backend, device, _) = line[1:].split(":", 2)
+        (backend, device) = line[1:].split(']')[0].split(":")
         devices.add("{}:{}".format(backend, device))
     config.sycl_devices = list(devices)
 

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -123,10 +123,9 @@ int main(int argc, char **argv) {
   if (filter) {
     std::cerr << "Warning: SYCL_DEVICE_FILTER environment variable is set to "
               << filter << "." << std::endl;
-    std::cerr
-        << "To see device ids, please unset SYCL_DEVICE_FILTER."
-        << std::endl
-        << std::endl;
+    std::cerr << "To see device ids, please unset SYCL_DEVICE_FILTER."
+              << std::endl
+              << std::endl;
     SuppressNumberPrinting = true;
   }
 
@@ -135,10 +134,9 @@ int main(int argc, char **argv) {
     std::cerr
         << "Warning: ONEAPI_DEVICE_SELECTOR environment variable is set to "
         << ods_targets << "." << std::endl;
-    std::cerr
-        << "To see device ids, please unset ONEAPI_DEVICE_SELECTOR."
-        << std::endl
-        << std::endl;
+    std::cerr << "To see device ids, please unset ONEAPI_DEVICE_SELECTOR."
+              << std::endl
+              << std::endl;
     SuppressNumberPrinting = true;
   }
 

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -117,14 +117,17 @@ int main(int argc, char **argv) {
     return EXIT_FAILURE;
   }
 
+  bool SuppressNumberPrinting = false;
+
   const char *filter = std::getenv("SYCL_DEVICE_FILTER");
   if (filter) {
     std::cerr << "Warning: SYCL_DEVICE_FILTER environment variable is set to "
               << filter << "." << std::endl;
     std::cerr
-        << "To see the correct device id, please unset SYCL_DEVICE_FILTER."
+        << "To see device ids, please unset SYCL_DEVICE_FILTER."
         << std::endl
         << std::endl;
+    SuppressNumberPrinting = true;
   }
 
   const char *ods_targets = std::getenv("ONEAPI_DEVICE_SELECTOR");
@@ -133,9 +136,10 @@ int main(int argc, char **argv) {
         << "Warning: ONEAPI_DEVICE_SELECTOR environment variable is set to "
         << ods_targets << "." << std::endl;
     std::cerr
-        << "To see the correct device id, please unset ONEAPI_DEVICE_SELECTOR."
+        << "To see device ids, please unset ONEAPI_DEVICE_SELECTOR."
         << std::endl
         << std::endl;
+    SuppressNumberPrinting = true;
   }
 
   try {
@@ -156,9 +160,13 @@ int main(int argc, char **argv) {
 
       for (const auto &Device : Devices) {
         std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
-                  << getDeviceTypeName(Device) << ":" << DeviceNums[Backend]
-                  << "] ";
-        ++DeviceNums[Backend];
+                  << getDeviceTypeName(Device) << "]";
+        if (!SuppressNumberPrinting) {
+          std::cout << "[" << detail::get_backend_name_no_vendor(Backend) << ":"
+                    << DeviceNums[Backend] << "]";
+          ++DeviceNums[Backend];
+        }
+        std::cout << " ";
         // Verbose parameter is set to false to print regular devices output
         // first
         printDeviceInfo(Device, false, PlatformName);
@@ -168,7 +176,8 @@ int main(int argc, char **argv) {
     if (verbose) {
       std::cout << "\nPlatforms: " << Platforms.size() << std::endl;
       uint32_t PlatformNum = 0;
-      DeviceNums.clear();
+      if (!SuppressNumberPrinting)
+        DeviceNums.clear();
       for (const auto &Platform : Platforms) {
         backend Backend = Platform.get_backend();
         ++PlatformNum;
@@ -183,9 +192,11 @@ int main(int argc, char **argv) {
         const auto &Devices = Platform.get_devices();
         std::cout << "    Devices  : " << Devices.size() << std::endl;
         for (const auto &Device : Devices) {
-          std::cout << "        Device [#" << DeviceNums[Backend]
-                    << "]:" << std::endl;
-          ++DeviceNums[Backend];
+          if (!SuppressNumberPrinting) {
+            std::cout << "        Device [#" << DeviceNums[Backend]
+                      << "]:" << std::endl;
+            ++DeviceNums[Backend];
+          }
           printDeviceInfo(Device, true, "        ");
         }
       }


### PR DESCRIPTION
Emit

  `[backend:device_type][backend:device_number] <Text...>`

in place of

  `[backend:device_type:device_number] <Text...>`

as ONEAPI_DEVICE_SELECTOR accepts either device_type or device_number and not both simultaneously.