### PR TITLE
[SYCL][ESIMD][E2E] Run aot_mixed.cpp only on Gen12 for now

### DIFF
--- a/sycl/test-e2e/ESIMD/aot_mixed.cpp
+++ b/sycl/test-e2e/ESIMD/aot_mixed.cpp
@@ -5,10 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// REQUIRES: ocloc
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -o %t.sycl.out -DENABLE_SYCL=0 %s
+// TODO: Enable on other GPUs once internal ticket is fixed
+// REQUIRES: ocloc && gpu-intel-gen12
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen -Xs "-device tgllp" -o %t.sycl.out -DENABLE_SYCL=0 %s
 // RUN: %{run} %t.sycl.out
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -o %t.out %s
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen -Xs "-device tgllp" -o %t.out %s
 // RUN: %{run} %t.out
 
 // This test checks the following ESIMD ahead-of-time compilation scenarios:


### PR DESCRIPTION
If we pass `%gpu_aot_target_opt` that compiles for all GPUs and we hit an ocloc bug when compiling for  xe-lpgplus-a0 in the new driver. This is blocking driver uplift. I will make an internal ticket for the IGC team.