### PR TITLE
[GENX][GPUToGENX] change symbols to khronos format

### DIFF
--- a/mlir/lib/Conversion/GPUToGENX/LowerGpuOpsToGENXOps.cpp
+++ b/mlir/lib/Conversion/GPUToGENX/LowerGpuOpsToGENXOps.cpp
@@ -164,20 +164,20 @@ void mlir::populateGpuToGENXConversionPatterns(LLVMTypeConverter &converter,
       StringAttr::get(&converter.getContext(),
                       GENX::GENXDialect::getKernelFuncAttrName()));
 
-  const llvm::StringRef prefix("__builtin_spirv_OpenCL_");
+  const llvm::StringRef prefix("_Z15__spirv_ocl_");
 
   populateOpPatterns<math::ExpOp>(converter, patterns,
-                                  (prefix + "exp_f32").str(),
-                                  (prefix + "exp_f64").str());
+                                  (prefix + "expf").str(),
+                                  (prefix + "expd").str());
   populateOpPatterns<math::LogOp>(converter, patterns,
-                                  (prefix + "log_f32").str(),
-                                  (prefix + "log_f64").str());
+                                  (prefix + "logf").str(),
+                                  (prefix + "logd").str());
   populateOpPatterns<math::CosOp>(converter, patterns,
-                                  (prefix + "cos_f32").str(),
-                                  (prefix + "cos_f64").str());
+                                  (prefix + "cosf").str(),
+                                  (prefix + "cosd").str());
   populateOpPatterns<math::SinOp>(converter, patterns,
-                                  (prefix + "sin_f32").str(),
-                                  (prefix + "sin_f64").str());
+                                  (prefix + "sinf").str(),
+                                  (prefix + "sind").str());
 }
 
 std::unique_ptr<OperationPass<gpu::GPUModuleOp>>

--- a/mlir/test/Conversion/GPUToGENX/gpu-to-genx.mlir
+++ b/mlir/test/Conversion/GPUToGENX/gpu-to-genx.mlir
@@ -59,14 +59,14 @@ gpu.module @test_module {
 // -----
 
 gpu.module @test_module {
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_exp_f32(f32) -> f32
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_exp_f64(f64) -> f64
+  // CHECK: llvm.func @_Z15__spirv_ocl_expf(f32) -> f32
+  // CHECK: llvm.func @_Z15__spirv_ocl_expd(f64) -> f64
   // CHECK-LABEL: func @gpu_exp
   func.func @gpu_exp(%arg_f32 : f32, %arg_f64 : f64) -> (f32, f64) {
     %result32 = math.exp %arg_f32 : f32
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_exp_f32(%{{.*}}) : (f32) -> f32
+    // CHECK: llvm.call @_Z15__spirv_ocl_expf(%{{.*}}) : (f32) -> f32
     %result64 = math.exp %arg_f64 : f64
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_exp_f64(%{{.*}}) : (f64) -> f64
+    // CHECK: llvm.call @_Z15__spirv_ocl_expd(%{{.*}}) : (f64) -> f64
     func.return %result32, %result64 : f32, f64
   }
 }
@@ -74,14 +74,14 @@ gpu.module @test_module {
 // -----
 
 gpu.module @test_module {
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_log_f32(f32) -> f32
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_log_f64(f64) -> f64
+  // CHECK: llvm.func @_Z15__spirv_ocl_logf(f32) -> f32
+  // CHECK: llvm.func @_Z15__spirv_ocl_logd(f64) -> f64
   // CHECK-LABEL: func @gpu_log
   func.func @gpu_log(%arg_f32 : f32, %arg_f64 : f64) -> (f32, f64) {
     %result32 = math.log %arg_f32 : f32
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_log_f32(%{{.*}}) : (f32) -> f32
+    // CHECK: llvm.call @_Z15__spirv_ocl_logf(%{{.*}}) : (f32) -> f32
     %result64 = math.log %arg_f64 : f64
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_log_f64(%{{.*}}) : (f64) -> f64
+    // CHECK: llvm.call @_Z15__spirv_ocl_logd(%{{.*}}) : (f64) -> f64
     func.return %result32, %result64 : f32, f64
   }
 }
@@ -89,14 +89,14 @@ gpu.module @test_module {
 // -----
 
 gpu.module @test_module {
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_sin_f32(f32) -> f32
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_sin_f64(f64) -> f64
+  // CHECK: llvm.func @_Z15__spirv_ocl_sinf(f32) -> f32
+  // CHECK: llvm.func @_Z15__spirv_ocl_sind(f64) -> f64
   // CHECK-LABEL: func @gpu_sin
   func.func @gpu_sin(%arg_f32 : f32, %arg_f64 : f64) -> (f32, f64) {
     %result32 = math.sin %arg_f32 : f32
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_sin_f32(%{{.*}}) : (f32) -> f32
+    // CHECK: llvm.call @_Z15__spirv_ocl_sinf(%{{.*}}) : (f32) -> f32
     %result64 = math.sin %arg_f64 : f64
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_sin_f64(%{{.*}}) : (f64) -> f64
+    // CHECK: llvm.call @_Z15__spirv_ocl_sind(%{{.*}}) : (f64) -> f64
     func.return %result32, %result64 : f32, f64
   }
 }
@@ -104,14 +104,14 @@ gpu.module @test_module {
 // -----
 
 gpu.module @test_module {
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_cos_f32(f32) -> f32
-  // CHECK: llvm.func @__builtin_spirv_OpenCL_cos_f64(f64) -> f64
+  // CHECK: llvm.func @_Z15__spirv_ocl_cosf(f32) -> f32
+  // CHECK: llvm.func @_Z15__spirv_ocl_cosd(f64) -> f64
   // CHECK-LABEL: func @gpu_cos
   func.func @gpu_cos(%arg_f32 : f32, %arg_f64 : f64) -> (f32, f64) {
     %result32 = math.cos %arg_f32 : f32
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_cos_f32(%{{.*}}) : (f32) -> f32
+    // CHECK: llvm.call @_Z15__spirv_ocl_cosf(%{{.*}}) : (f32) -> f32
     %result64 = math.cos %arg_f64 : f64
-    // CHECK: llvm.call @__builtin_spirv_OpenCL_cos_f64(%{{.*}}) : (f64) -> f64
+    // CHECK: llvm.call @_Z15__spirv_ocl_cosd(%{{.*}}) : (f64) -> f64
     func.return %result32, %result64 : f32, f64
   }
 }


### PR DESCRIPTION
This fixes the error below:
```
error: undefined reference to `__builtin_spirv_OpenCL_sin_f64'
in function: '__builtin_spirv_OpenCL_sin_f64' called by kernel: 'kernel_0d1d'
```