### PR TITLE
[SYCL][Doc] Add specialization constant-length alloca extension proposal

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -135,7 +135,7 @@ aligned_private_alloca(kernel_handler &kh);
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`. In
 the case of `aligned_private_alloca`, `Alignment` must be a power of 2
-fundamental alignment stricter than `ElementType`'s alignment requirement.
+fundamental alignment stricter than the alignment requirement of `ElementType`.
 
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in private memory.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -50,6 +50,15 @@ change incompatibly in future versions of {dpcpp} without prior notice.
 *Shipping software products should not rely on APIs defined in this
 specification.*
 
+== Backend support status
+
+The APIs in this extension may be used only on a device that has
+`aspect::ext_oneapi_scla`. The application must check that the device has this
+aspect before submitting a kernel using any of the APIs in this extension. If
+the application fails to do this, the implementation throws a synchronous
+exception with the `errc::kernel_not_supported` error code when the kernel is
+submitted to the queue.
+
 == Overview
 
 C++ arrays and `std::array` can be used in SYCL code to represent fixed-size
@@ -64,16 +73,9 @@ application, but that will not change when a SYCL kernel function is
 invoked. This way, specialization constants could be used to implement SYCL
 private arrays whose size is given during the execution of the SYCL
 application. There is no possible way of implementing this using `std::array`,
-as the size of such container must be known at compile time, so we propose to
+as the size of such containers must be known at compile time, so we propose to
 define a new `private_alloca` function whose size is specified using SYCL
 specialization constants.
-
-[NOTE]
-====
-This extension only supports SPIR-V backends for now, as it relies on
-SPIR-V-specific capabilities,
-such as specialization constants.
-====
 
 == Specification
 
@@ -97,6 +99,22 @@ implementation supports.
  feature-test macro always has this value.
 |===
 
+=== New Aspect for Specification Constant-Length Allocations
+
+This extension adds a new device aspect:
+
+[source,c++]
+----
+namespace sycl {
+enum class aspect : /*unspecified*/ {
+  ext_oneapi_scla
+};
+} // namespace sycl
+----
+
+The `ext_oneapi_scla` aspect indicates that the device is capable of using the
+`private_alloca` API defined in the following sections.
+
 === The `private_alloca` function
 
 [source,c++]
@@ -105,49 +123,24 @@ namespace sycl::ext::oneapi::experimental {
 template <typename ElementType, auto &SpecName,
           access::decorated DecorateAddress>
 private_ptr<ElementType, DecorateAddress>
-private_alloca(kernel_handler &h);
+private_alloca(kernel_handler &kh);
 } // namespace sycl::ext::oneapi::experimental
 ----
+_Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
+must be a reference to a specialization constant of integral `value_type`.
 
-This extension adds a new `private_alloca` function that can be used to allocate
-a private memory region with capacity for
-`h.get_specialization_constant<SpecName>()` elements of type `ElementType`. The
-returned pointer will be aligned for `ElementType`.
+_Effects_: `h.get_specialization_constant<size>()` elements of type
+`ElementType` are allocated and default initialized in the stack.
 
-The underlying memory region is automatically freed when the caller to
-`private_alloca` is returned.
+_Returns_: A pointer to a default initialized region of private memory of
+`h.get_specialization_constant<size>()` elements of type
+`ElementType`. `DecorateAddress` defines whether the returned `multi_ptr` is
+decorated.
 
-In case of private memory exhaustion, the underlying backend must report an
-error in the same fashion as if the allocation size were static.
-
-If this function is called from host context or an unsupported backend, an
-`exception` with the `errc::feature_not_supported` error code must be thrown.
-
-`ElementType` must be a cv-unqualified trivial type. The return memory is
-default initialized.
-
-==== Parameters
-
-`h`:: `sycl::kernel_handler` used to obtain the value of `SpecName`
-
-==== Template Parameters
-
-`ElementType`:: Cv-unqualified trivial type serving as `value_type` of the
-  returned `sycl::multi_ptr`.
-`SpecName`:: `sycl::specialization_id` of integral `value_type`. The allocated
-  memory region has capacity for `h.get_specialization_constant<SpecName>`
-  `ElementType` elements. The default value for the specialization constant must
-  be at least one and the specialization constant must not be set to a value
-  less than one. Setting the specialization constant to a value less than 1 or
-  providing a default value less than 1 is undefined behaviour.
-`DecorateAddress`:: Whether the returned `sycl::multi_ptr` is decorated or not.
-
-==== Return Value
-
-`sycl::private_ptr` to a region of `h.get_specialization_constant<SpecName>()`
-elements of type `ElementType` aligned for such type. The underlying memory
-region will be automatically deallocated when the function from which
-`private_alloca` is called returns.
+_Remarks_: In case of private memory exhaustion, the backend should notify the
+user in the same way as if a statically sized vector of private memory lead to
+memory exhaustion. In case of a successful call, memory is freed automatically
+when the function which called `private_alloca` returns to its caller.
 
 == Example usage
 
@@ -165,11 +158,11 @@ SYCL_EXTERNAL void impl(const float *in, float *out, size_t n,
 void run(queue q, const float *in, float *out, size_t n) {
   q.submit([&](handler &h) {
     h.set_specialization_constant<size>(n);
-    h.parallel_for<Kernel>(n, [=](id<1> i, kernel_handler h) {
+    h.parallel_for<Kernel>(n, [=](id<1> i, kernel_handler kh) {
       // Allocate memory for 'n' 'float's
-      auto ptr = private_alloca<float, size, access::decorated::yes>(h);
+      auto ptr = private_alloca<float, size, access::decorated::yes>(kh);
       // Use pointer in implementation
-      impl(in, out, h.get_specialization_constant<size>(), ptr);
+      impl(in, out, kh.get_specialization_constant<size>(), ptr);
     });
   });
 ----

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -129,6 +129,9 @@ private_alloca(kernel_handler &kh);
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`.
 
