### PR TITLE
[SYCL] Drop 'acc' in favor of 'fpga' from ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -166,7 +166,8 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
         // valid. E.g., for BackendName key, the allowed values are only ones
         // described in SyclBeMap
         ValidateEnumValues(BackendNameKeyName, getSyclBeMap());
-        ValidateEnumValues(DeviceTypeKeyName, getSyclDeviceTypeMap(true /*Enable 'acc'*/));
+        ValidateEnumValues(DeviceTypeKeyName,
+                           getSyclDeviceTypeMap(true /*Enable 'acc'*/));
 
         if (Key == DeviceVendorIdKeyName) {
           // DeviceVendorId should have hex format
@@ -380,7 +381,8 @@ void applyAllowList(std::vector<sycl::detail::pi::PiDevice> &PiDevices,
         Device, PI_DEVICE_INFO_TYPE, sizeof(sycl::detail::pi::PiDeviceType),
         &PiDevType, nullptr);
     sycl::info::device_type DeviceType = pi::cast<info::device_type>(PiDevType);
-    for (const auto &SyclDeviceType : getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
+    for (const auto &SyclDeviceType :
+         getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
       if (SyclDeviceType.second == DeviceType) {
         const auto &DeviceTypeValue = SyclDeviceType.first;
         DeviceDesc[DeviceTypeKeyName] = DeviceTypeValue;

--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -166,7 +166,7 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
         // valid. E.g., for BackendName key, the allowed values are only ones
         // described in SyclBeMap
         ValidateEnumValues(BackendNameKeyName, getSyclBeMap());
-        ValidateEnumValues(DeviceTypeKeyName, getSyclDeviceTypeMap());
+        ValidateEnumValues(DeviceTypeKeyName, getSyclDeviceTypeMap(true /*Enable 'acc'*/));
 
         if (Key == DeviceVendorIdKeyName) {
           // DeviceVendorId should have hex format
@@ -380,7 +380,7 @@ void applyAllowList(std::vector<sycl::detail::pi::PiDevice> &PiDevices,
         Device, PI_DEVICE_INFO_TYPE, sizeof(sycl::detail::pi::PiDeviceType),
         &PiDevType, nullptr);
     sycl::info::device_type DeviceType = pi::cast<info::device_type>(PiDevType);
-    for (const auto &SyclDeviceType : getSyclDeviceTypeMap()) {
+    for (const auto &SyclDeviceType : getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
       if (SyclDeviceType.second == DeviceType) {
         const auto &DeviceTypeValue = SyclDeviceType.first;
         DeviceDesc[DeviceTypeKeyName] = DeviceTypeValue;

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -161,6 +161,38 @@ void dumpConfig() {
 #undef CONFIG
 }
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+// Array is used by ONEAPI_DEVICE_SELECTOR.
+// TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
+// is removed.
+// TODO: At some point, we should also align the inputs of SYCL_DEVICE_ALLOWLIST
+// and ONEAPI_DEVICE_SELECTOR. Currently, SYCL_DEVICE_ALLOWLIST accepts 'acc' while
+// ONEAPI_DEVICE_SELECTOR accepts 'fpga'.
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getODSDeviceTypeMap() {
+  static const std::array<std::pair<std::string, info::device_type>, 5>
+      SyclDeviceTypeMap = {{{"host", info::device_type::host},
+                            {"cpu", info::device_type::cpu},
+                            {"gpu", info::device_type::gpu},
+                            {"fpga", info::device_type::accelerator},
+                            {"*", info::device_type::all}}};
+  return SyclDeviceTypeMap;
+}
+
+// Array is used by SYCL_DEVICE_ALLOWLIST.
+// TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
+// is removed.
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getSyclDeviceTypeMap() {
+  static const std::array<std::pair<std::string, info::device_type>, 5>
+      SyclDeviceTypeMap = {{{"host", info::device_type::host},
+                            {"cpu", info::device_type::cpu},
+                            {"gpu", info::device_type::gpu},
+                            {"acc", info::device_type::accelerator},
+                            {"*", info::device_type::all}}};
+  return SyclDeviceTypeMap;
+}
+#else
 // Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
 // TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
 // is removed.
@@ -175,6 +207,7 @@ getSyclDeviceTypeMap() {
                             {"*", info::device_type::all}}};
   return SyclDeviceTypeMap;
 }
+#endif
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -166,8 +166,8 @@ void dumpConfig() {
 // TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
 // is removed.
 // TODO: At some point, we should also align the inputs of SYCL_DEVICE_ALLOWLIST
-// and ONEAPI_DEVICE_SELECTOR. Currently, SYCL_DEVICE_ALLOWLIST accepts 'acc' while
-// ONEAPI_DEVICE_SELECTOR accepts 'fpga'.
+// and ONEAPI_DEVICE_SELECTOR. Currently, SYCL_DEVICE_ALLOWLIST accepts 'acc'
+// while ONEAPI_DEVICE_SELECTOR accepts 'fpga'.
 const std::array<std::pair<std::string, info::device_type>, 5> &
 getODSDeviceTypeMap() {
   static const std::array<std::pair<std::string, info::device_type>, 5>

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -171,7 +171,7 @@ getSyclDeviceTypeMap(bool supportAcc) {
           {{"host", info::device_type::host},
            {"cpu", info::device_type::cpu},
            {"gpu", info::device_type::gpu},
-           /* Duplicate entries is fine as this map is one-directional.*/
+           /* Duplicate entries are fine as this map is one-directional.*/
            {supportAcc ? "acc" : "fpga", info::device_type::accelerator},
            {"fpga", info::device_type::accelerator},
            {"*", info::device_type::all}}};

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -167,13 +167,14 @@ void dumpConfig() {
 const std::array<std::pair<std::string, info::device_type>, 6> &
 getSyclDeviceTypeMap(bool supportAcc) {
   static const std::array<std::pair<std::string, info::device_type>, 6>
-      SyclDeviceTypeMap = {{{"host", info::device_type::host},
-                            {"cpu", info::device_type::cpu},
-                            {"gpu", info::device_type::gpu},
-                            /* Duplicate entries is fine as this map is one-directional.*/
-                            {supportAcc ? "acc":"fpga", info::device_type::accelerator},
-                            {"fpga", info::device_type::accelerator},
-                            {"*", info::device_type::all}}};
+      SyclDeviceTypeMap = {
+          {{"host", info::device_type::host},
+           {"cpu", info::device_type::cpu},
+           {"gpu", info::device_type::gpu},
+           /* Duplicate entries is fine as this map is one-directional.*/
+           {supportAcc ? "acc" : "fpga", info::device_type::accelerator},
+           {"fpga", info::device_type::accelerator},
+           {"*", info::device_type::all}}};
   return SyclDeviceTypeMap;
 }
 

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -161,53 +161,21 @@ void dumpConfig() {
 #undef CONFIG
 }
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-// Array is used by ONEAPI_DEVICE_SELECTOR.
-// TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
-// is removed.
-// TODO: At some point, we should also align the inputs of SYCL_DEVICE_ALLOWLIST
-// and ONEAPI_DEVICE_SELECTOR. Currently, SYCL_DEVICE_ALLOWLIST accepts 'acc'
-// while ONEAPI_DEVICE_SELECTOR accepts 'fpga'.
-const std::array<std::pair<std::string, info::device_type>, 5> &
-getODSDeviceTypeMap() {
-  static const std::array<std::pair<std::string, info::device_type>, 5>
-      SyclDeviceTypeMap = {{{"host", info::device_type::host},
-                            {"cpu", info::device_type::cpu},
-                            {"gpu", info::device_type::gpu},
-                            {"fpga", info::device_type::accelerator},
-                            {"*", info::device_type::all}}};
-  return SyclDeviceTypeMap;
-}
-
-// Array is used by SYCL_DEVICE_ALLOWLIST.
-// TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
-// is removed.
-const std::array<std::pair<std::string, info::device_type>, 5> &
-getSyclDeviceTypeMap() {
-  static const std::array<std::pair<std::string, info::device_type>, 5>
-      SyclDeviceTypeMap = {{{"host", info::device_type::host},
-                            {"cpu", info::device_type::cpu},
-                            {"gpu", info::device_type::gpu},
-                            {"acc", info::device_type::accelerator},
-                            {"*", info::device_type::all}}};
-  return SyclDeviceTypeMap;
-}
-#else
 // Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
 // TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
 // is removed.
 const std::array<std::pair<std::string, info::device_type>, 6> &
-getSyclDeviceTypeMap() {
+getSyclDeviceTypeMap(bool supportAcc) {
   static const std::array<std::pair<std::string, info::device_type>, 6>
       SyclDeviceTypeMap = {{{"host", info::device_type::host},
                             {"cpu", info::device_type::cpu},
                             {"gpu", info::device_type::gpu},
-                            {"acc", info::device_type::accelerator},
+                            /* Duplicate entries is fine as this map is one-directional.*/
+                            {supportAcc ? "acc":"fpga", info::device_type::accelerator},
                             {"fpga", info::device_type::accelerator},
                             {"*", info::device_type::all}}};
   return SyclDeviceTypeMap;
 }
-#endif
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -231,9 +231,19 @@ public:
   }
 };
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+// Array is used by ONEAPI_DEVICE_SELECTOR.
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getODSDeviceTypeMap();
+
+// Array is used by SYCL_DEVICE_ALLOWLIST.
+const std::array<std::pair<std::string, info::device_type>, 5> &
+getSyclDeviceTypeMap();
+#else
 // Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
 const std::array<std::pair<std::string, info::device_type>, 6> &
 getSyclDeviceTypeMap();
+#endif
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -231,19 +231,11 @@ public:
   }
 };
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-// Array is used by ONEAPI_DEVICE_SELECTOR.
-const std::array<std::pair<std::string, info::device_type>, 5> &
-getODSDeviceTypeMap();
-
-// Array is used by SYCL_DEVICE_ALLOWLIST.
-const std::array<std::pair<std::string, info::device_type>, 5> &
-getSyclDeviceTypeMap();
-#else
 // Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
+// The 'supportAcc' parameter is used by SYCL_DEVICE_ALLOWLIST which,
+// unlike ONEAPI_DEVICE_SELECTOR, also accepts 'acc' as a valid device type.
 const std::array<std::pair<std::string, info::device_type>, 6> &
-getSyclDeviceTypeMap();
-#endif
+getSyclDeviceTypeMap(bool supportAcc = false);
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR
@@ -524,7 +516,7 @@ private:
       return Result;
 
     std::string ValueStr{ValueRaw};
-    auto DeviceTypeMap = getSyclDeviceTypeMap();
+    auto DeviceTypeMap = getSyclDeviceTypeMap(true /*Enable 'acc'*/);
 
     // Iterate over all configurations.
     size_t Start = 0, End = 0;

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -93,13 +93,12 @@ static void Parse_ODS_Device(ods_target &Target,
   std::string_view TopDeviceStr = DeviceSubTuple[0];
 
   // Handle explicit device type (e.g. 'gpu').
-  auto DeviceTypeMap =
-      getSyclDeviceTypeMap(
-        #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-          true /*Enable 'acc'*/
-        #endif
-      ); // <-- std::array<std::pair<std::string,
-                              // info::device::type>>
+  auto DeviceTypeMap = getSyclDeviceTypeMap(
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+      true /*Enable 'acc'*/
+#endif
+  ); // <-- std::array<std::pair<std::string,
+     // info::device::type>>
 
   auto It =
       std::find_if(std::begin(DeviceTypeMap), std::end(DeviceTypeMap),
@@ -268,9 +267,9 @@ std::ostream &operator<<(std::ostream &Out, const ods_target &Target) {
   Out << Target.Backend;
   if (Target.DeviceType) {
     auto DeviceTypeMap = getSyclDeviceTypeMap(
-      #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-          true /*Enable 'acc'*/
-      #endif
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
+        true /*Enable 'acc'*/
+#endif
     );
     auto Match = std::find_if(
         DeviceTypeMap.begin(), DeviceTypeMap.end(),
@@ -344,8 +343,9 @@ device_filter::device_filter(const std::string &FilterString) {
   if (TripleValueID >= Tokens.size()) {
     DeviceType = info::device_type::all;
   } else {
-    auto Iter = std::find_if(std::begin(getSyclDeviceTypeMap(true /*Enable 'acc'*/)),
-                             std::end(getSyclDeviceTypeMap(true /*Enable 'acc'*/)), FindElement);
+    auto Iter = std::find_if(
+        std::begin(getSyclDeviceTypeMap(true /*Enable 'acc'*/)),
+        std::end(getSyclDeviceTypeMap(true /*Enable 'acc'*/)), FindElement);
     // If no match is found, set device_type 'all',
     // which actually means 'any device_type' will be a match.
     if (Iter == getSyclDeviceTypeMap(true /*Enable 'acc'*/).end())

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -92,10 +92,18 @@ static void Parse_ODS_Device(ods_target &Target,
 
   std::string_view TopDeviceStr = DeviceSubTuple[0];
 
+  #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  // Handle explicit device type (e.g. 'gpu').
+  auto DeviceTypeMap =
+      getODSDeviceTypeMap(); // <-- std::array<std::pair<std::string,
+                              // info::device::type>>
+  #else
   // Handle explicit device type (e.g. 'gpu').
   auto DeviceTypeMap =
       getSyclDeviceTypeMap(); // <-- std::array<std::pair<std::string,
                               // info::device::type>>
+  #endif
+
   auto It =
       std::find_if(std::begin(DeviceTypeMap), std::end(DeviceTypeMap),
                    [&](auto DtPair) { return TopDeviceStr == DtPair.first; });
@@ -262,7 +270,13 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
 std::ostream &operator<<(std::ostream &Out, const ods_target &Target) {
   Out << Target.Backend;
   if (Target.DeviceType) {
-    auto DeviceTypeMap = getSyclDeviceTypeMap();
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  auto DeviceTypeMap =
+      getODSDeviceTypeMap();
+#else
+  auto DeviceTypeMap =
+      getSyclDeviceTypeMap();
+#endif
     auto Match = std::find_if(
         DeviceTypeMap.begin(), DeviceTypeMap.end(),
         [&](auto Pair) { return (Pair.second == Target.DeviceType); });

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -92,17 +92,17 @@ static void Parse_ODS_Device(ods_target &Target,
 
   std::string_view TopDeviceStr = DeviceSubTuple[0];
 
-  #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
   // Handle explicit device type (e.g. 'gpu').
   auto DeviceTypeMap =
       getODSDeviceTypeMap(); // <-- std::array<std::pair<std::string,
-                              // info::device::type>>
-  #else
+                             // info::device::type>>
+#else
   // Handle explicit device type (e.g. 'gpu').
   auto DeviceTypeMap =
       getSyclDeviceTypeMap(); // <-- std::array<std::pair<std::string,
                               // info::device::type>>
-  #endif
+#endif
 
   auto It =
       std::find_if(std::begin(DeviceTypeMap), std::end(DeviceTypeMap),
@@ -271,11 +271,9 @@ std::ostream &operator<<(std::ostream &Out, const ods_target &Target) {
   Out << Target.Backend;
   if (Target.DeviceType) {
 #ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-  auto DeviceTypeMap =
-      getODSDeviceTypeMap();
+    auto DeviceTypeMap = getODSDeviceTypeMap();
 #else
-  auto DeviceTypeMap =
-      getSyclDeviceTypeMap();
+    auto DeviceTypeMap = getSyclDeviceTypeMap();
 #endif
     auto Match = std::find_if(
         DeviceTypeMap.begin(), DeviceTypeMap.end(),

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -178,7 +178,7 @@ TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
 
 TEST(ParseAllowListTests, CheckAllValidDeviceTypeValuesAreProcessed) {
   std::string AllowList;
-  for (const auto &SyclDeviceType : sycl::detail::getSyclDeviceTypeMap()) {
+  for (const auto &SyclDeviceType : sycl::detail::getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
     if (!AllowList.empty())
       AllowList += "|";
     AllowList += "DeviceType:" + SyclDeviceType.first;

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -178,7 +178,8 @@ TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
 
 TEST(ParseAllowListTests, CheckAllValidDeviceTypeValuesAreProcessed) {
   std::string AllowList;
-  for (const auto &SyclDeviceType : sycl::detail::getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
+  for (const auto &SyclDeviceType :
+       sycl::detail::getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
     if (!AllowList.empty())
       AllowList += "|";
     AllowList += "DeviceType:" + SyclDeviceType.first;


### PR DESCRIPTION
As per the ONEAPI_DEVICE_SELECTOR [documentation](https://github.com/intel/llvm/blob/sycl/sycl/doc/EnvironmentVariables.md#oneapi_device_selector), the device type can only be cpu, gpu, or fpga (or any combination of those). Currently, 'acc' is also accepted by ONEAPI_DEVICE_SELECTOR as a valid device type, which is incorrect.

This PR modifies drops support of 'acc' in ONEAPI_DEVICE_SELECTOR in favor of 'fpga'. We have already updated existing test cases (#12551), testing scripts (#12596 ) to use 'fpga' with ONEAPI_DEVICE_SELECTOR.