### PR TITLE
[SYCL] test update: support single tile PVC 

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -53,11 +53,20 @@ bool IsPVC(device &d) {
   return masked_device_id == 0xbd0 || masked_device_id == 0xb60;
 }
 
+bool IsPVC_2T(device &d) {
+  // PVC-1T does not support partitioning by affinity domain,
+  // while PVC-2T does.
+  if (!isPartitionableByAffinityDomain(d))
+    return false;
+
+  return IsPVC(d);
+}
+
 void test_pvc(device &d) {
   std::cout << "Test PVC Begin" << std::endl;
   // CHECK-PVC: Test PVC Begin
-  std::cout << "IsPVC: " << IsPVC(d) << std::endl;
-  if (IsPVC(d)) {
+  std::cout << "IsPVC: " << IsPVC_2T(d) << std::endl;
+  if (IsPVC_2T(d)) {
     assert(isPartitionableByAffinityDomain(d));
     assert(!isPartitionableByCSlice(d));
     {
@@ -146,7 +155,7 @@ void test_pvc(device &d) {
 }
 
 void test_non_pvc(device &d) {
-  if (IsPVC(d))
+  if (IsPVC_2T(d))
     return;
 
   // Non-PVC devices are not partitionable by CSlice at any level of

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -53,9 +53,9 @@ bool IsPVC(device &d) {
   return masked_device_id == 0xbd0 || masked_device_id == 0xb60;
 }
 
-bool IsPVC_2T(device &d) {
-  // PVC-1T does not support partitioning by affinity domain,
-  // while PVC-2T does.
+bool IsPVC_MultiTiles(device &d) {
+  // PVC-1T (one tile) does not support partitioning by affinity domain,
+  // which this test requires
   if (!isPartitionableByAffinityDomain(d))
     return false;
 
@@ -65,8 +65,8 @@ bool IsPVC_2T(device &d) {
 void test_pvc(device &d) {
   std::cout << "Test PVC Begin" << std::endl;
   // CHECK-PVC: Test PVC Begin
-  std::cout << "IsPVC: " << IsPVC_2T(d) << std::endl;
-  if (IsPVC_2T(d)) {
+  std::cout << "IsPVC: " << IsPVC_MultiTiles(d) << std::endl;
+  if (IsPVC_MultiTiles(d)) {
     assert(isPartitionableByAffinityDomain(d));
     assert(!isPartitionableByCSlice(d));
     {
@@ -155,7 +155,7 @@ void test_pvc(device &d) {
 }
 
 void test_non_pvc(device &d) {
-  if (IsPVC_2T(d))
+  if (IsPVC_MultiTiles(d))
     return;
 
   // Non-PVC devices are not partitionable by CSlice at any level of

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -30,9 +30,9 @@ bool IsPVC(device &d) {
   return masked_device_id == 0xbd0 || masked_device_id == 0xb60;
 }
 
-bool IsPVC_2T(device &d) {
-  // PVC-1T does not support partitioning by affinity domain,
-  // while PVC-2T does.
+bool IsPVC_MultiTiles(device &d) {
+  // PVC-1T (one tile) does not support partitioning by affinity domain,
+  // which this test requires
   if (!isPartitionableByAffinityDomain(d))
     return false;
 
@@ -42,7 +42,7 @@ bool IsPVC_2T(device &d) {
 void test_pvc(device &d) {
   std::cout << "Test PVC Begin" << std::endl;
   // CHECK-PVC: Test PVC Begin
-  bool IsPVC = IsPVC_2T(d);
+  bool IsPVC = IsPVC_MultiTiles(d);
   std::cout << "IsPVC: " << std::boolalpha << IsPVC << std::endl;
   if (IsPVC) {
     assert(d.get_info<ext::intel::info::device::max_compute_queue_indices>() ==


### PR DESCRIPTION
A few of our tests assume that a given PVC installation always has multiple tiles available, which is not true. Putting appropriate guards into those tests.