### PR TITLE
[CUDA][LIBCLC] Fix fence impl to satisfy SYCL 2020.

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
+++ b/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
@@ -17,6 +17,9 @@ _CLC_OVERLOAD _CLC_DEF void __spirv_MemoryBarrier(unsigned int memory,
   // for sm_70 and above membar becomes semantically identical to fence.sc.
   // However sm_70 and above also introduces a lightweight fence.acq_rel that
   // can be used to form either acquire or release strong operations.
+  // Consult
+  // https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#parallel-synchronization-and-communication-instructions-membar-fence
+  // for details.
 
   unsigned int order = semantics & 0x1F;
   if (__clc_nvvm_reflect_arch() < 700 ||

--- a/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
+++ b/libclc/ptx-nvidiacl/libspirv/synchronization/barrier.cl
@@ -19,8 +19,7 @@ _CLC_OVERLOAD _CLC_DEF void __spirv_MemoryBarrier(unsigned int memory,
   // can be used to form either acquire or release strong operations.
 
   unsigned int order = semantics & 0x1F;
-  if (order == None) {
-  } else if (__clc_nvvm_reflect_arch() < 700 ||
+  if (__clc_nvvm_reflect_arch() < 700 ||
              order == SequentiallyConsistent) {
     if (memory == CrossDevice) {
       __nvvm_membar_sys();
@@ -29,7 +28,7 @@ _CLC_OVERLOAD _CLC_DEF void __spirv_MemoryBarrier(unsigned int memory,
     } else {
       __nvvm_membar_cta();
     }
-  } else {
+  } else if (order != None) {
     if (memory == CrossDevice) {
       __asm__ __volatile__("fence.acq_rel.sys;");
     } else if (memory == Device) {


### PR DESCRIPTION
- make relaxed fence a no op to satisfy the SYCL spec.
- make acquire/release/acq_rel use the lighter acq_rel fence for sm_70 instead of the seq_cst fence.