### PR TITLE
[SYCL] Choose image with inlined default values if default value is set explicitly

### DIFF
--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -205,6 +205,8 @@ protected:
   void get_specialization_constant_impl(const char *SpecName,
                                         void *Value) const noexcept;
 
+  // \returns a bool value which indicates if specialization constant was set to
+  // a value different from default value.
   bool is_specialization_constant_set(const char *SpecName) const noexcept;
 
   detail::KernelBundleImplPtr impl;

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -50,6 +50,8 @@ public:
     unsigned int CompositeOffset = 0;
     unsigned int Size = 0;
     unsigned int BlobOffset = 0;
+    // Indicates if the specialization constant was set to a value which is
+    // different from the default value.
     bool IsSet = false;
   };
 
@@ -61,7 +63,8 @@ public:
                     sycl::detail::pi::PiProgram Program)
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(std::move(Devices)), MState(State), MProgram(Program),
-        MKernelIDs(std::move(KernelIDs)) {
+        MKernelIDs(std::move(KernelIDs)),
+        MSpecConstsDefValBlob(getSpecConstsDefValBlob()) {
     updateSpecConstSymMap();
   }
 
@@ -74,6 +77,7 @@ public:
       : MBinImage(BinImage), MContext(std::move(Context)),
         MDevices(std::move(Devices)), MState(State), MProgram(Program),
         MKernelIDs(std::move(KernelIDs)), MSpecConstsBlob(SpecConstsBlob),
+        MSpecConstsDefValBlob(getSpecConstsDefValBlob()),
         MSpecConstSymMap(SpecConstMap) {}
 
   bool has_kernel(const kernel_id &KernelIDCand) const noexcept {
@@ -149,35 +153,25 @@ public:
     if (MSpecConstSymMap.count(std::string{SpecName}) == 0)
       return;
 
-    const uint8_t *DefVals = nullptr;
-    if (MBinImage) {
-      // get default values for specialization constants
-      const RTDeviceBinaryImage::PropertyRange &SCDefValRange =
-          MBinImage->getSpecConstantsDefaultValues();
-      bool HasDefaultValues = SCDefValRange.begin() != SCDefValRange.end();
-      if (HasDefaultValues) {
-        ByteArray DefValDescriptors =
-            DeviceBinaryProperty(*SCDefValRange.begin()).asByteArray();
-        assert(DefValDescriptors.size() - 8 == MSpecConstsBlob.size() &&
-               "Specialization constant default value blob do not have the "
-               "expected size.");
-        DefVals = &DefValDescriptors[8];
-      }
-    }
-
     std::vector<SpecConstDescT> &Descs =
         MSpecConstSymMap[std::string{SpecName}];
     for (SpecConstDescT &Desc : Descs) {
-      if (DefVals) {
-        if (std::memcmp(DefVals + Desc.BlobOffset,
-                        static_cast<const char *>(Value) + Desc.CompositeOffset,
-                        Desc.Size) != 0) {
-          Desc.IsSet = true;
-          std::memcpy(MSpecConstsBlob.data() + Desc.BlobOffset,
-                      static_cast<const char *>(Value) + Desc.CompositeOffset,
-                      Desc.Size);
-        }
-      }
+      // If there is a default value of the specialization constant and it is
+      // the same as the value which is being set then do nothing, runtime is
+      // going to handle this case just like if only the default value of the
+      // specialization constant was provided.
+      if (MSpecConstsDefValBlob.size() &&
+          (std::memcmp(MSpecConstsDefValBlob.begin() + Desc.BlobOffset,
+                       static_cast<const char *>(Value) + Desc.CompositeOffset,
+                       Desc.Size) == 0))
+        continue;
+
+      // Value of the specialization constant is set to a value which is
+      // different from the default value.
+      Desc.IsSet = true;
+      std::memcpy(MSpecConstsBlob.data() + Desc.BlobOffset,
+                  static_cast<const char *>(Value) + Desc.CompositeOffset,
+                  Desc.Size);
     }
   }
 
@@ -315,15 +309,29 @@ public:
   }
 
 private:
