### PR TITLE
[NFC][SYCL] Move helpers from builtins_preview.hpp to their single uses

### DIFF
--- a/sycl/include/sycl/builtins_preview.hpp
+++ b/sycl/include/sycl/builtins_preview.hpp
@@ -176,28 +176,12 @@ auto builtin_delegate_to_scalar(FuncTy F, const Ts &...x) {
 }
 
 template <typename T>
-struct any_elem_type
-    : std::bool_constant<check_type_in_v<
-          get_elem_type_t<T>, float, double, half, char, signed char, short,
-          int, long, long long, unsigned char, unsigned short, unsigned int,
-          unsigned long, unsigned long long>> {};
-template <typename T>
 struct fp_elem_type
     : std::bool_constant<
           check_type_in_v<get_elem_type_t<T>, float, double, half>> {};
 template <typename T>
 struct float_elem_type
     : std::bool_constant<check_type_in_v<get_elem_type_t<T>, float>> {};
-template <typename T>
-struct integer_elem_type
-    : std::bool_constant<
-          check_type_in_v<get_elem_type_t<T>, char, signed char, short, int,
-                          long, long long, unsigned char, unsigned short,
-                          unsigned int, unsigned long, unsigned long long>> {};
-template <typename T>
-struct suint32_elem_type
-    : std::bool_constant<
-          check_type_in_v<get_elem_type_t<T>, int32_t, uint32_t>> {};
 
 template <typename... Ts>
 struct same_basic_shape : std::bool_constant<builtin_same_shape_v<Ts...>> {};
@@ -244,13 +228,6 @@ struct builtin_enable
                               SHAPE_CHECKER, EXTRA_CONDITIONS, Ts...>::type;   \
   }
 } // namespace detail
-
-BUILTIN_CREATE_ENABLER(builtin_enable_generic, default_ret_type, any_elem_type,
-                       any_shape, same_elem_type)
-BUILTIN_CREATE_ENABLER(builtin_enable_generic_scalar, default_ret_type,
-                       any_elem_type, scalar_only, same_elem_type)
-BUILTIN_CREATE_ENABLER(builtin_enable_generic_non_scalar, default_ret_type,
-                       any_elem_type, non_scalar_only, same_elem_type)
 } // namespace _V1
 } // namespace sycl
 

--- a/sycl/include/sycl/detail/builtins/integer_functions.inc
+++ b/sycl/include/sycl/detail/builtins/integer_functions.inc
@@ -12,6 +12,18 @@
 
 namespace sycl {
 inline namespace _V1 {
+namespace detail {
+template <typename T>
+struct integer_elem_type
+    : std::bool_constant<
+          check_type_in_v<get_elem_type_t<T>, char, signed char, short, int,
+                          long, long long, unsigned char, unsigned short,
+                          unsigned int, unsigned long, unsigned long long>> {};
+template <typename T>
+struct suint32_elem_type
+    : std::bool_constant<
+          check_type_in_v<get_elem_type_t<T>, int32_t, uint32_t>> {};
+} // namespace detail
 BUILTIN_CREATE_ENABLER(builtin_enable_integer, default_ret_type,
                        integer_elem_type, any_shape, same_elem_type)
 BUILTIN_CREATE_ENABLER(builtin_enable_integer_non_scalar, default_ret_type,

--- a/sycl/include/sycl/detail/builtins/relational_functions.inc
+++ b/sycl/include/sycl/detail/builtins/relational_functions.inc
@@ -14,6 +14,13 @@ namespace sycl {
 inline namespace _V1 {
 namespace detail {
 template <typename T>
+struct any_elem_type
+    : std::bool_constant<check_type_in_v<
+          get_elem_type_t<T>, float, double, half, char, signed char, short,
+          int, long, long long, unsigned char, unsigned short, unsigned int,
+          unsigned long, unsigned long long>> {};
+
+template <typename T>
 struct rel_ret_traits
     : std::conditional<is_scalar_arithmetic_v<T>, bool,
                        std::conditional_t<
@@ -21,6 +28,13 @@ struct rel_ret_traits
                            same_size_signed_int_t<simplify_if_swizzle_t<T>>>> {
 };
 } // namespace detail
+
+BUILTIN_CREATE_ENABLER(builtin_enable_generic, default_ret_type, any_elem_type,
+                       any_shape, same_elem_type)
+BUILTIN_CREATE_ENABLER(builtin_enable_generic_scalar, default_ret_type,
+                       any_elem_type, scalar_only, same_elem_type)
+BUILTIN_CREATE_ENABLER(builtin_enable_generic_non_scalar, default_ret_type,
+                       any_elem_type, non_scalar_only, same_elem_type)
 BUILTIN_CREATE_ENABLER(builtin_enable_rel, rel_ret_traits, fp_elem_type,
                        non_scalar_only, same_elem_type)
 


### PR DESCRIPTION
There are some issues with them as well (both in naming and bugs in implementation), to be fixed in a separate PR to ease review.