### PR TITLE
[SYCL][Driver] Fix per-device ocloc argument

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1315,7 +1315,7 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
         // For AOT, Use ocloc's per-device options flag with the correct ocloc
         // option to honor the user's specification.
         PerDeviceArgs.push_back(
-            {DeviceName, Args.MakeArgString("-options " + BackendOptName)});
+            {DeviceName, Args.MakeArgString(BackendOptName)});
       } else if (Triple.isSPIR() &&
                  Triple.getSubArch() == llvm::Triple::NoSubArch) {
         // For JIT, pass -ftarget-register-alloc-mode=Device:BackendOpt to
@@ -1334,8 +1334,7 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     StringRef DeviceName = "pvc";
     StringRef BackendOptName = SYCL::gen::getGenGRFFlag("auto");
     if (IsGen)
-      PerDeviceArgs.push_back(
-          {DeviceName, Args.MakeArgString("-options " + BackendOptName)});
+      PerDeviceArgs.push_back({DeviceName, Args.MakeArgString(BackendOptName)});
     else if (Triple.isSPIR() &&
              Triple.getSubArch() == llvm::Triple::NoSubArch) {
       BeArgs.push_back(Args.MakeArgString(RegAllocModeOptName + DeviceName +

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
@@ -62,27 +62,27 @@
 // AUTO_AOT: ocloc{{.*}} "-output"
 // AUTO_AOT: -device_options
 // AUTO_AOT: pvc
-// AUTO_AOT: "-options -ze-intel-enable-auto-large-GRF-mode"
+// AUTO_AOT: "-ze-intel-enable-auto-large-GRF-mode"
 
 // LARGE_AOT: ocloc{{.*}} "-output"
 // LARGE_AOT: -device_options
 // LARGE_AOT: pvc
-// LARGE_AOT: "-options -ze-opt-large-register-file"
+// LARGE_AOT: "-ze-opt-large-register-file"
 
 // SMALL_AOT: ocloc{{.*}} "-output"
 // SMALL_AOT: -device_options
 // SMALL_AOT: pvc
-// SMALL_AOT: "-options -ze-intel-128-GRF-per-thread"
+// SMALL_AOT: "-ze-intel-128-GRF-per-thread"
 
 // DEFAULT_AOT-NOT: -device_options
 
 // MULTIPLE_ARGS_AOT: ocloc{{.*}} "-output"
 // MULTIPLE_ARGS_AOT: -device_options
 // MULTIPLE_ARGS_AOT: pvc
-// MULTIPLE_ARGS_AOT: "-options -ze-intel-128-GRF-per-thread"
+// MULTIPLE_ARGS_AOT: "-ze-intel-128-GRF-per-thread"
 // MULTIPLE_ARGS_AOT: -device_options
 // MULTIPLE_ARGS_AOT: pvc
-// MULTIPLE_ARGS_AOT: "-options -ze-opt-large-register-file"
+// MULTIPLE_ARGS_AOT: "-ze-opt-large-register-file"
 
 // AUTO_JIT: clang-offload-wrapper{{.*}} "-compile-opts=-ftarget-register-alloc-mode=pvc:-ze-intel-enable-auto-large-GRF-mode"
 


### PR DESCRIPTION
We shouldn't add `-options` as per the IGC team.