### PR TITLE
[SYCL][E2E][NFC] Fix Plugin/max_malloc.cpp test after PR#12375

### DIFF
--- a/sycl/test-e2e/Plugin/max_malloc.cpp
+++ b/sycl/test-e2e/Plugin/max_malloc.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: level_zero, level_zero_dev_kit
 // RUN: %{build} %level_zero_options -o %t.out
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS=-ze-intel-greater-than-4GB-buffer-required %{run} %t.out
+// RUN: env UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1 SYCL_PROGRAM_COMPILE_OPTIONS=-ze-intel-greater-than-4GB-buffer-required %{run} %t.out
 
 // TODO: Temporarily disabled on Linux due to failures.
 // UNSUPPORTED: linux


### PR DESCRIPTION
After PR#12375 user have to explicitly request > 4GB allocation support given the max allocation allowed on that system is less than 4GB. Setting UR_L0_ENABLE_RELAXED_ALLOCATION_LIMITS=1 will allow for the allocations to exceed the max single allocation size limit for that device.