### PR TITLE
[SYCL][COMPAT] Avoid local memory initialization through group_local_memory_for_overwrite

### DIFF
--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -62,7 +62,7 @@ namespace syclcompat {
 
 template <typename AllocT> auto *local_mem() {
   sycl::multi_ptr<AllocT, sycl::access::address_space::local_space>
-      As_multi_ptr = sycl::ext::oneapi::group_local_memory<AllocT>(
+      As_multi_ptr = sycl::ext::oneapi::group_local_memory_for_overwrite<AllocT>(
           sycl::ext::oneapi::experimental::this_nd_item<3>().get_group());
   auto *As = *As_multi_ptr;
   return As;


### PR DESCRIPTION
group_local_memory becomes an issue for performance due to the initialization phase.
group_local_memory_for_overwrite allocates memory similarly without initialization, so, if initialization is needed, the user is now responsible for it.

More info: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc