### PR TITLE
[SYCL] Don't assert for unsupported GRF sizes in CompileTimePropertiesPass

### DIFF
--- a/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
+++ b/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
@@ -444,8 +444,9 @@ attributeToExecModeMetadata(const Attribute &Attr, Function &F) {
     // TODO: Remove SYCL_REGISTER_ALLOC_MODE_ATTR support in next ABI break.
     uint32_t PropVal = getAttributeAsInteger<uint32_t>(Attr);
     if (AttrKindStr == SYCL_GRF_SIZE_ATTR) {
-      assert((PropVal == 0 || PropVal == 128 || PropVal == 256) &&
-             "Unsupported GRF Size");
+      // The RegisterAllocMode metadata only supports these cases.
+      if (PropVal != 0 && PropVal != 128 && PropVal != 256)
+        return std::nullopt;
       // Map sycl-grf-size values to RegisterAllocMode values used in SPIR-V.
       static constexpr int SMALL_GRF_REGALLOCMODE_VAL = 1;
       static constexpr int LARGE_GRF_REGALLOCMODE_VAL = 2;

--- a/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
+++ b/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
@@ -444,7 +444,8 @@ attributeToExecModeMetadata(const Attribute &Attr, Function &F) {
     // TODO: Remove SYCL_REGISTER_ALLOC_MODE_ATTR support in next ABI break.
     uint32_t PropVal = getAttributeAsInteger<uint32_t>(Attr);
     if (AttrKindStr == SYCL_GRF_SIZE_ATTR) {
-      // The RegisterAllocMode metadata only supports these cases.
+      // The RegisterAllocMode metadata supports only 0, 128, and 256 for
+      // PropVal.
       if (PropVal != 0 && PropVal != 128 && PropVal != 256)
         return std::nullopt;
       // Map sycl-grf-size values to RegisterAllocMode values used in SPIR-V.

--- a/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/sycl-grf-mode.ll
+++ b/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/sycl-grf-mode.ll
@@ -1,0 +1,10 @@
+; Check we don't assert for different GRF values and don't add the RegisterAllocMode metadata
+; RUN: opt -passes=compile-time-properties %s -S | FileCheck %s --implicit-check-not=RegisterAllocMode
+
+; CHECK: spir_kernel void @foo()
+define weak_odr dso_local spir_kernel void @foo() #0 {
+entry:
+  ret void
+}
+
+attributes #0 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-grf-size"="16384" "sycl-module-id"="main.cpp" "sycl-optlevel"="2" "uniform-work-group-size"="true" }


### PR DESCRIPTION
It's already checked up-front at compile time in the SYCL headers. I can provide more background for this change offline if required.