### PR TITLE
[SYCL][ESIMD] Implement compile-time properties version of scatter(acc, ...)

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -3401,7 +3401,7 @@ gather(AccessorT acc, OffsetSimdViewT byte_offsets, PropertyListT props = {}) {
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetT, typename PropertyListT = empty_properties_t>
 /// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets,
-///              simd<T, N>vals, PropertyListT props = {});       // (acc-sc-2)
+///              simd<T, N> vals, PropertyListT props = {});      // (acc-sc-2)
 
 /// The following two functions are similar to acc-sc-{1,2} with the
 /// 'byte_offsets' parameter represented as 'simd_view'.

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -2737,6 +2737,55 @@ scatter_impl(AccessorTy acc, simd<T, N> vals, simd<uint32_t, N> offsets,
   }
 }
 
+#ifndef __ESIMD_FORCE_STATELESS_MEM
+/// Accessor-based scatter.
+/// Supported platforms: DG2, PVC
+/// VISA instruction: lsc_store.ugm
+///
+/// Scatters elements to surface.
+///
+/// @tparam T is element type.
+/// @tparam NElts is the number of elements to store per address.
+/// @tparam DS is the data size.
+/// @tparam L1H is L1 cache hint.
+/// @tparam L2H is L2 cache hint.
+/// @tparam N is the number of channels (platform dependent).
+/// @tparam AccessorTy is the \ref sycl::accessor type.
+/// @param acc is the SYCL accessor.
+/// @param offsets is the zero-based offsets in bytes.
+/// @param vals is values to store.
+/// @param pred is predicates.
+///
+template <typename T, int NElts, lsc_data_size DS, cache_hint L1H,
+          cache_hint L2H, int N, typename AccessorTy, typename OffsetT>
+__ESIMD_API std::enable_if_t<
+    is_device_accessor_with_v<AccessorTy, accessor_mode_cap::can_write>>
+scatter_impl(AccessorTy acc, simd<OffsetT, N> offsets, simd<T, N * NElts> vals,
+             simd_mask<N> pred) {
+  static_assert(std::is_integral_v<OffsetT>,
+                "Scatter must have integral byte_offset type");
+  static_assert(sizeof(OffsetT) <= 4,
+                "Implicit truncation of 64-bit byte_offset to 32-bit is "
+                "disabled. Use -fsycl-esimd-force-stateless-mem or explicitly "
+                "convert offsets to a 32-bit vector");
+  check_lsc_vector_size<NElts>();
+  check_lsc_data_size<T, DS>();
+  check_cache_hint<cache_action::store, L1H, L2H>();
+  constexpr uint16_t AddressScale = 1;
+  constexpr int ImmOffset = 0;
+  constexpr lsc_data_size EDS = expand_data_size(finalize_data_size<T, DS>());
+  constexpr lsc_vector_size LSCNElts = to_lsc_vector_size<NElts>();
+  constexpr lsc_data_order Transposed = lsc_data_order::nontranspose;
+  using MsgT = typename lsc_expand_type<T>::type;
+  simd<MsgT, N * NElts> Tmp = lsc_format_input<MsgT, T>(vals);
+  simd<uint32_t, N> ByteOffsets32 = convert<uint32_t>(offsets);
+  auto si = get_surface_index(acc);
+  __esimd_lsc_store_bti<MsgT, L1H, L2H, AddressScale, ImmOffset, EDS, LSCNElts,
+                        Transposed, N>(pred.data(), ByteOffsets32.data(),
+                                       Tmp.data(), si);
+}
+#endif // __ESIMD_FORCE_STATELESS_MEM
+
 template <typename T, int N, typename AccessorTy>
 __ESIMD_API std::enable_if_t<
     (std::is_same_v<detail::LocalAccessorMarker, AccessorTy> ||
@@ -3343,6 +3392,200 @@ gather(AccessorT acc, OffsetSimdViewT byte_offsets, PropertyListT props = {}) {
 /// @anchor accessor_scatter
 /// Accessor-based scatter.
 ///
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-1)
+///
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	PropertyListT props = {});                         // (acc-sc-2)
+
+/// The following two functions are similar to acc-sc-{1,2} with the
+/// 'byte_offsets' parameter represented as 'simd_view'.
+
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-3)
+///
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+/// 	PropertyListT props = {});                         // (acc-sc-4)
+///
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-1)
+///
+/// Stores ("scatters") elements of the type 'T' to memory locations addressed
+/// by the accessor \p acc and byte offsets \p byte_offsets.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the store to
+/// (acc + byte_offsets[i]) is skipped.
+/// @tparam T Element type.
+/// @tparam N Number of elements to write.
+/// @tparam VS Vector size. It can also be read as the number of writes per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
+/// @param acc Accessor referencing the data to store.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param mask The access mask.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+template <typename T, int N, int VS = 1, typename AccessorTy, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    detail::is_device_accessor_with_v<AccessorTy,
+                                      detail::accessor_mode_cap::can_write> &&
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+        simd_mask<N / VS> mask, PropertyListT props = {}) {
+#ifdef __ESIMD_FORCE_STATELESS_MEM
+  scatter<T, N, VS>(__ESIMD_DNS::accessorToPointer<T>(acc), byte_offsets, vals,
+                    mask, props);
+#else
+  constexpr size_t Alignment =
+      detail::getPropertyValue<PropertyListT, alignment_key>(sizeof(T));
+  static_assert(Alignment >= sizeof(T),
+                "gather() requires at least element-size alignment");
+  constexpr auto L1Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L1_key>(
+          cache_hint::none);
+  constexpr auto L2Hint =
+      detail::getPropertyValue<PropertyListT, cache_hint_L2_key>(
+          cache_hint::none);
+  static_assert(!PropertyListT::template has_property<cache_hint_L3_key>(),
+                "L3 cache hint is reserved. The old/experimental L3 LSC cache "
+                "hint is cache_level::L2 now.");
+
+  if constexpr (L1Hint != cache_hint::none || L2Hint != cache_hint::none ||
+                VS > 1 || sizeof(T) > 4 || !detail::isPowerOf2(N, 32)) {
+    detail::scatter_impl<T, VS, detail::lsc_data_size::default_size, L1Hint,
+                         L2Hint>(acc, byte_offsets, vals, mask);
+  } else {
+    detail::scatter_impl<T, N, AccessorTy>(acc, vals, byte_offsets, 0, mask);
+  }
+
+#endif // __ESIMD_FORCE_STATELESS_MEM
+}
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+/// 	PropertyListT props = {});                         // (acc-sc-2)
+///
+/// Stores ("scatters") elements of the type 'T' to memory locations addressed
+/// by the accessor \p acc and byte offsets \p byte_offsets.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the store to
+/// (acc + byte_offsets[i]) is skipped.
+/// @tparam T Element type.
+/// @tparam N Number of elements to write.
+/// @tparam VS Vector size. It can also be read as the number of writes per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
+/// @param acc Accessor referencing the data to store.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+template <typename T, int N, int VS = 1, typename AccessorTy, typename OffsetT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    detail::is_device_accessor_with_v<AccessorTy,
+                                      detail::accessor_mode_cap::can_write> &&
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
+        PropertyListT props = {}) {
+  simd_mask<N / VS> Mask = 1;
+  scatter<T, N, VS>(acc, byte_offsets, vals, Mask, props);
+}
+
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-3)
+///
+/// Stores ("scatters") elements of the type 'T' to memory locations addressed
+/// by the accessor \p acc and byte offsets \p byte_offsets.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the store to
+/// (acc + byte_offsets[i]) is skipped.
+/// @tparam T Element type.
+/// @tparam N Number of elements to write.
+/// @tparam VS Vector size. It can also be read as the number of writes per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
+/// @param acc Accessor referencing the data to store.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes
+/// represented as a 'simd_view' object.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param mask The access mask.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+template <typename T, int N, int VS = 1, typename AccessorTy,
+          typename OffsetSimdViewT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    detail::is_device_accessor_with_v<AccessorTy,
+                                      detail::accessor_mode_cap::can_write> &&
+    detail::is_simd_view_type_v<OffsetSimdViewT> &&
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+        simd_mask<N / VS> mask, PropertyListT props = {}) {
+  scatter<T, N, VS>(acc, byte_offsets.read(), vals, mask, props);
+}
+
+/// template <typename T, int N, int VS = 1, typename AccessorTy,
+/// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
+/// void scatter(T *p, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+/// 	PropertyListT props = {});                         // (acc-sc-4)
+///
+/// Stores ("scatters") elements of the type 'T' to memory locations addressed
+/// by the accessor \p acc and byte offsets \p byte_offsets.
+/// Access to any element's memory location can be disabled via the input vector
+/// of predicates \p mask. If mask[i] is unset, then the store to
+/// (acc + byte_offsets[i]) is skipped.
+/// @tparam T Element type.
+/// @tparam N Number of elements to write.
+/// @tparam VS Vector size. It can also be read as the number of writes per each
+/// address. The parameter 'N' must be divisible by 'VS'. (VS > 1) is supported
+/// only on DG2 and PVC and only for 4- and 8-byte element vectors.
+/// @param acc Accessor referencing the data to store.
+/// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes
+/// represented as a 'simd_view' object.
+/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// If the alignment property is not passed, then it is assumed that each
+/// accessed address is aligned by element-size.
+/// @param props The optional compile-time properties. Only 'alignment'
+/// and cache hint properties are used.
+template <typename T, int N, int VS = 1, typename AccessorTy,
+          typename OffsetSimdViewT,
+          typename PropertyListT =
+              ext::oneapi::experimental::detail::empty_properties_t>
+__ESIMD_API std::enable_if_t<
+    detail::is_device_accessor_with_v<AccessorTy,
+                                      detail::accessor_mode_cap::can_write> &&
+    detail::is_simd_view_type_v<OffsetSimdViewT> &&
+    ext::oneapi::experimental::is_property_list_v<PropertyListT>>
+scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
+        PropertyListT props = {}) {
+  simd_mask<N / VS> Mask = 1;
+  scatter<T, N, VS>(acc, byte_offsets.read(), vals, Mask, props);
+}
+
 /// Writes elements of a \ref simd object into an accessor at given offsets.
 /// An element can be a 1, 2 or 4-byte value.
 ///
