### PR TITLE
[ESIMD] Fix atomic_update() implementation for N=16 and N=32 on Gen12

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
@@ -706,13 +706,13 @@ bool test_int_types_and_sizes(queue q, const Config &cfg) {
 
   passed &=
       test_int_types<8, Op, UseMask, UseLSCFeatures, UseAcc, SignMask>(q, cfg);
+  passed &=
+      test_int_types<16, Op, UseMask, UseLSCFeatures, UseAcc, SignMask>(q, cfg);
+  passed &=
+      test_int_types<32, Op, UseMask, UseLSCFeatures, UseAcc, SignMask>(q, cfg);
 
   // Supported by LSC atomic:
   if constexpr (UseLSCFeatures) {
-    passed &= test_int_types<16, Op, UseMask, UseLSCFeatures, UseAcc, SignMask>(
-        q, cfg);
-    passed &= test_int_types<32, Op, UseMask, UseLSCFeatures, UseAcc, SignMask>(
-        q, cfg);
     passed &= test_int_types<64, Op, UseMask, UseLSCFeatures, UseAcc, SignMask>(
         q, cfg);
     // non power of two values are supported only in newer driver.


### PR DESCRIPTION
atomic_update() for USM and ACC N=16,32 were lowered to SVM/DWORD atomic
intrinsics even though the HW instructions on Gen12 supported only
N up to 8 for USM and up to 16 for ACC.
    
GPU had legalization pass for N that split longer vectors to smaller and available in HW.
That GPU optimization/legalization workes incorrectly for USM as it
splits longer vectors assuming instruction is available for N=16 in case
of USM, which is not correct.
    
The patch here implements splitting of N=16 and N=32 cases for
atomic_update(usm, ...) to N=8 vectors until GPU fixes the legalization
for USM atomic_update.