### PR TITLE
[SYCL] Make ONEAPI_DEVICE_SELECTOR reject an empty string

### DIFF
--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -270,6 +270,9 @@ public:
     }
     const char *ValStr = BaseT::getRawValue();
     if (ValStr) {
+      // Return if the input string is empty.
+      if (ValStr[0] == '\0') return nullptr;
+
       DeviceTargets =
           &GlobalHandler::instance().getOneapiDeviceSelectorTargets(ValStr);
     }

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -269,9 +269,8 @@ public:
       return DeviceTargets;
     }
     const char *ValStr = BaseT::getRawValue();
-    if (ValStr) {
-      // Return if the input string is empty.
-      if (ValStr[0] == '\0') return nullptr;
+    // Return if the input string is empty.
+    if (ValStr && ValStr[0] != '\0') {
 
       DeviceTargets =
           &GlobalHandler::instance().getOneapiDeviceSelectorTargets(ValStr);

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -273,9 +273,9 @@ public:
       // Throw if the input string is empty.
       if (ValStr[0] == '\0')
         throw invalid_parameter_error(
-              "Invalid value for ONEAPI_DEVICE_SELECTOR environment "
-              "variable: value should not be null.",
-              PI_ERROR_INVALID_VALUE);
+            "Invalid value for ONEAPI_DEVICE_SELECTOR environment "
+            "variable: value should not be null.",
+            PI_ERROR_INVALID_VALUE);
 
       DeviceTargets =
           &GlobalHandler::instance().getOneapiDeviceSelectorTargets(ValStr);

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -269,8 +269,13 @@ public:
       return DeviceTargets;
     }
     const char *ValStr = BaseT::getRawValue();
-    // Return if the input string is empty.
-    if (ValStr && ValStr[0] != '\0') {
+    if (ValStr) {
+      // Throw if the input string is empty.
+      if (ValStr[0] == '\0')
+        throw invalid_parameter_error(
+              "Invalid value for ONEAPI_DEVICE_SELECTOR environment "
+              "variable: value should not be null.",
+              PI_ERROR_INVALID_VALUE);
 
       DeviceTargets =
           &GlobalHandler::instance().getOneapiDeviceSelectorTargets(ValStr);

--- a/sycl/test-e2e/OneapiDeviceSelector/empty_input_string.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/empty_input_string.cpp
@@ -1,0 +1,9 @@
+
+// ONEAPI_DEVICE_SELECTOR, when called with an empty string, should be
+// treated in the same manner when ONEAPI_DEVICE_SELECTOR is not set.
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
+
+// RUN: %{run-unfiltered-devices} %t.out > no_ods_output
+// RUN: env ONEAPI_DEVICE_SELECTOR="" %{run-unfiltered-devices} %t.out > ods_empty_string_output
+// RUN: diff no_ods_output ods_empty_string_output

--- a/sycl/test-e2e/OneapiDeviceSelector/empty_input_string.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/empty_input_string.cpp
@@ -1,9 +1,0 @@
-
-// ONEAPI_DEVICE_SELECTOR, when called with an empty string, should be
-// treated in the same manner when ONEAPI_DEVICE_SELECTOR is not set.
-
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
-
-// RUN: %{run-unfiltered-devices} %t.out > no_ods_output
-// RUN: env ONEAPI_DEVICE_SELECTOR="" %{run-unfiltered-devices} %t.out > ods_empty_string_output
-// RUN: diff no_ods_output ods_empty_string_output

--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_input.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_input.cpp
@@ -9,6 +9,7 @@
 // RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:" %{run-unfiltered-devices} %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:::gpu" %{run-unfiltered-devices} %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="level_zero:.1" %{run-unfiltered-devices} %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR="" %{run-unfiltered-devices} %t.out
 // XFAIL: *
 
 // Calling ONEAPI_DEVICE_SELECTOR with an illegal input should result in an

--- a/sycl/test/basic_tests/device-selectors-exception.cpp
+++ b/sycl/test/basic_tests/device-selectors-exception.cpp
@@ -1,7 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_FILTER="" %t.out
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fsycl-targets=%sycl_triple -fpreview-breaking-changes %s -o %t.out %}
-// RUN: %if preview-breaking-changes-supported %{ env ONEAPI_DEVICE_SELECTOR="" %t.out %}
+// ONEAPI_DEVICE_SELECTOR="*:-1" causes this test to not select any device at all.
+// RUN: %if preview-breaking-changes-supported %{ env ONEAPI_DEVICE_SELECTOR="*:-1" %t.out %}
 
 #include <sycl/sycl.hpp>
 using namespace sycl;

--- a/sycl/test/basic_tests/device-selectors-exception.cpp
+++ b/sycl/test/basic_tests/device-selectors-exception.cpp
@@ -1,7 +1,8 @@
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple %s -o %t.out
 // RUN: env SYCL_DEVICE_FILTER="" %t.out
 // RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fsycl-targets=%sycl_triple -fpreview-breaking-changes %s -o %t.out %}
-// ONEAPI_DEVICE_SELECTOR="*:-1" causes this test to not select any device at all.
+// ONEAPI_DEVICE_SELECTOR="*:-1" causes this test to not select any device at
+// all.
 // RUN: %if preview-breaking-changes-supported %{ env ONEAPI_DEVICE_SELECTOR="*:-1" %t.out %}
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
```ONEAPI_DEVICE_SELECTOR=""``` causes SYCL runtime to silently not select/initialize any device at all. This PR makes SYCL runtime to throw an error when input to ONEAPI_DEVICE_SELECTOR is null.