+_Preconditions_: `SpecName` has a default value of at least 1 and is not set to
+a value less than 1 during program execution.
+
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in the stack.
 
@@ -137,10 +140,10 @@ _Returns_: A pointer to a default initialized region of private memory of
 `ElementType`. `DecorateAddress` defines whether the returned `multi_ptr` is
 decorated.
 
-_Remarks_: In case of private memory exhaustion, the backend should notify the
-user in the same way as if a statically sized vector of private memory lead to
-memory exhaustion. In case of a successful call, memory is freed automatically
-when the function which called `private_alloca` returns to its caller.
+_Remarks_: In case of private memory exhaustion, the underlying backend must
+report an error in the same fashion as if the allocation size were static.. In
+case of a successful call, memory is freed automatically when the function which
+called `private_alloca` returns to its caller.
 
 == Example usage
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -142,7 +142,7 @@ report an error in the same fashion as if the allocation size were static. In
 case of a successful call, memory is freed automatically when the function which
 called `private_alloca` returns to its caller. Additionally, `SpecName` must
 have a default value of at least 1 and not be set to a value less than 1 during
-program execution. Violation of these conditions lead to undefined behavior.
+program execution. Violation of these conditions results in undefined behavior.
 
 == Example usage
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -179,6 +179,38 @@ of the underlying memory region was a concern too, but the current design
 automatically freeing the memory when the caller is returned is in line with
 similar constructs in other platforms.
 
