### PR TITLE
[SYCL][E2E] Disable get_backend.cpp on DG2

### DIFF
--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,5 +1,5 @@
 // Sporadic fails on DG2
-// TODO: Renable when internal ticket is resolved
+// TODO: Reenable when internal ticket is resolved
 // UNSUPPORTED: gpu-intel-dg2
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out

--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,5 +1,6 @@
-// Failing due to old driver
-// REQUIRES-INTEL-DRIVER: lin: 27427, win: 101.4827
+// Sporadic fails on DG2
+// TODO: Renable when internal ticket is resolved
+// UNSUPPORTED: gpu-intel-dg2
 // RUN: %{build} -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out
 //


### PR DESCRIPTION
It fails sporadically on DG2 even with the new driver. It does not sporadically fail on Gen12 with the new driver. I made an internal ticket to get to the bottom of it.