### PR TITLE
[SYCL] Fix unused variable warnings

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -321,10 +321,9 @@ areEventsSafeForSchedulerBypass(const std::vector<sycl::event> &DepEvents,
     return SyclEventImplPtr->getHandleRef() != nullptr;
   };
 
-  return std::all_of(DepEvents.begin(), DepEvents.end(),
-                     [&CheckEvent](const sycl::event &Event) {
-                       return CheckEvent(Event);
-                     });
+  return std::all_of(
+      DepEvents.begin(), DepEvents.end(),
+      [&CheckEvent](const sycl::event &Event) { return CheckEvent(Event); });
 }
 
 template <typename HandlerFuncT>

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -322,7 +322,7 @@ areEventsSafeForSchedulerBypass(const std::vector<sycl::event> &DepEvents,
   };
 
   return std::all_of(DepEvents.begin(), DepEvents.end(),
-                     [&Context, &CheckEvent](const sycl::event &Event) {
+                     [&CheckEvent](const sycl::event &Event) {
                        return CheckEvent(Event);
                      });
 }

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -744,8 +744,7 @@ protected:
 
   // template is needed for proper unit testing
   template <typename HandlerType = handler>
-  void finalizeHandler(HandlerType &Handler, const CG::CGTYPE &Type,
-                       event &EventRet) {
+  void finalizeHandler(HandlerType &Handler, event &EventRet) {
     if (MIsInorder) {
       // Accessing and changing of an event isn't atomic operation.
       // Hence, here is the lock for thread-safety.
@@ -831,11 +830,11 @@ protected:
             !(Handler.MKernel && Handler.MKernel->isInterop()) &&
             ProgramManager::getInstance().kernelUsesAssert(Handler.MKernelName);
 
-      finalizeHandler(Handler, Type, Event);
+      finalizeHandler(Handler, Event);
 
       (*PostProcess)(IsKernel, KernelUsesAssert, Event);
     } else
-      finalizeHandler(Handler, Type, Event);
+      finalizeHandler(Handler, Event);
 
     addEvent(Event);
     return Event;

--- a/sycl/unittests/scheduler/InOrderQueueSyncCheck.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueSyncCheck.cpp
@@ -72,35 +72,30 @@ TEST_F(SchedulerTest, InOrderQueueSyncCheck) {
   {
     LimitedHandlerSimulation MockCGH;
     EXPECT_CALL(MockCGH, depends_on).Times(0);
-    Queue->finalizeHandler<LimitedHandlerSimulation>(
-        MockCGH, detail::CG::CGTYPE::CodeplayHostTask, Event);
+    Queue->finalizeHandler<LimitedHandlerSimulation>(MockCGH, Event);
   }
   // host task
   {
     LimitedHandlerSimulation MockCGH;
     EXPECT_CALL(MockCGH, depends_on).Times(1);
-    Queue->finalizeHandler<LimitedHandlerSimulation>(
-        MockCGH, detail::CG::CGTYPE::CodeplayHostTask, Event);
+    Queue->finalizeHandler<LimitedHandlerSimulation>(MockCGH, Event);
   }
   // kernel task
   {
     LimitedHandlerSimulation MockCGH;
     EXPECT_CALL(MockCGH, depends_on).Times(1);
-    Queue->finalizeHandler<LimitedHandlerSimulation>(
-        MockCGH, detail::CG::CGTYPE::Kernel, Event);
+    Queue->finalizeHandler<LimitedHandlerSimulation>(MockCGH, Event);
   }
   // kernel task
   {
     LimitedHandlerSimulation MockCGH;
     EXPECT_CALL(MockCGH, depends_on).Times(1);
-    Queue->finalizeHandler<LimitedHandlerSimulation>(
-        MockCGH, detail::CG::CGTYPE::Kernel, Event);
+    Queue->finalizeHandler<LimitedHandlerSimulation>(MockCGH, Event);
   }
   // host task
   {
     LimitedHandlerSimulation MockCGH;
     EXPECT_CALL(MockCGH, depends_on).Times(1);
-    Queue->finalizeHandler<LimitedHandlerSimulation>(
-        MockCGH, detail::CG::CGTYPE::CodeplayHostTask, Event);
+    Queue->finalizeHandler<LimitedHandlerSimulation>(MockCGH, Event);
   }
 }


### PR DESCRIPTION
Fixes warnings introduced in https://github.com/intel/llvm/pull/11758