### PR TITLE
[UR][L0] Fix the multi device event cache to allocate lists as pointers

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,14 +56,8 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 24078c26ab871572067f520d856f4c65271cb9e5
-  # Merge: 227a5edf 89a66af7
-  # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Mon Feb 19 11:51:49 2024 +0100
-  #     Merge pull request #1299 from rafbiels/rafbiels/fix-cuda-maxreg-check
-  #     [CUDA] Fix MaxRegsPerBlock check in setKernelParams
-  set(UNIFIED_RUNTIME_TAG 24078c26ab871572067f520d856f4c65271cb9e5)
+  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
+  set(UNIFIED_RUNTIME_TAG 123c00f129e19db34c987990f13c336e5bef2db1)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -56,8 +56,14 @@ endif()
 if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/nrspruit/unified-runtime.git")
-  set(UNIFIED_RUNTIME_TAG 123c00f129e19db34c987990f13c336e5bef2db1)
+  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  # commit b4150ad1512476eb6ea0f2ede3bd29a6e3fd2b9e
+  # Merge: 4814e717 123c00f1
+  # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+  # Date:   Thu Feb 22 10:42:39 2024 +0000
+  #     Merge pull request #1366 from nrspruit/fix_multidevice_event_cache
+  #     [L0] Fix the multi device event cache to allocate lists as pointers
+  set(UNIFIED_RUNTIME_TAG b4150ad1512476eb6ea0f2ede3bd29a6e3fd2b9e)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
- fix to address a multi device crash given many devices causing a stack overflow. Event Caches per device are now explicitly allocated.

- pre-commit PR for https://github.com/oneapi-src/unified-runtime/pull/1366