### PR TITLE
[SYCL][Joint Matrix] Relax matrix_combinations error handling

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -923,6 +923,7 @@ struct get_device_info_impl<
     if (e.code() != errc::runtime) {
       std::rethrow_exception(std::make_exception_ptr(e));
     }
+    return {};
   }
 };
 

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -744,7 +744,7 @@ struct get_device_info_impl<
       // this helper lambda ignores all runtime-related exceptions from
       // quering the device architecture. For instance, if device architecture
       // on user's machine is not supported by
-      // sycl_ext_oneapi_device_architecture, the runtime exception is ommited,
+      // sycl_ext_oneapi_device_architecture, the runtime exception is omitted,
       // and std::nullopt is returned.
       try {
         return get_device_info_impl<

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -921,8 +921,7 @@ struct get_device_info_impl<
       }
     } catch (sycl::exception &e) {
       if (e.code() != errc::runtime) {
-        std::exception_ptr e_ptr = std::make_exception_ptr(e);
-        std::rethrow_exception(e_ptr);
+        std::rethrow_exception(std::make_exception_ptr(e));
       }
     }
     return {};

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -827,8 +827,8 @@ struct get_device_info_impl<
            matrix_type::fp64, matrix_type::fp64},
       };
     else if (backend::ext_oneapi_cuda == CurrentBackend) {
-      // TODO: Tho following can be simplified when comparison of
-      // architectures using < and > will be implemented
+      // TODO: Tho following can be simplified when comparison of architectures
+      // using < and > will be implemented
       using oneapi_exp_arch = sycl::ext::oneapi::experimental::architecture;
       constexpr std::pair<float, oneapi_exp_arch> NvidiaArchNumbs[] = {
           {5.0, oneapi_exp_arch::nvidia_gpu_sm_50},

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -744,186 +744,186 @@ struct get_device_info_impl<
       architecture DeviceArch = get_device_info_impl<
           ext::oneapi::experimental::architecture,
           ext::oneapi::experimental::info::device::architecture>::get(Dev);
-    } catch (sycl::exception const &e) {
-      if (e.code() == errc::runtime &&
-          std::string(e.what()) == "The current device architecture is not "
-                                   "supported by sycl_ext_oneapi_matrix.")
-        return {};
-    }
-    if (architecture::intel_cpu_spr == DeviceArch)
-      return {
-          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-      };
-    else if (architecture::intel_cpu_gnr == DeviceArch)
-      return {
-          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {16, 16, 32, 0, 0, 0, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-      };
-    else if (architecture::intel_gpu_pvc == DeviceArch)
-      return {
-          {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 16, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {8, 0, 0, 0, 16, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 32, 64, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {8, 0, 0, 0, 16, 8, matrix_type::tf32, matrix_type::tf32,
-           matrix_type::fp32, matrix_type::fp32},
-      };
-    else if ((architecture::intel_gpu_dg2_g10 == DeviceArch) ||
-             (architecture::intel_gpu_dg2_g11 == DeviceArch) ||
-             (architecture::intel_gpu_dg2_g12 == DeviceArch))
-      return {
-          {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {8, 0, 0, 0, 8, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {8, 0, 0, 0, 8, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-      };
-    else if (architecture::amd_gpu_gfx90a == DeviceArch)
-      return {
-          {0, 0, 0, 32, 32, 8, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 32, 32, 8, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 32, 32, 8, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
-           matrix_type::fp64, matrix_type::fp64},
-      };
-    else if (backend::ext_oneapi_cuda == CurrentBackend) {
-      // TODO: Tho following can be simplified when comparison of architectures
-      // using < and > will be implemented
-      using oneapi_exp_arch = sycl::ext::oneapi::experimental::architecture;
-      constexpr std::pair<float, oneapi_exp_arch> NvidiaArchNumbs[] = {
-          {5.0, oneapi_exp_arch::nvidia_gpu_sm_50},
-          {5.2, oneapi_exp_arch::nvidia_gpu_sm_52},
-          {5.3, oneapi_exp_arch::nvidia_gpu_sm_53},
-          {6.0, oneapi_exp_arch::nvidia_gpu_sm_60},
-          {6.1, oneapi_exp_arch::nvidia_gpu_sm_61},
-          {6.2, oneapi_exp_arch::nvidia_gpu_sm_62},
-          {7.0, oneapi_exp_arch::nvidia_gpu_sm_70},
-          {7.2, oneapi_exp_arch::nvidia_gpu_sm_72},
-          {7.5, oneapi_exp_arch::nvidia_gpu_sm_75},
-          {8.0, oneapi_exp_arch::nvidia_gpu_sm_80},
-          {8.6, oneapi_exp_arch::nvidia_gpu_sm_86},
-          {8.7, oneapi_exp_arch::nvidia_gpu_sm_87},
-          {8.9, oneapi_exp_arch::nvidia_gpu_sm_89},
-          {9.0, oneapi_exp_arch::nvidia_gpu_sm_90},
-      };
-      auto GetArchNum = [&](const architecture &arch) {
-        for (const auto &Item : NvidiaArchNumbs)
-          if (Item.second == arch)
-            return Item.first;
-        return {};
-      };
-      float ComputeCapability = GetArchNum(DeviceArch);
-      std::vector<combination> sm_70_combinations = {
-          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp16, matrix_type::fp16},
-          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp16, matrix_type::fp16},
-          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp16, matrix_type::fp16},
-          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp16},
-          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp16},
-          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp32, matrix_type::fp16},
-          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp16, matrix_type::fp32},
-          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp16, matrix_type::fp32},
-          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-           matrix_type::fp16, matrix_type::fp32}};
-      std::vector<combination> sm_72_combinations = {
-          {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 8, 32, 16, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 32, 8, 16, matrix_type::sint8, matrix_type::sint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 16, 16, 16, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 8, 32, 16, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32},
-          {0, 0, 0, 32, 8, 16, matrix_type::uint8, matrix_type::uint8,
-           matrix_type::sint32, matrix_type::sint32}};
-      std::vector<combination> sm_80_combinations = {
-          {0, 0, 0, 16, 16, 8, matrix_type::tf32, matrix_type::tf32,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 8, 32, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 32, 8, 16, matrix_type::bf16, matrix_type::bf16,
-           matrix_type::fp32, matrix_type::fp32},
-          {0, 0, 0, 8, 8, 4, matrix_type::fp64, matrix_type::fp64,
-           matrix_type::fp64, matrix_type::fp64}};
-      if (ComputeCapability >= 8.0) {
-        sm_80_combinations.insert(sm_80_combinations.end(),
-                                  sm_72_combinations.begin(),
-                                  sm_72_combinations.end());
-        sm_80_combinations.insert(sm_80_combinations.end(),
-                                  sm_70_combinations.begin(),
-                                  sm_70_combinations.end());
-        return sm_80_combinations;
-      } else if (ComputeCapability >= 7.2) {
-        sm_72_combinations.insert(sm_72_combinations.end(),
-                                  sm_70_combinations.begin(),
-                                  sm_70_combinations.end());
-        return sm_72_combinations;
-      } else if (ComputeCapability >= 7.0)
-        return sm_70_combinations;
+      if (architecture::intel_cpu_spr == DeviceArch)
+        return {
+            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+        };
+      else if (architecture::intel_cpu_gnr == DeviceArch)
+        return {
+            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {16, 16, 32, 0, 0, 0, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+        };
+      else if (architecture::intel_gpu_pvc == DeviceArch)
+        return {
+            {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 16, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {8, 0, 0, 0, 16, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 32, 64, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {8, 0, 0, 0, 16, 8, matrix_type::tf32, matrix_type::tf32,
+             matrix_type::fp32, matrix_type::fp32},
+        };
+      else if ((architecture::intel_gpu_dg2_g10 == DeviceArch) ||
+               (architecture::intel_gpu_dg2_g11 == DeviceArch) ||
+               (architecture::intel_gpu_dg2_g12 == DeviceArch))
+        return {
+            {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {8, 0, 0, 0, 8, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {8, 0, 0, 0, 8, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+        };
+      else if (architecture::amd_gpu_gfx90a == DeviceArch)
+        return {
+            {0, 0, 0, 32, 32, 8, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 32, 32, 8, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 32, 32, 8, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
+             matrix_type::fp64, matrix_type::fp64},
+        };
+      else if (backend::ext_oneapi_cuda == CurrentBackend) {
+        // TODO: Tho following can be simplified when comparison of
+        // architectures using < and > will be implemented
+        using oneapi_exp_arch = sycl::ext::oneapi::experimental::architecture;
+        constexpr std::pair<float, oneapi_exp_arch> NvidiaArchNumbs[] = {
+            {5.0, oneapi_exp_arch::nvidia_gpu_sm_50},
+            {5.2, oneapi_exp_arch::nvidia_gpu_sm_52},
+            {5.3, oneapi_exp_arch::nvidia_gpu_sm_53},
+            {6.0, oneapi_exp_arch::nvidia_gpu_sm_60},
+            {6.1, oneapi_exp_arch::nvidia_gpu_sm_61},
+            {6.2, oneapi_exp_arch::nvidia_gpu_sm_62},
+            {7.0, oneapi_exp_arch::nvidia_gpu_sm_70},
+            {7.2, oneapi_exp_arch::nvidia_gpu_sm_72},
+            {7.5, oneapi_exp_arch::nvidia_gpu_sm_75},
+            {8.0, oneapi_exp_arch::nvidia_gpu_sm_80},
+            {8.6, oneapi_exp_arch::nvidia_gpu_sm_86},
+            {8.7, oneapi_exp_arch::nvidia_gpu_sm_87},
+            {8.9, oneapi_exp_arch::nvidia_gpu_sm_89},
+            {9.0, oneapi_exp_arch::nvidia_gpu_sm_90},
+        };
+        auto GetArchNum = [&](const architecture &arch) {
+          for (const auto &Item : NvidiaArchNumbs)
+            if (Item.second == arch)
+              return Item.first;
+          return 0.f;
+        };
+        float ComputeCapability = GetArchNum(DeviceArch);
+        std::vector<combination> sm_70_combinations = {
+            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp16, matrix_type::fp16},
+            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp16, matrix_type::fp16},
+            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp16, matrix_type::fp16},
+            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp16},
+            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp16},
+            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp32, matrix_type::fp16},
+            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp16, matrix_type::fp32},
+            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp16, matrix_type::fp32},
+            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+             matrix_type::fp16, matrix_type::fp32}};
+        std::vector<combination> sm_72_combinations = {
+            {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 8, 32, 16, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 32, 8, 16, matrix_type::sint8, matrix_type::sint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 16, 16, 16, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 8, 32, 16, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32},
+            {0, 0, 0, 32, 8, 16, matrix_type::uint8, matrix_type::uint8,
+             matrix_type::sint32, matrix_type::sint32}};
+        std::vector<combination> sm_80_combinations = {
+            {0, 0, 0, 16, 16, 8, matrix_type::tf32, matrix_type::tf32,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 8, 32, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 32, 8, 16, matrix_type::bf16, matrix_type::bf16,
+             matrix_type::fp32, matrix_type::fp32},
+            {0, 0, 0, 8, 8, 4, matrix_type::fp64, matrix_type::fp64,
+             matrix_type::fp64, matrix_type::fp64}};
+        if (ComputeCapability >= 8.0) {
+          sm_80_combinations.insert(sm_80_combinations.end(),
+                                    sm_72_combinations.begin(),
+                                    sm_72_combinations.end());
+          sm_80_combinations.insert(sm_80_combinations.end(),
+                                    sm_70_combinations.begin(),
+                                    sm_70_combinations.end());
+          return sm_80_combinations;
+        } else if (ComputeCapability >= 7.2) {
+          sm_72_combinations.insert(sm_72_combinations.end(),
+                                    sm_70_combinations.begin(),
+                                    sm_70_combinations.end());
+          return sm_72_combinations;
+        } else if (ComputeCapability >= 7.0)
+          return sm_70_combinations;
+      }
+    } catch (sycl::exception &e) {
+      if (e.code() != errc::runtime) {
+        std::exception_ptr e_ptr = std::make_exception_ptr(e);
+        std::rethrow_exception(e_ptr);
+      }
     }
     return {};
   }

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -736,195 +736,193 @@ struct get_device_info_impl<
     std::vector<ext::oneapi::experimental::matrix::combination>,
     ext::oneapi::experimental::info::device::matrix_combinations> {
   static std::vector<ext::oneapi::experimental::matrix::combination>
-  get(const DeviceImplPtr &Dev) {
+  get(const DeviceImplPtr &Dev) try {
     using namespace ext::oneapi::experimental::matrix;
     using namespace ext::oneapi::experimental;
     backend CurrentBackend = Dev->getBackend();
-    try {
-      architecture DeviceArch = get_device_info_impl<
-          ext::oneapi::experimental::architecture,
-          ext::oneapi::experimental::info::device::architecture>::get(Dev);
-      if (architecture::intel_cpu_spr == DeviceArch)
-        return {
-            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-        };
-      else if (architecture::intel_cpu_gnr == DeviceArch)
-        return {
-            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {16, 16, 32, 0, 0, 0, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-        };
-      else if (architecture::intel_gpu_pvc == DeviceArch)
-        return {
-            {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 16, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {8, 0, 0, 0, 16, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 32, 64, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {8, 0, 0, 0, 16, 8, matrix_type::tf32, matrix_type::tf32,
-             matrix_type::fp32, matrix_type::fp32},
-        };
-      else if ((architecture::intel_gpu_dg2_g10 == DeviceArch) ||
-               (architecture::intel_gpu_dg2_g11 == DeviceArch) ||
-               (architecture::intel_gpu_dg2_g12 == DeviceArch))
-        return {
-            {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {8, 0, 0, 0, 8, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {8, 0, 0, 0, 8, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-        };
-      else if (architecture::amd_gpu_gfx90a == DeviceArch)
-        return {
-            {0, 0, 0, 32, 32, 8, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 32, 32, 8, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 32, 32, 8, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
-             matrix_type::fp64, matrix_type::fp64},
-        };
-      else if (backend::ext_oneapi_cuda == CurrentBackend) {
-        // TODO: Tho following can be simplified when comparison of
-        // architectures using < and > will be implemented
-        using oneapi_exp_arch = sycl::ext::oneapi::experimental::architecture;
-        constexpr std::pair<float, oneapi_exp_arch> NvidiaArchNumbs[] = {
-            {5.0, oneapi_exp_arch::nvidia_gpu_sm_50},
-            {5.2, oneapi_exp_arch::nvidia_gpu_sm_52},
-            {5.3, oneapi_exp_arch::nvidia_gpu_sm_53},
-            {6.0, oneapi_exp_arch::nvidia_gpu_sm_60},
-            {6.1, oneapi_exp_arch::nvidia_gpu_sm_61},
-            {6.2, oneapi_exp_arch::nvidia_gpu_sm_62},
-            {7.0, oneapi_exp_arch::nvidia_gpu_sm_70},
-            {7.2, oneapi_exp_arch::nvidia_gpu_sm_72},
-            {7.5, oneapi_exp_arch::nvidia_gpu_sm_75},
-            {8.0, oneapi_exp_arch::nvidia_gpu_sm_80},
-            {8.6, oneapi_exp_arch::nvidia_gpu_sm_86},
-            {8.7, oneapi_exp_arch::nvidia_gpu_sm_87},
-            {8.9, oneapi_exp_arch::nvidia_gpu_sm_89},
-            {9.0, oneapi_exp_arch::nvidia_gpu_sm_90},
-        };
-        auto GetArchNum = [&](const architecture &arch) {
-          for (const auto &Item : NvidiaArchNumbs)
-            if (Item.second == arch)
-              return Item.first;
-          return 0.f;
-        };
-        float ComputeCapability = GetArchNum(DeviceArch);
-        std::vector<combination> sm_70_combinations = {
-            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp16, matrix_type::fp16},
-            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp16, matrix_type::fp16},
-            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp16, matrix_type::fp16},
-            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp16},
-            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp16},
-            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp32, matrix_type::fp16},
-            {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp16, matrix_type::fp32},
-            {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp16, matrix_type::fp32},
-            {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
-             matrix_type::fp16, matrix_type::fp32}};
-        std::vector<combination> sm_72_combinations = {
-            {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 8, 32, 16, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 32, 8, 16, matrix_type::sint8, matrix_type::sint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 16, 16, 16, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 8, 32, 16, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32},
-            {0, 0, 0, 32, 8, 16, matrix_type::uint8, matrix_type::uint8,
-             matrix_type::sint32, matrix_type::sint32}};
-        std::vector<combination> sm_80_combinations = {
-            {0, 0, 0, 16, 16, 8, matrix_type::tf32, matrix_type::tf32,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 8, 32, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 32, 8, 16, matrix_type::bf16, matrix_type::bf16,
-             matrix_type::fp32, matrix_type::fp32},
-            {0, 0, 0, 8, 8, 4, matrix_type::fp64, matrix_type::fp64,
-             matrix_type::fp64, matrix_type::fp64}};
-        if (ComputeCapability >= 8.0) {
-          sm_80_combinations.insert(sm_80_combinations.end(),
-                                    sm_72_combinations.begin(),
-                                    sm_72_combinations.end());
-          sm_80_combinations.insert(sm_80_combinations.end(),
-                                    sm_70_combinations.begin(),
-                                    sm_70_combinations.end());
-          return sm_80_combinations;
-        } else if (ComputeCapability >= 7.2) {
-          sm_72_combinations.insert(sm_72_combinations.end(),
-                                    sm_70_combinations.begin(),
-                                    sm_70_combinations.end());
-          return sm_72_combinations;
-        } else if (ComputeCapability >= 7.0)
-          return sm_70_combinations;
-      }
-    } catch (sycl::exception &e) {
-      if (e.code() != errc::runtime) {
-        std::rethrow_exception(std::make_exception_ptr(e));
-      }
+    architecture DeviceArch = get_device_info_impl<
+        ext::oneapi::experimental::architecture,
+        ext::oneapi::experimental::info::device::architecture>::get(Dev);
+    if (architecture::intel_cpu_spr == DeviceArch)
+      return {
+          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+      };
+    else if (architecture::intel_cpu_gnr == DeviceArch)
+      return {
+          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 64, 0, 0, 0, matrix_type::uint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 64, 0, 0, 0, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {16, 16, 32, 0, 0, 0, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {16, 16, 32, 0, 0, 0, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+      };
+    else if (architecture::intel_gpu_pvc == DeviceArch)
+      return {
+          {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 16, 32, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {8, 0, 0, 0, 16, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 64, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {8, 0, 0, 0, 16, 8, matrix_type::tf32, matrix_type::tf32,
+           matrix_type::fp32, matrix_type::fp32},
+      };
+    else if ((architecture::intel_gpu_dg2_g10 == DeviceArch) ||
+             (architecture::intel_gpu_dg2_g11 == DeviceArch) ||
+             (architecture::intel_gpu_dg2_g12 == DeviceArch))
+      return {
+          {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 8, 32, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {8, 0, 0, 0, 8, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {8, 0, 0, 0, 8, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+      };
+    else if (architecture::amd_gpu_gfx90a == DeviceArch)
+      return {
+          {0, 0, 0, 32, 32, 8, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 32, 8, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 32, 32, 8, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 4, matrix_type::fp64, matrix_type::fp64,
+           matrix_type::fp64, matrix_type::fp64},
+      };
+    else if (backend::ext_oneapi_cuda == CurrentBackend) {
+      // TODO: Tho following can be simplified when comparison of
+      // architectures using < and > will be implemented
+      using oneapi_exp_arch = sycl::ext::oneapi::experimental::architecture;
+      constexpr std::pair<float, oneapi_exp_arch> NvidiaArchNumbs[] = {
+          {5.0, oneapi_exp_arch::nvidia_gpu_sm_50},
+          {5.2, oneapi_exp_arch::nvidia_gpu_sm_52},
+          {5.3, oneapi_exp_arch::nvidia_gpu_sm_53},
+          {6.0, oneapi_exp_arch::nvidia_gpu_sm_60},
+          {6.1, oneapi_exp_arch::nvidia_gpu_sm_61},
+          {6.2, oneapi_exp_arch::nvidia_gpu_sm_62},
+          {7.0, oneapi_exp_arch::nvidia_gpu_sm_70},
+          {7.2, oneapi_exp_arch::nvidia_gpu_sm_72},
+          {7.5, oneapi_exp_arch::nvidia_gpu_sm_75},
+          {8.0, oneapi_exp_arch::nvidia_gpu_sm_80},
+          {8.6, oneapi_exp_arch::nvidia_gpu_sm_86},
+          {8.7, oneapi_exp_arch::nvidia_gpu_sm_87},
+          {8.9, oneapi_exp_arch::nvidia_gpu_sm_89},
+          {9.0, oneapi_exp_arch::nvidia_gpu_sm_90},
+      };
+      auto GetArchNum = [&](const architecture &arch) {
+        for (const auto &Item : NvidiaArchNumbs)
+          if (Item.second == arch)
+            return Item.first;
+        return 0.f;
+      };
+      float ComputeCapability = GetArchNum(DeviceArch);
+      std::vector<combination> sm_70_combinations = {
+          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp16, matrix_type::fp16},
+          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp16, matrix_type::fp16},
+          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp16, matrix_type::fp16},
+          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp16},
+          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp16},
+          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp32, matrix_type::fp16},
+          {0, 0, 0, 16, 16, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp16, matrix_type::fp32},
+          {0, 0, 0, 8, 32, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp16, matrix_type::fp32},
+          {0, 0, 0, 32, 8, 16, matrix_type::fp16, matrix_type::fp16,
+           matrix_type::fp16, matrix_type::fp32}};
+      std::vector<combination> sm_72_combinations = {
+          {0, 0, 0, 16, 16, 16, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 8, 32, 16, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 32, 8, 16, matrix_type::sint8, matrix_type::sint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 16, 16, 16, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 8, 32, 16, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32},
+          {0, 0, 0, 32, 8, 16, matrix_type::uint8, matrix_type::uint8,
+           matrix_type::sint32, matrix_type::sint32}};
+      std::vector<combination> sm_80_combinations = {
+          {0, 0, 0, 16, 16, 8, matrix_type::tf32, matrix_type::tf32,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 16, 16, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 8, 32, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 32, 8, 16, matrix_type::bf16, matrix_type::bf16,
+           matrix_type::fp32, matrix_type::fp32},
+          {0, 0, 0, 8, 8, 4, matrix_type::fp64, matrix_type::fp64,
+           matrix_type::fp64, matrix_type::fp64}};
+      if (ComputeCapability >= 8.0) {
+        sm_80_combinations.insert(sm_80_combinations.end(),
+                                  sm_72_combinations.begin(),
+                                  sm_72_combinations.end());
+        sm_80_combinations.insert(sm_80_combinations.end(),
+                                  sm_70_combinations.begin(),
+                                  sm_70_combinations.end());
+        return sm_80_combinations;
+      } else if (ComputeCapability >= 7.2) {
+        sm_72_combinations.insert(sm_72_combinations.end(),
+                                  sm_70_combinations.begin(),
+                                  sm_70_combinations.end());
+        return sm_72_combinations;
+      } else if (ComputeCapability >= 7.0)
+        return sm_70_combinations;
     }
     return {};
+  } catch (sycl::exception &e) {
+    if (e.code() != errc::runtime) {
+      std::rethrow_exception(std::make_exception_ptr(e));
+    }
   }
 };
 


### PR DESCRIPTION
This patch relaxes reporting of unsupported HW for matrix_combinations
query.
Before: exception thrown in case customer uses matrix_combinations
query on platform unsupported by ext_oneapi_device_architecture.
With this patch: customer gets empty vector from matrix_combinations
query on platform unsupported by ext_oneapi_device_architecture.