### PR TITLE
[SYCL] Implement sycl_ext_oneapi_address_cast

### DIFF
--- a/clang/lib/Sema/SPIRVBuiltins.td
+++ b/clang/lib/Sema/SPIRVBuiltins.td
@@ -844,6 +844,9 @@ foreach Ty = [Void, ConstType<Void>, VolatileType<Void>, VolatileType<ConstType<
   def : SPVBuiltin<"GenericCastToPtrExplicit_ToGlobal", [PointerType<Ty, GlobalAS>, PointerType<Ty, DefaultAS>, Int], Attr.Const>;
   def : SPVBuiltin<"GenericCastToPtrExplicit_ToLocal", [PointerType<Ty, LocalAS>, PointerType<Ty, DefaultAS>, Int], Attr.Const>;
   def : SPVBuiltin<"GenericCastToPtrExplicit_ToPrivate", [PointerType<Ty, PrivateAS>, PointerType<Ty, DefaultAS>, Int], Attr.Const>;
+  def : SPVBuiltin<"GenericCastToPtr_ToGlobal", [PointerType<Ty, GlobalAS>, PointerType<Ty, DefaultAS>, Int], Attr.Const>;
+  def : SPVBuiltin<"GenericCastToPtr_ToLocal", [PointerType<Ty, LocalAS>, PointerType<Ty, DefaultAS>, Int], Attr.Const>;
+  def : SPVBuiltin<"GenericCastToPtr_ToPrivate", [PointerType<Ty, PrivateAS>, PointerType<Ty, DefaultAS>, Int], Attr.Const>;
 }
 
 foreach Type = TLFloat.List in {

--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -468,6 +468,94 @@ __SYCL_GenericCastToPtrExplicit_ToPrivate(const volatile void *Ptr) noexcept {
 }
 
 template <typename dataT>
+extern __attribute__((opencl_global)) dataT *
+__SYCL_GenericCastToPtr_ToGlobal(void *Ptr) noexcept {
+  return (__attribute__((opencl_global)) dataT *)
+      __spirv_GenericCastToPtr_ToGlobal(Ptr,
+                                        __spv::StorageClass::CrossWorkgroup);
+}
+
+template <typename dataT>
+extern const __attribute__((opencl_global)) dataT *
+__SYCL_GenericCastToPtr_ToGlobal(const void *Ptr) noexcept {
+  return (const __attribute__((opencl_global)) dataT *)
+      __spirv_GenericCastToPtr_ToGlobal(Ptr,
+                                        __spv::StorageClass::CrossWorkgroup);
+}
+
+template <typename dataT>
+extern volatile __attribute__((opencl_global)) dataT *
+__SYCL_GenericCastToPtr_ToGlobal(volatile void *Ptr) noexcept {
+  return (volatile __attribute__((opencl_global)) dataT *)
+      __spirv_GenericCastToPtr_ToGlobal(Ptr,
+                                        __spv::StorageClass::CrossWorkgroup);
+}
+
+template <typename dataT>
+extern const volatile __attribute__((opencl_global)) dataT *
+__SYCL_GenericCastToPtr_ToGlobal(const volatile void *Ptr) noexcept {
+  return (const volatile __attribute__((opencl_global)) dataT *)
+      __spirv_GenericCastToPtr_ToGlobal(Ptr,
+                                        __spv::StorageClass::CrossWorkgroup);
+}
+
+template <typename dataT>
+extern __attribute__((opencl_local)) dataT *
+__SYCL_GenericCastToPtr_ToLocal(void *Ptr) noexcept {
+  return (__attribute__((opencl_local)) dataT *)
+      __spirv_GenericCastToPtr_ToLocal(Ptr, __spv::StorageClass::Workgroup);
+}
+
+template <typename dataT>
+extern const __attribute__((opencl_local)) dataT *
+__SYCL_GenericCastToPtr_ToLocal(const void *Ptr) noexcept {
+  return (const __attribute__((opencl_local)) dataT *)
+      __spirv_GenericCastToPtr_ToLocal(Ptr, __spv::StorageClass::Workgroup);
+}
+
+template <typename dataT>
+extern volatile __attribute__((opencl_local)) dataT *
+__SYCL_GenericCastToPtr_ToLocal(volatile void *Ptr) noexcept {
+  return (volatile __attribute__((opencl_local)) dataT *)
+      __spirv_GenericCastToPtr_ToLocal(Ptr, __spv::StorageClass::Workgroup);
+}
+
+template <typename dataT>
+extern const volatile __attribute__((opencl_local)) dataT *
+__SYCL_GenericCastToPtr_ToLocal(const volatile void *Ptr) noexcept {
+  return (const volatile __attribute__((opencl_local)) dataT *)
+      __spirv_GenericCastToPtr_ToLocal(Ptr, __spv::StorageClass::Workgroup);
+}
+
+template <typename dataT>
+extern __attribute__((opencl_private)) dataT *
+__SYCL_GenericCastToPtr_ToPrivate(void *Ptr) noexcept {
+  return (__attribute__((opencl_private)) dataT *)
+      __spirv_GenericCastToPtr_ToPrivate(Ptr, __spv::StorageClass::Function);
+}
+
+template <typename dataT>
+extern const __attribute__((opencl_private)) dataT *
+__SYCL_GenericCastToPtr_ToPrivate(const void *Ptr) noexcept {
+  return (const __attribute__((opencl_private)) dataT *)
+      __spirv_GenericCastToPtr_ToPrivate(Ptr, __spv::StorageClass::Function);
+}
+
+template <typename dataT>
+extern volatile __attribute__((opencl_private)) dataT *
+__SYCL_GenericCastToPtr_ToPrivate(volatile void *Ptr) noexcept {
+  return (volatile __attribute__((opencl_private)) dataT *)
+      __spirv_GenericCastToPtr_ToPrivate(Ptr, __spv::StorageClass::Function);
+}
+
+template <typename dataT>
+extern const volatile __attribute__((opencl_private)) dataT *
+__SYCL_GenericCastToPtr_ToPrivate(const volatile void *Ptr) noexcept {
+  return (const volatile __attribute__((opencl_private)) dataT *)
+      __spirv_GenericCastToPtr_ToPrivate(Ptr, __spv::StorageClass::Function);
+}
+
+template <typename dataT>
 __SYCL_CONVERGENT__ extern __DPCPP_SYCL_EXTERNAL dataT
 __spirv_SubgroupShuffleINTEL(dataT Data, uint32_t InvocationId) noexcept;
 template <typename dataT>

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -1176,6 +1176,30 @@ __SYCL_GROUP_COLLECTIVE_OVERLOAD(BitwiseAndKHR)
 __SYCL_GROUP_COLLECTIVE_OVERLOAD(LogicalAndKHR)
 __SYCL_GROUP_COLLECTIVE_OVERLOAD(LogicalOrKHR)
 
+template <access::address_space Space, typename T>
+auto GenericCastToPtr(T *Ptr) ->
+    typename multi_ptr<T, Space, access::decorated::yes>::pointer {
+  if constexpr (Space == access::address_space::global_space) {
+    return __SYCL_GenericCastToPtr_ToGlobal<T>(Ptr);
+  } else if constexpr (Space == access::address_space::local_space) {
+    return __SYCL_GenericCastToPtr_ToLocal<T>(Ptr);
+  } else if constexpr (Space == access::address_space::private_space) {
+    return __SYCL_GenericCastToPtr_ToPrivate<T>(Ptr);
+  }
+}
+
+template <access::address_space Space, typename T>
+auto GenericCastToPtrExplicit(T *Ptr) ->
+    typename multi_ptr<T, Space, access::decorated::yes>::pointer {
+  if constexpr (Space == access::address_space::global_space) {
+    return __SYCL_GenericCastToPtrExplicit_ToGlobal<T>(Ptr);
+  } else if constexpr (Space == access::address_space::local_space) {
+    return __SYCL_GenericCastToPtrExplicit_ToLocal<T>(Ptr);
+  } else if constexpr (Space == access::address_space::private_space) {
+    return __SYCL_GenericCastToPtrExplicit_ToPrivate<T>(Ptr);
+  }
+}
+
 } // namespace spirv
 } // namespace detail
 } // namespace _V1