+== Issues
+
+=== Default `DecorateAddress` Value
+
+At the time this extension was first proposed, there was no consensus for a
+default value for `sycl::access::decorate` in SYCL. The SYCL specification
+chooses `sycl::access::decorate::legacy` to avoid making breaking changes, but
+this would not justify using that value in this extension.
+
+Although it would be desirable to have one, the SCLA extension will not commit
+to a default value until the SYCL community has come to an agreement.
+
+=== Passing Size as an Argument
+
+Initial design passes size as a `sycl::specialization_id<Integral> &` template
+argument and receives a `sycl::kernel_handler &` as an argument. This decision
+comes from the current situation in which `sycl::specialization_id` is a unique
+identifier to represent a specialization constant and `sycl::kernel_handler` is
+used to query the **value** of specialization constants with
+`sycl::kernel_handler::get_specialization_constant`. Having a
+`sycl::specialization_constant` class representing specialization constants
+would enable cleaner interfaces to this function like:
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+template <typename ElementType, access::decorated DecorateAddress>
+private_ptr<ElementType, DecorateAddress>
+private_alloca(const specialization_constant<std::size_t> &size);
+} // namespace sycl::ext::oneapi::experimental
+----
+
 == Revision History
 
 [cols="5,15,15,70"]

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -130,7 +130,7 @@ _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`.
 
 _Effects_: `h.get_specialization_constant<size>()` elements of type
-`ElementType` are allocated and default initialized in the stack.
+`ElementType` are allocated and default initialized in private memory.
 
 _Returns_: A pointer to a default initialized region of private memory of
 `h.get_specialization_constant<size>()` elements of type

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -115,7 +115,7 @@ enum class aspect : /*unspecified*/ {
 The `ext_oneapi_scla` aspect indicates that the device is capable of using the
 `private_alloca` API defined in the following sections.
 
-=== The `private_alloca` function
+=== The SCLA API
 
 [source,c++]
 ----
@@ -124,10 +124,18 @@ template <typename ElementType, auto &SpecName,
           access::decorated DecorateAddress>
 private_ptr<ElementType, DecorateAddress>
 private_alloca(kernel_handler &kh);
+
+template <typename ElementType, std::size_t Alignment, auto &SpecName,
+          access::decorated DecorateAddress>
+private_ptr<ElementType, DecorateAddress>
+aligned_private_alloca(kernel_handler &kh);
 } // namespace sycl::ext::oneapi::experimental
 ----
+
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
-must be a reference to a specialization constant of integral `value_type`.
+must be a reference to a specialization constant of integral `value_type`. In
+the case of `aligned_private_alloca`, `Alignment` must be a power of 2
+fundamental alignment stricter than `ElementType`'s alignment requirement.
 
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in private memory.
@@ -135,7 +143,9 @@ _Effects_: `h.get_specialization_constant<size>()` elements of type
 _Returns_: A pointer to a default initialized region of private memory of
 `h.get_specialization_constant<size>()` elements of type
 `ElementType`. `DecorateAddress` defines whether the returned `multi_ptr` is
-decorated.
+decorated. In the case of `private_alloca`, the pointer is suitably aligned for
+an object of type `ElementType`. In the case of `aligned_private_alloca`, the
+pointer is aligned to the specified `Alignment`.
 
 _Remarks_: In case of private memory exhaustion, the underlying backend must
 report an error in the same fashion as if the allocation size were static. In

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -129,9 +129,6 @@ private_alloca(kernel_handler &kh);
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`.
 
-_Preconditions_: `SpecName` has a default value of at least 1 and is not set to
-a value less than 1 during program execution.
-
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in the stack.
 
@@ -141,9 +138,11 @@ _Returns_: A pointer to a default initialized region of private memory of
 decorated.
 
 _Remarks_: In case of private memory exhaustion, the underlying backend must
-report an error in the same fashion as if the allocation size were static.. In
+report an error in the same fashion as if the allocation size were static. In
 case of a successful call, memory is freed automatically when the function which
