### PR TITLE
[SYCL][Fusion][NoSTL] Use free functions for configuration management

### DIFF
--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -54,13 +54,26 @@ private:
 class KernelFusion {
 
 public:
-  static FusionResult fuseKernels(
-      Config &&JITConfig, const std::vector<SYCLKernelInfo> &KernelInformation,
-      const char *FusedKernelName, jit_compiler::ParamIdentList &Identities,
-      BarrierFlags BarriersFlags,
-      const std::vector<jit_compiler::ParameterInternalization>
-          &Internalization,
-      const std::vector<jit_compiler::JITConstant> &JITConstants);
+  static FusionResult
+  fuseKernels(const std::vector<SYCLKernelInfo> &KernelInformation,
+              const char *FusedKernelName,
+              jit_compiler::ParamIdentList &Identities,
+              BarrierFlags BarriersFlags,
+              const std::vector<jit_compiler::ParameterInternalization>
+                  &Internalization,
+              const std::vector<jit_compiler::JITConstant> &JITConstants);
+
+  /// Clear all previously set options.
+  static void resetConfiguration();
+
+  /// Set \p Opt to the value built in-place by \p As.
+  template <typename Opt, typename... Args> static void set(Args &&...As) {
+    set(new Opt{std::forward<Args>(As)...});
+  }
+
+private:
+  /// Take ownership of \p Option and include it in the current configuration.
+  static void set(OptionPtrBase *Option);
 };
 
 } // namespace jit_compiler

--- a/sycl-fusion/jit-compiler/include/Options.h
+++ b/sycl-fusion/jit-compiler/include/Options.h
@@ -11,77 +11,43 @@
 
 #include "Kernel.h"
 
