### PR TITLE
[SYCL] Sort platforms in platform::get_platforms()

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -203,6 +203,21 @@ std::vector<platform> platform_impl::get_platforms() {
   // may be initialized after.
   GlobalHandler::registerDefaultContextReleaseHandler();
 
+  // Some applications/libraries prefer to implement their own device selection
+  // and default to just providing the first available device. Make sure that
+  // the first platform has the most preferrable device.
+  auto GetPlatformScore = [](const platform &p) {
+    auto devs = p.get_devices();
+    auto it =
+        std::max_element(devs.begin(), devs.end(), [](auto lhs, auto rhs) {
+          return default_selector_v(lhs) < default_selector_v(rhs);
+        });
+    return default_selector_v(*it);
+  };
+  std::stable_sort(Platforms.begin(), Platforms.end(), [&](auto lhs, auto rhs) {
+    return GetPlatformScore(lhs) > GetPlatformScore(rhs);
+  });
+
   return Platforms;
 }
 

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -214,9 +214,19 @@ std::vector<platform> platform_impl::get_platforms() {
         });
     return default_selector_v(*it);
   };
-  std::stable_sort(Platforms.begin(), Platforms.end(), [&](auto lhs, auto rhs) {
-    return GetPlatformScore(lhs) > GetPlatformScore(rhs);
+
+  std::vector<std::pair<platform, int>> PlatformScores;
+  PlatformScores.reserve(Platforms.size());
+  for (auto &p : Platforms)
+    PlatformScores.emplace_back(p, GetPlatformScore(p));
+
+  std::stable_sort(PlatformScores.begin(), PlatformScores.end(), [&](auto lhs, auto rhs) {
+    return lhs.second > rhs.second;
   });
+
+  Platforms.clear();
+  for (auto &e : PlatformScores )
+    Platforms.push_back(e.first);
 
   return Platforms;
 }

--- a/sycl/test-e2e/Basic/get_backend.cpp
+++ b/sycl/test-e2e/Basic/get_backend.cpp
@@ -1,8 +1,7 @@
-// Sporadic fails on DG2
-// TODO: Reenable when internal ticket is resolved
-// UNSUPPORTED: gpu-intel-dg2
 // RUN: %{build} -o %t.out
-// RUN: %{run-unfiltered-devices} %t.out
+// FPGA RT returns random CL_INVALID_CONTEXT in some configurations, tracked
+// internally. Avoid FPGA devices until that is fixed.
+// RUN: env ONEAPI_DEVICE_SELECTOR="*:gpu;*:cpu" %{run-unfiltered-devices} %t.out
 //
 //==----------------- get_backend.cpp ------------------------==//
 // This is a test of get_backend().

--- a/sycl/test-e2e/Config/select_device.cpp
+++ b/sycl/test-e2e/Config/select_device.cpp
@@ -123,7 +123,11 @@ static std::vector<DevDescT> getAllowListDesc(std::string allowList) {
         throw std::runtime_error("Malformed device allowlist");
       }
       decDescs.back().devDriverVer = allowList.substr(start, pos - start);
-      pos = pos + 3;
+      pos = pos + 2;
+
+      if (allowList[pos] == ',') {
+        pos++;
+      }
     }
 
     else if ((allowList.compare(pos, platformName.size(), platformName)) == 0) {


### PR DESCRIPTION
So that the first one would contain the most preferrable device in case SYCL applications/library performs manual device selection and defaults to the first available device.