### PR TITLE
[SYCL] Try to fix internal self-build after builtins refactoring PR

### DIFF
--- a/sycl/include/sycl/detail/builtins/helper_macros.hpp
+++ b/sycl/include/sycl/detail/builtins/helper_macros.hpp
@@ -188,6 +188,12 @@
   DEVICE_IMPL_TEMPLATE_CUSTOM_DELEGATE(NUM_ARGS, NAME, ENABLER,                \
                                        builtin_marray_impl, sycl, __VA_ARGS__)
 
+#ifdef __SYCL_BUILD_SYCL_DLL
+#define SYCL_BUILTIN_EXPORT __SYCL_EXPORT
+#else
+#define SYCL_BUILTIN_EXPORT
+#endif
+
 // Use extern function declaration in function scope to save compile time.
 // Otherwise the FE has to parse multiple types/VLs/functions costing us around
 // 0.3s in compile-time. It also allows us to skip providing all the explicit
@@ -204,7 +210,7 @@
      */                                                                        \
     using ret_ty = typename detail::RET_TYPE_TRAITS<                           \
         typename detail::first_type<Ts...>::type>::type;                       \
-    extern ret_ty __##NAME##_impl(Ts...);                                      \
+    extern SYCL_BUILTIN_EXPORT ret_ty __##NAME##_impl(Ts...);                  \
     return __##NAME##_impl(xs...);                                             \
   }                                                                            \
   template <NUM_ARGS##_TYPENAME_TYPE>                                          \
@@ -223,7 +229,8 @@
 
 #define HOST_IMPL_SCALAR_RET_TYPE(NUM_ARGS, NAME, RET_TYPE, TYPE)              \
   inline RET_TYPE NAME(NUM_ARGS##_TYPE_ARG(TYPE)) {                            \
-    extern RET_TYPE __##NAME##_impl(NUM_ARGS##_TYPE(TYPE));                    \
+    extern SYCL_BUILTIN_EXPORT RET_TYPE __##NAME##_impl(                       \
+        NUM_ARGS##_TYPE(TYPE));                                                \
     return __##NAME##_impl(NUM_ARGS##_ARG);                                    \
   }
 

--- a/sycl/include/sycl/detail/builtins/math_functions.inc
+++ b/sycl/include/sycl/detail/builtins/math_functions.inc
@@ -394,7 +394,7 @@ detail::builtin_enable_math_allow_scalar_t<T0> modf(
 #else
 #define SCALAR_EXTERN_LAST_INT(NAME, TYPE)                                     \
   inline TYPE NAME(TYPE x, int y) {                                            \
-    extern TYPE __##NAME##_impl(TYPE, int);                                    \
+    extern SYCL_BUILTIN_EXPORT TYPE __##NAME##_impl(TYPE, int);                \
     return __##NAME##_impl(x, y);                                              \
   }
 #define BUILTIN_MATH_LAST_INT(NAME)                                            \
@@ -488,15 +488,15 @@ inline int ilogb(half x) {
 DEVICE_IMPL_TEMPLATE(ONE_ARG, ilogb, builtin_enable_ilogb_t, __spirv_ocl_ilogb)
 #else
 inline int ilogb(float x) {
-  extern int __ilogb_impl(float);
+  extern SYCL_BUILTIN_EXPORT int __ilogb_impl(float);
   return __ilogb_impl(x);
 }
 inline int ilogb(double x) {
-  extern int __ilogb_impl(double);
+  extern SYCL_BUILTIN_EXPORT int __ilogb_impl(double);
   return __ilogb_impl(x);
 }
 inline int ilogb(half x) {
-  extern int __ilogb_impl(half);
+  extern SYCL_BUILTIN_EXPORT int __ilogb_impl(half);
   return __ilogb_impl(x);
 }
 HOST_IMPL_TEMPLATE(ONE_ARG, ilogb, builtin_enable_ilogb_t, math,


### PR DESCRIPTION
clang rejects dllexport defintion if previous declaration didn't have it, make sure we have declaration/definition in sync when building libsycl.