### PR TITLE
[SYCL][Graph] Skip prefetch/memadvise opencl tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/memadvise.cpp
+++ b/sycl/test-e2e/Graph/Explicit/memadvise.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %if linux && (level_zero || cuda) %{ env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 FileCheck %s %} %else %{ %{run} %t.out %}
 
+// Mem advise command not supported for OpenCL
+// UNSUPPORTED: opencl
+
 // Since Mem advise is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking PI function calls.

--- a/sycl/test-e2e/Graph/Explicit/prefetch.cpp
+++ b/sycl/test-e2e/Graph/Explicit/prefetch.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %if linux && (level_zero || cuda) %{ env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 FileCheck %s %} %else %{ %{run} %t.out %}
 
+// prefetch command not supported for OpenCL
+// UNSUPPORTED: opencl
+
 // Since Prefetch is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking PI function calls

--- a/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %if linux && (level_zero || cuda) %{ env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 FileCheck %s %} %else %{ %{run} %t.out %}
 
+// Mem advise command not supported for OpenCL
+// UNSUPPORTED: opencl
+
 // Since Mem advise is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking PI function calls.

--- a/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %if linux && (level_zero || cuda) %{ env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 FileCheck %s %} %else %{ %{run} %t.out %}
 
+// prefetch command not supported for OpenCL
+// UNSUPPORTED: opencl
+
 // Since Prefetch is only a memory hint that doesn't
 // impact results but only performances, we verify
 // that a node is correctly added by checking PI function calls


### PR DESCRIPTION
In https://github.com/intel/llvm/pull/11474 it was noted in the documentation that the `prefetch` and `memadvise` handler methods were not supported as graph nodes on the OpenCL command-buffer backend.

However, we never disabled the E2E tests for this target, which wasn't picked up by CI, as CI doesn't use the command-buffer extension in its OpenCL config. This PR corrects this oversight by marking the tests as unsupported for OpenCL.