### PR TITLE
[SYCL][Graph] Make debug print tests deterministic

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph.cpp
@@ -24,8 +24,10 @@
 // CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE5]]
 // CHECK-NEXT: "0x[[#%x,NODE6:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE6]]\nTYPE = CGCopy Device-to-Host \n"];
+// CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE6]]"
 // CHECK-NEXT: "0x[[#%x,NODE7:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE7]]\nTYPE = None \n"];
+// CHECK-DAG: "0x[[#NODE6]]" -> "0x[[#NODE7]]"
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Explicit/debug_print_graph_verbose.cpp
@@ -32,8 +32,10 @@
 // CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE5]]
 // CHECK-NEXT: "0x[[#%x,NODE6:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE6]]\nTYPE = CGCopy Device-to-Host \nSrc: 0x[[#%x,ADDR27:]] Dst: 0x[[#%x,ADDR28:]]\n"];
+// CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE6]]"
 // CHECK-NEXT: "0x[[#%x,NODE7:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE7]]\nTYPE = None \n"];
+// CHECK-DAG: "0x[[#NODE6]]" -> "0x[[#NODE7]]"
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
@@ -12,14 +12,12 @@ int main() {
 
   using T = unsigned short;
 
-  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
-  std::vector<T> DataA2D(Size * Size), DataB2D(Size * Size);
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size), DataD(Size);
 
   std::iota(DataA.begin(), DataA.end(), 1);
   std::iota(DataB.begin(), DataB.end(), 10);
   std::iota(DataC.begin(), DataC.end(), 1000);
-  std::iota(DataA2D.begin(), DataA2D.end(), 1);
-  std::iota(DataB2D.begin(), DataB2D.end(), 10);
+  std::iota(DataD.begin(), DataD.end(), 1);
 
   buffer<T> BufferA{DataA.data(), range<1>{DataA.size()}};
   BufferA.set_write_back(false);
@@ -27,8 +25,6 @@ int main() {
   BufferB.set_write_back(false);
   buffer<T> BufferC{DataC.data(), range<1>{DataC.size()}};
   BufferC.set_write_back(false);
-  buffer BufferA2D{DataA2D.data(), range<2>(Size, Size)};
-  BufferA2D.set_write_back(false);
   {
     exp_ext::command_graph Graph{
         Queue.get_context(),
@@ -47,7 +43,7 @@ int main() {
 
     auto Last = add_node(Graph, Queue, [&](handler &CGH) {
       auto Acc = BufferC.get_access<access::mode::read>(CGH);
-      CGH.copy(Acc, DataA2D.data());
+      CGH.copy(Acc, DataD.data());
     });
 
     add_empty_node(Graph, Queue, Last);

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph.cpp
@@ -45,12 +45,12 @@ int main() {
       CGH.copy(AccB, AccA);
     });
 
-    add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA2D.get_access<access::mode::read>(CGH);
-      CGH.copy(AccA, DataB2D.data());
+    auto Last = add_node(Graph, Queue, [&](handler &CGH) {
+      auto Acc = BufferC.get_access<access::mode::read>(CGH);
+      CGH.copy(Acc, DataA2D.data());
     });
 
-    add_empty_node(Graph, Queue);
+    add_empty_node(Graph, Queue, Last);
 
     Graph.print_graph("graph.dot");
 

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
@@ -12,14 +12,12 @@ int main() {
 
   using T = unsigned short;
 
-  std::vector<T> DataA(Size), DataB(Size), DataC(Size);
-  std::vector<T> DataA2D(Size * Size), DataB2D(Size * Size);
+  std::vector<T> DataA(Size), DataB(Size), DataC(Size), DataD(Size);
 
   std::iota(DataA.begin(), DataA.end(), 1);
   std::iota(DataB.begin(), DataB.end(), 10);
   std::iota(DataC.begin(), DataC.end(), 1000);
-  std::iota(DataA2D.begin(), DataA2D.end(), 1);
-  std::iota(DataB2D.begin(), DataB2D.end(), 10);
+  std::iota(DataD.begin(), DataD.end(), 1);
 
   buffer<T> BufferA{DataA.data(), range<1>{DataA.size()}};
   BufferA.set_write_back(false);
@@ -27,8 +25,6 @@ int main() {
   BufferB.set_write_back(false);
   buffer<T> BufferC{DataC.data(), range<1>{DataC.size()}};
   BufferC.set_write_back(false);
-  buffer BufferA2D{DataA2D.data(), range<2>(Size, Size)};
-  BufferA2D.set_write_back(false);
   {
     exp_ext::command_graph Graph{
         Queue.get_context(),
@@ -47,7 +43,7 @@ int main() {
 
     auto Last = add_node(Graph, Queue, [&](handler &CGH) {
       auto AccA = BufferC.get_access<access::mode::read>(CGH);
-      CGH.copy(AccA, DataB2D.data());
+      CGH.copy(AccA, DataD.data());
     });
 
     add_empty_node(Graph, Queue, Last);

--- a/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/Inputs/debug_print_graph_verbose.cpp
@@ -45,12 +45,12 @@ int main() {
       CGH.copy(AccB, AccA);
     });
 
-    add_node(Graph, Queue, [&](handler &CGH) {
-      auto AccA = BufferA2D.get_access<access::mode::read>(CGH);
+    auto Last = add_node(Graph, Queue, [&](handler &CGH) {
+      auto AccA = BufferC.get_access<access::mode::read>(CGH);
       CGH.copy(AccA, DataB2D.data());
     });
 
-    add_node(Graph, Queue, [&](handler &CGH) { /* empty node */ });
+    add_empty_node(Graph, Queue, Last);
 
     Graph.print_graph("graph_verbose.dot", true);
   }

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph.cpp
@@ -24,8 +24,10 @@
 // CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE5]]
 // CHECK-NEXT: "0x[[#%x,NODE6:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE6]]\nTYPE = CGCopy Device-to-Host \n"];
+// CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE6]]"
 // CHECK-NEXT: "0x[[#%x,NODE7:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE7]]\nTYPE = None \n"];
+// CHECK-DAG: "0x[[#NODE6]]" -> "0x[[#NODE7]]"
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/debug_print_graph_verbose.cpp
@@ -33,8 +33,10 @@
 // CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE5]]
 // CHECK-NEXT: "0x[[#%x,NODE6:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE6]]\nTYPE = CGCopy Device-to-Host \nSrc: 0x[[#%x,ADDR27:]] Dst: 0x[[#%x,ADDR28:]]\n"];
+// CHECK-DAG: "0x[[#NODE4]]" -> "0x[[#NODE6]]"
 // CHECK-NEXT: "0x[[#%x,NODE7:]]"
 // CHECK-SAME: [style=bold, label="ID = 0x[[#NODE7]]\nTYPE = None \n"];
+// CHECK-DAG: "0x[[#NODE6]]" -> "0x[[#NODE7]]"
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
The order of root node in debug print tests was not deterministic. 
This PR updates these tests to make them deterministic by creating dependencies between nodes.

Addresses Issue: #12397