### PR TITLE
[SYCL][Fusion] Enable fusion of rounded-range kernels

### DIFF
--- a/sycl/doc/design/KernelFusionJIT.md
+++ b/sycl/doc/design/KernelFusionJIT.md
@@ -300,6 +300,18 @@ During the fusion process at runtime, the JIT will load the LLVM IR and
 finalize the fused kernel to the final target. More information is available
 [here](./CompilerAndRuntimeDesign.md#kernel-fusion-support).
 
+### Interaction with `parallel_for` range rounding
+
+DPCPP's [range rounding](./ParallelForRangeRounding.md) transformation is
+transparent for fusion, meaning the generated wrapper kernel with the rounded up
+range will be used.
+
+[Private internalization](#internalization-behavior) is supported when fusing
+such kernels. We use the original, unrounded global size when computing the
+private memory size. As range rounding only applies to basic kernels
+(parametrized by a `sycl::range`), local internalization is not affected by the
+range rounding transformation.
+
 ### Unsupported SYCL constructs
 
 The following SYCL API constructs are currently not officially supported for

--- a/sycl/doc/design/KernelFusionJIT.md
+++ b/sycl/doc/design/KernelFusionJIT.md
@@ -307,10 +307,10 @@ transparent for fusion, meaning the generated wrapper kernel with the rounded up
 range will be used.
 
 [Private internalization](#internalization-behavior) is supported when fusing
-such kernels. We use the original, unrounded global size when computing the
-private memory size. As range rounding only applies to basic kernels
-(parametrized by a `sycl::range`), local internalization is not affected by the
-range rounding transformation.
+such kernels. We use the original, unrounded global size in dimension 0 when
+computing the private memory size. As range rounding only applies to basic
+kernels (parametrized by a `sycl::range`), local internalization is not affected
+by the range rounding transformation.
 
 ### Unsupported SYCL constructs
 

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -713,15 +713,16 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
         !Args.empty()) {
       auto &A0 = Args[0];
       auto Dims = KernelCG->MNDRDesc.Dims;
-      if (A0.MPtr && A0.MSize == static_cast<int>(Dims * sizeof(size_t)) &&
-          A0.MType == kernel_param_kind_t::kind_std_layout) {
-        size_t *UGS = reinterpret_cast<size_t *>(A0.MPtr);
-        // Range-rounding only applies to the first dimension.
-        assert(UGS[0] > KernelCG->MNDRDesc.GlobalSize[1]);
-        assert(Dims < 2 || UGS[1] == KernelCG->MNDRDesc.GlobalSize[1]);
-        assert(Dims < 3 || UGS[2] == KernelCG->MNDRDesc.GlobalSize[2]);
-        UserGlobalSize = UGS[0];
-      }
+      assert(A0.MPtr && A0.MSize == static_cast<int>(Dims * sizeof(size_t)) &&
+             A0.MType == kernel_param_kind_t::kind_std_layout &&
+             "Unexpected signature for rounded range kernel");
+
+      size_t *UGS = reinterpret_cast<size_t *>(A0.MPtr);
+      // Range-rounding only applies to the first dimension.
+      assert(UGS[0] > KernelCG->MNDRDesc.GlobalSize[1]);
+      assert(Dims < 2 || UGS[1] == KernelCG->MNDRDesc.GlobalSize[1]);
+      assert(Dims < 3 || UGS[2] == KernelCG->MNDRDesc.GlobalSize[2]);
+      UserGlobalSize = UGS[0];
     }
 
     ::jit_compiler::SYCLArgumentDescriptor ArgDescriptor{Args.size()};

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -712,8 +712,8 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
          KernelName.find("_ZTSN4sycl3_V16detail19__pf_kernel_wrapper") == 0) &&
         !Args.empty()) {
       auto &A0 = Args[0];
-      int Dims = KernelCG->MNDRDesc.Dims;
-      if (A0.MPtr && A0.MSize == (Dims * sizeof(size_t)) &&
+      auto Dims = KernelCG->MNDRDesc.Dims;
+      if (A0.MPtr && A0.MSize == static_cast<int>(Dims * sizeof(size_t)) &&
           A0.MType == kernel_param_kind_t::kind_std_layout) {
         size_t *UGS = reinterpret_cast<size_t *>(A0.MPtr);
         // Range-rounding only applies to the first dimension.

--- a/sycl/test-e2e/KernelFusion/different_nd_ranges.cpp
+++ b/sycl/test-e2e/KernelFusion/different_nd_ranges.cpp
@@ -262,4 +262,7 @@ int main() {
   // 1-D, 2-D and 3-D kernels with different global sizes.
   test({RangeDesc{{10}, R5}, RangeDesc{{10, 1}, {5, 1}},
         RangeDesc{{10, 1, 1}, {5, 1, 1}}});
+
+  // Test global sizes that trigger the rounded range kernel insertion.
+  test({RangeDesc{3000}, RangeDesc{7727}, RangeDesc{4096}});
 }

--- a/sycl/test-e2e/KernelFusion/different_nd_ranges.cpp
+++ b/sycl/test-e2e/KernelFusion/different_nd_ranges.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -o %t.out
-// RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
+// RUN: env SYCL_RT_WARNING_LEVEL=1 SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS=16:32:64 \
+// RUN:   %{run} %t.out 2>&1 | FileCheck %s
 
 // Test complete fusion of kernels with different ND-ranges.
 
@@ -264,5 +265,10 @@ int main() {
         RangeDesc{{10, 1, 1}, {5, 1, 1}}});
 
   // Test global sizes that trigger the rounded range kernel insertion.
-  test({RangeDesc{3000}, RangeDesc{7727}, RangeDesc{4096}});
+  // Note that we lower the RR threshold when running this test.
+  test({RangeDesc{67}, RangeDesc{87}, RangeDesc{64}});
+
+  // Test multi-dimensional range-rounded kernels. Only the first dimension will
+  // be rounded up.
+  test({RangeDesc{30, 67}, RangeDesc{76, 55}, RangeDesc{64, 64}});
 }

--- a/sycl/test-e2e/KernelFusion/private_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/private_internalization.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS=16:32:512 %{run} %t.out
 
 // Test complete fusion with private internalization specified on the
 // accessors.
@@ -71,7 +71,8 @@ int main() {
   test<512>();
 
   // Test prime size large enough to trigger rounded-range kernel insertion.
-  test<7727>();
+  // Note that we lower the RR threshold when running this test.
+  test<523>();
 
   return 0;
 }


### PR DESCRIPTION
Enable, test, and document the support for fusing rounded range kernels. This mostly worked already – we just have to query the original kernel's global size, and use that to compute the private memory size used for internalization.