### PR TITLE
[SYCL] Fix typo in host impl for some math builtins

### DIFF
--- a/sycl/source/builtins/math_functions.cpp
+++ b/sycl/source/builtins/math_functions.cpp
@@ -210,7 +210,7 @@ __SYCL_EXPORT half sincos_impl(half x, half *p) { return __sincos(x, p); }
   __SYCL_EXPORT float __##NAME##_impl(float x, int y) { return IMPL(x, y); }   \
   __SYCL_EXPORT double __##NAME##_impl(double x, int y) { return IMPL(x, y); } \
   __SYCL_EXPORT half __##NAME##_impl(half x, int y) { return IMPL(x, y); }     \
-  HOST_IMPL(NAME, pown /* delegate to scalar */)                               \
+  HOST_IMPL(NAME, NAME /* delegate to scalar */)                               \
   FOR_EACH1(EXPORT_VEC_LAST_INT_1_16, NAME, FP_TYPES)
 
 BUILTIN_MATH_LAST_INT(pown, std::pow)

--- a/sycl/test-e2e/Basic/built-ins/vec_math.cpp
+++ b/sycl/test-e2e/Basic/built-ins/vec_math.cpp
@@ -24,6 +24,9 @@
       }                                                                        \
       for (int i = 0; i < DIM; i++)                                            \
         assert(abs(result[i] - EXPECTED[i]) <= DELTA);                         \
+      auto host_result = FUNC(__VA_ARGS__);                                    \
+      for (int i = 0; i < DIM; i++)                                            \
+        assert(abs(host_result[i] - EXPECTED[i]) <= DELTA);                    \
     }                                                                          \
   }
 


### PR DESCRIPTION
The ones with FP/int vector parameters were implemented incorrectly.