### PR TITLE
[UR] call urGetAdapter before creating a device from native handle

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -1313,6 +1313,12 @@ piextDeviceCreateWithNativeHandle(pi_native_handle NativeHandle,
   PI_ASSERT(Device, PI_ERROR_INVALID_DEVICE);
   PI_ASSERT(NativeHandle, PI_ERROR_INVALID_VALUE);
 
+  ur_adapter_handle_t adapter = nullptr;
+  if (auto res = PiGetAdapter(adapter); res != PI_SUCCESS) {
+    return res;
+  }
+  (void)adapter;
+
   ur_native_handle_t UrNativeDevice =
       reinterpret_cast<ur_native_handle_t>(NativeHandle);
   ur_platform_handle_t UrPlatform =


### PR DESCRIPTION
This solves the same issues as #12432, but for `urDeviceCreateWithNativeHandle`. I considered a more generalized solution (e.g., calling `urGetAdapter` in `piPluginInit`), but I'm not sure that's worth it considering PI is going away. All the other `CreateWithNativeHandle` functions require either platform or a device to already exist.