### PR TITLE
[SYCL][Fusion] Enable -Werror for fusion library

### DIFF
--- a/sycl-fusion/CMakeLists.txt
+++ b/sycl-fusion/CMakeLists.txt
@@ -10,7 +10,12 @@ set(SYCL_JIT_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 set(LLVM_SPIRV_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/../llvm-spirv/include")
 
 # Set library-wide warning options.
-set(SYCL_FUSION_WARNING_FLAGS -Werror -Wall -Wextra)
+set(SYCL_FUSION_WARNING_FLAGS -Wall -Wextra)
+
+option(SYCL_FUSION_ENABLE_WERROR "Treat all warnings as errors in SYCL kernel fusion library" ON)
+if(SYCL_FUSION_ENABLE_WERROR)
+  list(APPEND SYCL_FUSION_WARNING_FLAGS -Werror)
+endif(SYCL_FUSION_ENABLE_WERROR)
 
 if(WIN32)
   message(WARNING "Kernel fusion not yet supported on Windows")

--- a/sycl-fusion/CMakeLists.txt
+++ b/sycl-fusion/CMakeLists.txt
@@ -9,6 +9,9 @@ set(SYCL_JIT_BASE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
 # directories, similar to how clang/CMakeLists.txt does it.
 set(LLVM_SPIRV_INCLUDE_DIRS "${LLVM_MAIN_SRC_DIR}/../llvm-spirv/include")
 
+# Set library-wide warning options.
+set(SYCL_FUSION_WARNING_FLAGS -Werror -Wall -Wextra)
+
 if(WIN32)
   message(WARNING "Kernel fusion not yet supported on Windows")
 else(WIN32)

--- a/sycl-fusion/common/CMakeLists.txt
+++ b/sycl-fusion/common/CMakeLists.txt
@@ -1,13 +1,15 @@
-add_library(sycl-fusion-common
+add_llvm_library(sycl-fusion-common
   lib/NDRangesHelper.cpp
-)
 
-llvm_map_components_to_libnames(llvm_libs
-  Support
+  LINK_COMPONENTS
+   Support
 )
 
 target_compile_options(sycl-fusion-common PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
 
+# Mark LLVM headers as system headers to ignore warnigns in them. This
+# classification remains intact even if the same path is added as a normal
+# include path in GCC and Clang.
 target_include_directories(sycl-fusion-common
   SYSTEM PRIVATE
   ${LLVM_MAIN_INCLUDE_DIR}
@@ -17,8 +19,6 @@ target_include_directories(sycl-fusion-common
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/lib
 )
-
-target_link_libraries(sycl-fusion-common PRIVATE ${llvm_libs})
 
 if (BUILD_SHARED_LIBS)
   if(NOT MSVC AND NOT APPLE)

--- a/sycl-fusion/common/CMakeLists.txt
+++ b/sycl-fusion/common/CMakeLists.txt
@@ -1,15 +1,24 @@
-add_llvm_library(sycl-fusion-common
+add_library(sycl-fusion-common
   lib/NDRangesHelper.cpp
-
-  LINK_COMPONENTS
-   Support
 )
 
+llvm_map_components_to_libnames(llvm_libs
+  Support
+)
+
+target_compile_options(sycl-fusion-common PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
+
+target_include_directories(sycl-fusion-common
+  SYSTEM PRIVATE
+  ${LLVM_MAIN_INCLUDE_DIR}
+)
 target_include_directories(sycl-fusion-common
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   ${CMAKE_CURRENT_SOURCE_DIR}/lib
 )
+
+target_link_libraries(sycl-fusion-common PRIVATE ${llvm_libs})
 
 if (BUILD_SHARED_LIBS)
   if(NOT MSVC AND NOT APPLE)

--- a/sycl-fusion/jit-compiler/CMakeLists.txt
+++ b/sycl-fusion/jit-compiler/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_llvm_library(sycl-fusion
+add_library(sycl-fusion
    lib/KernelFusion.cpp
    lib/translation/KernelTranslation.cpp
    lib/translation/SPIRVLLVMTranslation.cpp
@@ -8,11 +8,11 @@ add_llvm_library(sycl-fusion
    lib/fusion/JITContext.cpp
    lib/fusion/ModuleHelper.cpp
    lib/helper/ConfigHelper.cpp
+)
 
-   DEPENDS
-   intrinsics_gen
+add_dependencies(sycl-fusion intrinsics_gen)
 
-   LINK_COMPONENTS
+llvm_map_components_to_libnames(llvm_libs
    BitReader
    Core
    Support
@@ -29,6 +29,13 @@ add_llvm_library(sycl-fusion
    ${LLVM_TARGETS_TO_BUILD}
 )
 
+target_compile_options(sycl-fusion PRIVATE -fno-rtti ${SYCL_FUSION_WARNING_FLAGS})
+
+target_include_directories(sycl-fusion
+  SYSTEM PRIVATE
+  ${LLVM_MAIN_INCLUDE_DIR}
+  ${LLVM_SPIRV_INCLUDE_DIRS}
+)
 target_include_directories(sycl-fusion
   PUBLIC
   $<INSTALL_INTERFACE:include>
@@ -36,7 +43,6 @@ target_include_directories(sycl-fusion
   $<BUILD_INTERFACE:${SYCL_JIT_BASE_DIR}/common/include>
   PRIVATE
   ${CMAKE_CURRENT_SOURCE_DIR}/lib
-  ${LLVM_SPIRV_INCLUDE_DIRS}
 )
 
 find_package(Threads REQUIRED)
@@ -47,6 +53,7 @@ target_link_libraries(sycl-fusion
   LLVMSPIRVLib
   SYCLKernelFusionPasses
   ${CMAKE_THREAD_LIBS_INIT}
+  ${llvm_libs}
 )
 
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/sycl-fusion/jit-compiler/CMakeLists.txt
+++ b/sycl-fusion/jit-compiler/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-add_library(sycl-fusion
+add_llvm_library(sycl-fusion
    lib/KernelFusion.cpp
    lib/translation/KernelTranslation.cpp
    lib/translation/SPIRVLLVMTranslation.cpp
@@ -8,11 +8,11 @@ add_library(sycl-fusion
    lib/fusion/JITContext.cpp
    lib/fusion/ModuleHelper.cpp
    lib/helper/ConfigHelper.cpp
-)
 
-add_dependencies(sycl-fusion intrinsics_gen)
+   DEPENDS
+   intrinsics_gen
 
-llvm_map_components_to_libnames(llvm_libs
+   LINK_COMPONENTS
    BitReader
    Core
    Support
@@ -29,8 +29,11 @@ llvm_map_components_to_libnames(llvm_libs
    ${LLVM_TARGETS_TO_BUILD}
 )
 
-target_compile_options(sycl-fusion PRIVATE -fno-rtti ${SYCL_FUSION_WARNING_FLAGS})
+target_compile_options(sycl-fusion PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
 
+# Mark LLVM and SPIR-V headers as system headers to ignore warnigns in them.
+# This classification remains intact even if the same paths are added as normal
+# include paths in GCC and Clang.
 target_include_directories(sycl-fusion
   SYSTEM PRIVATE
   ${LLVM_MAIN_INCLUDE_DIR}
@@ -53,7 +56,6 @@ target_link_libraries(sycl-fusion
   LLVMSPIRVLib
   SYCLKernelFusionPasses
   ${CMAKE_THREAD_LIBS_INIT}
-  ${llvm_libs}
 )
 
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
+++ b/sycl-fusion/jit-compiler/lib/fusion/FusionHelper.cpp
@@ -169,14 +169,13 @@ Expected<std::unique_ptr<Module>> helper::FusionHelper::addFusedKernel(
 
           const auto S = [&]() -> StringRef {
             switch (Info.Intern) {
-            default:
-            case jit_compiler::Internalization::None:
-              llvm_unreachable(
-                  "Only a valid internalization kind should be used");
             case jit_compiler::Internalization::Local:
               return LocalInternalizationStr;
             case jit_compiler::Internalization::Private:
               return PrivateInternalizationStr;
+            default:
+              llvm_unreachable(
+                  "Only a valid internalization kind should be used");
             }
           }();
           EmplaceBackIntern(Info, S);

--- a/sycl-fusion/passes/CMakeLists.txt
+++ b/sycl-fusion/passes/CMakeLists.txt
@@ -13,7 +13,9 @@ add_library(SYCLKernelFusion MODULE
 
 add_dependencies(SYCLKernelFusion intrinsics_gen)
 
-target_compile_options(SYCLKernelFusion PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
+target_compile_options(SYCLKernelFusion PRIVATE -fno-rtti ${SYCL_FUSION_WARNING_FLAGS})
+
+set_target_properties(SYCLKernelFusion PROPERTIES PREFIX "")
 
 target_include_directories(SYCLKernelFusion
   SYSTEM PRIVATE

--- a/sycl-fusion/passes/CMakeLists.txt
+++ b/sycl-fusion/passes/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Module library for usage as library/pass-plugin with LLVM opt.
-add_llvm_library(SYCLKernelFusion MODULE
+add_library(SYCLKernelFusion MODULE
   SYCLFusionPasses.cpp
   kernel-fusion/Builtins.cpp
   kernel-fusion/SYCLKernelFusion.cpp
@@ -9,11 +9,16 @@ add_llvm_library(SYCLKernelFusion MODULE
   cleanup/Cleanup.cpp
   debug/PassDebug.cpp
   target/TargetFusionInfo.cpp
-
-  DEPENDS
-  intrinsics_gen
 )
 
+add_dependencies(SYCLKernelFusion intrinsics_gen)
+
+target_compile_options(SYCLKernelFusion PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
+
+target_include_directories(SYCLKernelFusion
+  SYSTEM PRIVATE
+  ${LLVM_MAIN_INCLUDE_DIR}
+)
 target_include_directories(SYCLKernelFusion
   PUBLIC
   ${CMAKE_CURRENT_SOURCE_DIR}
@@ -35,7 +40,7 @@ if("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
 endif()
 
 # Static library for linking with the jit_compiler
-add_llvm_library(SYCLKernelFusionPasses
+add_library(SYCLKernelFusionPasses
   SYCLFusionPasses.cpp
   kernel-fusion/Builtins.cpp
   kernel-fusion/SYCLKernelFusion.cpp
@@ -45,11 +50,11 @@ add_llvm_library(SYCLKernelFusionPasses
   cleanup/Cleanup.cpp
   debug/PassDebug.cpp
   target/TargetFusionInfo.cpp
+)
 
-  DEPENDS
-  intrinsics_gen
+add_dependencies(SYCLKernelFusionPasses intrinsics_gen)
 
-  LINK_COMPONENTS
+llvm_map_components_to_libnames(llvm_libs
   Core
   Support
   TransformUtils
@@ -57,6 +62,12 @@ add_llvm_library(SYCLKernelFusionPasses
   TargetParser
 )
 
+target_compile_options(SYCLKernelFusionPasses PRIVATE -fno-rtti ${SYCL_FUSION_WARNING_FLAGS})
+
+target_include_directories(SYCLKernelFusionPasses
+  SYSTEM PRIVATE
+  ${LLVM_MAIN_INCLUDE_DIR}
+)
 target_include_directories(SYCLKernelFusionPasses
   PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
@@ -67,6 +78,7 @@ target_include_directories(SYCLKernelFusionPasses
 target_link_libraries(SYCLKernelFusionPasses
   PRIVATE
   sycl-fusion-common
+  ${llvm_libs}
 )
 
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/sycl-fusion/passes/CMakeLists.txt
+++ b/sycl-fusion/passes/CMakeLists.txt
@@ -1,5 +1,5 @@
 # Module library for usage as library/pass-plugin with LLVM opt.
-add_library(SYCLKernelFusion MODULE
+add_llvm_library(SYCLKernelFusion MODULE
   SYCLFusionPasses.cpp
   kernel-fusion/Builtins.cpp
   kernel-fusion/SYCLKernelFusion.cpp
@@ -9,14 +9,16 @@ add_library(SYCLKernelFusion MODULE
   cleanup/Cleanup.cpp
   debug/PassDebug.cpp
   target/TargetFusionInfo.cpp
+
+  DEPENDS
+  intrinsics_gen
 )
 
-add_dependencies(SYCLKernelFusion intrinsics_gen)
+target_compile_options(SYCLKernelFusion PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
 
-target_compile_options(SYCLKernelFusion PRIVATE -fno-rtti ${SYCL_FUSION_WARNING_FLAGS})
-
-set_target_properties(SYCLKernelFusion PROPERTIES PREFIX "")
-
+# Mark LLVM headers as system headers to ignore warnigns in them. This
+# classification remains intact even if the same path is added as a normal
+# include path in GCC and Clang.
 target_include_directories(SYCLKernelFusion
   SYSTEM PRIVATE
   ${LLVM_MAIN_INCLUDE_DIR}
@@ -42,7 +44,7 @@ if("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
 endif()
 
 # Static library for linking with the jit_compiler
-add_library(SYCLKernelFusionPasses
+add_llvm_library(SYCLKernelFusionPasses
   SYCLFusionPasses.cpp
   kernel-fusion/Builtins.cpp
   kernel-fusion/SYCLKernelFusion.cpp
@@ -52,11 +54,11 @@ add_library(SYCLKernelFusionPasses
   cleanup/Cleanup.cpp
   debug/PassDebug.cpp
   target/TargetFusionInfo.cpp
-)
 
-add_dependencies(SYCLKernelFusionPasses intrinsics_gen)
+  DEPENDS
+  intrinsics_gen
 
-llvm_map_components_to_libnames(llvm_libs
+  LINK_COMPONENTS
   Core
   Support
   TransformUtils
@@ -64,8 +66,11 @@ llvm_map_components_to_libnames(llvm_libs
   TargetParser
 )
 
-target_compile_options(SYCLKernelFusionPasses PRIVATE -fno-rtti ${SYCL_FUSION_WARNING_FLAGS})
+target_compile_options(SYCLKernelFusionPasses PRIVATE ${SYCL_FUSION_WARNING_FLAGS})
 
+# Mark LLVM headers as system headers to ignore warnigns in them. This
+# classification remains intact even if the same path is added as a normal
+# include path in GCC and Clang.
 target_include_directories(SYCLKernelFusionPasses
   SYSTEM PRIVATE
   ${LLVM_MAIN_INCLUDE_DIR}
@@ -80,7 +85,6 @@ target_include_directories(SYCLKernelFusionPasses
 target_link_libraries(SYCLKernelFusionPasses
   PRIVATE
   sycl-fusion-common
-  ${llvm_libs}
 )
 
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)

--- a/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLKernelFusion.cpp
@@ -198,8 +198,7 @@ static bool needsGuard(const jit_compiler::NDRange &SrcNDRange,
 static FusionInsertPoints addGuard(IRBuilderBase &Builder,
                                    const TargetFusionInfo &TargetInfo,
                                    const jit_compiler::NDRange &SrcNDRange,
-                                   const jit_compiler::NDRange &FusedNDRange,
-                                   bool IsLast) {
+                                   const jit_compiler::NDRange &FusedNDRange) {
   // Guard:
 
   // entry:
@@ -240,8 +239,7 @@ static Expected<CallInst *> createFusionCall(
     const jit_compiler::NDRange &FusedNDRange, bool IsLast,
     jit_compiler::BarrierFlags BarriersFlags, jit_compiler::Remapper &Remapper,
     bool ShouldRemap, TargetFusionInfo &TargetInfo) {
-  const auto IPs =
-      addGuard(Builder, TargetInfo, SrcNDRange, FusedNDRange, IsLast);
+  const auto IPs = addGuard(Builder, TargetInfo, SrcNDRange, FusedNDRange);
 
   if (ShouldRemap) {
     auto FOrErr = Remapper.remapBuiltins(F, SrcNDRange, FusedNDRange);

--- a/sycl-fusion/passes/syclcp/SYCLCP.cpp
+++ b/sycl-fusion/passes/syclcp/SYCLCP.cpp
@@ -63,7 +63,7 @@ static Expected<SmallVector<ConstantInfo>> getCPFromMD(Function *F) {
 ///
 /// Returns a constant of the given scalar type and value.
 static Expected<Constant *> getConstantValue(const unsigned char **ValPtr,
-                                             Type *Ty, bool ByVal) {
+                                             Type *Ty) {
   if (Ty->isIntegerTy()) {
     unsigned NumBytes = Ty->getIntegerBitWidth() / 8;
     uint64_t IntValue = 0;
@@ -99,7 +99,7 @@ static Error initializeAggregateConstant(const unsigned char **ValPtr,
                                          ArrayRef<Value *> Indices) {
   if (CurrentTy->isIntegerTy() || CurrentTy->isFloatTy() ||
       CurrentTy->isDoubleTy()) {
-    Expected<Value *> CVal = getConstantValue(ValPtr, CurrentTy, false);
+    Expected<Value *> CVal = getConstantValue(ValPtr, CurrentTy);
     if (auto E = CVal.takeError()) {
       return E;
     }
@@ -185,8 +185,7 @@ static bool propagateConstants(Function *F, ArrayRef<ConstantInfo> Constants) {
       }
       CVal = AggVal.get();
     } else {
-      Expected<Constant *> ScalarVal =
-          getConstantValue(&ValPtr, ArgTy, Arg->hasByValAttr());
+      Expected<Constant *> ScalarVal = getConstantValue(&ValPtr, ArgTy);
       if (auto E = ScalarVal.takeError()) {
         handleAllErrors(std::move(E), [](const StringError &SE) {
           FUSION_DEBUG(llvm::dbgs() << SE.message() << "\n");

--- a/sycl-fusion/passes/target/TargetFusionInfo.cpp
+++ b/sycl-fusion/passes/target/TargetFusionInfo.cpp
@@ -408,8 +408,8 @@ public:
   }
 
   Function *createRemapperFunction(
-      const Remapper &R, BuiltinKind K, StringRef OrigName, Module *M,
-      const jit_compiler::NDRange &SrcNDRange,
+      const Remapper &R, BuiltinKind K, StringRef OrigName [[maybe_unused]],
+      Module *M, const jit_compiler::NDRange &SrcNDRange,
       const jit_compiler::NDRange &FusedNDRange) const override {
     const auto Name = Remapper::getFunctionName(K, SrcNDRange, FusedNDRange);
     assert(!M->getFunction(Name) && "Function name should be unique");
@@ -551,7 +551,7 @@ public:
                                                   uint32_t Idx) const = 0;
 
   Value *getGlobalIDWithoutOffset(IRBuilderBase &Builder,
-                                  const NDRange &FusedNDRange,
+                                  const NDRange &FusedNDRange [[maybe_unused]],
                                   uint32_t Idx) const override {
     // Construct (or reuse) a helper function to query the global ID.
     std::string GetGlobalIDName =
@@ -687,8 +687,9 @@ public:
     switch (K) {
     case BuiltinKind::NumWorkGroupsRemapper:
     case BuiltinKind::GroupIDRemapper:
-      return WrapValInFunc(
-          [&](uint32_t Idx) { return Builder.getInt32(R.getDefaultValue(K)); });
+      return WrapValInFunc([&](uint32_t Idx [[maybe_unused]]) {
+        return Builder.getInt32(R.getDefaultValue(K));
+      });
     case BuiltinKind::LocalSizeRemapper:
     case BuiltinKind::GlobalSizeRemapper: /* only AMDGCN */
       return WrapValInFunc([&](uint32_t Idx) {

--- a/sycl-fusion/passes/target/TargetFusionInfo.cpp
+++ b/sycl-fusion/passes/target/TargetFusionInfo.cpp
@@ -408,7 +408,7 @@ public:
   }
 
   Function *createRemapperFunction(
-      const Remapper &R, BuiltinKind K, StringRef OrigName [[maybe_unused]],
+      const Remapper &R, BuiltinKind K, [[maybe_unused]] StringRef OrigName,
       Module *M, const jit_compiler::NDRange &SrcNDRange,
       const jit_compiler::NDRange &FusedNDRange) const override {
     const auto Name = Remapper::getFunctionName(K, SrcNDRange, FusedNDRange);
@@ -551,7 +551,7 @@ public:
                                                   uint32_t Idx) const = 0;
 
   Value *getGlobalIDWithoutOffset(IRBuilderBase &Builder,
-                                  const NDRange &FusedNDRange [[maybe_unused]],
+                                  [[maybe_unused]] const NDRange &FusedNDRange,
                                   uint32_t Idx) const override {
     // Construct (or reuse) a helper function to query the global ID.
     std::string GetGlobalIDName =
@@ -687,7 +687,7 @@ public:
     switch (K) {
     case BuiltinKind::NumWorkGroupsRemapper:
     case BuiltinKind::GroupIDRemapper:
-      return WrapValInFunc([&](uint32_t Idx [[maybe_unused]]) {
+      return WrapValInFunc([&]([[maybe_unused]] uint32_t Idx) {
         return Builder.getInt32(R.getDefaultValue(K));
       });
     case BuiltinKind::LocalSizeRemapper:


### PR DESCRIPTION
Treat warnings as errors, and fix the last remaining warnings in the fusion library.