### PR TITLE
[SYCL][Doc] Update address_cast specification

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
@@ -99,12 +99,25 @@ multi_ptr<ElementType, Space, access::decorated::no>
 static_address_cast(ElementType* ptr);
 
 template <access::address_space Space,
+          typename ElementType,
+          access::decorated DecorateAddress>
+multi_ptr<ElementType, Space, DecorateAddress>
+static_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+
+template <access::address_space Space,
           typename ElementType>
 multi_ptr<ElementType, Space, access::decorated::no>
 dynamic_address_cast(ElementType* ptr);
 
+template <access::address_space Space,
+          typename ElementType,
+          access::decorated DecorateAddress>
+multi_ptr<ElementType, Space, DecorateAddress>
+dynamic_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+
 } // namespace sycl::ext::oneapi::experimental
 ----
+
 
 [source,c++]
 ----
@@ -118,6 +131,20 @@ designated by `Space`.
 
 _Returns_: A `multi_ptr` with the specified address space that points to the
 same object as `ptr`.
+
+[source,c++]
+----
+template <access::address_space Space,
+          typename ElementType,
+          access::decorated DecorateAddress>
+multi_ptr<ElementType, Space, DecorateAddress>
+static_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+----
+_Preconditions_: `ptr` points to an object allocated in the address space
+designated by `Space`.
+
+_Returns_: A `multi_ptr` with the specified address space that points to the
+same object as `ptr` and has the same decoration.
 
 [NOTE]
 ====
@@ -139,6 +166,20 @@ _Preconditions_: The memory at `ptr` is accessible to the calling work-item.
 _Returns_: A `multi_ptr` with the specified address space that points to the
 same object as `ptr` if `ptr` points to an object allocated in the address
 space designated by `Space`, and `nullptr` otherwise.
+
+[source,c++]
+----
+template <access::address_space Space,
+          typename ElementType,
+          access::decorated DecorateAddress>
+multi_ptr<ElementType, Space, DecorateAddress>
+dynamic_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+----
+_Preconditions_: The memory at `ptr` is accessible to the calling work-item.
+
+_Returns_: A `multi_ptr` with the specified address space that points to the
+same object as `ptr` and has the same decoration, if `ptr` points to an object
+allocated in the address space designated by `Space`, and `nullptr` otherwise.
 
 [NOTE]
 ====

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
@@ -93,6 +93,12 @@ implementation supports.
 ----
 namespace sycl::ext::oneapi::experimental {
 
+// Shorthands for address space names
+constexpr inline address_space global_space = sycl::access::address_space::global_space;
+constexpr inline address_space local_space = sycl::access::address_space::local_space;
+constexpr inline address_space private_space = sycl::access::address_space::private_space;
+constexpr inline address_space generic_space = sycl::access::address_space::generic_space;
+
 template <access::address_space Space,
           typename ElementType>
 multi_ptr<ElementType, Space, access::decorated::no>
@@ -102,7 +108,7 @@ template <access::address_space Space,
           typename ElementType,
           access::decorated DecorateAddress>
 multi_ptr<ElementType, Space, DecorateAddress>
-static_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+static_address_cast(multi_ptr<ElementType, generic_space, DecorateAddress> ptr);
 
 template <access::address_space Space,
           typename ElementType>
@@ -113,7 +119,7 @@ template <access::address_space Space,
           typename ElementType,
           access::decorated DecorateAddress>
 multi_ptr<ElementType, Space, DecorateAddress>
-dynamic_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+dynamic_address_cast(multi_ptr<ElementType, generic_space, DecorateAddress> ptr);
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -138,7 +144,7 @@ template <access::address_space Space,
           typename ElementType,
           access::decorated DecorateAddress>
 multi_ptr<ElementType, Space, DecorateAddress>
-static_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+static_address_cast(multi_ptr<ElementType, generic_space, DecorateAddress> ptr);
 ----
 _Preconditions_: `ptr` points to an object allocated in the address space
 designated by `Space`.
@@ -173,7 +179,7 @@ template <access::address_space Space,
           typename ElementType,
           access::decorated DecorateAddress>
 multi_ptr<ElementType, Space, DecorateAddress>
-dynamic_address_cast(multi_ptr<ElementType, access::address_space::generic_space, DecorateAddress> ptr);
+dynamic_address_cast(multi_ptr<ElementType, generic_space, DecorateAddress> ptr);
 ----
 _Preconditions_: The memory at `ptr` is accessible to the calling work-item.
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
@@ -93,14 +93,14 @@ implementation supports.
 ----
 namespace sycl::ext::oneapi::experimental {
 
-template <access::address_space Space, access::decorated DecorateAddress,
+template <access::address_space Space,
           typename ElementType>
-multi_ptr<ElementType, Space, DecorateAddress>
+multi_ptr<ElementType, Space, access::decorated::no>
 static_address_cast(ElementType* ptr);
 
-template <access::address_space Space, access::decorated DecorateAddress,
+template <access::address_space Space,
           typename ElementType>
-multi_ptr<ElementType, Space, DecorateAddress>
+multi_ptr<ElementType, Space, access::decorated::no>
 dynamic_address_cast(ElementType* ptr);
 
 } // namespace sycl::ext::oneapi::experimental
@@ -108,16 +108,16 @@ dynamic_address_cast(ElementType* ptr);
 
 [source,c++]
 ----
-template <access::address_space Space, access::decorated DecorateAddress,
+template <access::address_space Space,
           typename ElementType>
-multi_ptr<ElementType, Space, DecorateAddress>
+multi_ptr<ElementType, Space, access::decorated::no>
 static_address_cast(ElementType* ptr);
 ----
 _Preconditions_: `ptr` points to an object allocated in the address space
 designated by `Space`.
 
-_Returns_: A `multi_ptr` with the specified address space and decoration that
-points to the same object as `ptr`.
+_Returns_: A `multi_ptr` with the specified address space that points to the
+same object as `ptr`.
 
 [NOTE]
 ====
@@ -129,16 +129,16 @@ does not point to an object allocated in the address space designated by
 
 [source,c++]
 ----
-template <access::address_space Space, access::decorated DecorateAddress,
+template <access::address_space Space,
           typename ElementType>
-multi_ptr<ElementType, Space, DecorateAddress>
+multi_ptr<ElementType, Space, access::decorated::no>
 dynamic_address_cast(ElementType* ptr);
 ----
 _Preconditions_: The memory at `ptr` is accessible to the calling work-item.
 
-_Returns_: A `multi_ptr` with the specified address space and decoration that
-points to the same object as `ptr` if `ptr` points to an object allocated in
-the address space designated by `Space`, and `nullptr` otherwise.
+_Returns_: A `multi_ptr` with the specified address space that points to the
+same object as `ptr` if `ptr` points to an object allocated in the address
+space designated by `Space`, and `nullptr` otherwise.
 
 [NOTE]
 ====


### PR DESCRIPTION
This PR contains three improvements to the specification:
- Default address_cast to no decoration.
- Add overloads for generic multi_ptr.
- Add address_space shorthands.

This allows developers using generic raw pointers to cast to `multi_ptr` without worrying about decoration:
```c++
float* ptr = ...;
auto mptr = syclex::static_address_cast<syclex::local_space>(ptr);
```

...or to opt-in to decoration by using a generic multi-pointer, which propagates decoration information:
```c++
multi_ptr<float, syclex::generic_space, access::decorated::yes> decorated_in = ...;
auto decorated_out = syclex::static_address_cast<syclex::local_space>(decorated_in);
```