### PR TITLE
[DRAFT][SYCL] Remove `acc` from device type in ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -161,7 +161,21 @@ void dumpConfig() {
 #undef CONFIG
 }
 
-// Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
+// Array is used by ONEAPI_DEVICE_SELECTOR.
+// TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
+// is removed.
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getODSDeviceTypeMap() {
+  static const std::array<std::pair<std::string, info::device_type>, 5>
+      SyclDeviceTypeMap = {{{"host", info::device_type::host},
+                            {"cpu", info::device_type::cpu},
+                            {"gpu", info::device_type::gpu},
+                            {"fpga", info::device_type::accelerator},
+                            {"*", info::device_type::all}}};
+  return SyclDeviceTypeMap;
+}
+
+// Array is used by SYCL_DEVICE_ALLOWLIST.
 // TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
 // is removed.
 const std::array<std::pair<std::string, info::device_type>, 6> &

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -231,7 +231,11 @@ public:
   }
 };
 
-// Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
+// Array is used by ONEAPI_DEVICE_SELECTOR.
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getODSDeviceTypeMap();
+
+// Array is used by SYCL_DEVICE_ALLOWLIST.
 const std::array<std::pair<std::string, info::device_type>, 6> &
 getSyclDeviceTypeMap();
 

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -94,7 +94,7 @@ static void Parse_ODS_Device(ods_target &Target,
 
   // Handle explicit device type (e.g. 'gpu').
   auto DeviceTypeMap =
-      getSyclDeviceTypeMap(); // <-- std::array<std::pair<std::string,
+      getODSDeviceTypeMap(); // <-- std::array<std::pair<std::string,
                               // info::device::type>>
   auto It =
       std::find_if(std::begin(DeviceTypeMap), std::end(DeviceTypeMap),
@@ -262,7 +262,7 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
 std::ostream &operator<<(std::ostream &Out, const ods_target &Target) {
   Out << Target.Backend;
   if (Target.DeviceType) {
-    auto DeviceTypeMap = getSyclDeviceTypeMap();
+    auto DeviceTypeMap = getODSDeviceTypeMap();
     auto Match = std::find_if(
         DeviceTypeMap.begin(), DeviceTypeMap.end(),
         [&](auto Pair) { return (Pair.second == Target.DeviceType); });

--- a/sycl/test-e2e/Sampler/basic-rw.cpp
+++ b/sycl/test-e2e/Sampler/basic-rw.cpp
@@ -15,7 +15,7 @@
     ONEAPI_DEVICE_SELECTOR=level_zero:gpu ./binx.bin
     ONEAPI_DEVICE_SELECTOR=opencl:cpu ./binx.bin
 
-    ONEAPI_DEVICE_SELECTOR=opecl:acc ../binx.bin    <--  does not support image
+    ONEAPI_DEVICE_SELECTOR=opencl:fpga ../binx.bin    <--  does not support image
    operations at this time.
 
 */


### PR DESCRIPTION
ONEAPI_DEVICE_SELECTOR does not throw an exception upon passing an invalid device name 'acc'. AFAIK, 'acc' device type is valid for SYCL_DEVICE_FILTER (now depreciated) but is invalid for ONEAPI_DEVICE_SELECTOR.

This PR makes ONEAPI_DEVICE_SELECTOR to not accept 'acc' as a device type, 'fpga' should be used instead.