### PR TITLE
[NFC][SYCL][Bindless] Define VERBOSE_PRINT before include user_types_common.hpp

### DIFF
--- a/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
@@ -4,12 +4,12 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 #include "user_types_common.hpp"
 #include <iostream>
 #include <sycl/sycl.hpp>
-
-// Uncomment to print additional test information
-// #define VERBOSE_PRINT
 
 // Returns true if test case was passed and validated
 template <typename MyType, int NElems, typename OutType,

--- a/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
@@ -4,12 +4,12 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Uncomment to print additional test information
+// #define VERBOSE_PRINT
+
 #include "user_types_common.hpp"
 #include <iostream>
 #include <sycl/sycl.hpp>
-
-// Uncomment to print additional test information
-// #define VERBOSE_PRINT
 
 template <typename MyType, int NElems, typename OutType,
           sycl::image_channel_order ChannelOrder,
@@ -146,24 +146,24 @@ int main() {
                sycl::image_channel_order::rg,
                sycl::image_channel_type::unsigned_int32, class myuint_2>();
 
-  printTestName("Running my_short4");
+  printTestName("Running my_ushort4");
   validated &=
       run_test<my_ushort4, 4, sycl::vec<uint16_t, 4>,
                sycl::image_channel_order::rgba,
                sycl::image_channel_type::unsigned_int16, class myushort_4>();
 
-  printTestName("Running my_short2");
+  printTestName("Running my_ushort2");
   validated &=
       run_test<my_ushort2, 2, sycl::vec<uint16_t, 2>,
                sycl::image_channel_order::rg,
                sycl::image_channel_type::unsigned_int16, class myushort_2>();
 
-  printTestName("Running my_char4");
+  printTestName("Running my_uchar4");
   validated &=
       run_test<my_uchar4, 4, sycl::vec<uint8_t, 4>,
                sycl::image_channel_order::rgba,
                sycl::image_channel_type::unsigned_int8, class myuchar_4>();
-  printTestName("Running my_char2");
+  printTestName("Running my_uchar2");
   validated &=
       run_test<my_uchar2, 2, sycl::vec<uint8_t, 2>,
                sycl::image_channel_order::rg,

--- a/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
@@ -86,6 +86,10 @@ bool run_test() {
 
     q.ext_oneapi_copy(imgMemoryOut.get_handle(), dataOut, desc);
     q.wait_and_throw();
+
+    syclexp::destroy_image_handle(unsampledImgIn, q);
+    syclexp::destroy_image_handle(sampledImgIn, q);
+    syclexp::destroy_image_handle(imgOut, q);
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what() << "\n";
     return false;


### PR DESCRIPTION
Because VERBOSE_PRINT is also used inside file user_types_common.hpp