### PR TITLE
[SYCL][Fusion][NoSTL][NFC] Move SYCLModuleInfo to its own header

### DIFF
--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -12,12 +12,11 @@
 #include "DynArray.h"
 
 #include <algorithm>
-#include <array>
 #include <cassert>
 #include <cstdint>
 #include <cstring>
-#include <string>
-#include <vector>
+#include <functional>
+#include <type_traits>
 
 namespace jit_compiler {
 
@@ -346,33 +345,6 @@ struct SYCLKernelInfo {
 
   SYCLKernelInfo(const char *KernelName, size_t NumArgs)
       : Name{KernelName}, Args{NumArgs}, Attributes{}, NDR{}, BinaryInfo{} {}
-};
-
-///
-/// Represents a SPIR-V translation unit containing SYCL kernels by the
-/// KernelInfo for each of the contained kernels.
-class SYCLModuleInfo {
-public:
-  using KernelInfoList = std::vector<SYCLKernelInfo>;
-
-  void addKernel(SYCLKernelInfo &Kernel) { Kernels.push_back(Kernel); }
-
-  KernelInfoList &kernels() { return Kernels; }
-
-  bool hasKernelFor(const std::string &KernelName) {
-    return getKernelFor(KernelName) != nullptr;
-  }
-
-  SYCLKernelInfo *getKernelFor(const std::string &KernelName) {
-    auto It =
-        std::find_if(Kernels.begin(), Kernels.end(), [&](SYCLKernelInfo &K) {
-          return K.Name == KernelName.c_str();
-        });
-    return (It != Kernels.end()) ? &*It : nullptr;
-  }
-
-private:
-  KernelInfoList Kernels;
 };
 
 } // namespace jit_compiler

--- a/sycl-fusion/common/lib/ModuleInfo.h
+++ b/sycl-fusion/common/lib/ModuleInfo.h
@@ -1,0 +1,49 @@
+//==------------ ModuleInfo.h - Manages kernel info for the JIT ------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#ifndef SYCL_FUSION_COMMON_MODULEINFO_H
+#define SYCL_FUSION_COMMON_MODULEINFO_H
+
+#include "Kernel.h"
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace jit_compiler {
+
+///
+/// Represents a SPIR-V translation unit containing SYCL kernels by the
+/// KernelInfo for each of the contained kernels.
+class SYCLModuleInfo {
+public:
+  using KernelInfoList = std::vector<SYCLKernelInfo>;
+
+  void addKernel(SYCLKernelInfo &Kernel) { Kernels.push_back(Kernel); }
+
+  KernelInfoList &kernels() { return Kernels; }
+
+  bool hasKernelFor(const std::string &KernelName) {
+    return getKernelFor(KernelName) != nullptr;
+  }
+
+  SYCLKernelInfo *getKernelFor(const std::string &KernelName) {
+    auto It =
+        std::find_if(Kernels.begin(), Kernels.end(), [&](SYCLKernelInfo &K) {
+          return K.Name == KernelName.c_str();
+        });
+    return (It != Kernels.end()) ? &*It : nullptr;
+  }
+
+private:
+  KernelInfoList Kernels;
+};
+
+} // namespace jit_compiler
+
+#endif // SYCL_FUSION_COMMON_MODULEINFO_H

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionPipeline.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionPipeline.h
@@ -10,6 +10,7 @@
 #define SYCL_FUSION_JIT_COMPILER_FUSION_FUSIONPIPELINE_H
 
 #include "Kernel.h"
+#include "ModuleInfo.h"
 #include "llvm/IR/Module.h"
 
 namespace jit_compiler {

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.h
@@ -10,6 +10,7 @@
 #define SYCL_FUSION_PASSES_SYCLKERNELFUSION_H
 
 #include "Kernel.h"
+#include "ModuleInfo.h"
 #include "target/TargetFusionInfo.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"

--- a/sycl-fusion/passes/kernel-info/SYCLKernelInfo.h
+++ b/sycl-fusion/passes/kernel-info/SYCLKernelInfo.h
@@ -13,6 +13,7 @@
 #include "llvm/Passes/PassPlugin.h"
 
 #include "Kernel.h"
+#include "ModuleInfo.h"
 
 ///
 /// Analysis pass to make the SYCLModuleInfo available to other


### PR DESCRIPTION
Move `SYCLModuleInfo` class to its own header under the `common` directory (because it has users from `jit-compiler` and `passes`).

_This PR is part of a series of changes to remove uses of STL classes in the kernel fusion interface to prevent ABI issues in the future._