### PR TITLE
[SYCL] Treat "ar" image format as PI_DEVICE_BINARY_TYPE_NATIVE

### DIFF
--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -701,6 +701,14 @@ getBinaryImageFormat(const unsigned char *ImgData, size_t ImgSize) {
     // 'I', 'N', 'T', 'C' ; Intel native
     return PI_DEVICE_BINARY_TYPE_LLVMIR_BITCODE;
 
+  if (MatchMagicNumber(std::array{'!', '<', 'a', 'r', 'c', 'h', '>', '\n'}))
+    // "ar" format is used to pack binaries for multiple devices, e.g. via
+    //
+    //   -Xsycl-target-backend=spir64_gen "-device acm-g10,acm-g11"
+    //
+    // option.
+    return PI_DEVICE_BINARY_TYPE_NATIVE;
+
   // Check for ELF format, size requirements include data we'll read in case of
   // succesful match.
   if (ImgSize < 18 || !MatchMagicNumber(uint32_t{0x464c457F}))


### PR DESCRIPTION
That's what AOT for Intel GPUs produces when targeting multiple devices
at once.

This PR is built on top of https://github.com/intel/llvm/pull/12586.