### PR TITLE
[SYCL] Add '--ignore-device-selectors' CLI option to sycl-ls and improve warning messages

### DIFF
--- a/sycl/test/tools/sycl-ls.test
+++ b/sycl/test/tools/sycl-ls.test
@@ -3,16 +3,16 @@
 RUN: sycl-ls --verbose > vanilla_verbose.out
 RUN: sycl-ls > vanilla.out
 
--- Check the functioning of 'discard-filters' CLI option.
+-- Check the functioning of '--ignore-device-selector' CLI option.
 
-RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --discard-filters > ods_discard_filter.out
-RUN: diff vanilla.out ods_discard_filter.out
+RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --ignore-device-selectors > ods_ignore_device_selector.out
+RUN: diff vanilla.out ods_ignore_device_selector.out
 
-RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --discard-filters --verbose > ods_discard_filter_v.out
-RUN: diff vanilla_verbose.out ods_discard_filter_v.out
+RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --ignore-device-selectors --verbose > ods_ignore_device_selector_v.out
+RUN: diff vanilla_verbose.out ods_ignore_device_selector_v.out
 
-RUN: env SYCL_DEVICE_ALLOWLIST="BackendName:opencl" sycl-ls --discard-filters > sda_discard_filter.out
-RUN: diff vanilla.out sda_discard_filter.out
+RUN: env SYCL_DEVICE_ALLOWLIST="BackendName:opencl" sycl-ls --ignore-device-selectors > sda_ignore_device_selector.out
+RUN: diff vanilla.out sda_ignore_device_selector.out
 
-RUN: env SYCL_DEVICE_ALLOWLIST="BackendName:opencl" sycl-ls --discard-filters --verbose > sda_discard_filter_v.out
-RUN: diff vanilla_verbose.out sda_discard_filter_v.out
+RUN: env SYCL_DEVICE_ALLOWLIST="BackendName:opencl" sycl-ls --ignore-device-selectors --verbose > sda_ignore_device_selector_v.out
+RUN: diff vanilla_verbose.out sda_ignore_device_selector_v.out

--- a/sycl/test/tools/sycl-ls.test
+++ b/sycl/test/tools/sycl-ls.test
@@ -1,4 +1,4 @@
--- Check that sycl-ls exits with 0 exit code.
+-- Check sycl-ls exit code and output.
 
 RUN: sycl-ls --verbose > vanilla_verbose.out
 RUN: sycl-ls > vanilla.out

--- a/sycl/test/tools/sycl-ls.test
+++ b/sycl/test/tools/sycl-ls.test
@@ -1,3 +1,18 @@
--- Check that sycl-ls exits with 0 exit code. 
+-- Check that sycl-ls exits with 0 exit code.
 
-RUN: sycl-ls --verbose
+RUN: sycl-ls --verbose > vanilla_verbose.out
+RUN: sycl-ls > vanilla.out
+
+-- Check the functioning of 'discard-filters' CLI option.
+
+RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --discard-filters > ods_discard_filter.out
+RUN: diff vanilla.out ods_discard_filter.out
+
+RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --discard-filters --verbose > ods_discard_filter_v.out
+RUN: diff vanilla_verbose.out ods_discard_filter_v.out
+
+RUN: env SYCL_DEVICE_ALLOWLIST="BackendName:opencl" sycl-ls --discard-filters > sda_discard_filter.out
+RUN: diff vanilla.out sda_discard_filter.out
+
+RUN: env SYCL_DEVICE_ALLOWLIST="BackendName:opencl" sycl-ls --discard-filters --verbose > sda_discard_filter_v.out
+RUN: diff vanilla_verbose.out sda_discard_filter_v.out

--- a/sycl/test/tools/sycl-ls.test
+++ b/sycl/test/tools/sycl-ls.test
@@ -3,7 +3,7 @@
 RUN: sycl-ls --verbose > vanilla_verbose.out
 RUN: sycl-ls > vanilla.out
 
