### PR TITLE
[SYCL] Fix abs_diff host implementation

### DIFF
--- a/sycl/source/builtins/integer_functions.cpp
+++ b/sycl/source/builtins/integer_functions.cpp
@@ -90,11 +90,11 @@ BUILTIN_GENINT(ONE_ARG, abs, [](auto x) -> decltype(x) {
 })
 
 BUILTIN_GENINT_SU(TWO_ARGS, abs_diff, [](auto x, auto y) -> decltype(x) {
-  // From SYCL 2020 revision 8:
-  //
-  // > The subtraction is done without modulo overflow. The behavior is
-  // > undefined if the result cannot be represented by the return type.
-  return sycl::abs(x - y);
+  if constexpr (std::is_signed_v<decltype(x)>)
+    if ((x < 0) != (y < 0))
+      return std::abs(x) + std::abs(y);
+
+  return std::max(x, y) - std::min(x, y);
 })
 
 BUILTIN_GENINT_SU(TWO_ARGS, add_sat, [](auto x, auto y) -> decltype(x) {

--- a/sycl/test-e2e/Basic/built-ins/marray_integer.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_integer.cpp
@@ -45,5 +45,12 @@ int main() {
          marray<uint8_t, 2>{3, 2});
   }
 
+  {
+    // Test abs_diff:
+    auto AbsDiff = [](auto... xs) { return abs_diff(xs...); };
+    Test(AbsDiff, marray<unsigned, 2>{1, 1}, marray<unsigned, 2>{0, 1},
+         marray<unsigned, 2>{1, 0});
+  }
+
   return 0;
 }


### PR DESCRIPTION
In https://github.com/intel/llvm/pull/12856 I misunderstood what the spec meant by

> When the inputs are scalars, returns |x - y|. Otherwise, returns
> |x[i]- y[i]| for each element of x and y. The subtraction is done
> without modulo overflow. The behavior is undefined if the result
> cannot be represented by the return type.

Fix it here. We still differ from non-preview mode in return type - it used to be `unsigned` prior to SYCL2020 revision 8, I believe.