### PR TITLE
[SYCL][Doc] Update free function queries extension

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -81,8 +81,8 @@ implementation supports.
 
 === Accessing instances of special SYCL classes
 
-The `sycl::ext::oneapi::this_kernel` namespace contains functionality related
-to the currently executing kernel.
+The `sycl::ext::oneapi::this_work_item` namespace contains functionality
+related to the currently executing kernel.
 
 It is the user's responsibility to ensure that these functions are called
 in a manner that is compatible with the kernel's launch parameters, as detailed
@@ -91,10 +91,7 @@ kernel results in undefined behavior.
 
 [source,c++]
 ----
-namespace sycl {
-namespace ext {
-namespace oneapi {
-namespace this_kernel {
+namespace sycl::ext::oneapi::this_work_item {
 
 template <int Dimensions>
 nd_item<Dimensions> get_nd_item();
@@ -104,9 +101,6 @@ group<Dimensions> get_work_group();
 
 sub_group get_sub_group();
 
-}
-}
-}
 }
 ----
 
@@ -206,20 +200,20 @@ is removed in a future version of the SYCL specification. _{endnote}_]
 template <int Dimensions>
 nd_item<Dimensions> get_nd_item();
 ____
-_Effects_: Equivalent to `return this_kernel::get_nd_item()`.
+_Effects_: Equivalent to `return this_work_item::get_nd_item()`.
 
 [source,c++]
 ----
 template <int Dimensions>
 group<Dimensions> get_group();
 ____
-_Effects_: Equivalent to `return this_kernel::get_work_group()`.
+_Effects_: Equivalent to `return this_work_item::get_work_group()`.
 
 [source,c++]
 ----
 sub_group get_sub_group();
 ____
-_Effects_: Equivalent to `return this_kernel::get_sub_group()`.
+_Effects_: Equivalent to `return this_work_item::get_sub_group()`.
 
 
 == Issues

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -44,9 +44,9 @@ SYCL specification refer to that revision.
 
 == Overview
 
-The extension allows to get `sycl::id`, `sycl::item`, `sycl::nd_item`,
-`sycl::group` and `sycl::sub_group` instances globally, without having to
-explicitly pass them as arguments to each function used on the device.
+The extension allows developers to access `sycl::nd_item`, `sycl::group` and
+`sycl::sub_group` instances globally, without having to explicitly pass them as
+arguments to each function used on the device.
 
 NOTE: Passing such instances as arguments can result in a clearer interface
 that is less error-prone to use. For example, if a function accepts a
