### PR TITLE
[CI] Uplift Ubuntu version for GH pages workflow.

### DIFF
--- a/.github/workflows/gh_pages.yml
+++ b/.github/workflows/gh_pages.yml
@@ -13,7 +13,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
This should fix the installation of GitHub Actions dependencies broken by recent updates. See https://github.com/intel/llvm/pull/12498#issuecomment-1914328314 for more details.