### PR TITLE
[SYCL] Update test scripts and sycl-ls to use 'fpga' with ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -590,7 +590,7 @@ config.sycl_dev_features = {}
 config.intel_driver_ver = {}
 for sycl_device in config.sycl_devices:
     env = copy.copy(llvm_config.config.environment)
-    env["ONEAPI_DEVICE_SELECTOR"] = sycl_device
+    env["ONEAPI_DEVICE_SELECTOR"] = sycl_device.replace(":acc", ":fpga")
     if sycl_device.startswith("cuda:"):
         env["SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT"] = "1"
     # When using the ONEAPI_DEVICE_SELECTOR environment variable, sycl-ls

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -427,7 +427,7 @@ if len(config.sycl_devices) > 1:
 config.sycl_devices = [x.replace("ext_oneapi_", "") for x in config.sycl_devices]
 
 available_devices = {
-    "opencl": ("cpu", "gpu", "acc"),
+    "opencl": ("cpu", "gpu", "fpga"),
     "cuda": "gpu",
     "level_zero": "gpu",
     "hip": "gpu",
@@ -590,7 +590,7 @@ config.sycl_dev_features = {}
 config.intel_driver_ver = {}
 for sycl_device in config.sycl_devices:
     env = copy.copy(llvm_config.config.environment)
-    env["ONEAPI_DEVICE_SELECTOR"] = sycl_device.replace(":acc", ":fpga")
+    env["ONEAPI_DEVICE_SELECTOR"] = sycl_device
     if sycl_device.startswith("cuda:"):
         env["SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT"] = "1"
     # When using the ONEAPI_DEVICE_SELECTOR environment variable, sycl-ls

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -49,7 +49,7 @@ std::string getDeviceTypeName(const device &Device) {
   case info::device_type::host:
     return "host";
   case info::device_type::accelerator:
-    return "acc";
+    return "fpga";
   default:
     return "unknown";
   }


### PR DESCRIPTION
As per the ONEAPI_DEVICE_SELECTOR [documentation](https://github.com/intel/llvm/blob/sycl/sycl/doc/EnvironmentVariables.md#oneapi_device_selector), the device type can only be cpu, gpu, or fpga (or any combination of those). Currently, 'acc' is also accepted by ONEAPI_DEVICE_SELECTOR as a valid device type, which is incorrect.

This PR modifies lit.cfg.py and sycl-ls  to use 'fpga' instead of 'acc' in ONEAPI_DEVICE_SELECTOR.