--- Check the functioning of '--ignore-device-selector' CLI option.
+-- Check the functioning of '--ignore-device-selectors' CLI option.
 
 RUN: env ONEAPI_DEVICE_SELECTOR="opencl:*" sycl-ls --ignore-device-selectors > ods_ignore_device_selector.out
 RUN: diff vanilla.out ods_ignore_device_selector.out

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -114,7 +114,8 @@ static void printSelectorChoice(const device_selector &Selector,
 }
 
 static int printUsageAndExit() {
-  std::cout << "Usage: sycl-ls [--verbose] [--ignore-device-selectors]" << std::endl;
+  std::cout << "Usage: sycl-ls [--verbose] [--ignore-device-selectors]"
+            << std::endl;
   std::cout << "This program lists all devices and backends discovered by SYCL."
             << std::endl;
   std::cout << "\n Options:" << std::endl;
@@ -142,9 +143,10 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
       std::cerr << "INFO: Output filtered by SYCL_DEVICE_FILTER "
                 << "environment variable, which is set to " << filter << "."
                 << std::endl;
-      std::cerr << "To see device ids, use the --ignore-device-selectors CLI option."
-                << std::endl
-                << std::endl;
+      std::cerr
+          << "To see device ids, use the --ignore-device-selectors CLI option."
+          << std::endl
+          << std::endl;
       SuppressNumberPrinting = true;
     } else
       FilterEnvVars.push_back("SYCL_DEVICE_FILTER");
@@ -157,9 +159,10 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
       std::cerr << "INFO: Output filtered by ONEAPI_DEVICE_SELECTOR "
                 << "environment variable, which is set to " << ods_targets
                 << "." << std::endl;
-      std::cerr << "To see device ids, use the --ignore-device-selectors CLI option."
-                << std::endl
-                << std::endl;
+      std::cerr
+          << "To see device ids, use the --ignore-device-selectors CLI option."
+          << std::endl
+          << std::endl;
       SuppressNumberPrinting = true;
     } else
       FilterEnvVars.push_back("ONEAPI_DEVICE_SELECTOR");
@@ -171,9 +174,10 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
       std::cerr << "INFO: Output filtered by SYCL_DEVICE_ALLOWLIST "
                 << "environment variable, which is set to " << sycl_dev_allow
                 << "." << std::endl;
-      std::cerr << "To see device ids, use the --ignore-device-selectors CLI option."
-                << std::endl
-                << std::endl;
+      std::cerr
+          << "To see device ids, use the --ignore-device-selectors CLI option."
+          << std::endl
+          << std::endl;
       SuppressNumberPrinting = true;
     } else
       FilterEnvVars.push_back("SYCL_DEVICE_ALLOWLIST");

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -113,16 +113,18 @@ static void printSelectorChoice(const device_selector &Selector,
 
 static int printUsageAndExit() {
   std::cout << "Usage: sycl-ls [--verbose] [--discard-filters]" << std::endl;
-  std::cout << "This program lists all devices and backends discovered by SYCL." << std::endl;
+  std::cout << "This program lists all devices and backends discovered by SYCL."
+            << std::endl;
   std::cout << "\n Options:" << std::endl;
-  std::cout << "\t --verbose "
-              << "\t Verbosely prints all the discovered platforms. "
-              << "It also lists the device chosen by various SYCL device selectors."
-              << std::endl;
-  std::cout << "\t --discard-filters "
-              << "\t Lists all platforms available on the system irrespective "
-              << "of the filter environment variables (like ONEAPI_DEVICE_SELECTOR)."
-              << std::endl;
+  std::cout
+      << "\t --verbose " << "\t Verbosely prints all the discovered platforms. "
+      << "It also lists the device chosen by various SYCL device selectors."
+      << std::endl;
+  std::cout
+      << "\t --discard-filters "
+      << "\t Lists all platforms available on the system irrespective "
+      << "of the filter environment variables (like ONEAPI_DEVICE_SELECTOR)."
+      << std::endl;
 
   return EXIT_FAILURE;
 }
@@ -136,14 +138,13 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
   if (filter) {
     if (!DiscardFilters) {
       std::cerr << "INFO: Output filtered by SYCL_DEVICE_FILTER "
-                << "environment variable, which is set to "
-                << filter << "." << std::endl;
+                << "environment variable, which is set to " << filter << "."
+                << std::endl;
       std::cerr << "To see device ids, use the --discard-filters CLI option."
                 << std::endl
                 << std::endl;
       SuppressNumberPrinting = true;
-    }
-    else
+    } else
       FilterEnvVars.insert({"SYCL_DEVICE_FILTER", filter});
   }
 #endif
