### PR TITLE
[SYCL][Fusion][NoSTL] Simplify kernel attributes by making them less generic

### DIFF
--- a/sycl-fusion/jit-compiler/lib/translation/KernelTranslation.cpp
+++ b/sycl-fusion/jit-compiler/lib/translation/KernelTranslation.cpp
@@ -24,20 +24,18 @@ using namespace jit_compiler::translation;
 using namespace llvm;
 
 ///
-/// Get an attribute value consisting of NumValues scalar constant integers
-/// from the MDNode.
-static void getAttributeValues(std::vector<std::string> &Values, MDNode *MD) {
-  for (const auto &MDOp : MD->operands()) {
-    auto *ConstantMD = cast<ConstantAsMetadata>(MDOp);
-    auto *ConstInt = cast<ConstantInt>(ConstantMD->getValue());
-    Values.push_back(std::to_string(ConstInt->getZExtValue()));
-  }
+/// Get an `Indices` object from the MDNode's three constant integer operands.
+static Indices getAttributeValues(MDNode *MD) {
+  assert(MD->getNumOperands() == Indices::size());
+  Indices Res;
+  std::transform(MD->op_begin(), MD->op_end(), Res.begin(),
+                 [](const auto &MDOp) {
+                   auto *ConstantMD = cast<ConstantAsMetadata>(MDOp);
+                   auto *ConstInt = cast<ConstantInt>(ConstantMD->getValue());
+                   return ConstInt->getZExtValue();
+                 });
+  return Res;
 }
-
-// NOLINTNEXTLINE(readability-identifier-naming)
-static const char *REQD_WORK_GROUP_SIZE_ATTR = "reqd_work_group_size";
-// NOLINTNEXTLINE(readability-identifier-naming)
-static const char *WORK_GROUP_SIZE_HINT_ATTR = "work_group_size_hint";
 
 ///
 /// Restore kernel attributes for the kernel in Info from the metadata
@@ -48,16 +46,20 @@ static const char *WORK_GROUP_SIZE_HINT_ATTR = "work_group_size_hint";
 static void restoreKernelAttributes(Module *Mod, SYCLKernelInfo &Info) {
   auto *KernelFunction = Mod->getFunction(Info.Name);
   assert(KernelFunction && "Kernel function not present in module");
-  if (auto *MD = KernelFunction->getMetadata(REQD_WORK_GROUP_SIZE_ATTR)) {
-    SYCLKernelAttribute ReqdAttr{REQD_WORK_GROUP_SIZE_ATTR};
-    getAttributeValues(ReqdAttr.Values, MD);
-    Info.Attributes.push_back(ReqdAttr);
+  SmallVector<SYCLKernelAttribute, 2> Attrs;
+  using AttrKind = SYCLKernelAttribute::AttrKind;
+  if (auto *MD = KernelFunction->getMetadata(
+          SYCLKernelAttribute::ReqdWorkGroupSizeName)) {
+    Attrs.emplace_back(AttrKind::ReqdWorkGroupSize, getAttributeValues(MD));
   }
-  if (auto *MD = KernelFunction->getMetadata(WORK_GROUP_SIZE_HINT_ATTR)) {
-    SYCLKernelAttribute HintAttr{WORK_GROUP_SIZE_HINT_ATTR};
-    getAttributeValues(HintAttr.Values, MD);
-    Info.Attributes.push_back(HintAttr);
+  if (auto *MD = KernelFunction->getMetadata(
+          SYCLKernelAttribute::WorkGroupSizeHintName)) {
+    Attrs.emplace_back(AttrKind::WorkGroupSizeHint, getAttributeValues(MD));
   }
+  if (Attrs.empty())
+    return;
+  Info.Attributes = SYCLAttributeList{Attrs.size()};
+  llvm::copy(Attrs, Info.Attributes.begin());
 }
 
 llvm::Expected<std::unique_ptr<llvm::Module>>

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
@@ -444,10 +444,10 @@ Error SYCLKernelFusion::fuseKernel(
     assert(FusedParamKinds.size() == FusedArgUsageMask.size());
     jit_compiler::SYCLKernelInfo KI{FusedKernelName.str(),
                                     FusedParamKinds.size()};
+    KI.Attributes = KernelAttributeList{FusedAttributes.size()};
     llvm::copy(FusedParamKinds, KI.Args.Kinds.begin());
     llvm::copy(FusedArgUsageMask, KI.Args.UsageMask.begin());
-    KI.Attributes.insert(KI.Attributes.end(), FusedAttributes.begin(),
-                         FusedAttributes.end());
+    llvm::copy(FusedAttributes, KI.Attributes.begin());
     ModInfo->addKernel(KI);
   }
   jit_compiler::SYCLKernelInfo &FusedKernelInfo =
@@ -700,16 +700,16 @@ void SYCLKernelFusion::attachKernelAttributeMD(
   // Attach kernel attribute information as metadata to a kernel function.
   for (jit_compiler::SYCLKernelAttribute &KernelAttr :
        FusedKernelInfo.Attributes) {
-    if (KernelAttr.AttributeName == "reqd_work_group_size" ||
-        KernelAttr.AttributeName == "work_group_size_hint") {
+    if (KernelAttr.Kind == KernelAttrKind::ReqdWorkGroupSize ||
+        KernelAttr.Kind == KernelAttrKind::WorkGroupSizeHint) {
       // 'reqd_work_group_size' and 'work_group_size_hint' get attached as
       // metadata with their three values as constant integer metadata.
       SmallVector<Metadata *, 3> MDValues;
-      for (std::string &Val : KernelAttr.Values) {
+      for (auto Val : KernelAttr.Values) {
         MDValues.push_back(ConstantAsMetadata::get(
-            ConstantInt::get(Type::getInt32Ty(LLVMCtx), std::stoi(Val))));
+            ConstantInt::get(Type::getInt32Ty(LLVMCtx), Val)));
       }
-      attachFusedMetadata(FusedFunction, KernelAttr.AttributeName, MDValues);
+      attachFusedMetadata(FusedFunction, KernelAttr.getName(), MDValues);
     }
     // The two kernel attributes above are currently the only attributes
     // attached as metadata, so we don't do anything for other attributes.
@@ -773,7 +773,7 @@ void SYCLKernelFusion::mergeKernelAttributes(
   // want to keep it anyways.
   for (const jit_compiler::SYCLKernelAttribute &OtherAttr : Other) {
     SYCLKernelFusion::KernelAttr *Attr =
-        getAttribute(Attributes, OtherAttr.AttributeName);
+        getAttribute(Attributes, OtherAttr.Kind);
     SYCLKernelFusion::AttrMergeResult MergeResult =
         mergeAttribute(Attr, OtherAttr);
     switch (MergeResult) {
@@ -786,7 +786,7 @@ void SYCLKernelFusion::mergeKernelAttributes(
       addAttribute(Attributes, OtherAttr);
       break;
     case AttrMergeResult::RemoveAttr:
-      removeAttribute(Attributes, OtherAttr.AttributeName);
+      removeAttribute(Attributes, OtherAttr.Kind);
       break;
     case AttrMergeResult::Error:
       llvm_unreachable("Failed to merge attribute");
@@ -798,14 +798,15 @@ void SYCLKernelFusion::mergeKernelAttributes(
 SYCLKernelFusion::AttrMergeResult
 SYCLKernelFusion::mergeAttribute(KernelAttr *Attr,
                                  const KernelAttr &Other) const {
-  if (Other.AttributeName == "reqd_work_group_size") {
+  switch (Other.Kind) {
+  case KernelAttrKind::ReqdWorkGroupSize:
     return mergeReqdWorkgroupSize(Attr, Other);
-  }
-  if (Other.AttributeName == "work_group_size_hint") {
+  case KernelAttrKind::WorkGroupSizeHint:
     return mergeWorkgroupSizeHint(Attr, Other);
+  default:
+    // Unknown attribute name, return an error.
+    return SYCLKernelFusion::AttrMergeResult::Error;
   }
-  // Unknown attribute name, return an error.
-  return SYCLKernelFusion::AttrMergeResult::Error;
 }
 
 SYCLKernelFusion::AttrMergeResult
@@ -816,11 +817,9 @@ SYCLKernelFusion::mergeReqdWorkgroupSize(KernelAttr *Attr,
     // new one
     return SYCLKernelFusion::AttrMergeResult::AddAttr;
   }
-  for (size_t I = 0; I < 3; ++I) {
-    if (getAttrValueAsInt(*Attr, I) != getAttrValueAsInt(Other, I)) {
-      // Two different required work-group sizes, causes an error.
-      return SYCLKernelFusion::AttrMergeResult::Error;
-    }
+  if (Attr->Values != Other.Values) {
+    // Two different required work-group sizes, causes an error.
+    return SYCLKernelFusion::AttrMergeResult::Error;
   }
   // The required workgroup sizes are identical, keep it.
   return SYCLKernelFusion::AttrMergeResult::KeepAttr;
@@ -834,11 +833,9 @@ SYCLKernelFusion::mergeWorkgroupSizeHint(KernelAttr *Attr,
     // the new one
     return SYCLKernelFusion::AttrMergeResult::AddAttr;
   }
-  for (size_t I = 0; I < 3; ++I) {
-    if (getAttrValueAsInt(*Attr, I) != getAttrValueAsInt(Other, I)) {
-      // Two different hints, remove the hint altogether.
-      return SYCLKernelFusion::AttrMergeResult::RemoveAttr;
-    }
+  if (Attr->Values != Other.Values) {
+    // Two different hints, remove the hint altogether.
+    return SYCLKernelFusion::AttrMergeResult::RemoveAttr;
   }
   // The given hint is identical, keep it.
   return SYCLKernelFusion::AttrMergeResult::KeepAttr;
@@ -846,8 +843,8 @@ SYCLKernelFusion::mergeWorkgroupSizeHint(KernelAttr *Attr,
 
 SYCLKernelFusion::KernelAttr *
 SYCLKernelFusion::getAttribute(MutableAttributeList &Attributes,
-                               StringRef AttrName) const {
-  auto *It = findAttribute(Attributes, AttrName);
+                               KernelAttrKind AttrKind) const {
+  auto *It = findAttribute(Attributes, AttrKind);
   if (It != Attributes.end()) {
     return &*It;
   }
@@ -860,8 +857,8 @@ void SYCLKernelFusion::addAttribute(MutableAttributeList &Attributes,
 }
 
 void SYCLKernelFusion::removeAttribute(MutableAttributeList &Attributes,
-                                       StringRef AttrName) const {
-  auto *It = findAttribute(Attributes, AttrName);
+                                       KernelAttrKind AttrKind) const {
+  auto *It = findAttribute(Attributes, AttrKind);
   if (It != Attributes.end()) {
     Attributes.erase(It);
   }
@@ -869,16 +866,8 @@ void SYCLKernelFusion::removeAttribute(MutableAttributeList &Attributes,
 
 SYCLKernelFusion::MutableAttributeList::iterator
 SYCLKernelFusion::findAttribute(MutableAttributeList &Attributes,
-                                StringRef AttrName) const {
+                                KernelAttrKind AttrKind) const {
   return llvm::find_if(Attributes, [=](SYCLKernelFusion::KernelAttr &Attr) {
-    return Attr.AttributeName == AttrName.str();
+    return Attr.Kind == AttrKind;
   });
-}
-
-unsigned SYCLKernelFusion::getAttrValueAsInt(const KernelAttr &Attr,
-                                             size_t Idx) const {
-  assert(Idx < Attr.Values.size());
-  unsigned Result = 0;
-  StringRef(Attr.Values[Idx]).getAsInteger(0, Result);
-  return Result;
 }

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
@@ -144,9 +144,10 @@ private:
                           jit_compiler::SYCLArgumentDescriptor &InputDef,
                           const llvm::ArrayRef<bool> ParamUseMask) const;
 
-  using KernelAttributeList = jit_compiler::AttributeList;
+  using KernelAttributeList = jit_compiler::SYCLAttributeList;
 
   using KernelAttr = jit_compiler::SYCLKernelAttribute;
+  using KernelAttrKind = jit_compiler::SYCLKernelAttribute::AttrKind;
 
   ///
   /// Indicates the result of merging two attributes of the same kind.
@@ -187,10 +188,10 @@ private:
                                          const KernelAttr &Other) const;
 
   ///
-  /// Get the attribute with the specified name from the list or return nullptr
+  /// Get the attribute with the specified kind from the list or return nullptr
   /// in case no such attribute is present.
   KernelAttr *getAttribute(MutableAttributeList &Attributes,
-                           llvm::StringRef AttrName) const;
+                           KernelAttrKind AttrKind) const;
 
   ///
   /// Add the attribute to the list.
@@ -198,19 +199,15 @@ private:
                     const KernelAttr &Attr) const;
 
   ///
-  /// Remove the attribute with the specified name from the list, if present.
+  /// Remove the attribute with the specified kind from the list, if present.
   void removeAttribute(MutableAttributeList &Attributes,
-                       llvm::StringRef AttrName) const;
+                       KernelAttrKind AttrKind) const;
 
   ///
-  /// Find the attribute with the specified name in the list, or return the
+  /// Find the attribute with the specified kind in the list, or return the
   /// end() iterator if no such attribute is present.
   MutableAttributeList::iterator findAttribute(MutableAttributeList &Attributes,
-                                               llvm::StringRef AttrName) const;
-
-  ///
-  /// Retrieve the attribute value at the given index as unsigned integer.
-  unsigned getAttrValueAsInt(const KernelAttr &Attr, size_t Idx) const;
+                                               KernelAttrKind AttrKind) const;
 };
 
 #endif // SYCL_FUSION_PASSES_SYCLKERNELFUSION_H

--- a/sycl-fusion/passes/kernel-info/SYCLKernelInfo.cpp
+++ b/sycl-fusion/passes/kernel-info/SYCLKernelInfo.cpp
@@ -84,22 +84,25 @@ void SYCLModuleInfoAnalysis::loadModuleInfoFromMetadata(Module &M) {
                     KernelInfo.Args.UsageMask.begin(), getUInt<ArgUsageUT>);
 
     // Operands 3..n: Attributes
-    for (; It != End; ++It) {
-      auto *AIMD = cast<MDNode>(*It);
-      assert(AIMD->getNumOperands() > 1);
+    KernelInfo.Attributes = jit_compiler::SYCLAttributeList{
+        static_cast<size_t>(std::distance(It, End))};
+    std::transform(It, End, KernelInfo.Attributes.begin(), [](const auto &Op) {
+      auto *AIMD = cast<MDNode>(Op);
+      assert(AIMD->getNumOperands() == 4);
       const auto *AttrIt = AIMD->op_begin(), *AttrEnd = AIMD->op_end();
 
       // Operand 0: Attribute name
       auto Name = cast<MDString>(*AttrIt)->getString().str();
+      auto Kind = SYCLKernelAttribute::parseKind(Name.c_str());
+      assert(Kind != SYCLKernelAttribute::AttrKind::Invalid);
       ++AttrIt;
 
-      // Operands 1..m: String values
-      auto &KernelAttr = KernelInfo.Attributes.emplace_back(std::move(Name));
-      for (; AttrIt != AttrEnd; ++AttrIt) {
-        auto Value = cast<MDString>(*AttrIt)->getString().str();
-        KernelAttr.Values.emplace_back(std::move(Value));
-      }
-    }
+      // Operands 1..3: Values
+      Indices Values;
+      std::transform(AttrIt, AttrEnd, Values.begin(), getUInt<size_t>);
+
+      return SYCLKernelAttribute{Kind, Values};
+    });
 
     ModuleInfo->addKernel(KernelInfo);
   }
@@ -156,7 +159,7 @@ PreservedAnalyses SYCLModuleInfoPrinter::run(Module &Mod,
 
     Out.indent(Indent) << "Attributes:\n";
     for (const auto &AttrInfo : KernelInfo.Attributes) {
-      Out.indent(Indent * 2) << AttrInfo.AttributeName << ':';
+      Out.indent(Indent * 2) << AttrInfo.getName() << ':';
       Out.PadToColumn(Pad);
       llvm::interleaveComma(AttrInfo.Values, Out);
       Out << '\n';

--- a/sycl-fusion/test/kernel-fusion/check-failed-remapping-amdgpu.ll
+++ b/sycl-fusion/test/kernel-fusion/check-failed-remapping-amdgpu.ll
@@ -43,6 +43,6 @@ attributes #0 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!14}

--- a/sycl-fusion/test/kernel-fusion/check-failed-remapping-cuda.ll
+++ b/sycl-fusion/test/kernel-fusion/check-failed-remapping-cuda.ll
@@ -43,6 +43,6 @@ attributes #0 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!14}

--- a/sycl-fusion/test/kernel-fusion/check-failed-remapping.ll
+++ b/sycl-fusion/test/kernel-fusion/check-failed-remapping.ll
@@ -42,6 +42,6 @@ attributes #0 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!14}

--- a/sycl-fusion/test/kernel-fusion/check-remapping-amdgpu.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-amdgpu.ll
@@ -835,6 +835,6 @@ attributes #2 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!47}

--- a/sycl-fusion/test/kernel-fusion/check-remapping-cuda.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-cuda.ll
@@ -697,6 +697,6 @@ attributes #2 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!47}

--- a/sycl-fusion/test/kernel-fusion/check-remapping-interproc-amdgpu.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-interproc-amdgpu.ll
@@ -365,6 +365,6 @@ attributes #2 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!47}

--- a/sycl-fusion/test/kernel-fusion/check-remapping-interproc-cuda.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-interproc-cuda.ll
@@ -323,6 +323,6 @@ attributes #2 = { nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!47}

--- a/sycl-fusion/test/kernel-fusion/check-remapping-interproc.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping-interproc.ll
@@ -278,6 +278,6 @@ attributes #4 = { willreturn nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!47}

--- a/sycl-fusion/test/kernel-fusion/check-remapping.ll
+++ b/sycl-fusion/test/kernel-fusion/check-remapping.ll
@@ -452,6 +452,6 @@ attributes #4 = { willreturn nounwind }
     !"StdLayout", !"StdLayout", !"StdLayout", !"Accessor", !"StdLayout",
     !"StdLayout", !"StdLayout"},
   !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1},
-  !{!"work_group_size_hint", !"1", !"1", !"64"}
+  !{!"work_group_size_hint", i32 1, i32 1, i32 64}
 }
 !sycl.moduleinfo = !{!47}

--- a/sycl-fusion/test/kernel-fusion/required_work_group_size.ll
+++ b/sycl-fusion/test/kernel-fusion/required_work_group_size.ll
@@ -56,7 +56,7 @@ attributes #3 = { alwaysinline nounwind }
   !"StdLayout", !"StdLayout"
 }
 !20 = !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1}
-!21 = !{!"KernelOne", !19, !20, !{!"reqd_work_group_size", !"1", !"1", !"32"}}
+!21 = !{!"KernelOne", !19, !20, !{!"reqd_work_group_size", i32 1, i32 1, i32 32}}
 !22 = !{!"KernelTwo", !19, !20}
 !sycl.moduleinfo = !{!21, !22}
 

--- a/sycl-fusion/test/kernel-fusion/work_group_size_hint.ll
+++ b/sycl-fusion/test/kernel-fusion/work_group_size_hint.ll
@@ -57,7 +57,7 @@ attributes #3 = { alwaysinline nounwind }
   !"StdLayout", !"StdLayout"
 }
 !20 = !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1}
-!21 = !{!"KernelOne", !19, !20, !{!"work_group_size_hint", !"1", !"1", !"64"}}
+!21 = !{!"KernelOne", !19, !20, !{!"work_group_size_hint", i32 1, i32 1, i32 64}}
 !22 = !{!"KernelTwo", !19, !20}
 !sycl.moduleinfo = !{!21, !22}
 

--- a/sycl-fusion/test/kernel-info/kernel-info.ll
+++ b/sycl-fusion/test/kernel-info/kernel-info.ll
@@ -11,8 +11,8 @@ target triple = "spir64-unknown-unknown"
 !1 = !{i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1, i8 1, i8 0, i8 0, i8 1}
 !2 = !{!"_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_E9KernelOne", !0, !1}
 !3 = !{!"_ZTSZZ4mainENKUlRN4sycl3_V17handlerEE0_clES2_E9KernelTwo", !0, !1,
-       !{!"work_group_size_hint", !"1", !"2", !"3"},
-       !{!"reqd_work_group_size", !"4", !"5", !"6"}}
+       !{!"work_group_size_hint", i32 1, i32 2, i32 3},
+       !{!"reqd_work_group_size", i32 4, i32 5, i32 6}}
 !sycl.moduleinfo = !{!2, !3}
 
 ; Test scenario: Test if the analysis and the printing pass work correctly

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -962,7 +962,8 @@ pi_device_binaries jit_compiler::createPIDeviceBinary(
     auto ReqdWGS = std::find_if(
         FusedKernelInfo.Attributes.begin(), FusedKernelInfo.Attributes.end(),
         [](const ::jit_compiler::SYCLKernelAttribute &Attr) {
-          return Attr.AttributeName == "reqd_work_group_size";
+          return Attr.Kind == ::jit_compiler::SYCLKernelAttribute::AttrKind::
+                                  ReqdWorkGroupSize;
         });
     if (ReqdWGS != FusedKernelInfo.Attributes.end()) {
       auto Encoded = encodeReqdWorkGroupSize(*ReqdWGS);
@@ -1028,7 +1029,8 @@ std::vector<uint8_t> jit_compiler::encodeArgUsageMask(
 
 std::vector<uint8_t> jit_compiler::encodeReqdWorkGroupSize(
     const ::jit_compiler::SYCLKernelAttribute &Attr) const {
-  assert(Attr.AttributeName == "reqd_work_group_size");
+  assert(Attr.Kind ==
+         ::jit_compiler::SYCLKernelAttribute::AttrKind::ReqdWorkGroupSize);
   size_t NumBytes = sizeof(uint64_t) + (Attr.Values.size() * sizeof(uint32_t));
   std::vector<uint8_t> Encoded(NumBytes, 0u);
   uint8_t *Ptr = Encoded.data();
@@ -1036,7 +1038,7 @@ std::vector<uint8_t> jit_compiler::encodeReqdWorkGroupSize(
   // See CUDA PI (pi_cuda.cpp) _pi_program::set_metadata for reference.
   Ptr += sizeof(uint64_t);
   for (const auto &Val : Attr.Values) {
-    uint32_t UVal = std::stoul(Val);
+    auto UVal = static_cast<uint32_t>(Val);
     std::memcpy(Ptr, &UVal, sizeof(uint32_t));
     Ptr += sizeof(uint32_t);
   }


### PR DESCRIPTION
Kernel attributes were previously modeled as an `std::string` name, and an arbitrarily long `std::vector` of string values, however we currently don't need this genericity to represent `reqd_work_group_size` and `work_group_size_hint` attributes. In fact, an attribute kind enum and an `Indices` object (= 3 integers) suffice. 

_This PR is part of a series of changes to remove uses of STL classes in the kernel fusion interface to prevent ABI issues in the future._