--- a/sycl/include/sycl/ext/oneapi/experimental/address_cast.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/address_cast.hpp
@@ -1,0 +1,46 @@
+//==----------- address_cast.hpp - sycl_ext_oneapi_address_cast ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+#include <sycl/multi_ptr.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+namespace ext {
+namespace oneapi {
+namespace experimental {
+
+template <access::address_space Space, access::decorated DecorateAddress,
+          typename ElementType>
+multi_ptr<ElementType, Space, DecorateAddress>
+static_address_cast(ElementType *Ptr) {
+#ifdef __SYCL_DEVICE_ONLY__
+  auto CastPtr = sycl::detail::spirv::GenericCastToPtr<Space>(Ptr);
+  return multi_ptr<ElementType, Space, DecorateAddress>(CastPtr);
+#else
+  return multi_ptr<ElementType, Space, DecorateAddress>(Ptr);
+#endif
+}
+
+template <access::address_space Space, access::decorated DecorateAddress,
+          typename ElementType>
+multi_ptr<ElementType, Space, DecorateAddress>
+dynamic_address_cast(ElementType *Ptr) {
+#ifdef __SYCL_DEVICE_ONLY__
+  auto CastPtr = sycl::detail::spirv::GenericCastToPtrExplicit<Space>(Ptr);
+  return multi_ptr<ElementType, Space, DecorateAddress>(CastPtr);
+#else
+  return multi_ptr<ElementType, Space, DecorateAddress>(Ptr);
+#endif
+}
+
+} // namespace experimental
+} // namespace oneapi
+} // namespace ext
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -74,6 +74,7 @@
 #include <sycl/ext/oneapi/bindless_images.hpp>
 #include <sycl/ext/oneapi/device_global/device_global.hpp>
 #include <sycl/ext/oneapi/device_global/properties.hpp>
