### PR TITLE
[SYCL] Reintroduce sub_group_mask version 2

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/tangle_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/tangle_group.hpp
@@ -153,9 +153,7 @@ get_tangle_group(Group group) {
   // TODO: Construct from compiler-generated mask. Return an invalid group in
   //       in the meantime. CUDA devices will report false for the tangle_group
   //       support aspect so kernels launch should ensure this is never run.
-  return tangle_group<sycl::sub_group>(
-      sycl::detail::Builder::createSubGroupMask<
-          sycl::ext::oneapi::sub_group_mask>(0, 0));
+  return tangle_group<sycl::sub_group>(0);
 #endif
 #else
   throw runtime_error("Non-uniform groups are not supported on host device.",

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -42,6 +42,7 @@
 #include <utility>
 
 #include <sycl/builtins.hpp>
+#include <sycl/ext/intel/experimental/usm_properties.hpp>
 #include <sycl/ext/oneapi/group_local_memory.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/source/feature_test.hpp.in
+++ b/sycl/source/feature_test.hpp.in
@@ -31,7 +31,7 @@ inline namespace _V1 {
 // TODO: Move these feature-test macros to compiler driver.
 #define SYCL_EXT_INTEL_DEVICE_INFO 6
 #define SYCL_EXT_ONEAPI_DEVICE_ARCHITECTURE 1
-#define SYCL_EXT_ONEAPI_SUB_GROUP_MASK 1
+#define SYCL_EXT_ONEAPI_SUB_GROUP_MASK 2
 #define SYCL_EXT_ONEAPI_LOCAL_MEMORY 1
 #define SYCL_EXT_ONEAPI_MATRIX 1
 #define SYCL_EXT_ONEAPI_ASSERT 1

--- a/sycl/test-e2e/SubGroupMask/sub_group_mask_ver2.cpp
+++ b/sycl/test-e2e/SubGroupMask/sub_group_mask_ver2.cpp
@@ -1,0 +1,119 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+#define TEST_ON_DEVICE(TEST_BODY)                                              \
+  {                                                                            \
+    sycl::queue queue;                                                         \
+    sycl::buffer<bool, 1> buf(&res, 1);                                        \
+    queue.submit([&](sycl::handler &h) {                                       \
+      auto acc = buf.get_access<sycl::access_mode::write>(h);                  \
+      h.parallel_for(sycl::nd_range<1>(sycl::range<1>(1), sycl::range<1>(1)),  \
+                     [=](sycl::nd_item<1> item) { TEST_BODY });                \
+    });                                                                        \
+    queue.wait();                                                              \
+  }                                                                            \
+  assert(res);
+
+int main() {
+#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK >= 2
+  using mask_type = sycl::ext::oneapi::sub_group_mask;
+
+  // sub_group_mask()
+  {
+    mask_type mask;
+    assert(mask.none() && mask_type::max_bits == mask.size());
+
+    bool res = false;
+    // clang-format off
+    TEST_ON_DEVICE(
+      mask_type mask;
+      auto sg = item.get_sub_group();
+      acc[0] = mask.none() && (sg.get_max_local_range().size() == mask.size());
+    )
+    // clang-format on
+  }
+  // sub_group_mask(unsigned long long val)
+  {
+    unsigned long long val = 4815162342;
+    mask_type mask(val);
+    std::bitset<sizeof(val) * CHAR_BIT> bs(val);
+    bool res = true;
+    for (size_t i = 0;
+         i < std::min(static_cast<size_t>(mask.size()), bs.size()); ++i)
+      res &= mask[i] == bs[i];
+    assert(res);
+
+    // clang-format off
+    TEST_ON_DEVICE(
+      mask_type mask(val);
+      auto sg = item.get_sub_group();
+      acc[0] = sg.get_max_local_range().size() == mask.size();
+      for (size_t i = 0;
+            i < sycl::min(static_cast<size_t>(mask.size()), bs.size());
+            ++i)
+        acc[0] &= mask[i] == bs[i];
+    )
+    // clang-format on
+  }
+  // template <typename T, std::size_t K> sub_group_mask(const sycl::marray<T,
+  // K>& &val)
+  {
+    sycl::marray<char, 4> marr{1, 2, 3, 4};
+    mask_type mask(marr);
+    std::bitset<CHAR_BIT> bs[4] = {1, 2, 3, 4};
+    bool res = true;
+    for (size_t i = 0; i < mask.size() && (i / CHAR_BIT) < 4; ++i)
+      res &= mask[i] == bs[i / CHAR_BIT][i % CHAR_BIT];
+    assert(res);
+
+    // clang-format off
+    TEST_ON_DEVICE(
+      mask_type mask(marr);
+      auto sg = item.get_sub_group();
+      acc[0] = sg.get_max_local_range().size() == mask.size();
+      for (size_t i = 0; i < mask.size() && (i / CHAR_BIT) < 4; ++i)
+        acc[0] &= mask[i] == bs[i / CHAR_BIT][i % CHAR_BIT];
+    )
+    // clang-format on
+  }
+  {
+    // sub_group_mask(const sub_group_mask &other)
+    unsigned long long val = 4815162342;
+    mask_type mask1(val);
+    mask_type mask2(mask1);
+    assert(mask1 == mask2);
+
+    bool res = false;
+    // clang-format off
+    TEST_ON_DEVICE(
+      mask_type mask1(val);
+      mask_type mask2(mask1);
+      acc[0] = mask1 == mask2;
+    )
+    // clang-format on
+  }
+  {
+    // sub_group_mask& operator=(const sub_group_mask &other)
+    unsigned long long val = 4815162342;
+    mask_type mask1(val);
+    mask_type mask2 = mask1;
+    assert(mask1 == mask2);
+
+    bool res = false;
+    // clang-format off
+    TEST_ON_DEVICE(
+      mask_type mask1(val);
+      mask_type mask2 = mask1;
+      acc[0] = mask1 == mask2;
+    )
+    // clang-format on
+  }
+#else
+  std::cout << "Test skipped due to unsupported extension." << std::endl;
+#endif
+
+  return 0;
+}

--- a/sycl/test/extensions/macro.cpp
+++ b/sycl/test/extensions/macro.cpp
@@ -9,7 +9,7 @@ constexpr bool backend_opencl_macro_defined = true;
 constexpr bool backend_opencl_macro_defined = false;
 #endif
 
-#if SYCL_EXT_ONEAPI_SUB_GROUP_MASK == 1
+#ifdef SYCL_EXT_ONEAPI_SUB_GROUP_MASK
 constexpr bool sub_group_mask_macro_defined = true;
 #else
 constexpr bool sub_group_mask_macro_defined = false;

--- a/sycl/test/extensions/sub_group_mask.cpp
+++ b/sycl/test/extensions/sub_group_mask.cpp
@@ -1,8 +1,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only %s
 //
 // This test is intended to check sycl::ext::oneapi::sub_group_mask interface.
-// There is a work in progress update to the spec: intel/llvm#8174
-// TODO: udpate this test once revision 2 of the extension is supported
+// test for spec ver.2: sycl/test-e2e/SubGroupMask/sub_group_mask_ver2.cpp
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
Was reverted by fb8c82dee68e966dac5854d99cc6bb1a5784eece due to performance regressions on some devices.

It turned out that the problem is not with this patch. So applying it again without any changes.

Previously reviewed here: https://github.com/intel/llvm/pull/11195