### PR TITLE
[SYCL][Graph] Fix bug when host-task is submitted to in-order queue

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -134,7 +134,11 @@ event queue_impl::memset(const std::shared_ptr<detail::queue_impl> &Self,
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
 
-    if (isInOrder()) {
+    // When a queue is recorded by a graph, the dependencies are managed in the
+    // graph implementaton. Additionally, CG recorded for a graph are outside of
+    // the in-order queue execution sequence. Therefore, these CG must not
+    // update MLastEvent.
+    if (isInOrder() && (getCommandGraph() == nullptr)) {
       MLastEvent = ResEvent;
       // We don't create a command group for usm commands, so set it to None.
       // This variable is used to perform explicit dependency management when
@@ -231,7 +235,11 @@ event queue_impl::memcpy(const std::shared_ptr<detail::queue_impl> &Self,
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
 
-    if (isInOrder()) {
+    // When a queue is recorded by a graph, the dependencies are managed in the
+    // graph implementaton. Additionally, CG recorded for a graph are outside of
+    // the in-order queue execution sequence. Therefore, these CG must not
+    // update MLastEvent.
+    if (isInOrder() && (getCommandGraph() == nullptr)) {
       MLastEvent = ResEvent;
       // We don't create a command group for usm commands, so set it to None.
       // This variable is used to perform explicit dependency management when
@@ -289,7 +297,11 @@ event queue_impl::mem_advise(const std::shared_ptr<detail::queue_impl> &Self,
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
 
-    if (isInOrder()) {
+    // When a queue is recorded by a graph, the dependencies are managed in the
+    // graph implementaton. Additionally, CG recorded for a graph are outside of
+    // the in-order queue execution sequence. Therefore, these CG must not
+    // update MLastEvent.
+    if (isInOrder() && (getCommandGraph() == nullptr)) {
       MLastEvent = ResEvent;
       // We don't create a command group for usm commands, so set it to None.
       // This variable is used to perform explicit dependency management when
@@ -338,7 +350,11 @@ event queue_impl::memcpyToDeviceGlobal(
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
 
-    if (isInOrder()) {
+    // When a queue is recorded by a graph, the dependencies are managed in the
+    // graph implementaton. Additionally, CG recorded for a graph are outside of
+    // the in-order queue execution sequence. Therefore, these CG must not
+    // update MLastEvent.
+    if (isInOrder() && (getCommandGraph() == nullptr)) {
       MLastEvent = ResEvent;
       // We don't create a command group for usm commands, so set it to None.
       // This variable is used to perform explicit dependency management when
@@ -387,7 +403,11 @@ event queue_impl::memcpyFromDeviceGlobal(
     if (MContext->is_host())
       return MDiscardEvents ? createDiscardedEvent() : event();
 
-    if (isInOrder()) {
+    // When a queue is recorded by a graph, the dependencies are managed in the
+    // graph implementaton. Additionally, CG recorded for a graph are outside of
+    // the in-order queue execution sequence. Therefore, these CG must not
+    // update MLastEvent.
+    if (isInOrder() && (getCommandGraph() == nullptr)) {
       MLastEvent = ResEvent;
       // We don't create a command group for usm commands, so set it to None.
       // This variable is used to perform explicit dependency management when

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -740,7 +740,11 @@ protected:
   template <typename HandlerType = handler>
   void finalizeHandler(HandlerType &Handler, const CG::CGTYPE &Type,
                        event &EventRet) {
-    if (MIsInorder) {
+    // When a queue is recorded by a graph, the dependencies are managed in the
+    // graph implementaton. Additionally, CG recorded for a graph are outside of
+    // the in-order queue execution sequence. Therefore, these CG must not
+    // update MLastEvent.
+    if (MIsInorder && (getCommandGraph() == nullptr)) {
 
       auto IsExpDepManaged = [](const CG::CGTYPE &Type) {
         return Type == CG::CGTYPE::CodeplayHostTask;

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -12,6 +11,10 @@ int main() {
 
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
                sycl::property::queue::in_order{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   // Check if device has usm shared allocation
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations))

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Tests submitting an host kernel to an in-order queue before recording
+// Tests submitting a host kernel to an in-order queue before recording
 // commands from it.
 
 #include "../graph_common.hpp"

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
@@ -1,0 +1,65 @@
+// REQUIRES: cuda || level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests submitting an host kernel to an in-order queue before recording
+// commands from it.
+
+#include "../graph_common.hpp"
+
+int main() {
+  using T = int;
+
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
+               sycl::property::queue::in_order{}}};
+
+  // Check if device has usm shared allocation
+  if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations))
+    return 0;
+
+  T *TestData = sycl::malloc_shared<T>(Size, Queue);
+
+  ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
+                                                 Queue.get_device()};
+
+  Queue.submit([&](handler &CGH) {
+    CGH.host_task([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        TestData[i] = static_cast<T>(i);
+      }
+    });
+  });
+
+  Graph.begin_recording(Queue);
+
+  auto GraphEvent = Queue.submit([&](handler &CGH) {
+    CGH.single_task<class TestKernel2>([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        TestData[i] += static_cast<T>(i);
+      }
+    });
+  });
+
+  Graph.end_recording(Queue);
+
+  auto GraphExec = Graph.finalize();
+  Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+
+  Queue.submit([&](handler &CGH) {
+    CGH.single_task<class TestKernel3>([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        TestData[i] *= static_cast<T>(i);
+      }
+    });
+  });
+
+  Queue.wait_and_throw();
+
+  for (size_t i = 0; i < Size; i++) {
+    assert(TestData[i] == ((i + i) * i));
+  }
+
+  sycl::free(TestData, Queue);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -51,7 +51,7 @@ int main() {
 
   // Check Outputs
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == 1+i;
+    assert(TestDataOut[i] == 1+i);
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -51,7 +51,7 @@ int main() {
 
   // Check Outputs
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == 1+i);
+    assert(TestDataOut[i] == 1 + i);
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -12,6 +11,10 @@ int main() {
 
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
                sycl::property::queue::in_order{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   // Check if device has usm shared allocation
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations))

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -49,15 +49,9 @@ int main() {
 
   Queue.wait_and_throw();
 
-  std::vector<T> Reference(Size);
-  std::memset(Reference.data(), 1, Size * sizeof(T));
-  for (size_t i = 0; i < Size; i++) {
-    Reference[i] += i;
-  }
-
   // Check Outputs
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == Reference[i]);
+    assert(TestDataOut[i] == 1+i;
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -1,0 +1,63 @@
+// REQUIRES: cuda || level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests submitting memcpy to an in-order queue before recording
+// commands from it.
+
+#include "../graph_common.hpp"
+
+int main() {
+  using T = int;
+
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
+               sycl::property::queue::in_order{}}};
+
+  // Check if device has usm shared allocation
+  if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations))
+    return 0;
+
+  std::vector<T> TestDataIn(Size);
+  T *TestData = sycl::malloc_shared<T>(Size, Queue);
+  T *TestDataOut = sycl::malloc_shared<T>(Size, Queue);
+
+  ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
+                                                 Queue.get_device()};
+
+  std::memset(TestDataIn.data(), 1, Size * sizeof(T));
+  Queue.memcpy(TestData, TestDataIn.data(), Size * sizeof(T));
+
+  Graph.begin_recording(Queue);
+
+  auto GraphEvent = Queue.submit([&](handler &CGH) {
+    CGH.single_task<class TestKernel2>([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        TestData[i] += static_cast<T>(i);
+      }
+    });
+  });
+
+  Graph.end_recording(Queue);
+
+  auto GraphExec = Graph.finalize();
+  Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+
+  Queue.memcpy(TestDataOut, TestData, Size * sizeof(T));
+
+  Queue.wait_and_throw();
+
+  std::vector<T> Reference(Size);
+  std::memset(Reference.data(), 1, Size * sizeof(T));
+  for (size_t i = 0; i < Size; i++) {
+    Reference[i] += i;
+  }
+
+  // Check Outputs
+  for (size_t i = 0; i < Size; i++) {
+    assert(TestDataOut[i] == Reference[i]);
+  }
+
+  sycl::free(TestData, Queue);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -50,8 +50,10 @@ int main() {
   Queue.wait_and_throw();
 
   // Check Outputs
+  T Reference = 0;
+  std::memset(&Reference, 1, sizeof(T));
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == 1 + i);
+    assert(TestDataOut[i] == (Reference + i));
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -48,8 +48,10 @@ int main() {
   Queue.wait_and_throw();
 
   // Check Outputs
+  T Reference = 0;
+  std::memset(&Reference, 1, sizeof(T));
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == 1 + i);
+    assert(TestDataOut[i] == (Reference + i));
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -49,7 +49,7 @@ int main() {
 
   // Check Outputs
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == 1+i);
+    assert(TestDataOut[i] == 1 + i);
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -1,0 +1,61 @@
+// REQUIRES: cuda || level_zero, gpu
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests submitting memset to an in-order queue before recording
+// commands from it.
+
+#include "../graph_common.hpp"
+
+int main() {
+  using T = int;
+
+  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
+               sycl::property::queue::in_order{}}};
+
+  // Check if device has usm shared allocation
+  if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations))
+    return 0;
+
+  T *TestData = sycl::malloc_shared<T>(Size, Queue);
+  T *TestDataOut = sycl::malloc_shared<T>(Size, Queue);
+
+  ext::oneapi::experimental::command_graph Graph{Queue.get_context(),
+                                                 Queue.get_device()};
+
+  Queue.memset(TestData, 1, Size * sizeof(T));
+
+  Graph.begin_recording(Queue);
+
+  auto GraphEvent = Queue.submit([&](handler &CGH) {
+    CGH.single_task<class TestKernel2>([=]() {
+      for (size_t i = 0; i < Size; i++) {
+        TestData[i] += static_cast<T>(i);
+      }
+    });
+  });
+
+  Graph.end_recording(Queue);
+
+  auto GraphExec = Graph.finalize();
+  Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+
+  Queue.memcpy(TestDataOut, TestData, Size * sizeof(T));
+
+  Queue.wait_and_throw();
+
+  std::vector<T> Reference(Size);
+  std::memset(Reference.data(), 1, Size * sizeof(T));
+  for (size_t i = 0; i < Size; i++) {
+    Reference[i] += i;
+  }
+
+  // Check Outputs
+  for (size_t i = 0; i < Size; i++) {
+    assert(TestDataOut[i] == Reference[i]);
+  }
+
+  sycl::free(TestData, Queue);
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -49,7 +49,7 @@ int main() {
 
   // Check Outputs
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == 1+i;
+    assert(TestDataOut[i] == 1+i);
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: cuda || level_zero, gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -12,6 +11,10 @@ int main() {
 
   queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
                sycl::property::queue::in_order{}}};
+
+  if (!are_graphs_supported(Queue)) {
+    return 0;
+  }
 
   // Check if device has usm shared allocation
   if (!Queue.get_device().has(sycl::aspect::usm_shared_allocations))

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -47,15 +47,9 @@ int main() {
 
   Queue.wait_and_throw();
 
-  std::vector<T> Reference(Size);
-  std::memset(Reference.data(), 1, Size * sizeof(T));
-  for (size_t i = 0; i < Size; i++) {
-    Reference[i] += i;
-  }
-
   // Check Outputs
   for (size_t i = 0; i < Size; i++) {
-    assert(TestDataOut[i] == Reference[i]);
+    assert(TestDataOut[i] == 1+i;
   }
 
   sycl::free(TestData, Queue);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1265,8 +1265,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
 
   auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
   auto EventGraphWaitList = EventGraphImpl->getWaitList();
-  // Previous task is an host task. Explicit dependency is needed to enfore the
-  // execution order
+  // Previous task is a memset. Explicit dependency is needed to enforce the
+  // execution order.
   ASSERT_EQ(EventGraphWaitList.size(), 1lu);
   ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);
 
@@ -1341,7 +1341,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
 
   auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
   auto EventGraphWaitList = EventGraphImpl->getWaitList();
-  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // Previous task is a memcpy. Explicit dependency is needed to enforce the
   // execution order
   ASSERT_EQ(EventGraphWaitList.size(), 1lu);
   ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1285,7 +1285,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
   experimental::command_graph<experimental::graph_state::modifiable>
       InOrderGraph{InOrderQueue.get_context(), InOrderQueue.get_device()};
 
-  // Check if device has usm shared allocation
+  // Check if device has usm shared allocation.
   if (!InOrderQueue.get_device().has(sycl::aspect::usm_shared_allocations))
     return;
   size_t Size = 128;

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1199,7 +1199,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto EventLastWaitList = EventLastImpl->getWaitList();
-  // Previous task is not an host task. In Order queue dependency are managed by
+  // Previous task is not a host task. In Order queue dependency are managed by
   // the backend for non-host kernels
   ASSERT_EQ(EventLastWaitList.size(), 0lu);
 }

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1085,7 +1085,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
       InOrderQueue.submit([&](handler &CGH) { CGH.host_task([=]() {}); });
   auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
-  // Record in-order queue with three nodes
+  // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1130,7 +1130,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto WaitList = EventLastImpl->getWaitList();
   // Previous task is a host task. Explicit dependency is needed to enforce the
-  // execution order
+  // execution order.
   ASSERT_EQ(WaitList.size(), 1lu);
   ASSERT_EQ(WaitList[0], EventInitialImpl);
 }

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1200,7 +1200,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto EventLastWaitList = EventLastImpl->getWaitList();
   // Previous task is not a host task. In Order queue dependency are managed by
-  // the backend for non-host kernels
+  // the backend for non-host kernels.
   ASSERT_EQ(EventLastWaitList.size(), 0lu);
 }
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1190,7 +1190,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
 
   auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
   auto EventGraphWaitList = EventGraphImpl->getWaitList();
-  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // Previous task is a host task. Explicit dependency is needed to enforce the
   // execution order
   ASSERT_EQ(EventGraphWaitList.size(), 1lu);
   ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1350,8 +1350,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
       InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto EventLastWaitList = EventLastImpl->getWaitList();
-  // Previous task is not an host task. In Order queue dependency are managed by
-  // the backend for non-host kernels
+  // Previous task is not a host task. In Order queue dependency is managed by
+  // the backend for non-host kernels.
   ASSERT_EQ(EventLastWaitList.size(), 0lu);
 }
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1220,7 +1220,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   auto EventInitial = InOrderQueue.memset(TestData, 1, Size * sizeof(int));
   auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
-  // Record in-order queue with three nodes
+  // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1274,8 +1274,8 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
       InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto EventLastWaitList = EventLastImpl->getWaitList();
-  // Previous task is not an host task. In Order queue dependency are managed by
-  // the backend for non-host kernels
+  // Previous task is not a host task. In Order queue dependency is managed by
+  // the backend for non-host kernels.
   ASSERT_EQ(EventLastWaitList.size(), 0lu);
 }
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1210,7 +1210,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   experimental::command_graph<experimental::graph_state::modifiable>
       InOrderGraph{InOrderQueue.get_context(), InOrderQueue.get_device()};
 
-  // Check if device has usm shared allocation
+  // Check if device has usm shared allocation.
   if (!InOrderQueue.get_device().has(sycl::aspect::usm_shared_allocations))
     return;
   size_t Size = 128;

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1129,7 +1129,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
 
   auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
   auto WaitList = EventLastImpl->getWaitList();
-  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // Previous task is a host task. Explicit dependency is needed to enforce the
   // execution order
   ASSERT_EQ(WaitList.size(), 1lu);
   ASSERT_EQ(WaitList[0], EventInitialImpl);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1105,7 +1105,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode1->MSuccessors.front().lock(), PtrNode2);
   ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
@@ -1118,7 +1118,7 @@ TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode2->MSuccessors.front().lock(), PtrNode3);
   ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
 
