### PR TITLE
[GEN] Change barrier to use local fence

### DIFF
--- a/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/GENXOps.td
@@ -125,18 +125,19 @@ def GENX_GridDimZOp : GENX_DeviceFunctionOp<"grid.dim.z",
 // Synchronization
 //===----------------------------------------------------------------------===//
 
+// TODO: Add attribute to set the memory fence semantics.
 def GENX_BarrierOp : GENX_Op<"barrier"> {
   let summary = "Workgroup barrier";
 
   string baseDescription = [{
     The `genx.barrier` operation performs a workgroup barrier and ensures all
-    outstanding memory transaction using local or global memory are complete.
+    outstanding memory transaction using local memory are complete.
   }];
 
   string llvmBuilder = [{
     llvm::Type *retType = builder.getVoidTy();
     llvm::Type *argType = builder.getInt32Ty();
-    int memFence = 3; // local + global memory fence
+    int memFence = 1; // local memory fence
     llvm::Value *arg = llvm::ConstantInt::get(argType, memFence);
     createDeviceFunctionCall(builder, "_Z7barrierj", retType, {argType}, {arg},
                              true /*convergent*/);

--- a/mlir/test/Target/LLVMIR/genx.mlir
+++ b/mlir/test/Target/LLVMIR/genx.mlir
@@ -34,7 +34,7 @@ llvm.func @genx_special_regs() -> i32 {
 
 llvm.func @genx.barrier() {
   // CHECK-LABEL: genx.barrier
-  // CHECK: call void @_Z7barrierj(i32 3) [[ATTR:#.*]]
+  // CHECK: call void @_Z7barrierj(i32 1) [[ATTR:#.*]]
   genx.barrier
   llvm.return
 }


### PR DESCRIPTION
We use `genx.barrier` to lower `gpu.barrier` and the latter doesn't have attributes to specify any fence scope. We should be fine using local fences for `genx.barrier` unconditionally for now.