### PR TITLE
[syclcompat][CUDA] FIX UB in test / seq_cst requires sm_70 on CUDA.

### DIFF
--- a/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip || (windows && level_zero)
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_70 %} %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/sycl.hpp>
@@ -41,8 +41,8 @@
 #include "../common.hpp"
 #include "atomic_fixt.hpp"
 
-constexpr size_t numBlocks = 64;
-constexpr size_t numThreads = 256;
+constexpr size_t numBlocks = 1;
+constexpr size_t numThreads = 1;
 constexpr size_t numData = 6;
 
 template <typename T, typename AtomicType>

--- a/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_70 %} %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>


### PR DESCRIPTION
Fix UB in test by using a single thread task.

A shared USM variable was being simultaneously written to by multiple threads without using atomics. AFAIK this is generally not a well defined program, and was leading to invalid values.

seq_cst also requires sm_70 on CUDA, so the compilation invocation is updated to reflect this.
The CI device is >= sm_70 so it can use seq_cst. However this test did not compile for >=sm_70.

