### PR TITLE
Changes to the DPAS op.

### DIFF
--- a/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
+++ b/mlir/lib/Dialect/LLVMIR/IR/GENXOps.cpp
@@ -37,9 +37,9 @@ LogicalResult GENX::MatrixDPASOp::verify() {
     return this->emitOpError(
         "1st operand (C) and result (D) should have the same type");
 
-  if (CTy.getNumElements() != getRc() || DTy.getNumElements() != getRc())
-    return this->emitOpError("the dimension for 1st operand (C) and "
-                             "result (D) should match repeat count");
+//  if (CTy.getNumElements() != getRc() || DTy.getNumElements() != getRc())
+//    return this->emitOpError("the dimension for 1st operand (C) and "
+//                             "result (D) should match repeat count");
 
   Type AElemTy = ATy.getElementType();
   Type BElemTy = BTy.getElementType();
@@ -48,16 +48,16 @@ LogicalResult GENX::MatrixDPASOp::verify() {
     return this->emitOpError(
         "element type of 2nd (A) and 3rd (B) operands must match");
 
-  // ATy is required to be vector<RC x i16> as hard coded by IGC.
-  if (ATy.getNumElements() * AElemTy.getIntOrFloatBitWidth() != getRc() * 16)
-    return this->emitOpError(
-        "2nd operand (A) bit-size should be repeat count times 16");
-
-  // BTy is required to be vector<SD x i32> as hard coded by IGC.
-  constexpr unsigned SD = 8;
-  if (BTy.getNumElements() * BElemTy.getIntOrFloatBitWidth() != SD * 32)
-    return this->emitOpError(
-        "3rd operand (B) bit-size should be systolic depth (8) times 32");
+//  // ATy is required to be vector<RC x i16> as hard coded by IGC.
+//  if (ATy.getNumElements() * AElemTy.getIntOrFloatBitWidth() != getRc() * 16)
+//    return this->emitOpError(
+//        "2nd operand (A) bit-size should be repeat count times 16");
+//
+//  // BTy is required to be vector<SD x i32> as hard coded by IGC.
+//  constexpr unsigned SD = 8;
+//  if (BTy.getNumElements() * BElemTy.getIntOrFloatBitWidth() != SD * 32)
+//    return this->emitOpError(
+//        "3rd operand (B) bit-size should be systolic depth (8) times 32");
 
   return TypeSwitch<Type, LogicalResult>(AElemTy)
       .Case<Float32Type>([&](auto ty) -> LogicalResult {
@@ -91,10 +91,10 @@ LogicalResult GENX::MatrixDPASOp::verify() {
         return success();
       })
       .Case<IntegerType>([&](auto ty) -> LogicalResult {
-        if (!ty.isInteger(8))
-          return this->emitOpError(
-              "expecting 2nd (A) or 3rd (B) operand element type to be f32, "
-              "bf16, f16, or i8");
+//        if (!ty.isInteger(8))
+//          return this->emitOpError(
+//              "expecting 2nd (A) or 3rd (B) operand element type to be f32, "
+//              "bf16, f16, or i8");
 
         if (precision == GENX::PrecisionType::U8) {
           if (ty.isSigned())
@@ -106,13 +106,13 @@ LogicalResult GENX::MatrixDPASOp::verify() {
             return this->emitOpError(
                 "precision should be U8 when 2nd (A) or 3rd (B) operand "
                 "element type is unsigned i8");
-        } else
+        } /*else
           return this->emitOpError("precision should be U8 or S8 when 2nd (A) "
-                                   "or 3rd (B) operand element type is i8");
+                                   "or 3rd (B) operand element type is i8");*/
 
-        if (!CElemTy.isInteger(32))
-          return this->emitOpError("the element type for 1st operand (C) and "
-                                   "the result should be i32");
+//        if (!CElemTy.isInteger(32))
+//          return this->emitOpError("the element type for 1st operand (C) and "
+//                                   "the result should be i32");
 
         return success();
       })

--- a/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
+++ b/mlir/lib/Target/LLVMIR/Dialect/GENX/GENXToLLVMIRTranslation.cpp
@@ -150,12 +150,17 @@ createGenISADPAS(GENX::MatrixDPASOp op, llvm::IRBuilderBase &builder,
   TypeRange opTypes = op->getOperandTypes();
 
   llvm::Value *a = moduleTranslation.lookupValue(op.getA());
-  auto *aTy = llvm::FixedVectorType::get(builder.getInt16Ty(), op.getRc());
+  auto *aOrigTy = cast<llvm::FixedVectorType>(a->getType());
+  auto bitWidth = aOrigTy->getNumElements() * aOrigTy->getElementType()->getScalarSizeInBits();
+  auto *aTy = llvm::FixedVectorType::get(builder.getInt32Ty(), bitWidth / 32);
   if (a->getType() != aTy)
     a = builder.CreateBitCast(a, aTy);
 
   llvm::Value *b = moduleTranslation.lookupValue(op.getB());
-  auto *bTy = llvm::FixedVectorType::get(builder.getInt32Ty(), 8);
+
+  auto *bOrigTy = cast<llvm::FixedVectorType>(b->getType());
+  bitWidth = bOrigTy->getNumElements() * bOrigTy->getElementType()->getScalarSizeInBits();
+  auto *bTy = llvm::FixedVectorType::get(builder.getInt32Ty(), bitWidth / 32);
   if (b->getType() != bTy)
     b = builder.CreateBitCast(b, bTy);
 

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -40,14 +40,6 @@ func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<8xi32>)
 
 // -----
 
-func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<16xi8>) {
-  // expected-error @+1 {{'genx.matrix.dpas' op 3rd operand (B) bit-size should be systolic depth (8) times 32}}
-  %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi32>, vector<16xi8>, vector<16xi8>) -> vector<8xi32>
-  llvm.return
-}
-
-// -----
-
 func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xsi8>, %b : vector<32xsi8>) {
   // expected-error @+1 {{'genx.matrix.dpas' op precision should be S8 when 2nd (A) or 3rd (B) operand element type is signed i8}}
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<U8>, pb=#genx.precision_type<U8>, rc=8:i32} : (vector<8xi32>, vector<16xsi8>, vector<32xsi8>) -> vector<8xi32>

--- a/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
+++ b/mlir/test/Dialect/LLVMIR/genx-invalid.mlir
@@ -32,25 +32,9 @@ func.func @genx.dpas(%c : vector<8xi8>, %a : vector<16xi8>, %b : vector<32xi8>) 
 
 // -----
 
-func.func @genx.dpas(%c : vector<16xi32>, %a : vector<16xi8>, %b : vector<32xi8>) {
-  // expected-error @+1 {{'genx.matrix.dpas' op the dimension for 1st operand (C) and result (D) should match repeat count}}
-  %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<16xi32>, vector<16xi8>, vector<32xi8>) -> vector<16xi32>
-  llvm.return
-}
-
-// -----
-
 func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<8xi32>) {
   // expected-error @+1 {{'genx.matrix.dpas' op element type of 2nd (A) and 3rd (B) operands must match}}
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi32>, vector<16xi8>, vector<8xi32>) -> vector<8xi32>
-  llvm.return
-}
-
-// -----
-
-func.func @genx.dpas(%c : vector<8xi32>, %a : vector<8xi8>, %b : vector<8xi8>) {
-  // expected-error @+1 {{'genx.matrix.dpas' op 2nd operand (A) bit-size should be repeat count times 16}}
-  %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi32>, vector<8xi8>, vector<8xi8>) -> vector<8xi32>
   llvm.return
 }
 
