### PR TITLE
[SYCL][COMPAT] Force device function to be inlined

### DIFF
--- a/sycl/include/syclcompat/launch.hpp
+++ b/sycl/include/syclcompat/launch.hpp
@@ -63,7 +63,8 @@ launch(const sycl::nd_range<3> &range, sycl::queue q, Args... args) {
       std::is_same<std::invoke_result_t<decltype(F), Args...>, void>::value,
       "SYCL kernels should return void");
 
-  return q.parallel_for(range, [=](sycl::nd_item<3>) { F(args...); });
+  return q.parallel_for(
+      range, [=](sycl::nd_item<3>) { [[clang::always_inline]] F(args...); });
 }
 
 template <auto F, typename... Args>
@@ -81,7 +82,7 @@ sycl::event launch(const sycl::nd_range<3> &range, size_t mem_size,
     auto local_acc = sycl::local_accessor<char, 1>(mem_size, cgh);
     cgh.parallel_for(range, [=](sycl::nd_item<3>) {
       auto local_mem = local_acc.get_pointer();
-      F(args..., local_mem);
+      [[clang::always_inline]] F(args..., local_mem);
     });
   });
 }


### PR DESCRIPTION
Due to the way the inliner works, the launched function may become very large and go above the inline threshold. This results with a short kernel which only call one function.

The patch adds an always_inline on the call site to force the user function to be inline in the SYCL kernel to reduce overhead.