-#include <memory>
-#include <unordered_map>
-
 namespace jit_compiler {
 
 enum OptionID { VerboseOutput, EnableCaching, TargetDeviceInfo };
 
-class OptionPtrBase {};
-
-class Config {
+class OptionPtrBase {
+protected:
+  explicit OptionPtrBase(OptionID Id) : Id(Id) {}
 
 public:
-  template <typename Opt> void set(typename Opt::ValueType Value) {
-    Opt::set(*this, Value);
-  }
-
-  template <typename Opt> typename Opt::ValueType get() {
-    return Opt::get(*this);
-  }
-
-private:
-  std::unordered_map<OptionID, std::unique_ptr<OptionPtrBase>> OptionValues;
-
-  void set(OptionID ID, std::unique_ptr<OptionPtrBase> Value) {
-    OptionValues[ID] = std::move(Value);
-  }
-
-  OptionPtrBase *get(OptionID ID) {
-    if (OptionValues.count(ID)) {
-      return OptionValues.at(ID).get();
-    }
-    return nullptr;
-  }
-
-  template <OptionID ID, typename T> friend class OptionBase;
+  const OptionID Id;
 };
 
-template <OptionID ID, typename T> class OptionBase : public OptionPtrBase {
-public:
+template <OptionID ID, typename T> struct OptionBase : public OptionPtrBase {
+  static constexpr OptionID Id = ID;
   using ValueType = T;
 
-protected:
-  static void set(Config &Cfg, T Value) {
-    Cfg.set(ID,
-            std::unique_ptr<OptionBase<ID, T>>{new OptionBase<ID, T>{Value}});
-  }
+  template <typename... Args>
+  explicit OptionBase(Args &&...As)
+      : OptionPtrBase{ID}, Value{std::forward<Args>(As)...} {}
 
-  static const T get(Config &Cfg) {
-    auto *ConfigValue = Cfg.get(ID);
-    if (!ConfigValue) {
-      return T{};
-    }
-    return static_cast<OptionBase<ID, T> *>(ConfigValue)->Value;
-  }
-
-private:
   T Value;
-
-  OptionBase(T Val) : Value{Val} {}
-
-  friend Config;
 };
 
 namespace option {
 
-struct JITEnableVerbose : public OptionBase<OptionID::VerboseOutput, bool> {};
+struct JITEnableVerbose : public OptionBase<OptionID::VerboseOutput, bool> {
+  using OptionBase::OptionBase;
+};
 
-struct JITEnableCaching : public OptionBase<OptionID::EnableCaching, bool> {};
+struct JITEnableCaching : public OptionBase<OptionID::EnableCaching, bool> {
+  using OptionBase::OptionBase;
+};
 
 struct JITTargetInfo
-    : public OptionBase<OptionID::TargetDeviceInfo, TargetInfo> {};
+    : public OptionBase<OptionID::TargetDeviceInfo, TargetInfo> {
+  using OptionBase::OptionBase;
+};
 
 } // namespace option
 } // namespace jit_compiler

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -71,14 +71,11 @@ static bool isTargetFormatSupported(BinaryFormat TargetFormat) {
 }
 
 FusionResult KernelFusion::fuseKernels(
-    Config &&JITConfig, const std::vector<SYCLKernelInfo> &KernelInformation,
+    const std::vector<SYCLKernelInfo> &KernelInformation,
     const char *FusedKernelName, ParamIdentList &Identities,
     BarrierFlags BarriersFlags,
     const std::vector<jit_compiler::ParameterInternalization> &Internalization,
     const std::vector<jit_compiler::JITConstant> &Constants) {
-  // Initialize the configuration helper to make the options for this invocation
-  // available (on a per-thread basis).
-  ConfigHelper::setConfig(std::move(JITConfig));
 
   std::vector<std::string> KernelsToFuse;
   llvm::transform(KernelInformation, std::back_inserter(KernelsToFuse),
@@ -193,4 +190,10 @@ FusionResult KernelFusion::fuseKernels(
   }
 
   return FusionResult{FusedKernelInfo};
+}
+
+void KernelFusion::resetConfiguration() { ConfigHelper::reset(); }
+
+void KernelFusion::set(OptionPtrBase *Option) {
+  ConfigHelper::getConfig().set(Option);
 }

--- a/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
+++ b/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
@@ -11,11 +11,44 @@
 
 #include "Options.h"
 
+#include <memory>
+#include <unordered_map>
+
 namespace jit_compiler {
+
+class Config {
+
+public:
+  template <typename Opt> typename Opt::ValueType get() const {
+    using T = typename Opt::ValueType;
+
+    auto *ConfigValue = get(Opt::Id);
+    if (!ConfigValue) {
+      return T{};
+    }
+    return static_cast<const OptionBase<Opt::Id, T> *>(ConfigValue)->Value;
+  }
+
+  void set(OptionPtrBase *Option) {
+    OptionValues[Option->Id] = std::unique_ptr<OptionPtrBase>(Option);
+  }
+
+private:
+  std::unordered_map<OptionID, std::unique_ptr<OptionPtrBase>> OptionValues;
+
+  const OptionPtrBase *get(OptionID ID) const {
+    const auto Iter = OptionValues.find(ID);
+    if (Iter == OptionValues.end()) {
+      return nullptr;
+    }
+    return Iter->second.get();
+  }
+};
 
 class ConfigHelper {
 public:
-  static void setConfig(Config &&JITConfig) { Cfg = std::move(JITConfig); }
+  static void reset() { Cfg = {}; }
+  static Config &getConfig() { return Cfg; }
 
   template <typename Opt> static typename Opt::ValueType get() {
     return Cfg.get<Opt>();

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -823,20 +823,22 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
 
   static size_t FusedKernelNameIndex = 0;
   auto FusedKernelName = "fused_" + std::to_string(FusedKernelNameIndex++);
-  ::jit_compiler::Config JITConfig;
+  ::jit_compiler::KernelFusion::resetConfiguration();
   bool DebugEnabled =
       detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() > 0;
-  JITConfig.set<::jit_compiler::option::JITEnableVerbose>(DebugEnabled);
-  JITConfig.set<::jit_compiler::option::JITEnableCaching>(
+  ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITEnableVerbose>(
+      DebugEnabled);
+  ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITEnableCaching>(
       detail::SYCLConfig<detail::SYCL_ENABLE_FUSION_CACHING>::get());
 
   ::jit_compiler::TargetInfo TargetInfo = getTargetInfo(Queue);
   ::jit_compiler::BinaryFormat TargetFormat = TargetInfo.getFormat();
-  JITConfig.set<::jit_compiler::option::JITTargetInfo>(TargetInfo);
+  ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITTargetInfo>(
+      std::move(TargetInfo));
 
   auto FusionResult = ::jit_compiler::KernelFusion::fuseKernels(
-      std::move(JITConfig), InputKernelInfo, FusedKernelName.c_str(),
-      ParamIdentities, BarrierFlags, InternalizeParams, JITConstants);
+      InputKernelInfo, FusedKernelName.c_str(), ParamIdentities, BarrierFlags,
+      InternalizeParams, JITConstants);
 
   if (FusionResult.failed()) {
     if (DebugEnabled) {


### PR DESCRIPTION
Untangle the interaction between options and the `Config` class, and hide `Config` (which needs to store options in a map) from the KF interface.

The idea is to introduce free functions to interact with the `thread_local` instance of `Config` held by the existing `ConfigHelper` class, instead of letting the client construct the `Config` object and handing it to over `ConfigHelper` for storing it.

_This PR is part of a series of changes to remove uses of STL classes in the kernel fusion interface to prevent ABI issues in the future._