### PR TITLE
[Bindless][Exp][NFC] Deprecate `read_image` for more descriptive naming

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
@@ -986,11 +986,11 @@ listed above caused the failure.
 namespace sycl::ext::oneapi::experimental {
 
 template <typename DataT, typename HintT = DataT, typename CoordT>
-DataT read_image(const unsampled_image_handle &ImageHandle,
-                 const CoordT &Coords);
+DataT fetch_image(const unsampled_image_handle &ImageHandle,
+                  const CoordT &Coords);
 template <typename DataT, typename HintT = DataT, typename CoordT>
-DataT read_image(const sampled_image_handle &ImageHandle, 
-                 const CoordT &Coords);
+DataT sample_image(const sampled_image_handle &ImageHandle, 
+                   const CoordT &Coords);
 
 template <typename DataT, typename CoordT>
 void write_image(unsampled_image_handle &ImageHandle,
@@ -998,27 +998,29 @@ void write_image(unsampled_image_handle &ImageHandle,
 }
 ```
 
-Inside a kernel, it's possible to read an image via `read_image`, passing 
-the image handle. For the form that takes `unsampled_image_handle`, image data 
-will be fetched exactly as is in device memory. For the form that takes a 
-`sampled_image_handle`, the image will be sampled according to the 
+Inside a kernel, it's possible to retrieve data from an image via `fetch_image` 
+or  `sample_image`, passing the appropirate image handle. The `fetch_image` API 
+is only applicable to unsampled images, and the data will be fetched exactly as 
+is in device memory. The `sample_image` API is only applicable to sampled 
+images, the image data will be sampled according to the 
 `bindless_image_sampler` that was passed to the image upon construction.
 
 The user is required to pass a `DataT` template parameter, which specifies the
-return type of the `read_image` function. If `DataT` is not a recognized 
-standard type, as defined in <<recognized_standard_types>>, and instead a 
-user-defined type, the user must provide a `HintT` template parameter to the 
-`read_image` function, to allow the backend to select the correct device 
-intrinsic to fetch or sample their data.
+return type of the `fetch_image` and `sample_image` functions. If `DataT` is 
+not a recognized standard type, as defined in <<recognized_standard_types>>, 
+and instead a user-defined type, the user must provide a `HintT` template 
+parameter to the `fetch_image` and `sample_image` functions, to allow the 
+backend to select the correct device intrinsic to fetch or sample their data.
+
 `HintT` must be one of the the <<recognized_standard_types>>, and must be the 
 same size as `DataT`.
 If `DataT` is a recognized standard type, and `HintT` is also passed, `HintT` 
 will be ignored.
 
-When reading a texture backed by a normalized integer channel type, either 
-`DataT` must be a 32-bit or 16-bit floating point value, a `sycl::vec` of 
-32-bit or 16-bit floating point values, or, in the case `DataT` is not one of 
-the above, then `HintT` must be one of the above, and be of the same size as 
+When fetching or sampling an image backed by a normalized integer channel type, 
+either `DataT` must be a 32-bit or 16-bit floating point value, a `sycl::vec` 
+of 32-bit or 16-bit floating point values, or, in the case `DataT` is not one 
+of the above, then `HintT` must be one of the above, and be of the same size as 
 `DataT`.
 
 It's possible to write to an unsampled image via `write_image` passing the 
@@ -1029,8 +1031,8 @@ of the <<recognized_standard_types>>.
 
 Sampled images cannot be written to using `write_image`.
 
-For reading and writing of unsampled images, coordinates are specified by `int`, 
-`sycl::vec<int, 2>`, and `sycl::vec<int, 3>` for 1D, 2D, and 3D images, 
+For fetching and writing of unsampled images, coordinates are specified by 
+`int`, `sycl::vec<int, 2>`, and `sycl::vec<int, 3>` for 1D, 2D, and 3D images, 
 respectively.
 
 Sampled image reads take `float`, `sycl::vec<float, 2>`, and 
@@ -1046,8 +1048,8 @@ kernel must be submitted for the written data to be accessible.
 
 [NOTE]
 ====
-Attempting to read an image with `read_mipmap` or any other defined read 
-function will result in undefined behaviour.
+Attempting to sample a standard sampled image with `sample_mipmap` or any other 
+defined sampling function will result in undefined behaviour.
 ====
 
 === Recognized standard types [[recognized_standard_types]]
@@ -1057,7 +1059,8 @@ standard types.
 
 * All POD types (`char`, `short`, `int`, `float`, etc.) excluding `double`
 * `sycl::half`
-* Variants of `sycl::vec<T, N>` where `T` is one of the above, and `N` is `1`, `2`, or `3`
+* Variants of `sycl::vec<T, N>` where `T` is one of the above, and `N` is `1`, 
+  `2`, or `3`
 
 Any other types are classified as user-defined types.
 
@@ -1168,26 +1171,26 @@ level of a given top-level descriptor.
 
 === Reading a mipmap
 
-Inside the kernel, it's possible to read a mipmap via `read_mipmap`, passing the 
-`sampled_image_handle`, the coordinates, and either the level or anisotropic 
-gradient values.
+Inside the kernel, it's possible to sample a mipmap via `sample_mipmap`, 
+passing the `sampled_image_handle`, the coordinates, and either the level or 
+anisotropic gradient values.
 
-The method of sampling a mipmap is different based on which `read_mipmap` 
+The method of sampling a mipmap is different based on which `sample_mipmap` 
 function is used, and the sampler attributes passed upon creation of the 
 mipmap.
 
 ```c++
 // Nearest/linear filtering between mip levels
 template <typename DataT, typename HintT = DataT, typename CoordT>
-DataT read_mipmap(const sampled_image_handle &ImageHandle,
-                  const CoordT &Coords,
-                  const float Level);
+DataT sample_mipmap(const sampled_image_handle &ImageHandle,
+                    const CoordT &Coords,
+                    const float Level);
 
 // Anisotropic filtering
 template <typename DataT, typename HintT = DataT, typename CoordT>
-DataT read_mipmap(const sampled_image_handle &ImageHandle,
-                  const CoordT &Coords,
-                  const CoordT &Dx, const CoordT &Dy);
+DataT sample_mipmap(const sampled_image_handle &ImageHandle,
+                    const CoordT &Coords,
+                    const CoordT &Dx, const CoordT &Dy);
 ```
 
 Reading a mipmap follows the same restrictions on what coordinate types may be 
@@ -1199,8 +1202,8 @@ the restrictions as laid out in <<reading_writing_inside_kernel>>.
 
 [NOTE]
 ====
-Attempting to read a mipmap with `read_image` or any other defined read function 
-will result in undefined behaviour.
+Attempting to sample a mipmap with `sample_image` or any other defined sample 
+function will result in undefined behaviour.
 ====
 
 == Interoperability
@@ -1544,7 +1547,7 @@ try {
 
     cgh.parallel_for(width, [=](sycl::id<1> id) {
       // Extension: read image data from handle
-      float pixel = sycl::ext::oneapi::experimental::read_image<float>(
+      float pixel = sycl::ext::oneapi::experimental::fetch_image<float>(
           imgIn, int(id[0]));
 
       // Extension: write to image data using handle
@@ -1646,7 +1649,7 @@ try {
           float sum = 0;
           for (int i = 0; i < numImages; i++) {
             // Extension: read image data from handle
-            sum += (sycl::ext::oneapi::experimental::read_image<float>(
+            sum += (sycl::ext::oneapi::experimental::fetch_image<float>(
                 imgHandleAcc[i], sycl::vec<int, 2>(dim0, dim1)));
           }
           outAcc[sycl::id{dim1, dim0}] = sum;
@@ -1736,9 +1739,9 @@ try {
       float x = (static_cast<float>(id[0]) + 0.5f) / static_cast<float>(width);
       // Read mipmap level 0 with anisotropic filtering
       // and level 1 with level filtering
-      float px1 = sycl::ext::oneapi::experimental::read_mipmap<float>(
+      float px1 = sycl::ext::oneapi::experimental::sample_mipmap<float>(
           mipHandle, x, 0.0f, 0.0f);
-      float px2 = sycl::ext::oneapi::experimental::read_mipmap<float>(
+      float px2 = sycl::ext::oneapi::experimental::sample_mipmap<float>(
           mipHandle, x, 1.0f);
 
       sum = px1 + px2;
@@ -1874,7 +1877,7 @@ try {
 
           // Extension: read image data from handle to imported image
           uint32_t pixel =
-              sycl::ext::oneapi::experimental::read_image<uint32_t>(
+              sycl::ext::oneapi::experimental::fetch_image<uint32_t>(
                   img_input, sycl::vec<int, 2>(dim0, dim1));
 
           // Modify the data before writing back
@@ -2076,4 +2079,9 @@ These features still need to be handled:
                    user-defined type.
 |5.1|2023-12-06| - Added unique addressing modes per dimension to the 
                    `bindless_image_sampler`
+|5.2|2024-02-14| - Image read and write functions now accept 3-component 
+                   coordinates for 3D reads, instead of 4-component coordinates.
+|5.3|2024-02-16| - Replace `read_image` and `read_mipmap` APIs in favor of more 
+                   descriptive naming, with `fetch_image`, `sample_image`, and
+                   `sample_mipmap`.
 |======================

--- a/sycl/include/sycl/ext/oneapi/bindless_images.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images.hpp
@@ -759,14 +759,14 @@ template <typename DataT> constexpr bool is_recognized_standard_type() {
 } // namespace detail
 
 /**
- *  @brief   Read an unsampled image using its handle
+ *  @brief   [Deprecated] Read an unsampled image using its handle
  *
  *  @tparam  DataT The return type
  *  @tparam  HintT A hint type that can be used to select for a specialized
  *           backend intrinsic when a user-defined type is passed as `DataT`.
  *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
  *           HintT must also have the same size as DataT.
- *  @tparam  CoordT The input coordinate type. e.g. int, int2, or int4 for
+ *  @tparam  CoordT The input coordinate type. e.g. int, int2, or int3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The image handle
  *  @param   coords The coordinates at which to fetch image data
@@ -779,8 +779,36 @@ template <typename DataT> constexpr bool is_recognized_standard_type() {
  *             another
  */
 template <typename DataT, typename HintT = DataT, typename CoordT>
+__SYCL_DEPRECATED("read_image for standard unsampled images is deprecated. "
+                  "Instead use fetch_image.")
 DataT read_image(const unsampled_image_handle &imageHandle [[maybe_unused]],
                  const CoordT &coords [[maybe_unused]]) {
+  return fetch_image(imageHandle, coords);
+}
+
+/**
+ *  @brief   Fetch data from an unsampled image using its handle
+ *
+ *  @tparam  DataT The return type
+ *  @tparam  HintT A hint type that can be used to select for a specialized
+ *           backend intrinsic when a user-defined type is passed as `DataT`.
+ *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
+ *           HintT must also have the same size as DataT.
+ *  @tparam  CoordT The input coordinate type. e.g. int, int2, or int3 for
+ *           1D, 2D, and 3D, respectively
+ *  @param   imageHandle The image handle
+ *  @param   coords The coordinates at which to fetch image data
+ *  @return  Image data
+ *
+ *  __NVPTX__: Name mangling info
+ *             Cuda surfaces require integer coords (by bytes)
+ *             Cuda textures require float coords (by element or normalized)
+ *             The name mangling should therefore not interfere with one
+ *             another
+ */
+template <typename DataT, typename HintT = DataT, typename CoordT>
+DataT fetch_image(const unsampled_image_handle &imageHandle [[maybe_unused]],
+                  const CoordT &coords [[maybe_unused]]) {
   detail::assert_unsampled_coords<CoordT>();
   constexpr size_t coordSize = detail::coord_size<CoordT>();
   static_assert(coordSize == 1 || coordSize == 2 || coordSize == 3,
@@ -805,17 +833,17 @@ DataT read_image(const unsampled_image_handle &imageHandle [[maybe_unused]],
 }
 
 /**
- *  @brief   Read a sampled image using its handle
+ *  @brief   [Deprecated] Read a sampled image using its handle
  *
  *  @tparam  DataT The return type
  *  @tparam  HintT A hint type that can be used to select for a specialized
  *           backend intrinsic when a user-defined type is passed as `DataT`.
  *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
  *           HintT must also have the same size as DataT.
- *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The image handle
- *  @param   coords The coordinates at which to fetch image data
+ *  @param   coords The coordinates at which to sample image data
  *  @return  Sampled image data
  *
  *  __NVPTX__: Name mangling info
@@ -825,8 +853,36 @@ DataT read_image(const unsampled_image_handle &imageHandle [[maybe_unused]],
  *             another
  */
 template <typename DataT, typename HintT = DataT, typename CoordT>
+__SYCL_DEPRECATED("read_image for standard sampled images is deprecated. "
+                  "Instead use sample_image.")
 DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
                  const CoordT &coords [[maybe_unused]]) {
+  return sample_image(imageHandle, coords);
+}
+
+/**
+ *  @brief   Sample data from a sampled image using its handle
+ *
+ *  @tparam  DataT The return type
+ *  @tparam  HintT A hint type that can be used to select for a specialized
+ *           backend intrinsic when a user-defined type is passed as `DataT`.
+ *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
+ *           HintT must also have the same size as DataT.
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
+ *           1D, 2D, and 3D, respectively
+ *  @param   imageHandle The image handle
+ *  @param   coords The coordinates at which to sample image data
+ *  @return  Sampled image data
+ *
+ *  __NVPTX__: Name mangling info
+ *             Cuda surfaces require integer coords (by bytes)
+ *             Cuda textures require float coords (by element or normalized)
+ *             The name mangling should therefore not interfere with one
+ *             another
+ */
+template <typename DataT, typename HintT = DataT, typename CoordT>
+DataT sample_image(const sampled_image_handle &imageHandle [[maybe_unused]],
+                   const CoordT &coords [[maybe_unused]]) {
   detail::assert_sampled_coords<CoordT>();
   constexpr size_t coordSize = detail::coord_size<CoordT>();
   static_assert(coordSize == 1 || coordSize == 2 || coordSize == 3,
@@ -851,24 +907,76 @@ DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
 }
 
 /**
- *  @brief   Read a mipmap image using its handle with LOD filtering
+ *  @brief   [Deprecated] Read a mipmap image using its handle with LOD
+ *           filtering
  *
  *  @tparam  DataT The return type
  *  @tparam  HintT A hint type that can be used to select for a specialized
  *           backend intrinsic when a user-defined type is passed as `DataT`.
  *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
  *           HintT must also have the same size as DataT.
- *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The mipmap image handle
- *  @param   coords The coordinates at which to fetch mipmap image data
+ *  @param   coords The coordinates at which to sample mipmap image data
  *  @param   level The mipmap level at which to sample
  *  @return  Mipmap image data with LOD filtering
  */
 template <typename DataT, typename HintT = DataT, typename CoordT>
+__SYCL_DEPRECATED("read_mipmap has been deprecated. "
+                  "Instead use sample_mipmap.")
 DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
                   const CoordT &coords [[maybe_unused]],
                   const float level [[maybe_unused]]) {
+  return sample_mipmap(imageHandle, coords, level);
+}
+
+/**
+ *  @brief   [Deprecated] Read a mipmap image using its handle with anisotropic
+ *           filtering
+ *
+ *  @tparam  DataT The return type
+ *  @tparam  HintT A hint type that can be used to select for a specialized
+ *           backend intrinsic when a user-defined type is passed as `DataT`.
+ *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
+ *           HintT must also have the same size as DataT.
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
+ *           1D, 2D, and 3D, respectively
+ *  @param   imageHandle The mipmap image handle
+ *  @param   coords The coordinates at which to sample mipmap image data
+ *  @param   dX Screen space gradient in the x dimension
+ *  @param   dY Screen space gradient in the y dimension
+ *  @return  Mipmap image data with anisotropic filtering
+ */
+template <typename DataT, typename HintT = DataT, typename CoordT>
+__SYCL_DEPRECATED("read_mipmap has been deprecated. "
+                  "Instead use sample_mipmap.")
+DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
+                  const CoordT &coords [[maybe_unused]],
+                  const CoordT &dX [[maybe_unused]],
+                  const CoordT &dY [[maybe_unused]]) {
+  return sample_mipmap(imageHandle, coords, dX, dY);
+}
+
+/**
+ *  @brief   Sample a mipmap image using its handle with LOD filtering
+ *
+ *  @tparam  DataT The return type
+ *  @tparam  HintT A hint type that can be used to select for a specialized
+ *           backend intrinsic when a user-defined type is passed as `DataT`.
+ *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
+ *           HintT must also have the same size as DataT.
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
+ *           1D, 2D, and 3D, respectively
+ *  @param   imageHandle The mipmap image handle
+ *  @param   coords The coordinates at which to sample mipmap image data
+ *  @param   level The mipmap level at which to sample
+ *  @return  Mipmap image data with LOD filtering
+ */
+template <typename DataT, typename HintT = DataT, typename CoordT>
+DataT sample_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
+                    const CoordT &coords [[maybe_unused]],
+                    const float level [[maybe_unused]]) {
   detail::assert_sampled_coords<CoordT>();
   constexpr size_t coordSize = detail::coord_size<CoordT>();
   static_assert(coordSize == 1 || coordSize == 2 || coordSize == 3,
@@ -893,26 +1001,26 @@ DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
 }
 
 /**
- *  @brief   Read a mipmap image using its handle with anisotropic filtering
+ *  @brief   Sample a mipmap image using its handle with anisotropic filtering
  *
  *  @tparam  DataT The return type
  *  @tparam  HintT A hint type that can be used to select for a specialized
  *           backend intrinsic when a user-defined type is passed as `DataT`.
  *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
  *           HintT must also have the same size as DataT.
- *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The mipmap image handle
- *  @param   coords The coordinates at which to fetch mipmap image data
+ *  @param   coords The coordinates at which to sample mipmap image data
  *  @param   dX Screen space gradient in the x dimension
  *  @param   dY Screen space gradient in the y dimension
  *  @return  Mipmap image data with anisotropic filtering
  */
 template <typename DataT, typename HintT = DataT, typename CoordT>
-DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
-                  const CoordT &coords [[maybe_unused]],
-                  const CoordT &dX [[maybe_unused]],
-                  const CoordT &dY [[maybe_unused]]) {
+DataT sample_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
+                    const CoordT &coords [[maybe_unused]],
+                    const CoordT &dX [[maybe_unused]],
+                    const CoordT &dY [[maybe_unused]]) {
   detail::assert_sampled_coords<CoordT>();
   constexpr size_t coordSize = detail::coord_size<CoordT>();
   static_assert(coordSize == 1 || coordSize == 2 || coordSize == 3,
@@ -946,40 +1054,20 @@ DataT read_mipmap(const sampled_image_handle &imageHandle [[maybe_unused]],
  *           backend intrinsic when a user-defined type is passed as `DataT`.
  *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
  *           HintT must also have the same size as DataT.
- *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The mipmap image handle
- *  @param   coords The coordinates at which to fetch mipmap image data
+ *  @param   coords The coordinates at which to sample mipmap image data
  *  @param   level The mipmap level at which to sample
  *  @return  Mipmap image data with LOD filtering
  */
 template <typename DataT, typename HintT = DataT, typename CoordT>
 __SYCL_DEPRECATED("read_image for mipmaps is deprecated. "
-                  "Instead use read_mipmap.")
+                  "Instead use sample_mipmap.")
 DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
                  const CoordT &coords [[maybe_unused]],
                  const float level [[maybe_unused]]) {
-  detail::assert_sampled_coords<CoordT>();
-  constexpr size_t coordSize = detail::coord_size<CoordT>();
-  static_assert(coordSize == 1 || coordSize == 2 || coordSize == 3,
-                "Expected input coordinate to be have 1, 2, or 3 components "
-                "for 1D, 2D and 3D images, respectively.");
-
-#ifdef __SYCL_DEVICE_ONLY__
-  if constexpr (detail::is_recognized_standard_type<DataT>()) {
-    return __invoke__ImageReadLod<DataT>(imageHandle.raw_handle, coords, level);
-  } else {
-    static_assert(sizeof(HintT) == sizeof(DataT),
-                  "When trying to read a user-defined type, HintT must be of "
-                  "the same size as the user-defined DataT.");
-    static_assert(detail::is_recognized_standard_type<HintT>(),
-                  "HintT must always be a recognized standard type");
-    return sycl::bit_cast<DataT>(
-        __invoke__ImageReadLod<HintT>(imageHandle.raw_handle, coords, level));
-  }
-#else
-  assert(false); // Bindless images not yet implemented on host
-#endif
+  return sample_mipmap(imageHandle, coords, level);
 }
 
 /**
@@ -991,7 +1079,7 @@ DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
  *           backend intrinsic when a user-defined type is passed as `DataT`.
  *           HintT should be a `sycl::vec` type, `sycl::half` type, or POD type.
  *           HintT must also have the same size as DataT.
- *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float4 for
+ *  @tparam  CoordT The input coordinate type. e.g. float, float2, or float3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The mipmap image handle
  *  @param   coords The coordinates at which to fetch mipmap image data
@@ -1001,40 +1089,19 @@ DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
  */
 template <typename DataT, typename HintT = DataT, typename CoordT>
 __SYCL_DEPRECATED("read_image for mipmaps is deprecated. "
-                  "Instead use read_mipmap.")
+                  "Instead use sample_mipmap.")
 DataT read_image(const sampled_image_handle &imageHandle [[maybe_unused]],
                  const CoordT &coords [[maybe_unused]],
                  const CoordT &dX [[maybe_unused]],
                  const CoordT &dY [[maybe_unused]]) {
-  detail::assert_sampled_coords<CoordT>();
-  constexpr size_t coordSize = detail::coord_size<CoordT>();
-  static_assert(coordSize == 1 || coordSize == 2 || coordSize == 3,
-                "Expected input coordinates and gradients to have 1, 2, or 3 "
-                "components for 1D, 2D, and 3D images, respectively.");
-
-#ifdef __SYCL_DEVICE_ONLY__
-  if constexpr (detail::is_recognized_standard_type<DataT>()) {
-    return __invoke__ImageReadGrad<DataT>(imageHandle.raw_handle, coords, dX,
-                                          dY);
-  } else {
-    static_assert(sizeof(HintT) == sizeof(DataT),
-                  "When trying to read a user-defined type, HintT must be of "
-                  "the same size as the user-defined DataT.");
-    static_assert(detail::is_recognized_standard_type<HintT>(),
-                  "HintT must always be a recognized standard type");
-    return sycl::bit_cast<DataT>(
-        __invoke__ImageReadGrad<HintT>(imageHandle.raw_handle, coords, dX, dY));
-  }
-#else
-  assert(false); // Bindless images not yet implemented on host
-#endif
+  return sample_mipmap(imageHandle, coords, dX, dY);
 }
 
 /**
  *  @brief   Write to an unsampled image using its handle
  *
  *  @tparam  DataT The data type to write
- *  @tparam  CoordT The input coordinate type. e.g. int, int2, or int4 for
+ *  @tparam  CoordT The input coordinate type. e.g. int, int2, or int3 for
  *           1D, 2D, and 3D, respectively
  *  @param   imageHandle The image handle
  *  @param   coords The coordinates at which to write image data

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
@@ -95,11 +95,11 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
       cgh.parallel_for<kernel<DType, CType>>(N, [=](sycl::id<1> id) {
         DType sum = 0;
         float x = float(id[0] + 0.5f) / (float)N;
-        // Extension: read mipmap level 0 with anisotropic filtering and level 1
-        // with LOD
-        VecType px1 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
+        // Extension: sample mipmap level 0 with anisotropic filtering and
+        // level 1 with LOD
+        VecType px1 = sycl::ext::oneapi::experimental::sample_mipmap<VecType>(
             mipHandle, x, 0.0f);
-        VecType px2 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
+        VecType px2 = sycl::ext::oneapi::experimental::sample_mipmap<VecType>(
             mipHandle, x, 1.0f);
 
         sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
@@ -110,9 +110,10 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
             float fdim0 = float(dim0 + 0.5f) / (float)width;
             float fdim1 = float(dim1 + 0.5f) / (float)height;
 
-            // Extension: read mipmap level 1 with LOD
-            VecType px2 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
-                mipHandle, sycl::float2(fdim0, fdim1), 1.0f);
+            // Extension: sample mipmap level 1 with LOD
+            VecType px2 =
+                sycl::ext::oneapi::experimental::sample_mipmap<VecType>(
+                    mipHandle, sycl::float2(fdim0, fdim1), 1.0f);
 
             outAcc[sycl::id<2>{dim1, dim0}] = px2[0];
           });

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
@@ -99,11 +99,13 @@ template <typename DType, sycl::image_channel_type CType> bool runTest() {
             float fdim1 = float(dim1 + 0.5f) / (float)height;
             float fdim2 = float(dim2 + 0.5f) / (float)depth;
 
-            // Extension: read mipmap with anisotropic filtering with zero
+            // Extension: sample mipmap with anisotropic filtering with zero
             // viewing gradients
-            VecType px1 = sycl::ext::oneapi::experimental::read_mipmap<VecType>(
-                mipHandle, sycl::float3(fdim0, fdim1, fdim2),
-                sycl::float3(0.0f, 0.0f, 0.0f), sycl::float3(0.0f, 0.0f, 0.0f));
+            VecType px1 =
+                sycl::ext::oneapi::experimental::sample_mipmap<VecType>(
+                    mipHandle, sycl::float3(fdim0, fdim1, fdim2),
+                    sycl::float3(0.0f, 0.0f, 0.0f),
+                    sycl::float3(0.0f, 0.0f, 0.0f));
 
             outAcc[sycl::id<3>{dim2, dim1, dim0}] = px1[0];
           });

--- a/sycl/test-e2e/bindless_images/read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/read_1D.cpp
@@ -93,12 +93,12 @@ int main() {
 
       cgh.parallel_for<image_addition>(width, [=](sycl::id<1> id) {
         float sum = 0;
-        // Extension: read image data from handle
+        // Extension: fetch image data from handle
         sycl::float4 px1 =
-            sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+            sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                 imgHandle1, int(id[0]));
         sycl::float4 px2 =
-            sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+            sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                 imgHandle2, int(id[0]));
 
         sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/read_2D.cpp
+++ b/sycl/test-e2e/bindless_images/read_2D.cpp
@@ -73,12 +73,12 @@ int main() {
             size_t dim0 = it.get_local_id(0);
             size_t dim1 = it.get_local_id(1);
             float sum = 0;
-            // Extension: read image data from handle
+            // Extension: fetch image data from handle
             sycl::float4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgHandle1, sycl::int2(dim0, dim1));
             sycl::float4 px2 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgHandle2, sycl::int2(dim0, dim1));
 
             sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/read_2D_dynamic.cpp
+++ b/sycl/test-e2e/bindless_images/read_2D_dynamic.cpp
@@ -83,9 +83,10 @@ int main() {
             // Sum each image by reading their handle
             float sum = 0;
             for (int i = 0; i < numImages; i++) {
-              // Extension: read image data from handle
-              sum += (sycl::ext::oneapi::experimental::read_image<sycl::float4>(
-                  imgHandleAcc[i], sycl::int2(dim0, dim1)))[0];
+              // Extension: fetch image data from handle
+              sum +=
+                  (sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
+                      imgHandleAcc[i], sycl::int2(dim0, dim1)))[0];
             }
             outAcc[sycl::id<2>{dim1, dim0}] = sum;
           });

--- a/sycl/test-e2e/bindless_images/read_3D.cpp
+++ b/sycl/test-e2e/bindless_images/read_3D.cpp
@@ -73,12 +73,12 @@ int main() {
             size_t dim1 = it.get_global_id(1);
             size_t dim2 = it.get_global_id(2);
             float sum = 0;
-            // Extension: read image data from handle
+            // Extension: fetch image data from handle
             sycl::float4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgHandle1, sycl::int3(dim0, dim1, dim2));
             sycl::float4 px2 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgHandle2, sycl::int3(dim0, dim1, dim2));
 
             sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -63,14 +63,14 @@ bool run_test(sycl::range<NDims> globalSize, sycl::range<NDims> localSize) {
 
             if constexpr (NDims == 1) {
               OutputType pixel =
-                  syclexp::read_image<OutputType>(imgIn, float(dim0));
+                  syclexp::sample_image<OutputType>(imgIn, float(dim0));
               syclexp::write_image(imgOut, int(dim0), pixel);
             } else if constexpr (NDims == 2) {
-              OutputType pixel = syclexp::read_image<OutputType>(
+              OutputType pixel = syclexp::sample_image<OutputType>(
                   imgIn, sycl::float2(dim0, dim1));
               syclexp::write_image(imgOut, sycl::int2(dim0, dim1), pixel);
             } else if constexpr (NDims == 3) {
-              OutputType pixel = syclexp::read_image<OutputType>(
+              OutputType pixel = syclexp::sample_image<OutputType>(
                   imgIn, sycl::float3(dim0, dim1, dim2));
               syclexp::write_image(imgOut, sycl::int3(dim0, dim1, dim2), pixel);
             }

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -795,7 +795,7 @@ runNDimTestDevice(sycl::queue &q, sycl::range<NDims> globalSize,
               accessorCoords[i] = it.get_global_id(NDims - i - 1);
             }
 
-            VecType px1 = syclexp::read_image<VecType>(inputImage, coords);
+            VecType px1 = syclexp::sample_image<VecType>(inputImage, coords);
 
             outAcc[accessorCoords] = px1;
           });

--- a/sycl/test-e2e/bindless_images/read_write_1D.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_1D.cpp
@@ -62,12 +62,12 @@ int main() {
     q.submit([&](sycl::handler &cgh) {
       cgh.parallel_for<image_addition>(width, [=](sycl::id<1> id) {
         float sum = 0;
-        // Extension: read image data from handle
+        // Extension: fetch image data from handle
         sycl::float4 px1 =
-            sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+            sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                 imgIn1, int(id[0]));
         sycl::float4 px2 =
-            sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+            sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                 imgIn2, int(id[0]));
 
         sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/read_write_1D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_1D_subregion.cpp
@@ -73,10 +73,10 @@ int main() {
     q.submit([&](sycl::handler &cgh) {
       cgh.parallel_for<image_addition>(width, [=](sycl::id<1> id) {
         float sum = 0;
-        // Extension: read image data from handle
-        float px1 = sycl::ext::oneapi::experimental::read_image<float>(
+        // Extension: fetch image data from handle
+        float px1 = sycl::ext::oneapi::experimental::fetch_image<float>(
             imgHandle1, int(id[0]));
-        float px2 = sycl::ext::oneapi::experimental::read_image<float>(
+        float px2 = sycl::ext::oneapi::experimental::fetch_image<float>(
             imgHandle2, int(id[0]));
 
         sum = px1 + px2;

--- a/sycl/test-e2e/bindless_images/read_write_2D.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_2D.cpp
@@ -68,12 +68,12 @@ int main() {
             size_t dim0 = it.get_local_id(0);
             size_t dim1 = it.get_local_id(1);
             float sum = 0;
-            // Extension: read image data from handle
+            // Extension: fetch image data from handle
             sycl::float4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgIn1, sycl::int2(dim0, dim1));
             sycl::float4 px2 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgIn2, sycl::int2(dim0, dim1));
 
             sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/read_write_2D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_2D_subregion.cpp
@@ -90,10 +90,10 @@ int main() {
             size_t dim0 = it.get_local_id(0);
             size_t dim1 = it.get_local_id(1);
             float sum = 0;
-            // Extension: read image data from handle
-            float px1 = sycl::ext::oneapi::experimental::read_image<float>(
+            // Extension: fetch image data from handle
+            float px1 = sycl::ext::oneapi::experimental::fetch_image<float>(
                 imgHandle1, sycl::int2(dim0, dim1));
-            float px2 = sycl::ext::oneapi::experimental::read_image<float>(
+            float px2 = sycl::ext::oneapi::experimental::fetch_image<float>(
                 imgHandle2, sycl::int2(dim0, dim1));
 
             sum = px1 + px2;

--- a/sycl/test-e2e/bindless_images/read_write_3D.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_3D.cpp
@@ -73,12 +73,12 @@ int main() {
             size_t dim1 = it.get_local_id(1);
             size_t dim2 = it.get_local_id(2);
             float sum = 0;
-            // Extension: read image data from handle
+            // Extension: fetch image data from handle
             sycl::float4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgIn1, sycl::int3(dim0, dim1, dim2));
             sycl::float4 px2 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::fetch_image<sycl::float4>(
                     imgIn2, sycl::int3(dim0, dim1, dim2));
 
             sum = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/read_write_3D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_3D_subregion.cpp
@@ -109,10 +109,10 @@ int main() {
             size_t dim1 = it.get_global_id(1);
             size_t dim2 = it.get_global_id(2);
             float sum = 0;
-            // Extension: read image data from handle
-            float px1 = sycl::ext::oneapi::experimental::read_image<float>(
+            // Extension: fetch image data from handle
+            float px1 = sycl::ext::oneapi::experimental::fetch_image<float>(
                 imgHandle1, sycl::int3(dim0, dim1, dim2));
-            float px2 = sycl::ext::oneapi::experimental::read_image<float>(
+            float px2 = sycl::ext::oneapi::experimental::fetch_image<float>(
                 imgHandle2, sycl::int3(dim0, dim1, dim2));
 
             sum = px1 + px2;

--- a/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
@@ -98,10 +98,10 @@ struct util {
 
               if constexpr (NChannels >= 1) {
                 VecType px1 =
-                    sycl::ext::oneapi::experimental::read_image<VecType>(
+                    sycl::ext::oneapi::experimental::fetch_image<VecType>(
                         input_0, sycl::int3(dim0, dim1, dim2));
                 VecType px2 =
-                    sycl::ext::oneapi::experimental::read_image<VecType>(
+                    sycl::ext::oneapi::experimental::fetch_image<VecType>(
                         input_1, sycl::int3(dim0, dim1, dim2));
 
                 auto sum =
@@ -109,9 +109,9 @@ struct util {
                 sycl::ext::oneapi::experimental::write_image<VecType>(
                     output, sycl::int3(dim0, dim1, dim2), VecType(sum));
               } else {
-                DType px1 = sycl::ext::oneapi::experimental::read_image<DType>(
+                DType px1 = sycl::ext::oneapi::experimental::fetch_image<DType>(
                     input_0, sycl::int3(dim0, dim1, dim2));
-                DType px2 = sycl::ext::oneapi::experimental::read_image<DType>(
+                DType px2 = sycl::ext::oneapi::experimental::fetch_image<DType>(
                     input_1, sycl::int3(dim0, dim1, dim2));
 
                 auto sum = DType(util::add_kernel<DType, NChannels>(px1, px2));
@@ -148,10 +148,10 @@ struct util {
 
               if constexpr (NChannels >= 1) {
                 VecType px1 =
-                    sycl::ext::oneapi::experimental::read_image<VecType>(
+                    sycl::ext::oneapi::experimental::fetch_image<VecType>(
                         input_0, sycl::int2(dim0, dim1));
                 VecType px2 =
-                    sycl::ext::oneapi::experimental::read_image<VecType>(
+                    sycl::ext::oneapi::experimental::fetch_image<VecType>(
                         input_1, sycl::int2(dim0, dim1));
 
                 auto sum =
@@ -159,9 +159,9 @@ struct util {
                 sycl::ext::oneapi::experimental::write_image<VecType>(
                     output, sycl::int2(dim0, dim1), VecType(sum));
               } else {
-                DType px1 = sycl::ext::oneapi::experimental::read_image<DType>(
+                DType px1 = sycl::ext::oneapi::experimental::fetch_image<DType>(
                     input_0, sycl::int2(dim0, dim1));
-                DType px2 = sycl::ext::oneapi::experimental::read_image<DType>(
+                DType px2 = sycl::ext::oneapi::experimental::fetch_image<DType>(
                     input_1, sycl::int2(dim0, dim1));
 
                 auto sum = DType(util::add_kernel<DType, NChannels>(px1, px2));
@@ -197,10 +197,10 @@ struct util {
 
               if constexpr (NChannels >= 1) {
                 VecType px1 =
-                    sycl::ext::oneapi::experimental::read_image<VecType>(
+                    sycl::ext::oneapi::experimental::fetch_image<VecType>(
                         input_0, int(dim0));
                 VecType px2 =
-                    sycl::ext::oneapi::experimental::read_image<VecType>(
+                    sycl::ext::oneapi::experimental::fetch_image<VecType>(
                         input_1, int(dim0));
 
                 auto sum =
@@ -208,9 +208,9 @@ struct util {
                 sycl::ext::oneapi::experimental::write_image<VecType>(
                     output, int(dim0), VecType(sum));
               } else {
-                DType px1 = sycl::ext::oneapi::experimental::read_image<DType>(
+                DType px1 = sycl::ext::oneapi::experimental::fetch_image<DType>(
                     input_0, int(dim0));
-                DType px2 = sycl::ext::oneapi::experimental::read_image<DType>(
+                DType px2 = sycl::ext::oneapi::experimental::fetch_image<DType>(
                     input_1, int(dim0));
 
                 auto sum = DType(util::add_kernel<DType, NChannels>(px1, px2));

--- a/sycl/test-e2e/bindless_images/sampling_1D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_1D.cpp
@@ -68,9 +68,9 @@ int main() {
       cgh.parallel_for<image_addition>(N, [=](sycl::id<1> id) {
         // Normalize coordinate -- +0.5 to look towards centre of pixel
         float x = float(id[0] + 0.5f) / (float)N;
-        // Extension: read image data from handle
+        // Extension: sample image data from handle
         float px1 =
-            sycl::ext::oneapi::experimental::read_image<float>(imgHandle, x);
+            sycl::ext::oneapi::experimental::sample_image<float>(imgHandle, x);
 
         outAcc[id] = px1;
       });

--- a/sycl/test-e2e/bindless_images/sampling_2D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D.cpp
@@ -98,12 +98,12 @@ int main() {
             float fdim0 = float(dim0 + 0.5f) / (float)width;
             float fdim1 = float(dim1 + 0.5f) / (float)height;
 
-            // Extension: read image data from handle
+            // Extension: sample image data from handle
             sycl::float4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::sample_image<sycl::float4>(
                     imgHandle1, sycl::float2(fdim0, fdim1));
             sycl::float4 px2 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::sample_image<sycl::float4>(
                     imgHandle2, sycl::float2(fdim0, fdim1));
 
             outAcc[sycl::id<2>{dim1, dim0}] = px1[0] + px2[0];

--- a/sycl/test-e2e/bindless_images/sampling_2D_USM_shared.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_USM_shared.cpp
@@ -97,8 +97,8 @@ int main() {
             float fdim0 = float(dim0 + 0.5f) / (float)width;
             float fdim1 = float(dim1 + 0.5f) / (float)height;
 
-            // Extension: read image data from handle
-            float px = sycl::ext::oneapi::experimental::read_image<float>(
+            // Extension: sample image data from handle
+            float px = sycl::ext::oneapi::experimental::sample_image<float>(
                 imgHandle, sycl::float2(fdim0, fdim1));
 
             outAcc[sycl::id<2>{dim1, dim0}] = px;

--- a/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
@@ -82,9 +82,9 @@ int main() {
             float fdim0 = float(dim0 + 0.5f) / (float)width;
             float fdim1 = float(dim1 + 0.5f) / (float)height;
 
-            // Extension: read image data from handle
+            // Extension: sample image data from handle
             sycl::half4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::half4>(
+                sycl::ext::oneapi::experimental::sample_image<sycl::half4>(
                     imgHandle, sycl::float2(fdim0, fdim1));
 
             outAcc[sycl::id<2>{dim1, dim0}] = px1[0];

--- a/sycl/test-e2e/bindless_images/sampling_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_3D.cpp
@@ -77,9 +77,9 @@ int main() {
             float fdim1 = float(dim1 + 0.5f) / (float)height;
             float fdim2 = float(dim2 + 0.5f) / (float)depth;
 
-            // Extension: read image data from handle
+            // Extension: sample image data from handle
             sycl::float4 px1 =
-                sycl::ext::oneapi::experimental::read_image<sycl::float4>(
+                sycl::ext::oneapi::experimental::sample_image<sycl::float4>(
                     imgHandle, sycl::float3(fdim0, fdim1, fdim2));
 
             outAcc[sycl::id<3>{dim2, dim1, dim0}] = px1[0];

--- a/sycl/test-e2e/bindless_images/sampling_unique_addr_modes.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_unique_addr_modes.cpp
@@ -88,8 +88,8 @@ int main() {
             float fdim1 = float(dim1 + height + 0.5) / (float)height;
             float fdim2 = float(dim2 + depth + 0.5) / (float)depth;
 
-            // Extension: read image data from handle
-            float px1 = syclexp::read_image<float>(
+            // Extension: sample image data from handle
+            float px1 = syclexp::sample_image<float>(
                 imgHandle, sycl::float3(fdim0, fdim1, fdim2));
 
             outAcc[sycl::id<3>{dim2, dim1, dim0}] = px1;

--- a/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
@@ -119,9 +119,9 @@ bool run_test() {
             float fdim0 = float(dim0 + 0.5f) / (float)width;
             float fdim1 = float(dim1 + 0.5f) / (float)height;
 
-            // Extension: read mipmap level 1 with LOD
+            // Extension: sample mipmap level 1 with LOD
             MyType pixel =
-                sycl::ext::oneapi::experimental::read_mipmap<MyType, OutType>(
+                sycl::ext::oneapi::experimental::sample_mipmap<MyType, OutType>(
                     mipHandle, sycl::float2(fdim0, fdim1), 1.0f);
 
             outAcc[sycl::id<2>{dim1, dim0}] = pixel;

--- a/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
@@ -72,12 +72,12 @@ bool run_test() {
 
         MyType myPixel{};
 
-        // Unsampled read
-        myPixel = syclexp::read_image<MyType, OutType>(unsampledImgIn, coords);
+        // Unsampled fetch
+        myPixel = syclexp::fetch_image<MyType, OutType>(unsampledImgIn, coords);
 
         // Sampled read
         myPixel +=
-            syclexp::read_image<MyType, OutType>(sampledImgIn, floatCoords);
+            syclexp::sample_image<MyType, OutType>(sampledImgIn, floatCoords);
 
         syclexp::write_image(imgOut, coords, myPixel);
       });

--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
@@ -147,9 +147,9 @@ bool run_sycl(sycl::range<NDims> globalSize, sycl::range<NDims> localSize,
               float fdim1 = float(dim1 + 0.5f) / (float)height;
               float fdim2 = float(dim2 + 0.5f) / (float)depth;
 
-              // Extension: read image data from handle (Vulkan imported)
+              // Extension: sample image data from handle (Vulkan imported)
               VecType pixel;
-              pixel = syclexp::read_image<
+              pixel = syclexp::sample_image<
                   std::conditional_t<NChannels == 1, DType, VecType>>(
                   handles.imgInput, sycl::float3(fdim0, fdim1, fdim2));
 
@@ -163,8 +163,8 @@ bool run_sycl(sycl::range<NDims> globalSize, sycl::range<NDims> localSize,
               float fdim0 = float(dim0 + 0.5f) / (float)width;
               float fdim1 = float(dim1 + 0.5f) / (float)height;
 
-              // Extension: read image data from handle (Vulkan imported)
-              VecType pixel = syclexp::read_image<
+              // Extension: sample image data from handle (Vulkan imported)
+              VecType pixel = syclexp::sample_image<
                   std::conditional_t<NChannels == 1, DType, VecType>>(
                   handles.imgInput, sycl::float2(fdim0, fdim1));
 

--- a/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/unsampled_images.cpp
@@ -185,9 +185,9 @@ void run_ndim_test(sycl::range<NDims> global_size,
 
             if constexpr (NDims == 2) {
               if constexpr (NChannels > 1) {
-                VecType px1 = syclexp::read_image<VecType>(
+                VecType px1 = syclexp::fetch_image<VecType>(
                     handles.input_1, sycl::int2(dim0, dim1));
-                VecType px2 = syclexp::read_image<VecType>(
+                VecType px2 = syclexp::fetch_image<VecType>(
                     handles.input_2, sycl::int2(dim0, dim1));
 
                 auto sum =
@@ -195,10 +195,10 @@ void run_ndim_test(sycl::range<NDims> global_size,
                 syclexp::write_image<VecType>(
                     handles.output, sycl::int2(dim0, dim1), VecType(sum));
               } else {
-                DType px1 = syclexp::read_image<DType>(handles.input_1,
-                                                       sycl::int2(dim0, dim1));
-                DType px2 = syclexp::read_image<DType>(handles.input_2,
-                                                       sycl::int2(dim0, dim1));
+                DType px1 = syclexp::fetch_image<DType>(handles.input_1,
+                                                        sycl::int2(dim0, dim1));
+                DType px2 = syclexp::fetch_image<DType>(handles.input_2,
+                                                        sycl::int2(dim0, dim1));
 
                 auto sum = DType(util::add_kernel<DType, NChannels>(px1, px2));
                 syclexp::write_image<DType>(handles.output,
@@ -208,9 +208,9 @@ void run_ndim_test(sycl::range<NDims> global_size,
               size_t dim2 = it.get_global_id(2);
 
               if constexpr (NChannels > 1) {
-                VecType px1 = syclexp::read_image<VecType>(
+                VecType px1 = syclexp::fetch_image<VecType>(
                     handles.input_1, sycl::int3(dim0, dim1, dim2));
-                VecType px2 = syclexp::read_image<VecType>(
+                VecType px2 = syclexp::fetch_image<VecType>(
                     handles.input_2, sycl::int3(dim0, dim1, dim2));
 
                 auto sum =
@@ -218,9 +218,9 @@ void run_ndim_test(sycl::range<NDims> global_size,
                 syclexp::write_image<VecType>(
                     handles.output, sycl::int3(dim0, dim1, dim2), VecType(sum));
               } else {
-                DType px1 = syclexp::read_image<DType>(
+                DType px1 = syclexp::fetch_image<DType>(
                     handles.input_1, sycl::int3(dim0, dim1, dim2));
-                DType px2 = syclexp::read_image<DType>(
+                DType px2 = syclexp::fetch_image<DType>(
                     handles.input_2, sycl::int3(dim0, dim1, dim2));
 
                 auto sum = DType(util::add_kernel<DType, NChannels>(px1, px2));

--- a/sycl/test/extensions/bindless_images.cpp
+++ b/sycl/test/extensions/bindless_images.cpp
@@ -35,7 +35,7 @@ int main() {
       auto outAcc = buf.get_access<sycl::access_mode::write>(cgh, width);
 
       cgh.parallel_for<image_read>(width, [=](sycl::id<1> id) {
-        sycl::float4 px1 = read_image<sycl::float4>(imgHandle1, int(id[0]));
+        sycl::float4 px1 = fetch_image<sycl::float4>(imgHandle1, int(id[0]));
         outAcc[id] = px1[0];
       });
     });


### PR DESCRIPTION
- The `read_image` and `read_mipmap` APIs have been deprecated
- They are replaced with the more descriptive `fetch_image`, `sample_image`, and `sample_mipmap` (for unsampled reads, sampled reads, and mipmap sampled reads, respectively).
- This change is made in preperation for future functionality of fetching data from sampled images.
- The reason behind this change is to avoid determining the underlying image read operation based on the coordinate type passed, and instead making it more transparent for the user which operation is performed based on the name of the function.
- The extension document, bindless images headers, and all bindless images tests have all been updated.
- The specification revision history has been updated to include a missed changelog entry for PR https://github.com/intel/llvm/pull/12581