@@ -3365,29 +3608,22 @@ __ESIMD_API
                      detail::is_device_accessor_with_v<
                          AccessorTy, detail::accessor_mode_cap::can_write>>
     scatter(AccessorTy acc, simd<detail::DeviceAccessorOffsetT, N> offsets,
-            simd<T, N> vals, detail::DeviceAccessorOffsetT glob_offset = 0,
+            simd<T, N> vals, detail::DeviceAccessorOffsetT glob_offset,
             simd_mask<N> mask = 1) {
-#ifdef __ESIMD_FORCE_STATELESS_MEM
-  scatter<T, N>(__ESIMD_DNS::accessorToPointer<T>(acc, glob_offset), offsets,
-                vals, mask);
-#else
-  detail::scatter_impl<T, N, AccessorTy>(acc, vals, offsets, glob_offset, mask);
-#endif
+  offsets += glob_offset;
+  scatter<T, N>(acc, offsets, vals, mask);
 }
 
-#ifdef __ESIMD_FORCE_STATELESS_MEM
-template <typename T, int N, typename AccessorTy, typename Toffset>
-__ESIMD_API std::enable_if_t<
-    (detail::isPowerOf2(N, 32)) &&
-    detail::is_device_accessor_with_v<AccessorTy,
-                                      detail::accessor_mode_cap::can_write> &&
-    std::is_integral_v<Toffset> && !std::is_same_v<Toffset, uint64_t>>
-scatter(AccessorTy acc, simd<Toffset, N> offsets, simd<T, N> vals,
-        uint64_t glob_offset = 0, simd_mask<N> mask = 1) {
-  scatter<T, N, AccessorTy>(acc, convert<uint64_t>(offsets), vals, glob_offset,
-                            mask);
+template <typename T, int N, typename AccessorTy>
+__ESIMD_API
+    std::enable_if_t<(detail::isPowerOf2(N, 32)) &&
+                     detail::is_device_accessor_with_v<
+                         AccessorTy, detail::accessor_mode_cap::can_write>>
+    scatter(AccessorTy acc, detail::DeviceAccessorOffsetT glob_offset,
+            simd<T, N> vals, simd_mask<N> mask = 1) {
+  simd<detail::DeviceAccessorOffsetT, N> ByteOffsets = 0;
+  scatter<T, N>(acc, ByteOffsets, vals, glob_offset, mask);
 }
-#endif
 
 /// Load a scalar value from an accessor.
 /// @tparam T Type of the value.

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -3394,13 +3394,14 @@ gather(AccessorT acc, OffsetSimdViewT byte_offsets, PropertyListT props = {}) {
 ///
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetT, typename PropertyListT = empty_properties_t>
-/// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N>
-/// vals, 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-1)
+/// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets,
+///              simd<T, N> vals, simd_mask<N / VS> mask,
+///              PropertyListT props = {});                        // (acc-sc-1)
 ///
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetT, typename PropertyListT = empty_properties_t>
-/// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N>
-/// vals, 	PropertyListT props = {});                         // (acc-sc-2)
+/// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets,
+///              simd<T, N>vals, PropertyListT props = {});       // (acc-sc-2)
 
 /// The following two functions are similar to acc-sc-{1,2} with the
 /// 'byte_offsets' parameter represented as 'simd_view'.
@@ -3408,17 +3409,18 @@ gather(AccessorT acc, OffsetSimdViewT byte_offsets, PropertyListT props = {}) {
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
 /// void scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
-/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-3)
+/// 	         simd_mask<N / VS> mask, PropertyListT props = {});// (acc-sc-3)
 ///
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
 /// void scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
-/// 	PropertyListT props = {});                         // (acc-sc-4)
+/// 	         PropertyListT props = {});                       // (acc-sc-4)
 ///
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetT, typename PropertyListT = empty_properties_t>
 /// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N>
-/// vals, 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-1)
+///              simd<T, N> vals, simd_mask<N / VS> mask,
+///              PropertyListT props = {});                      // (acc-sc-1)
 ///
 /// Stores ("scatters") elements of the type 'T' to memory locations addressed
 /// by the accessor \p acc and byte offsets \p byte_offsets.
@@ -3432,7 +3434,7 @@ gather(AccessorT acc, OffsetSimdViewT byte_offsets, PropertyListT props = {}) {
 /// only on DG2 and PVC and only for 4- and 8-byte element vectors.
 /// @param acc Accessor referencing the data to store.
 /// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
-/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// For each i, (acc + byte_offsets[i]) must be element size aligned.
 /// If the alignment property is not passed, then it is assumed that each
 /// accessed address is aligned by element-size.
 /// @param mask The access mask.
@@ -3477,14 +3479,11 @@ scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
 }
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetT, typename PropertyListT = empty_properties_t>
-/// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N>
-/// vals, 	PropertyListT props = {});                         // (acc-sc-2)
+/// void scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets,
+///              simd<T, N> vals, PropertyListT props = {});   // (acc-sc-2)
 ///
 /// Stores ("scatters") elements of the type 'T' to memory locations addressed
 /// by the accessor \p acc and byte offsets \p byte_offsets.
-/// Access to any element's memory location can be disabled via the input vector
-/// of predicates \p mask. If mask[i] is unset, then the store to
-/// (acc + byte_offsets[i]) is skipped.
 /// @tparam T Element type.
 /// @tparam N Number of elements to write.
 /// @tparam VS Vector size. It can also be read as the number of writes per each
@@ -3492,7 +3491,7 @@ scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
 /// only on DG2 and PVC and only for 4- and 8-byte element vectors.
 /// @param acc Accessor referencing the data to store.
 /// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes.
-/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// For each i, (acc + byte_offsets[i]) must be element size aligned.
 /// If the alignment property is not passed, then it is assumed that each
 /// accessed address is aligned by element-size.
 /// @param props The optional compile-time properties. Only 'alignment'
@@ -3513,7 +3512,8 @@ scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
 /// void scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
-/// 	simd_mask<N / VS> mask, PropertyListT props = {}); // (acc-sc-3)
+/// 	         simd_mask<N / VS> mask,
+///              PropertyListT props = {});                       // (acc-sc-3)
 ///
 /// Stores ("scatters") elements of the type 'T' to memory locations addressed
 /// by the accessor \p acc and byte offsets \p byte_offsets.
@@ -3528,7 +3528,7 @@ scatter(AccessorTy acc, simd<OffsetT, N / VS> byte_offsets, simd<T, N> vals,
 /// @param acc Accessor referencing the data to store.
 /// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes
 /// represented as a 'simd_view' object.
-/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// For each i, (acc + byte_offsets[i]) must be element size aligned.
 /// If the alignment property is not passed, then it is assumed that each
 /// accessed address is aligned by element-size.
 /// @param mask The access mask.
@@ -3551,13 +3551,10 @@ scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
 /// template <typename T, int N, int VS = 1, typename AccessorTy,
 /// typename OffsetSimdViewT, typename PropertyListT = empty_properties_t>
 /// void scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
-/// 	PropertyListT props = {});                         // (acc-sc-4)
+/// 	         PropertyListT props = {});                        // (acc-sc-4)
 ///
 /// Stores ("scatters") elements of the type 'T' to memory locations addressed
 /// by the accessor \p acc and byte offsets \p byte_offsets.
-/// Access to any element's memory location can be disabled via the input vector
-/// of predicates \p mask. If mask[i] is unset, then the store to
-/// (acc + byte_offsets[i]) is skipped.
 /// @tparam T Element type.
 /// @tparam N Number of elements to write.
 /// @tparam VS Vector size. It can also be read as the number of writes per each
@@ -3566,7 +3563,7 @@ scatter(AccessorTy acc, OffsetSimdViewT byte_offsets, simd<T, N> vals,
 /// @param acc Accessor referencing the data to store.
 /// @param byte_offsets the vector of 32-bit or 64-bit offsets in bytes
 /// represented as a 'simd_view' object.
-/// For each i, ((byte*)p + byte_offsets[i]) must be element size aligned.
+/// For each i, (acc + byte_offsets[i]) must be element size aligned.
 /// If the alignment property is not passed, then it is assumed that each
 /// accessed address is aligned by element-size.
 /// @param props The optional compile-time properties. Only 'alignment'
@@ -3628,7 +3625,6 @@ __ESIMD_API
 #ifdef __ESIMD_FORCE_STATELESS_MEM
 template <typename T, int N, typename AccessorTy, typename Toffset>
 __ESIMD_API std::enable_if_t<
-    (detail::isPowerOf2(N, 32)) &&
     detail::is_device_accessor_with_v<AccessorTy,
                                       detail::accessor_mode_cap::can_write> &&
     std::is_integral_v<Toffset> && !std::is_same_v<Toffset, uint64_t>>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -1531,23 +1531,7 @@ lsc_scatter(AccessorTy acc,
   lsc_scatter<T, NElts, DS, L1H, L3H>(__ESIMD_DNS::accessorToPointer<T>(acc),
                                       offsets, vals, pred);
 #else
-  detail::check_lsc_vector_size<NElts>();
-  detail::check_lsc_data_size<T, DS>();
-  detail::check_lsc_cache_hint<detail::lsc_action::store, L1H, L3H>();
-  constexpr uint16_t _AddressScale = 1;
-  constexpr int _ImmOffset = 0;
-  constexpr lsc_data_size _DS =
-      detail::expand_data_size(detail::finalize_data_size<T, DS>());
-  constexpr detail::lsc_vector_size _VS = detail::to_lsc_vector_size<NElts>();
-  constexpr detail::lsc_data_order _Transposed =
-      detail::lsc_data_order::nontranspose;
-  using MsgT = typename detail::lsc_expand_type<T>::type;
-  using _CstT = __ESIMD_DNS::uint_type_t<sizeof(T)>;
-  __ESIMD_NS::simd<MsgT, N * NElts> Tmp = vals.template bit_cast_view<_CstT>();
-  auto si = __ESIMD_NS::get_surface_index(acc);
-  __esimd_lsc_store_bti<MsgT, L1H, L3H, _AddressScale, _ImmOffset, _DS, _VS,
-                        _Transposed, N>(pred.data(), offsets.data(), Tmp.data(),
-                                        si);
+  __ESIMD_DNS::scatter_impl<T, NElts, DS, L1H, L3H>(acc, offsets, vals, pred);
 #endif
 }
 

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/scatter.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/scatter.hpp
@@ -174,59 +174,141 @@ bool testUSM(queue Q, uint32_t MaskStride,
   return Passed;
 }
 
-template <typename T, TestFeatures Features> bool testUSM(queue Q) {
-  constexpr bool CheckMask = true;
-  constexpr bool CheckProperties = true;
-  properties EmptyProps;
-  properties AlignElemProps{alignment<sizeof(T)>};
+template <typename T, uint16_t N, uint16_t VS, bool UseMask, bool UseProperties,
+          typename ScatterPropertiesT>
+bool testACC(queue Q, uint32_t MaskStride,
+             ScatterPropertiesT ScatterProperties) {
+  uint32_t Groups = 8;
+  uint32_t Threads = 16;
+  size_t Size = Groups * Threads * N;
+  using shared_allocator = sycl::usm_allocator<T, sycl::usm::alloc::shared, 16>;
+  using shared_vector = std::vector<T, shared_allocator>;
+  static_assert(VS > 0 && N % VS == 0,
+                "Incorrect VS parameter. N must be divisible by VS.");
+  constexpr int NOffsets = N / VS;
+  using Tuint = sycl::_V1::ext::intel::esimd::detail::uint_type_t<sizeof(T)>;
 
-  bool Passed = true;
+  std::cout << "ACC case: T=" << esimd_test::type_name<T>() << ",N=" << N
+            << ", VS=" << VS << ",UseMask=" << UseMask
+            << ",UseProperties=" << UseProperties << std::endl;
 
-  // Test scatter() that is available on Gen12 and PVC.
-  Passed &= testUSM<T, 1, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 2, 1, !CheckMask, CheckProperties>(Q, 1, EmptyProps);
-  Passed &= testUSM<T, 4, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 8, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 16, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  sycl::range<1> GlobalRange{Groups};
+  sycl::range<1> LocalRange{Threads};
+  sycl::nd_range<1> Range{GlobalRange * LocalRange, LocalRange};
+  shared_vector Out(Size, shared_allocator{Q});
+  for (size_t i = 0; i < Size; i++)
+    Out[i] = i;
 
-  Passed &= testUSM<T, 32, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  try {
+    buffer<T, 1> OutBuf(Out);
+    Q.submit([&](handler &cgh) {
+       accessor OutAcc{OutBuf, cgh};
+       cgh.parallel_for(Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
+         ScatterPropertiesT Props{};
+         uint16_t GlobalID = ndi.get_global_id(0);
+         simd<int32_t, NOffsets> ByteOffsets(GlobalID * N * sizeof(T),
+                                             VS * sizeof(T));
+         auto ByteOffsetsView = ByteOffsets.template select<NOffsets, 1>();
+         simd<T, N> Vals = gather<T, N, VS>(OutAcc, ByteOffsets);
+         Vals *= 2;
+         auto ValsView = Vals.template select<N, 1>();
+         simd_mask<NOffsets> Pred = 0;
+         for (int I = 0; I < NOffsets; I++)
+           Pred[I] = (I % MaskStride == 0) ? 1 : 0;
+         if constexpr (VS > 1) { // VS > 1 requires specifying <T, N, VS>
+           if constexpr (UseMask) {
+             if constexpr (UseProperties) {
+               if (GlobalID % 4 == 0)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, Vals, Pred, Props);
+               else if (GlobalID % 4 == 1)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, Vals, Pred, Props);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, ValsView, Pred, Props);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, ValsView, Pred,
+                                   Props);
+             } else { // UseProperties == false
+               if (GlobalID % 4 == 0)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, Vals, Pred);
+               else if (GlobalID % 4 == 1)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, Vals, Pred);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, ValsView, Pred);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, ValsView, Pred);
+             }
+           } else { // UseMask == false
+             if constexpr (UseProperties) {
+               if (GlobalID % 4 == 0)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, Vals, Props);
+               else if (GlobalID % 4 == 1)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, Vals, Props);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, ValsView, Props);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, ValsView, Props);
+             } else { // UseProperties == false
+               if (GlobalID % 4 == 0)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, Vals);
+               else if (GlobalID % 4 == 1)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, Vals);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N, VS>(OutAcc, ByteOffsets, ValsView);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N, VS>(OutAcc, ByteOffsetsView, ValsView);
+             }
+           }
+         } else { // VS == 1
+           if constexpr (UseMask) {
+             if constexpr (UseProperties) {
+               if (GlobalID % 4 == 0)
+                 scatter(OutAcc, ByteOffsets, Vals, Pred, Props);
+               else if (GlobalID % 4 == 1)
+                 scatter(OutAcc, ByteOffsetsView, Vals, Pred, Props);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N>(OutAcc, ByteOffsets, ValsView, Pred, Props);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N>(OutAcc, ByteOffsetsView, ValsView, Pred, Props);
+             } else { // UseProperties == false
+               if (GlobalID % 4 == 0)
+                 scatter(OutAcc, ByteOffsets, Vals, Pred);
+               else if (GlobalID % 4 == 1)
+                 scatter(OutAcc, ByteOffsetsView, Vals, Pred);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N>(OutAcc, ByteOffsets, ValsView, Pred);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N>(OutAcc, ByteOffsetsView, ValsView, Pred);
+             }
+           } else { // UseMask == false
+             if constexpr (UseProperties) {
+               if (GlobalID % 4 == 0)
+                 scatter(OutAcc, ByteOffsets, Vals, Props);
+               else if (GlobalID % 4 == 1)
+                 scatter(OutAcc, ByteOffsetsView, Vals, Props);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N>(OutAcc, ByteOffsets, ValsView, Props);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N>(OutAcc, ByteOffsetsView, ValsView, Props);
+             } else { // UseProperties == false
+               if (GlobalID % 4 == 0)
+                 scatter(OutAcc, ByteOffsets, Vals);
+               else if (GlobalID % 4 == 1)
+                 scatter(OutAcc, ByteOffsetsView, Vals);
+               else if (GlobalID % 4 == 2)
+                 scatter<T, N>(OutAcc, ByteOffsets, ValsView);
+               else if (GlobalID % 4 == 3)
+                 scatter<T, N>(OutAcc, ByteOffsetsView, ValsView);
+             }
+           }
+         }
+       });
+     }).wait();
+  } catch (sycl::exception const &e) {
+    std::cout << "SYCL exception caught: " << e.what() << '\n';
+    return false;
+  }
 
