### PR TITLE
[SYCL][ESIMD][E2E] Disable two LSC tests on DG2

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke_cmpxchg.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // This test checks local accessor cmpxchg atomic operations.
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || gpu-intel-dg2
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/ESIMD/lsc/lsc_slm_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_slm_atomic_smoke.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 // This test checks LSC SLM atomic operations.
 //===----------------------------------------------------------------------===//
-// REQUIRES: gpu-intel-pvc || gpu-intel-dg2
+// REQUIRES: gpu-intel-pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
They started failing in the recent driver update. I can't reproduce it locally with the same driver version but the hardware we have is a little different, maybe that's why. I made an internal tracker for this.