### PR TITLE
[SYCL][E2E] Fix USM/usm_leak_check.cpp test for multi-card PVC

### DIFF
--- a/sycl/test-e2e/USM/usm_leak_check.cpp
+++ b/sycl/test-e2e/USM/usm_leak_check.cpp
@@ -5,9 +5,9 @@
 
 // RUN: %{build} -o %t.out
 
-// RUN: %{l0_leak_check} %{run} %t.out u 2>&1 | FileCheck %s --check-prefix CHECK-USM
-// RUN: %{l0_leak_check} %{run} %t.out s 2>&1 | FileCheck %s --check-prefix CHECK-SMALL-BUF
-// RUN: %{l0_leak_check} %{run} %t.out l 2>&1 | FileCheck %s --check-prefix CHECK-LARGE-BUF
+// RUN: %{l0_leak_check} %{run} %t.out u 2>&1 | FileCheck %s --implicit-check-not=LEAK
+// RUN: %{l0_leak_check} %{run} %t.out s 2>&1 | FileCheck %s --implicit-check-not=LEAK
+// RUN: %{l0_leak_check} %{run} %t.out l 2>&1 | FileCheck %s --implicit-check-not=LEAK
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
@@ -79,23 +79,3 @@ int main(int argc, char *argv[]) {
 
   return 0;
 }
-
-// Account for 4 extra allocations made by UMF to query page sizes
-
-// CHECK-USM: GPU will use {{zeMemAllocHost|zeMemAllocDevice}}
-// CHECK-USM: zeMemAllocDevice = 2
-// CHECK-USM:   zeMemAllocHost = 2
-// CHECK-USM: zeMemAllocShared = 3
-// CHECK-USM-SAME:   zeMemFree = 7
-
-// CHECK-SMALL-BUF: GPU will use [[API:zeMemAllocHost|zeMemAllocDevice]]
-// CHECK-SMALL-BUF: zeMemAllocDevice = {{1|2}}
-// CHECK-SMALL-BUF: zeMemAllocHost = {{1|2}}
-// CHECK-SMALL-BUF: zeMemAllocShared = 2
-// CHECK-SMALL-BUF-SAME: zeMemFree = 5
-
-// CHECK-LARGE-BUF: GPU will use [[API:zeMemAllocHost|zeMemAllocDevice]]
-// CHECK-LARGE-BUF: zeMemAllocDevice = {{1|4}}
-// CHECK-LARGE-BUF: zeMemAllocHost = {{1|4}}
-// CHECK-LARGE-BUF: zeMemAllocShared = 2
-// CHECK-LARGE-BUF-SAME: zeMemFree = 7


### PR DESCRIPTION
**Problem:**
USM/usm_leak_check.cpp fails on multi-card PVC because the number of zeMemAlloc* and zeMemFree calls doesn't match what the test expects. This is mainly because of the recent changes to USM memory allocation, like a different memory pool logic.

**Proposed Fix**
Since the objective of this test is to just check for USM leaks, I don't think that we even have to check the output of UR_L0_LEAKS_DEBUG=1. It is my understanding that UR_L0_LEAKS_DEBUG=1 will abort upon finding a mismatch in the number of alloc/free calls. So, this PR removes explicit checks for zeMemAlloc* and zeMemFree calls.