### PR TITLE
[SYCL][NFC] Avoid `XPASS`-es in some graph tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
@@ -10,7 +10,8 @@
 // should. So the Sycl graph support cannot correctly catch the error and throw
 // the approriate exception for negative test. An issue has been reported
 // https://github.com/bashbaug/SimpleOpenCLSamples/issues/95
-// XFAIL: cuda, opencl
+// XFAIL: cuda
+// UNSUPPORTED: opencl
 // Note: failing negative test with HIP in the original test
 // TODO: disable hip when HIP backend will be supported by Graph
 

--- a/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
@@ -10,7 +10,8 @@
 // should. So the Sycl graph support cannot correctly catch the error and throw
 // the approriate exception for negative test. An issue has been reported
 // https://github.com/bashbaug/SimpleOpenCLSamples/issues/95
-// XFAIL: cuda, opencl
+// XFAIL: cuda
+// UNSUPPORTED: opencl
 // Note: failing negative test with HIP in the original test
 // TODO: disable hip when HIP backend will be supported by Graph
 


### PR DESCRIPTION
A couple of graph related tests were marked as `XFAIL`ed on OpenCL backend and it works just fine for intel/llvm. At intel/llvm we launch E2E tests for multiple targets in one LIT run, but there are some side effects of that mechanism like treating `XFAIL` as `UNSUPPORTED`.

We have downstream testing environments where E2E tests are launched for a single target. When those tests are launched on an OpenCL device without graphs support, they do early exit with exit code zero which is equivalent to `PASS` from LIT point of view. That turns into an `XPASS` due to `XFAIL` in the test, causing our CI to report failures.

Changed `XFAIL` to `UNSUPPORTED`, which will work for all possible environments, regardless of amount of targets for E2E tests and status of graphs support on OpenCL devices used in testing.