### PR TITLE
[SYCL] Remove esimd_emulator from filters

### DIFF
--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -177,14 +177,13 @@ getSyclDeviceTypeMap() {
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR
-const std::array<std::pair<std::string, backend>, 8> &getSyclBeMap() {
-  static const std::array<std::pair<std::string, backend>, 8> SyclBeMap = {
+const std::array<std::pair<std::string, backend>, 7> &getSyclBeMap() {
+  static const std::array<std::pair<std::string, backend>, 7> SyclBeMap = {
       {{"host", backend::host},
        {"opencl", backend::opencl},
        {"level_zero", backend::ext_oneapi_level_zero},
        {"cuda", backend::ext_oneapi_cuda},
        {"hip", backend::ext_oneapi_hip},
-       {"esimd_emulator", backend::ext_intel_esimd_emulator},
        {"native_cpu", backend::ext_oneapi_native_cpu},
        {"*", backend::all}}};
   return SyclBeMap;

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -238,7 +238,7 @@ getSyclDeviceTypeMap();
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR
-const std::array<std::pair<std::string, backend>, 8> &getSyclBeMap();
+const std::array<std::pair<std::string, backend>, 7> &getSyclBeMap();
 
 // ---------------------------------------
 // ONEAPI_DEVICE_SELECTOR support

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -293,12 +293,10 @@ ods_target_list::ods_target_list(const std::string &envStr) {
 // 2. Filter backend match exactly with the given 'Backend'
 bool ods_target_list::backendCompatible(backend Backend) {
 
-  bool isESIMD = Backend == backend::ext_intel_esimd_emulator;
   return std::any_of(
       TargetList.begin(), TargetList.end(), [&](ods_target &Target) {
         backend TargetBackend = Target.Backend.value_or(backend::all);
-        return (TargetBackend == Backend) ||
-               (TargetBackend == backend::all && !isESIMD);
+        return (TargetBackend == Backend) || (TargetBackend == backend::all);
       });
 }
 
@@ -363,7 +361,7 @@ device_filter::device_filter(const std::string &FilterString) {
       std::string Message =
           std::string("Invalid device filter: ") + FilterString +
           "\nPossible backend values are "
-          "{opencl,level_zero,cuda,hip,esimd_emulator,*}.\n"
+          "{opencl,level_zero,cuda,hip,*}.\n"
           "Possible device types are {cpu,gpu,acc,*}.\n"
           "Device number should be an non-negative integer.\n";
       throw sycl::invalid_parameter_error(Message, PI_ERROR_INVALID_VALUE);

--- a/sycl/source/detail/filter_selector_impl.cpp
+++ b/sycl/source/detail/filter_selector_impl.cpp
@@ -74,8 +74,6 @@ filter create_filter(const std::string &Input) {
       Result.Backend = backend::ext_oneapi_cuda;
     } else if (Token == "hip" && !Result.Backend) {
       Result.Backend = backend::ext_oneapi_hip;
-    } else if (Token == "esimd_emulator" && !Result.Backend) {
-      Result.Backend = backend::ext_intel_esimd_emulator;
     } else if (std::regex_match(Token, IntegerExpr) && !Result.DeviceNum) {
       try {
         Result.DeviceNum = std::stoi(Token);

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -169,7 +169,7 @@ TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
   sycl::detail::AllowListParsedT ExpectedValue{
       {{"BackendName", "host"}},       {{"BackendName", "opencl"}},
       {{"BackendName", "level_zero"}}, {{"BackendName", "cuda"}},
-      {{"BackendName", "hip"}},       {{"BackendName", "native_cpu"}},
+      {{"BackendName", "hip"}},        {{"BackendName", "native_cpu"}},
       {{"BackendName", "*"}}};
   EXPECT_EQ(ExpectedValue, ActualValue);
 }

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -169,8 +169,8 @@ TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
   sycl::detail::AllowListParsedT ExpectedValue{
       {{"BackendName", "host"}},       {{"BackendName", "opencl"}},
       {{"BackendName", "level_zero"}}, {{"BackendName", "cuda"}},
-      {{"BackendName", "hip"}},        {{"BackendName", "esimd_emulator"}},
-      {{"BackendName", "native_cpu"}}, {{"BackendName", "*"}}};
+      {{"BackendName", "hip"}},       {{"BackendName", "native_cpu"}},
+      {{"BackendName", "*"}}};
   EXPECT_EQ(ExpectedValue, ActualValue);
 }
 


### PR DESCRIPTION
This PR removes esimd_emulator from device filters and filter selectors. Esimd_emulator is already depreciated.