### PR TITLE
[SYCL][E2E] Disable assert_in_multiple_tus[_one_ndebug].cpp on cuda

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus.cpp
@@ -3,6 +3,9 @@
 // https://github.com/intel/llvm/issues/7634
 // UNSUPPORTED: hip
 //
+// https://github.com/intel/llvm/issues/8832
+// UNSUPPORTED: cuda
+//
 // FIXME: Remove XFAIL one intel/llvm#11364 is resolved
 // XFAIL: (opencl && gpu)
 

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug.cpp
@@ -3,6 +3,9 @@
 // https://github.com/intel/llvm/issues/7634
 // UNSUPPORTED: hip
 //
+// https://github.com/intel/llvm/issues/8832
+// UNSUPPORTED: cuda
+//
 // FIXME: Remove XFAIL one intel/llvm#11364 is resolved
 // XFAIL: (opencl && gpu)
 


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/8832, the test is flaky in post-commit/nightly.