### PR TITLE
[SYCL][LinkerWrapper][NFC] Align code structure to community

### DIFF
--- a/clang/tools/clang-linker-wrapper/CMakeLists.txt
+++ b/clang/tools/clang-linker-wrapper/CMakeLists.txt
@@ -28,7 +28,6 @@ endif()
 
 add_clang_tool(clang-linker-wrapper
   ClangLinkerWrapper.cpp
-  SYCLOffloadWrapper.cpp
 
   DEPENDS
   ${tablegen_deps}

--- a/llvm/include/llvm/Frontend/Offloading/SYCLOffloadWrapper.h
+++ b/llvm/include/llvm/Frontend/Offloading/SYCLOffloadWrapper.h
@@ -18,6 +18,9 @@
 #include <utility>
 #include <vector>
 
+namespace llvm {
+namespace offloading {
+
 // SYCL binary image formats supported.
 enum class SYCLBinaryImageFormat {
   BIF_None,   // Undetermined Image kind
@@ -50,8 +53,14 @@ struct SYCLWrappingOptions {
   std::string LinkOptions;
 };
 
+/// Wraps the input bundled images and accompanied data into the module \p M
+/// as global symbols and registers the images with the SYCL Runtime.
+/// \param Options Settings that allows to turn on optional data and settings.
 llvm::Error
 wrapSYCLBinaries(llvm::Module &M, llvm::SmallVector<SYCLImage> &Images,
                  SYCLWrappingOptions Options = SYCLWrappingOptions());
+
+} // namespace offloading
+} // namespace llvm
 
 #endif

--- a/llvm/lib/Frontend/Offloading/CMakeLists.txt
+++ b/llvm/lib/Frontend/Offloading/CMakeLists.txt
@@ -1,6 +1,8 @@
 add_llvm_component_library(LLVMFrontendOffloading
   Utility.cpp
   OffloadWrapper.cpp
+  SYCLOffloadWrapper.cpp
+
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/Frontend

--- a/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
+++ b/llvm/lib/Frontend/Offloading/SYCLOffloadWrapper.cpp
@@ -14,7 +14,7 @@
 //  sycl/include/sycl/detail/pi.h
 //===----------------------------------------------------------------------===//
 
-#include "SYCLOffloadWrapper.h"
+#include "llvm/Frontend/Offloading/SYCLOffloadWrapper.h"
 #include "llvm/ADT/ArrayRef.h"
 #include "llvm/ADT/SmallVector.h"
 #include "llvm/ADT/StringRef.h"
@@ -40,6 +40,7 @@
 #include <utility>
 
 using namespace llvm;
+using namespace llvm::offloading;
 using namespace llvm::util;
 
 namespace {
@@ -727,8 +728,9 @@ struct Wrapper {
 
 } // anonymous namespace
 
-Error wrapSYCLBinaries(llvm::Module &M, SmallVector<SYCLImage> &Images,
-                       SYCLWrappingOptions Options) {
+Error llvm::offloading::wrapSYCLBinaries(llvm::Module &M,
+                                         SmallVector<SYCLImage> &Images,
+                                         SYCLWrappingOptions Options) {
   Wrapper W(M, Options);
   GlobalVariable *Desc = W.createFatbinDesc(Images);
   if (!Desc)


### PR DESCRIPTION
This patch moves 'clang/tools/clang-linker-wrapper/SYCLOffloadWrapper.*' functionality to 'llvm/Frontend/Offloading' to be aligned with the community code structure.