### PR TITLE
[DebugInfo] Generate debug info for system typedefs with -fno-system-debug

### DIFF
--- a/clang/lib/CodeGen/CGDebugInfo.cpp
+++ b/clang/lib/CodeGen/CGDebugInfo.cpp
@@ -6027,6 +6027,18 @@ bool clang::CodeGen::noSystemDebugInfo(const Decl *D,
                                        const CodeGenModule &CGM) {
   // Declaration is in system file
   if (CGM.getContext().getSourceManager().isInSystemHeader(D->getLocation())) {
+    // Make an exception for typedefs in system header files.  Generate debug
+    // information for these decls because these are rare (thus they will not
+    // greatly increase debug size) and a user could rely on these typedefs
+    // during debugging. For example uid_t in in "sys/types.h" can be used in
+    // the gdb command:
+    //
+    //    print ruid == (uid_t)-1
+    //
+    // This occurs in GDB test gdb.reverse/getresuid-reverse.c
+    if (isa<TypedefDecl>(D))
+      return false;
+
     // -fno-system-debug was used.  Do not generate debug info.
     if (CGM.getCodeGenOpts().NoSystemDebug)
       return true;

--- a/clang/test/CodeGen/debug-info-system-typedef.c
+++ b/clang/test/CodeGen/debug-info-system-typedef.c
@@ -4,6 +4,9 @@
 // typedef-ed in system headers.  Thus, the increased debuggability
 // is worth the small extra cost.
 
+// Windows does not have <unistd.h>
+// UNSUPPORTED: system-windows
+
 // RUN: %clang -fno-system-debug -emit-llvm -S -g %s -o %t.ll
 
 // RUN: FileCheck %s < %t.ll

--- a/clang/test/CodeGen/debug-info-system-typedef.c
+++ b/clang/test/CodeGen/debug-info-system-typedef.c
@@ -1,0 +1,25 @@
+// Ensure that debug info for typedefs in system headers is still generated
+// even if -fno-system-debug is used.  This is justified because debug size 
+// savings is small, but debugging is commonly done with types that are
+// typedef-ed in system headers.  Thus, the increased debuggability
+// is worth the small extra cost.
+
+// RUN: %clang -fno-system-debug -emit-llvm -S -g %s -o %t.ll
+
+// RUN: FileCheck %s < %t.ll
+
+// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "gid_t",
+// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "__gid_t",
+// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "uid_t",
+// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "__uid_t",
+  
+#include <unistd.h>
+
+uid_t xuid;
+gid_t xgid;
+
+int
+main (void)
+{
+  return 0;
+}

--- a/clang/test/CodeGen/debug-info-system-typedef.c
+++ b/clang/test/CodeGen/debug-info-system-typedef.c
@@ -4,22 +4,31 @@
 // typedef-ed in system headers.  Thus, the increased debuggability
 // is worth the small extra cost.
 
-// Windows does not have <unistd.h>
-// UNSUPPORTED: system-windows
-
 // RUN: %clang -fno-system-debug -emit-llvm -S -g %s -o %t.ll
 
 // RUN: FileCheck %s < %t.ll
 
-// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "gid_t",
-// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "__gid_t",
-// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "uid_t",
-// CHECK: !DIDerivedType(tag: DW_TAG_typedef, name: "__uid_t",
-  
-#include <unistd.h>
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "int_fast8_t",
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "int_fast16_t",
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "int_fast32_t",
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "int_fast64_t",
 
-uid_t xuid;
-gid_t xgid;
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "uint_fast8_t",
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "uint_fast16_t",
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "uint_fast32_t",
+// CHECK-DAG: !DIDerivedType(tag: DW_TAG_typedef, name: "uint_fast64_t",
+  
+#include <stdint.h>
+
+int_fast8_t   f8;
+int_fast16_t  f16;
+int_fast32_t  f32;
+int_fast64_t  f64;
+
+uint_fast8_t   uf8;
+uint_fast16_t  uf16;
+uint_fast32_t  uf32;
+uint_fast64_t  uf64;
 
 int
 main (void)


### PR DESCRIPTION
Generate debug info for system typedefs even with -fno-system-debug.  Allow this because system typedefs are rare and thus the amount of extra info is small.  Also it is not uncommon to use typedefs supplied in a header file for debugging.  This makes it less likely for -fno-system-debug to cause a debugging problem at a small cost in debug info size.