### PR TITLE
[SYCL][Fusion] Handle GEPs that were canonicalized to byte offsets

### DIFF
--- a/sycl-fusion/passes/internalization/Internalization.cpp
+++ b/sycl-fusion/passes/internalization/Internalization.cpp
@@ -189,6 +189,21 @@ static void updateInternalizationMD(Function *F, StringRef Kind,
 }
 
 ///
+/// If \p GEPI represents a constant offset in bytes, return it, otherwise
+/// return an empty value.
+static std::optional<unsigned> getConstantByteOffset(GetElementPtrInst *GEPI,
+                                                     const DataLayout &DL) {
+  MapVector<Value *, APInt> VariableOffsets;
+  auto IW = DL.getIndexSizeInBits(GEPI->getPointerAddressSpace());
+  APInt ConstantOffset = APInt::getZero(IW);
+  if (GEPI->collectOffset(DL, IW, VariableOffsets, ConstantOffset) &&
+      VariableOffsets.empty()) {
+    return ConstantOffset.getZExtValue();
+  }
+  return {};
+}
+
+///
 /// When performing internalization, GEP instructions must be remapped, as the
 /// address space has changed from N to N / LocalSize.
 static void remap(GetElementPtrInst *GEPI, const PromotionInfo &PromInfo) {
@@ -198,6 +213,25 @@ static void remap(GetElementPtrInst *GEPI, const PromotionInfo &PromInfo) {
     // Squash the index and let instcombine clean-up afterwards.
     GEPI->idx_begin()->set(Builder.getInt64(0));
     return;
+  }
+
+  // GEPs with constant offset may be marked for remapping even if their element
+  // size differs from the accessor's element size. However we know that the
+  // offset is a multiple of the latter. Rewrite the instruction to represent a
+  // number of _elements_ to make it compatible with other GEPs in the current
+  // chain.
+  auto &DL = GEPI->getModule()->getDataLayout();
+  auto SrcElemTySz = DL.getTypeAllocSize(GEPI->getSourceElementType());
+  if (SrcElemTySz != PromInfo.ElemSize) {
+    auto COff = getConstantByteOffset(GEPI, DL);
+    // This is special case #2 in `getGEPKind`.
+    assert(COff.has_value() && *COff % PromInfo.ElemSize == 0 &&
+           GEPI->getNumIndices() == 1);
+    auto *IntTypeWithSameWidthAsAccessorElementType =
+        Builder.getIntNTy(PromInfo.ElemSize * 8);
+    GEPI->setSourceElementType(IntTypeWithSameWidthAsAccessorElementType);
+    GEPI->setResultElementType(IntTypeWithSameWidthAsAccessorElementType);
+    GEPI->idx_begin()->set(Builder.getInt64(*COff / PromInfo.ElemSize));
   }
 
   // An individual `GEP(ptr, offset)` is rewritten as
@@ -302,15 +336,19 @@ static int getGEPKind(GetElementPtrInst *GEPI, const PromotionInfo &PromInfo) {
     return Kind;
   }
 
-  // Check whether `GEPI` adds a constant offset, e.g. a byte offset to address
-  // into a padded structure, smaller than the element size.
-  MapVector<Value *, APInt> VariableOffsets;
-  auto IW = DL.getIndexSizeInBits(GEPI->getPointerAddressSpace());
-  APInt ConstantOffset = APInt::getZero(IW);
-  if (GEPI->collectOffset(DL, IW, VariableOffsets, ConstantOffset) &&
-      VariableOffsets.empty() &&
-      ConstantOffset.getZExtValue() < PromInfo.ElemSize) {
-    return ADDRESSES_INTO_AGGREGATE;
+  // We can handle a mismatch between `GEPI`'s element size and the accessors
+  // element size if `GEPI` represents a constant offset.
+  if (auto COff = getConstantByteOffset(GEPI, DL)) {
+    if (*COff < PromInfo.ElemSize) {
+      // Special case #1: The offset is less than the element size, hence we're
+      // addressing into an aggregrate and no remapping is required.
+      return ADDRESSES_INTO_AGGREGATE;
+    }
+    if (*COff % PromInfo.ElemSize == 0 && GEPI->getNumIndices() == 1) {
+      // Special case #2: The offset is a multiple of the element size, meaning
+      // `GEPI` selects an element and is subject to remapping.
+      return NEEDS_REMAPPING;
+    }
   }
 
   // We don't know what `GEPI` addresses; bail out.

--- a/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
@@ -1,6 +1,5 @@
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: hip,cuda
 
 // Test complete fusion with private internalization specified on the
 // accessors for a device kernel with sycl::vec::load and sycl::vec::store.


### PR DESCRIPTION
Upstream now canonicalizes constant GEPs to represent byte offsets, i.e. using `i8` as source element type. This PR adapts the internalization pass to this change by also remapping GEPs with a constant offset, if that offset is a multiple of the internalized accessor's element size.