-called `private_alloca` returns to its caller.
+called `private_alloca` returns to its caller. Additionally, `SpecName` must
+have a default value of at least 1 and not be set to a value less than 1 during
+program execution. Violation of these conditions lead to undefined behavior.
 
 == Example usage
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -1,0 +1,195 @@
+= sycl_ext_oneapi_spec_constant_length_alloca
+
+:source-highlighter: coderay
+:coderay-linenums-mode: table
+
+// This section needs to be after the document title.
+:doctype: book
+:toc2:
+:toc: left
+:encoding: utf-8
+:lang: en
+:dpcpp: pass:[DPC++]
+
+// Set the default source code type in this document to C++,
+// for syntax highlighting purposes.  This is needed because
+// docbook uses c++ and html5 uses cpp.
+:language: {basebackend@docbook:c++:cpp}
+
+
+== Notice
+
+[%hardbreaks]
+Copyright (C) Codeplay Software Limited.  All rights reserved.
+
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
+permission by Khronos.
+
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
+
+== Dependencies
+
+This extension is written against the SYCL 2020 revision 8 specification.  All
+references below to the "core SYCL specification" or to section numbers in the
+SYCL specification refer to that revision.
+
+
+== Status
+
+This is an experimental extension specification, intended to provide early
+access to features and gather community feedback.  Interfaces defined in this
+specification are implemented in {dpcpp}, but they are not finalized and may
+change incompatibly in future versions of {dpcpp} without prior notice.
+*Shipping software products should not rely on APIs defined in this
+specification.*
+
+== Overview
+
+C++ arrays and `std::array` can be used in SYCL code to represent fixed-size
+sequences of objects. However, these constructs have a significant restriction:
+the number of elements must be known at compile time. In host-code context,
+users can make use of dynamic memory allocations, e.g., `std::vector`, but this
+is not the case in SYCL device code.
+
+SYCL specialization constants (SYCL Section 4.9.5.) can be used to represent
+constants whose values can be set dynamically during the execution of a SYCL
+application, but that will not change when a SYCL kernel function is
+invoked. This way, specialization constants could be used to implement SYCL
+private arrays whose size is given during the execution of the SYCL
+application. There is no possible way of implementing this using `std::array`,
+as the size of such container must be known at compile time, so we propose to
+define a new `private_alloca` function whose size is specified using SYCL
+specialization constants.
+
+[NOTE]
+====
+This extension only supports SPIR-V backends for now, as it relies on
+SPIR-V-specific capabilities,
+such as specialization constants.
+====
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.  An implementation supporting this extension must predefine the
+macro `SYCL_EXT_ONEAPI_SPEC_CONSTANT_LENGTH_ALLOCA` to one of the values defined
+in the table below. Applications can test for the existence of this macro to
+determine if the implementation supports this feature, or applications can test
+the macro's value to determine which of the extension's features the
+implementation supports.
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|The APIs of this experimental extension are not versioned, so the
+ feature-test macro always has this value.
+|===
+
+=== The `private_alloca` function
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+template <typename ElementType, auto &SpecName,
+          access::decorated DecorateAddress>
+private_ptr<ElementType, DecorateAddress>
+private_alloca(kernel_handler &h);
+} // namespace sycl::ext::oneapi::experimental
+----
+
+This extension adds a new `private_alloca` function that can be used to allocate
+a private memory region with capacity for
+`h.get_specialization_constant<SpecName>()` elements of type `ElementType`. The
+returned pointer will be aligned for `ElementType`.
+
+The underlying memory region is automatically freed when the caller to
+`private_alloca` is returned.
+
+In case of private memory exhaustion, the underlying backend must report an
+error in the same fashion as if the allocation size were static.
+
+If this function is called from host context or an unsupported backend, an
+`exception` with the `errc::feature_not_supported` error code must be thrown.
+
+`ElementType` must be a cv-unqualified trivial type. The return memory is
+default initialized.
+
+==== Parameters
+
+`h`:: `sycl::kernel_handler` used to obtain the value of `SpecName`
+
+==== Template Parameters
+
+`ElementType`:: Cv-unqualified trivial type serving as `value_type` of the
+  returned `sycl::multi_ptr`.
+`SpecName`:: `sycl::specialization_id` of integral `value_type`. The allocated
+  memory region has capacity for `h.get_specialization_constant<SpecName>`
+  `ElementType` elements. The default value for the specialization constant must
+  be at least one and the specialization constant must not be set to a value
+  less than one. Setting the specialization constant to a value less than 1 or
+  providing a default value less than 1 is undefined behaviour.
+`DecorateAddress`:: Whether the returned `sycl::multi_ptr` is decorated or not.
+
+==== Return Value
+
+`sycl::private_ptr` to a region of `h.get_specialization_constant<SpecName>()`
+elements of type `ElementType` aligned for such type. The underlying memory
+region will be automatically deallocated when the function from which
+`private_alloca` is called returns.
+
+== Example usage
+
+This non-normative section shows some example usages of the extension.
+
+[source,c++]
+----
+constexpr specialization_id<int> size(1);
+
+class Kernel;
+
+SYCL_EXTERNAL void impl(const float *in, float *out, size_t n,
+                        decorated_private_ptr<float> ptr);
+
+void run(queue q, const float *in, float *out, size_t n) {
+  q.submit([&](handler &h) {
+    h.set_specialization_constant<size>(n);
+    h.parallel_for<Kernel>(n, [=](id<1> i, kernel_handler h) {
+      // Allocate memory for 'n' 'float's
+      auto ptr = private_alloca<float, size, access::decorated::yes>(h);
+      // Use pointer in implementation
+      impl(in, out, h.get_specialization_constant<size>(), ptr);
+    });
+  });
+----
+
+== Design Constraints
+
+The big design constraint stems from the unknown allocation size at compile
+time. C++ does not support variable length arrays and complete type sizes must
+be known at compile time. Thus, the free function interface returning a pointer
+to private memory is the better way to represent this construct in C++. Lifetime
+of the underlying memory region was a concern too, but the current design
+automatically freeing the memory when the caller is returned is in line with
+similar constructs in other platforms.
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Authors|Changes
+|1|2024-02-08|Victor Lomüller, Lukas Sommer, Victor Perez, Julian Oppermann, Tadej Ciglaric, Romain Biessy|*Initial draft*
+|========================================

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -158,6 +158,8 @@ conditions results in undefined behaviour.
 
 This non-normative section shows some example usages of the extension.
 
+=== Basic Usage
+
 [source,c++]
 ----
 constexpr specialization_id<int> size(1);
@@ -175,6 +177,37 @@ void run(queue q, const float *in, float *out, size_t n) {
       auto ptr = private_alloca<float, size, access::decorated::yes>(kh);
       // Use pointer in implementation
       impl(in, out, kh.get_specialization_constant<size>(), ptr);
+    });
+  });
+----
+
+=== Storage Duration Clarification
+
+The following example is intended to clarify storage duration of memory
+allocated by `private_alloca`.
+
+[source,c++]
+----
+constexpr specialization_id<int> size(1);
+
+class Kernel;
+
+SYCL_EXTERNAL void impl(const float *in, float *out, size_t n,
+                        raw_private_ptr<float> ptr);
+
+void run(queue q, const float *in, float *out, size_t n) {
+  q.submit([&](handler &h) {
+    h.set_specialization_constant<size>(n);
+    h.parallel_for<Kernel>(n, [=](id<1> i, kernel_handler kh) {
+      raw_private_ptr<float> ptr;
+      {
+        ptr = private_alloca<float, size, access::decorated::no>(kh);
+        // 'private_alloca' has allocated a private memory region we can use in
+        // this block.
+        impl(in, out, kh.get_specialization_constant<size>(), ptr);
+      }
+      // Memory allocated by 'private_alloca' has been deallocated.
+      // Dereferencing 'ptr' at this program point is undefined behaviour.
     });
   });
 ----

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -103,7 +103,7 @@ implementation supports.
 
 This extension adds a new device aspect:
 
-[source,c++]
+[source]
 ----
 namespace sycl {
 enum class aspect : /*unspecified*/ {
@@ -117,7 +117,7 @@ The `ext_oneapi_scla` aspect indicates that the device is capable of using the
 
 === The SCLA API
 
-[source,c++]
+[source]
 ----
 namespace sycl::ext::oneapi::experimental {
 template <typename ElementType, auto &SpecName,
@@ -160,7 +160,7 @@ This non-normative section shows some example usages of the extension.
 
 === Basic Usage
 
-[source,c++]
+[source]
 ----
 constexpr specialization_id<int> size(1);
 
@@ -186,7 +186,7 @@ void run(queue q, const float *in, float *out, size_t n) {
 The following example is intended to clarify storage duration of memory
 allocated by `private_alloca`.
 
-[source,c++]
+[source]
 ----
 constexpr specialization_id<int> size(1);
 
@@ -240,12 +240,12 @@ Initial design passes size as a `sycl::specialization_id<Integral> &` template
 argument and receives a `sycl::kernel_handler &` as an argument. This decision
 comes from the current situation in which `sycl::specialization_id` is a unique
 identifier to represent a specialization constant and `sycl::kernel_handler` is
-used to query the **value** of specialization constants with
+used to query the *value* of specialization constants with
 `sycl::kernel_handler::get_specialization_constant`. Having a
 `sycl::specialization_constant` class representing specialization constants
 would enable cleaner interfaces to this function like:
 
-[source,c++]
+[source]
 ----
 namespace sycl::ext::oneapi::experimental {
 template <typename ElementType, access::decorated DecorateAddress>

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -149,10 +149,10 @@ pointer is aligned to the specified `Alignment`.
 
 _Remarks_: In case of private memory exhaustion, the underlying backend must
 report an error in the same fashion as if the allocation size were static. In
-case of a successful call, memory is freed automatically when the function which
-called `private_alloca` returns to its caller. Additionally, `SpecName` must
-have a default value of at least 1 and not be set to a value less than 1 during
-program execution. Violation of these conditions results in undefined behavior.
+case of a successful call, allocated memory has automatic storage
+duration. Additionally, `SpecName` must have a default value of at least 1 and
+not be set to a value less than 1 during program execution. Violation of these
+conditions results in undefined behaviour.
 
 == Example usage
 
@@ -185,9 +185,9 @@ The big design constraint stems from the unknown allocation size at compile
 time. C++ does not support variable length arrays and complete type sizes must
 be known at compile time. Thus, the free function interface returning a pointer
 to private memory is the better way to represent this construct in C++. Lifetime
-of the underlying memory region was a concern too, but the current design
-automatically freeing the memory when the caller is returned is in line with
-similar constructs in other platforms.
+of the underlying memory region was a concern too, but the current design with
+automatic storage duration for the allocated memory region closely follows what
+the user would get from a stack-allocated array.
 
 == Issues
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -100,7 +100,7 @@ implementation supports.
  feature-test macro always has this value.
 |===
 
-=== New Aspect for Specification Constant-Length Allocations
+=== New aspect for specialization constant-length allocations
 
 This extension adds a new device aspect:
 
@@ -136,7 +136,7 @@ aligned_private_alloca(kernel_handler &kh);
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`. In
 the case of `aligned_private_alloca`, `Alignment` must be a power of 2
-fundamental alignment stricter than the alignment requirement of `ElementType`.
+fundamental alignment and must be a positive multiple of `alignof(ElementType)`.
 
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in private memory.
@@ -148,18 +148,18 @@ decorated. In the case of `private_alloca`, the pointer is suitably aligned for
 an object of type `ElementType`. In the case of `aligned_private_alloca`, the
 pointer is aligned to the specified `Alignment`.
 
-_Remarks_: In case of private memory exhaustion, the underlying backend must
-report an error in the same fashion as if the allocation size were static. In
-case of a successful call, allocated memory has automatic storage
-duration. Additionally, `SpecName` must have a default value of at least 1 and
-not be set to a value less than 1 during program execution. Violation of these
-conditions results in undefined behaviour.
+_Remarks_: In case of private memory exhaustion, the implementation must report
+an error in the same fashion as if the allocation size were static. In case of a
+successful call, allocated memory has automatic storage duration. Additionally,
+`SpecName` must have a default value of at least 1 and not be set to a value
+less than 1 during program execution. Violation of these conditions results in
+undefined behaviour.
 
 == Example usage
 
 This non-normative section shows some example usages of the extension.
 
-=== Basic Usage
+=== Basic usage
 
 [source,c++]
 ----
@@ -182,7 +182,7 @@ void run(queue q, const float *in, float *out, size_t n) {
   });
 ----
 
-=== Storage Duration Clarification
+=== Storage duration clarification
 
 The following example is intended to clarify storage duration of memory
 allocated by `private_alloca`.
@@ -213,7 +213,7 @@ void run(queue q, const float *in, float *out, size_t n) {
   });
 ----
 
-== Design Constraints
+== Design constraints
 
 The big design constraint stems from the unknown allocation size at compile
 time. {cpp} does not support variable length arrays and complete type sizes must
@@ -225,7 +225,7 @@ closely follows what the user would get from a stack-allocated array.
 
 == Issues
 
-=== Default `DecorateAddress` Value
+=== Default `DecorateAddress` value
 
 At the time this extension was first proposed, there was no consensus for a
 default value for `sycl::access::decorate` in SYCL. The SYCL specification
@@ -235,7 +235,7 @@ this would not justify using that value in this extension.
 Although it would be desirable to have one, the SCLA extension will not commit
 to a default value until the SYCL community has come to an agreement.
 
-=== Passing Size as an Argument
+=== Passing size as an argument
 
 Initial design passes size as a `sycl::specialization_id<Integral> &` template
 argument and receives a `sycl::kernel_handler &` as an argument. This decision
@@ -255,7 +255,7 @@ private_alloca(const specialization_constant<std::size_t> &size);
 } // namespace sycl::ext::oneapi::experimental
 ----
 
-== Revision History
+== Revision history
 
 [cols="5,15,15,70"]
 [grid="rows"]

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -103,7 +103,7 @@ implementation supports.
 
 This extension adds a new device aspect:
 
-[source]
+[source,c++]
 ----
 namespace sycl {
 enum class aspect : /*unspecified*/ {
@@ -117,7 +117,7 @@ The `ext_oneapi_scla` aspect indicates that the device is capable of using the
 
 === The SCLA API
 
-[source]
+[source,c++]
 ----
 namespace sycl::ext::oneapi::experimental {
 template <typename ElementType, auto &SpecName,
@@ -160,7 +160,7 @@ This non-normative section shows some example usages of the extension.
 
 === Basic Usage
 
-[source]
+[source,c++]
 ----
 constexpr specialization_id<int> size(1);
 
@@ -186,7 +186,7 @@ void run(queue q, const float *in, float *out, size_t n) {
 The following example is intended to clarify storage duration of memory
 allocated by `private_alloca`.
 
-[source]
+[source,c++]
 ----
 constexpr specialization_id<int> size(1);
 
@@ -215,12 +215,12 @@ void run(queue q, const float *in, float *out, size_t n) {
 == Design Constraints
 
 The big design constraint stems from the unknown allocation size at compile
-time. C++ does not support variable length arrays and complete type sizes must
+time. C\+\+ does not support variable length arrays and complete type sizes must
 be known at compile time. Thus, the free function interface returning a pointer
-to private memory is the better way to represent this construct in C++. Lifetime
-of the underlying memory region was a concern too, but the current design with
-automatic storage duration for the allocated memory region closely follows what
-the user would get from a stack-allocated array.
+to private memory is the better way to represent this construct in
+C\+\+. Lifetime of the underlying memory region was a concern too, but the
+current design with automatic storage duration for the allocated memory region
+closely follows what the user would get from a stack-allocated array.
 
 == Issues
 
@@ -245,7 +245,7 @@ used to query the *value* of specialization constants with
 `sycl::specialization_constant` class representing specialization constants
 would enable cleaner interfaces to this function like:
 
-[source]
+[source,c++]
 ----
 namespace sycl::ext::oneapi::experimental {
 template <typename ElementType, access::decorated DecorateAddress>

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_spec_constant_length_alloca.asciidoc
@@ -10,6 +10,7 @@
 :encoding: utf-8
 :lang: en
 :dpcpp: pass:[DPC++]
+:cpp: pass:[C++]
 
 // Set the default source code type in this document to C++,
 // for syntax highlighting purposes.  This is needed because
@@ -61,7 +62,7 @@ submitted to the queue.
 
 == Overview
 
-C++ arrays and `std::array` can be used in SYCL code to represent fixed-size
+{cpp} arrays and `std::array` can be used in SYCL code to represent fixed-size
 sequences of objects. However, these constructs have a significant restriction:
 the number of elements must be known at compile time. In host-code context,
 users can make use of dynamic memory allocations, e.g., `std::vector`, but this
@@ -215,10 +216,10 @@ void run(queue q, const float *in, float *out, size_t n) {
 == Design Constraints
 
 The big design constraint stems from the unknown allocation size at compile
-time. C\+\+ does not support variable length arrays and complete type sizes must
+time. {cpp} does not support variable length arrays and complete type sizes must
 be known at compile time. Thus, the free function interface returning a pointer
 to private memory is the better way to represent this construct in
-C\+\+. Lifetime of the underlying memory region was a concern too, but the
+{cpp}. Lifetime of the underlying memory region was a concern too, but the
 current design with automatic storage duration for the allocated memory region
 closely follows what the user would get from a stack-allocated array.
 

--- a/sycl/doc/extensions/experimental/sycl_ext_private_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_private_alloca.asciidoc
@@ -134,8 +134,8 @@ aligned_private_alloca(kernel_handler &kh);
 
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`. In
-the case of `aligned_private_alloca`, `Alignment` must be a power of 2
-fundamental alignment and must be a positive multiple of `alignof(ElementType)`.
+the case of `aligned_private_alloca`, `Alignment` must be a fundamental
+alignment and must be a positive multiple of `alignof(ElementType)`.
 
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in private memory.

--- a/sycl/doc/extensions/experimental/sycl_ext_private_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_private_alloca.asciidoc
@@ -134,8 +134,9 @@ aligned_private_alloca(kernel_handler &kh);
 
 _Mandates_: `ElementType` must be a cv-unqualified trivial type and `SpecName`
 must be a reference to a specialization constant of integral `value_type`. In
-the case of `aligned_private_alloca`, `Alignment` must be a fundamental
-alignment and must be a positive multiple of `alignof(ElementType)`.
+the case of `aligned_private_alloca`, `Alignment` must be an alignment value and
+must be a positive multiple of `alignof(ElementType)`. If `Alignment` is an
+extended alignment, it must be supported by the implementation.
 
 _Effects_: `h.get_specialization_constant<size>()` elements of type
 `ElementType` are allocated and default initialized in private memory.

--- a/sycl/doc/extensions/experimental/sycl_ext_private_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_private_alloca.asciidoc
@@ -1,4 +1,4 @@
-= sycl_ext_oneapi_spec_constant_length_alloca
+= sycl_ext_oneapi_private_alloca
 
 :source-highlighter: coderay
 :coderay-linenums-mode: table
@@ -54,11 +54,11 @@ specification.*
 == Backend support status
 
 The APIs in this extension may be used only on a device that has
-`aspect::ext_oneapi_scla`. The application must check that the device has this
-aspect before submitting a kernel using any of the APIs in this extension. If
-the application fails to do this, the implementation throws a synchronous
-exception with the `errc::kernel_not_supported` error code when the kernel is
-submitted to the queue.
+`aspect::ext_oneapi_private_alloca`. The application must check that the device
+has this aspect before submitting a kernel using any of the APIs in this
+extension. If the application fails to do this, the implementation throws a
+synchronous exception with the `errc::kernel_not_supported` error code when the
+kernel is submitted to the queue.
 
 == Overview
 
@@ -84,11 +84,10 @@ specialization constants.
 
 This extension provides a feature-test macro as described in the core SYCL
 specification.  An implementation supporting this extension must predefine the
-macro `SYCL_EXT_ONEAPI_SPEC_CONSTANT_LENGTH_ALLOCA` to one of the values defined
-in the table below. Applications can test for the existence of this macro to
-determine if the implementation supports this feature, or applications can test
-the macro's value to determine which of the extension's features the
-implementation supports.
+macro `SYCL_EXT_ONEAPI_PRIVATE_ALLOCA` to one of the values defined in the table
+below. Applications can test for the existence of this macro to determine if the
+implementation supports this feature, or applications can test the macro's value
+to determine which of the extension's features the implementation supports.
 
 [%header,cols="1,5"]
 |===
@@ -108,15 +107,15 @@ This extension adds a new device aspect:
 ----
 namespace sycl {
 enum class aspect : /*unspecified*/ {
-  ext_oneapi_scla
+  ext_oneapi_private_alloca
 };
 } // namespace sycl
 ----
 
-The `ext_oneapi_scla` aspect indicates that the device is capable of using the
-`private_alloca` API defined in the following sections.
+The `ext_oneapi_private_alloca` aspect indicates that the device is capable of
+using the `private_alloca` API defined in the following sections.
 
-=== The SCLA API
+=== The `private_alloca` API
 
 [source,c++]
 ----
@@ -232,8 +231,8 @@ default value for `sycl::access::decorate` in SYCL. The SYCL specification
 chooses `sycl::access::decorate::legacy` to avoid making breaking changes, but
 this would not justify using that value in this extension.
 
-Although it would be desirable to have one, the SCLA extension will not commit
-to a default value until the SYCL community has come to an agreement.
+Although it would be desirable to have one, the `private_alloca` extension will
+not commit to a default value until the SYCL community has come to an agreement.
 
 === Passing size as an argument
 


### PR DESCRIPTION
Document extension proposal for specialization constant length private memory allocations. Users will be able to perform dynamic memory allocations using specialization constants and new `private_alloca` and `aligned_private_alloca` functions returning a `private_ptr` to a memory region of automatic storage duration.

This is included as an experimental extension as implementation will shortly follow once the extension is approved.