### PR TITLE
Fix a leak in pi_unified_runtime.cpp.

### DIFF
--- a/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
+++ b/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
@@ -1349,6 +1349,7 @@ __SYCL_EXPORT pi_result piPluginInit(pi_plugin *PluginInit) {
   }
 
   HANDLE_ERRORS(urLoaderInit(0, LoaderConfig));
+  HANDLE_ERRORS(urLoaderConfigRelease(LoaderConfig));
 
   uint32_t NumAdapters;
   HANDLE_ERRORS(urAdapterGet(0, nullptr, &NumAdapters));


### PR DESCRIPTION
`LoaderConfig` is created and stored in a local pointer and never released when done using, causing it to be leaked.
This patch releases the `LoaderConfig` when finished using it.