### PR TITLE
[SYCL][NFC] Make E2E more robust in different environments

### DIFF
--- a/sycl/test-e2e/ESIMD/linear/linear.cpp
+++ b/sycl/test-e2e/ESIMD/linear/linear.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// UNSUPPORTED: gpu-intel-pvc
+// REQUIRES: aspect-ext_intel_legacy_image
 // Use -O2 to avoid huge stack usage under -O0.
 // RUN: %{build} -O2 -I%S/.. -o %t.out
 // RUN: %{run} %t.out %S/linear_in.bmp %S/linear_gold_hw.bmp

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_size/simd8.cpp
@@ -1,7 +1,5 @@
-// Test not intended to run on PVC
-// UNSUPPORTED: gpu-intel-pvc
-//
 // REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
+// REQUIRES: sg-8
 //
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out

--- a/sycl/test-e2e/KernelFusion/jit_caching_multispirv.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multispirv.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu, (opencl || level_zero)
+// REQUIRES: (gpu && (opencl || level_zero)), cpu
 // RUN: %{build} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 

--- a/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
@@ -1,10 +1,6 @@
-// REQUIRES: gpu, (hip || cuda)
+// REQUIRES: (gpu && (hip || cuda)), cpu
 // RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
-// XFAIL: *
-
-// COM: This test is expected to fail on CI, as CUDA and HIP runners do not
-// provide a CPU backend.
 
 // Test caching for JIT fused kernels when devices with different architectures
 // are involved.


### PR DESCRIPTION
Adjusted `REQUIRES` clauses in SYCL E2E tests to better represent their requirements: those tests were either gated by wrong device types, or they were gated by specific HW identifier instead of an aspecto/optional feature.

All changed tests fail in my local environment without the patch.