### PR TITLE
[SYCL][Fusion] Set `IsNewDbgInfoFormat` when creating new functions

### DIFF
--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -64,6 +64,7 @@ Expected<std::unique_ptr<Module>> helper::FusionHelper::addFusedKernel(
     // correct name and signature only during the fusion pass.
     auto *F = Function::Create(FT, GlobalValue::LinkageTypes::ExternalLinkage,
                                "fused_kernel", *NewMod);
+    F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
 
     // Attach metadata to the function stub.
     // The metadata specifies the name of the fused kernel (as the

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -64,7 +64,7 @@ Expected<std::unique_ptr<Module>> helper::FusionHelper::addFusedKernel(
     // correct name and signature only during the fusion pass.
     auto *F = Function::Create(FT, GlobalValue::LinkageTypes::ExternalLinkage,
                                "fused_kernel", *NewMod);
-    F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+    F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
 
     // Attach metadata to the function stub.
     // The metadata specifies the name of the fused kernel (as the

--- a/sycl-fusion/passes/cleanup/Cleanup.cpp
+++ b/sycl-fusion/passes/cleanup/Cleanup.cpp
@@ -51,7 +51,7 @@ static Function *createMaskedFunction(const BitVector &Mask, Function *F,
   FunctionType *NFTy = createMaskedFunctionType(Mask, F->getFunctionType());
   Function *NF = Function::Create(NFTy, F->getLinkage(), F->getAddressSpace(),
                                   F->getName(), F->getParent());
-  NF->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+  NF->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
   copyAttributesFrom(Mask, NF, F);
   NF->setComdat(F->getComdat());
   NF->takeName(F);

--- a/sycl-fusion/passes/cleanup/Cleanup.cpp
+++ b/sycl-fusion/passes/cleanup/Cleanup.cpp
@@ -51,6 +51,7 @@ static Function *createMaskedFunction(const BitVector &Mask, Function *F,
   FunctionType *NFTy = createMaskedFunctionType(Mask, F->getFunctionType());
   Function *NF = Function::Create(NFTy, F->getLinkage(), F->getAddressSpace(),
                                   F->getName(), F->getParent());
+  NF->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
   copyAttributesFrom(Mask, NF, F);
   NF->setComdat(F->getComdat());
   NF->takeName(F);

--- a/sycl-fusion/passes/internalization/Internalization.cpp
+++ b/sycl-fusion/passes/internalization/Internalization.cpp
@@ -564,8 +564,11 @@ getPromotedFunctionDeclaration(Function *F, ArrayRef<PromotionInfo> PromInfos,
   // declaration.
   FunctionType *NewTy =
       ChangeTypes ? getPromotedFunctionType(Ty, PromInfos, AS) : Ty;
-  return Function::Create(NewTy, F->getLinkage(), F->getAddressSpace(),
-                          F->getName(), F->getParent());
+  Function *NewF =
+      Function::Create(NewTy, F->getLinkage(), F->getAddressSpace(),
+                       F->getName(), F->getParent());
+  NewF->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+  return NewF;
 }
 
 ///

--- a/sycl-fusion/passes/internalization/Internalization.cpp
+++ b/sycl-fusion/passes/internalization/Internalization.cpp
@@ -567,7 +567,7 @@ getPromotedFunctionDeclaration(Function *F, ArrayRef<PromotionInfo> PromInfos,
   Function *NewF =
       Function::Create(NewTy, F->getLinkage(), F->getAddressSpace(),
                        F->getName(), F->getParent());
-  NewF->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+  NewF->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
   return NewF;
 }
 

--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -125,7 +125,7 @@ getOrCreateGetGlobalLinearIDFunction(const TargetFusionInfo &TargetInfo,
   auto *Ty = FunctionType::get(Builder.getIntNTy(N), /*isVarArg*/ false);
   F = Function::Create(Ty, Function::LinkageTypes::InternalLinkage, Name, M);
   TargetInfo.setMetadataForGeneratedFunction(F);
-  F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+  F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
 
   auto *EntryBlock = BasicBlock::Create(Context, "entry", F);
   Builder.SetInsertPoint(EntryBlock);

--- a/sycl-fusion/passes/kernel-fusion/Builtins.cpp
+++ b/sycl-fusion/passes/kernel-fusion/Builtins.cpp
@@ -125,6 +125,7 @@ getOrCreateGetGlobalLinearIDFunction(const TargetFusionInfo &TargetInfo,
   auto *Ty = FunctionType::get(Builder.getIntNTy(N), /*isVarArg*/ false);
   F = Function::Create(Ty, Function::LinkageTypes::InternalLinkage, Name, M);
   TargetInfo.setMetadataForGeneratedFunction(F);
+  F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
 
   auto *EntryBlock = BasicBlock::Create(Context, "entry", F);
   Builder.SetInsertPoint(EntryBlock);

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
@@ -473,6 +473,7 @@ Error SYCLKernelFusion::fuseKernel(
   Function *FusedFunction = Function::createWithDefaultAttr(
       FT, GlobalValue::LinkageTypes::ExternalLinkage,
       M.getDataLayout().getProgramAddressSpace(), KernelName->getString(), &M);
+  FusedFunction->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
   {
     auto DefaultAttr = FusedFunction->getAttributes();
     // Add uniform function attributes, i.e., attributes with identical value on

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
@@ -473,7 +473,7 @@ Error SYCLKernelFusion::fuseKernel(
   Function *FusedFunction = Function::createWithDefaultAttr(
       FT, GlobalValue::LinkageTypes::ExternalLinkage,
       M.getDataLayout().getProgramAddressSpace(), KernelName->getString(), &M);
-  FusedFunction->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+  FusedFunction->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
   {
     auto DefaultAttr = FusedFunction->getAttributes();
     // Add uniform function attributes, i.e., attributes with identical value on

--- a/sycl-fusion/passes/target/TargetFusionInfo.cpp
+++ b/sycl-fusion/passes/target/TargetFusionInfo.cpp
@@ -230,7 +230,7 @@ public:
       F->setAttributes(
           AttributeList::get(LLVMMod->getContext(), FnAttrs, {}, {}));
       F->setCallingConv(CallingConv::SPIR_FUNC);
-      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+      F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
     }
 
     // See
@@ -397,7 +397,7 @@ public:
                     Attribute::get(Ctx, Attribute::AttrKind::NoUnwind)}),
           {}, {}));
       F->setCallingConv(CallingConv::SPIR_FUNC);
-      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+      F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
     }
 
     auto *Call = Builder.CreateCall(F, {Builder.getInt32(Idx)});
@@ -420,7 +420,7 @@ public:
                                  /*isVarArg*/ false);
     auto *F = Function::Create(Ty, Function::InternalLinkage, Name, *M);
     setMetadataForGeneratedFunction(F);
-    F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+    F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
 
     auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
     Builder.SetInsertPoint(EntryBlock);
@@ -565,7 +565,7 @@ public:
                                    /*isVarArg*/ false);
       F = Function::Create(Ty, Function::InternalLinkage, GetGlobalIDName, M);
       setMetadataForGeneratedFunction(F);
-      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+      F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
 
       auto *EntryBlock = BasicBlock::Create(Builder.getContext(), "entry", F);
       Builder.SetInsertPoint(EntryBlock);
@@ -625,7 +625,7 @@ public:
                                     /*isVarArg*/ false);
       auto *F = Function::Create(FTy, Function::InternalLinkage, Name, *M);
       setMetadataForGeneratedFunction(F);
-      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+      F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
 
       auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
       Builder.SetInsertPoint(EntryBlock);
@@ -643,7 +643,7 @@ public:
       auto *FTy = FunctionType::get(Builder.getInt32Ty(), /*isVarArg*/ false);
       auto *F = Function::Create(FTy, Function::InternalLinkage, Name, *M);
       setMetadataForGeneratedFunction(F);
-      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
+      F->IsNewDbgInfoFormat = UseNewDbgInfoFormat;
 
       auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
       Builder.SetInsertPoint(EntryBlock);

--- a/sycl-fusion/passes/target/TargetFusionInfo.cpp
+++ b/sycl-fusion/passes/target/TargetFusionInfo.cpp
@@ -18,10 +18,13 @@
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/IntrinsicsAMDGPU.h"
 #include "llvm/IR/IntrinsicsNVPTX.h"
+#include "llvm/Support/CommandLine.h"
 #include "llvm/Support/raw_ostream.h"
 #include "llvm/TargetParser/Triple.h"
 
 using namespace jit_compiler;
+
+extern llvm::cl::opt<bool> UseNewDbgInfoFormat;
 
 template <typename ForwardIt, typename KeyTy>
 static ForwardIt mapArrayLookup(ForwardIt Begin, ForwardIt End,
@@ -227,6 +230,7 @@ public:
       F->setAttributes(
           AttributeList::get(LLVMMod->getContext(), FnAttrs, {}, {}));
       F->setCallingConv(CallingConv::SPIR_FUNC);
+      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
     }
 
     // See
@@ -393,6 +397,7 @@ public:
                     Attribute::get(Ctx, Attribute::AttrKind::NoUnwind)}),
           {}, {}));
       F->setCallingConv(CallingConv::SPIR_FUNC);