@@ -95,14 +95,6 @@ namespace ext {
 namespace oneapi {
 namespace this_kernel {
 
-size_t get_linear_id();
-
-template <int Dimensions>
-id<Dimensions> get_id();
-
-template <int Dimensions>
-item<Dimensions, false> get_item();
-
 template <int Dimensions>
 nd_item<Dimensions> get_nd_item();
 
@@ -116,49 +108,6 @@ sub_group get_sub_group();
 }
 }
 ----
-
-[source,c++]
-----
-size_t get_linear_id();
-----
-_Preconditions_: The currently executing kernel must have been launched with a
-`sycl::range` or `sycl::nd_range` argument.
-
-_Returns_: A `size_t` representing the current work-item's linear position in
-the global iteration space. Multi-dimensional indices are converted into a
-linear index following the linearization equations defined in Section 3.11.1 of
-the SYCL 2020 specification.
-
-[source,c++]
-----
-template <int Dimensions>
-id<Dimensions> get_id();
-----
-_Preconditions_: `Dimensions` must match the dimensionality of the currently
-executing kernel. The currently executing kernel must have been launched with a
-`sycl::range` or `sycl::nd_range` argument.
-
-_Returns_: A `sycl::id` instance representing the current work-item in the
-global iteration space.
-
-[source,c++]
-----
-template <int Dimensions>
-item<Dimensions, false> get_item();
-----
-_Preconditions_: `Dimensions` must match the dimensionality of the currently
-executing kernel. The currently executing kernel must have been launched with a
-`sycl::range` or `sycl::nd_range` argument.
-
-_Returns_: A `sycl::item` instance representing the current work-item in the
-global iteration space.
-
-NOTE: The `offset` parameter to `parallel_for` is deprecated in SYCL 2020, as
-is the ability of an `item` to carry an offset. This extension returns an
-`item` where the `WithOffset` template parameter is set to `false` to prevent
-usage of the new queries in conjunction with deprecated functionality. The
-return type of `get_item()` is expected to change when the `offset` parameter
-is removed in a future version of the SYCL specification.
 
 [source,c++]
 ----

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -99,7 +99,7 @@ template <int Dimensions>
 nd_item<Dimensions> get_nd_item();
 
 template <int Dimensions>
-group<Dimensions> get_group();
+group<Dimensions> get_work_group();
 
 sub_group get_sub_group();
 
@@ -124,7 +124,7 @@ _Returns_: A `sycl::nd_item` instance representing the current work-item in a
 [source,c++]
 ----
 template <int Dimensions>
-group<Dimensions> get_group();
+group<Dimensions> get_work_group();
 ----
 _Preconditions_: `Dimensions` must match the dimensionality of the currently
 executing kernel. The currently executing kernel must have been launched with a

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -179,7 +179,7 @@ global iteration space.
 [source,c++]
 ----
 template <int Dimensions>
-item<Dimensions, false> get_item();
+item<Dimensions, false> this_item();
 ----
 _Preconditions_: `Dimensions` must match the dimensionality of the currently
 executing kernel. The currently executing kernel must have been launched with a
@@ -198,21 +198,21 @@ is removed in a future version of the SYCL specification. _{endnote}_]
 [source,c++]
 ----
 template <int Dimensions>
-nd_item<Dimensions> get_nd_item();
-____
+nd_item<Dimensions> this_nd_item();
+----
 _Effects_: Equivalent to `return this_work_item::get_nd_item()`.
 
 [source,c++]
 ----
 template <int Dimensions>
-group<Dimensions> get_group();
-____
+group<Dimensions> this_group();
+----
 _Effects_: Equivalent to `return this_work_item::get_work_group()`.
 
 [source,c++]
 ----
-sub_group get_sub_group();
-____
+sub_group this_sub_group();
+----
 _Effects_: Equivalent to `return this_work_item::get_sub_group()`.
 
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -43,6 +43,17 @@ references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
 
+== Status
+
+This is a proposed update to an existing extension.  Interfaces defined in this
+specification may not be implemented yet or may be in a preliminary state.  The
+specification itself may also change in incompatible ways before it is
+finalized.  *Shipping software products should not rely on APIs defined in this
+specification.*  See
+link:../experimental/sycl_ext_oneapi_free_function_queries.asciidoc[here] for
+the existing extension, which is implemented.
+
+
 == Overview
 
 The extension allows developers to access `sycl::nd_item`, `sycl::group` and

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -8,6 +8,7 @@
 :toc: left
 :encoding: utf-8
 :lang: en
+:dpcpp: pass:[DPC++]
 
 :blank: pass:[ +]
 
@@ -16,53 +17,30 @@
 // docbook uses c++ and html5 uses cpp.
 :language: {basebackend@docbook:c++:cpp}
 
-== Introduction
-IMPORTANT: This specification is a draft.
-
-NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by permission by Khronos.
-
-This document describes an extension that adds features for SYCL work items and groups to be available globally.
 
 == Notice
 
-Copyright (c) 2020-2021 Intel Corporation.  All rights reserved.
+[%hardbreaks]
+Copyright (C) 2020-2024 Intel Corporation.  All rights reserved.
 
-== Status
+Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
+of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by
+permission by Khronos.
 
