### PR TITLE
[SYCL][ESIMD] named_barrier_signal should have a fence

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -402,7 +402,8 @@ __ESIMD_API void named_barrier_signal(uint8_t barrier_id,
   __ESIMD_DNS::vector_type_t<uint32_t, 8> payload = 0;
   payload[2] = (num_consumers & 0xff) << 24 | (num_producers & 0xff) << 16 |
                producer_consumer_mode << 14 | (barrier_id & 0b11111) << 0;
-
+  __esimd_fence(__ESIMD_NS::fence_mask::global_coherent_fence |
+                __ESIMD_NS::fence_mask::local_barrier);
   __esimd_raw_send_nbarrier_signal<uint32_t, 8>(
       0 /*sendc*/, gateway, descriptor, payload, 1 /*pred*/);
 }

--- a/sycl/test/esimd/nbarriers.cpp
+++ b/sycl/test/esimd/nbarriers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fsycl-device-only -Xclang -emit-llvm %s -o %t
+// RUN: %clangxx -fsycl -c -fsycl-device-only -Xclang -emit-llvm %s -o - 2>&1 | FileCheck %s
 
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
@@ -15,6 +15,8 @@ void caller(int x) {
   kernel<class kernel_esimd>([=]() SYCL_ESIMD_KERNEL {
     named_barrier_init<7>();
     named_barrier_wait(2);
+    // CHECK: call spir_func void @_Z13__esimd_fenceh(i8 noundef zeroext 33)
+    // CHECK-NEXT: call spir_func void @_Z32__esimd_raw_send_nbarrier_signal{{.*}}
     named_barrier_signal(0, 0, 4, 4);
   });
 }


### PR DESCRIPTION
It's required.