### PR TITLE
[SYCL] Remove the implicitly passed -ze-take-global-address IGC option

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -380,13 +380,6 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
         return Dev.is_gpu() &&
                Dev.get_info<info::device::vendor_id>() == 0x8086;
       });
-  if (IsIntelGPU && Img.getDeviceGlobals().size() != 0) {
-    // If the image has device globals we need to add the
-    // -ze-take-global-address option to tell IGC to record addresses of these.
-    if (!CompileOpts.empty())
-      CompileOpts += " ";
-    CompileOpts += "-ze-take-global-address";
-  }
   if (!CompileOptsEnv) {
     static const char *TargetCompileFast = "-ftarget-compile-fast";
     if (auto Pos = CompileOpts.find(TargetCompileFast);


### PR DESCRIPTION
The -ze-take-global-address IGC option was required for IGC to correctly record addresses of device globals. This should be on automatically in newer IGC versions however, so this commit removes the option.