### PR TITLE
[ESIMD][E2E] Disable lsc_*store_2d_u16* tests

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/lsc_store_2d_u16.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_store_2d_u16.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc
+// TODO: GPU Driver fails with "add3 src operand only supports integer D/W type"
+// error. Enable the test when it is fixed.
+// UNSUPPORTED: gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc
+// TODO: GPU Driver fails with "add3 src operand only supports integer D/W type"
+// error. Enable the test when it is fixed.
+// UNSUPPORTED: gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16_64.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u8_u16_64.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc
+// TODO: GPU Driver fails with "add3 src operand only supports integer D/W type"
+// error. Enable the test when it is fixed.
+// UNSUPPORTED: gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
The tests fail with a JIT compilation error:
"add3 src operand only supports integer D/W type".

The tests should be enabled again when the issue in fixed in GPU driver.