-Working Draft
-
-This is a preview extension specification, intended to provide early access to a feature for review and community feedback. When the feature matures, this specification may be released as a formal extension.
-
-Because the interfaces defined by this specification are not final and are subject to change they are not intended to be used by shipping software products.
-
-== Version
-
-Revision: 1
 
 == Contact
-Ruslan Arutyunyan, Intel (ruslan 'dot' arutyunyan 'at' intel 'dot' com)
 
-John Pennycook, Intel (john 'dot' pennycook 'at' intel 'dot' com)
+To report problems with this extension, please open a new issue at:
+
+https://github.com/intel/llvm/issues
+
 
 == Dependencies
 
-This extension is written against the SYCL 2020 specification, Revision 4.
+This extension is written against the SYCL 2020 revision 8 specification.  All
+references below to the "core SYCL specification" or to section numbers in the
+SYCL specification refer to that revision.
 
-== Feature Test Macro
-
-This extension provides a feature-test macro as described in the core SYCL
-specification section 6.3.3 "Feature test macros". Therefore, an implementation
-supporting this extension must predefine the macro `SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES`
-to one of the values defined in the table below. Applications can test for the
-existence of this macro to determine if the implementation supports this
-feature, or applications can test the macro's value to determine which of the
-extension's APIs the implementation supports.
-
-[%header,cols="1,5"]
-|===
-|Value |Description
-|1     |Initial extension version. Base features are supported.
-|===
 
 == Overview
 
@@ -77,7 +55,30 @@ that is less error-prone to use. For example, if a function accepts a
 satisfied. It is recommended that this extension is used only when modifying
 existing interfaces is not feasible.
 
-== Accessing Instances of Special SYCL Classes
+
+== Specification
+
+=== Feature test macro
+
+This extension provides a feature-test macro as described in the core SYCL
+specification.  An implementation supporting this extension must predefine the
+macro `SYCL_EXT_ONEAPI_FREE_FUNCTION_QUERIES` to one of the values defined in
+the table below.  Applications can test for the existence of this macro to
+determine if the implementation supports this feature, or applications can test
+the macro's value to determine which of the extension's features the
+implementation supports.
+
+
+[%header,cols="1,5"]
+|===
+|Value
+|Description
+
+|1
+|Initial version of this extension.
+|===
+
+=== Accessing instances of special SYCL classes
 
 The `sycl::ext::oneapi::this_kernel` namespace contains functionality related
 to the currently executing kernel.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -143,6 +143,84 @@ _Preconditions_: The currently executing kernel must have been launched with a
 _Returns_: A `sycl::sub_group` instance representing the sub-group to which the
 current work-item belongs.
 
+=== Deprecated functionality
+
+The functionality in this section was previously part of an experimental
+version of this extension, but is now deprecated.
+
+[source,c++]
+----
+namespace sycl::ext::oneapi::experimental {
+
+template <int Dimensions>
+id<Dimensions> this_id();
+
+template <int Dimensions>
+item<Dimensions> this_item();
+
+template <int Dimensions>
+nd_item<Dimensions> this_nd_item();
+
+template <int Dimensions>
+group this_group();
+
+sub_group this_sub_group();
+
+}
+----
+
+[source,c++]
+----
+template <int Dimensions>
+id<Dimensions> this_id();
+----
+_Preconditions_: `Dimensions` must match the dimensionality of the currently
+executing kernel. The currently executing kernel must have been launched with a
+`sycl::range` or `sycl::nd_range` argument.
+
+_Returns_: A `sycl::id` instance representing the current work-item in the
+global iteration space.
+
+[source,c++]
+----
+template <int Dimensions>
+item<Dimensions, false> get_item();
+----
+_Preconditions_: `Dimensions` must match the dimensionality of the currently
+executing kernel. The currently executing kernel must have been launched with a
+`sycl::range` or `sycl::nd_range` argument.
+
+_Returns_: A `sycl::item` instance representing the current work-item in the
+global iteration space.
+
+NOTE: The `offset` parameter to `parallel_for` is deprecated in SYCL 2020, as
+is the ability of an `item` to carry an offset. This extension returns an
+`item` where the `WithOffset` template parameter is set to `false` to prevent
+usage of the new queries in conjunction with deprecated functionality. The
+return type of `get_item()` is expected to change when the `offset` parameter
+is removed in a future version of the SYCL specification.
+
+[source,c++]
+----
+template <int Dimensions>
+nd_item<Dimensions> get_nd_item();
+____
+_Effects_: Equivalent to `return this_kernel::get_nd_item()`.
+
+[source,c++]
+----
+template <int Dimensions>
+group<Dimensions> get_group();
+____
+_Effects_: Equivalent to `return this_kernel::get_work_group()`.
+
+[source,c++]
+----
+sub_group get_sub_group();
+____
+_Effects_: Equivalent to `return this_kernel::get_sub_group()`.
+
+
 == Issues
 
 . Can undefined behavior be avoided or detected?

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -9,6 +9,7 @@
 :encoding: utf-8
 :lang: en
 :dpcpp: pass:[DPC++]
