### PR TITLE
[SYCL] vec<bfloat16> optimization fix

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -905,6 +905,8 @@ public:
   // Implement operator [] in the same way for host and device.
   // TODO: change host side implementation when underlying type for host side
   // will be changed to std::array.
+  // NOTE: aliasing on bfloat16 may lead to problems if aggressively optimized.
+  // specializing with noinline to avoid as workaround.
 
   template <typename T = DataT>
   typename std::enable_if<!std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
@@ -920,8 +922,8 @@ public:
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }
 
-#pragma clang optimize off
   template <typename T = DataT>
+  __attribute__((noinline))
   typename std::enable_if<std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
                           const DataT &>::type
   operator[](int i) const {
@@ -929,12 +931,12 @@ public:
   }
 
   template <typename T = DataT>
+  __attribute__((noinline))
   typename std::enable_if<std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
                           DataT &>::type
   operator[](int i) {
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }
-#pragma clang optimize on
 
   // Begin hi/lo, even/odd, xyzw, and rgba swizzles.
 private:

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -905,18 +905,18 @@ public:
   // Implement operator [] in the same way for host and device.
   // TODO: change host side implementation when underlying type for host side
   // will be changed to std::array.
-  // NOTE: aliasing on bfloat16 may lead to problems if aggressively optimized.
-  // specializing with noinline to avoid as workaround.
+  // NOTE: aliasing the incompatible types of bfloat16 may lead to problems if
+  // aggressively optimized. Specializing with noinline to avoid as workaround.
 
   template <typename T = DataT>
-  typename std::enable_if<!std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
+  typename std::enable_if<!std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
                           const DataT &>::type
   operator[](int i) const {
     return reinterpret_cast<const DataT *>(&m_Data)[i];
   }
 
   template <typename T = DataT>
-  typename std::enable_if<!std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
+  typename std::enable_if<!std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
                           DataT &>::type
   operator[](int i) {
     return reinterpret_cast<DataT *>(&m_Data)[i];
@@ -929,18 +929,22 @@ public:
 #endif
 
   template <typename T = DataT>
-  __SYCL_NOINLINE_BF16 typename std::enable_if<
-      std::is_same<T, sycl::ext::oneapi::bfloat16>::value, const DataT &>::type
-  operator[](int i) const {
+  __SYCL_NOINLINE_BF16
+      typename std::enable_if<std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
+                              const DataT &>::type
+      operator[](int i) const {
     return reinterpret_cast<const DataT *>(&m_Data)[i];
   }
 
   template <typename T = DataT>
-  __SYCL_NOINLINE_BF16 typename std::enable_if<
-      std::is_same<T, sycl::ext::oneapi::bfloat16>::value, DataT &>::type
-  operator[](int i) {
+  __SYCL_NOINLINE_BF16
+      typename std::enable_if<std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
+                              DataT &>::type
+      operator[](int i) {
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }
+
+#undef __SYCL_NOINLINE_BF16
 
   // Begin hi/lo, even/odd, xyzw, and rgba swizzles.
 private:

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -905,11 +905,36 @@ public:
   // Implement operator [] in the same way for host and device.
   // TODO: change host side implementation when underlying type for host side
   // will be changed to std::array.
-  const DataT &operator[](int i) const {
+
+  template <typename T = DataT>
+  typename std::enable_if<!std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
+                          const DataT &>::type
+  operator[](int i) const {
     return reinterpret_cast<const DataT *>(&m_Data)[i];
   }
 
-  DataT &operator[](int i) { return reinterpret_cast<DataT *>(&m_Data)[i]; }
+  template <typename T = DataT>
+  typename std::enable_if<!std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
+                          DataT &>::type
+  operator[](int i) {
+    return reinterpret_cast<DataT *>(&m_Data)[i];
+  }
+
+#pragma clang optimize off
+  template <typename T = DataT>
+  typename std::enable_if<std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
+                          const DataT &>::type
+  operator[](int i) const {
+    return reinterpret_cast<const DataT *>(&m_Data)[i];
+  }
+
+  template <typename T = DataT>
+  typename std::enable_if<std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
+                          DataT &>::type
+  operator[](int i) {
+    return reinterpret_cast<DataT *>(&m_Data)[i];
+  }
+#pragma clang optimize on
 
   // Begin hi/lo, even/odd, xyzw, and rgba swizzles.
 private:

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -909,15 +909,15 @@ public:
   // aggressively optimized. Specializing with noinline to avoid as workaround.
 
   template <typename T = DataT>
-  typename std::enable_if<!std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
-                          const DataT &>::type
+  typename std::enable_if_t<!std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
+                            const DataT &>
   operator[](int i) const {
     return reinterpret_cast<const DataT *>(&m_Data)[i];
   }
 
   template <typename T = DataT>
-  typename std::enable_if<!std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
-                          DataT &>::type
+  typename std::enable_if_t<!std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
+                            DataT &>
   operator[](int i) {
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }
@@ -930,16 +930,16 @@ public:
 
   template <typename T = DataT>
   __SYCL_NOINLINE_BF16
-      typename std::enable_if<std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
-                              const DataT &>::type
+      typename std::enable_if_t<std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
+                                const DataT &>
       operator[](int i) const {
     return reinterpret_cast<const DataT *>(&m_Data)[i];
   }
 
   template <typename T = DataT>
   __SYCL_NOINLINE_BF16
-      typename std::enable_if<std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
-                              DataT &>::type
+      typename std::enable_if_t<std::is_same_v<T, sycl::ext::oneapi::bfloat16>,
+                                DataT &>
       operator[](int i) {
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -922,18 +922,22 @@ public:
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }
 
+#ifdef _MSC_VER
+#define __SYCL_NOINLINE_BF16 __declspec(noinline)
+#else
+#define __SYCL_NOINLINE_BF16 __attribute__((noinline))
+#endif
+
   template <typename T = DataT>
-  __attribute__((noinline))
-  typename std::enable_if<std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
-                          const DataT &>::type
+  __SYCL_NOINLINE_BF16 typename std::enable_if<
+      std::is_same<T, sycl::ext::oneapi::bfloat16>::value, const DataT &>::type
   operator[](int i) const {
     return reinterpret_cast<const DataT *>(&m_Data)[i];
   }
 
   template <typename T = DataT>
-  __attribute__((noinline))
-  typename std::enable_if<std::is_same<T, sycl::ext::oneapi::bfloat16>::value,
-                          DataT &>::type
+  __SYCL_NOINLINE_BF16 typename std::enable_if<
+      std::is_same<T, sycl::ext::oneapi::bfloat16>::value, DataT &>::type
   operator[](int i) {
     return reinterpret_cast<DataT *>(&m_Data)[i];
   }

--- a/sycl/test-e2e/InvokeSimd/Spec/clang_run_error/sycl_vec_argument.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/clang_run_error/sycl_vec_argument.cpp
@@ -24,7 +24,7 @@ ESIMD_CALLEE(float *A, esimd::simd<float, VL> b, int i,
   esimd::simd<float, VL> a;
   a.copy_from(A + i);
   return a + b + v[i % VL];
-  // CHECK: {{.*}}error: function 'sycl::{{.*}}vec<{{.*}}' is not supported in ESIMD context{{.*}}
+  // CHECK: {{.*}}error: function '{{.*}}sycl::{{.*}}vec<{{.*}}' is not supported in ESIMD context{{.*}}
 }
 
 [[intel::device_indirectly_callable]] SYCL_EXTERNAL


### PR DESCRIPTION
bfloat16 type reinterpretation may cause problems when aggressive optimizations are employed. Splitting them off to avoid this.