### PR TITLE
[SYCL][Graph] Bump UR commit to OpenCL kernel update

### DIFF
--- a/sycl/doc/design/CommandGraph.md
+++ b/sycl/doc/design/CommandGraph.md
@@ -537,9 +537,18 @@ adapter where there is matching support for each function in the list.
 |  | clGetCommandBufferInfoKHR | No |
 |  | clCommandSVMMemcpyKHR | No |
 |  | clCommandSVMMemFillKHR | No |
+| urCommandBufferUpdateKernelLaunchExp | clUpdateMutableCommandsKHR | Yes[1] |
 
 We are looking to address these gaps in the future so that SYCL-Graph can be
 fully supported on a `cl_khr_command_buffer` backend.
+
+[1] Support for `urCommandBufferUpdateKernelLaunchExp` used to update the
+configuration of kernel commands requires an OpenCL implementation with the
+[cl_khr_command_buffer_mutable_dispatch](https://registry.khronos.org/OpenCL/specs/3.0-unified/html/OpenCL_Ext.html#cl_khr_command_buffer_mutable_dispatch)
+extension. The optional capabilities that are reported by this extension must
+include all of of `CL_MUTABLE_DISPATCH_GLOBAL_OFFSET_KHR`,
+`CL_MUTABLE_DISPATCH_GLOBAL_SIZE_KHR`, `CL_MUTABLE_DISPATCH_LOCAL_SIZE_KHR`,
+`CL_MUTABLE_DISPATCH_ARGUMENTS_KHR`, and `CL_MUTABLE_DISPATCH_EXEC_INFO_KHR`.
 
 #### UR Command-Buffer Implementation
 

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -95,13 +95,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 31d0fe153733601fe4864fffb9148d554fe9a7ca
-  # Merge: 2eea85f2 6a602134
+  # commit b37fa2c4b09a49839a83228f687c811595fce3fd
+  # Merge: c7fade0d f61e81e9
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Mon Apr 22 14:38:18 2024 +0100
-  #     Merge pull request #1243 from kbenzie/benie/fix-urinfo-device-uuid-printing
-  #     [urinfo] Fix printing of device UUID
-  set(UNIFIED_RUNTIME_TAG 31d0fe153733601fe4864fffb9148d554fe9a7ca)
+  # Date:   Tue Apr 23 16:17:41 2024 +0100
+  #    Merge pull request #1544 from kbenzie/benie/l0-fix-rhel-error
+  #    [L0] Add missing <iomanip> include
+  set(UNIFIED_RUNTIME_TAG b37fa2c4b09a49839a83228f687c811595fce3fd)
 
   fetch_adapter_source(level_zero
     ${UNIFIED_RUNTIME_REPO}

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -4835,15 +4835,11 @@ inline pi_result piextCommandBufferUpdateKernelLaunch(
   ur_exp_command_buffer_update_kernel_launch_desc_t UrDesc;
 
   UrDesc.stype = ur_structure_type_t::
-      UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_EXEC_INFO_DESC;
+      UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_UPDATE_KERNEL_LAUNCH_DESC;
   UrDesc.numNewMemObjArgs = desc->num_mem_obj_args;
   UrDesc.numNewPointerArgs = desc->num_ptr_args;
   UrDesc.numNewValueArgs = desc->num_value_args;
   UrDesc.newWorkDim = desc->num_work_dim;
-
-  // Exec info updates are unused and will be removed from UR in future
-  UrDesc.numNewExecInfos = 0;
-  UrDesc.pNewExecInfoList = nullptr;
 
   // Convert arg descs
   std::vector<ur_exp_command_buffer_update_memobj_arg_desc_t> UrMemObjDescs;


### PR DESCRIPTION
Test the UR commit that enables updating kernel commands in a command-buffer in the OpenCL adapter https://github.com/oneapi-src/unified-runtime/pull/1358