### PR TITLE
[SYCL][Doc][NFC] Rename 'fallback' to 'generic' in two specs

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -973,7 +973,7 @@ int main() {
     syclex::if_architecture_is<syclex::architecture::intel_gpu_pvc>([&]{
       // Code for PVC
     }).otherwise([&]{
-      // Fallback code
+      // Generic code
     });
   });
 
@@ -987,7 +987,7 @@ int main() {
                                        syclex::architecture::amd_gpu_gfx1013>([&]{
       // Code for AMD devices between gfx1010 and gfx1013 (inclusive)
     }).otherwise([&]{
-      // Fallback code
+      // Generic code
     });
   });
 }

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_if.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_if.asciidoc
@@ -152,7 +152,7 @@ executes the `if_device_has` function has **all** of the aspects listed in this
 pack.  If the condition is `true`, the implementation calls `fn`.  Otherwise,
 the function `fn` is potentially discarded as described below.
 
-=== Fallback code
+=== Generic code
 
 The value returned by `if_device_has` is an object _F_ of an unspecified type,
 which provides the following member functions:
@@ -200,7 +200,7 @@ void frob() {
   }).else_if_device_has<aspect::bar>([] {
     // code that uses features tied to "bar" aspect
   }).otherwise([] {
-    // fallback code that works on all devices
+    // generic code that works on all devices
   });
 }
 ```


### PR DESCRIPTION
The change was made based on a comment
https://github.com/intel/llvm/pull/12259#pullrequestreview-1843169980