### PR TITLE
[GHA] Uplift Linux GPU RT version to 23.48.27912.11

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "23.43.27642.18",
-      "version": "23.43.27642.18",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/23.43.27642.18",
+      "github_tag": "23.48.27912.11",
+      "version": "23.48.27912.11",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/23.48.27912.11",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.15468.11",
-      "version": "1.0.15468.11",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.15468.11",
+      "github_tag": "igc-1.0.15610.11",
+      "version": "1.0.15610.11",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.15610.11",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {


### PR DESCRIPTION
Scheduled drivers uplift