### PR TITLE
[SYCL][E2E] Update minimum driver version for get_backend.cpp

### DIFF
--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,5 +1,5 @@
 // Failing due to old driver
-// REQUIRES-INTEL-DRIVER: lin: 27202, win: 101.4677
+// REQUIRES-INTEL-DRIVER: lin: 27427, win: 101.4827
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 //


### PR DESCRIPTION
I manually tested this on DG2.