### PR TITLE
[SYCL][E2E] Disable USM/usm_pooling.cpp on gpu-intel-dg2

### DIFF
--- a/sycl/test-e2e/USM/usm_pooling.cpp
+++ b/sycl/test-e2e/USM/usm_pooling.cpp
@@ -1,6 +1,9 @@
 // REQUIRES: level_zero
 // RUN: %{build} -o %t.out
 
+// https://github.com/intel/llvm/issues/12397
+// UNSUPPORTED: gpu-intel-dg2
+
 // Allocate 2 items of 2MB. Free 2. Allocate 3 more of 2MB.
 
 // With no pooling: 1,2,3,4,5 allocs lead to ZE call.


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/12397, the test is flaky in post-commit.