### PR TITLE
[SYCL] Fix failing specialization constants tests.

### DIFF
--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer-array-of-arrays.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer-array-of-arrays.ll
@@ -1,7 +1,7 @@
 ; RUN: sycl-post-link --spec-const=native -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
-; RUN: sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ;
 ; This test is intended to check that SpecConstantsPass is able to handle the
 ; situation where specialization constants with complex types such as arrays

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer-array-of-arrays.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer-array-of-arrays.ll
@@ -1,7 +1,7 @@
 ; RUN: sycl-post-link --spec-const=native -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; This test is intended to check that SpecConstantsPass is able to handle the
 ; situation where specialization constants with complex types such as arrays

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer.ll
@@ -1,5 +1,5 @@
 ; RUN: sycl-post-link --ir-output-only --spec-const=native %s -S -o - | FileCheck %s
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; This test is intended to check that SpecConstantsPass is able to handle the
 ; situation where specialization constants have zeroinitializer in LLVM IR

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020-zeroinitializer.ll
@@ -1,5 +1,5 @@
 ; RUN: sycl-post-link --ir-output-only --spec-const=native %s -S -o - | FileCheck %s
-; RUN: sycl-post-link -debug-only=SpecConst --spec-const=native %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ;
 ; This test is intended to check that SpecConstantsPass is able to handle the
 ; situation where specialization constants have zeroinitializer in LLVM IR

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020.ll
@@ -4,8 +4,8 @@
 ; RUN: sycl-post-link -spec-const=native < %s -S -o %t.table
 ; RUN: FileCheck %s -check-prefixes=CHECK,CHECK-RT < %t_0.ll
 ; RUN: FileCheck %s --check-prefixes=CHECK-PROPS < %t_0.prop
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=native < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE %} %else %{ %}
 
 ; This test checks that the post link tool is able to correctly transform
 ; SYCL 2020 specialization constant intrinsics for different types in a device

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL-2020.ll
@@ -4,8 +4,8 @@
 ; RUN: sycl-post-link -spec-const=native < %s -S -o %t.table
 ; RUN: FileCheck %s -check-prefixes=CHECK,CHECK-RT < %t_0.ll
 ; RUN: FileCheck %s --check-prefixes=CHECK-PROPS < %t_0.prop
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION %} %else %{ %}
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s -S 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE %}
 
 ; This test checks that the post link tool is able to correctly transform
 ; SYCL 2020 specialization constant intrinsics for different types in a device

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL2020-struct-with-undef-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL2020-struct-with-undef-padding.ll
@@ -1,7 +1,7 @@
 ; RUN: sycl-post-link --spec-const=native -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; This test is intended to check that SpecConstantsPass is able to handle the
 ; situation where specialization constants with complex types such as structs

--- a/llvm/test/tools/sycl-post-link/spec-constants/SYCL2020-struct-with-undef-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/SYCL2020-struct-with-undef-padding.ll
@@ -1,7 +1,7 @@
 ; RUN: sycl-post-link --spec-const=native -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll --check-prefix CHECK-IR
 ; RUN: FileCheck %s -input-file=%t.files_0.prop --check-prefix CHECK-PROP
-; RUN: sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ;
 ; This test is intended to check that SpecConstantsPass is able to handle the
 ; situation where specialization constants with complex types such as structs

--- a/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
@@ -2,8 +2,8 @@
 ; RUN: FileCheck %s --input-file=%t.ll --implicit-check-not "call i8 bitcast" --check-prefixes=CHECK,CHECK-RT
 ; RUN: sycl-post-link -spec-const=emulation -S < %s --ir-output-only -o %t.ll
 ; RUN: FileCheck %s --input-file=%t.ll --check-prefixes=CHECK,CHECK-DEF
-; RUN: %if asserts %{sycl-post-link -debug-only=SpecConst -spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE %} %else %{ %}
-; RUN: %if asserts %{sycl-post-link -debug-only=SpecConst -spec-const=emulation -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION} %else %{ %}
+; RUN: %if asserts %{sycl-post-link -debug-only=SpecConst -spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE %}
+; RUN: %if asserts %{sycl-post-link -debug-only=SpecConst -spec-const=emulation -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION %}
 
 
 ; CHECK-LABEL: void @kernel_A

