### PR TITLE
[SYCL] [E2E] Remove XFAIL from usm_leak_check.cpp on DG2

### DIFF
--- a/sycl/test-e2e/USM/usm_leak_check.cpp
+++ b/sycl/test-e2e/USM/usm_leak_check.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: level_zero
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 // RUN: %{build} -o %t.out
 
 // RUN: %{l0_leak_check} %{run} %t.out u 2>&1 | FileCheck %s --implicit-check-not=LEAK


### PR DESCRIPTION
usm_leak_check.cpp seems to be passing now on DG2 (https://github.com/intel/llvm/actions/runs/8055002796/job/22002608145) after my change in https://github.com/intel/llvm/commit/1b5719ec3c0af051f237023f7e2ca65e5374c680.

This PR removes XFAIL from this test on DG2.