### PR TITLE
[SYCL][DOC] Update marray specification

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
@@ -205,7 +205,7 @@ public:
 
   /// Compares complex numbers z and w and returns true if they are different, otherwise false.
   friend constexpr bool operator!=(const complex<value_type> &z, const complex<value_type> &w);
-  ///Compares complex number z and real y and returns true if they are different, otherwise false.
+  /// Compares complex number z and real y and returns true if they are different, otherwise false.
   friend constexpr bool operator!=(const complex<value_type> &z, value_type y);
   /// Compares real x and complex number w and returns true if they are different, otherwise false.
   friend constexpr bool operator!=(value_type x, const complex<value_type> &w);

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
@@ -249,70 +249,70 @@ public:
 
   /* ... */
 
-  /// Adds and assigns marray rhs to marray lhs.
+  /// Adds marray rhs to marray lhs and assigns the result to lhs.
   friend marray &operator +=(marray &lhs, const marray &rhs);
-  /// Adds and assigns complex number rhs to marray lhs.
+  /// Adds complex number rhs to marray lhs and assigns the result to lhs.
   friend marray &operator +=(marray &lhs, const value_type &rhs);
 
-  /// Subtracts and assigns marray rhs to marray lhs.
+  /// Subtracts marray rhs from marray lhs and assigns the result to lhs.
   friend marray &operator -=(marray &lhs, const marray &rhs);
-  /// Subtracts and assigns complex number rhs to marray lhs.
+  /// Subtracts complex number rhs from marray lhs and assigns the result to lhs.
   friend marray &operator -=(marray &lhs, const value_type &rhs);
 
-  /// Multiplies and assigns marray rhs to marray lhs.
+  /// Multiplies marray rhs to marray lhs and assigns the result to lhs.
   friend marray &operator *=(marray &lhs, const marray &rhs);
-  /// Multiplies and assigns complex number rhs to marray lhs.
+  /// Multiplies complex number rhs to marray lhs and assigns the result to lhs.
   friend marray &operator *=(marray &lhs, const value_type &rhs);
 
-  /// Divides and assigns marray rhs to marray lhs.
+  /// Divides marray lhs by marray rhs and assigns the result to lhs.
   friend marray &operator /=(marray &lhs, const marray &rhs);
-  /// Divides and assigns complex number rhs to marray lhs.
+  /// Divides marray lhs by complex number rhs and assigns the result to lhs.
   friend marray &operator /=(marray &lhs, const value_type &rhs);
 
-  /// Adds marray rhs and marray lhs and returns the result.
+  /// Adds marray rhs to marray lhs and returns the result.
   friend marray operator +(const marray &lhs, const marray &rhs);
-  /// Adds complex number rhs and marray lhs and returns the result.
+  /// Adds complex number rhs to marray lhs and returns the result.
   friend marray operator +(const marray &lhs, const value_type &rhs);
-  /// Adds marray rhs and complex number lhs and returns the result.
+  /// Adds marray rhs to complex number lhs and returns the result.
   friend marray operator +(const value_type &lhs, const marray &rhs);
-  /// Returns a copy of the input marray.
+  /// Returns a copy of marray lhs.
   friend marray operator +(const marray &lhs);
 
-  /// Subtracts marray rhs and marray lhs and returns the result.
+  /// Subtracts marray rhs from marray lhs and returns the result.
   friend marray operator -(const marray &lhs, const marray &rhs);
-  /// Subtracts complex number rhs and marray lhs and returns the result.
+  /// Subtracts complex number rhs from marray lhs and returns the result.
   friend marray operator -(const marray &lhs, const value_type &rhs);
-  /// Subtracts marray rhs and complex number lhs and returns the result.
+  /// Subtracts marray rhs from complex number lhs and returns the result.
   friend marray operator -(const value_type &lhs, const marray &rhs);
-  /// Negates each element of the input marray.
+  /// Negates each element of marray lhs.
   friend marray operator -(const marray &lhs);
 
-  /// Mulitplies marray rhs and marray lhs and returns the result.
+  /// Multiplies marray rhs to marray lhs and returns the result.
   friend marray operator *(const marray &lhs, const marray &rhs);
