### PR TITLE
[SYCL][ClangLinkerWrapper] Fix race condition

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1622,6 +1622,7 @@ linkAndWrapDeviceFiles(SmallVectorImpl<OffloadFile> &LinkerInputFiles,
       // separate path inside 'linkDevice' call seen above.
       // This will eventually be refactored to use the 'common' wrapping logic
       // that is used for other offload kinds.
+      std::scoped_lock Guard(ImageMtx);
       WrappedOutput.push_back(*SYCLOutputOrErr);
     }
 


### PR DESCRIPTION
This patch fixes a data race in the following line of the code that is supposed to be run parallelly and needs mutex protection.

WrappedOutput.push_back(*SYCLOutputOrErr);