### PR TITLE
[SYCL][Graph] Fix post-commit unused parameter warning

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -4636,6 +4636,9 @@ inline pi_result piextCommandBufferAdviseUSM(
     pi_ext_command_buffer CommandBuffer, const void *Ptr, size_t Length,
     pi_mem_advice Advice, pi_uint32 NumSyncPointsInWaitList,
     const pi_ext_sync_point *SyncPointWaitList, pi_ext_sync_point *SyncPoint) {
+  // TODO: Handle advice correctly
+  (void)Advice;
+
   ur_exp_command_buffer_handle_t UrCommandBuffer =
       reinterpret_cast<ur_exp_command_buffer_handle_t>(CommandBuffer);
 


### PR DESCRIPTION
Fixes post-commit CI failure seen here https://github.com/intel/llvm/actions/runs/7559355777/job/20582987874 and caused by merging of https://github.com/intel/llvm/pull/11474