### PR TITLE
[SYCL][NFC] Cleanup handler.hpp includes

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -11,16 +11,12 @@
 #include <sycl/access/access.hpp>
 #include <sycl/accessor.hpp>
 #include <sycl/context.hpp>
-#include <sycl/detail/array.hpp>
 #include <sycl/detail/cg.hpp>
 #include <sycl/detail/cg_types.hpp>
-#include <sycl/detail/cl.h>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/export.hpp>
-#include <sycl/detail/helpers.hpp>
 #include <sycl/detail/impl_utils.hpp>
-#include <sycl/detail/item_base.hpp>
 #include <sycl/detail/kernel_desc.hpp>
 #include <sycl/detail/pi.h>
 #include <sycl/detail/pi.hpp>
@@ -28,7 +24,6 @@
 #include <sycl/device.hpp>
 #include <sycl/event.hpp>
 #include <sycl/exception.hpp>
-#include <sycl/exception_list.hpp>
 #include <sycl/ext/intel/experimental/fp_control_kernel_properties.hpp>
 #include <sycl/ext/intel/experimental/kernel_execution_properties.hpp>
 #include <sycl/ext/oneapi/bindless_images_descriptor.hpp>
@@ -52,7 +47,6 @@
 #include <sycl/property_list.hpp>
 #include <sycl/range.hpp>
 #include <sycl/sampler.hpp>
-#include <sycl/types.hpp>
 #include <sycl/usm/usm_enums.hpp>
 #include <sycl/usm/usm_pointer_info.hpp>
 
@@ -68,7 +62,7 @@
 #include <vector>
 
 // TODO: refactor this header
-// 47(!!!) includes of SYCL headers + 10 includes of standard headers.
+// 41(!!!) includes of SYCL headers + 10 includes of standard headers.
 // 3300+ lines of code
 
 // SYCL_LANGUAGE_VERSION is 4 digit year followed by 2 digit revision


### PR DESCRIPTION
Removed 6 includes. The code still compiles. I've tried to do some `grep`ing to ensure that `handler.hpp` doesn't really use anything from those includes. However, it could be that I've missed something and we can still compile because those files are included from somewhere else implicitly. 