### PR TITLE
[SYCL][NFC] Fix L0 USM capabilities test

### DIFF
--- a/sycl/test-e2e/Plugin/level-zero-usm-capabilities.cpp
+++ b/sycl/test-e2e/Plugin/level-zero-usm-capabilities.cpp
@@ -13,7 +13,7 @@
 // CHECK:  usm_shared_allocations: 1
 // CHECK:  usm_system_allocations: 0
 // CHECK:  usm_atomic_host_allocations: 0
-// CHECK:  usm_atomic_shared_allocations: 0
+// usm_atomic_shared_allocations is device and driver version dependent.
 
 using namespace sycl;
 


### PR DESCRIPTION
usm_atomic_shared_allocations is supported on PVC with newer GPU driver versions.