### PR TITLE
[SYCL][Doc] Fix namespace in forward_progress spec

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_forward_progress.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_forward_progress.asciidoc
@@ -254,7 +254,7 @@ of forward progress guarantee defined in the {cpp} core language specification.
 
 [source,c++]
 ----
-namespace ext::oneapi::experimental::sycl {
+namespace sycl::ext::oneapi::experimental {
 
 enum class forward_progress_guarantee {
   concurrent,
@@ -279,7 +279,7 @@ execution within a SYCL implementation.
 
 [source,c++]
 ----
-namespace ext::oneapi::experimental::sycl {
+namespace sycl::ext::oneapi::experimental {
 
 enum class execution_scope {
   work_item,


### PR DESCRIPTION
An automated renaming led to the sycl part of the namespace appearing in the wrong place.