### PR TITLE
[SYCL][Graph] Disable USM tests on gpu-intel-dg2

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/empty_node.cpp
+++ b/sycl/test-e2e/Graph/Explicit/empty_node.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/host_task.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/host_task2.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task2.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/host_task_last.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_last.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/host_task_successive.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_successive.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
@@ -4,6 +4,10 @@
 // RUN: %if level_zero %{env UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s %}
 //
 // CHECK-NOT: LEAK
+//
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/Explicit/repeated_exec.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_execute_without_parent.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_multiple_submission.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_nested.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph_two_parent_graphs.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -7,7 +7,9 @@
 //
 //
 // USM copy command not supported for OpenCL
-// UNSUPPORTED: opencl
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: opencl, gpu-intel-dg2 
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
@@ -6,7 +6,9 @@
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 // USM memset command not supported for OpenCL
-// UNSUPPORTED: opencl
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: opencl, gpu-intel-dg2 
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/RecordReplay/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/add_nodes_after_finalize.cpp
@@ -7,7 +7,9 @@
 //
 //
 // Temporarily disabled until failure is addressed.
-// UNSUPPORTED: windows
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: windows, gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 // This test attempts recording a set of kernels after they have already been
 // executed once before.

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #include "../graph_common.hpp"
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/empty_node.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/empty_node.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task2.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task2.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_in_order.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 // This test uses a host_task when adding a command_graph node to an
 // in-order queue.

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_last.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_last.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_successive.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_successive.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
@@ -4,6 +4,10 @@
 // RUN: %if level_zero %{env UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s %}
 //
 // CHECK-NOT: LEAK
+//
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/repeated_exec.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/repeated_exec.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_execute_without_parent.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_execute_without_parent.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_multiple_submission.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_multiple_submission.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_nested.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_nested.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_two_parent_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_two_parent_graphs.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -7,7 +7,9 @@
 //
 //
 // USM copy command not supported for OpenCL
-// UNSUPPORTED: opencl
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable the tests while investigating the bug.
+// UNSUPPORTED: opencl, gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
@@ -6,7 +6,10 @@
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // USM memset command not supported for OpenCL
-// UNSUPPORTED: opencl
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: opencl, gpu-intel-dg2
+
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/empty_graph.cpp
+++ b/sycl/test-e2e/Graph/empty_graph.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 UR_L0_LEAKS_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
+// Post-commit test failed https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479
+// Temporary disable USM based tests while investigating the bug.
+// UNSUPPORTED: gpu-intel-dg2
 
 // Tests the ability to finalize and submit a command graph which doesn't
 // contain any nodes.


### PR DESCRIPTION
After PR https://github.com/intel/llvm/pull/12279, the USM tests fail in post-commit CIs (https://github.com/intel/llvm/actions/runs/7814201804/job/21315560479).
We temporarily disable these tests during the bug investigation.