### PR TITLE
[SYCL][NFC] Refresh inline asm E2E tests

### DIFF
--- a/sycl/test-e2e/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_missing_label.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_missing_label.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_missing_region.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_missing_region.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_simple.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_simple.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // UNSUPPORTED: ze_debug
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -13,7 +13,7 @@ struct KernelFunctor {
   void operator()(sycl::handler &cgh) {
     cgh.parallel_for<KernelFunctor>(
         sycl::range<1>{16},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile(".decl tmp1 v_type=G type=d num_elts=16 align=GRF\n"
                        ".decl tmp2 v_type=G type=d num_elts=16 align=GRF\n"
@@ -25,6 +25,6 @@ struct KernelFunctor {
 
 int main() {
   KernelFunctor f;
-  launchInlineASMTest(f, /* sg size */ true, /* exception expected */ true);
+  launchInlineASMTest(f, {16}, /* exception expected */ true);
   return 0;
 }

--- a/sycl/test-e2e/InlineAsm/asm_16_empty.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_empty.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda || hip_nvidia
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           C[wiID] = 43;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("");
@@ -30,7 +30,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 43))

--- a/sycl/test-e2e/InlineAsm/asm_16_matrix_mult.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_matrix_mult.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           volatile int output = 0;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d" : "=rw"(output));
@@ -33,7 +33,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 7))

--- a/sycl/test-e2e/InlineAsm/asm_16_no_input_int.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_no_input_int.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           volatile int output = 0;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("mov (M1,16) %0(0,0)<1> 0x7:d" : "=rw"(output));
@@ -33,7 +33,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 7))

--- a/sycl/test-e2e/InlineAsm/asm_16_no_opts.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_16_no_opts.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           for (int i = 0; i < 10; ++i) {
 #if defined(__SYCL_DEVICE_ONLY__)
             asm("fence_sw");
@@ -35,7 +35,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 45))

--- a/sycl/test-e2e/InlineAsm/asm_8_empty.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_8_empty.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda || hip_nvidia
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-8
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(8)]] {
           C[wiID] = 43;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("");
@@ -30,7 +30,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f, true, false, {8}))
+  if (!launchInlineASMTest(f, {8}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 43))

--- a/sycl/test-e2e/InlineAsm/asm_8_no_input_int.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_8_no_input_int.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-8
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(8)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(8)]] {
           volatile int output = 0;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("mov (M1,8) %0(0,0)<1> 0x7:d" : "=rw"(output));
@@ -33,7 +33,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f, true, false, {8}))
+  if (!launchInlineASMTest(f, {8}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 7))

