### PR TITLE
[SYCL][Docs] Invert group numbering for ballot groups

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc
@@ -337,8 +337,8 @@ id_type get_group_id() const;
 ----
 _Returns_: An `id` representing the index of the ballot-group.
 
-NOTE: This will always be either 0 (representing the group of work-items where
-the predicate was true) or 1 (representing the group of work-items where the
+NOTE: This will always be either 1 (representing the group of work-items where
+the predicate was true) or 0 (representing the group of work-items where the
 predicate was false).
 
 [source,c++]

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc
@@ -357,6 +357,8 @@ _Returns_: A `range` representing the number of ballot-groups.
 NOTE: This will always return a `range` of 2, as there will always be two groups;
 one representing the group of work-items where the predicate was true and
 another representing the group of work-items where the predicate was false.
+It is possible for one of these groups to contain no work-items, if the
+predicate has the same value on all work-items.
 
 [source,c++]
 ----


### PR DESCRIPTION
The current extension for non-uniform groups state that ballot groups are numbered 0 if the predicate was true and 1 if the predicate was false. However, the implementation has the inverse numbering. This commit changes the extension to make the numbering consistent with the implementation, in turn making the group numbering directly convertible to a boolean value equal to the corresponding predicate.