-  // Test scatter() without passing compile-time properties argument.
-  Passed &= testUSM<T, 16, 1, !CheckMask, !CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 32, 1, !CheckMask, !CheckProperties>(Q, 2, EmptyProps);
-
-  // Test scatter() with mask
-  Passed &= testUSM<T, 2, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 4, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 8, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
-  Passed &= testUSM<T, 16, 1, CheckMask, !CheckProperties>(Q, 2, EmptyProps);
-
-  if constexpr (Features == TestFeatures::PVC ||
-                Features == TestFeatures::DG2) {
-    properties LSCProps{cache_hint_L1<cache_hint::streaming>,
-                        cache_hint_L2<cache_hint::uncached>,
-                        alignment<sizeof(T)>};
-    Passed &= testUSM<T, 1, 1, !CheckMask, CheckProperties>(Q, 2, LSCProps);
-    Passed &= testUSM<T, 2, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
-    Passed &= testUSM<T, 4, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
-    Passed &= testUSM<T, 8, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
-
-    Passed &= testUSM<T, 32, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
-
-    // Check VS > 1. GPU supports only dwords and qwords in this mode.
-    if constexpr (sizeof(T) >= 4) {
-      // TODO: This test case causes flaky fail. Enable it after the issue
-      // in GPU driver is fixed.
-      // Passed &=
-      //     testUSM<T, 16, 2, CheckMask, CheckProperties>(Q, 2, AlignElemProps)
-      Passed &=
-          testUSM<T, 32, 2, !CheckMask, CheckProperties>(Q, 2, AlignElemProps);
-      Passed &=
-          testUSM<T, 32, 2, CheckMask, CheckProperties>(Q, 2, AlignElemProps);
-      Passed &=
-          testUSM<T, 32, 2, CheckMask, !CheckProperties>(Q, 2, AlignElemProps);
-    }
-  } // TestPVCFeatures
+  bool Passed = verify(Out.data(), N, Size, VS, MaskStride, UseMask);
 
   return Passed;
 }