-  /// Multiplies complex number rhs and marray lhs and returns the result.
+  /// Multiplies complex number rhs to marray lhs and returns the result.
   friend marray operator *(const marray &lhs, const value_type &rhs);
-  /// Multiplies marray rhs and complex number lhs and returns the result.
+  /// Multiplies marray rhs to complex number lhs and returns the result.
   friend marray operator *(const value_type &lhs, const marray &rhs);
 
-  /// Divides marray rhs and marray lhs and returns the result.
+  /// Divides marray lhs by marray rhs and returns the result.
   friend marray operator /(const marray &lhs, const marray &rhs);
-  /// Divides complex number rhs and marray lhs and returns the result.
+  /// Divides marray lhs by complex number rhs and returns the result.
   friend marray operator /(const marray &lhs, const value_type &rhs);
-  /// Divides marray rhs and complex number lhs and returns the result.
+  /// Divides complex number lhs by marray rhs and returns the result.
   friend marray operator /(const value_type &lhs, const marray &rhs);
 
-  /// Compares marray rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
+  /// Compares marray rhs to marray lhs and returns an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
   friend marray<bool, NumElements> operator ==(const marray &lhs, const marray &rhs);
-  /// Compares complex number rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
+  /// Compares complex number rhs to marray lhs and returns an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
   friend marray<bool, NumElements> operator ==(const marray &lhs, const value_type &rhs);
-  /// Compares marray rhs and complex number lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
+  /// Compares marray rhs to complex number lhs and returns an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
   friend marray<bool, NumElements> operator ==(const value_type &lhs, const marray &rhs);
 
-  /// Compares marray rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
+  /// Compares marray rhs to marray lhs and returns an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
   friend marray<bool, NumElements> operator !=(const marray &lhs, const marray &rhs);
-  /// Compares complex number rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
+  /// Compares complex number rhs to marray lhs and returns an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
   friend marray<bool, NumElements> operator !=(const marray &lhs, const value_type &rhs);
-  /// Compares marray rhs and complex number lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs dffers, otherwise false.
+  /// Compares marray rhs to complex number lhs and returns an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
   friend marray<bool, NumElements> operator !=(const value_type &lhs, const marray &rhs);
 
   /* ... */

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
@@ -324,7 +324,6 @@ public:
 
   friend marray &operator %=(marray &lhs, const marray &rhs) = delete;
   friend marray &operator %=(marray &lhs, const value_type &rhs) = delete;
-  friend marray &operator %=(value_type &lhs, const marray &rhs) = delete;
 
   friend marray operator ++(marray &lhs, int) = delete;
   friend marray &operator ++(marray &lhs) = delete;
@@ -332,26 +331,32 @@ public:
   friend marray operator --(marray &lhs, int) = delete;
   friend marray &operator --(marray &lhs) = delete;
 
+  friend marray &operator +=(marray &lhs) = delete;
+  friend marray operator  +=(marray &lhs, int) = delete;
+
+  friend marray &operator -=(marray &lhs) = delete;
+  friend marray operator  -=(marray &lhs, int) = delete;
+
   friend marray operator &(const marray &lhs, const marray &rhs) = delete;
   friend marray operator &(const marray &lhs, const value_type &rhs) = delete;
+  friend marray operator &(const value_type &lhs, const marray &rhs) = delete;
 
   friend marray operator |(const marray &lhs, const marray &rhs) = delete;
   friend marray operator |(const marray &lhs, const value_type &rhs) = delete;
+  friend marray operator |(const value_type &lhs, const marray &rhs) = delete;
 
   friend marray operator ^(const marray &lhs, const marray &rhs) = delete;
   friend marray operator ^(const marray &lhs, const value_type &rhs) = delete;
+  friend marray operator ^(const value_type &lhs, const marray &rhs) = delete;
 
   friend marray &operator &=(marray &lhs, const marray &rhs) = delete;
   friend marray &operator &=(marray &lhs, const value_type &rhs) = delete;