+  // Get the specialization constant default value blob.
+  ByteArray getSpecConstsDefValBlob() {
+    if (!MBinImage)
+      return ByteArray(nullptr, 0);
+
+    // Get default values for specialization constants.
+    const RTDeviceBinaryImage::PropertyRange &SCDefValRange =
+        MBinImage->getSpecConstantsDefaultValues();
+    if (!SCDefValRange.size())
+      return ByteArray(nullptr, 0);
+
+    ByteArray DefValDescriptors =
+        DeviceBinaryProperty(*SCDefValRange.begin()).asByteArray();
+    // First 8 bytes are consumed by the size of the property.
+    DefValDescriptors.dropBytes(8);
+    return DefValDescriptors;
+  }
+
   void updateSpecConstSymMap() {
     if (MBinImage) {
       const RTDeviceBinaryImage::PropertyRange &SCRange =
           MBinImage->getSpecConstants();
       using SCItTy = RTDeviceBinaryImage::PropertyRange::ConstIterator;
-
-      // get default values for specialization constants
-      const RTDeviceBinaryImage::PropertyRange &SCDefValRange =
-          MBinImage->getSpecConstantsDefaultValues();
 
       // This variable is used to calculate spec constant value offset in a
       // flat byte array.
@@ -363,16 +371,13 @@ private:
       }
       MSpecConstsBlob.resize(BlobOffset);
 
-      bool HasDefaultValues = SCDefValRange.begin() != SCDefValRange.end();
-
-      if (HasDefaultValues) {
-        ByteArray DefValDescriptors =
-            DeviceBinaryProperty(*SCDefValRange.begin()).asByteArray();
-        assert(DefValDescriptors.size() - 8 == MSpecConstsBlob.size() &&
+      if (MSpecConstsDefValBlob.size()) {
+        assert(MSpecConstsDefValBlob.size() == MSpecConstsBlob.size() &&
                "Specialization constant default value blob do not have the "
                "expected size.");
-        std::uninitialized_copy(&DefValDescriptors[8],
-                                &DefValDescriptors[8] + MSpecConstsBlob.size(),
+        std::uninitialized_copy(MSpecConstsDefValBlob.begin(),
+                                MSpecConstsDefValBlob.begin() +
+                                    MSpecConstsBlob.size(),
                                 MSpecConstsBlob.data());
       }
     }
@@ -394,6 +399,9 @@ private:
   // Binary blob which can have values of all specialization constants in the
   // image
   std::vector<unsigned char> MSpecConstsBlob;
+  // Binary blob which can have default values of all specialization constants
+  // in the image.
+  ByteArray MSpecConstsDefValBlob;
   // Buffer containing binary blob which can have values of all specialization
   // constants in the image, it is using for storing non-native specialization
   // constants

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -163,8 +163,11 @@ public:
       if (MSpecConstsDefValBlob.size() &&
           (std::memcmp(MSpecConstsDefValBlob.begin() + Desc.BlobOffset,
                        static_cast<const char *>(Value) + Desc.CompositeOffset,
-                       Desc.Size) == 0))
+                       Desc.Size) == 0)) {
+        // Now we have default value, so reset to false.
+        Desc.IsSet = false;
         continue;
+      }
 
       // Value of the specialization constant is set to a value which is
       // different from the default value.

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -310,7 +310,7 @@ public:
 
 private:
   // Get the specialization constant default value blob.
-  ByteArray getSpecConstsDefValBlob() {
+  ByteArray getSpecConstsDefValBlob() const {
     if (!MBinImage)
       return ByteArray(nullptr, 0);
 

--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -24,12 +24,12 @@
 // clang-format on
 
 // Check the behaviour when -fsycl-add-default-spec-consts-image option is used
-// and default value is overriden with the same value - we are supposed to
+// and default value is explicitly set with the same value - we are supposed to
 // choose images with inlined values in this case.
 
 // clang-format off
 // RUN: %clangxx  -fsycl-add-default-spec-consts-image -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts %s -o %t3.out
-// RUN: env SYCL_PI_TRACE=-1 %{run} %t3.out | FileCheck --match-full-lines --check-prefix=CHECK-DEFAULT-OVERRIDEN %s
+// RUN: env SYCL_PI_TRACE=-1 %{run} %t3.out | FileCheck --match-full-lines --check-prefix=CHECK-DEFAULT-EXPLICIT-SET %s
 // clang-format on
 
 #include <sycl/sycl.hpp>
@@ -203,15 +203,15 @@ int main() {
   // Test that if user calls set_specialization_constant with the value equal to
   // default then we choose image with inlined default values of specialization
   // constants.
-  // CHECK-DEFAULT-OVERRIDEN: Default value overriden
-  // CHECK-DEFAULT-OVERRIDEN: ---> piextKernelSetArgMemObj(
-  // CHECK-DEFAULT-OVERRIDEN-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-OVERRIDEN-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-OVERRIDEN-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-OVERRIDEN-NEXT:	<unknown> : 0
-  // CHECK-DEFAULT-OVERRIDEN-NEXT: ) ---> 	pi_result : PI_SUCCESS
-  // CHECK-DEFAULT-OVERRIDEN: Default value of specialization constant was used.
-  std::cout << "Default value overriden" << std::endl;
+  // CHECK-DEFAULT-EXPLICIT-SET: Default value was explicitly set
+  // CHECK-DEFAULT-EXPLICIT-SET: ---> piextKernelSetArgMemObj(
+  // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}
+  // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}
+  // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}
+  // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : 0
+  // CHECK-DEFAULT-EXPLICIT-SET-NEXT: ) ---> 	pi_result : PI_SUCCESS
+  // CHECK-DEFAULT-EXPLICIT-SET: Default value of specialization constant was used.
+  std::cout << "Default value was explicitly set" << std::endl;
   Q.submit([&](sycl::handler &cgh) {
      cgh.set_specialization_constant<int_id>(3);
 

--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -202,7 +202,8 @@ int main() {
 
   // Test that if user calls set_specialization_constant with the value equal to
   // default then we choose image with inlined default values of specialization
-  // constants. We are verifying that by checking the 4th parameter is set to zero.
+  // constants. We are verifying that by checking the 4th parameter is set to
+  // zero.
   // CHECK-DEFAULT-EXPLICIT-SET: Default value was explicitly set
   // CHECK-DEFAULT-EXPLICIT-SET: ---> piextKernelSetArgMemObj(
   // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}

--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -202,7 +202,7 @@ int main() {
 
   // Test that if user calls set_specialization_constant with the value equal to
   // default then we choose image with inlined default values of specialization
-  // constants.
+  // constants. We are verifying that by checking the 4th parameter is set to zero.
   // CHECK-DEFAULT-EXPLICIT-SET: Default value was explicitly set
   // CHECK-DEFAULT-EXPLICIT-SET: ---> piextKernelSetArgMemObj(
   // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}


### PR DESCRIPTION
If -fsycl-add-default-spec-consts-image option is used then DPCPP generates a device image where default values of specialization constants are inlined (in addition to regular device image).

Currently we always choose regular device image if somebody calls `set_specialization_constant ` API.
This PR improves this behavior: if  `set_specialization_constant` sets the value equal to default value then we can choose  the device image where default values of specialization constants are inlined.