### PR TITLE
[SYCL] fix for syclcompat test on Windows

### DIFF
--- a/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: windows
 
-// RUN: %clangxx -shared -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_module.cpp -o %t.so
-// RUN: %clangxx -DTEST_SHARED_LIB='"%/t.so"' -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_function.cpp -o %t.out
+// RUN: %clangxx /clang:-shared -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_module.cpp -o %t.dll
+// RUN: %clangxx -DTEST_SHARED_LIB='"%/t.dll"' -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_function.cpp -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: windows
 
-// RUN: %clangxx /clang:-shared -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_module.cpp -o %t.dll
+// DEFINE: %{sharedflag} = %if cl_options %{/clang:-shared%} %else %{-shared%}
+
+// RUN: %clangxx %{sharedflag} -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_module.cpp -o %t.dll
 // RUN: %clangxx -DTEST_SHARED_LIB='"%/t.dll"' -fsycl -fsycl-targets=%{sycl_triple} %S\Inputs\kernel_function.cpp -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
-shared flag is a clang/linux option. On Windows we need to be cognizant of possibly using MSVC compatible driver (e.g. icx) Needs `/clang` passthrough when using non MSVC options