### PR TITLE
[SYCL] Limit bfloat16 operators to scalar datatypes convertible to float

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/bfloat16_type_traits.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/bfloat16_type_traits.hpp
@@ -94,6 +94,8 @@ inline std::ostream &operator<<(std::ostream &O, bfloat16 const &rhs) {
   return O;
 }
 
+template <> struct is_esimd_arithmetic_type<bfloat16, void> : std::true_type {};
+
 } // namespace ext::intel::esimd::detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -156,28 +156,15 @@ public:
     return lhs = f;                                                            \
   }                                                                            \
   template <typename T>                                                        \
-  friend std::enable_if_t<                                                     \
-      std::is_convertible_v<T, float> && std::is_scalar_v<T>, bfloat16>        \
+  friend std::enable_if_t<std::is_convertible_v<T, float>, bfloat16>           \
       &operator op(bfloat16 & lhs, const T & rhs) {                            \
     float f = static_cast<float>(lhs);                                         \
     f op static_cast<float>(rhs);                                              \
     return lhs = f;                                                            \
   }                                                                            \
   template <typename T>                                                        \
-  friend std::enable_if_t<std::is_convertible_v<T, T> && std::is_scalar_v<T>,  \
-                          bfloat16>                                            \
-      &operator op(T & lhs, const bfloat16 & rhs) {                            \
-    float f = static_cast<float>(lhs);                                         \
-    f op static_cast<float>(rhs);                                              \
-    return lhs = f;                                                            \
-  }                                                                            \
-                                                                               \
-  friend bfloat16 &operator op(bfloat16 & lhs, const sycl::half & rhs) {       \
-    float f = static_cast<float>(lhs);                                         \
-    f op static_cast<float>(rhs);                                              \
-    return lhs = f;                                                            \
-  }                                                                            \
-  friend sycl::half &operator op(sycl::half & lhs, const bfloat16 & rhs) {     \
+  friend std::enable_if_t<std::is_convertible_v<T, float>, T> &operator op(    \
+      T & lhs, const bfloat16 & rhs) {                                         \
     float f = static_cast<float>(lhs);                                         \
     f op static_cast<float>(rhs);                                              \
     return lhs = f;                                                            \
@@ -194,21 +181,13 @@ public:
     return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
   }                                                                            \
   template <typename T>                                                        \
-  friend std::enable_if_t<                                                     \
-      std::is_convertible_v<T, float> && std::is_scalar_v<T>, type>            \
-  operator op(const bfloat16 & lhs, const T & rhs) {                           \
+  friend std::enable_if_t<std::is_convertible_v<T, float>, type> operator op(  \
+      const bfloat16 & lhs, const T & rhs) {                                   \
     return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
   }                                                                            \
   template <typename T>                                                        \
-  friend std::enable_if_t<                                                     \
-      std::is_convertible_v<T, float> && std::is_scalar_v<T>, type>            \
-  operator op(const T & lhs, const bfloat16 & rhs) {                           \
-    return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
-  }                                                                            \
-  friend type operator op(const bfloat16 &lhs, const sycl::half &rhs) {        \
-    return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
-  }                                                                            \
-  friend type operator op(const sycl::half &lhs, const bfloat16 &rhs) {        \
+  friend std::enable_if_t<std::is_convertible_v<T, float>, type> operator op(  \
+      const T & lhs, const bfloat16 & rhs) {                                   \
     return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
   }
   OP(bfloat16, +)

--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -156,12 +156,28 @@ public:
     return lhs = f;                                                            \
   }                                                                            \
   template <typename T>                                                        \
-  friend bfloat16 &operator op(bfloat16 & lhs, const T & rhs) {                \
+  friend std::enable_if_t<                                                     \
+      std::is_convertible_v<T, float> && std::is_scalar_v<T>, bfloat16>        \
+      &operator op(bfloat16 & lhs, const T & rhs) {                            \
     float f = static_cast<float>(lhs);                                         \
     f op static_cast<float>(rhs);                                              \
     return lhs = f;                                                            \
   }                                                                            \
-  template <typename T> friend T &operator op(T & lhs, const bfloat16 & rhs) { \
+  template <typename T>                                                        \
+  friend std::enable_if_t<std::is_convertible_v<T, T> && std::is_scalar_v<T>,  \
+                          bfloat16>                                            \
+      &operator op(T & lhs, const bfloat16 & rhs) {                            \
+    float f = static_cast<float>(lhs);                                         \
+    f op static_cast<float>(rhs);                                              \
+    return lhs = f;                                                            \
+  }                                                                            \
+                                                                               \
+  friend bfloat16 &operator op(bfloat16 & lhs, const sycl::half & rhs) {       \
+    float f = static_cast<float>(lhs);                                         \
+    f op static_cast<float>(rhs);                                              \
+    return lhs = f;                                                            \
+  }                                                                            \
+  friend sycl::half &operator op(sycl::half & lhs, const bfloat16 & rhs) {     \
     float f = static_cast<float>(lhs);                                         \
     f op static_cast<float>(rhs);                                              \
     return lhs = f;                                                            \
@@ -178,11 +194,21 @@ public:
     return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
   }                                                                            \
   template <typename T>                                                        \
-  friend type operator op(const bfloat16 &lhs, const T &rhs) {                 \
+  friend std::enable_if_t<                                                     \
+      std::is_convertible_v<T, float> && std::is_scalar_v<T>, type>            \
+  operator op(const bfloat16 & lhs, const T & rhs) {                           \
     return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
   }                                                                            \
   template <typename T>                                                        \
-  friend type operator op(const T &lhs, const bfloat16 &rhs) {                 \
+  friend std::enable_if_t<                                                     \
+      std::is_convertible_v<T, float> && std::is_scalar_v<T>, type>            \
+  operator op(const T & lhs, const bfloat16 & rhs) {                           \
+    return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
+  }                                                                            \
+  friend type operator op(const bfloat16 &lhs, const sycl::half &rhs) {        \
+    return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
+  }                                                                            \
+  friend type operator op(const sycl::half &lhs, const bfloat16 &rhs) {        \
     return type{static_cast<float>(lhs) op static_cast<float>(rhs)};           \
   }
   OP(bfloat16, +)

--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -154,20 +154,6 @@ public:
     float f = static_cast<float>(lhs);                                         \
     f op static_cast<float>(rhs);                                              \
     return lhs = f;                                                            \
-  }                                                                            \
-  template <typename T>                                                        \
-  friend std::enable_if_t<std::is_convertible_v<T, float>, bfloat16>           \
-      &operator op(bfloat16 & lhs, const T & rhs) {                            \
-    float f = static_cast<float>(lhs);                                         \
-    f op static_cast<float>(rhs);                                              \
-    return lhs = f;                                                            \
-  }                                                                            \
-  template <typename T>                                                        \
-  friend std::enable_if_t<std::is_convertible_v<T, float>, T> &operator op(    \
-      T & lhs, const bfloat16 & rhs) {                                         \
-    float f = static_cast<float>(lhs);                                         \
-    f op static_cast<float>(rhs);                                              \
-    return lhs = f;                                                            \
   }
   OP(+=)
   OP(-=)

--- a/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar.cpp
@@ -19,7 +19,7 @@ using namespace sycl::ext::intel::experimental::esimd;
 template <typename T> ESIMD_NOINLINE bool test(queue Q) {
   std::cout << "Testing T=" << esimd_test::type_name<T>() << "...\n";
 
-  constexpr int N = 1;
+  constexpr int N = 8;
 
   constexpr int NumOps = 4;
   constexpr int CSize = NumOps * N;

--- a/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//= bfloat16_half_vector_plus_eq_scalar.cpp - Test for bfloat16 operators =//
+//==- bfloat16_vector_plus_scalar.cpp - Test for bfloat16 operators ------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -19,7 +19,7 @@ using namespace sycl::ext::intel::experimental::esimd;
 template <typename T> ESIMD_NOINLINE bool test(queue Q) {
   std::cout << "Testing T=" << esimd_test::type_name<T>() << "...\n";
 
-  constexpr int N = 8;
+  constexpr int N = 1;
 
   constexpr int NumOps = 4;
   constexpr int CSize = NumOps * N;
@@ -31,22 +31,22 @@ template <typename T> ESIMD_NOINLINE bool test(queue Q) {
   Q.single_task([=]() SYCL_ESIMD_KERNEL {
      {
        simd<T, N> Vec(TOne);
-       Vec += TTen;
+       Vec = Vec + TTen;
        Vec.copy_to(Mem);
      }
      {
        simd<T, N> Vec(TOne);
-       Vec -= TTen;
+       Vec = Vec - TTen;
        Vec.copy_to(Mem + N);
      }
      {
        simd<T, N> Vec(TOne);
-       Vec *= TTen;
+       Vec = Vec * TTen;
        Vec.copy_to(Mem + 2 * N);
      }
      {
        simd<T, N> Vec(TOne);
-       Vec /= TTen;
+       Vec = Vec / TTen;
        Vec.copy_to(Mem + 3 * N);
      }
    }).wait();
@@ -89,7 +89,6 @@ int main() {
   if (SupportsHalf) {
     Passed &= test<sycl::half>(Q);
   }
-
 #ifdef USE_BF16
   Passed &= test<sycl::ext::oneapi::bfloat16>(Q);
 #endif

--- a/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar_pvc.cpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// This test validates operations between simd vector and scalars for
+// bfloat16 and tfloat32 types that are available only on PVC.
+//===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bfloat16_vector_plus_scalar_pvc.cpp
@@ -1,0 +1,14 @@
+//==- bfloat16_vector_plus_scalar_pvc.cpp - Test for bfloat16 operators -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#define USE_BF16
+#define USE_TF32
+#include "bfloat16_vector_plus_scalar.cpp"

--- a/sycl/test/type_traits/half_operator_types.cpp
+++ b/sycl/test/type_traits/half_operator_types.cpp
@@ -103,6 +103,8 @@ int main() {
   check_half_math_operator_types<int, sycl::half>(Queue);
   check_half_math_operator_types<long, sycl::half>(Queue);
   check_half_math_operator_types<long long, sycl::half>(Queue);
+  check_half_math_operator_types<sycl::ext::oneapi::bfloat16,
+                                 sycl::ext::oneapi::bfloat16>(Queue);
 
   check_half_logical_operator_types<sycl::half>(Queue);
   check_half_logical_operator_types<double>(Queue);
@@ -110,4 +112,5 @@ int main() {
   check_half_logical_operator_types<int>(Queue);
   check_half_logical_operator_types<long>(Queue);
   check_half_logical_operator_types<long long>(Queue);
+  check_half_logical_operator_types<sycl::ext::oneapi::bfloat16>(Queue);
 }


### PR DESCRIPTION
Aligns implementation with the spec: https://github.com/intel/llvm/blob/48ec4dd6ff45b25b405b99d63f3c5b8537b1475d/sycl/doc/extensions/supported/sycl_ext_oneapi_bfloat16.asciidoc