@@ -1165,7 +1165,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode1->MSuccessors.front().lock(), PtrNode2);
   ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
@@ -1178,7 +1178,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode2->MSuccessors.front().lock(), PtrNode3);
   ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
 
@@ -1240,7 +1240,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode1->MSuccessors.front().lock(), PtrNode2);
   ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
@@ -1253,7 +1253,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode2->MSuccessors.front().lock(), PtrNode3);
   ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
 
@@ -1316,7 +1316,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
   ASSERT_NE(PtrNode2, nullptr);
   ASSERT_NE(PtrNode2, PtrNode1);
   ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode1->MSuccessors.front().lock(), PtrNode2);
   ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
 
@@ -1329,7 +1329,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
   ASSERT_NE(PtrNode3, nullptr);
   ASSERT_NE(PtrNode3, PtrNode2);
   ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
-  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode2->MSuccessors.front().lock(), PtrNode3);
   ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
   ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1145,7 +1145,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
       InOrderQueue.submit([&](handler &CGH) { CGH.host_task([=]() {}); });
   auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
-  // Record in-order queue with three nodes
+  // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1191,7 +1191,7 @@ TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
   auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
   auto EventGraphWaitList = EventGraphImpl->getWaitList();
   // Previous task is a host task. Explicit dependency is needed to enforce the
