### PR TITLE
[ESIMD][NFC][E2E] Fix 570 compilation warnings in ESIMD E2E tests

### DIFF
--- a/sycl/test-e2e/ESIMD/accessor_global.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_global.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} -fsycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 
-// This test verifies usage of accessor methods operator[] and get_pointer().
+// This test verifies usage of accessor methods operator[] and get_multi_ptr().
 
 #include "esimd_test_utils.hpp"
 
@@ -39,7 +39,8 @@ bool test(queue Q, uint32_t LocalRange, uint32_t GlobalRange) {
            for (int I = 0; I < VL; I++)
              TmpAcc[GID * VL + I] = GID * 100 + I;
          } else {
-           T *Ptr = TmpAcc.get_pointer();
+           T *Ptr =
+               TmpAcc.template get_multi_ptr<access::decorated::yes>().get();
            simd<int, VL> IntValues(GID * 100, 1);
            simd<T, VL> Values = IntValues;
            block_store(Ptr + GID * VL, Values);
@@ -53,12 +54,13 @@ bool test(queue Q, uint32_t LocalRange, uint32_t GlobalRange) {
                for (int I = 0; I < VL; I++)
                  Out[(GID + LID) * VL + I] = TmpAcc[(GID + LID) * VL + I];
              } else {
-               T *Ptr = TmpAcc.get_pointer();
+               T *Ptr = TmpAcc.template get_multi_ptr<access::decorated::yes>()
+                            .get();
                simd<T, VL> Values = block_load<T, VL>(Ptr + (GID + LID) * VL);
                Values.template copy_to(Out + (GID + LID) * VL);
              }
            } // end for (int LID = 0; LID < LocalRange; LID++)
-         }   // end if (LID == 0)
+         } // end if (LID == 0)
        });
      }).wait();
   } catch (sycl::exception const &e) {

--- a/sycl/test-e2e/ESIMD/accessor_local.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_local.cpp
@@ -43,8 +43,10 @@ bool test(queue Q, uint32_t LocalRange, uint32_t GlobalRange) {
        CGH.parallel_for(NDRange, [=](nd_item<1> Item) SYCL_ESIMD_KERNEL {
          uint32_t GID = Item.get_global_id(0);
          uint32_t LID = Item.get_local_id(0);
-         uint32_t LocalAccOffset = static_cast<uint32_t>(
-             reinterpret_cast<std::uintptr_t>(LocalAcc.get_pointer().get()));
+         uint32_t LocalAccOffset =
+             static_cast<uint32_t>(reinterpret_cast<std::uintptr_t>(
+                 LocalAcc.template get_multi_ptr<access::decorated::yes>()
+                     .get()));
          if constexpr (TestSubscript) {
            for (int I = 0; I < VL; I++)
              LocalAcc[LID * VL + I] = GID * 100 + I;
@@ -67,7 +69,7 @@ bool test(queue Q, uint32_t LocalRange, uint32_t GlobalRange) {
                ValuesFromSLM.copy_to(Out + (GID + LID) * VL);
              }
            } // end for (int LID = 0; LID < LocalRange; LID++)
-         }   // end if (LID == 0)
+         } // end if (LID == 0)
        });
      }).wait();
   } catch (sycl::exception const &e) {

--- a/sycl/test-e2e/ESIMD/api/simd_view_copy_move_assign.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_view_copy_move_assign.cpp
@@ -24,7 +24,7 @@ using namespace sycl::ext::intel::esimd;
 template <unsigned VL, class T, class F>
 bool test(queue q, std::string str, F funcUnderTest) {
   std::cout << "Testing " << str << ", VL = " << VL << " ...\n";
-  size_t Size = 4 * VL;
+  constexpr size_t Size = 4 * VL;
   T A[Size];
   T B[Size];
   constexpr unsigned HalfVL = VL > 1 ? (VL / 2) : 1;

--- a/sycl/test-e2e/ESIMD/dpas/dpas_common.hpp
+++ b/sycl/test-e2e/ESIMD/dpas/dpas_common.hpp
@@ -51,9 +51,7 @@ std::string toString(dpas_argument_type T) {
     return "bf16";
   case dpas_argument_type::tf32:
     return "tf32";
-  case dpas_argument_type::s1:
-  case dpas_argument_type::u1:
-  case dpas_argument_type::Invalid:
+  default:
     return "UNSUPPORTED";
   }
   return "UNRECOGNIZED";
@@ -127,9 +125,7 @@ template <dpas_argument_type T> constexpr int getBitSize() {
   case dpas_argument_type::tf32:
     return 32;
 
-  case dpas_argument_type::Invalid:
-  case dpas_argument_type::s1:
-  case dpas_argument_type::u1:
+  default:
     break;
   }
   return 0;
@@ -405,7 +401,7 @@ bool test(queue &Q, bool Print) {
                   << ") != expected (" << GoldRes << ")" << std::endl;
       }
     } // end for JJ
-  }   // end for II
+  } // end for II
 
   free(Res, Q);
   free(APacked, Q);

