### PR TITLE
[SYCL] Don't set PI_USM_INDIRECT_ACCESS if platform don't support it

### DIFF
--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -27,8 +27,11 @@ kernel_impl::kernel_impl(sycl::detail::pi::PiKernel Kernel,
   // Enable USM indirect access for interoperability kernels.
   // Some PI Plugins (like OpenCL) require this call to enable USM
   // For others, PI will turn this into a NOP.
-  getPlugin()->call<PiApiKind::piKernelSetExecInfo>(
-      MKernel, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
+  if (Context->getPlatformImpl()->getBackend() != backend::opencl ||
+      Context->getPlatformImpl()->has_extension(
+          "cl_intel_unified_shared_memory"))
+    getPlugin()->call<PiApiKind::piKernelSetExecInfo>(
+        MKernel, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
 
   // This constructor is only called in the interoperability kernel constructor.
   MIsInterop = true;

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -402,8 +402,12 @@ program_impl::get_pi_kernel_arg_mask_pair(const std::string &KernelName) const {
 
     // Some PI Plugins (like OpenCL) require this call to enable USM
     // For others, PI will turn this into a NOP.
-    Plugin->call<PiApiKind::piKernelSetExecInfo>(
-        Result.first, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
+    if (getContextImplPtr()->getPlatformImpl()->getBackend() !=
+            backend::opencl ||
+        getContextImplPtr()->getPlatformImpl()->has_extension(
+            "cl_intel_unified_shared_memory"))
+      Plugin->call<PiApiKind::piKernelSetExecInfo>(
+          Result.first, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
 
     return Result;
 }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -689,10 +689,15 @@ ProgramManager::getOrCreateKernel(const ContextImplPtr &ContextImpl,
     Plugin->call<errc::kernel_not_supported, PiApiKind::piKernelCreate>(
         Program, KernelName.c_str(), &Kernel);
 
-    // Some PI Plugins (like OpenCL) require this call to enable USM
-    // For others, PI will turn this into a NOP.
-    Plugin->call<PiApiKind::piKernelSetExecInfo>(Kernel, PI_USM_INDIRECT_ACCESS,
-                                                 sizeof(pi_bool), &PI_TRUE);
+    // Only set PI_USM_INDIRECT_ACCESS if the platform can handle it.
+    if (ContextImpl->getPlatformImpl()->getBackend() != backend::opencl ||
+        ContextImpl->getPlatformImpl()->has_extension(
+            "cl_intel_unified_shared_memory")) {
+      // Some PI Plugins (like OpenCL) require this call to enable USM
+      // For others, PI will turn this into a NOP.
+      Plugin->call<PiApiKind::piKernelSetExecInfo>(
+          Kernel, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
+    }
 
     const KernelArgMask *ArgMask = nullptr;
     if (!m_UseSpvFile)
@@ -2361,8 +2366,11 @@ ProgramManager::getOrCreateKernel(const context &Context,
     Plugin->call<PiApiKind::piKernelCreate>(Program, KernelName.c_str(),
                                             &Kernel);
 
-    Plugin->call<PiApiKind::piKernelSetExecInfo>(Kernel, PI_USM_INDIRECT_ACCESS,
-                                                 sizeof(pi_bool), &PI_TRUE);
+    // Only set PI_USM_INDIRECT_ACCESS if the platform can handle it.
+    if (Ctx->getPlatformImpl()->getBackend() != backend::opencl ||
+        Ctx->getPlatformImpl()->has_extension("cl_intel_unified_shared_memory"))
+      Plugin->call<PiApiKind::piKernelSetExecInfo>(
+          Kernel, PI_USM_INDIRECT_ACCESS, sizeof(pi_bool), &PI_TRUE);
 
     // Ignore possible m_UseSpvFile for now.
     // TODO consider making m_UseSpvFile interact with kernel bundles as well.


### PR DESCRIPTION
If the OpenCL platform doesn't support USM, don't set PI_USM_INDIRECT_ACCESS exec info. This will avoid SYCL program to fail when they don't use USM. If the program do need USM support, the runtime will fail on other API calls (like memory allocation).