@@ -391,6 +473,120 @@ bool testSLM(queue Q, uint32_t MaskStride,
   bool Passed = verify(Out, N, Size, VS, MaskStride, UseMask);
 
   sycl::free(Out, Q);
+
+  return Passed;
+}
+
+template <typename T, TestFeatures Features> bool testUSM(queue Q) {
+  constexpr bool CheckMask = true;
+  constexpr bool CheckProperties = true;
+  properties EmptyProps;
+  properties AlignElemProps{alignment<sizeof(T)>};
+
+  bool Passed = true;
+
+  // Test scatter() that is available on Gen12 and PVC.
+  Passed &= testUSM<T, 1, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 2, 1, !CheckMask, CheckProperties>(Q, 1, EmptyProps);
+  Passed &= testUSM<T, 4, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 8, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 16, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+
+  Passed &= testUSM<T, 32, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+
+  // Test scatter() without passing compile-time properties argument.
+  Passed &= testUSM<T, 16, 1, !CheckMask, !CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 32, 1, !CheckMask, !CheckProperties>(Q, 2, EmptyProps);
+
+  // Test scatter() with mask
+  Passed &= testUSM<T, 2, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 4, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 8, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testUSM<T, 16, 1, CheckMask, !CheckProperties>(Q, 2, EmptyProps);
+
+  if constexpr (Features == TestFeatures::PVC ||
+                Features == TestFeatures::DG2) {
+    properties LSCProps{cache_hint_L1<cache_hint::streaming>,
+                        cache_hint_L2<cache_hint::uncached>,
+                        alignment<sizeof(T)>};
+    Passed &= testUSM<T, 1, 1, !CheckMask, CheckProperties>(Q, 2, LSCProps);
+    Passed &= testUSM<T, 2, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+    Passed &= testUSM<T, 4, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+    Passed &= testUSM<T, 8, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+
+    Passed &= testUSM<T, 32, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+
+    // Check VS > 1. GPU supports only dwords and qwords in this mode.
+    if constexpr (sizeof(T) >= 4) {
+      // TODO: This test case causes flaky fail. Enable it after the issue
+      // in GPU driver is fixed.
+      // Passed &=
+      //     testUSM<T, 16, 2, CheckMask, CheckProperties>(Q, 2, AlignElemProps)
+      Passed &=
+          testUSM<T, 32, 2, !CheckMask, CheckProperties>(Q, 2, AlignElemProps);
+      Passed &=
+          testUSM<T, 32, 2, CheckMask, CheckProperties>(Q, 2, AlignElemProps);
+      Passed &=
+          testUSM<T, 32, 2, CheckMask, !CheckProperties>(Q, 2, AlignElemProps);
+    }
+  } // TestPVCFeatures
+
+  return Passed;
+}
+
+template <typename T, TestFeatures Features> bool testACC(queue Q) {
+  constexpr bool CheckMask = true;
+  constexpr bool CheckProperties = true;
+  properties EmptyProps;
+  properties AlignElemProps{alignment<sizeof(T)>};
+
+  bool Passed = true;
+
+  // Test scatter() that is available on Gen12 and PVC.
+  Passed &= testACC<T, 1, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 2, 1, !CheckMask, CheckProperties>(Q, 1, EmptyProps);
+  Passed &= testACC<T, 4, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 8, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 16, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+
+  Passed &= testACC<T, 32, 1, !CheckMask, CheckProperties>(Q, 2, EmptyProps);
+
+  // Test scatter() without passing compile-time properties argument.
+  Passed &= testACC<T, 16, 1, !CheckMask, !CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 32, 1, !CheckMask, !CheckProperties>(Q, 2, EmptyProps);
+
+  // Test scatter() with mask
+  Passed &= testACC<T, 2, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 4, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 8, 1, CheckMask, CheckProperties>(Q, 2, EmptyProps);
+  Passed &= testACC<T, 16, 1, CheckMask, !CheckProperties>(Q, 2, EmptyProps);
+
+  if constexpr (Features == TestFeatures::PVC ||
+                Features == TestFeatures::DG2) {
+    properties LSCProps{cache_hint_L1<cache_hint::streaming>,
+                        cache_hint_L2<cache_hint::uncached>,
+                        alignment<sizeof(T)>};
+    Passed &= testACC<T, 1, 1, !CheckMask, CheckProperties>(Q, 2, LSCProps);
+    Passed &= testACC<T, 2, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+    Passed &= testACC<T, 4, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+    Passed &= testACC<T, 8, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+
+    Passed &= testACC<T, 32, 1, CheckMask, CheckProperties>(Q, 2, LSCProps);
+
+    // Check VS > 1. GPU supports only dwords and qwords in this mode.
+    if constexpr (sizeof(T) >= 4) {
+      // TODO: This test case causes flaky fail. Enable it after the issue
+      // in GPU driver is fixed.
+      // Passed &=
+      //     testACC<T, 16, 2, CheckMask, CheckProperties>(Q, 2, AlignElemProps)
+      Passed &=
+          testACC<T, 32, 2, !CheckMask, CheckProperties>(Q, 2, AlignElemProps);
+      Passed &=
+          testACC<T, 32, 2, CheckMask, CheckProperties>(Q, 2, AlignElemProps);
+      Passed &=
+          testACC<T, 32, 2, CheckMask, !CheckProperties>(Q, 2, AlignElemProps);
+    }
+  } // TestPVCFeatures
 
   return Passed;
 }

