### PR TITLE
Turn on LLVM_USE_SPLIT_DWARF by default for Linux Debug build

### DIFF
--- a/llvm/CMakeLists.txt
+++ b/llvm/CMakeLists.txt
@@ -687,8 +687,15 @@ set(LLVM_UBSAN_FLAGS
 set(LLVM_LIB_FUZZING_ENGINE "" CACHE PATH
   "Path to fuzzing library for linking with fuzz targets")
 
-option(LLVM_USE_SPLIT_DWARF
-  "Use -gsplit-dwarf when compiling llvm and --gdb-index when linking." OFF)
+# Turn on split-dwarf by default for Linux, take effect on Debug/RelWithDbgInfo builds only.
+# TODO: -gsplit-dwarf is not supported on Windows yet, turn it on after adding the support.
+if (CMAKE_SYSTEM_NAME MATCHES "Linux")
+  option(LLVM_USE_SPLIT_DWARF
+    "Use -gsplit-dwarf when compiling llvm and --gdb-index when linking." ON)
+else()
+  option(LLVM_USE_SPLIT_DWARF
+    "Use -gsplit-dwarf when compiling llvm and --gdb-index when linking." OFF)
+endif()
 
 # Define an option controlling whether we should build for 32-bit on 64-bit
 # platforms, where supported.


### PR DESCRIPTION
split-dwarf feature can help reducing compile time and build footprint
See examples from:
https://www.productive-cpp.com/improving-cpp-builds-with-split-dwarf/

Locally measured size reduction using debug build shows around 20%
reduction for static linked build.

Footprint reduction using after compile.py: 48G -> 37G (23%)
after check-all: 170G -> 140G (18%)

Debugability should not be affected.
Should help with compile time, especially
incremental build as well.

-gsplit-dwarf not yet supported on windows, so not turn it on for
now.
