### PR TITLE
[SYCL][Fusion] Improve error messages on incompatible ND-ranges

### DIFF
--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -265,12 +265,18 @@ public:
   constexpr int getDimensions() const { return Dimensions; }
 
   bool hasSpecificLocalSize() const { return LocalSize != AllZeros; }
+  bool hasUniformWorkGroupSizes() const {
+    for (int I = 0; I < Dimensions; ++I) {
+      if (GlobalSize[I] % LocalSize[I] != 0) {
+        return false;
+      }
+    }
+    return true;
+  }
 
   friend constexpr bool operator==(const NDRange &LHS, const NDRange &RHS) {
     return LHS.Dimensions == RHS.Dimensions &&
-           LHS.GlobalSize == RHS.GlobalSize &&
-           (!LHS.hasSpecificLocalSize() || !RHS.hasSpecificLocalSize() ||
-            LHS.LocalSize == RHS.LocalSize) &&
+           LHS.GlobalSize == RHS.GlobalSize && LHS.LocalSize == RHS.LocalSize &&
            LHS.Offset == RHS.Offset;
   }
 
@@ -293,19 +299,11 @@ public:
       return false;
     }
 
-    if (!LHS.hasSpecificLocalSize() && RHS.hasSpecificLocalSize()) {
+    if (LHS.LocalSize < RHS.LocalSize) {
       return true;
     }
-    if (LHS.hasSpecificLocalSize() && !RHS.hasSpecificLocalSize()) {
+    if (LHS.LocalSize > RHS.LocalSize) {
       return false;
-    }
-    if (LHS.hasSpecificLocalSize() && RHS.hasSpecificLocalSize()) {
-      if (LHS.LocalSize < RHS.LocalSize) {
-        return true;
-      }
-      if (LHS.LocalSize > RHS.LocalSize) {
-        return false;
-      }
     }
 
     return LHS.Offset < RHS.Offset;

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -266,6 +266,7 @@ public:
 
   bool hasSpecificLocalSize() const { return LocalSize != AllZeros; }
   bool hasUniformWorkGroupSizes() const {
+    assert(hasSpecificLocalSize() && "Local size must be specified");
     for (int I = 0; I < Dimensions; ++I) {
       if (GlobalSize[I] % LocalSize[I] != 0) {
         return false;

--- a/sycl-fusion/common/lib/NDRangesHelper.cpp
+++ b/sycl-fusion/common/lib/NDRangesHelper.cpp
@@ -8,32 +8,67 @@
 
 #include "NDRangesHelper.h"
 
-#include <map>
-
 using namespace jit_compiler;
 using namespace llvm;
 
+namespace {
+/// Helper class to obtain the maximal global size using a given order
 ///
-/// Return the maximal global size using the following order:
+/// This class obtains the maximal global size using the following order:
 /// 1. A range is greater than another range if it contains more elements (see
 /// linearize());
 /// 2. Else if it appears more times in the input list of ranges;
 /// 3. Else if it is greater in lexicographical order.
-static Indices getMaximalGlobalSize(ArrayRef<NDRange> NDRanges) {
-  size_t NumElements{0};
-  std::map<Indices, size_t> FreqMap;
-  for (const auto &ND : NDRanges) {
-    const auto &GS = ND.getGlobalSize();
-    const auto N = NDRange::linearize(GS);
-    if (N < NumElements) {
-      continue;
-    }
-    if (N > NumElements) {
-      NumElements = N;
-      FreqMap.clear();
-    }
-    ++FreqMap[GS];
+class IndicesFrequenceMap {
+public:
+  IndicesFrequenceMap()
+      : GlobalLinearSize(0), IsHeterogeneousList(false), FreqMap() {}
+
+  void add(const Indices &I);
+
+  bool isHeterogeneousList() const { return IsHeterogeneousList; }
+  const Indices &getMax() const;
+
+private:
+  std::size_t GlobalLinearSize;
+  bool IsHeterogeneousList;
+  SmallVector<std::pair<Indices, size_t>> FreqMap;
+};
+} // namespace
+
+void IndicesFrequenceMap::add(const Indices &I) {
+  std::size_t GLS = NDRange::linearize(I);
+  if (FreqMap.empty()) {
+    GlobalLinearSize = GLS;
+    FreqMap.emplace_back(I, 1);
+    return;
   }
+  if (GLS < GlobalLinearSize) {
+    IsHeterogeneousList = true;
+    return;
+  }
+  if (GLS == GlobalLinearSize) {
+    auto *Iter = lower_bound(FreqMap, I,
+                             [](const std::pair<Indices, size_t> &P,
+                                const Indices &I) { return P.first < I; });
+    if (Iter != FreqMap.end() && Iter->first == I) {
+      // Already seen global size
+      ++(Iter->second);
+      return;
+    }
+    // New global size
+    IsHeterogeneousList = true;
+    FreqMap.insert(Iter, {I, 1});
+    return;
+  }
+  // GLS > GlobalLinearSize
+  GlobalLinearSize = GLS;
+  IsHeterogeneousList = true;
+  FreqMap.clear();
+  FreqMap.emplace_back(I, 1);
+}
+
+const Indices &IndicesFrequenceMap::getMax() const {
   return std::max_element(FreqMap.begin(), FreqMap.end(),
                           [](const auto &LHS, const auto &RHS) {
                             const auto LHSN = LHS.second;
@@ -49,70 +84,87 @@ static Indices getMaximalGlobalSize(ArrayRef<NDRange> NDRanges) {
       ->first;
 }
 
-static bool compatibleRanges(const NDRange &LHS, const NDRange &RHS) {
-  const auto Dimensions = std::max(LHS.getDimensions(), RHS.getDimensions());
-  const auto EqualIndices = [Dimensions](const Indices &LHS,
-                                         const Indices &RHS) {
-    return std::equal(LHS.begin(), LHS.begin() + Dimensions, RHS.begin());
+Expected<FusedNDRange>
+jit_compiler::FusedNDRange::get(ArrayRef<NDRange> NDRanges) {
+  assert(!NDRanges.empty() && "Expecting at least one ND-range");
+  constexpr auto GetPtrIfNonZero = [](const Indices &I) {
+    return I == NDRange::AllZeros ? nullptr : &I;
   };
-  return (!LHS.hasSpecificLocalSize() || !RHS.hasSpecificLocalSize() ||
-          EqualIndices(LHS.getLocalSize(), RHS.getLocalSize())) &&
-         EqualIndices(LHS.getOffset(), RHS.getOffset()) &&
-         (!requireIDRemapping(LHS, RHS) ||
-          LHS.getOffset() == NDRange::AllZeros);
-}
 
-NDRange jit_compiler::combineNDRanges(ArrayRef<NDRange> NDRanges) {
-  assert(isValidCombination(NDRanges) && "Invalid ND-ranges combination");
-  const auto Dimensions =
-      std::max_element(NDRanges.begin(), NDRanges.end(),
-                       [](const auto &LHS, const auto &RHS) {
-                         return LHS.getDimensions() < RHS.getDimensions();
-                       })
-          ->getDimensions();
-  const auto GlobalSize = getMaximalGlobalSize(NDRanges);
-  const auto *End = NDRanges.end();
-  const auto *LocalSizeIter = findSpecifiedLocalSize(NDRanges);
-  const auto &LocalSize =
-      LocalSizeIter == End ? NDRange::AllZeros : LocalSizeIter->getLocalSize();
-  const auto &Front = NDRanges.front();
-  return {Dimensions, GlobalSize, LocalSize, Front.getOffset()};
+  constexpr auto Override = [](const Indices *&Current, const Indices *New) {
+    if (Current) {
+      return !New || *Current == *New;
+    }
+    Current = New;
+    return true;
+  };
+
+  // The resulting number of dimensions will be the largest found
+  int Dimensions = NDRanges.front().getDimensions();
+  // The global size is given by the algorithm implemented by
+  // IndicesFrequenceMap
+  IndicesFrequenceMap GlobalSizeFreqMap;
+  GlobalSizeFreqMap.add(NDRanges.front().getGlobalSize());
+  // All local sizes and offsets must be the same
+  const Indices *LocalSize = GetPtrIfNonZero(NDRanges.front().getLocalSize());
+  const Indices *Offset = GetPtrIfNonZero(NDRanges.front().getOffset());
+  bool IsHeterogeneousList = false;
+  for (const NDRange &NDR : NDRanges.drop_front()) {
+    // Accumulate dimension
+    IsHeterogeneousList =
+        IsHeterogeneousList || Dimensions != NDR.getDimensions();
+    Dimensions = std::max(Dimensions, NDR.getDimensions());
+
+    // Add global size to map
+    GlobalSizeFreqMap.add(NDR.getGlobalSize());
+
+    // Get local size or return error
+    if (!Override(LocalSize, GetPtrIfNonZero(NDR.getLocalSize()))) {
+      return createStringError(
+          inconvertibleErrorCode(),
+          "Cannot fuse kernels with different local sizes");
+    }
+
+    // Get offset or return error
+    if (!Override(Offset, GetPtrIfNonZero(NDR.getOffset()))) {
+      return createStringError(inconvertibleErrorCode(),
+                               "Cannot fuse kernels with different offsets");
+    }
+  }
+
+  NDRange Fused{Dimensions, GlobalSizeFreqMap.getMax(),
+                LocalSize ? *LocalSize : NDRange::AllZeros,
+                Offset ? *Offset : NDRange::AllZeros};
+  IsHeterogeneousList =
+      IsHeterogeneousList || GlobalSizeFreqMap.isHeterogeneousList();
+
+  if (IsHeterogeneousList) {
+    // ND-ranges requiring remapping cannot have non-zero offsets
+    if (Offset && !all_of(NDRanges, [Fused](const NDRange &NDR) {
+          return !requireIDRemapping(Fused, NDR) ||
+                 NDR.getOffset() == NDRange::AllZeros;
+        })) {
+      return createStringError(inconvertibleErrorCode(),
+                               "Cannot fuse kernels with different global "
+                               "sizes in dimensions [2, N) "
+                               "and non-zero offsets");
+    }
+
+    // Fused ND-range would not yield uniform work-group sizes.
+    if (LocalSize && !Fused.hasUniformWorkGroupSizes()) {
+      return createStringError(inconvertibleErrorCode(),
+                               "Cannot fuse kernels whose fusion would "
+                               "yield non-uniform work-group sizes");
+    }
+  }
+
+  return FusedNDRange{Fused, IsHeterogeneousList, NDRanges};
 }
 
 bool jit_compiler::isHeterogeneousList(ArrayRef<NDRange> NDRanges) {
-  const auto *FirstSpecifiedLocalSize = findSpecifiedLocalSize(NDRanges);
-  const auto &ND = FirstSpecifiedLocalSize == NDRanges.end()
-                       ? NDRanges.front()
-                       : *FirstSpecifiedLocalSize;
-  return any_of(NDRanges, [&ND](const auto &Other) { return ND != Other; });
-}
-
-static bool wouldYieldUniformWorkGroupSize(const Indices &LocalSize,
-                                           llvm::ArrayRef<NDRange> NDRanges) {
-  const auto GlobalSize = getMaximalGlobalSize(NDRanges);
-  return llvm::all_of(llvm::zip_equal(GlobalSize, LocalSize),
-                      [](const std::tuple<std::size_t, std::size_t> &P) {
-                        const auto &[GlobalSize, LocalSize] = P;
-                        return GlobalSize % LocalSize == 0;
-                      });
-}
-
-bool jit_compiler::isValidCombination(llvm::ArrayRef<NDRange> NDRanges) {
-  if (NDRanges.empty()) {
-    return false;
-  }
-  const auto *FirstSpecifiedLocalSize = findSpecifiedLocalSize(NDRanges);
-  const auto &ND = FirstSpecifiedLocalSize == NDRanges.end()
-                       ? NDRanges.front()
-                       : *FirstSpecifiedLocalSize;
-  return llvm::all_of(NDRanges,
-                      [&ND](const auto &Other) {
-                        return compatibleRanges(ND, Other);
-                      }) &&
-         // Either no local size is specified or the maximal global size is
-         // compatible with the specified local size.
-         (FirstSpecifiedLocalSize == NDRanges.end() ||
-          wouldYieldUniformWorkGroupSize(ND.getLocalSize(), NDRanges));
+  const auto &ND = NDRanges.front();
+  return any_of(NDRanges.drop_front(),
+                [&ND](const auto &Other) { return ND != Other; });
 }
 
 bool jit_compiler::requireIDRemapping(const NDRange &LHS, const NDRange &RHS) {

--- a/sycl-fusion/common/lib/NDRangesHelper.h
+++ b/sycl-fusion/common/lib/NDRangesHelper.h
@@ -12,26 +12,32 @@
 #include "Kernel.h"
 
 #include "llvm/ADT/ArrayRef.h"
-#include "llvm/ADT/STLExtras.h"
+#include "llvm/Support/Error.h"
 
 namespace jit_compiler {
-///
-/// Combine a list of ND-ranges, obtaining the resulting "fused" ND-range.
-NDRange combineNDRanges(llvm::ArrayRef<NDRange> NDRanges);
+class FusedNDRange {
+public:
+  static llvm::Expected<FusedNDRange> get(llvm::ArrayRef<NDRange> NDRanges);
 
-inline llvm::ArrayRef<NDRange>::const_iterator
-findSpecifiedLocalSize(llvm::ArrayRef<NDRange> NDRanges) {
-  return llvm::find_if(
-      NDRanges, [](const auto &ND) { return ND.hasSpecificLocalSize(); });
-}
+  const NDRange &getNDR() const { return NDR; }
+  llvm::ArrayRef<NDRange> getNDRanges() const { return NDRanges; }
+  bool isHeterogeneousList() const { return IsHeterogeneousList; }
+
+private:
+  FusedNDRange() = default;
+  FusedNDRange(const NDRange &NDR, bool IsHeterogeneousList,
+               llvm::ArrayRef<NDRange> NDRanges)
+      : NDR(NDR), IsHeterogeneousList(IsHeterogeneousList), NDRanges(NDRanges) {
+  }
+
+  NDRange NDR;
+  bool IsHeterogeneousList;
+  llvm::ArrayRef<NDRange> NDRanges;
+};
 
 ///
 /// Returns whether the input list of ND-ranges is heterogeneous or not.
 bool isHeterogeneousList(llvm::ArrayRef<NDRange> NDRanges);
-
-///
-/// Return whether a combination of ND-ranges is valid for fusion.
-bool isValidCombination(llvm::ArrayRef<NDRange> NDRanges);
 
 ///
 /// Return whether ID remapping will be needed.

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -108,10 +108,11 @@ Expected<std::unique_ptr<Module>> helper::FusionHelper::addFusedKernel(
 
       // Attach ND-range of the fused kernel
       assert(!F->hasMetadata(SYCLKernelFusion::NDRangeMDKey));
-      F->setMetadata(SYCLKernelFusion::NDRangeMDKey, MDFromND(FF.FusedNDRange));
+      F->setMetadata(SYCLKernelFusion::NDRangeMDKey,
+                     MDFromND(FF.FusedNDRange.getNDR()));
 
       // Attach ND-ranges of each kernel to be fused
-      const auto SrcNDRanges = FF.NDRanges;
+      const auto SrcNDRanges = FF.FusedNDRange.getNDRanges();
       SmallVector<Metadata *> Nodes;
       std::transform(SrcNDRanges.begin(), SrcNDRanges.end(),
                      std::back_inserter(Nodes), MDFromND);

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.h
@@ -33,12 +33,11 @@ public:
         llvm::ArrayRef<jit_compiler::ParameterInternalization>
             ParameterInternalization,
         llvm::ArrayRef<jit_compiler::JITConstant> Constants,
-        llvm::ArrayRef<jit_compiler::NDRange> NDRanges)
+        const jit_compiler::FusedNDRange &FusedNDRange)
         : FusedName{FusedName}, FusedKernels{FusedKernels},
           ParameterIdentities{ParameterIdentities},
           ParameterInternalization{ParameterInternalization},
-          Constants{Constants}, NDRanges{NDRanges},
-          FusedNDRange{jit_compiler::combineNDRanges(NDRanges)} {}
+          Constants{Constants}, FusedNDRange{FusedNDRange} {}
 
     const char *FusedName;
     llvm::ArrayRef<std::string> FusedKernels;
@@ -46,8 +45,7 @@ public:
     llvm::ArrayRef<jit_compiler::ParameterInternalization>
         ParameterInternalization;
     llvm::ArrayRef<jit_compiler::JITConstant> Constants;
-    llvm::ArrayRef<jit_compiler::NDRange> NDRanges;
-    jit_compiler::NDRange FusedNDRange;
+    jit_compiler::FusedNDRange FusedNDRange;
   };
 
   ///

--- a/sycl/test-e2e/KernelFusion/abort_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_fusion.cpp
@@ -96,13 +96,15 @@ int main() {
       q, nd_range<1>{range<1>{dataSize}, range<1>{16}},
       nd_range<1>{range<1>{dataSize}, range<1>{8}});
   // CHECK: ERROR: JIT compilation for kernel fusion failed with message:
-  // CHECK-NEXT: Cannot fuse kernels with different offsets or local sizes
+  // CHECK-NEXT: Illegal ND-range combination
+  // CHECK-NEXT: Detailed information:
+  // CHECK-NEXT: Cannot fuse kernels with different local sizes
   // CHECK: COMPUTATION OK
 
   // Scenario: An empty fusion list should not be classified as having
   // incompatible ND ranges.
   emptyFusionList(q);
-  // CHECK-NOT: Cannot fuse kernels with different offsets or local sizes
+  // CHECK-NOT: Illegal ND-range combination
   // CHECK: WARNING: Fusion list is empty
 
   // Scenario: Fusing two kernels that would lead to non-uniform work-group
@@ -110,7 +112,9 @@ int main() {
   performFusion<class Kernel1_4, class Kernel2_4>(
       q, nd_range<1>{range<1>{9}, range<1>{3}}, range<1>{dataSize});
   // CHECK: ERROR: JIT compilation for kernel fusion failed with message:
-  // CHECK-NEXT: Cannot fuse kernels with different offsets or local sizes
+  // CHECK-NEXT: Illegal ND-range combination
+  // CHECK-NEXT: Detailed information:
+  // CHECK-NEXT: Cannot fuse kernels whose fusion would yield non-uniform work-group sizes
   // CHECK: COMPUTATION OK
 
   return 0;

--- a/sycl/test-e2e/KernelFusion/abort_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization.cpp
@@ -152,7 +152,9 @@ int main() {
   // CHECK: Local(8), Local(16)
   // CHECK: WARNING: Not performing specified local promotion due to work-group size mismatch
   // CHECK: ERROR: JIT compilation for kernel fusion failed with message:
-  // CHECK: Cannot fuse kernels with different offsets or local sizes
+  // CHECK: Illegal ND-range combination
+  // CHECK: Detailed information:
+  // CHECK: Cannot fuse kernels with different local sizes
   // CHECK: COMPUTATION OK
 
   // Scenario: One accessor with local internalization, one with private


### PR DESCRIPTION
Show detailed error messages when users try to fuse kernels with incompatible ND-ranges, showing different errors for each different scenario. Also combine the validation and fusion logic to reduce the number of ND-ranges list traversals.