@@ -151,32 +152,28 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
   const char *ods_targets = std::getenv("ONEAPI_DEVICE_SELECTOR");
   if (ods_targets) {
     if (!DiscardFilters) {
-      std::cerr
-          << "INFO: Output filtered by ONEAPI_DEVICE_SELECTOR "
-          << "environment variable, which is set to "
-          << ods_targets << "." << std::endl;
+      std::cerr << "INFO: Output filtered by ONEAPI_DEVICE_SELECTOR "
+                << "environment variable, which is set to " << ods_targets
+                << "." << std::endl;
       std::cerr << "To see device ids, use the --discard-filters CLI option."
                 << std::endl
                 << std::endl;
       SuppressNumberPrinting = true;
-    }
-    else
+    } else
       FilterEnvVars.insert({"ONEAPI_DEVICE_SELECTOR", ods_targets});
   }
 
   const char *sycl_dev_allow = std::getenv("SYCL_DEVICE_ALLOWLIST");
   if (sycl_dev_allow) {
     if (!DiscardFilters) {
-      std::cerr
-          << "INFO: Output filtered by SYCL_DEVICE_ALLOWLIST "
-          << "environment variable, which is set to "
-          << sycl_dev_allow << "." << std::endl;
+      std::cerr << "INFO: Output filtered by SYCL_DEVICE_ALLOWLIST "
+                << "environment variable, which is set to " << sycl_dev_allow
+                << "." << std::endl;
       std::cerr << "To see device ids, use the --discard-filters CLI option."
                 << std::endl
                 << std::endl;
       SuppressNumberPrinting = true;
-    }
-    else
+    } else
       FilterEnvVars.insert({"SYCL_DEVICE_ALLOWLIST", sycl_dev_allow});
   }
 }