-  // execution order
+  // execution order.
   ASSERT_EQ(EventGraphWaitList.size(), 1lu);
   ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);
 

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1075,6 +1075,286 @@ TEST_F(CommandGraphTest, InOrderQueueWithEmptyLast) {
   ASSERT_EQ(InOrderQueue.get_context(), GraphExecImpl->getContext());
 }
 
+TEST_F(CommandGraphTest, InOrderQueueWithPreviousHostTask) {
+  sycl::property_list Properties{sycl::property::queue::in_order()};
+  sycl::queue InOrderQueue{Dev, Properties};
+  experimental::command_graph<experimental::graph_state::modifiable>
+      InOrderGraph{InOrderQueue.get_context(), InOrderQueue.get_device()};
+
+  auto EventInitial =
+      InOrderQueue.submit([&](handler &CGH) { CGH.host_task([=]() {}); });
+  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
+
+  // Record in-order queue with three nodes
+  InOrderGraph.begin_recording(InOrderQueue);
+  auto Node1Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode1 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode1, nullptr);
+  ASSERT_TRUE(PtrNode1->MPredecessors.empty());
+
+  auto Node2Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode2 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode2, nullptr);
+  ASSERT_NE(PtrNode2, PtrNode1);
+  ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
+
+  auto Node3Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode3 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode3, nullptr);
+  ASSERT_NE(PtrNode3, PtrNode2);
+  ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
+
+  InOrderGraph.end_recording(InOrderQueue);
+
+  auto EventLast = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
+  auto WaitList = EventLastImpl->getWaitList();
+  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // execution order
+  ASSERT_EQ(WaitList.size(), 1lu);
+  ASSERT_EQ(WaitList[0], EventInitialImpl);
+}
+
+TEST_F(CommandGraphTest, InOrderQueueHostTaskAndGraph) {
+  sycl::property_list Properties{sycl::property::queue::in_order()};
+  sycl::queue InOrderQueue{Dev, Properties};
+  experimental::command_graph<experimental::graph_state::modifiable>
+      InOrderGraph{InOrderQueue.get_context(), InOrderQueue.get_device()};
+
+  auto EventInitial =
+      InOrderQueue.submit([&](handler &CGH) { CGH.host_task([=]() {}); });
+  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
+
+  // Record in-order queue with three nodes
+  InOrderGraph.begin_recording(InOrderQueue);
+  auto Node1Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode1 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode1, nullptr);
+  ASSERT_TRUE(PtrNode1->MPredecessors.empty());
+
+  auto Node2Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode2 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode2, nullptr);
+  ASSERT_NE(PtrNode2, PtrNode1);
+  ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
+
+  auto Node3Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode3 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode3, nullptr);
+  ASSERT_NE(PtrNode3, PtrNode2);
+  ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
+
+  InOrderGraph.end_recording(InOrderQueue);
+
+  auto InOrderGraphExec = InOrderGraph.finalize();
+  auto EventGraph = InOrderQueue.submit(
+      [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(InOrderGraphExec); });
+
+  auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
+  auto EventGraphWaitList = EventGraphImpl->getWaitList();
+  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // execution order
+  ASSERT_EQ(EventGraphWaitList.size(), 1lu);
+  ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);
+
+  auto EventLast = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+  auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
+  auto EventLastWaitList = EventLastImpl->getWaitList();
+  // Previous task is not an host task. In Order queue dependency are managed by
+  // the backend for non-host kernels
+  ASSERT_EQ(EventLastWaitList.size(), 0lu);
+}
+
+TEST_F(CommandGraphTest, InOrderQueueMemsetAndGraph) {
+  sycl::property_list Properties{sycl::property::queue::in_order()};
+  sycl::queue InOrderQueue{Dev, Properties};
+  experimental::command_graph<experimental::graph_state::modifiable>
+      InOrderGraph{InOrderQueue.get_context(), InOrderQueue.get_device()};
+
+  // Check if device has usm shared allocation
+  if (!InOrderQueue.get_device().has(sycl::aspect::usm_shared_allocations))
+    return;
+  size_t Size = 128;
+  std::vector<int> TestDataHost(Size);
+  int *TestData = sycl::malloc_shared<int>(Size, InOrderQueue);
+
+  auto EventInitial = InOrderQueue.memset(TestData, 1, Size * sizeof(int));
+  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
+
+  // Record in-order queue with three nodes
+  InOrderGraph.begin_recording(InOrderQueue);
+  auto Node1Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode1 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode1, nullptr);
+  ASSERT_TRUE(PtrNode1->MPredecessors.empty());
+
+  auto Node2Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode2 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode2, nullptr);
+  ASSERT_NE(PtrNode2, PtrNode1);
+  ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
+
+  auto Node3Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode3 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode3, nullptr);
+  ASSERT_NE(PtrNode3, PtrNode2);
+  ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
+
+  InOrderGraph.end_recording(InOrderQueue);
+
+  auto InOrderGraphExec = InOrderGraph.finalize();
+  auto EventGraph = InOrderQueue.submit(
+      [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(InOrderGraphExec); });
+
+  auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
+  auto EventGraphWaitList = EventGraphImpl->getWaitList();
+  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // execution order
+  ASSERT_EQ(EventGraphWaitList.size(), 1lu);
+  ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);
+
+  auto EventLast =
+      InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
+  auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
+  auto EventLastWaitList = EventLastImpl->getWaitList();
+  // Previous task is not an host task. In Order queue dependency are managed by
+  // the backend for non-host kernels
+  ASSERT_EQ(EventLastWaitList.size(), 0lu);
+}
+
+TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
+  sycl::property_list Properties{sycl::property::queue::in_order()};
+  sycl::queue InOrderQueue{Dev, Properties};
+  experimental::command_graph<experimental::graph_state::modifiable>
+      InOrderGraph{InOrderQueue.get_context(), InOrderQueue.get_device()};
+
+  // Check if device has usm shared allocation
+  if (!InOrderQueue.get_device().has(sycl::aspect::usm_shared_allocations))
+    return;
+  size_t Size = 128;
+  std::vector<int> TestDataHost(Size);
+  int *TestData = sycl::malloc_shared<int>(Size, InOrderQueue);
+
+  auto EventInitial =
+      InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
+  auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
+
+  // Record in-order queue with three nodes
+  InOrderGraph.begin_recording(InOrderQueue);
+  auto Node1Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode1 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode1, nullptr);
+  ASSERT_TRUE(PtrNode1->MPredecessors.empty());
+
+  auto Node2Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode2 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode2, nullptr);
+  ASSERT_NE(PtrNode2, PtrNode1);
+  ASSERT_EQ(PtrNode1->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode1->MSuccessors.front(), PtrNode2);
+  ASSERT_EQ(PtrNode2->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MPredecessors.front().lock(), PtrNode1);
+
+  auto Node3Graph = InOrderQueue.submit(
+      [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });
+
+  auto PtrNode3 =
+      sycl::detail::getSyclObjImpl(InOrderGraph)
+          ->getLastInorderNode(sycl::detail::getSyclObjImpl(InOrderQueue));
+  ASSERT_NE(PtrNode3, nullptr);
+  ASSERT_NE(PtrNode3, PtrNode2);
+  ASSERT_EQ(PtrNode2->MSuccessors.size(), 1lu);
+  ASSERT_EQ(PtrNode2->MSuccessors.front(), PtrNode3);
+  ASSERT_EQ(PtrNode3->MPredecessors.size(), 1lu);
+  ASSERT_EQ(PtrNode3->MPredecessors.front().lock(), PtrNode2);
+
+  InOrderGraph.end_recording(InOrderQueue);
+
+  auto InOrderGraphExec = InOrderGraph.finalize();
+  auto EventGraph = InOrderQueue.submit(
+      [&](sycl::handler &CGH) { CGH.ext_oneapi_graph(InOrderGraphExec); });
+
+  auto EventGraphImpl = sycl::detail::getSyclObjImpl(EventGraph);
+  auto EventGraphWaitList = EventGraphImpl->getWaitList();
+  // Previous task is an host task. Explicit dependency is needed to enfore the
+  // execution order
+  ASSERT_EQ(EventGraphWaitList.size(), 1lu);
+  ASSERT_EQ(EventGraphWaitList[0], EventInitialImpl);
+
+  auto EventLast =
+      InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
+  auto EventLastImpl = sycl::detail::getSyclObjImpl(EventLast);
+  auto EventLastWaitList = EventLastImpl->getWaitList();
+  // Previous task is not an host task. In Order queue dependency are managed by
+  // the backend for non-host kernels
+  ASSERT_EQ(EventLastWaitList.size(), 0lu);
+}
+
 TEST_F(CommandGraphTest, ExplicitBarrierException) {
 
   std::error_code ExceptionCode = make_error_code(sycl::errc::success);

--- a/sycl/unittests/Extensions/CommandGraph.cpp
+++ b/sycl/unittests/Extensions/CommandGraph.cpp
@@ -1296,7 +1296,7 @@ TEST_F(CommandGraphTest, InOrderQueueMemcpyAndGraph) {
       InOrderQueue.memcpy(TestData, TestDataHost.data(), Size * sizeof(int));
   auto EventInitialImpl = sycl::detail::getSyclObjImpl(EventInitial);
 
-  // Record in-order queue with three nodes
+  // Record in-order queue with three nodes.
   InOrderGraph.begin_recording(InOrderQueue);
   auto Node1Graph = InOrderQueue.submit(
       [&](sycl::handler &cgh) { cgh.single_task<TestKernel<>>([]() {}); });


### PR DESCRIPTION
When a host-task is submitted to in-order queue, dependency between this host-task and the successor is explicitly handled.
However, when we record an in-order queue, the recorded CG are not part of the regular in-order queue execution sequence.
But inter-CG dependencies are managed by the graph implementation.
This PR implements this point and ensures that recording an in-order does not impact the normal execution sequence.
Tests (e2e and unitest) have been added to check it.