--- a/sycl/test-e2e/ESIMD/unified_memory_api/scatter_acc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/scatter_acc.cpp
@@ -1,0 +1,36 @@
+//==------- scatter_acc.cpp - DPC++ ESIMD on-device test ---------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies esimd::scatter() functions accepting accessors
+// and optional compile-time esimd::properties.
+// The scatter() calls in this test do not use cache-hint
+// properties to not impose using DG2/PVC features.
+
+#include "Inputs/scatter.hpp"
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  constexpr auto TestFeatures = TestFeatures::Generic;
+  bool Passed = true;
+
+  Passed &= testACC<int8_t, TestFeatures>(Q);
+  Passed &= testACC<int16_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp16))
+    Passed &= testACC<sycl::half, TestFeatures>(Q);
+  Passed &= testACC<uint32_t, TestFeatures>(Q);
+  Passed &= testACC<float, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp64))
+    Passed &= testACC<double, TestFeatures>(Q);
+
+  std::cout << (Passed ? "Passed\n" : "FAILED\n");
+  return Passed ? 0 : 1;
+}

--- a/sycl/test-e2e/ESIMD/unified_memory_api/scatter_acc_dg2_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/scatter_acc_dg2_pvc.cpp
@@ -1,0 +1,38 @@
+//==------- scatter_acc_dg2_pvc.cpp - DPC++ ESIMD on-device test--------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===------------------------------------------------------------------===//
+// REQUIRES: gpu-intel-pvc || gpu-intel-dg2
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies esimd::scatter() functions accepting accessors
+// and optional compile-time esimd::properties.
+// The scatter() calls in this test uses cache-hint
+// properties and requires DG2 or PVC.
+
+#include "Inputs/scatter.hpp"
+
+int main() {
+  auto Q = queue{gpu_selector_v};
+  esimd_test::printTestLabel(Q);
+
+  constexpr auto TestFeatures = TestFeatures::PVC;
+  bool Passed = true;
+
+  Passed &= testACC<int8_t, TestFeatures>(Q);
+  Passed &= testACC<int16_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp16))
+    Passed &= testACC<sycl::half, TestFeatures>(Q);
+  Passed &= testACC<uint32_t, TestFeatures>(Q);
+  Passed &= testACC<float, TestFeatures>(Q);
+  Passed &= testACC<int64_t, TestFeatures>(Q);
+  if (Q.get_device().has(sycl::aspect::fp64))
+    Passed &= testACC<double, TestFeatures>(Q);
+
+  std::cout << (Passed ? "Passed\n" : "FAILED\n");
+  return Passed ? 0 : 1;
+}

