### PR TITLE
[GENX]: Use get_global_size IGC builtin instead of opencl function

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -71,7 +71,7 @@ class GENX_DeviceFunctionOp<string mnemonic, string fnName,
     Results<(outs LLVM_Type:$res)>, Arguments<(ins)> {
   string llvmBuilder = [{
     llvm::Type *retType = nullptr;
-    if ("}] # fnName # [{" == "__builtin_IB_get_global_size") {
+    if (std::string("}] # fnName # [{") == std::string("__builtin_IB_get_global_size")) {
       retType = builder.getInt32Ty();
     } else {
       retType = builder.getInt64Ty();

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -70,7 +70,12 @@ class GENX_DeviceFunctionOp<string mnemonic, string fnName,
   : GENX_Op<mnemonic, !listconcat(traits, [Pure])>,
     Results<(outs LLVM_Type:$res)>, Arguments<(ins)> {
   string llvmBuilder = [{
-    llvm::Type *retType = builder.getInt64Ty();
+    llvm::Type *retType = nullptr;
+    if ("}] # fnName # [{" == "__builtin_IB_get_global_size") {
+      retType = builder.getInt32Ty();
+    } else {
+      retType = builder.getInt64Ty();
+    }
     llvm::Type *argType = builder.getInt32Ty();
     llvm::Value *val = llvm::ConstantInt::get(argType, }] # arg # [{);
     llvm::CallInst *ci = createDeviceFunctionCall(builder, "}] # fnName # [{",
@@ -115,11 +120,11 @@ def GENX_BlockDimYOp : GENX_DeviceFunctionOp<"workgroup.dim.y",
 def GENX_BlockDimZOp : GENX_DeviceFunctionOp<"workgroup.dim.z",
                         "_Z12get_local_sizej", 2>;
 def GENX_GridDimXOp : GENX_DeviceFunctionOp<"grid.dim.x",
-                        "_Z12get_global_sizej", 0>;
+                        "__builtin_IB_get_global_size", 0>;
 def GENX_GridDimYOp : GENX_DeviceFunctionOp<"grid.dim.y",
-                        "_Z12get_global_sizej", 1>;
+                        "__builtin_IB_get_global_size", 1>;
 def GENX_GridDimZOp : GENX_DeviceFunctionOp<"grid.dim.z",
-                        "_Z12get_global_sizej", 2>;
+                        "__builtin_IB_get_global_size", 2>;
 
 //===----------------------------------------------------------------------===//
 // Synchronization

--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -119,6 +119,9 @@ def GENX_BlockDimYOp : GENX_DeviceFunctionOp<"workgroup.dim.y",
                         "_Z12get_local_sizej", 1>;
 def GENX_BlockDimZOp : GENX_DeviceFunctionOp<"workgroup.dim.z",
                         "_Z12get_local_sizej", 2>;
+// opencl function is currently not being parsed properly by IGC. 
+// Once IGC fixes this issue, we can switch back to the mangled function name or use 
+// a GenISA intrinsic. 
 def GENX_GridDimXOp : GENX_DeviceFunctionOp<"grid.dim.x",
                         "__builtin_IB_get_global_size", 0>;
 def GENX_GridDimYOp : GENX_DeviceFunctionOp<"grid.dim.y",

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -21,11 +21,12 @@ llvm.func @genx_special_regs() -> i32 {
   %8 = genx.workgroup.dim.y : i64
   // CHECK: call i64 @_Z12get_local_sizej(i32 2)
   %9 = genx.workgroup.dim.z : i32
-  // CHECK: call i64 @_Z12get_global_sizej(i32 0)
+  // CHECK: call i32 @__builtin_IB_get_global_size(i32 0)
   %10 = genx.grid.dim.x : i32
-  // CHECK: call i64 @_Z12get_global_sizej(i32 1)
+  // CHECK: [[CI:%.*]] = call i32 @__builtin_IB_get_global_size(i32 1)
+  // CHECK-NEXT: zext i32 [[CI]] to i64
   %11 = genx.grid.dim.y : i64
-  // CHECK: call i64 @_Z12get_global_sizej(i32 2)
+  // CHECK: call i32 @__builtin_IB_get_global_size(i32 2)
   %12 = genx.grid.dim.z : i32
   llvm.return %1 : i32
 }


### PR DESCRIPTION
The opencl function `get_global_size` is not recognized by IGC:

Given the following Kernel:
``` 
; Function Attrs: nounwind
define spir_kernel void @kernel_0d1d2de(float addrspace(1)* nocapture readonly %0, float addrspace(1)* nocapture %1, i32 %2, float addrspace(3)* nocapture %3) #0 !dbg !265 {
  %5 = call spir_func i64 @_Z12get_local_idj(i32 0) #0, !dbg !268
  %6 = trunc i64 %5 to i32, !dbg !268
  %7 = and i32 %6, 31, !dbg !268
  %8 = lshr i32 %6, 3, !dbg !268
  %9 = and i32 %8, 15, !dbg !268
  %10 = or i32 %9, 16, !dbg !268
  %11 = shl i32 %6, 2, !dbg !268
  %12 = and i32 %11, 28, !dbg !268
  %13 = call spir_func i64 @_Z12get_group_idj(i32 0) #0, !dbg !269
  %14 = trunc i64 %13 to i32, !dbg !269
  %15 = call spir_func i64 @_Z12get_group_idj(i32 1) #0, !dbg !270
  %16 = trunc i64 %15 to i32, !dbg !270
  %17 = call spir_func i64 @_Z12get_global_sizej(i32 1) #0, !dbg !271
  %18 = trunc i64 %17 to i32, !dbg !271
```

IGC correctly replaces all opencl functions except `get_global_size`:

```
; Function Attrs: convergent nounwind
define spir_kernel void @kernel_0d1d2de(float addrspace(1)* nocapture readonly %0, float addrspace(1)* nocapture %1, i32 %2, float addrspace(3)* nocapture %3, <8 x i32> %r0, <8 x i32> %payloadHeader, i16 %localIdX, i16 %localIdY, i16 %localIdZ, i8* %privateBase, i32 %bufferOffset, i32 %bufferOffset1) #1 !dbg !327 {
  call void @llvm.genx.GenISA.CatchAllDebugLine(), !dbg !331
  %scalar = extractelement <8 x i32> %r0, i32 0
  %scalar22 = extractelement <8 x i32> %r0, i32 1
  %scalar23 = extractelement <8 x i32> %r0, i32 2
  %scalar24 = extractelement <8 x i32> %r0, i32 3
  %scalar25 = extractelement <8 x i32> %r0, i32 4
  %scalar26 = extractelement <8 x i32> %r0, i32 5
  %scalar27 = extractelement <8 x i32> %r0, i32 6
  %scalar28 = extractelement <8 x i32> %r0, i32 7
  %5 = zext i16 %localIdX to i32, !dbg !332
  %6 = and i32 %5, 31, !dbg !332
  %7 = lshr i32 %5, 3, !dbg !332
  %8 = and i32 %7, 15, !dbg !332
  %9 = or i32 %8, 16, !dbg !332
  %10 = shl nuw nsw i32 %5, 2, !dbg !332
  %11 = and i32 %10, 28, !dbg !332
  %12 = call spir_func i64 @_Z12get_global_sizej(i32 1) #7, !dbg !333
  %13 = trunc i64 %12 to i32, !dbg !333
  %14 = shl i32 %scalar22, 5, !dbg !334
  %15 = or i32 %14, %8, !dbg !335
  %16 = or i32 %9, %14, !dbg !335
  %17 = or i32 %14, %6, !dbg !335
  %18 = add i32 %2, 31, !dbg !336
  %19 = sdiv i32 %18, 32, !dbg !340
  %20 = mul i32 %15, %2, !dbg !341
  %21 = mul i32 %16, %2, !dbg !341
  %22 = sext i32 %20 to i64, !dbg !342
  %23 = getelementptr float, float addrspace(1)* %0, i64 %22, !dbg !342
  %24 = sext i32 %21 to i64, !dbg !342
  %25 = getelementptr float, float addrspace(1)* %0, i64 %24, !dbg !342
  %26 = icmp sgt i32 %19, %scalar27, !dbg !343
  br i1 %26, label %.lr.ph, label %._crit_edge, !dbg !343
```

After discussion with IGC team it was proposed to use SPIRV builtins - but we do not currently see a path to demangling SPIRV builtin names in the `genx` dialect. The IGC compiler builtins are not considered to be a public or stable interface and their use was not recommended by the IGC team, but the use of said builtin allows us to progress pass this issue and enable a wide set of additional tests in the LLVM Triton backend. We will continue to look for alternate strategies but for now this appears to be the best way forward for supporting Triton functionality on Intel GPU using LLVM. 