### PR TITLE
[SYCL][Fusion][Test] XFAIL `KernelFusion/Reduction/reduction.cpp`

### DIFF
--- a/sycl/test-e2e/KernelFusion/Reduction/reduction.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/reduction.cpp
@@ -1,5 +1,6 @@
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
+// XFAIL: cpu
 
 // Test fusion works with reductions.
 


### PR DESCRIPTION
XFAIL failing test on CPU until the issue is fixed.