### PR TITLE
[SYCL] Fix remove_decoration for cv-qual decorated ponters/refs

### DIFF
--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -256,10 +256,44 @@ struct deduce_AS
 };
 #endif
 
+template <typename T> struct remove_decoration_impl {
+  using type = T;
+};
+
+#ifdef __SYCL_DEVICE_ONLY__
+template <typename T> struct remove_decoration_impl<__OPENCL_GLOBAL_AS__ T> {
+  using type = T;
+};
+
+#ifdef __ENABLE_USM_ADDR_SPACE__
+template <typename T>
+struct remove_decoration_impl<__OPENCL_GLOBAL_DEVICE_AS__ T> {
+  using type = T;
+};
+
+template <typename T>
+struct remove_decoration_impl<__OPENCL_GLOBAL_HOST_AS__ T> {
+  using type = T;
+};
+
+#endif // __ENABLE_USM_ADDR_SPACE__
+
+template <typename T> struct remove_decoration_impl<__OPENCL_PRIVATE_AS__ T> {
+  using type = T;
+};
+
+template <typename T> struct remove_decoration_impl<__OPENCL_LOCAL_AS__ T> {
+  using type = T;
+};
+
+template <typename T> struct remove_decoration_impl<__OPENCL_CONSTANT_AS__ T> {
+  using type = T;
+};
+#endif // __SYCL_DEVICE_ONLY__
 } // namespace detail
 
 template <typename T> struct remove_decoration {
-  using type = T;
+  using type = typename detail::remove_decoration_impl<T>::type;
 };
 
 // Propagate through const qualifier.
@@ -286,35 +320,6 @@ template <typename T> struct remove_decoration<T &> {
 template <typename T> struct remove_decoration<const T &> {
   using type = const typename remove_decoration<T>::type &;
 };
-
-#ifdef __SYCL_DEVICE_ONLY__
-template <typename T> struct remove_decoration<__OPENCL_GLOBAL_AS__ T> {
-  using type = T;
-};
-
-#ifdef __ENABLE_USM_ADDR_SPACE__
-template <typename T> struct remove_decoration<__OPENCL_GLOBAL_DEVICE_AS__ T> {
-  using type = T;
-};
-
-template <typename T> struct remove_decoration<__OPENCL_GLOBAL_HOST_AS__ T> {
-  using type = T;
-};
-
-#endif // __ENABLE_USM_ADDR_SPACE__
-
-template <typename T> struct remove_decoration<__OPENCL_PRIVATE_AS__ T> {
-  using type = T;
-};
-
-template <typename T> struct remove_decoration<__OPENCL_LOCAL_AS__ T> {
-  using type = T;
-};
-
-template <typename T> struct remove_decoration<__OPENCL_CONSTANT_AS__ T> {
-  using type = T;
-};
-#endif // __SYCL_DEVICE_ONLY__
 
 template <typename T>
 using remove_decoration_t = typename remove_decoration<T>::type;

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -227,5 +227,23 @@ int main() {
   test_is_same_vector_size<true, s::constant_ptr<s::int2>, s::int2>();
   test_is_same_vector_size<false, s::constant_ptr<s::int2>, float>();
 
+#ifdef __SYCL_DEVICE_ONLY__
+  static_assert(
+      std::is_same_v<
+          s::remove_decoration_t<const __attribute__((opencl_global)) int>,
+          const int>);
+  static_assert(
+      std::is_same_v<s::remove_decoration_t<const volatile
+                                            __attribute__((opencl_global)) int>,
+                     const volatile int>);
+  static_assert(
+      std::is_same_v<
+          s::remove_decoration_t<const __attribute__((opencl_global)) int *>,
+          const int *>);
+  static_assert(std::is_same_v<s::remove_decoration_t<const __attribute__((
+                                   opencl_global)) int *const>,
+                               const int *const>);
+#endif
+
   return 0;
 }


### PR DESCRIPTION
Previous implementation was incorrect because multiple specialization were matching resulting in an ambiguity.