-  friend marray &operator &=(value_type &lhs, const marray &rhs) = delete;
 
   friend marray &operator |=(marray &lhs, const marray &rhs) = delete;
   friend marray &operator |=(marray &lhs, const value_type &rhs) = delete;
-  friend marray &operator |=(value_type &lhs, const marray &rhs) = delete;
 
   friend marray &operator ^=(marray &lhs, const marray &rhs) = delete;
   friend marray &operator ^=(marray &lhs, const value_type &rhs) = delete;
-  friend marray &operator ^=(value_type &lhs, const marray &rhs) = delete;
 
   friend marray<bool, NumElements> operator <<(const marray &lhs, const marray &rhs) = delete;
   friend marray<bool, NumElements> operator <<(const marray &lhs, const value_type &rhs) = delete;
@@ -382,6 +387,14 @@ public:
   friend marray<bool, NumElements> operator >=(const marray &lhs, const marray &rhs) = delete;
   friend marray<bool, NumElements> operator >=(const marray &lhs, const value_type &rhs) = delete;
   friend marray<bool, NumElements> operator >=(const value_type &lhs, const marray &rhs) = delete;
+
+  friend marray<bool, NumElements> operator &&(const marray &lhs, const marray &hhs) = delete;
+  friend marray<bool, NumElements> operator &&(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator &&(const value_type &lhs, const marray &rhs) = delete;
+
+  friend marray<bool, NumElements> operator ||(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator ||(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator ||(const value_type &lhs, const marray &rhs) = delete;
 
   friend marray operator ~(const marray &lhs) = delete;
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
@@ -257,10 +257,10 @@ public:
   friend marray &operator %=(value_type &lhs, const marray &rhs) = delete;
 
   friend marray operator ++(marray &lhs, int) = delete;
-  friend marray &operator ++(marray & rhs) = delete;
+  friend marray &operator ++(marray &lhs) = delete;
 
   friend marray operator --(marray &lhs, int) = delete;
-  friend marray &operator --(marray & rhs) = delete;
+  friend marray &operator --(marray &lhs) = delete;
 
   friend marray operator &(const marray &lhs, const marray &rhs) = delete;
   friend marray operator &(const marray &lhs, const value_type &rhs) = delete;
@@ -271,51 +271,51 @@ public:
   friend marray operator ^(const marray &lhs, const marray &rhs) = delete;
   friend marray operator ^(const marray &lhs, const value_type &rhs) = delete;
 
-  friend marray &operator &=(marray & lhs, const marray & rhs) = delete;
-  friend marray &operator &=(marray & lhs, const value_type & rhs) = delete;
-  friend marray &operator &=(value_type & lhs, const marray & rhs) = delete;
+  friend marray &operator &=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator &=(marray &lhs, const value_type &rhs) = delete;
+  friend marray &operator &=(value_type &lhs, const marray &rhs) = delete;
 
-  friend marray &operator |=(marray & lhs, const marray & rhs) = delete;
-  friend marray &operator |=(marray & lhs, const value_type & rhs) = delete;
-  friend marray &operator |=(value_type & lhs, const marray & rhs) = delete;
+  friend marray &operator |=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator |=(marray &lhs, const value_type &rhs) = delete;
+  friend marray &operator |=(value_type &lhs, const marray &rhs) = delete;
 
-  friend marray &operator ^=(marray & lhs, const marray & rhs) = delete;
-  friend marray &operator ^=(marray & lhs, const value_type & rhs) = delete;
-  friend marray &operator ^=(value_type & lhs, const marray & rhs) = delete;
+  friend marray &operator ^=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator ^=(marray &lhs, const value_type &rhs) = delete;
+  friend marray &operator ^=(value_type &lhs, const marray &rhs) = delete;
 
-  friend marray<bool, NumElements> operator <<(const marray & lhs, const marray & rhs) = delete;
-  friend marray<bool, NumElements> operator <<(const marray & lhs, const value_type & rhs) = delete;
-  friend marray<bool, NumElements> operator <<(const value_type & lhs, const marray & rhs) = delete;
+  friend marray<bool, NumElements> operator <<(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator <<(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator <<(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray<bool, NumElements> operator >>(const marray & lhs, const marray & rhs) = delete;
-  friend marray<bool, NumElements> operator >>(const marray & lhs, const value_type & rhs) = delete;
-  friend marray<bool, NumElements> operator >>(const value_type & lhs, const marray & rhs) = delete;
+  friend marray<bool, NumElements> operator >>(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator >>(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator >>(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray &operator <<=(marray & lhs, const marray & rhs) = delete;
-  friend marray &operator <<=(marray & lhs, const value_type & rhs) = delete;
+  friend marray &operator <<=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator <<=(marray &lhs, const value_type &rhs) = delete;
 
-  friend marray &operator >>=(marray & lhs, const marray & rhs) = delete;
-  friend marray &operator >>=(marray & lhs, const value_type & rhs) = delete;
+  friend marray &operator >>=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator >>=(marray &lhs, const value_type &rhs) = delete;
 
-  friend marray<bool, NumElements> operator <(const marray & lhs, const marray & rhs) = delete;
-  friend marray<bool, NumElements> operator <(const marray & lhs, const value_type & rhs) = delete;
-  friend marray<bool, NumElements> operator <(const value_type & lhs, const marray & rhs) = delete;
+  friend marray<bool, NumElements> operator <(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator <(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator <(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray<bool, NumElements> operator >(const marray & lhs, const marray & rhs) = delete;
-  friend marray<bool, NumElements> operator >(const marray & lhs, const value_type & rhs) = delete;
-  friend marray<bool, NumElements> operator >(const value_type & lhs, const marray & rhs) = delete;
+  friend marray<bool, NumElements> operator >(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator >(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator >(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray<bool, NumElements> operator <=(const marray & lhs, const marray & rhs) = delete;
-  friend marray<bool, NumElements> operator <=(const marray & lhs, const value_type & rhs) = delete;
-  friend marray<bool, NumElements> operator <=(const value_type & lhs, const marray & rhs) = delete;
+  friend marray<bool, NumElements> operator <=(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator <=(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator <=(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray<bool, NumElements> operator >=(const marray & lhs, const marray & rhs) = delete;
-  friend marray<bool, NumElements> operator >=(const marray & lhs, const value_type & rhs) = delete;
-  friend marray<bool, NumElements> operator >=(const value_type & lhs, const marray & rhs) = delete;
+  friend marray<bool, NumElements> operator >=(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator >=(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator >=(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray operator ~(const marray &v) = delete;
+  friend marray operator ~(const marray &lhs) = delete;
 
-  friend marray<bool, NumElements> operator !(const marray &v) = delete;
+  friend marray<bool, NumElements> operator !(const marray &lhs) = delete;
 };
 
 } // namespace sycl

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
@@ -269,17 +269,14 @@ public:
   /// Divides and assigns complex number rhs to marray lhs.
   friend marray &operator /=(marray &lhs, const value_type &rhs);
 
-  /// Returns a copy of the input marray.
-  friend marray operator +(const marray &lhs);
-  /// Negates each element of the input marray.
-  friend marray operator -(const marray &lhs);
-
   /// Adds marray rhs and marray lhs and returns the result.
   friend marray operator +(const marray &lhs, const marray &rhs);
   /// Adds complex number rhs and marray lhs and returns the result.
   friend marray operator +(const marray &lhs, const value_type &rhs);
   /// Adds marray rhs and complex number lhs and returns the result.
   friend marray operator +(const value_type &lhs, const marray &rhs);
+  /// Returns a copy of the input marray.
+  friend marray operator +(const marray &lhs);
 
   /// Subtracts marray rhs and marray lhs and returns the result.
   friend marray operator -(const marray &lhs, const marray &rhs);
@@ -287,6 +284,8 @@ public:
   friend marray operator -(const marray &lhs, const value_type &rhs);
   /// Subtracts marray rhs and complex number lhs and returns the result.
   friend marray operator -(const value_type &lhs, const marray &rhs);
+  /// Negates each element of the input marray.
+  friend marray operator -(const marray &lhs);
 
   /// Mulitplies marray rhs and marray lhs and returns the result.
   friend marray operator *(const marray &lhs, const marray &rhs);
@@ -318,24 +317,41 @@ public:
 
   /* ... */
 
-  friend marray operator %(const marray &lhs, const marray &rhs) = delete;
-  friend marray operator %(const marray &lhs, const value_type &rhs) = delete;
-  friend marray operator %(const value_type &lhs, const marray &rhs) = delete;
-
   friend marray &operator %=(marray &lhs, const marray &rhs) = delete;
   friend marray &operator %=(marray &lhs, const value_type &rhs) = delete;
 
-  friend marray operator ++(marray &lhs, int) = delete;
-  friend marray &operator ++(marray &lhs) = delete;
+  friend marray &operator &=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator &=(marray &lhs, const value_type &rhs) = delete;
 
-  friend marray operator --(marray &lhs, int) = delete;
+  friend marray &operator |=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator |=(marray &lhs, const value_type &rhs) = delete;
+
+  friend marray &operator ^=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator ^=(marray &lhs, const value_type &rhs) = delete;
+
+  friend marray &operator <<=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator <<=(marray &lhs, const value_type &rhs) = delete;
+
+  friend marray &operator >>=(marray &lhs, const marray &rhs) = delete;
+  friend marray &operator >>=(marray &lhs, const value_type &rhs) = delete;
+
+  friend marray &operator ++(marray &lhs) = delete;
+  friend marray operator ++(marray &lhs, int) = delete;
+
   friend marray &operator --(marray &lhs) = delete;
+  friend marray operator --(marray &lhs, int) = delete;
 
   friend marray &operator +=(marray &lhs) = delete;
   friend marray operator  +=(marray &lhs, int) = delete;
 
   friend marray &operator -=(marray &lhs) = delete;
   friend marray operator  -=(marray &lhs, int) = delete;
+
+  friend marray operator %(const marray &lhs, const marray &rhs) = delete;
+  friend marray operator %(const marray &lhs, const value_type &rhs) = delete;
+  friend marray operator %(const value_type &lhs, const marray &rhs) = delete;
+
+  friend marray operator ~(const marray &lhs) = delete;
 
   friend marray operator &(const marray &lhs, const marray &rhs) = delete;
   friend marray operator &(const marray &lhs, const value_type &rhs) = delete;
@@ -349,15 +365,6 @@ public:
   friend marray operator ^(const marray &lhs, const value_type &rhs) = delete;
   friend marray operator ^(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray &operator &=(marray &lhs, const marray &rhs) = delete;
-  friend marray &operator &=(marray &lhs, const value_type &rhs) = delete;
-
-  friend marray &operator |=(marray &lhs, const marray &rhs) = delete;
-  friend marray &operator |=(marray &lhs, const value_type &rhs) = delete;
-
-  friend marray &operator ^=(marray &lhs, const marray &rhs) = delete;
-  friend marray &operator ^=(marray &lhs, const value_type &rhs) = delete;
-
   friend marray<bool, NumElements> operator <<(const marray &lhs, const marray &rhs) = delete;
   friend marray<bool, NumElements> operator <<(const marray &lhs, const value_type &rhs) = delete;
   friend marray<bool, NumElements> operator <<(const value_type &lhs, const marray &rhs) = delete;
@@ -366,11 +373,15 @@ public:
   friend marray<bool, NumElements> operator >>(const marray &lhs, const value_type &rhs) = delete;
   friend marray<bool, NumElements> operator >>(const value_type &lhs, const marray &rhs) = delete;
 
-  friend marray &operator <<=(marray &lhs, const marray &rhs) = delete;
-  friend marray &operator <<=(marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator !(const marray &lhs) = delete;
 
-  friend marray &operator >>=(marray &lhs, const marray &rhs) = delete;
-  friend marray &operator >>=(marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator &&(const marray &lhs, const marray &hhs) = delete;
+  friend marray<bool, NumElements> operator &&(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator &&(const value_type &lhs, const marray &rhs) = delete;
+
+  friend marray<bool, NumElements> operator ||(const marray &lhs, const marray &rhs) = delete;
+  friend marray<bool, NumElements> operator ||(const marray &lhs, const value_type &rhs) = delete;
+  friend marray<bool, NumElements> operator ||(const value_type &lhs, const marray &rhs) = delete;
 
   friend marray<bool, NumElements> operator <(const marray &lhs, const marray &rhs) = delete;
   friend marray<bool, NumElements> operator <(const marray &lhs, const value_type &rhs) = delete;
@@ -387,18 +398,6 @@ public:
   friend marray<bool, NumElements> operator >=(const marray &lhs, const marray &rhs) = delete;
   friend marray<bool, NumElements> operator >=(const marray &lhs, const value_type &rhs) = delete;
   friend marray<bool, NumElements> operator >=(const value_type &lhs, const marray &rhs) = delete;
-
-  friend marray<bool, NumElements> operator &&(const marray &lhs, const marray &hhs) = delete;
-  friend marray<bool, NumElements> operator &&(const marray &lhs, const value_type &rhs) = delete;
-  friend marray<bool, NumElements> operator &&(const value_type &lhs, const marray &rhs) = delete;
-
-  friend marray<bool, NumElements> operator ||(const marray &lhs, const marray &rhs) = delete;
-  friend marray<bool, NumElements> operator ||(const marray &lhs, const value_type &rhs) = delete;
-  friend marray<bool, NumElements> operator ||(const value_type &lhs, const marray &rhs) = delete;
-
-  friend marray operator ~(const marray &lhs) = delete;
-
-  friend marray<bool, NumElements> operator !(const marray &lhs) = delete;
 };
 
 } // namespace sycl

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_complex.asciidoc
@@ -228,15 +228,16 @@ public:
 This proposal also introduces the specialization of the `sycl::marray` class to
 support SYCL `complex`. The `marray` class undergoes slight modification for
 this specialization, primarily involving the removal of operators that are
-inapplicable. No new functions or operators are introduced to the `marray`
-class.
+inapplicable and implementing the operators that are *only* supported by
+`complex<T>`.
+No new functions or operators are introduced to the `marray` class.
 
 The `complex`'s `marray` specialization maintains the principles of trivial
 copyability (as seen in the <<Complex Class, `complex` class description>>),
 with the `is_device_copyable` type trait resolving to `std::true_type`.
 
 The `marray` specialization for `complex<T>` deletes any operator that is not
-supported by `complex<T>`.
+supported by `complex<T>` and implements the ones supported.
 
 ```C++
 namespace sycl {
@@ -245,6 +246,75 @@ namespace sycl {
 template <typename T, std::size_t NumElements>
 class marray<sycl::ext::oneapi::experimental::complex<T>, NumElements> {
 public:
+
+  /* ... */
+
+  /// Adds and assigns marray rhs to marray lhs.
+  friend marray &operator +=(marray &lhs, const marray &rhs);
+  /// Adds and assigns complex number rhs to marray lhs.
+  friend marray &operator +=(marray &lhs, const value_type &rhs);
+
+  /// Subtracts and assigns marray rhs to marray lhs.
+  friend marray &operator -=(marray &lhs, const marray &rhs);
+  /// Subtracts and assigns complex number rhs to marray lhs.
+  friend marray &operator -=(marray &lhs, const value_type &rhs);
+
+  /// Multiplies and assigns marray rhs to marray lhs.
+  friend marray &operator *=(marray &lhs, const marray &rhs);
+  /// Multiplies and assigns complex number rhs to marray lhs.
+  friend marray &operator *=(marray &lhs, const value_type &rhs);
+
+  /// Divides and assigns marray rhs to marray lhs.
+  friend marray &operator /=(marray &lhs, const marray &rhs);
+  /// Divides and assigns complex number rhs to marray lhs.
+  friend marray &operator /=(marray &lhs, const value_type &rhs);
+
+  /// Returns a copy of the input marray.
+  friend marray operator +(const marray &lhs);
+  /// Negates each element of the input marray.
+  friend marray operator -(const marray &lhs);
+
+  /// Adds marray rhs and marray lhs and returns the result.
+  friend marray operator +(const marray &lhs, const marray &rhs);
+  /// Adds complex number rhs and marray lhs and returns the result.
+  friend marray operator +(const marray &lhs, const value_type &rhs);
+  /// Adds marray rhs and complex number lhs and returns the result.
+  friend marray operator +(const value_type &lhs, const marray &rhs);
+
+  /// Subtracts marray rhs and marray lhs and returns the result.
+  friend marray operator -(const marray &lhs, const marray &rhs);
+  /// Subtracts complex number rhs and marray lhs and returns the result.
+  friend marray operator -(const marray &lhs, const value_type &rhs);
+  /// Subtracts marray rhs and complex number lhs and returns the result.
+  friend marray operator -(const value_type &lhs, const marray &rhs);
+
+  /// Mulitplies marray rhs and marray lhs and returns the result.
+  friend marray operator *(const marray &lhs, const marray &rhs);
+  /// Multiplies complex number rhs and marray lhs and returns the result.
+  friend marray operator *(const marray &lhs, const value_type &rhs);
+  /// Multiplies marray rhs and complex number lhs and returns the result.
+  friend marray operator *(const value_type &lhs, const marray &rhs);
+
+  /// Divides marray rhs and marray lhs and returns the result.
+  friend marray operator /(const marray &lhs, const marray &rhs);
+  /// Divides complex number rhs and marray lhs and returns the result.
+  friend marray operator /(const marray &lhs, const value_type &rhs);
+  /// Divides marray rhs and complex number lhs and returns the result.
+  friend marray operator /(const value_type &lhs, const marray &rhs);
+
+  /// Compares marray rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
+  friend marray<bool, NumElements> operator ==(const marray &lhs, const marray &rhs);
+  /// Compares complex number rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
+  friend marray<bool, NumElements> operator ==(const marray &lhs, const value_type &rhs);
+  /// Compares marray rhs and complex number lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs are the same, otherwise false.
+  friend marray<bool, NumElements> operator ==(const value_type &lhs, const marray &rhs);
+
+  /// Compares marray rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
+  friend marray<bool, NumElements> operator !=(const marray &lhs, const marray &rhs);
+  /// Compares complex number rhs and marray lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs differs, otherwise false.
+  friend marray<bool, NumElements> operator !=(const marray &lhs, const value_type &rhs);
+  /// Compares marray rhs and complex number lhs, returning an marray of booleans where each element is true if the corresponding elements in lhs and rhs dffers, otherwise false.
+  friend marray<bool, NumElements> operator !=(const value_type &lhs, const marray &rhs);
 
   /* ... */
 


### PR DESCRIPTION
# Description

In response to feedback from @steffenlarsen on the specification implementation (https://github.com/intel/llvm/pull/8647), several adjustments were made:

- Corrected missing operators identified in the specification (See 3rd commit: https://github.com/intel/llvm/commit/3b3570487b59b331d0b6256f8a2e9bb1e8d96c68)
- Removed unnecessary operators initially added (See 3rd commit: https://github.com/intel/llvm/commit/3b3570487b59b331d0b6256f8a2e9bb1e8d96c68)
- Applied formatting and reordering for improved readability (See 1st and 4th commit: https://github.com/intel/llvm/commit/ff1f4e39fa8d0ee643dfeadedb9d0f7a1b30730a, https://github.com/intel/llvm/commit/7147da46423c5548129e8702fe6544bdf401de1b)

# Question

Additionally, I question the need to explicitly delete operators, considering they are not automatically generated nor inherited from the generic `marray`. I propose an approach to only include the necessary operators for implementation (See 2nd commit: https://github.com/intel/llvm/commit/300a22eea94237b956c93b4dcbff7827d4a8b287).

If agreed, the part that stipulates to delete the operators and the deleted operators in the inline code would be removed. (Explaining why this PR is a Draft)

If not, this raises a question for future implementers: Is it necessary to explicitly delete all operators, or can the declarations be omitted?