### PR TITLE
[UR][L0] Fix native kernel usage, multi device kernel pointer and WorkSize

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,8 +56,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
-  set(UNIFIED_RUNTIME_TAG 18f1d565408483d243a9fabe3ff8d069dd390168)
+  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime")
+  # commit 73d85ef9f48ec4d1f213066a31ed7e4402b5499b
+  # Merge: e46dc359 7985d3ee
+  # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+  # Date:   Mon Jan 29 14:26:08 2024 +0000
+  #     Merge pull request #1289 from nrspruit/fix_multiDevice
+  #     [L0] Fix native kernel usage, multi device kernel pointer and WorkSize
+  set(UNIFIED_RUNTIME_TAG 73d85ef9f48ec4d1f213066a31ed7e4402b5499b)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,14 +56,8 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime")
-  # commit 51d7180c344bbc2f942533e5fc51b0b04871f8d5
-  # Merge: b66cf9b1 0e37380e
-  # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Fri Jan 26 12:20:20 2024 +0000
-  #     Merge pull request #1205 from ykhatav/ur_dependentload
-  #     [UR] add dependent-load flag to exclude CWD from default search path …
-  set(UNIFIED_RUNTIME_TAG 51d7180c344bbc2f942533e5fc51b0b04871f8d5)
+  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
+  set(UNIFIED_RUNTIME_TAG 18f1d565408483d243a9fabe3ff8d069dd390168)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
- Fix native kernel usage given no kernel creation in kernel map
- fix set of kernel function pointer given multi device
- Fix Global WorkSize variable to use a local variable to avoid invalid memory access.
- pre-commit PR for https://github.com/oneapi-src/unified-runtime/pull/1289