### PR TITLE
[SYCL][HIP] Re-enable reduction nd lambda test

### DIFF
--- a/sycl/test-e2e/Reduction/reduction_nd_lambda.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_lambda.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// Inconsistently fails on HIP AMD, HIP Nvidia.
-// UNSUPPORTED: hip_amd || hip_nvidia
-
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows
 


### PR DESCRIPTION
This test is now passing.

It is noted as inconsistently failing, I couldn't reproduce the failure locally and the CI passed, so I'd like to try to re-enable it as we improved the HIP backend significantly since it was disabled.

I will keep an eye out and revert this if it starts failing again.