+#include <sycl/ext/oneapi/experimental/address_cast.hpp>
 #include <sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp>
 #include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/experimental/annotated_usm/alloc_device.hpp>
@@ -100,7 +101,6 @@
 #include <sycl/ext/oneapi/sub_group.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 #include <sycl/ext/oneapi/weak_object.hpp>
-
 #if !defined(SYCL2020_CONFORMANT_APIS) &&                                      \
     !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
 // We used to include those and some code might be reliant on that.

--- a/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
@@ -7,7 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // Issue with OpenCL CPU runtime implementation of OpGenericCastToPtrExplicit
-// UNSUPPORTED: cpu
+// OpGenericCastToPtr* intrinsics not implemented on AMD
+// UNSUPPORTED: cpu, hip
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
@@ -1,0 +1,111 @@
+//==--------- dynamic_address_cast.cpp - dynamic address_cast test ---------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Issue with OpenCL CPU runtime implementation of OpGenericCastToPtrExplicit
+// UNSUPPORTED: cpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+#include <sycl/sycl.hpp>
+
+int main() {
+
+  sycl::queue Queue;
+
+  sycl::range<1> NItems{1};
+
+  sycl::buffer<int, 1> GlobalBuffer{NItems};
+  sycl::buffer<bool, 1> ResultBuffer{NItems};
+
+  Queue
+      .submit([&](sycl::handler &cgh) {
+        auto GlobalAccessor =
+            GlobalBuffer.get_access<sycl::access::mode::read_write>(cgh);
+        auto LocalAccessor = sycl::local_accessor<int>(1, cgh);
+        auto ResultAccessor =
+            ResultBuffer.get_access<sycl::access::mode::write>(cgh);
+        cgh.parallel_for<class Kernel>(
+            sycl::nd_range<1>(NItems, 1), [=](sycl::nd_item<1> Item) {
+              bool Success = true;
+              size_t Index = Item.get_global_id(0);
+
+              int *RawGlobalPointer = &GlobalAccessor[Index];
+              {
+                auto GlobalPointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::global_space,
+                        sycl::access::decorated::no>(RawGlobalPointer);
+                auto LocalPointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::local_space,
+                        sycl::access::decorated::no>(RawGlobalPointer);
+                auto PrivatePointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::private_space,
+                        sycl::access::decorated::no>(RawGlobalPointer);
+                Success &= reinterpret_cast<size_t>(RawGlobalPointer) ==
+                           reinterpret_cast<size_t>(GlobalPointer.get_raw());
+                Success &= LocalPointer.get_raw() == nullptr;
+                Success &= PrivatePointer.get_raw() == nullptr;
+              }
+
+              int *RawLocalPointer = &LocalAccessor[0];
+              {
+                auto GlobalPointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::global_space,
+                        sycl::access::decorated::no>(RawLocalPointer);
+                auto LocalPointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::local_space,
+                        sycl::access::decorated::no>(RawLocalPointer);
+                auto PrivatePointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::private_space,
+                        sycl::access::decorated::no>(RawLocalPointer);
+                Success &= GlobalPointer.get_raw() == nullptr;
+                Success &= reinterpret_cast<size_t>(RawLocalPointer) ==
+                           reinterpret_cast<size_t>(LocalPointer.get_raw());
+                Success &= PrivatePointer.get_raw() == nullptr;
+              }
+
+              int PrivateVariable = 0;
+              int *RawPrivatePointer = &PrivateVariable;
+              {
+                auto GlobalPointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::global_space,
+                        sycl::access::decorated::no>(RawPrivatePointer);
+                auto LocalPointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::local_space,
+                        sycl::access::decorated::no>(RawPrivatePointer);
+                auto PrivatePointer =
+                    sycl::ext::oneapi::experimental::dynamic_address_cast<
+                        sycl::access::address_space::private_space,
+                        sycl::access::decorated::no>(RawPrivatePointer);
+                Success &= GlobalPointer.get_raw() == nullptr;
+                Success &= LocalPointer.get_raw() == nullptr;
+                Success &= reinterpret_cast<size_t>(RawPrivatePointer) ==
+                           reinterpret_cast<size_t>(PrivatePointer.get_raw());
+              }
+
+              ResultAccessor[Index] = Success;
+            });
+      })
+      .wait();
+
+  bool Success = true;
+  {
+    auto ResultAccessor = sycl::host_accessor(ResultBuffer);
+    for (int i = 0; i < NItems.size(); ++i) {
+      Success &= ResultAccessor[i];
+    };
+  }
+
+  return (Success) ? 0 : -1;
+}