+:endnote: &#8212;{nbsp}end{nbsp}note
 
 :blank: pass:[ +]
 
@@ -48,12 +49,12 @@ The extension allows developers to access `sycl::nd_item`, `sycl::group` and
 `sycl::sub_group` instances globally, without having to explicitly pass them as
 arguments to each function used on the device.
 
-NOTE: Passing such instances as arguments can result in a clearer interface
+[_Note:_ Passing such instances as arguments can result in a clearer interface
 that is less error-prone to use. For example, if a function accepts a
 `sycl::group`, the caller must assume that function may call a
 `sycl::group_barrier` and ensure that associated control flow requirements are
 satisfied. It is recommended that this extension is used only when modifying
-existing interfaces is not feasible.
+existing interfaces is not feasible. _{endnote}_]
 
 
 == Specification
@@ -193,12 +194,12 @@ executing kernel. The currently executing kernel must have been launched with a
 _Returns_: A `sycl::item` instance representing the current work-item in the
 global iteration space.
 
-NOTE: The `offset` parameter to `parallel_for` is deprecated in SYCL 2020, as
+[_Note:_ The `offset` parameter to `parallel_for` is deprecated in SYCL 2020, as
 is the ability of an `item` to carry an offset. This extension returns an
 `item` where the `WithOffset` template parameter is set to `false` to prevent
 usage of the new queries in conjunction with deprecated functionality. The
 return type of `get_item()` is expected to change when the `offset` parameter
-is removed in a future version of the SYCL specification.
+is removed in a future version of the SYCL specification. _{endnote}_]
 
 [source,c++]
 ----

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -151,7 +151,7 @@ template <int Dimensions>
 id<Dimensions> this_id();
 
 template <int Dimensions>
-item<Dimensions> this_item();
+item<Dimensions, false> this_item();
 
 template <int Dimensions>
 nd_item<Dimensions> this_nd_item();
@@ -191,9 +191,8 @@ global iteration space.
 [_Note:_ The `offset` parameter to `parallel_for` is deprecated in SYCL 2020, as
 is the ability of an `item` to carry an offset. This extension returns an
 `item` where the `WithOffset` template parameter is set to `false` to prevent
-usage of the new queries in conjunction with deprecated functionality. The
-return type of `get_item()` is expected to change when the `offset` parameter
-is removed in a future version of the SYCL specification. _{endnote}_]
+usage of the new queries in conjunction with deprecated
+functionality._{endnote}_]
 
 [source,c++]
 ----


### PR DESCRIPTION
- Removes get_linear_id(), get_id() and get_item()
- Renames get_group() to get_work_group()
- Adds deprecated functionality section
- Renames this_kernel namespace to this_work_item