### PR TITLE
[SYCL][Bindless] Fix Grad flag

### DIFF
--- a/sycl/include/sycl/detail/image_ocl_types.hpp
+++ b/sycl/include/sycl/detail/image_ocl_types.hpp
@@ -110,7 +110,7 @@ static RetType __invoke__ImageReadGrad(SmpImageT SmpImg, CoordT Coords,
   auto TmpGraddX = sycl::detail::convertToOpenCLType(Dx);
   auto TmpGraddY = sycl::detail::convertToOpenCLType(Dy);
 
-  enum ImageOperands { Grad = 0x3 };
+  enum ImageOperands { Grad = 0x4 };
 
   // OpImageSampleExplicitLod
   // Its components must be the same as Sampled Type of the underlying


### PR DESCRIPTION
Grad flag was set to 0x3 (meaning Lod + Bias) instead of 0x4.
See https://registry.khronos.org/SPIR-V/specs/unified1/SPIRV.html#Image_Operands