### PR TITLE
[SYCL][E2E] Fix sycl-ls discovery

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -400,7 +400,9 @@ if config.dump_ir_supported:
 
 lit_config.note("Targeted devices: {}".format(", ".join(config.sycl_devices)))
 
-sycl_ls = FindTool("sycl-ls").resolve(llvm_config, config.llvm_tools_dir)
+sycl_ls = FindTool('sycl-ls').resolve(llvm_config,
+                                      os.path.join(config.llvm_tools_dir,
+                                                   os.environ.get('PATH', '')))
 if not sycl_ls:
     lit_config.fatal("can't find `sycl-ls`")
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -400,9 +400,9 @@ if config.dump_ir_supported:
 
 lit_config.note("Targeted devices: {}".format(", ".join(config.sycl_devices)))
 
-sycl_ls = FindTool('sycl-ls').resolve(llvm_config,
-                                      os.path.join(config.llvm_tools_dir,
-                                                   os.environ.get('PATH', '')))
+sycl_ls = FindTool("sycl-ls").resolve(
+    llvm_config, os.path.join(config.llvm_tools_dir, os.environ.get("PATH", ""))
+)
 if not sycl_ls:
     lit_config.fatal("can't find `sycl-ls`")
 


### PR DESCRIPTION
We should also look for `sycl-ls` in the `PATH` and not just in the llvm tools dir.