### PR TITLE
[SYCL] [E2E] Remove XFAIL from Plugin/level_zero_usm_residency.cpp

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_usm_residency.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_usm_residency.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: gpu, level_zero
 
-// https://github.com/intel/llvm/issues/11434
-// XFAIL: gpu-intel-dg2
-
 // RUN: %{build} %level_zero_options -o %t.out
 // RUN: env SYCL_PI_TRACE=-1 UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --check-prefixes=DEVICE %s
 // RUN: env SYCL_PI_LEVEL_ZERO_USM_RESIDENT=0x001 SYCL_PI_TRACE=-1 UR_L0_DEBUG=-1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck --check-prefixes=DEVICE %s


### PR DESCRIPTION
Plugin/level_zero_usm_residency.cpp started passing in post-commit on DG2 (https://github.com/intel/llvm/actions/runs/8148488311/job/22271712949) after my change in https://github.com/intel/llvm/pull/12844.
