### PR TITLE
[SYCL][E2E] XPASS->UNSUPPORTED for KernelFusion/Reduction/reduction.cpp

### DIFF
--- a/sycl/test-e2e/KernelFusion/Reduction/reduction.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/reduction.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: cpu
+//
+// The test fails on opencl:cpu when running on AMD runner and passes when
+// running on Intel Arc GPU runner.
+// UNSUPPORTED: cpu
 
 // Test fusion works with reductions.
 


### PR DESCRIPTION
See notes in
https://github.com/intel/llvm/pull/12540#issuecomment-1927506081 https://github.com/intel/llvm/pull/12586#issuecomment-1927494475