### PR TITLE
[SYCL] Mark parallel_for_work_item even when called indirectly

### DIFF
--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -82,11 +82,15 @@ bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
     F.setMetadata(WG_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
     return true;
   case SYCLScopeAttr::Level::WorkItem:
+printf("In case\n");
+FD.dump();
     F.setMetadata(WI_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
-    if (isPFWI(FD))
+    if (isPFWI(FD)) {
       // also emit specific marker for parallel_for_work_item, as it needs to
       // be handled specially in the SYCL lowering pass
+printf("In if\n");
       F.setMetadata(PFWI_MD_ID, llvm::MDNode::get(F.getContext(), {}));
+    }
     return true;
   }
   llvm_unreachable("unknown sycl scope");

--- a/clang/lib/CodeGen/CGSYCLRuntime.cpp
+++ b/clang/lib/CodeGen/CGSYCLRuntime.cpp
@@ -82,15 +82,11 @@ bool CGSYCLRuntime::actOnFunctionStart(const FunctionDecl &FD,
     F.setMetadata(WG_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
     return true;
   case SYCLScopeAttr::Level::WorkItem:
-printf("In case\n");
-FD.dump();
     F.setMetadata(WI_SCOPE_MD_ID, llvm::MDNode::get(F.getContext(), {}));
-    if (isPFWI(FD)) {
+    if (isPFWI(FD))
       // also emit specific marker for parallel_for_work_item, as it needs to
       // be handled specially in the SYCL lowering pass
-printf("In if\n");
       F.setMetadata(PFWI_MD_ID, llvm::MDNode::get(F.getContext(), {}));
-    }
     return true;
   }
   llvm_unreachable("unknown sycl scope");

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -33,6 +33,10 @@ template <int dimensions = 1>
 class __SYCL_TYPE(group) group {
 public:
   group() = default; // fake constructor
+// Dummy parallel_for_work_item function to mimic calls from
+// parallel_for_work_group.
+  void parallel_for_work_item() {
+  }
 };
 
 namespace access {

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -33,8 +33,8 @@ template <int dimensions = 1>
 class __SYCL_TYPE(group) group {
 public:
   group() = default; // fake constructor
-// Dummy parallel_for_work_item function to mimic calls from
-// parallel_for_work_group.
+  // Dummy parallel_for_work_item function to mimic calls from
+  // parallel_for_work_group.
   void parallel_for_work_item() {
   }
 };

--- a/clang/test/CodeGenSYCL/sycl-pf-work-item.cpp
+++ b/clang/test/CodeGenSYCL/sycl-pf-work-item.cpp
@@ -1,0 +1,21 @@
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -internal-isystem %S/Inputs -emit-llvm %s -o - | FileCheck %s
+// This test checks if the parallel_for_work_item called indirecly from
+// parallel_for_work_group gets the work_item_scope marker on it.
+#include <sycl.hpp>
+
+void foo(sycl::group<1> work_group) {
+  work_group.parallel_for_work_item();
+}
+
+int main(int argc, char **argv) {
+  sycl::queue q;
+  q.submit([&](sycl::handler &cgh) {
+     cgh.parallel_for_work_group(
+         sycl::range<1>{1}, sycl::range<1>{1024}, ([=](sycl::group<1> wGroup) {
+           foo(wGroup);
+         }));
+   });
+  return 0;
+}
+
+// CHECK: define {{.*}} void @{{.*}}sycl{{.*}}group{{.*}}parallel_for_work_item{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) {{.*}}!work_item_scope {{.*}}!parallel_for_work_item


### PR DESCRIPTION
Previously, we would mark parallel_for_work_item FunctionDecl only
when called directly from a parallel_for_work_group region.  This
change marks it when called even indirectly.