### PR TITLE
[SYCL] Fix a stream related in-order queue hang

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -510,7 +510,7 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
 
   std::vector<EventImplPtr> StreamsServiceEvents;
   {
-    std::lock_guard<std::mutex> Lock(MMutex);
+    std::lock_guard<std::mutex> Lock(MStreamsServiceEventsMutex);
     StreamsServiceEvents.swap(MStreamsServiceEvents);
   }
   for (const EventImplPtr &Event : StreamsServiceEvents)

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -689,7 +689,7 @@ public:
 #endif
 
   void registerStreamServiceEvent(const EventImplPtr &Event) {
-    std::lock_guard<std::mutex> Lock(MMutex);
+    std::lock_guard<std::mutex> Lock(MStreamsServiceEventsMutex);
     MStreamsServiceEvents.push_back(Event);
   }
 
@@ -945,6 +945,7 @@ protected:
   const bool MIsInorder;
 
   std::vector<EventImplPtr> MStreamsServiceEvents;
+  std::mutex MStreamsServiceEventsMutex;
 
   // All member variable defined here  are needed for the SYCL instrumentation
   // layer. Do not guard these variables below with XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/test-e2e/Basic/stream/auto_flush.cpp
+++ b/sycl/test-e2e/Basic/stream/auto_flush.cpp
@@ -15,17 +15,25 @@
 
 using namespace sycl;
 
-int main() {
-  queue Queue;
+// Test that data is flushed to the buffer at the end of kernel execution even
+// without explicit flush
 
-  // Test that data is flushed to the buffer at the end of kernel execution even
-  // without explicit flush
+void test(queue &Queue) {
   Queue.submit([&](handler &CGH) {
     stream Out(1024, 80, CGH);
     CGH.parallel_for<class auto_flush1>(
         range<1>(2), [=](id<1> i) { Out << "Hello World!\n"; });
   });
   Queue.wait();
+}
+int main() {
+  queue Queue;
+  test(Queue);
+  // CHECK: Hello World!
+  // CHECK-NEXT: Hello World!
+
+  queue InOrderQueue{{sycl::property::queue::in_order()}};
+  test(InOrderQueue);
   // CHECK: Hello World!
   // CHECK-NEXT: Hello World!
 


### PR DESCRIPTION
Now that submitting a task to an in-order queue can lock its main mutex, the vector of stream service events (which can be accessed during that same submission) should use a different mutex to avoid deadlocks.