### PR TITLE
[SYCL] Partially revert "Sort platforms in platform::get_platforms() (#12719)"

### DIFF
--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -203,31 +203,6 @@ std::vector<platform> platform_impl::get_platforms() {
   // may be initialized after.
   GlobalHandler::registerDefaultContextReleaseHandler();
 
-  // Some applications/libraries prefer to implement their own device selection
-  // and default to just providing the first available device. Make sure that
-  // the first platform has the most preferrable device.
-  auto GetPlatformScore = [](const platform &p) {
-    auto devs = p.get_devices();
-    auto it =
-        std::max_element(devs.begin(), devs.end(), [](auto lhs, auto rhs) {
-          return default_selector_v(lhs) < default_selector_v(rhs);
-        });
-    return default_selector_v(*it);
-  };
-
-  std::vector<std::pair<platform, int>> PlatformScores;
-  PlatformScores.reserve(Platforms.size());
-  for (auto &p : Platforms)
-    PlatformScores.emplace_back(p, GetPlatformScore(p));
-
-  std::stable_sort(PlatformScores.begin(), PlatformScores.end(), [&](auto lhs, auto rhs) {
-    return lhs.second > rhs.second;
-  });
-
-  Platforms.clear();
-  for (auto &e : PlatformScores )
-    Platforms.push_back(e.first);
-
   return Platforms;
 }
 


### PR DESCRIPTION
This commit reverts the functional change because device filtering accesses plugins directly and not through the get_platforms() interface resulting in inconsistent device numbering. Test bug-fixes from the PR are not being reverted though.