### PR TITLE
[SYCL] Disable implicit-float-size-conversion warning in community tests

### DIFF
--- a/clang/test/SemaHLSL/standard_conversion_sequences.hlsl
+++ b/clang/test/SemaHLSL/standard_conversion_sequences.hlsl
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -Wconversion -verify -o - %s
-// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -Wno-conversion -DNO_ERR -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -Wconversion -Wno-implicit-float-size-conversion -verify -o - %s
+// RUN: %clang_cc1 -triple dxil-pc-shadermodel6.3-library -Wno-conversion -Wno-implicit-float-size-conversion -DNO_ERR -ast-dump %s | FileCheck %s
 
 void test() {
   


### PR DESCRIPTION
The test fails due missing warning, the warning was added in SYCL web
long time ago, vs e4f5d55f91f19ebc13852e3cdd60b39d68251bab

The test is newly added test from change:
5c57fd717d5d6a285efeb8402c6fe0c8f70592f3
