### PR TITLE
[SYCL] [NATIVECPU] Add OCK subdirectory with EXCLUDE_FROM_ALL

### DIFF
--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -42,7 +42,7 @@ if(NATIVECPU_USE_OCK)
     FetchContent_Populate(oneapi-ck)
     message(STATUS "oneAPI Construction Kit cloned in ${oneapi-ck_SOURCE_DIR}")
     set(CA_NATIVE_CPU 1)
-    add_subdirectory(${oneapi-ck_SOURCE_DIR} ${oneapi-ck_BINARY_DIR})
+    add_subdirectory(${oneapi-ck_SOURCE_DIR} ${oneapi-ck_BINARY_DIR} EXCLUDE_FROM_ALL)
   endif()
   target_compile_definitions(LLVMSYCLLowerIR PRIVATE  NATIVECPU_USE_OCK)
   target_include_directories(LLVMSYCLLowerIR PRIVATE 


### PR DESCRIPTION
Adding `EXCLUDE_FROM_ALL` to the `add_subdirectory` for the OneAPI Construction Kit, in order to to avoid building its components unless they are required by the SYCL toolchain.