### PR TITLE
[SYCL][Doc] Use "a std::" instead of "an std::"

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_intel_online_compiler.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_intel_online_compiler.asciidoc
@@ -64,7 +64,7 @@ public:
 
 === Compiler API
 
-To compile a source, a user program must first construct an instance of the `sycl::ext::intel::online_compiler` class. Then pass the source as an `std::string` object to online compiler's `compile` function along with other relevant parameters. The `online_compiler` is templated by the source language, and the `compile` function is a variadic template function. Instantiations of the `online_compiler::compile` for different languages may have different sets of formal parameters. The `compile` function returns a binary blob - an `std::vector<unsigned char>` - with the device code compiled according to the compilation target specification provided at online compiler construction time.
+To compile a source, a user program must first construct an instance of the `sycl::ext::intel::online_compiler` class. Then pass the source as a `std::string` object to online compiler's `compile` function along with other relevant parameters. The `online_compiler` is templated by the source language, and the `compile` function is a variadic template function. Instantiations of the `online_compiler::compile` for different languages may have different sets of formal parameters. The `compile` function returns a binary blob - a `std::vector<unsigned char>` - with the device code compiled according to the compilation target specification provided at online compiler construction time.
 
 ==== Online compiler
 [source,c++]

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -187,8 +187,8 @@ kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
 !====
 
 _Preconditions:_ There are two overloads of this function: one that reads the
-source code of the kernel from an `std::string`, and one that reads the source
-code of the kernel from an `std::vector` of `std::byte`.
+source code of the kernel from a `std::string`, and one that reads the source
+code of the kernel from a `std::vector` of `std::byte`.
 Each source language `lang` specifies whether the language is text format or
 binary format, and the application must use the overload that corresponds to
 that format.


### PR DESCRIPTION
When referring to the `std` namespace use `a` instead of `an` (because the pronunciation is "a stood namespace" not "an s-t-d namespace"). This is consistent with cppreference and the C++ specification.