### PR TITLE
[SYCL][Fusion][NoSTL] Implement custom view class to replace input vector references

### DIFF
--- a/sycl-fusion/common/include/DynArray.h
+++ b/sycl-fusion/common/include/DynArray.h
@@ -97,7 +97,7 @@ private:
 /// String-like class that owns its character storage.
 class DynString {
 public:
-  explicit DynString(const char *Str) : Chars{std::strlen(Str) + 1} {
+  explicit DynString(const char *Str = "") : Chars{std::strlen(Str) + 1} {
     std::copy(Str, Str + Chars.size(), Chars.begin());
   }
 

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -131,7 +131,7 @@ using ArgUsageUT = std::underlying_type_t<ArgUsage>;
 ///
 /// Describe the list of arguments by their kind and usage.
 struct SYCLArgumentDescriptor {
-  explicit SYCLArgumentDescriptor(size_t NumArgs)
+  explicit SYCLArgumentDescriptor(size_t NumArgs = 0)
       : Kinds(NumArgs), UsageMask(NumArgs){};
 
   DynArray<ParameterKind> Kinds;
@@ -338,6 +338,8 @@ struct SYCLKernelInfo {
   NDRange NDR;
 
   SYCLKernelBinaryInfo BinaryInfo;
+
+  SYCLKernelInfo() = default;
 
   SYCLKernelInfo(const char *KernelName, const SYCLArgumentDescriptor &ArgDesc,
                  const NDRange &NDR, const SYCLKernelBinaryInfo &BinInfo)

--- a/sycl-fusion/common/include/View.h
+++ b/sycl-fusion/common/include/View.h
@@ -1,0 +1,45 @@
+//==------------- View.h - Non-owning view to contiguous memory ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_COMMON_VIEW_H
+#define SYCL_FUSION_COMMON_VIEW_H
+
+#include <cstddef>
+#include <type_traits>
+
+namespace jit_compiler {
+
+/// Read-only, non-owning view of a linear sequence of \p T.
+template <typename T> class View {
+public:
+  constexpr View(const T *Ptr, size_t Size) : Ptr(Ptr), Size(Size) {}
+
+  template <template <typename...> typename C>
+  explicit constexpr View(const C<T> &Cont)
+      : Ptr(Cont.data()), Size(Cont.size()) {}
+
+  constexpr const T *begin() const { return Ptr; }
+  constexpr const T *end() const { return Ptr + Size; }
+  constexpr size_t size() const { return Size; }
+
+  template <template <typename...> typename C> auto to() const {
+    return C<T>{begin(), end()};
+  }
+
+private:
+  const T *const Ptr;
+  const size_t Size;
+};
+
+// Deduction guide
+template <template <typename...> typename C, typename T>
+View(const C<T> &) -> View<T>;
+
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_COMMON_VIEW_H

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -9,59 +9,57 @@
 #ifndef SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H
 #define SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H
 
+#include "DynArray.h"
 #include "Kernel.h"
 #include "Options.h"
 #include "Parameter.h"
+#include "View.h"
+
 #include <cassert>
-#include <string>
-#include <variant>
-#include <vector>
 
 namespace jit_compiler {
 
 class FusionResult {
 public:
-  explicit FusionResult(std::string &&ErrorMessage)
-      : Type{FusionResultType::FAILED}, Value{std::move(ErrorMessage)} {}
+  explicit FusionResult(const char *ErrorMessage)
+      : Type{FusionResultType::FAILED}, KernelInfo{},
+        ErrorMessage{ErrorMessage} {}
 
-  explicit FusionResult(SYCLKernelInfo KernelInfo, bool Cached = false)
+  explicit FusionResult(const SYCLKernelInfo &KernelInfo, bool Cached = false)
       : Type{(Cached) ? FusionResultType::CACHED : FusionResultType::NEW},
-        Value{std::forward<SYCLKernelInfo>(KernelInfo)} {}
+        KernelInfo(KernelInfo), ErrorMessage{} {}
 
   bool failed() const { return Type == FusionResultType::FAILED; }
 
   bool cached() const { return Type == FusionResultType::CACHED; }
 
-  const std::string &getErrorMessage() const {
-    assert(failed() && std::holds_alternative<std::string>(Value) &&
-           "No error message present");
-    return std::get<std::string>(Value);
+  const char *getErrorMessage() const {
+    assert(failed() && "No error message present");
+    return ErrorMessage.c_str();
   }
 
   const SYCLKernelInfo &getKernelInfo() const {
-    assert(!failed() && std::holds_alternative<SYCLKernelInfo>(Value) &&
-           "No kernel info");
-    return std::get<SYCLKernelInfo>(Value);
+    assert(!failed() && "No kernel info");
+    return KernelInfo;
   }
 
 private:
   enum class FusionResultType { FAILED, CACHED, NEW };
-  FusionResultType Type;
 
-  std::variant<std::string, SYCLKernelInfo> Value;
+  FusionResultType Type;
+  SYCLKernelInfo KernelInfo;
+  DynString ErrorMessage;
 };
 
 class KernelFusion {
 
 public:
   static FusionResult
-  fuseKernels(const std::vector<SYCLKernelInfo> &KernelInformation,
-              const char *FusedKernelName,
-              jit_compiler::ParamIdentList &Identities,
+  fuseKernels(View<SYCLKernelInfo> KernelInformation,
+              const char *FusedKernelName, View<ParameterIdentity> Identities,
               BarrierFlags BarriersFlags,
-              const std::vector<jit_compiler::ParameterInternalization>
-                  &Internalization,
-              const std::vector<jit_compiler::JITConstant> &JITConstants);
+              View<ParameterInternalization> Internalization,
+              View<jit_compiler::JITConstant> JITConstants);
 
   /// Clear all previously set options.
   static void resetConfiguration();

--- a/sycl-fusion/jit-compiler/include/Parameter.h
+++ b/sycl-fusion/jit-compiler/include/Parameter.h
@@ -13,7 +13,6 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <vector>
 
 namespace jit_compiler {
 ///
@@ -59,8 +58,6 @@ struct ParameterIdentity {
     return !(LHS == RHS);
   }
 };
-
-using ParamIdentList = std::vector<ParameterIdentity>;
 
 ///
 /// Express how a parameter can be lowered using promotion to local or global

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -34,7 +34,7 @@ static FusionResult errorToFusionResult(llvm::Error &&Err,
                           // compiled without exception support.
                           ErrMsg << "\t" << StrErr.getMessage() << "\n";
                         });
-  return FusionResult{ErrMsg.str()};
+  return FusionResult{ErrMsg.str().c_str()};
 }
 
 static std::vector<jit_compiler::NDRange>
@@ -71,17 +71,16 @@ static bool isTargetFormatSupported(BinaryFormat TargetFormat) {
 }
 
 FusionResult KernelFusion::fuseKernels(
-    const std::vector<SYCLKernelInfo> &KernelInformation,
-    const char *FusedKernelName, ParamIdentList &Identities,
-    BarrierFlags BarriersFlags,
-    const std::vector<jit_compiler::ParameterInternalization> &Internalization,
-    const std::vector<jit_compiler::JITConstant> &Constants) {
+    View<SYCLKernelInfo> KernelInformation, const char *FusedKernelName,
+    View<ParameterIdentity> Identities, BarrierFlags BarriersFlags,
+    View<ParameterInternalization> Internalization,
+    View<jit_compiler::JITConstant> Constants) {
 
   std::vector<std::string> KernelsToFuse;
   llvm::transform(KernelInformation, std::back_inserter(KernelsToFuse),
                   [](const auto &KI) { return std::string{KI.Name.c_str()}; });
 
-  const auto NDRanges = gatherNDRanges(KernelInformation);
+  const auto NDRanges = gatherNDRanges(KernelInformation.to<llvm::ArrayRef>());
 
   if (!isValidCombination(NDRanges)) {
     return FusionResult{
@@ -105,10 +104,10 @@ FusionResult KernelFusion::fuseKernels(
   bool CachingEnabled = ConfigHelper::get<option::JITEnableCaching>();
   CacheKeyT CacheKey{TargetArch,
                      KernelsToFuse,
-                     Identities,
+                     Identities.to<std::vector>(),
                      BarriersFlags,
-                     Internalization,
-                     Constants,
+                     Internalization.to<std::vector>(),
+                     Constants.to<std::vector>(),
                      IsHeterogeneousList
                          ? std::optional<std::vector<NDRange>>{NDRanges}
                          : std::optional<std::vector<NDRange>>{std::nullopt}};
@@ -147,9 +146,12 @@ FusionResult KernelFusion::fuseKernels(
 
   // Add information about the kernel that should be fused as metadata into the
   // LLVM module.
-  FusedFunction FusedKernel{
-      FusedKernelName, KernelsToFuse, std::move(Identities),
-      Internalization, Constants,     NDRanges};
+  FusedFunction FusedKernel{FusedKernelName,
+                            KernelsToFuse,
+                            Identities.to<llvm::ArrayRef>(),
+                            Internalization.to<llvm::ArrayRef>(),
+                            Constants.to<llvm::ArrayRef>(),
+                            NDRanges};
   FusedFunctionList FusedKernelList;
   FusedKernelList.push_back(FusedKernel);
   llvm::Expected<std::unique_ptr<llvm::Module>> NewModOrError =

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
@@ -27,22 +27,22 @@ public:
   /// Representation of a fused kernel named FusedName and fusing
   /// all the kernels listed in FusedKernels.
   struct FusedFunction {
-    FusedFunction(const std::string &FusedName,
-                  const std::vector<std::string> &FusedKernels,
-                  const jit_compiler::ParamIdentList &ParameterIdentities,
-                  llvm::ArrayRef<jit_compiler::ParameterInternalization>
-                      ParameterInternalization,
-                  llvm::ArrayRef<jit_compiler::JITConstant> Constants,
-                  llvm::ArrayRef<jit_compiler::NDRange> NDRanges)
+    FusedFunction(
+        const char *FusedName, llvm::ArrayRef<std::string> FusedKernels,
+        llvm::ArrayRef<jit_compiler::ParameterIdentity> ParameterIdentities,
+        llvm::ArrayRef<jit_compiler::ParameterInternalization>
+            ParameterInternalization,
+        llvm::ArrayRef<jit_compiler::JITConstant> Constants,
+        llvm::ArrayRef<jit_compiler::NDRange> NDRanges)
         : FusedName{FusedName}, FusedKernels{FusedKernels},
           ParameterIdentities{ParameterIdentities},
           ParameterInternalization{ParameterInternalization},
           Constants{Constants}, NDRanges{NDRanges},
           FusedNDRange{jit_compiler::combineNDRanges(NDRanges)} {}
 
-    std::string FusedName;
-    std::vector<std::string> FusedKernels;
-    jit_compiler::ParamIdentList ParameterIdentities;
+    const char *FusedName;
+    llvm::ArrayRef<std::string> FusedKernels;
+    llvm::ArrayRef<jit_compiler::ParameterIdentity> ParameterIdentities;
     llvm::ArrayRef<jit_compiler::ParameterInternalization>
         ParameterInternalization;
     llvm::ArrayRef<jit_compiler::JITConstant> Constants;

--- a/sycl-fusion/jit-compiler/lib/fusion/JITContext.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/JITContext.h
@@ -29,9 +29,9 @@ class LLVMContext;
 namespace jit_compiler {
 
 using CacheKeyT =
-    std::tuple<DeviceArchitecture, std::vector<std::string>, ParamIdentList,
-               BarrierFlags, std::vector<ParameterInternalization>,
-               std::vector<JITConstant>,
+    std::tuple<DeviceArchitecture, std::vector<std::string>,
+               std::vector<ParameterIdentity>, BarrierFlags,
+               std::vector<ParameterInternalization>, std::vector<JITConstant>,
                // This field of the cache is optional because, if all of the
                // ranges are equal, we will perform no remapping, so that fused
                // kernels can be reused with different lists of equal nd-ranges.

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -440,7 +440,7 @@ static ParamIterator preProcessArguments(
     std::vector<::jit_compiler::ParameterInternalization> &InternalizeParams,
     std::vector<::jit_compiler::JITConstant> &JITConstants,
     ParamList &NonIdenticalParams,
-    ::jit_compiler::ParamIdentList &ParamIdentities) {
+    std::vector<::jit_compiler::ParameterIdentity> &ParamIdentities) {
 
   // Unused arguments are still in the list at this point (because we
   // need them for accessor handling), but there's not pre-processing
@@ -806,7 +806,7 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   // can be constant-propagated by the JIT compiler.
   std::vector<::jit_compiler::ParameterInternalization> InternalizeParams;
   std::vector<::jit_compiler::JITConstant> JITConstants;
-  ::jit_compiler::ParamIdentList ParamIdentities;
+  std::vector<::jit_compiler::ParameterIdentity> ParamIdentities;
   ParamList NonIdenticalParameters;
   for (auto PI = FusedParams.begin(); PI != FusedParams.end();) {
     PI = preProcessArguments(ArgsStorage, PI, PromotedAccs, InternalizeParams,
@@ -836,9 +836,10 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITTargetInfo>(
       std::move(TargetInfo));
 
+  using ::jit_compiler::View;
   auto FusionResult = ::jit_compiler::KernelFusion::fuseKernels(
-      InputKernelInfo, FusedKernelName.c_str(), ParamIdentities, BarrierFlags,
-      InternalizeParams, JITConstants);
+      View{InputKernelInfo}, FusedKernelName.c_str(), View(ParamIdentities),
+      BarrierFlags, View(InternalizeParams), View(JITConstants));
 
   if (FusionResult.failed()) {
     if (DebugEnabled) {


### PR DESCRIPTION
Implement a very simple view class to transport the input vector's raw data pointers and sizes across the fusion interface, and modify `FusionResult` to work without `std::string` and `std::variant`.

_This PR is part of a series of changes to remove uses of STL classes in the kernel fusion interface to prevent ABI issues in the future._