### PR TITLE
[SYCL][E2E] Fix Config/allowlist.cpp to correctly parse '+' in device name

### DIFF
--- a/sycl/test-e2e/Config/allowlist.cpp
+++ b/sycl/test-e2e/Config/allowlist.cpp
@@ -24,7 +24,8 @@ static void replaceSpecialCharacters(std::string &Str) {
   std::replace_if(
       Str.begin(), Str.end(),
       [](const char Sym) {
-        return '(' == Sym || ')' == Sym || '[' == Sym || ']' == Sym;
+        return '(' == Sym || ')' == Sym || '[' == Sym || ']' == Sym ||
+               '+' == Sym;
       },
       '.');
 }


### PR DESCRIPTION
The CPU name of SPR contains a special symbol, '+', which Config/allowlist does not parse correctly and thus, generates a wrong regex string.
This causes this test case to fail on SPR.