### PR TITLE
[SYCL][Graph] Remove expired limitations from specification

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1823,10 +1823,6 @@ or layered as a separate extension proposal.
 The following features are not yet supported, and an exception will be thrown
 if used in application code.
 
-. Using `handler::fill` in a graph node implemented for USM only.
-. Using `handler::memset` in a graph node.
-. Using `handler::prefetch` in a graph node.
-. Using `handler::memadvise` in a graph node.
 . Using reductions in a graph node.
 . Using sycl streams in a graph node.
 . Profiling an event returned from graph submission with


### PR DESCRIPTION
The merged PR https://github.com/intel/llvm/pull/11472 added support for `handler::fill` and `handler::memset` nodes in a graph, while merged PR
https://github.com/intel/llvm/pull/11474 added support for `handler::prefetch` and `handler::mem_advise`. Remove mentions of these as limitations from the specification, as they are now supported.