### PR TITLE
[CUDA][HIP] Fix `local_space nullptr` handling for NVPTX and `local/private nullptr` value for AMDGPU.

### DIFF
--- a/clang/lib/Basic/Targets/AMDGPU.h
+++ b/clang/lib/Basic/Targets/AMDGPU.h
@@ -427,8 +427,10 @@ public:
   // value ~0.
   uint64_t getNullPointerValue(LangAS AS) const override {
     // FIXME: Also should handle region.
-    return (AS == LangAS::opencl_local || AS == LangAS::opencl_private)
-      ? ~0 : 0;
+    return (AS == LangAS::opencl_local || AS == LangAS::opencl_private ||
+            AS == LangAS::sycl_local || AS == LangAS::sycl_private)
+               ? ~0
+               : 0;
   }
 
   void setAuxTarget(const TargetInfo *Aux) override;

--- a/clang/lib/CodeGen/Targets/NVPTX.cpp
+++ b/clang/lib/CodeGen/Targets/NVPTX.cpp
@@ -47,6 +47,10 @@ public:
                            CodeGen::CodeGenModule &M) const override;
   bool shouldEmitStaticExternCAliases() const override;
 
+  llvm::Constant *getNullPointer(const CodeGen::CodeGenModule &CGM,
+                                 llvm::PointerType *T,
+                                 QualType QT) const override;
+
   llvm::Type *getCUDADeviceBuiltinSurfaceDeviceType() const override {
     // On the device side, surface reference is represented as an object handle
     // in 64-bit integer.
@@ -327,6 +331,20 @@ void NVPTXTargetCodeGenInfo::addNVVMMetadata(llvm::GlobalValue *GV,
 
 bool NVPTXTargetCodeGenInfo::shouldEmitStaticExternCAliases() const {
   return false;
+}
+
+llvm::Constant *
+NVPTXTargetCodeGenInfo::getNullPointer(const CodeGen::CodeGenModule &CGM,
+                                       llvm::PointerType *PT,
+                                       QualType QT) const {
+  auto &Ctx = CGM.getContext();
+  if (PT->getAddressSpace() != Ctx.getTargetAddressSpace(LangAS::opencl_local))
+    return llvm::ConstantPointerNull::get(PT);
+
+  auto NPT = llvm::PointerType::get(
+      PT->getContext(), Ctx.getTargetAddressSpace(LangAS::opencl_generic));
+  return llvm::ConstantExpr::getAddrSpaceCast(
+      llvm::ConstantPointerNull::get(NPT), PT);
 }
 }
 

--- a/sycl/test-e2e/Basic/multi_ptr_null_value.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_null_value.cpp
@@ -1,0 +1,34 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// REQUIRES: cuda || hip || level_zero
+
+#include <sycl/sycl.hpp>
+
+template <sycl::access::address_space address_space> void nullPtrTest() {
+  auto queue = sycl::queue();
+  int value = 0;
+  {
+    sycl::buffer<int> val_buffer(&value, sycl::range(1));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto acc_for_multi_ptr = val_buffer.template get_access(cgh);
+          cgh.single_task([=] {
+            sycl::multi_ptr<int, address_space, sycl::access::decorated::yes>
+                mp;
+            mp = nullptr;
+            acc_for_multi_ptr[0] = mp.get_raw() == nullptr;
+          });
+        })
+        .wait_and_throw();
+  }
+
+  assert(value && "Invalid value for multi_ptr nullptr comparison!");
+}
+
+int main() {
+  nullPtrTest<sycl::access::address_space::local_space>();
+  nullPtrTest<sycl::access::address_space::private_space>();
+  nullPtrTest<sycl::access::address_space::global_space>();
+  nullPtrTest<sycl::access::address_space::generic_space>();
+  return 0;
+}


### PR DESCRIPTION
- Address space cast of  `nullptr` in `local_space`  into a `generic_space` for the CUDA backend. The reason for this cast was having invalid local memory base address for the associated variable.  
- In the context of AMD GPU, assigns a NULL value as `~0` for the address spaces of `sycl_local` and `sycl_private` to match the ones for `opencl_local` and  `opencl_private`.