### PR TITLE
[NFC][SYCL] Move a helper to its single legacy use

### DIFF
--- a/sycl/include/sycl/builtins_legacy_scalar.hpp
+++ b/sycl/include/sycl/builtins_legacy_scalar.hpp
@@ -330,6 +330,22 @@ inline constexpr bool is_non_deprecated_nan_type_v =
     std::is_same_v<get_elem_type_t<T>, uint16_t> ||
     std::is_same_v<get_elem_type_t<T>, uint32_t> ||
     std::is_same_v<get_elem_type_t<T>, uint64_t>;
+
+template <typename T, typename B, typename Enable = void>
+struct convert_data_type_impl;
+
+template <typename T, typename B>
+struct convert_data_type_impl<T, B, std::enable_if_t<is_sgentype_v<T>, T>> {
+  B operator()(T t) { return static_cast<B>(t); }
+};
+
+template <typename T, typename B>
+struct convert_data_type_impl<T, B, std::enable_if_t<is_vgentype_v<T>, T>> {
+  vec<B, T::size()> operator()(T t) { return t.template convert<B>(); }
+};
+
+template <typename T, typename B>
+using convert_data_type = convert_data_type_impl<T, B, T>;
 } // namespace detail
 
 template <typename T>

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -405,22 +405,6 @@ template <typename T>
 using make_unsinged_integer_t =
     make_type_t<T, gtl::scalar_unsigned_integer_list>;
 
-template <typename T, typename B, typename Enable = void>
-struct convert_data_type_impl;
-
-template <typename T, typename B>
-struct convert_data_type_impl<T, B, std::enable_if_t<is_sgentype_v<T>, T>> {
-  B operator()(T t) { return static_cast<B>(t); }
-};
-
-template <typename T, typename B>
-struct convert_data_type_impl<T, B, std::enable_if_t<is_vgentype_v<T>, T>> {
-  vec<B, T::size()> operator()(T t) { return t.template convert<B>(); }
-};
-
-template <typename T, typename B>
-using convert_data_type = convert_data_type_impl<T, B, T>;
-
 // TryToGetElementType<T>::type is T::element_type or T::value_type if those
 // exist, otherwise T.
 template <typename T> class TryToGetElementType {


### PR DESCRIPTION
Old builtins implementation is going to be removed in the next ABI breaking window and that helper is only used there.