### PR TITLE
[SYCL][ESIMD] Remove no-fast-math option for tests

### DIFF
--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_core.cpp
@@ -5,10 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once the issue is investigated and the test
-// is fixed.
-// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for core types.

--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_fill_fp_extra.cpp
@@ -5,10 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// TODO: remove fno-fast-math option once the issue is investigated and the test
-// is fixed.
-// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 //
 // Test for simd fill constructor for extra fp types.


### PR DESCRIPTION
The tests are passing with the latest xmain/driver