@@ -209,8 +206,7 @@ int main(int argc, char **argv) {
   if (argc == 1) {
     verbose = false;
     DiscardFilters = false;
-  }
-  else {
+  } else {
     // Parse CLI options.
     for (int i = 1; i < argc; i++) {
       if (std::string(argv[i]) == "--verbose")

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -127,7 +127,7 @@ static int printUsageAndExit() {
   return EXIT_FAILURE;
 }
 
-// Print warning and supress printing device ids if any of
+// Print warning and suppress printing device ids if any of
 // the filter environment variable is set.
 static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
 
@@ -185,14 +185,22 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
 // ONEAPI_DEVICE_SELECTOR, and SYCL_DEVICE_ALLOWLIST.
 static void unsetFilterEnvVars() {
   for (auto it : FilterEnvVars) {
+#ifdef _WIN32
+    _putenv_s(it.first.c_str(), "");
+#else
     unsetenv(it.first.c_str());
+#endif
   }
 }
 
 // Restore filter related environment variables that we unset earlier.
 static void restoreFilterEnvVars() {
   for (auto it : FilterEnvVars) {
+#ifdef _WIN32
+    _putenv_s(it.first.c_str(), it.second.c_str());
+#else
     setenv(it.first.c_str(), it.second.c_str(), 1);
+#endif
   }
 }
 
@@ -202,7 +210,7 @@ int main(int argc, char **argv) {
     verbose = false;
     DiscardFilters = false;
   }
-  else if (argc > 1 && argc < 4) {
+  else {
     // Parse CLI options.
     for (int i = 1; i < argc; i++) {
       if (std::string(argv[i]) == "--verbose")
@@ -213,16 +221,13 @@ int main(int argc, char **argv) {
         return printUsageAndExit();
     }
   }
-  else
-    return printUsageAndExit();
 
   bool SuppressNumberPrinting = false;
-  // Print warning and supress printing device ids if any of
+  // Print warning and suppress printing device ids if any of
   // the filter environment variable is set.
   printWarningIfFiltersUsed(SuppressNumberPrinting);
 
   try {
-
     // Unset all filter env. vars to get all available devices in the system.
     if (DiscardFilters)
       unsetFilterEnvVars();

--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -114,7 +114,7 @@ static void printSelectorChoice(const device_selector &Selector,
 }
 
 static int printUsageAndExit() {
-  std::cout << "Usage: sycl-ls [--verbose] [--discard-filters]" << std::endl;
+  std::cout << "Usage: sycl-ls [--verbose] [--ignore-device-selectors]" << std::endl;
   std::cout << "This program lists all devices and backends discovered by SYCL."
             << std::endl;
   std::cout << "\n Options:" << std::endl;
@@ -123,9 +123,9 @@ static int printUsageAndExit() {
       << "It also lists the device chosen by various SYCL device selectors."
       << std::endl;
   std::cout
-      << "\t --discard-filters "
+      << "\t --ignore-device-selectors "
       << "\t Lists all platforms available on the system irrespective "
-      << "of the filter environment variables (like ONEAPI_DEVICE_SELECTOR)."
+      << "of DPCPP filter environment variables (like ONEAPI_DEVICE_SELECTOR)."
       << std::endl;
 
   return EXIT_FAILURE;
@@ -142,7 +142,7 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
       std::cerr << "INFO: Output filtered by SYCL_DEVICE_FILTER "
                 << "environment variable, which is set to " << filter << "."
                 << std::endl;
-      std::cerr << "To see device ids, use the --discard-filters CLI option."
+      std::cerr << "To see device ids, use the --ignore-device-selectors CLI option."
                 << std::endl
                 << std::endl;
       SuppressNumberPrinting = true;
@@ -157,7 +157,7 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
       std::cerr << "INFO: Output filtered by ONEAPI_DEVICE_SELECTOR "
                 << "environment variable, which is set to " << ods_targets
                 << "." << std::endl;
-      std::cerr << "To see device ids, use the --discard-filters CLI option."
+      std::cerr << "To see device ids, use the --ignore-device-selectors CLI option."
                 << std::endl
                 << std::endl;
       SuppressNumberPrinting = true;
@@ -171,7 +171,7 @@ static void printWarningIfFiltersUsed(bool &SuppressNumberPrinting) {
       std::cerr << "INFO: Output filtered by SYCL_DEVICE_ALLOWLIST "
                 << "environment variable, which is set to " << sycl_dev_allow
                 << "." << std::endl;
-      std::cerr << "To see device ids, use the --discard-filters CLI option."
+      std::cerr << "To see device ids, use the --ignore-device-selectors CLI option."
                 << std::endl
                 << std::endl;
       SuppressNumberPrinting = true;
@@ -202,7 +202,7 @@ int main(int argc, char **argv) {
     for (int i = 1; i < argc; i++) {
       if (argv[i] == "--verbose"sv)
         verbose = true;
-      else if (argv[i] == "--discard-filters"sv)
+      else if (argv[i] == "--ignore-device-selectors"sv)
         DiscardFilters = true;
       else
         return printUsageAndExit();


### PR DESCRIPTION
This PR adds a '--ignore-device-selectors' CLI option to sycl-ls that prints all platforms available in the user's system, irrespective of the DPCPP filter environment variables like ONEAPI_DEVICE_SELECTOR. 