--- a/sycl/test-e2e/InlineAsm/asm_arbitrary_ops_order.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_arbitrary_ops_order.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -33,7 +33,7 @@ struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("mad (M1, 16) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0> %3(0, "
               "0)<1;1,0>"
@@ -56,7 +56,7 @@ int main() {
   }
 
   KernelFunctor<> f(inputA, inputB, inputC);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &D = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_decl_in_scope.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_decl_in_scope.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -29,7 +29,7 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
     // declaration of temp within and outside the scope
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("{\n"
@@ -59,7 +59,7 @@ int main() {
   }
 
   KernelFunctor<> f(inputA, inputB);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &C = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_float_add.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_add.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -30,7 +30,7 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("add (M1, 16) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
               : "=rw"(C[wiID])
@@ -51,7 +51,7 @@ int main() {
   }
 
   KernelFunctor<> f(inputA, inputB);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &C = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_imm_arg.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -27,7 +27,7 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("mul (M1, 16) %0(0, 0)<1> %1(0, 0)<1;1,0> %2"
               : "=rw"(B[wiID])
@@ -45,7 +45,7 @@ int main() {
     input[i] = (float)1 / std::pow(2, i);
 
   KernelFunctor<> f(input);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &B = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_float_neg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_float_neg.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -25,7 +25,7 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("mov (M1, 16) %0(0, 0)<1> (-)%1(0, 0)<1;1,0>"
               : "=rw"(B[wiID])
@@ -45,7 +45,7 @@ int main() {
     input[i] = 1.0 / i;
 
   KernelFunctor<> f(input);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &R = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_if.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_if.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -18,7 +18,7 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
     bool switchField = false;
     CGH.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           int Output = 0;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("{\n"
@@ -42,7 +42,7 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> Functor(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(Functor))
+  if (!launchInlineASMTest(Functor, {16}))
     return 0;
 
   if (verify_all_the_same(Functor.getOutputBufferData(), 7))

--- a/sycl/test-e2e/InlineAsm/asm_imm_arg.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_imm_arg.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -26,7 +26,7 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("add (M1, 16) %0(0, 0)<1> %1(0, 0)<1;1,0> %2"
               : "=rw"(B[wiID])
@@ -44,7 +44,7 @@ int main() {
     input[i] = i;
 
   KernelFunctor<> f(input);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &B = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_loop.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_loop.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -29,7 +29,7 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
             CGH);
     CGH.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("{\n"
                        ".decl P1 v_type=P num_elts=16\n"
@@ -67,7 +67,7 @@ int main() {
   }
 
   KernelFunctor<> Functor(InputA, InputB);
-  if (!launchInlineASMTest(Functor))
+  if (!launchInlineASMTest(Functor, {16}))
     return 0;
 
   auto &C = Functor.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_mul.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_mul.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -28,7 +28,7 @@ struct KernelFunctor : WithInputBuffers<T, 2>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("mul (M1, 16) %0(0, 0)<1> %1(0, 0)<1;1,0> %2(0, 0)<1;1,0>"
               : "=rw"(C[wiID])
@@ -49,7 +49,7 @@ int main() {
   }
 
   KernelFunctor<> f(inputA, inputB);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &C = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_multiple_instructions.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_multiple_instructions.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda || hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -DTO_PASS -o %t.out.pass
 // RUN: %{run} %t.out.pass
 // RUN: %{build} -o %t.out
@@ -36,7 +36,7 @@ struct KernelFunctor : WithInputBuffers<T, 3>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(TO_PASS)
           // The code below passing verification
           volatile int output = -1;
@@ -85,7 +85,7 @@ int main() {
   }
 
   KernelFunctor<> f(inputA, inputB, inputC);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(),

--- a/sycl/test-e2e/InlineAsm/asm_no_operands.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_no_operands.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -12,10 +12,7 @@ int main() {
   sycl::queue Queue;
   sycl::device Device = Queue.get_device();
 
-  auto Vec = Device.get_info<sycl::info::device::extensions>();
-  if (!isInlineASMSupported(Device) ||
-      std::find(Vec.begin(), Vec.end(), "cl_intel_required_subgroup_size") ==
-          std::end(Vec)) {
+  if (!isInlineASMSupported(Device)) {
     std::cout << "Skipping test\n";
     return 0;
   }
@@ -27,7 +24,7 @@ int main() {
     // Executing kernel
     cgh.parallel_for<no_operands_kernel>(
         NumOfWorkItems,
-        [=](sycl::id<1> WIid) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> WIid) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("barrier");
 #endif

--- a/sycl/test-e2e/InlineAsm/asm_no_output.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_no_output.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda || hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -19,7 +19,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
             cgh);
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           volatile int local_var = 47;
           local_var += C[0];
 #if defined(__SYCL_DEVICE_ONLY__)
@@ -37,7 +37,7 @@ template <typename T = dataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> f(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   if (verify_all_the_same(f.getOutputBufferData(), 0))

--- a/sycl/test-e2e/InlineAsm/asm_plus_mod.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_plus_mod.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda || hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -25,7 +25,7 @@ struct KernelFunctor : WithInputBuffers<T, 1>, WithOutputBuffer<T> {
 
     cgh.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
           asm("add (M1, 16) %0(0, 0)<1> %0(0, 0)<1;1,0> %1(0, 0)<1;1,0>"
               : "+rw"(B[wiID])
@@ -47,7 +47,7 @@ int main() {
   }
 
   KernelFunctor<> f(inputA, inputB);
-  if (!launchInlineASMTest(f))
+  if (!launchInlineASMTest(f, {16}))
     return 0;
 
   auto &B = f.getOutputBufferData();

--- a/sycl/test-e2e/InlineAsm/asm_switch.cpp
+++ b/sycl/test-e2e/InlineAsm/asm_switch.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda || hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -18,7 +18,7 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
     int switchField = 2;
     CGH.parallel_for<KernelFunctor<T>>(
         sycl::range<1>{this->getOutputBufferSize()},
-        [=](sycl::id<1> wiID) [[intel::reqd_sub_group_size(16)]] {
+        [=](sycl::id<1> wiID) [[sycl::reqd_sub_group_size(16)]] {
           int Output = 0;
 #if defined(__SYCL_DEVICE_ONLY__)
           asm volatile("{\n"
@@ -62,7 +62,7 @@ template <typename T = DataType> struct KernelFunctor : WithOutputBuffer<T> {
 
 int main() {
   KernelFunctor<> Functor(DEFAULT_PROBLEM_SIZE);
-  if (!launchInlineASMTest(Functor))
+  if (!launchInlineASMTest(Functor, {16}))
     return 0;
 
   if (verify_all_the_same(Functor.getOutputBufferData(), 7))

--- a/sycl/test-e2e/InlineAsm/letter_example.cpp
+++ b/sycl/test-e2e/InlineAsm/letter_example.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16,aspect-usm_shared_allocations
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -15,10 +15,7 @@ int main() {
   sycl::queue q;
   sycl::device Device = q.get_device();
 
-  auto Vec = Device.get_info<sycl::info::device::extensions>();
-  if (!isInlineASMSupported(Device) ||
-      std::find(Vec.begin(), Vec.end(), "cl_intel_required_subgroup_size") ==
-          std::end(Vec)) {
+  if (!isInlineASMSupported(Device)) {
     std::cout << "Skipping test\n";
     return 0;
   }
@@ -31,7 +28,7 @@ int main() {
   q.submit([&](sycl::handler &cgh) {
      cgh.parallel_for<kernel_name>(
          sycl::range<1>(problem_size),
-         [=](sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+         [=](sycl::id<1> idx) [[sycl::reqd_sub_group_size(16)]] {
 #if defined(__SYCL_DEVICE_ONLY__)
            int i = idx[0];
            asm volatile("{\n.decl V52 v_type=G type=d num_elts=16 align=GRF\n"

--- a/sycl/test-e2e/InlineAsm/malloc_shared_32.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_32.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-32,aspect-usm_shared_allocations
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -16,10 +16,7 @@ int main() {
 
   sycl::device Device = q.get_device();
 
-  auto Vec = Device.get_info<sycl::info::device::extensions>();
-  if (!isInlineASMSupported(Device) ||
-      std::find(Vec.begin(), Vec.end(), "cl_intel_required_subgroup_size") ==
-          std::end(Vec)) {
+  if (!isInlineASMSupported(Device)) {
     std::cout << "Skipping test\n";
     return 0;
   }
@@ -40,7 +37,7 @@ int main() {
   q.submit([&](sycl::handler &cgh) {
      cgh.parallel_for<kernel_name>(
          sycl::range<1>(problem_size),
-         [=](sycl::id<1> idx) [[intel::reqd_sub_group_size(32)]] {
+         [=](sycl::id<1> idx) [[sycl::reqd_sub_group_size(32)]] {
            int i = idx[0];
 #if defined(__SYCL_DEVICE_ONLY__)
            asm volatile(R"a(

--- a/sycl/test-e2e/InlineAsm/malloc_shared_in_out_dif.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_in_out_dif.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16,aspect-usm_shared_allocations
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -16,10 +16,7 @@ int main() {
 
   sycl::device Device = q.get_device();
 
-  auto Vec = Device.get_info<sycl::info::device::extensions>();
-  if (!isInlineASMSupported(Device) ||
-      std::find(Vec.begin(), Vec.end(), "cl_intel_required_subgroup_size") ==
-          std::end(Vec)) {
+  if (!isInlineASMSupported(Device)) {
     std::cout << "Skipping test\n";
     return 0;
   }
@@ -37,7 +34,7 @@ int main() {
   q.submit([&](sycl::handler &cgh) {
      cgh.parallel_for<kernel_name>(
          sycl::range<1>(problem_size),
-         [=](sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+         [=](sycl::id<1> idx) [[sycl::reqd_sub_group_size(16)]] {
            int i = idx[0];
            volatile int tmp = a[i];
            tmp += 1;

--- a/sycl/test-e2e/InlineAsm/malloc_shared_no_input.cpp
+++ b/sycl/test-e2e/InlineAsm/malloc_shared_no_input.cpp
@@ -1,5 +1,5 @@
 // UNSUPPORTED: cuda, hip
-// REQUIRES: gpu,linux
+// REQUIRES: gpu,linux,sg-16,aspect-usm_shared_allocations
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -15,10 +15,7 @@ int main() {
   sycl::queue q;
   sycl::device Device = q.get_device();
 
-  auto Vec = Device.get_info<sycl::info::device::extensions>();
-  if (!isInlineASMSupported(Device) ||
-      std::find(Vec.begin(), Vec.end(), "cl_intel_required_subgroup_size") ==
-          std::end(Vec)) {
+  if (!isInlineASMSupported(Device)) {
     std::cout << "Skipping test\n";
     return 0;
   }
@@ -31,7 +28,7 @@ int main() {
   q.submit([&](sycl::handler &cgh) {
      cgh.parallel_for<kernel_name>(
          sycl::range<1>(problem_size),
-         [=](sycl::id<1> idx) [[intel::reqd_sub_group_size(16)]] {
+         [=](sycl::id<1> idx) [[sycl::reqd_sub_group_size(16)]] {
            int i = idx[0];
 #if defined(__SYCL_DEVICE_ONLY__)
            asm volatile("mov (M1, 16) %0(0,0)<1> 0x7:d" : "=rw"(a[i]));


### PR DESCRIPTION
This PR should improve tests stability and transparency (when it comes to unsupported tests). List of changes:

- switched from `[[intel::reqd_sub_group_size]]` to `[[sycl::reqd_sub_group_size]]` attribute;
- removed uses of deprecated `device::has_extension` API: there is no need for that check, because, `[[sycl::reqd_sub_group_size]]` is a core SYCL 2020 functionality;
- simplified helpers to remove unnecessary extra arguments which could be inferred otherwise;
- updated `REQUIRES` directives to include required sub-group size requirements in there. Adjusted calls to `launchInlineASMTest` helper to consistently pass required sub-group size in there as well;