+      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
     }
 
     auto *Call = Builder.CreateCall(F, {Builder.getInt32(Idx)});
@@ -415,6 +420,7 @@ public:
                                  /*isVarArg*/ false);
     auto *F = Function::Create(Ty, Function::InternalLinkage, Name, *M);
     setMetadataForGeneratedFunction(F);
+    F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
 
     auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
     Builder.SetInsertPoint(EntryBlock);
@@ -559,6 +565,7 @@ public:
                                    /*isVarArg*/ false);
       F = Function::Create(Ty, Function::InternalLinkage, GetGlobalIDName, M);
       setMetadataForGeneratedFunction(F);
+      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
 
       auto *EntryBlock = BasicBlock::Create(Builder.getContext(), "entry", F);
       Builder.SetInsertPoint(EntryBlock);
@@ -618,6 +625,7 @@ public:
                                     /*isVarArg*/ false);
       auto *F = Function::Create(FTy, Function::InternalLinkage, Name, *M);
       setMetadataForGeneratedFunction(F);
+      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
 
       auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
       Builder.SetInsertPoint(EntryBlock);
@@ -635,6 +643,7 @@ public:
       auto *FTy = FunctionType::get(Builder.getInt32Ty(), /*isVarArg*/ false);
       auto *F = Function::Create(FTy, Function::InternalLinkage, Name, *M);
       setMetadataForGeneratedFunction(F);
+      F->setIsNewDbgInfoFormat(UseNewDbgInfoFormat);
 
       auto *EntryBlock = BasicBlock::Create(Ctx, "entry", F);
       Builder.SetInsertPoint(EntryBlock);


### PR DESCRIPTION
Set `IsNewDbgInfoFormat` to the default value for functions created in the SYCL Kernel Fusion pipeline. This prepares `sycl-fusion` for migration to the new debug info format.