### PR TITLE
[SYCL] Return nullptr when allocation size is zero in usm allocator

### DIFF
--- a/sycl/include/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/sycl/usm/usm_allocator.hpp
@@ -71,6 +71,9 @@ public:
   T *allocate(size_t NumberOfElements, const detail::code_location CodeLoc =
                                            detail::code_location::current()) {
 
+    if (!NumberOfElements)
+      return nullptr;
+
     auto Result = reinterpret_cast<T *>(
         aligned_alloc(getAlignment(), NumberOfElements * sizeof(value_type),
                       MDevice, MContext, AllocKind, MPropList, CodeLoc));

--- a/sycl/test-e2e/USM/usm_allocator_zero_allocation.cpp
+++ b/sycl/test-e2e/USM/usm_allocator_zero_allocation.cpp
@@ -4,21 +4,27 @@
 #include <sycl/sycl.hpp>
 
 using namespace sycl;
-#define ALLOC_SIZE 0
+
+template <usm::alloc alloc_kind> void test(queue &q) {
+  sycl::usm_allocator<int, alloc_kind> ua(q);
+  int *p = ua.allocate(0);
+
+  assert(!p && "Our implementation of usm_allocator is expected to return a "
+               "null pointer when allocation "
+               "size is zero.");
+
+  ua.deallocate(p, 0);
+}
 
 int main() {
   queue q;
   auto dev = q.get_device();
-  auto ctxt = q.get_context();
 
   if (dev.get_info<info::device::usm_host_allocations>()) {
-    sycl::usm_allocator<int, sycl::usm::alloc::host> ua{ctxt, dev};
-    int *p = ua.allocate(ALLOC_SIZE);
-
-    assert(!p && "usm_allocator should return a null pointer when allocation "
-                 "size is zero.");
-
-    ua.deallocate(p, ALLOC_SIZE);
+    test<usm::alloc::host>(q);
+  }
+  if (dev.get_info<info::device::usm_shared_allocations>()) {
+    test<usm::alloc::shared>(q);
   }
 
   return 0;

--- a/sycl/test-e2e/USM/usm_allocator_zero_allocation.cpp
+++ b/sycl/test-e2e/USM/usm_allocator_zero_allocation.cpp
@@ -10,8 +10,7 @@ template <usm::alloc alloc_kind> void test(queue &q) {
   int *p = ua.allocate(0);
 
   assert(!p && "Our implementation of usm_allocator is expected to return a "
-               "null pointer when allocation "
-               "size is zero.");
+               "null pointer when allocation size is zero.");
 
   ua.deallocate(p, 0);
 }
@@ -20,10 +19,10 @@ int main() {
   queue q;
   auto dev = q.get_device();
 
-  if (dev.get_info<info::device::usm_host_allocations>()) {
+  if (dev.has(aspect::usm_host_allocations)) {
     test<usm::alloc::host>(q);
   }
-  if (dev.get_info<info::device::usm_shared_allocations>()) {
+  if (dev.has(aspect::usm_shared_allocations)) {
     test<usm::alloc::shared>(q);
   }
 

--- a/sycl/test-e2e/USM/usm_allocator_zero_allocation.cpp
+++ b/sycl/test-e2e/USM/usm_allocator_zero_allocation.cpp
@@ -1,0 +1,25 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+#define ALLOC_SIZE 0
+
+int main() {
+  queue q;
+  auto dev = q.get_device();
+  auto ctxt = q.get_context();
+
+  if (dev.get_info<info::device::usm_host_allocations>()) {
+    sycl::usm_allocator<int, sycl::usm::alloc::host> ua{ctxt, dev};
+    int *p = ua.allocate(ALLOC_SIZE);
+
+    assert(!p && "usm_allocator should return a null pointer when allocation "
+                 "size is zero.");
+
+    ua.deallocate(p, ALLOC_SIZE);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Currently, usm allocator throws when the allocation size is zero. However, this behavior is not aligned with that of std::allocator.
Refer https://github.com/KhronosGroup/SYCL-Docs/issues/355 for discussion regarding this. The spec says that the allocation functions must succeed when the size is zero.  The value returned in this case is unspecified (it can either be a NULL pointer or a non-NULL pointer)

This PR makes USM allocator return a null pointer when the allocation size is zero.