### PR TITLE
[SYCL][E2E] Fix Plugin/level_zero_usm_residency.cpp on Multi-card PVC

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_usm_residency.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_usm_residency.cpp
@@ -23,7 +23,6 @@ int main(int argc, char *argv[]) {
   // DEVICE: ---> piextUSMDeviceAlloc
   // DEVICE: ZE ---> zeMemAllocDevice
   // DEVICE: ZE ---> zeContextMakeMemoryResident
-  // DEVICE-NOT: ZE ---> zeContextMakeMemoryResident
 
   auto ptr2 = malloc_shared<int>(1, Q);
   // SHARED: ---> piextUSMSharedAlloc


### PR DESCRIPTION
**Problem:**
Plugin/level_zero_usm_residency.cpp fails on **Multi-card PVC** due to unexpected number of calls to zeContextMakeMemoryResident. The test was expecting just one call to zeContextMakeMemoryResident upon piextUSMDeviceAlloc. However, 
`// RUN: env SYCL_PI_TRACE=-1 UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out 2>&1`
produces two calls to zeContextMakeMemoryResident.

```
---> piextUSMDeviceAlloc(
<unknown> : 0x7ffc41c1d888
<unknown> : 0x3086680
<unknown> : 0x3084230
<unknown> : 0x7ffc41c1d8b0
<unknown> : 4
<unknown> : 4
ZE ---> zeMemAllocDevice(Context->ZeContext, &ZeDesc, Size, Alignment, Device->ZeDevice, ResultPtr)
ZE ---> zeDeviceCanAccessPeer(D->ZeDevice, Device->ZeDevice, &P2P)
ZE ---> zeContextMakeMemoryResident(Context->ZeContext, D->ZeDevice, Ptr, Size)
ZE ---> zeContextMakeMemoryResident(Context->ZeContext, D->ZeDevice, Ptr, Size)
) --->  pi_result : PI_SUCCESS
        [out]<unknown> ** : 0x7ffc41c1d888[ 0xff00fffffffe0000 ... ]
```

**Solution**:
The default value of SYCL_PI_LEVEL_ZERO_USM_RESIDENT is 0x002, which makes memory residence on all devices, which IIUC, means on all tiles of a multi-card PVC. That's why we see two calls to zeContextMakeMemoryResident, one for each tile of a multi-tile PVC.

This doesn't look like a bug in the code, but in the test instead. This PR updates the test case to also accept more than one calls to zeContextMakeMemoryResident for device allocations.
