### PR TITLE
[SYCL][E2E] Remove XFAIL from Basic/accessor/empty_zero_dim_accessor.cpp

### DIFF
--- a/sycl/test-e2e/Basic/accessor/empty_zero_dim_accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/empty_zero_dim_accessor.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 // Tests the size and iterator members of an empty zero-dimensional accessor.
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
The behavior seems to have changed after
https://github.com/intel/llvm/pull/12764.