### PR TITLE
[SYCL][Graph] Clean-up E2E Tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_fill.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{env %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/Explicit/buffer_fill_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_fill_2d.cpp
@@ -1,8 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{env %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
-//
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/Explicit/buffer_fill_3d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_fill_3d.cpp
@@ -1,8 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{env %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
-//
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/Explicit/queue_constructor_buffer.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_constructor_buffer.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero  %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s %}
-//
-// CHECK-NOT: LEAK
-//
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
@@ -1,10 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/stream.cpp
+++ b/sycl/test-e2e/Graph/Explicit/stream.cpp
@@ -1,7 +1,9 @@
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out %GPU_CHECK_PLACEHOLDER
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out %GPU_CHECK_PLACEHOLDER 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Skip as sycl streams aren't implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED

--- a/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{env %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
 // USM memset command not supported for OpenCL
 // UNSUPPORTED: opencl
 

--- a/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_buffer.cpp
@@ -39,10 +39,8 @@ int main() {
 
     auto GraphExec = Graph.finalize();
 
-    event Event;
     for (unsigned n = 0; n < Iterations; n++) {
-      Event =
-          Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
     }
     Queue.wait_and_throw();
   }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
@@ -38,10 +38,6 @@ int main() {
 
   auto GraphExec = Graph.finalize();
 
-  auto SubmitGraph = [&]() {
-    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
-  };
-
   for (unsigned n = 0; n < Iterations; n++) {
     Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }

--- a/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm.cpp
@@ -2,7 +2,6 @@
 // and submission of the graph.
 
 #include "../graph_common.hpp"
-#include <thread>
 
 int main() {
   queue Queue{};
@@ -13,7 +12,6 @@ int main() {
 
   using T = int;
 
-  const unsigned NumThreads = std::thread::hardware_concurrency();
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);
 
   std::iota(DataA.begin(), DataA.end(), 1);
@@ -38,19 +36,14 @@ int main() {
   // Add commands to graph
   add_nodes(Graph, Queue, Size, PtrA, PtrB, PtrC);
 
-  Barrier SyncPoint{NumThreads};
-
   auto GraphExec = Graph.finalize();
 
   auto SubmitGraph = [&]() {
-    SyncPoint.wait();
     Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   };
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_host.cpp
@@ -42,10 +42,8 @@ int main() {
 
   auto GraphExec = Graph.finalize();
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_mixed.cpp
@@ -45,10 +45,8 @@ int main() {
 
   auto GraphExec = Graph.finalize();
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_shared.cpp
@@ -42,10 +42,8 @@ int main() {
 
   auto GraphExec = Graph.finalize();
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
+++ b/sycl/test-e2e/Graph/Inputs/basic_usm_system.cpp
@@ -42,10 +42,8 @@ int main() {
 
   auto GraphExec = Graph.finalize();
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy.cpp
@@ -108,10 +108,8 @@ int main() {
 
     auto GraphExec = Graph.finalize();
 
-    event Event;
     for (unsigned n = 0; n < Iterations; n++) {
-      Event =
-          Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
     }
     Queue.wait_and_throw();
   }

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_2d.cpp
@@ -103,12 +103,9 @@ int main() {
 
     auto GraphExec = Graph.finalize();
 
-    event Event;
     for (unsigned n = 0; n < Iterations; n++) {
-      Event =
-          Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
     }
-    // Event.wait();
     Queue.wait_and_throw();
   }
 

--- a/sycl/test-e2e/Graph/Inputs/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_fill.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_fill_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_fill_2d.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/buffer_fill_3d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_fill_3d.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/memadvise.cpp
+++ b/sycl/test-e2e/Graph/Inputs/memadvise.cpp
@@ -8,7 +8,7 @@ int main() {
 
   using T = int;
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Inputs/multiple_exec_graphs.cpp
@@ -33,17 +33,12 @@ int main() {
   Queue.copy(DataC.data(), PtrC, Size);
   Queue.wait_and_throw();
 
-  // event Event = add_nodes(Graph, Queue, Size, PtrA, PtrB, PtrC);
-  // Queue.wait_and_throw();
-
   add_nodes(Graph, Queue, Size, PtrA, PtrB, PtrC);
 
   // Finalize and execute several iterations of the graph
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
     auto GraphExec = Graph.finalize();
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
   Queue.wait_and_throw();
 

--- a/sycl/test-e2e/Graph/Inputs/prefetch.cpp
+++ b/sycl/test-e2e/Graph/Inputs/prefetch.cpp
@@ -8,7 +8,7 @@ int main() {
 
   using T = int;
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/queue_constructor_buffer.cpp
+++ b/sycl/test-e2e/Graph/Inputs/queue_constructor_buffer.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;
@@ -37,10 +37,8 @@ int main() {
 
     auto GraphExec = Graph.finalize();
 
-    event Event;
     for (unsigned n = 0; n < Iterations; n++) {
-      Event =
-          Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
     }
     Queue.wait_and_throw();
   }

--- a/sycl/test-e2e/Graph/Inputs/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/Inputs/queue_constructor_usm.cpp
@@ -4,7 +4,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;
@@ -41,10 +41,8 @@ int main() {
     Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   };
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
 
   Queue.wait_and_throw();

--- a/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_graph.cpp
@@ -101,10 +101,8 @@ int main() {
   // Finalize a graph with the additional kernel for writing out to
   auto MainGraphExec = MainGraph.finalize();
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event = Queue.submit(
-        [&](handler &CGH) { CGH.ext_oneapi_graph(MainGraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(MainGraphExec); });
   }
   Queue.wait_and_throw();
 

--- a/sycl/test-e2e/Graph/Inputs/sub_group_prop.cpp
+++ b/sycl/test-e2e/Graph/Inputs/sub_group_prop.cpp
@@ -141,7 +141,7 @@ void test(queue &Queue, const std::vector<size_t> SupportedSGSizes) {
 }
 
 int main() {
-  queue Queue({sycl::ext::intel::property::queue::no_immediate_command_list{}});
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
+++ b/sycl/test-e2e/Graph/Inputs/temp_buffer_reinterpret.cpp
@@ -46,10 +46,8 @@ int main() {
     }
     auto GraphExec = Graph.finalize();
 
-    event Event;
     for (unsigned n = 0; n < Iterations; n++) {
-      Event =
-          Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+      Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
     }
 
     Queue.copy(BufferA.get_access(), DataA.data());

--- a/sycl/test-e2e/Graph/Inputs/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/Inputs/usm_memset.cpp
@@ -4,7 +4,7 @@
 
 int main() {
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;
@@ -54,8 +54,7 @@ int main() {
   // Execute several iterations of the graph (first iteration has already run
   // before graph recording)
   for (unsigned n = 1; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
   Queue.wait_and_throw();
 

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -62,7 +62,7 @@ event run_kernels_usm_with_barrier(queue Q, const size_t Size, T *DataA,
 }
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;
@@ -98,10 +98,8 @@ int main() {
 
   auto GraphExec = Graph.finalize();
 
-  event Event;
   for (unsigned n = 0; n < Iterations; n++) {
-    Event =
-        Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
   }
   Queue.wait_and_throw();
 

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_fill.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_fill.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_fill_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_fill_2d.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_fill_3d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_fill_3d.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/RecordReplay/concurrent_queue.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/concurrent_queue.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order.cpp
@@ -11,9 +11,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list Properties{
-      property::queue::in_order{},
-      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  property_list Properties{property::queue::in_order{}};
   queue Queue{Properties};
 
   if (!are_graphs_supported(Queue)) {

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_pause.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_pause.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK  %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
@@ -29,9 +29,7 @@ void foo(sycl::queue Queue, size_t N, int *X, int *Y, int *Z) {
 }
 
 int main() {
-  property_list Properties{
-      property::queue::in_order{},
-      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  property_list Properties{property::queue::in_order{}};
   queue Queue{Properties};
 
   if (!are_graphs_supported(Queue)) {

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_in_order_with_empty_nodes.cpp
@@ -13,9 +13,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list Properties{
-      property::queue::in_order{},
-      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  property_list Properties{property::queue::in_order{}};
   queue Queue{Properties};
 
   if (!are_graphs_supported(Queue)) {

--- a/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/dotp_multiple_queues.cpp
@@ -11,9 +11,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list Properties{
-      property::queue::in_order{},
-      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  property_list Properties{property::queue::in_order{}};
   queue QueueA{Properties};
 
   if (!are_graphs_supported(QueueA)) {

--- a/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/exception_inconsistent_contexts.cpp
@@ -11,7 +11,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/finalize_while_recording.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_in_order.cpp
@@ -12,8 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{property::queue::in_order{},
-               sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue{property::queue::in_order{}};
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies.cpp
@@ -9,8 +9,7 @@
 int main() {
   using T = int;
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
-               sycl::property::queue::in_order{}}};
+  queue Queue{sycl::property::queue::in_order{}};
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memcpy.cpp
@@ -9,8 +9,7 @@
 int main() {
   using T = int;
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
-               sycl::property::queue::in_order{}}};
+  queue Queue{sycl::property::queue::in_order{}};
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/in_order_queue_with_host_managed_dependencies_memset.cpp
@@ -9,8 +9,7 @@
 int main() {
   using T = int;
 
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{},
-               sycl::property::queue::in_order{}}};
+  queue Queue{sycl::property::queue::in_order{}};
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/queue_constructor_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_constructor_buffer.cpp
@@ -1,10 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero  %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s %}
-//
-// CHECK-NOT: LEAK
-//
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
 // TODO enable cuda once buffer issue investigated and fixed
 // UNSUPPORTED: cuda
 

--- a/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
@@ -1,10 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/return_values.cpp
@@ -1,8 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{env %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Tests the return values from queue graph functions which change the
 // internal queue state.
@@ -10,7 +11,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/stream.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/stream.cpp
@@ -1,7 +1,9 @@
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out %GPU_CHECK_PLACEHOLDER
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out %GPU_CHECK_PLACEHOLDER 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Skip as sycl::stream is not implemented yet
 // REQUIRES: NOT_YET_IMPLEMENTED

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph_in_order.cpp
@@ -11,9 +11,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list Properties{
-      property::queue::in_order{},
-      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  property_list Properties{property::queue::in_order{}};
   queue Queue{Properties};
 
   if (!are_graphs_supported(Queue)) {

--- a/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_buffer.cpp
@@ -17,7 +17,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/temp_scope.cpp
@@ -26,8 +26,7 @@ void run_some_kernel(queue Queue, int *Data) {
 }
 
 int main() {
-  queue Queue{default_selector_v,
-              {sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue{default_selector_v};
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -14,9 +14,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  property_list Properties{
-      property::queue::in_order{},
-      sycl::ext::intel::property::queue::no_immediate_command_list{}};
+  property_list Properties{property::queue::in_order{}};
   queue Queue{Properties};
 
   if (!are_graphs_supported(Queue)) {

--- a/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 

--- a/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/valid_no_end.cpp
@@ -12,7 +12,7 @@
 #include "../graph_common.hpp"
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -1,14 +1,11 @@
 // RUN: %{build_pthread_inc} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s %}
-//
-// CHECK-NOT: LEAK
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test submitting a graph in a threaded situation.
-// The second run is to check that there are no leaks reported with the embedded
-// UR_L0_LEAKS_DEBUG=1 testing capability.
-
-// Note that we do not check the outputs becuse multiple concurrent executions
+// Note that we do not check the outputs because multiple concurrent executions
 // is indeterministic (and depends on the backend command management).
 // However, this test verifies that concurrent graph submissions do not trigger
 // errors nor memory leaks.
@@ -18,7 +15,7 @@
 #include <thread>
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;

--- a/sycl/test-e2e/Graph/empty_graph.cpp
+++ b/sycl/test-e2e/Graph/empty_graph.cpp
@@ -4,7 +4,6 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
 
 // Tests the ability to finalize and submit a command graph which doesn't
 // contain any nodes.

--- a/sycl/test-e2e/Graph/event_profiling_info.cpp
+++ b/sycl/test-e2e/Graph/event_profiling_info.cpp
@@ -1,14 +1,15 @@
 // REQUIRES: level_zero || cuda, gpu
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out 2>&1
-// RUN: %if ext_oneapi_level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --implicit-check-not=LEAK %s %}
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // This test checks the profiling of an event returned
 // from graph submission with event::get_profiling_info().
 // It first tests a graph made exclusively of memory operations,
 // then tests a graph made of kernels.
-// The second run is to check that there are no leaks reported with the embedded
-// UR_L0_LEAKS_DEBUG testing capability.
 
 #include "graph_common.hpp"
 
@@ -76,13 +77,11 @@ bool compareProfiling(event Event1, event Event2) {
   return (Pass1 && Pass2);
 }
 
-// The test checks that get_profiling_info waits for command asccociated with
+// The test checks that get_profiling_info waits for command associated with
 // event to complete execution.
 int main() {
   device Dev;
-  queue Queue{Dev,
-              {sycl::ext::intel::property::queue::no_immediate_command_list{},
-               sycl::property::queue::enable_profiling()}};
+  queue Queue{Dev, {sycl::property::queue::enable_profiling()}};
 
   const size_t Size = 100000;
   int Data[Size] = {0};

--- a/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
+++ b/sycl/test-e2e/Graph/graph_exception_global_device_extension.cpp
@@ -141,7 +141,7 @@ template <OperationPath PathKind> void test(queue Queue) {
 }
 
 int main() {
-  queue Queue{{sycl::ext::intel::property::queue::no_immediate_command_list{}}};
+  queue Queue;
 
   if (!are_graphs_supported(Queue)) {
     return 0;


### PR DESCRIPTION
Some clean-up for SYCL-Graph E2E tests:
* Remove redundant `Event` variables that are initialized over loop iterations but never used.
* Remove all instances of the no immediate command-list property, and use environment variable instead to test both paths.
* Always use FileCheck leak checking rather than `CHECK-NOT: Leak`.
* Remove unnecessary threading code from `Inputs/basic_usm.cpp`