### PR TITLE
[SYCL][NATIVECPU] Separate lit tag for oneAPI Construction Kit

### DIFF
--- a/sycl/test/check_device_code/native_cpu/vectorization.cpp
+++ b/sycl/test/check_device_code/native_cpu/vectorization.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu_ock
 // RUN: %clangxx -fsycl-device-only  -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-opt -mllvm -inline-threshold=500 -S -emit-llvm  -o %t_temp.ll %s
 // RUN: %clangxx -O2 -mllvm -sycl-native-cpu-backend -S -emit-llvm -o - %t_temp.ll | FileCheck %s --check-prefix=CHECK-DEFAULT
 // RUN: %clangxx -O2 -mllvm -sycl-native-cpu-backend -mllvm -sycl-native-cpu-vecz-width=16 -S -emit-llvm -o - %t_temp.ll | FileCheck %s --check-prefix=CHECK-16

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -159,6 +159,9 @@ if config.level_zero_be == "ON":
 if config.native_cpu_be == "ON":
     config.available_features.add("native_cpu_be")
 
+if config.native_cpu_ock == "ON":
+    config.available_features.add("native_cpu_ock")
+
 if "nvptx64-nvidia-cuda" in triple:
     llvm_config.with_system_environment("CUDA_PATH")
     config.available_features.add("cuda")

--- a/sycl/test/lit.site.cfg.py.in
+++ b/sycl/test/lit.site.cfg.py.in
@@ -31,6 +31,7 @@ config.hip_be = '@SYCL_BUILD_PI_HIP@'
 config.opencl_be = '@SYCL_BUILD_PI_OPENCL@'
 config.level_zero_be = '@SYCL_BUILD_PI_LEVEL_ZERO@'
 config.native_cpu_be = '@SYCL_BUILD_NATIVE_CPU@'
+config.native_cpu_ock = '@NATIVECPU_USE_OCK@'
 config.sycl_preview_lib_enabled = '@SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB@'
 
 import lit.llvm

--- a/sycl/test/native_cpu/barrier-external.cpp
+++ b/sycl/test/native_cpu/barrier-external.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu_ock
 // RUN: %clangxx -DFILE1 -fsycl -fsycl-targets=native_cpu %s -g -c -o %t1.o
 // RUN: %clangxx -DFILE2 -fsycl -fsycl-targets=native_cpu %s -g -c -o %t2.o
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %t1.o %t2.o -g -o %t

--- a/sycl/test/native_cpu/barrier-simple.cpp
+++ b/sycl/test/native_cpu/barrier-simple.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu_ock
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 


### PR DESCRIPTION
Currently the oneAPI Construction Kit is an optional dependency for the Native CPU backend, so we need to differentiate test requirements based on whether or not it is available.