### PR TITLE
[SYCL][sycl-post-link] Add check for deleted Spec Constant Operands

### DIFF
--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -1004,9 +1004,11 @@ bool SpecConstantsPass::collectSpecConstantDefaultValuesMetadata(
 
   unsigned Offset = 0;
   for (const auto *Node : N->operands()) {
-    auto *Constant = cast<ConstantAsMetadata>(Node->getOperand(0))->getValue();
-    collectCompositeElementsDefaultValuesRecursive(M, Constant, Offset,
-                                                   DefaultValues);
+    if (Node->getOperand(0)) {
+      auto *Constant = cast<ConstantAsMetadata>(Node->getOperand(0))->getValue();
+      collectCompositeElementsDefaultValuesRecursive(M, Constant, Offset,
+                                                     DefaultValues);
+    }
   }
 
   return true;

--- a/llvm/tools/sycl-post-link/SpecConstants.cpp
+++ b/llvm/tools/sycl-post-link/SpecConstants.cpp
@@ -1005,7 +1005,8 @@ bool SpecConstantsPass::collectSpecConstantDefaultValuesMetadata(
   unsigned Offset = 0;
   for (const auto *Node : N->operands()) {
     if (Node->getOperand(0)) {
-      auto *Constant = cast<ConstantAsMetadata>(Node->getOperand(0))->getValue();
+      auto *Constant =
+          cast<ConstantAsMetadata>(Node->getOperand(0))->getValue();
       collectCompositeElementsDefaultValuesRecursive(M, Constant, Offset,
                                                      DefaultValues);
     }


### PR DESCRIPTION
When we turn on -emit-only-kernel-as-entry-points by default for sycl-post-link tools, there are some entries in some of the specialization constant metadata are not carried over. Hence, a check is required to ensure we are not parsing 'null' specialization constants.

Thanks