### PR TITLE
[SYCL][E2E] Fix the test script after changing sycl-ls output

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -669,7 +669,7 @@ for sycl_device in config.sycl_devices:
     features.update(sg_size_features)
 
     be, dev = sycl_device.split(":")
-    features.add(dev.replace("acc", "accelerator"))
+    features.add(dev.replace("fpga", "accelerator"))
     # Use short names for LIT rules.
     features.add(be)
 


### PR DESCRIPTION
In PR#https://github.com/intel/llvm/pull/12596, we changed the output of sycl-ls to use 'fpga' instead of 'acc'. This has caused several tests to fail when fpga is available on the system. This PR fixes that.

In retrospect, we should have enabled testing on FPGA in pre-commit testing as this bug could have been caught earlier.