### PR TITLE
[SYCL][Matrix] Update builtin name for the checked matrix construct SPIR-V instruction

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -51,9 +51,9 @@ template <typename T, typename Tp, std::size_t R, std::size_t C,
           __spv::Scope::Flag S = __spv::Scope::Flag::Subgroup>
 extern __DPCPP_SYCL_EXTERNAL
     __spv::__spirv_JointMatrixINTEL<Tp, R, C, L, S, U> *
-    __spirv_CompositeConstructCheckedINTEL(const T Value, size_t Height,
-                                           size_t Stride, size_t Width,
-                                           size_t CoordX, size_t CoordY);
+    __spirv_CooperativeMatrixConstructCheckedINTEL(const T Value, size_t Height,
+                                                   size_t Stride, size_t Width,
+                                                   size_t CoordX, size_t CoordY);
 
 template <typename T, typename Tp, std::size_t R, std::size_t C,
           __spv::MatrixUse U,

--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-intel.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-intel.hpp
@@ -616,7 +616,7 @@ inline __SYCL_ALWAYS_INLINE void joint_matrix_fill_checked(
   using storage_element_type =
       typename oneapi::detail::jm_type_interpretation_helper_trait<
           T>::storage_element_type;
-  Res.spvm = __spirv_CompositeConstructCheckedINTEL<
+  Res.spvm = __spirv_CooperativeMatrixConstructCheckedINTEL<
       storage_element_type, T, NumRows, NumCols,
       spv_matrix_use_traits<Use>::value,
       spv_matrix_layout_traits<Layout>::value>(


### PR DESCRIPTION
In order to support OpCooperativeMatrixConstructCheckedINTEL instruction the builtin name must be updated to the corresponding spelling: __spirv_CooperativeMatrixConstructCheckedINTEL