### PR TITLE
[SYCL] Generalize group_algorithm helpers

### DIFF
--- a/sycl/include/sycl/group_algorithm.hpp
+++ b/sycl/include/sycl/group_algorithm.hpp
@@ -59,24 +59,29 @@ template <> inline id<3> linear_id_to_id(range<3> r, size_t linear_id) {
 }
 
 // ---- get_local_linear_range
-template <typename Group> size_t get_local_linear_range(Group g);
-template <> inline size_t get_local_linear_range<group<1>>(group<1> g) {
+template <typename Group>
+inline typename Group::linear_id_type get_local_linear_range(Group g) {
+  return g.get_local_linear_range();
+}
+
+template <>
+inline group<1>::linear_id_type get_local_linear_range<group<1>>(group<1> g) {
   return g.get_local_range(0);
 }
-template <> inline size_t get_local_linear_range<group<2>>(group<2> g) {
+template <>
+inline group<2>::linear_id_type get_local_linear_range<group<2>>(group<2> g) {
   return g.get_local_range(0) * g.get_local_range(1);
 }
-template <> inline size_t get_local_linear_range<group<3>>(group<3> g) {
-  return g.get_local_range(0) * g.get_local_range(1) * g.get_local_range(2);
-}
 template <>
-inline size_t get_local_linear_range<sycl::sub_group>(sycl::sub_group g) {
-  return g.get_local_range()[0];
+inline group<3>::linear_id_type get_local_linear_range<group<3>>(group<3> g) {
+  return g.get_local_range(0) * g.get_local_range(1) * g.get_local_range(2);
 }
 
 // ---- get_local_linear_id
 template <typename Group>
-inline typename Group::linear_id_type get_local_linear_id(Group g);
+inline typename Group::linear_id_type get_local_linear_id(Group g) {
+  return g.get_local_id();
+}
 
 #ifdef __SYCL_DEVICE_ONLY__
 #define __SYCL_GROUP_GET_LOCAL_LINEAR_ID(D)                                    \
@@ -90,12 +95,6 @@ __SYCL_GROUP_GET_LOCAL_LINEAR_ID(2);
 __SYCL_GROUP_GET_LOCAL_LINEAR_ID(3);
 #undef __SYCL_GROUP_GET_LOCAL_LINEAR_ID
 #endif // __SYCL_DEVICE_ONLY__
-
-template <>
-inline sycl::sub_group::linear_id_type
-get_local_linear_id<sycl::sub_group>(sycl::sub_group g) {
-  return g.get_local_id()[0];
-}
 
 // ---- is_native_op
 template <typename T>


### PR DESCRIPTION
This commit generalizes two helper functions in group_algorithm.hpp to make it so they can also handle non-uniform groups.