### PR TITLE
[SYCL][Fusion][NFC] Comment fusion abortion on inter-fusion dependency

### DIFF
--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -967,7 +967,7 @@ Scheduler::GraphBuildResult Scheduler::GraphBuilder::addCG(
           continue;
         }
         // Handle event dependencies on any commands part of another active
-        // fusion.
+        // fusion by aborting it.
         if (EvDepCmd->getQueue() != Queue && isPartOfActiveFusion(EvDepCmd)) {
           printFusionWarning(
               "Aborting fusion because of event dependency from a "

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -966,8 +966,8 @@ Scheduler::GraphBuildResult Scheduler::GraphBuilder::addCG(
           ++Ev;
           continue;
         }
-        // Handle event dependencies on any commands part of another active
-        // fusion by aborting it.
+        // Event dependencies on commands part of another active fusion are
+        // handled by cancelling fusion in that other queue.
         if (EvDepCmd->getQueue() != Queue && isPartOfActiveFusion(EvDepCmd)) {
           printFusionWarning(
               "Aborting fusion because of event dependency from a "


### PR DESCRIPTION
Add comment stating event dependencies on any commands part of a different active fusion leads to the abortion of that fusion.