### PR TITLE
[SYCL][Fusion][NoSTL] Store JIT constant data in a DynArray

### DIFF
--- a/sycl-fusion/common/include/DynArray.h
+++ b/sycl-fusion/common/include/DynArray.h
@@ -55,6 +55,14 @@ public:
   const T &operator[](int Idx) const { return Values[Idx]; }
   T &operator[](int Idx) { return Values[Idx]; }
 
+  friend bool operator==(const DynArray<T> &A, const DynArray<T> &B) {
+    return std::equal(A.begin(), A.end(), B.begin(), B.end());
+  }
+
+  friend bool operator!=(const DynArray<T> &A, const DynArray<T> &B) {
+    return !(A == B);
+  }
+
 private:
   T *Values = nullptr;
   size_t Size = 0;

--- a/sycl-fusion/jit-compiler/include/Parameter.h
+++ b/sycl-fusion/jit-compiler/include/Parameter.h
@@ -9,8 +9,10 @@
 #ifndef SYCL_FUSION_JIT_COMPILER_PARAMETER_H
 #define SYCL_FUSION_JIT_COMPILER_PARAMETER_H
 
+#include "DynArray.h"
+
+#include <algorithm>
 #include <cstdint>
-#include <string>
 #include <vector>
 
 namespace jit_compiler {
@@ -103,10 +105,13 @@ struct ParameterInternalization {
 /// Client of the API owns the data held by `ValPtr`.
 struct JITConstant {
   Parameter Param;
-  std::string Value;
+  DynArray<char> Value;
   JITConstant() = default;
   JITConstant(const Parameter &Parameter, void *Ptr, size_t Size)
-      : Param{Parameter}, Value{reinterpret_cast<const char *>(Ptr), Size} {}
+      : Param{Parameter}, Value{Size} {
+    auto *CPtr = reinterpret_cast<const char *>(Ptr);
+    std::copy(CPtr, CPtr + Size, Value.begin());
+  }
 
   friend bool operator==(const JITConstant &LHS,
                          const JITConstant &RHS) noexcept {

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -22,8 +22,8 @@ static Metadata *getConstantIntMD(llvm::LLVMContext &LLVMContext, T Val) {
 }
 
 static Metadata *getConstantMD(llvm::LLVMContext &LLVMCtx,
-                               llvm::StringRef Data) {
-  return MDString::get(LLVMCtx, Data);
+                               const jit_compiler::DynArray<char> &Data) {
+  return MDString::get(LLVMCtx, StringRef{Data.begin(), Data.size()});
 }
 
 static Metadata *getMDParam(LLVMContext &LLVMCtx,

--- a/sycl-fusion/jit-compiler/lib/fusion/Hashing.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/Hashing.h
@@ -42,6 +42,10 @@ inline llvm::hash_code hash_value(const NDRange &ND) {
   return llvm::hash_combine(ND.getDimensions(), ND.getGlobalSize(),
                             ND.getLocalSize(), ND.getOffset());
 }
+
+template <typename T> inline llvm::hash_code hash_value(const DynArray<T> &DA) {
+  return llvm::hash_combine_range(DA.begin(), DA.end());
+}
 } // namespace jit_compiler
 
 namespace std {


### PR DESCRIPTION
Use our custom `DynArray` container instead of an `std::string` to store a JIT constant's bytes.

*This PR is part of a series of changes to remove uses of STL classes in the kernel fusion interface to prevent ABI issues in the future.*