### PR TITLE
[SYCL] Make 'supportAcc' a template variable in getSyclDeviceTypeMap

### DIFF
--- a/sycl/source/detail/allowlist.cpp
+++ b/sycl/source/detail/allowlist.cpp
@@ -167,7 +167,7 @@ AllowListParsedT parseAllowList(const std::string &AllowListRaw) {
         // described in SyclBeMap
         ValidateEnumValues(BackendNameKeyName, getSyclBeMap());
         ValidateEnumValues(DeviceTypeKeyName,
-                           getSyclDeviceTypeMap(true /*Enable 'acc'*/));
+                           getSyclDeviceTypeMap<true /*Enable 'acc'*/>());
 
         if (Key == DeviceVendorIdKeyName) {
           // DeviceVendorId should have hex format
@@ -382,7 +382,7 @@ void applyAllowList(std::vector<sycl::detail::pi::PiDevice> &PiDevices,
         &PiDevType, nullptr);
     sycl::info::device_type DeviceType = pi::cast<info::device_type>(PiDevType);
     for (const auto &SyclDeviceType :
-         getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
+         getSyclDeviceTypeMap<true /*Enable 'acc'*/>()) {
       if (SyclDeviceType.second == DeviceType) {
         const auto &DeviceTypeValue = SyclDeviceType.first;
         DeviceDesc[DeviceTypeKeyName] = DeviceTypeValue;

--- a/sycl/source/detail/config.cpp
+++ b/sycl/source/detail/config.cpp
@@ -161,23 +161,6 @@ void dumpConfig() {
 #undef CONFIG
 }
 
-// Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
-// TODO: host device type will be removed once sycl_ext_oneapi_filter_selector
-// is removed.
-const std::array<std::pair<std::string, info::device_type>, 6> &
-getSyclDeviceTypeMap(bool supportAcc) {
-  static const std::array<std::pair<std::string, info::device_type>, 6>
-      SyclDeviceTypeMap = {
-          {{"host", info::device_type::host},
-           {"cpu", info::device_type::cpu},
-           {"gpu", info::device_type::gpu},
-           /* Duplicate entries are fine as this map is one-directional.*/
-           {supportAcc ? "acc" : "fpga", info::device_type::accelerator},
-           {"fpga", info::device_type::accelerator},
-           {"*", info::device_type::all}}};
-  return SyclDeviceTypeMap;
-}
-
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR
 // TODO: Remove esimd_emulator in the next ABI breaking window.

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -234,8 +234,20 @@ public:
 // Array is used by SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR.
 // The 'supportAcc' parameter is used by SYCL_DEVICE_ALLOWLIST which,
 // unlike ONEAPI_DEVICE_SELECTOR, also accepts 'acc' as a valid device type.
+template <bool supportAcc = false>
 const std::array<std::pair<std::string, info::device_type>, 6> &
-getSyclDeviceTypeMap(bool supportAcc = false);
+getSyclDeviceTypeMap() {
+  static const std::array<std::pair<std::string, info::device_type>, 6>
+      SyclDeviceTypeMap = {
+          {{"host", info::device_type::host},
+           {"cpu", info::device_type::cpu},
+           {"gpu", info::device_type::gpu},
+           /* Duplicate entries are fine as this map is one-directional.*/
+           {supportAcc ? "acc" : "fpga", info::device_type::accelerator},
+           {"fpga", info::device_type::accelerator},
+           {"*", info::device_type::all}}};
+  return SyclDeviceTypeMap;
+}
 
 // Array is used by SYCL_DEVICE_FILTER and SYCL_DEVICE_ALLOWLIST and
 // ONEAPI_DEVICE_SELECTOR
@@ -512,7 +524,7 @@ private:
       return Result;
 
     std::string ValueStr{ValueRaw};
-    auto DeviceTypeMap = getSyclDeviceTypeMap(true /*Enable 'acc'*/);
+    auto DeviceTypeMap = getSyclDeviceTypeMap<true /*Enable 'acc'*/>();
 
     // Iterate over all configurations.
     size_t Start = 0, End = 0;

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -93,12 +93,12 @@ static void Parse_ODS_Device(ods_target &Target,
   std::string_view TopDeviceStr = DeviceSubTuple[0];
 
   // Handle explicit device type (e.g. 'gpu').
-  auto DeviceTypeMap = getSyclDeviceTypeMap(
+  auto DeviceTypeMap = getSyclDeviceTypeMap<
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
       true /*Enable 'acc'*/
 #endif
-  ); // <-- std::array<std::pair<std::string,
-     // info::device::type>>
+      >(); // <-- std::array<std::pair<std::string,
+           // info::device::type>>
 
   auto It =
       std::find_if(std::begin(DeviceTypeMap), std::end(DeviceTypeMap),
@@ -266,11 +266,11 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
 std::ostream &operator<<(std::ostream &Out, const ods_target &Target) {
   Out << Target.Backend;
   if (Target.DeviceType) {
-    auto DeviceTypeMap = getSyclDeviceTypeMap(
+    auto DeviceTypeMap = getSyclDeviceTypeMap<
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
         true /*Enable 'acc'*/
 #endif
-    );
+        >();
     auto Match = std::find_if(
         DeviceTypeMap.begin(), DeviceTypeMap.end(),
         [&](auto Pair) { return (Pair.second == Target.DeviceType); });
@@ -344,11 +344,11 @@ device_filter::device_filter(const std::string &FilterString) {
     DeviceType = info::device_type::all;
   } else {
     auto Iter = std::find_if(
-        std::begin(getSyclDeviceTypeMap(true /*Enable 'acc'*/)),
-        std::end(getSyclDeviceTypeMap(true /*Enable 'acc'*/)), FindElement);
+        std::begin(getSyclDeviceTypeMap<true /*Enable 'acc'*/>()),
+        std::end(getSyclDeviceTypeMap<true /*Enable 'acc'*/>()), FindElement);
     // If no match is found, set device_type 'all',
     // which actually means 'any device_type' will be a match.
-    if (Iter == getSyclDeviceTypeMap(true /*Enable 'acc'*/).end())
+    if (Iter == getSyclDeviceTypeMap<true /*Enable 'acc'*/>().end())
       DeviceType = info::device_type::all;
     else {
       DeviceType = Iter->second;

--- a/sycl/unittests/allowlist/ParseAllowList.cpp
+++ b/sycl/unittests/allowlist/ParseAllowList.cpp
@@ -179,7 +179,7 @@ TEST(ParseAllowListTests, CheckAllValidBackendNameValuesAreProcessed) {
 TEST(ParseAllowListTests, CheckAllValidDeviceTypeValuesAreProcessed) {
   std::string AllowList;
   for (const auto &SyclDeviceType :
-       sycl::detail::getSyclDeviceTypeMap(true /*Enable 'acc'*/)) {
+       sycl::detail::getSyclDeviceTypeMap<true /*Enable 'acc'*/>()) {
     if (!AllowList.empty())
       AllowList += "|";
     AllowList += "DeviceType:" + SyclDeviceType.first;


### PR DESCRIPTION
The output of getSyclDeviceTypeMap() is different for SYCL_DEVICE_ALLOWLIST and ONEAPI_DEVICE_SELECTOR. However, currently, we return a reference to a 'static const' type, which causes calls to getSyclDeviceTypeMap() return the same value, irrespective of 'supportAcc'. This results in several test failures.

This PR makes 'supportAcc' a template parameter instead.