--- a/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
@@ -7,8 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // Issue with OpenCL CPU runtime implementation of OpGenericCastToPtrExplicit
-// OpGenericCastToPtr* intrinsics not implemented on AMD
-// UNSUPPORTED: cpu, hip
+// OpGenericCastToPtr* intrinsics not implemented on AMD or NVIDIA
+// UNSUPPORTED: cpu, hip, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/AddressCast/static_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/static_address_cast.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// OpGenericCastToPtr* intrinsics not implemented on AMD
-// UNSUPPORTED: hip
+// OpGenericCastToPtr* intrinsics not implemented on AMD or NVIDIA
+// UNSUPPORTED: hip, cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/AddressCast/static_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/static_address_cast.cpp
@@ -6,6 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
+// OpGenericCastToPtr* intrinsics not implemented on AMD
+// UNSUPPORTED: hip
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include <sycl/sycl.hpp>

--- a/sycl/test-e2e/AddressCast/static_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/static_address_cast.cpp
@@ -1,0 +1,73 @@
+//==---------- static_address_cast.cpp - static address_cast test ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+#include <sycl/sycl.hpp>
+
+int main() {
+
+  sycl::queue Queue;
+
+  sycl::range<1> NItems{1};
+
+  sycl::buffer<int, 1> GlobalBuffer{NItems};
+  sycl::buffer<bool, 1> ResultBuffer{NItems};
+
+  Queue
+      .submit([&](sycl::handler &cgh) {
+        auto GlobalAccessor =
+            GlobalBuffer.get_access<sycl::access::mode::read_write>(cgh);
+        auto LocalAccessor = sycl::local_accessor<int>(1, cgh);
+        auto ResultAccessor =
+            ResultBuffer.get_access<sycl::access::mode::write>(cgh);
+        cgh.parallel_for<class Kernel>(
+            sycl::nd_range<1>(NItems, 1), [=](sycl::nd_item<1> Item) {
+              bool Success = true;
+              size_t Index = Item.get_global_id(0);
+
+              int *RawGlobalPointer = &GlobalAccessor[Index];
+              auto GlobalPointer =
+                  sycl::ext::oneapi::experimental::static_address_cast<
+                      sycl::access::address_space::global_space,
+                      sycl::access::decorated::no>(RawGlobalPointer);
+              Success &= reinterpret_cast<size_t>(RawGlobalPointer) ==
+                         reinterpret_cast<size_t>(GlobalPointer.get_raw());
+
+              int *RawLocalPointer = &LocalAccessor[0];
+              auto LocalPointer =
+                  sycl::ext::oneapi::experimental::static_address_cast<
+                      sycl::access::address_space::local_space,
+                      sycl::access::decorated::no>(RawLocalPointer);
+              Success &= reinterpret_cast<size_t>(RawLocalPointer) ==
+                         reinterpret_cast<size_t>(LocalPointer.get_raw());
+
+              int PrivateVariable = 0;
+              int *RawPrivatePointer = &PrivateVariable;
+              auto PrivatePointer =
+                  sycl::ext::oneapi::experimental::static_address_cast<
+                      sycl::access::address_space::private_space,
+                      sycl::access::decorated::no>(RawPrivatePointer);
+              Success &= reinterpret_cast<size_t>(RawPrivatePointer) ==
+                         reinterpret_cast<size_t>(PrivatePointer.get_raw());
+
+              ResultAccessor[Index] = Success;
+            });
+      })
+      .wait();
+
+  bool Success = true;
+  {
+    auto ResultAccessor = sycl::host_accessor(ResultBuffer);
+    for (int i = 0; i < NItems.size(); ++i) {
+      Success &= ResultAccessor[i];
+    };
+  }
+
+  return (Success) ? 0 : -1;
+}


### PR DESCRIPTION
- Adds support for OpGenericCastToPtr SPIR-V intrinsic.
- Implements static_address_cast using OpGenericCastToPtr.
- Implements dynamic_address_cast using OpGenericCastToPtrExplicit.
- Adds tests for both new forms of address_cast.