### PR TITLE
[UR] Call PiGetAdapter in piextContextCreateWithNativeHandle

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -1514,6 +1514,12 @@ inline pi_result piextContextCreateWithNativeHandle(
   PI_ASSERT(NativeHandle, PI_ERROR_INVALID_VALUE);
   PI_ASSERT(RetContext, PI_ERROR_INVALID_VALUE);
 
+  ur_adapter_handle_t adapter = nullptr;
+  if (auto res = PiGetAdapter(adapter); res != PI_SUCCESS) {
+    return res;
+  }
+  (void)adapter;
+
   ur_native_handle_t NativeContext =
       reinterpret_cast<ur_native_handle_t>(NativeHandle);
   const ur_device_handle_t *UrDevices =


### PR DESCRIPTION
This ensures that global setup has completed and interop objects will function correctly even if an application bootstraps directly in at the context level.