### PR TITLE
[SYCL][ESIMD][E2E] Re-enable matrix_transpose_glb.cpp

### DIFF
--- a/sycl/test-e2e/ESIMD/matrix_transpose_glb.cpp
+++ b/sycl/test-e2e/ESIMD/matrix_transpose_glb.cpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: gpu
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
It was fixed with the driver update. I can reproduce the failure with the old driver and reproduced it passing with the new driver.