--- a/sycl/test/esimd/memory_properties.cpp
+++ b/sycl/test/esimd/memory_properties.cpp
@@ -1351,6 +1351,67 @@ test_gather_scatter(AccType &acc, LocalAccType &local_acc, float *ptrf,
   // intrinsic is used
   // CHECK-COUNT-1: call void @llvm.masked.scatter.v10f32.v10p4(<10 x float> {{[^)]+}}, <10 x ptr addrspace(4)> {{[^)]+}}, i32 4, <10 x i1> {{[^)]+}})
   scatter(ptrf, ioffset_n10, usm_n10);
+
+  // Test accessor
+  // CHECK-STATEFUL-COUNT-4: call void @llvm.genx.scatter.scaled.v32i1.v32i32.v32f32(<32 x i1> {{[^)]+}}, i16 0, i32 {{[^)]+}}, i32 {{[^)]+}}, <32 x i32> {{[^)]+}}, <32 x float> {{[^)]+}})
+  // CHECK-STATELESS-COUNT-4: call void @llvm.masked.scatter.v32f32.v32p4(<32 x float> {{[^)]+}}, <32 x ptr addrspace(4)> {{[^)]+}}, i32 4, <32 x i1> {{[^)]+}})
+  scatter(acc, ioffset_n32, usm, mask_n32);
+
+  scatter(acc, ioffset_n32, usm);
+
+  scatter(acc, ioffset_n32, usm, mask_n32, props_align4);
+
+  scatter(acc, ioffset_n32, usm, props_align4);
+
+  // CHECK-STATEFUL-COUNT-8: call void @llvm.genx.lsc.store.bti.v32i1.v32i32.v32i32(<32 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i32> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-STATELESS-COUNT-8: call void @llvm.genx.lsc.store.stateless.v32i1.v32i64.v32i32(<32 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 1, i8 1, i8 0, <32 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
+  scatter(acc, ioffset_n32, usm, mask_n32, props_cache_load);
+  scatter(acc, ioffset_n32, usm, props_cache_load);
+
+  scatter(acc, ioffset_n32_view, usm, mask_n32, props_cache_load);
+  scatter(acc, ioffset_n32_view, usm, props_cache_load);
+
+  scatter<float, 32>(acc, ioffset_n32, usm_view, mask_n32, props_cache_load);
+  scatter<float, 32>(acc, ioffset_n32, usm_view, props_cache_load);
+
+  scatter<float, 32>(acc, ioffset_n32_view, usm_view, mask_n32,
+                     props_cache_load);
+  scatter<float, 32>(acc, ioffset_n32_view, usm_view, props_cache_load);
+
+  // VS > 1
+  // CHECK-STATELESS-COUNT-8: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-8: call void @llvm.genx.lsc.store.bti.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 1, i8 1, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  scatter<float, 32, 2>(acc, ioffset_n16, usm, mask_n16, props_cache_load);
+
+  scatter<float, 32, 2>(acc, ioffset_n16, usm, props_cache_load);
+
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm, mask_n16, props_cache_load);
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm, props_cache_load);
+
+  scatter<float, 32, 2>(acc, ioffset_n16, usm_view, mask_n16, props_cache_load);
+  scatter<float, 32, 2>(acc, ioffset_n16, usm_view, props_cache_load);
+
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm_view, mask_n16,
+                        props_cache_load);
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm_view, props_cache_load);
+
+  // CHECK-STATELESS-COUNT-8: call void @llvm.genx.lsc.store.stateless.v16i1.v16i64.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i64> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 0)
+  // CHECK-STATEFUL-COUNT-8:  call void @llvm.genx.lsc.store.bti.v16i1.v16i32.v32i32(<16 x i1> {{[^)]+}}, i8 4, i8 0, i8 0, i16 1, i32 0, i8 3, i8 2, i8 1, i8 0, <16 x i32> {{[^)]+}}, <32 x i32> {{[^)]+}}, i32 {{[^)]+}})
+  scatter<float, 32, 2>(acc, ioffset_n16, usm, mask_n16);
+
+  scatter<float, 32, 2>(acc, ioffset_n16, usm);
+
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm, mask_n16);
+
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm);
+
+  scatter<float, 32, 2>(acc, ioffset_n16, usm_view, mask_n16);
+
+  scatter<float, 32, 2>(acc, ioffset_n16, usm_view);
+
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm_view, mask_n16);
+
+  scatter<float, 32, 2>(acc, ioffset_n16_view, usm_view);
 }
 
 // CHECK-LABEL: define {{.*}} @_Z23test_slm_gather_scatter{{.*}}


### PR DESCRIPTION
This implements the new compile-time properties API for scatter with accessors. I believe this is the last missing piece.