--- a/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/bool.ll
@@ -2,8 +2,9 @@
 ; RUN: FileCheck %s --input-file=%t.ll --implicit-check-not "call i8 bitcast" --check-prefixes=CHECK,CHECK-RT
 ; RUN: sycl-post-link -spec-const=emulation -S < %s --ir-output-only -o %t.ll
 ; RUN: FileCheck %s --input-file=%t.ll --check-prefixes=CHECK,CHECK-DEF
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=emulation -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION
+; RUN: %if asserts %{sycl-post-link -debug-only=SpecConst -spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-NATIVE %} %else %{ %}
+; RUN: %if asserts %{sycl-post-link -debug-only=SpecConst -spec-const=emulation -S < %s 2>&1 | FileCheck %s --check-prefixes=CHECK-LOG,CHECK-LOG-EMULATION} %else %{ %}
+
 
 ; CHECK-LABEL: void @kernel_A
 ; CHECK-RT: %[[CALL:.*]] = call i8 @_Z20__spirv_SpecConstantia(i32 [[#]], i8 1)

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-O2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-O2.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=native --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
-; RUN: sycl-post-link -spec-const=native -debug-only=SpecConst < %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -spec-const=native -debug-only=SpecConst < %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ;
 ; This test is intended to check that sycl-post-link tool is capable of handling
 ; composite specialization constants by lowering them into a set of SPIR-V

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-O2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-O2.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=native --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
-; RUN: %if asserts %{ sycl-post-link -spec-const=native -debug-only=SpecConst < %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -spec-const=native -debug-only=SpecConst < %s -S 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; This test is intended to check that sycl-post-link tool is capable of handling
 ; composite specialization constants by lowering them into a set of SPIR-V

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value-padding.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=emulation < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; This test checks that composite specialization constants with padding gets the
 ; correct padding in their default values to prevent values being inserted at

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-default-value-padding.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=emulation < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=emulation < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ;
 ; This test checks that composite specialization constants with padding gets the
 ; correct padding in their default values to prevent values being inserted at

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-no-sret.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-no-sret.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=native --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue" --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK: %[[#NS0:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID:]], i32
 ; CHECK: %[[#NS1:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID + 1]], i32 42)

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-no-sret.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-no-sret.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=native --ir-output-only < %s -S -o - \
 ; RUN: | FileCheck %s --implicit-check-not "call {{.*}} __sycl_getCompositeSpecConstantValue" --implicit-check-not "call {{.*}} __sycl_getComposite2020SpecConstantValue"
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK: %[[#NS0:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID:]], i32
 ; CHECK: %[[#NS1:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID + 1]], i32 42)

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-padding-desc.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-padding-desc.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=native < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{  %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; This test checks that composite specialization constants with implicit padding
 ; at the end of the composite type will have an additional padding descriptor at

--- a/llvm/test/tools/sycl-post-link/spec-constants/composite-padding-desc.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/composite-padding-desc.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -spec-const=native < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.prop
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG 
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{  %}
 ;
 ; This test checks that composite specialization constants with implicit padding
 ; at the end of the composite type will have an additional padding descriptor at

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/bool.ll
@@ -2,7 +2,7 @@
 
 ; RUN: sycl-post-link -split=auto -spec-const=native -S -o %t.table %s -generate-device-image-default-spec-consts
 ; RUN: FileCheck %s -input-file %t_1.ll --implicit-check-not="SpecConst"
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK: %bool1 = trunc i8 1 to i1
 ; CHECK: %frombool = zext i1 %bool1 to i8

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/bool.ll
@@ -2,7 +2,7 @@
 
 ; RUN: sycl-post-link -split=auto -spec-const=native -S -o %t.table %s -generate-device-image-default-spec-consts
 ; RUN: FileCheck %s -input-file %t_1.ll --implicit-check-not="SpecConst"
-; RUN: sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK: %bool1 = trunc i8 1 to i1
 ; CHECK: %frombool = zext i1 %bool1 to i8

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/device-image.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/device-image.ll
@@ -10,7 +10,7 @@
 ; RUN: FileCheck %s -input-file %t_1.ll -check-prefix=CHECK-IR1 --implicit-check-not "SpecConstant"
 ; RUN: FileCheck %s -input-file %t_0.sym -check-prefix=CHECK-SYM0
 ; RUN: FileCheck %s -input-file %t_1.sym -check-prefix=CHECK-SYM1
-; RUN: sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK-TABLE: {{.*}}_0.ll|{{.*}}_0.prop|{{.*}}_0.sym
 ; CHECK-TABLE: {{.*}}_1.ll|{{.*}}_1.prop|{{.*}}_1.sym

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/device-image.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/device-image.ll
@@ -10,7 +10,7 @@
 ; RUN: FileCheck %s -input-file %t_1.ll -check-prefix=CHECK-IR1 --implicit-check-not "SpecConstant"
 ; RUN: FileCheck %s -input-file %t_0.sym -check-prefix=CHECK-SYM0
 ; RUN: FileCheck %s -input-file %t_1.sym -check-prefix=CHECK-SYM1
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK-TABLE: {{.*}}_0.ll|{{.*}}_0.prop|{{.*}}_0.sym
 ; CHECK-TABLE: {{.*}}_1.ll|{{.*}}_1.prop|{{.*}}_1.sym

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/esimd.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/esimd.ll
@@ -4,7 +4,7 @@
 ; RUN: FileCheck %s -input-file=%t.table -check-prefix=CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t_1.prop -check-prefix=CHECK-PROP
 ; RUN: FileCheck %s -input-file=%t_esimd_1.prop -check-prefix=CHECK-ESIMD-PROP
-; RUN: sycl-post-link -debug-only=SpecConst -split=auto -split-esimd -lower-esimd -O2 -spec-const=native %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -split-esimd -lower-esimd -O2 -spec-const=native %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK-TABLE: {{.*}}_esimd_0.bc|{{.*}}_esimd_0.prop
 ; CHECK-TABLE: {{.*}}_0.bc|{{.*}}_0.prop

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/esimd.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/esimd.ll
@@ -4,7 +4,7 @@
 ; RUN: FileCheck %s -input-file=%t.table -check-prefix=CHECK-TABLE
 ; RUN: FileCheck %s -input-file=%t_1.prop -check-prefix=CHECK-PROP
 ; RUN: FileCheck %s -input-file=%t_esimd_1.prop -check-prefix=CHECK-ESIMD-PROP
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -split-esimd -lower-esimd -O2 -spec-const=native %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -split-esimd -lower-esimd -O2 -spec-const=native %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK-TABLE: {{.*}}_esimd_0.bc|{{.*}}_esimd_0.prop
 ; CHECK-TABLE: {{.*}}_0.bc|{{.*}}_0.prop

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/struct-with-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/struct-with-padding.ll
@@ -4,7 +4,7 @@
 ; RUN: cat %t.table | FileCheck %s -check-prefix=CHECK-TABLE
 ; RUN: cat %t_1.prop | FileCheck %s -check-prefix=CHECK-PROP1
 ; RUN: cat %t_1.ll | FileCheck %s -check-prefix=CHECK-IR1 --implicit-check-not SpecConstant
-; RUN: sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK-TABLE: {{.*}}_0.ll|{{.*}}_0.prop
 ; CHECK-TABLE: {{.*}}_1.ll|{{.*}}_1.prop

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/struct-with-padding.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/struct-with-padding.ll
@@ -4,7 +4,7 @@
 ; RUN: cat %t.table | FileCheck %s -check-prefix=CHECK-TABLE
 ; RUN: cat %t_1.prop | FileCheck %s -check-prefix=CHECK-PROP1
 ; RUN: cat %t_1.ll | FileCheck %s -check-prefix=CHECK-IR1 --implicit-check-not SpecConstant
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK-TABLE: {{.*}}_0.ll|{{.*}}_0.prop
 ; CHECK-TABLE: {{.*}}_1.ll|{{.*}}_1.prop

--- a/llvm/test/tools/sycl-post-link/spec-constants/nested-struct.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/nested-struct.ll
@@ -3,7 +3,7 @@
 
 ; RUN: sycl-post-link --spec-const=native -S %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll
-; RUN: sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG 
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK: %[[#SCV1:]] = call i8 @_Z20__spirv_SpecConstantia(i32 [[#SCID1:]], i8 120)
 ; CHECK: %[[#SCV2:]] = call i8 @_Z20__spirv_SpecConstantia(i32 [[#SCID2:]], i8 121)

--- a/llvm/test/tools/sycl-post-link/spec-constants/nested-struct.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/nested-struct.ll
@@ -3,7 +3,7 @@
 
 ; RUN: sycl-post-link --spec-const=native -S %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -spec-const=native < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK: %[[#SCV1:]] = call i8 @_Z20__spirv_SpecConstantia(i32 [[#SCID1:]], i8 120)
 ; CHECK: %[[#SCV2:]] = call i8 @_Z20__spirv_SpecConstantia(i32 [[#SCID2:]], i8 121)

--- a/llvm/test/tools/sycl-post-link/spec-constants/remove-dead-private-constants.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/remove-dead-private-constants.ll
@@ -4,7 +4,7 @@
 ; RUN: sycl-post-link -split=auto -spec-const=native -symbols -S -o %t.table %s -generate-device-image-default-spec-consts
 ; RUN: FileCheck %s -input-file %t_0.ll -check-prefix=CHECK-IR0
 ; RUN: FileCheck %s -input-file %t_1.ll -check-prefix=CHECK-IR1
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 
 ; CHECK-IR0-NOT: @__usid_str = private
 ; CHECK-IR1-NOT: @__usid_str = private

--- a/llvm/test/tools/sycl-post-link/spec-constants/remove-dead-private-constants.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/remove-dead-private-constants.ll
@@ -4,7 +4,7 @@
 ; RUN: sycl-post-link -split=auto -spec-const=native -symbols -S -o %t.table %s -generate-device-image-default-spec-consts
 ; RUN: FileCheck %s -input-file %t_0.ll -check-prefix=CHECK-IR0
 ; RUN: FileCheck %s -input-file %t_1.ll -check-prefix=CHECK-IR1
-; RUN: sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst -split=auto -spec-const=native -symbols -S %s -generate-device-image-default-spec-consts 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 
 ; CHECK-IR0-NOT: @__usid_str = private
 ; CHECK-IR1-NOT: @__usid_str = private

--- a/llvm/test/tools/sycl-post-link/spec-constants/struct-with-padding-in-the-middle.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/struct-with-padding-in-the-middle.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link --spec-const=native -S %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll
-; RUN: sycl-post-link -debug-only=SpecConst --spec-const=native -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ; LLVM IR for this test is produced from the following SYCL code snippet:
 ;
 ; #include <sycl/sycl.hpp>

--- a/llvm/test/tools/sycl-post-link/spec-constants/struct-with-padding-in-the-middle.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/struct-with-padding-in-the-middle.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link --spec-const=native -S %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.ll
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ; LLVM IR for this test is produced from the following SYCL code snippet:
 ;
 ; #include <sycl/sycl.hpp>

--- a/llvm/test/tools/sycl-post-link/spec-constants/struct-with-undef-padding-2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/struct-with-undef-padding-2.ll
@@ -36,7 +36,7 @@
 ;
 ; RUN: sycl-post-link --spec-const=native -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll
-; RUN: sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
 ;
 ; CHECK: %[[#A:]] = call float @_Z20__spirv_SpecConstantif(i32 [[#ID:]], float 0x40091EB860000000)
 ; CHECK: %[[#B:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID+1]], i32 42)

--- a/llvm/test/tools/sycl-post-link/spec-constants/struct-with-undef-padding-2.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/struct-with-undef-padding-2.ll
@@ -36,7 +36,7 @@
 ;
 ; RUN: sycl-post-link --spec-const=native -S < %s -o %t.files.table
 ; RUN: FileCheck %s -input-file=%t.files_0.ll
-; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %} %else %{ %}
+; RUN: %if asserts %{ sycl-post-link -debug-only=SpecConst --spec-const=native -S < %s 2>&1 | FileCheck %s --check-prefix=CHECK-LOG %}
 ;
 ; CHECK: %[[#A:]] = call float @_Z20__spirv_SpecConstantif(i32 [[#ID:]], float 0x40091EB860000000)
 ; CHECK: %[[#B:]] = call i32 @_Z20__spirv_SpecConstantii(i32 [[#ID+1]], i32 42)

--- a/sycl/test/basic_tests/SYCL-2020-spec-constants.cpp
+++ b/sycl/test/basic_tests/SYCL-2020-spec-constants.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -c -o %t.bc %s
-// RUN: sycl-post-link -debug-only=SpecConst %t.bc -spec-const=native -o %t-split1.txt 2>&1 | FileCheck %s -check-prefixes=CHECK-LOG
+// RUN: %if asserts %{sycl-post-link -debug-only=SpecConst %t.bc -spec-const=native -o %t-split1.txt 2>&1 | FileCheck %s -check-prefixes=CHECK-LOG %} %else %{sycl-post-link %t.bc -spec-const=native -o %t-split1.txt 2>&1 %}
 // RUN: cat %t-split1_0.prop | FileCheck %s -check-prefixes=CHECK,CHECK-RT
 // RUN: sycl-post-link %t.bc -spec-const=emulation -o %t-split2.txt
 // RUN: cat %t-split2_0.prop | FileCheck %s -check-prefixes=CHECK,CHECK-DEF


### PR DESCRIPTION
Recent changes made to specialization constants tests relied on `--debug-only` option, which is only enabled when assertions are enabled. This commit guards the commands using such an option to be run only when assertions are enabled.

This should fix the post-commit CI failure observed after #12647 was merged.