### PR TITLE
[CI][Devops]enable OSSF scorecard workflow to run on intel/llvm

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -22,7 +22,7 @@ jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
-    if: github.repository == 'llvm/llvm-project'
+    if: github.repository == 'intel/llvm'
     permissions:
       # Needed to upload the results to code-scanning dashboard.
       security-events: write


### PR DESCRIPTION
Enable the OSSF (https://github.com/ossf) scorecard workflow to run and generate the repo security score for tracking current repo security issues. 

Currently enabled to run nightly while we resolve any open issues, will then move to weekly once clean runs. 