--- a/sycl/test-e2e/ESIMD/esimd_test_utils.hpp
+++ b/sycl/test-e2e/ESIMD/esimd_test_utils.hpp
@@ -27,6 +27,10 @@ using namespace sycl;
 
 namespace esimd_test {
 
+template <typename T>
+using shared_allocator = sycl::usm_allocator<T, sycl::usm::alloc::shared>;
+template <typename T> using shared_vector = std::vector<T, shared_allocator<T>>;
+
 // This is the function provided to SYCL runtime by the application to decide
 // on which device to run, or whether to run at all.
 // When selecting a device, SYCL runtime first takes (1) a selector provided by

--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -388,7 +388,10 @@ bool test(queue &Q, const std::string &Name, InitF Init = InitNarrow<T>{},
     if constexpr (sizeof(T) <= 2)
       delta = delta + delta;
 
-    bool BothFinite = std::isfinite(Test) && std::isfinite(Gold);
+    bool BothFinite = true;
+#ifndef TEST_FAST_MATH
+    BothFinite = std::isfinite(Test) && std::isfinite(Gold);
+#endif
     if (BothFinite && std::abs(Test - Gold) > delta) {
       if (++ErrCnt < 10) {
         std::cout << "    failed at index " << I << ", " << Test

--- a/sycl/test-e2e/ESIMD/grf.cpp
+++ b/sycl/test-e2e/ESIMD/grf.cpp
@@ -71,13 +71,10 @@ int main(void) {
     A[i] = i;
   }
 
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
   try {
     buffer<float, 1> bufa(A.data(), range<1>(Size));
-    queue q(gpu_selector{}, esimd_test::createExceptionHandler());
-
-    auto dev = q.get_device();
-    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-
     auto e = q.submit([&](handler &cgh) {
       auto PA = bufa.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<class SyclKernel>(Size,
@@ -98,11 +95,6 @@ int main(void) {
 
   try {
     buffer<float, 1> bufa(A.data(), range<1>(Size));
-    queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
-
-    auto dev = q.get_device();
-    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-
     auto e = q.submit([&](handler &cgh) {
       auto PA = bufa.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<class EsimdKernel>(Size, [=](id<1> i) SYCL_ESIMD_KERNEL {
@@ -128,7 +120,6 @@ int main(void) {
 
   try {
     buffer<float, 1> bufa(A.data(), range<1>(Size));
-    queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
 #ifdef USE_AUTO
     sycl::ext::oneapi::experimental::properties prop{grf_size_automatic};
 #elif defined(USE_NEW_API)
@@ -137,9 +128,6 @@ int main(void) {
     sycl::ext::oneapi::experimental::properties prop{
         register_alloc_mode<register_alloc_mode_enum::large>};
 #endif
-    auto dev = q.get_device();
-    std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
-
     auto e = q.submit([&](handler &cgh) {
       auto PA = bufa.get_access<access::mode::read_write>(cgh);
       cgh.parallel_for<class EsimdKernelSpecifiedGRF>(

--- a/sycl/test-e2e/ESIMD/histogram.cpp
+++ b/sycl/test-e2e/ESIMD/histogram.cpp
@@ -85,15 +85,15 @@ int main(int argc, char *argv[]) {
 
   // Allocate Input Buffer
   queue q = esimd_test::createQueue();
+  esimd_test::printTestLabel(q);
 
-  auto dev = q.get_device();
-  unsigned char *srcY = malloc_shared<unsigned char>(width * height, q);
-  if (srcY == NULL) {
-    std::cerr << "Out of memory\n";
-    exit(1);
-  }
-  unsigned int *bins = malloc_shared<unsigned int>(NUM_BINS, q);
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  esimd_test::shared_vector<uint8_t> srcY_vec(
+      width * height, esimd_test::shared_allocator<uint8_t>{q});
+  esimd_test::shared_vector<unsigned int> bins_vec(
+      NUM_BINS, esimd_test::shared_allocator<unsigned int>{q});
+  uint8_t *srcY = srcY_vec.data();
+  ;
+  unsigned int *bins = bins_vec.data();
 
   uint range_width = width / BLOCK_WIDTH;
   uint range_height = height / BLOCK_HEIGHT;
@@ -106,16 +106,12 @@ int main(int argc, char *argv[]) {
     FILE *f = fopen(input_file, "rb");
     if (f == NULL) {
       std::cerr << "Error opening file " << input_file;
-      free(srcY, q);
-      free(bins, q);
       std::exit(1);
     }
 
     unsigned int cnt = fread(srcY, sizeof(unsigned char), input_size, f);
     if (cnt != input_size) {
       std::cerr << "Error reading input from " << input_file;
-      free(srcY, q);
-      free(bins, q);
       std::exit(1);
     }
   } else {
@@ -171,9 +167,9 @@ int main(int argc, char *argv[]) {
               uint h_pos = (tid % range_width) * BLOCK_WIDTH;
               uint v_pos = (tid / range_width) * BLOCK_HEIGHT;
 
-              // Declare a 8x32 uchar matrix to store the input block pixel
+              // Declare a 8x32 uint8_t matrix to store the input block pixel
               // value
-              simd<unsigned char, 8 * 32> in;
+              simd<uint8_t, 8 * 32> in;
 
               // Declare a vector to store the local histogram
               simd<unsigned int, NUM_BINS> histogram(0);
@@ -181,8 +177,7 @@ int main(int argc, char *argv[]) {
               // Each thread handles BLOCK_HEIGHTxBLOCK_WIDTH pixel block
               for (int y = 0; y < BLOCK_HEIGHT / 8; y++) {
                 // Perform 2D media block read to load 8x32 pixel block
-                in = media_block_load<unsigned char, 8, 32>(readAcc, h_pos,
-                                                            v_pos);
+                in = media_block_load<uint8_t, 8, 32>(readAcc, h_pos, v_pos);
 
             // Accumulate local histogram for each pixel value
 #pragma unroll
@@ -236,8 +231,6 @@ int main(int argc, char *argv[]) {
     // make sure data is given back to the host at the end of this scope
   } catch (sycl::exception const &e) {
     std::cerr << "SYCL exception caught: " << e.what() << '\n';
-    free(srcY, q);
-    free(bins, q);
     return 1;
   }
 
@@ -251,8 +244,6 @@ int main(int argc, char *argv[]) {
   writeHist(cpuHistogram);
   // Checking Histogram
   bool Success = checkHistogram(cpuHistogram, bins);
-  free(srcY, q);
-  free(bins, q);
 
   if (!Success) {
     std::cerr << "FAILED\n";

--- a/sycl/test-e2e/ESIMD/histogram_256_slm_spec_2020.cpp
+++ b/sycl/test-e2e/ESIMD/histogram_256_slm_spec_2020.cpp
@@ -41,7 +41,7 @@ ESIMD_INLINE void histogram_atomic(const uint32_t *input_ptr, uint32_t *output,
   for (int y = 0; y < num_blocks; y++) {
     auto start_addr = ((unsigned int *)input_ptr) + start_off;
     auto data = block_load<uint, 32>(start_addr);
-    auto in = data.bit_cast_view<uchar>();
+    auto in = data.bit_cast_view<uint8_t>();
 
 #pragma unroll
     for (int j = 0; j < BLOCK_WIDTH * sizeof(int); j += 16) {
@@ -71,7 +71,7 @@ void HistogramCPU(unsigned int size, unsigned int *src,
                   unsigned int *cpu_histogram) {
   for (int i = 0; i < size; i++) {
     unsigned int x = src[i];
-    cpu_histogram[(x)&0xFFU] += 1;
+    cpu_histogram[(x) & 0xFFU] += 1;
     cpu_histogram[(x >> 8) & 0xFFU] += 1;
     cpu_histogram[(x >> 16) & 0xFFU] += 1;
     cpu_histogram[(x >> 24) & 0xFFU] += 1;
@@ -103,8 +103,7 @@ class histogram_slm;
 
 int main(int argc, char **argv) {
   queue q = esimd_test::createQueue();
-  auto dev = q.get_device();
-  auto ctxt = q.get_context();
+  esimd_test::printTestLabel(q);
 
   const char *input_file = nullptr;
   unsigned int width = 1024 * sizeof(unsigned int);
@@ -112,8 +111,10 @@ int main(int argc, char **argv) {
 
   // Initializes input.
   unsigned int input_size = width * height;
-  unsigned int *input_ptr =
-      (unsigned int *)malloc_shared(input_size, dev, ctxt);
+  esimd_test::shared_vector<unsigned int> input_vec(
+      input_size, esimd_test::shared_allocator<unsigned int>{q});
+  unsigned int *input_ptr = input_vec.data();
+
   printf("Processing %dx%d inputs\n", (int)(width / sizeof(unsigned int)),
          height);
 
@@ -128,12 +129,8 @@ int main(int argc, char **argv) {
 
   // Allocates system memory for output buffer.
   int buffer_size = sizeof(unsigned int) * NUM_BINS;
-  unsigned int *hist = new unsigned int[buffer_size];
-  if (hist == nullptr) {
-    std::cerr << "Out of memory\n";
-    exit(1);
-  }
-  memset(hist, 0, buffer_size);
+  std::vector<unsigned int> hist_vec(buffer_size, 0);
+  unsigned int *hist = hist_vec.data();
 
   // Uses the CPU to calculate the histogram output data.
   unsigned int cpu_histogram[NUM_BINS];
@@ -144,9 +141,9 @@ int main(int argc, char **argv) {
   std::cout << "finish cpu_histogram\n";
 
   // Uses the GPU to calculate the histogram output data.
-  unsigned int *output_surface =
-      (uint32_t *)malloc_shared(4 * NUM_BINS, dev, ctxt);
-  memset(output_surface, 0, 4 * NUM_BINS);
+  esimd_test::shared_vector<unsigned int> output_vec(
+      NUM_BINS, esimd_test::shared_allocator<unsigned int>{q});
+  unsigned int *output_surface = output_vec.data();
 
   unsigned int num_blocks{NUM_BLOCKS};
   if (argc == 2) {
@@ -188,11 +185,11 @@ int main(int argc, char **argv) {
       e.wait();
       if (profiling) {
         etime = esimd_test::report_time("kernel time", e, e);
-      if (iter > 0)
-        kernel_times += etime;
+        if (iter > 0)
+          kernel_times += etime;
       }
       if (iter == 0)
-      start = timer.Elapsed();
+        start = timer.Elapsed();
     }
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
@@ -209,10 +206,6 @@ int main(int argc, char **argv) {
 
   memcpy(hist, output_surface, 4 * NUM_BINS);
 
-  free(output_surface, ctxt);
-
-  free(input_ptr, ctxt);
-
   // Compares the CPU histogram output data with the
   // GPU histogram output data.
   // If there is no difference, the result is correct.
@@ -222,8 +215,6 @@ int main(int argc, char **argv) {
     std::cout << "PASSED\n";
   else
     std::cout << "FAILED\n";
-
-  delete[] hist;
 
   return res ? 0 : -1;
 }

--- a/sycl/test-e2e/ESIMD/histogram_2d.cpp
+++ b/sycl/test-e2e/ESIMD/histogram_2d.cpp
@@ -34,7 +34,7 @@ typedef uint64_t Toffset;
 typedef uint32_t Toffset;
 #endif
 
-void histogram_CPU(unsigned int width, unsigned int height, unsigned char *srcY,
+void histogram_CPU(unsigned int width, unsigned int height, uint8_t *srcY,
                    unsigned int *cpuHistogram) {
   int i;
   for (i = 0; i < width * height; i++) {
@@ -85,16 +85,15 @@ int main(int argc, char *argv[]) {
 
   // Allocate Input Buffer
   queue q = esimd_test::createQueue();
+  esimd_test::printTestLabel(q);
 
-  auto dev = q.get_device();
-  unsigned char *srcY = malloc_shared<unsigned char>(width * height, q);
-  if (srcY == NULL) {
-    std::cerr << "Out of memory\n";
-    exit(1);
-  }
-
-  unsigned int *bins = malloc_shared<unsigned int>(NUM_BINS, q);
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  esimd_test::shared_vector<uint8_t> srcY_vec(
+      width * height, esimd_test::shared_allocator<uint8_t>{q});
+  esimd_test::shared_vector<unsigned int> bins_vec(
+      NUM_BINS, esimd_test::shared_allocator<unsigned int>{q});
+  uint8_t *srcY = srcY_vec.data();
+  ;
+  unsigned int *bins = bins_vec.data();
 
   uint range_width = width / BLOCK_WIDTH;
   uint range_height = height / BLOCK_HEIGHT;
@@ -107,16 +106,12 @@ int main(int argc, char *argv[]) {
     FILE *f = fopen(input_file, "rb");
     if (f == NULL) {
       std::cerr << "Error opening file " << input_file;
-      free(srcY, q);
-      free(bins, q);
       std::exit(1);
     }
 
-    unsigned int cnt = fread(srcY, sizeof(unsigned char), input_size, f);
+    unsigned int cnt = fread(srcY, sizeof(uint8_t), input_size, f);
     if (cnt != input_size) {
       std::cerr << "Error reading input from " << input_file;
-      free(srcY, q);
-      free(bins, q);
       std::exit(1);
     }
   } else {
@@ -173,9 +168,9 @@ int main(int argc, char *argv[]) {
               uint h_pos = ndi.get_group(0) * BLOCK_WIDTH;
               uint v_pos = ndi.get_group(1) * BLOCK_HEIGHT;
 
-              // Declare a 8x32 uchar matrix to store the input block pixel
+              // Declare a 8x32 uint8_t matrix to store the input block pixel
               // value
-              simd<unsigned char, 8 * 32> in;
+              simd<uint8_t, 8 * 32> in;
 
               // Declare a vector to store the local histogram
               simd<unsigned int, NUM_BINS> histogram(0);
@@ -183,8 +178,7 @@ int main(int argc, char *argv[]) {
               // Each thread handles BLOCK_HEIGHTxBLOCK_WIDTH pixel block
               for (int y = 0; y < BLOCK_HEIGHT / 8; y++) {
                 // Perform 2D media block read to load 8x32 pixel block
-                in = media_block_load<unsigned char, 8, 32>(readAcc, h_pos,
-                                                            v_pos);
+                in = media_block_load<uint8_t, 8, 32>(readAcc, h_pos, v_pos);
 
             // Accumulate local histogram for each pixel value
 #pragma unroll
@@ -239,8 +233,6 @@ int main(int argc, char *argv[]) {
     // make sure data is given back to the host at the end of this scope
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    free(srcY, q);
-    free(bins, q);
     return 1;
   }
 
@@ -254,8 +246,6 @@ int main(int argc, char *argv[]) {
   writeHist(cpuHistogram);
   // Checking Histogram
   int result = checkHistogram(cpuHistogram, bins);
-  free(srcY, q);
-  free(bins, q);
   if (result) {
     std::cerr << "PASSED\n";
     return 0;

--- a/sycl/test-e2e/ESIMD/histogram_raw_send.cpp
+++ b/sycl/test-e2e/ESIMD/histogram_raw_send.cpp
@@ -36,7 +36,7 @@ using namespace sycl;
 #define BLOCK_WIDTH 32
 #define BLOCK_HEIGHT 64
 
-void histogram_CPU(unsigned int width, unsigned int height, unsigned char *srcY,
+void histogram_CPU(unsigned int width, unsigned int height, uint8_t *srcY,
                    unsigned int *cpuHistogram) {
   int i;
   for (i = 0; i < width * height; i++) {
@@ -124,23 +124,18 @@ int main(int argc, char *argv[]) {
 
   // Allocate Input Buffer
   queue q = esimd_test::createQueue();
+  esimd_test::printTestLabel(q);
 
-  auto dev = q.get_device();
-  auto ctxt = q.get_context();
-  unsigned char *srcY =
-      static_cast<unsigned char *>(malloc_shared(width * height, dev, ctxt));
-  unsigned int *bins = static_cast<unsigned int *>(
-      malloc_shared(NUM_BINS * sizeof(unsigned int), dev, ctxt));
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  esimd_test::shared_vector<uint8_t> srcY_vec(
+      width * height, esimd_test::shared_allocator<uint8_t>{q});
+  esimd_test::shared_vector<unsigned int> bins_vec(
+      NUM_BINS, esimd_test::shared_allocator<unsigned int>{q});
+  uint8_t *srcY = srcY_vec.data();
+  ;
+  unsigned int *bins = bins_vec.data();
 
   uint range_width = width / BLOCK_WIDTH;
   uint range_height = height / BLOCK_HEIGHT;
-
-  if (srcY == NULL) {
-    std::cerr << "Out of memory\n";
-    exit(1);
-  }
 
   // Initializes input.
   unsigned int input_size = width * height;

--- a/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_surf.hpp
@@ -37,13 +37,13 @@ int main() {
   std::iota(vec_2.begin(), vec_2.end(), 0);
   std::iota(vec_3.begin(), vec_3.end(), 0);
   std::iota(vec_4.begin(), vec_4.end(), 0);
-  auto buf_0 = buffer{vec_0};
-  auto buf_1 = buffer{vec_1};
-  auto buf_2 = buffer{vec_2};
-  auto buf_3 = buffer{vec_3};
-  auto buf_4 = buffer{vec_4};
 
   try {
+    auto buf_0 = buffer{vec_0};
+    auto buf_1 = buffer{vec_1};
+    auto buf_2 = buffer{vec_2};
+    auto buf_3 = buffer{vec_3};
+    auto buf_4 = buffer{vec_4};
     q.submit([&](handler &h) {
       auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
       auto access_1 = buf_1.template get_access<access::mode::read_write>(h);
@@ -80,11 +80,6 @@ int main() {
           });
     });
     q.wait();
-    buf_0.template get_access<access::mode::read_write>();
-    buf_1.template get_access<access::mode::read_write>();
-    buf_2.template get_access<access::mode::read_write>();
-    buf_3.template get_access<access::mode::read_write>();
-    buf_4.template get_access<access::mode::read_write>();
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     return 1;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_argument_type_deduction.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_argument_type_deduction.cpp
@@ -28,9 +28,9 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
   auto vec_0 = std::vector<int>(size);
 
   std::iota(vec_0.begin(), vec_0.end(), 0);
-  auto buf_0 = buffer{vec_0};
 
   try {
+    auto buf_0 = buffer{vec_0};
     q.submit([&](handler &h) {
       auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
 
@@ -44,7 +44,6 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
           });
     });
     q.wait();
-    buf_0.template get_access<access::mode::read_write>();
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     return 1;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_predicate.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_predicate.cpp
@@ -30,10 +30,10 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
 
   std::iota(vec_0.begin(), vec_0.end(), 0);
   std::iota(vec_2.begin(), vec_2.end(), 0);
-  auto buf_0 = buffer{vec_0};
-  auto buf_2 = buffer{vec_2};
 
   try {
+    auto buf_0 = buffer{vec_0};
+    auto buf_2 = buffer{vec_2};
     q.submit([&](handler &h) {
       auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
       auto access_2 = buf_2.template get_access<access::mode::read_write>(h);
@@ -58,8 +58,6 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
           });
     });
     q.wait();
-    buf_0.template get_access<access::mode::read_write>();
-    buf_2.template get_access<access::mode::read_write>();
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     return 1;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_predicate_stateless.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_predicate_stateless.cpp
@@ -32,10 +32,10 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
 
   std::iota(vec_0.begin(), vec_0.end(), 0);
   std::iota(vec_2.begin(), vec_2.end(), 0);
-  auto buf_0 = buffer{vec_0};
-  auto buf_2 = buffer{vec_2};
 
   try {
+    auto buf_0 = buffer{vec_0};
+    auto buf_2 = buffer{vec_2};
     q.submit([&](handler &h) {
       auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
       auto access_2 = buf_2.template get_access<access::mode::read_write>(h);
@@ -60,8 +60,6 @@ template <unsigned SIMDSize> int testAccessor(queue q) {
           });
     });
     q.wait();
-    buf_0.template get_access<access::mode::read_write>();
-    buf_2.template get_access<access::mode::read_write>();
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     return 1;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_slm.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_slm.cpp
@@ -35,13 +35,13 @@ int main() {
   auto vec_2 = std::vector<int>(size);
   auto vec_3 = std::vector<int>(size);
   auto vec_4 = std::vector<int>(size);
-  auto buf_0 = buffer{vec_0};
-  auto buf_1 = buffer{vec_1};
-  auto buf_2 = buffer{vec_2};
-  auto buf_3 = buffer{vec_3};
-  auto buf_4 = buffer{vec_4};
 
   try {
+    auto buf_0 = buffer{vec_0};
+    auto buf_1 = buffer{vec_1};
+    auto buf_2 = buffer{vec_2};
+    auto buf_3 = buffer{vec_3};
+    auto buf_4 = buffer{vec_4};
     q.submit([&](handler &h) {
       auto access_0 = buf_0.template get_access<access::mode::read_write>(h);
       auto access_1 = buf_1.template get_access<access::mode::read_write>(h);
@@ -86,11 +86,6 @@ int main() {
           });
     });
     q.wait();
-    buf_0.template get_access<access::mode::read_write>();
-    buf_1.template get_access<access::mode::read_write>();
-    buf_2.template get_access<access::mode::read_write>();
-    buf_3.template get_access<access::mode::read_write>();
-    buf_4.template get_access<access::mode::read_write>();
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     return 1;

--- a/sycl/test-e2e/ESIMD/lsc/lsc_slm_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_slm_atomic_smoke.cpp
@@ -41,10 +41,16 @@ template <class, int, template <class, int> class> class TestID;
 
 const char *to_string(LSCAtomicOp op) {
   switch (op) {
+  case LSCAtomicOp::predec:
+    return "lsc::predec";
   case LSCAtomicOp::add:
     return "lsc::add";
   case LSCAtomicOp::sub:
     return "lsc::sub";
+  case LSCAtomicOp::fadd:
+    return "lsc::fadd";
+  case LSCAtomicOp::fsub:
+    return "lsc::fsub";
   case LSCAtomicOp::inc:
     return "lsc::inc";
   case LSCAtomicOp::dec:
@@ -53,6 +59,8 @@ const char *to_string(LSCAtomicOp op) {
     return "lsc::umin";
   case LSCAtomicOp::umax:
     return "lsc::umax";
+  case LSCAtomicOp::xchg:
+    return "lsc::xchg";
   case LSCAtomicOp::cmpxchg:
     return "lsc::cmpxchg";
   case LSCAtomicOp::bit_and:

--- a/sycl/test-e2e/ESIMD/named_barriers/exec_in_order.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/exec_in_order.cpp
@@ -15,10 +15,11 @@
 // stores data to addresses that partially overlap with addresses used by
 // previous thread.
 
+#include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
-#include <iostream>
+#include "../esimd_test_utils.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
@@ -100,7 +101,7 @@ bool test(QueueTY q) {
             else
               lsc_block_store<int, VL>(acc, off, val);
 
-            lsc_fence();
+            fence();
 
             // idx == 0 arrives here first and signals barrier 1
             // idx == 1 arrives here next and signals barrier 2
@@ -143,11 +144,8 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto GPUSelector = gpu_selector{};
-  auto q = queue{GPUSelector};
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
 
   bool passed = true;
 

--- a/sycl/test-e2e/ESIMD/named_barriers/exec_in_order_branched.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/exec_in_order_branched.cpp
@@ -16,10 +16,11 @@
 // previous thread. Same as "exec_in_order.cpp", but each thread in separate
 // 'if' branch.
 
+#include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
-#include <iostream>
+#include "../esimd_test_utils.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
@@ -89,9 +90,9 @@ bool test(QueueTY q) {
               if constexpr (UseSLM) {
                 lsc_slm_block_store<int, VL>(off, val);
               } else {
-                lsc_fence();
+                fence();
                 lsc_block_store<int, VL>(acc, off, val);
-                lsc_fence();
+                fence();
               }
 
               // T0 signals barrier 1 and locks
@@ -108,9 +109,9 @@ bool test(QueueTY q) {
               if constexpr (UseSLM) {
                 lsc_slm_block_store<int, VL>(off, val);
               } else {
-                lsc_fence();
+                fence();
                 lsc_block_store<int, VL>(acc, off, val);
-                lsc_fence();
+                fence();
               }
 
               // T1 signals barrier 2 and locks
@@ -128,9 +129,9 @@ bool test(QueueTY q) {
               if constexpr (UseSLM) {
                 lsc_slm_block_store<int, VL>(off, val);
               } else {
-                lsc_fence();
+                fence();
                 lsc_block_store<int, VL>(acc, off, val);
-                lsc_fence();
+                fence();
               }
 
               // T2 signals barrier 3 and locks, waiting for signal from T3
@@ -147,9 +148,9 @@ bool test(QueueTY q) {
               if constexpr (UseSLM) {
                 lsc_slm_block_store<int, VL>(off, val);
               } else {
-                lsc_fence();
+                fence();
                 lsc_block_store<int, VL>(acc, off, val);
-                lsc_fence();
+                fence();
               }
             }
 
@@ -184,11 +185,8 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto GPUSelector = gpu_selector{};
-  auto q = queue{GPUSelector};
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
 
   bool passed = true;
 

--- a/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
@@ -15,10 +15,11 @@
 // Each iteration has 1 barrier and 1 producer. Producer stores data to SLM,
 // then all threads read SLM and store data to surface.
 
+#include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
-#include <iostream>
+#include "../esimd_test_utils.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
@@ -97,9 +98,9 @@ bool test(QueueTY q) {
               auto val = lsc_slm_block_load<int, VL>(off);
               // and storing it to output surface
               unsigned int store_off = off + i * SlmSize * sizeof(int);
-              lsc_fence();
+              fence();
               lsc_block_store<int, VL>(acc, store_off, val);
-              lsc_fence();
+              fence();
             }
           });
     });
@@ -134,11 +135,8 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto GPUSelector = gpu_selector{};
-  auto q = queue{GPUSelector};
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
 
   bool passed = true;
 

--- a/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
@@ -15,10 +15,11 @@
 // producers. Producer stores data to SLM, then all threads read SLM and store
 // data to surface.
 
+#include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
-#include <iostream>
+#include "../esimd_test_utils.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
@@ -47,63 +48,66 @@ bool test(QueueTY q) {
 
     auto e = q.submit([&](handler &cgh) {
       auto acc = buf.get_access<access::mode::write>(cgh);
-      cgh.parallel_for<KernelID<
-          case_num>>(Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
-        // 2 named barriers, id 0 reserved for unnamed
-        constexpr unsigned bnum = 3;
+      cgh.parallel_for<KernelID<case_num>>(
+          Range, [=](sycl::nd_item<1> ndi) SYCL_ESIMD_KERNEL {
+            // 2 named barriers, id 0 reserved for unnamed
+            constexpr unsigned bnum = 3;
 
-        // SLM size is half of output surface size so
-        // content of SLM can be copied to out buffer on each iteration
-        constexpr unsigned SlmSize = Size / 2;     // 32
-        constexpr unsigned VL = SlmSize / Threads; // 4
+            // SLM size is half of output surface size so
+            // content of SLM can be copied to out buffer on each iteration
+            constexpr unsigned SlmSize = Size / 2;     // 32
+            constexpr unsigned VL = SlmSize / Threads; // 4
 
-        named_barrier_init<bnum>();
+            named_barrier_init<bnum>();
 
-        unsigned int idx = ndi.get_local_id(0);
-        unsigned int off = idx * VL * sizeof(int);
+            unsigned int idx = ndi.get_local_id(0);
+            unsigned int off = idx * VL * sizeof(int);
 
-        // 2 producers on first iteration, 1 producer on second
-        unsigned int indexes[2][2] = {{1, 2}, {3, 3}}; // local ids of producers
-        unsigned int prods[2] = {2, 1};                // number of producers
+            // 2 producers on first iteration, 1 producer on second
+            unsigned int indexes[2][2] = {{1, 2},
+                                          {3, 3}}; // local ids of producers
+            unsigned int prods[2] = {2, 1};        // number of producers
 
-        slm_init(SlmSize * sizeof(int));
-        lsc_slm_block_store<int, VL>(off, simd<int, VL>(0));
-        barrier();
+            slm_init(SlmSize * sizeof(int));
+            lsc_slm_block_store<int, VL>(off, simd<int, VL>(0));
+            barrier();
 
-        for (int b = bnum - 1; b > 0; b--) {
-          int j = bnum - b - 1; // iteration index
+            for (int b = bnum - 1; b > 0; b--) {
+              int j = bnum - b - 1; // iteration index
 
-          bool is_producer = idx == indexes[j][0] || idx == indexes[j][1];
-          bool is_consumer = !is_producer;
-          // only-consumer or only-producer modes
-          unsigned int flag = is_producer ? 0x1 : 0x2;
+              bool is_producer = idx == indexes[j][0] || idx == indexes[j][1];
+              bool is_consumer = !is_producer;
+              // only-consumer or only-producer modes
+              unsigned int flag = is_producer ? 0x1 : 0x2;
 
-          unsigned int producers = prods[j];
-          unsigned int consumers = Threads - producers;
+              unsigned int producers = prods[j];
+              unsigned int consumers = Threads - producers;
 
-          if (is_producer) {
-            unsigned int p_off = j * sizeof(int) * SlmSize / 4;
-            // second iteration store partialy overlaps first iteration stores
-            unsigned int dx = producers == 2 ? (idx - 1) : 0;
-            p_off += dx * sizeof(int) * SlmSize / 2;
-            int v = 0xdead0000 + idx;
-            simd<int, SlmSize / 2> init(v);
-            // producer stores to SLM
-            lsc_slm_block_store<int, SlmSize / 2>(p_off, init);
-          }
+              if (is_producer) {
+                unsigned int p_off = j * sizeof(int) * SlmSize / 4;
+                // second iteration store partialy overlaps first iteration
+                // stores
+                unsigned int dx = producers == 2 ? (idx - 1) : 0;
+                p_off += dx * sizeof(int) * SlmSize / 2;
+                int v = 0xdead0000 + idx;
+                simd<int, SlmSize / 2> init(v);
+                // producer stores to SLM
+                lsc_slm_block_store<int, SlmSize / 2>(p_off, init);
+              }
 
-          named_barrier_signal(b, flag, producers, consumers);
+              named_barrier_signal(b, flag, producers, consumers);
 
-          if (is_consumer)
-            named_barrier_wait(b); // consumers waiting for signal
+              if (is_consumer)
+                named_barrier_wait(b); // consumers waiting for signal
 
-          auto val = lsc_slm_block_load<int, VL>(off); // reading SLM
-          // and storing it to output surface
-          lsc_fence();
-          lsc_block_store<int, VL>(acc, off + j * SlmSize * sizeof(int), val);
-          lsc_fence();
-        }
-      });
+              auto val = lsc_slm_block_load<int, VL>(off); // reading SLM
+              // and storing it to output surface
+              fence();
+              lsc_block_store<int, VL>(acc, off + j * SlmSize * sizeof(int),
+                                       val);
+              fence();
+            }
+          });
     });
     e.wait();
   } catch (sycl::exception const &e) {
@@ -136,11 +140,8 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto GPUSelector = gpu_selector{};
-  auto q = queue{GPUSelector};
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
 
   bool passed = true;
 

--- a/sycl/test-e2e/ESIMD/named_barriers/multiple_wg.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/multiple_wg.cpp
@@ -17,9 +17,10 @@
 // Producers store to SLM; consumers read SLM and store data to surface.
 
 #include <CL/sycl.hpp>
+#include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 
-#include <iostream>
+#include "../esimd_test_utils.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
@@ -134,11 +135,8 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto GPUSelector = gpu_selector{};
-  auto q = queue{GPUSelector};
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
 
   bool passed = true;
 

--- a/sycl/test-e2e/ESIMD/named_barriers/single_wg.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/single_wg.cpp
@@ -16,10 +16,11 @@
 // Producers store data to SLM, then all threads read SLM and store data to
 // surface.
 
+#include <iostream>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
-#include <iostream>
+#include "../esimd_test_utils.hpp"
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;
@@ -116,11 +117,8 @@ bool test(QueueTY q) {
 }
 
 int main() {
-  auto GPUSelector = gpu_selector{};
-  auto q = queue{GPUSelector};
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<sycl::info::device::name>()
-            << "\n";
+  queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(q);
 
   bool passed = true;
 

--- a/sycl/test-e2e/ESIMD/noinline_call_from_func.cpp
+++ b/sycl/test-e2e/ESIMD/noinline_call_from_func.cpp
@@ -34,9 +34,7 @@ template <typename AccTy> ESIMD_NOINLINE void test(AccTy acc, int A, int B) {
 
 int main(int argc, char **argv) {
   queue q(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
-
-  auto dev = q.get_device();
-  std::cout << "Running on " << dev.get_info<info::device::name>() << "\n";
+  esimd_test::printTestLabel(q);
 
   int result = 0;
   int *output = &result;
@@ -56,7 +54,7 @@ int main(int argc, char **argv) {
     });
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << std::endl;
-    return e.get_cl_code();
+    return 1;
   }
 
   if (result != (in1 + in2)) {

--- a/sycl/test-e2e/ESIMD/radix_sort.cpp
+++ b/sycl/test-e2e/ESIMD/radix_sort.cpp
@@ -299,7 +299,7 @@ void cmk_prefix_iterative(unsigned *buf, unsigned h_pos,
     if (i == n_iter - 1)
       cnt_table.column(31) -= cnt_table.column(30);
 
-    scatter_rgba<unsigned int, 32, GATHER_SCATTER_MASK>(buf, element_offset, S);
+    scatter_rgba<GATHER_SCATTER_MASK>(buf, element_offset, S);
 
     element_offset += stride_elems * TUPLE_SZ * sizeof(unsigned) * 32;
     prev = cnt_table.column(31);
@@ -397,7 +397,7 @@ void cmk_radix_count(
   simd<unsigned, N_WI> elem_offset =
       (init * N_ELEM_WI + offset) * sizeof(unsigned); // byte offset
 
-  simd<unsigned, RADIX *N_WI> V = 0;
+  simd<unsigned, RADIX * N_WI> V = 0;
   auto counters = V.bit_cast_view<unsigned, RADIX, N_WI>();
 
   // each WI process N_ELEM_WI. each iteration reads in 4 elements (gather_rgba)

--- a/sycl/test-e2e/ESIMD/regression/Inputs/complex-lib-sycl.cpp
+++ b/sycl/test-e2e/ESIMD/regression/Inputs/complex-lib-sycl.cpp
@@ -4,7 +4,8 @@ sycl::event iota(size_t n, sycl::buffer<int, 1> &buf, sycl::queue &Q) {
   auto HK = [&](sycl::handler &H) {
     sycl::accessor acc_y{buf, H, sycl::write_only};
     auto K = [=](sycl::id<1> id) {
-      int *y = acc_y.get_pointer();
+      int *y =
+          acc_y.template get_multi_ptr<sycl::access::decorated::yes>().get();
       size_t i = id.get(0);
       y[i] = static_cast<int>(i);
     };

--- a/sycl/test-e2e/ESIMD/regression/Inputs/dgetrf.hpp
+++ b/sycl/test-e2e/ESIMD/regression/Inputs/dgetrf.hpp
@@ -18,6 +18,8 @@
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
+#include "../../esimd_test_utils.hpp"
+
 #define ABS(x) ((x) >= 0 ? (x) : -(x))
 #define MIN(x, y) ((x) <= (y) ? (x) : (y))
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
@@ -445,7 +447,8 @@ void dgetrfnp_batch_strided_c(int64_t m, int64_t n, double *a, int64_t lda,
                               int64_t *info);
 
 int main(int argc, char *argv[]) {
-  queue queue((gpu_selector()));
+  queue queue(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(queue);
 
   if (!queue.get_device().has(aspect::fp64))
     return 0;

--- a/sycl/test-e2e/ESIMD/regression/big_const_initializer.cpp
+++ b/sycl/test-e2e/ESIMD/regression/big_const_initializer.cpp
@@ -64,7 +64,7 @@ int main(int argc, char **argv) {
     std::cout << "*** EXCEPTION caught: " << e.what() << "\n";
     return 1;
   }
-  auto acc = r.template get_access<sycl::access::mode::read>();
+  auto acc = r.template get_host_access(sycl::read_only);
   for (int i = 0; i < N_PRINT; i++) {
     std::cout << acc[i] << " ";
   }
@@ -78,8 +78,7 @@ int main(int argc, char **argv) {
     if (test != gold) {
       if (++err_cnt < 10) {
         std::cout << "failed at index " << i << ", " << test << " != " << gold
-                  << " (expected)"
-                  << "\n";
+                  << " (expected)" << "\n";
       }
     }
   }

--- a/sycl/test-e2e/ESIMD/regression/dgetrf_8x8.cpp
+++ b/sycl/test-e2e/ESIMD/regression/dgetrf_8x8.cpp
@@ -19,6 +19,8 @@
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
+#include "../esimd_test_utils.hpp"
+
 #define ABS(x) ((x) >= 0 ? (x) : -(x))
 #define MIN(x, y) ((x) <= (y) ? (x) : (y))
 #define MAX(x, y) ((x) >= (y) ? (x) : (y))
@@ -266,7 +268,8 @@ static int dgetrfnp_batch_strided_check(int64_t m, int64_t n, double *a_in,
 }
 
 int main(int argc, char *argv[]) {
-  queue queue((gpu_selector()));
+  queue queue(esimd_test::ESIMDSelector, esimd_test::createExceptionHandler());
+  esimd_test::printTestLabel(queue);
 
   int exit_status = 0;
   constexpr int64_t m = 8, n = 8, lda = 8;


### PR DESCRIPTION
Warnings fixed:
- deprecated scatter_rgba
- deprecated get_cl_code
- deprecated lsc_fence
- deprecated uchar type usage
- deprecated get_access on HOST
- deprecated get_pointer
- usage of isfinite with -ffast-math
- deprecated dpas_argument_type::s1
- deprecated gpu_selector()

Also, the memory alloc/free in historgram*.cpp tests were updated to simplify the potential memory leak avoidance.