### PR TITLE
[SYCL] Disable dynamic_address_cast test on FPGA

### DIFF
--- a/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
+++ b/sycl/test-e2e/AddressCast/dynamic_address_cast.cpp
@@ -8,7 +8,8 @@
 
 // Issue with OpenCL CPU runtime implementation of OpGenericCastToPtrExplicit
 // OpGenericCastToPtr* intrinsics not implemented on AMD or NVIDIA
-// UNSUPPORTED: cpu, hip, cuda
+// FPGA emulator affected by same issue as OpenCL CPU runtime
+// UNSUPPORTED: cpu, hip, cuda, accelerator
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
The FPGA emulator is currently affected by the same issue as the CPU runtime.