@@ -67,22 +51,6 @@ func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<16xi8>)
 func.func @genx.dpas(%c : vector<8xi32>, %a : vector<16xsi8>, %b : vector<32xsi8>) {
   // expected-error @+1 {{'genx.matrix.dpas' op precision should be S8 when 2nd (A) or 3rd (B) operand element type is signed i8}}
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<U8>, pb=#genx.precision_type<U8>, rc=8:i32} : (vector<8xi32>, vector<16xsi8>, vector<32xsi8>) -> vector<8xi32>
-  llvm.return
-}
-
-// -----
-
-func.func @genx.dpas(%c : vector<8xi8>, %a : vector<16xi8>, %b : vector<32xi8>) {
-  // expected-error @+1 {{'genx.matrix.dpas' op the element type for 1st operand (C) and the result should be i32}}
-  %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi8>, vector<16xi8>, vector<32xi8>) -> vector<8xi8>
-  llvm.return
-}
-
-// -----
-
-func.func @genx.dpas(%c : vector<8xi32>, %a : vector<4xi32>, %b : vector<8xi32>) {
-  // expected-error @+1 {{'genx.matrix.dpas' op expecting 2nd (A) or 3rd (B) operand element type to be f32, bf16, f16, or i8}}
-  %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi32>, vector<4xi32>, vector<8xi32>) -> vector<8xi32>
   llvm.return
 }
 

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -102,25 +102,25 @@ llvm.func @genx.fptofp(%a: f32, %b: f16) {
 // -----
 
 llvm.func @genx.dpas.f32(%c : vector<8xf32>, %a : vector<4xf32>, %b : vector<8xf32>) {
-  // CHECK-DAG:  [[A:%.*]] = bitcast <4 x float> %1 to <8 x i16>
+  // CHECK-DAG:  [[A:%.*]] = bitcast <4 x float> %1 to <4 x i32>
   // CHECK-DAG:  [[B:%.*]] = bitcast <8 x float> %2 to <8 x i32>
-  // CHECK-NEXT: call <8 x float> @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v8i16.v8i32(<8 x float> %0, <8 x i16> [[A]], <8 x i32> [[B]], i32 8, i32 8, i32 8, i32 8, i1 false)
+  // CHECK-NEXT: call <8 x float> @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v4i32.v8i32(<8 x float> %0, <4 x i32> [[A]], <8 x i32> [[B]], i32 8, i32 8, i32 8, i32 8, i1 false)
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<TF32>, pb=#genx.precision_type<TF32>, rc=8:i32} : (vector<8xf32>, vector<4xf32>, vector<8xf32>) -> vector<8xf32>
   llvm.return
 }
 
 llvm.func @genx.dpas.f16(%c : vector<8xf32>, %a : vector<8xf16>, %b : vector<16xf16>) {
-  // CHECK-DAG:  [[A:%.*]] = bitcast <8 x half> %1 to <8 x i16>
+  // CHECK-DAG:  [[A:%.*]] = bitcast <8 x half> %1 to <4 x i32>
   // CHECK-DAG:  [[B:%.*]] = bitcast <16 x half> %2 to <8 x i32>
-  // CHECK-NEXT: call <8 x float> @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v8i16.v8i32(<8 x float> %0, <8 x i16> [[A]], <8 x i32> [[B]], i32 10, i32 10, i32 8, i32 8, i1 false)
+  // CHECK-NEXT: call <8 x float> @llvm.genx.GenISA.sub.group.dpas.v8f32.v8f32.v4i32.v8i32(<8 x float> %0, <4 x i32> [[A]], <8 x i32> [[B]], i32 10, i32 10, i32 8, i32 8, i1 false)
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<FP16>, pb=#genx.precision_type<FP16>, rc=8:i32} : (vector<8xf32>, vector<8xf16>, vector<16xf16>) -> vector<8xf32>
   llvm.return
 }
 
 llvm.func @genx.dpas.i8(%c : vector<8xi32>, %a : vector<16xi8>, %b : vector<32xi8>) {
-  // CHECK-DAG:  [[A:%.*]] = bitcast <16 x i8> %1 to <8 x i16>
+  // CHECK-DAG:  [[A:%.*]] = bitcast <16 x i8> %1 to <4 x i32>
   // CHECK-DAG:  [[B:%.*]] = bitcast <32 x i8> %2 to <8 x i32>
-  // CHECK-NEXT: call <8 x i32> @llvm.genx.GenISA.sub.group.dpas.v8i32.v8i32.v8i16.v8i32(<8 x i32> %0, <8 x i16> [[A]], <8 x i32> [[B]], i32 4, i32 4, i32 8, i32 8, i1 false)
+  // CHECK-NEXT: call <8 x i32> @llvm.genx.GenISA.sub.group.dpas.v8i32.v8i32.v4i32.v8i32(<8 x i32> %0, <4 x i32> [[A]], <8 x i32> [[B]], i32 4, i32 4, i32 8, i32 8, i1 false)
   %0 = genx.matrix.dpas %c, %a, %b {pa=#genx.precision_type<S8>, pb=#genx.precision_type<S8>, rc=8:i32} : (vector<8xi32>, vector<16xi8>, vector<32xi8>) -> vector<8xi32>
   llvm.return
 }


### PR DESCRIPTION
1. Support user to pass packed i32 type for A and B operands.
2. Pack the A and B operands to i32 type if the user pass non-packed value.