### PR TITLE
[CUDA][HIP][TEST-E2E] Include the necessary environment paths during the test-e2e build for CUDA and HIP backends.

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -80,6 +80,12 @@ llvm_config.with_system_environment(
 
 llvm_config.with_environment("PATH", config.lit_tools_dir, append_path=True)
 
+if "cuda:gpu" in config.sycl_devices:
+    llvm_config.with_system_environment("CUDA_PATH")
+
+if "hip:gpu" in config.sycl_devices:
+    llvm_config.with_system_environment("ROCM_PATH")
+
 # Configure LD_LIBRARY_PATH or corresponding os-specific alternatives
 if platform.system() == "Linux":
     config.available_features.add("linux")


### PR DESCRIPTION
Include the necessary environment paths during the test-e2e build for `CUDA` and `HIP` backends.
The absence of the added path leads to the inability to locate libdevice for specific architectures, resulting in a failure. 
Below is the reported error when expected `CUDA_PATH` is missing
`
clang++: error: cannot find libdevice for `sm_50`; provide path to different `CUDA` installation via '--cuda-path', or pass '-nocudalib' to build without linking with libdevice
`
