### PR TITLE
[NFC][SYCL] Set some target restrictions for some tests

### DIFF
--- a/clang/test/Driver/sycl-offload-amdgcn.cpp
+++ b/clang/test/Driver/sycl-offload-amdgcn.cpp
@@ -1,6 +1,7 @@
 /// Tests specific to `-fsycl-targets=amdgcn-amd-amdhsa`
 
 // UNSUPPORTED: system-windows
+// REQUIRES: amdgpu-registered-target
 
 // Check that the offload arch is required
 // RUN: not %clangxx -### -std=c++11 -target x86_64-unknown-linux-gnu -fsycl \

--- a/clang/test/Driver/sycl-triple-dae-flags.cpp
+++ b/clang/test/Driver/sycl-triple-dae-flags.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: nvptx-registered-target, amdgpu-registered-target
+
 // RUN: %clangxx -### -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 -fsycl-dead-args-optimization -nogpulib %s 2> %t.rocm.out
 // RUN: FileCheck %s --input-file %t.rocm.out
 // CHECK-NOT: -fenable-sycl-dae

--- a/clang/test/Driver/sycl-unsupported-arch.cpp
+++ b/clang/test/Driver/sycl-unsupported-arch.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: amdgpu-registered-target
+
 /// Verify that compiler passes are correctly determined
 // RUN: %clangxx -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx600 -nogpulib -c -ccc-print-phases %s 2>&1 | FileCheck %s --check-prefix=CHECK-PHASES
 // CHECK-PHASES: offload, "device-sycl (amdgcn-amd-amdhsa:gfx600)"


### PR DESCRIPTION
A few tests in the driver area require amdgpu or nvptx targets to be built in order to properly run.  Add these requirements to the tests.