### PR TITLE
[SYCL] Fix component device as descendent device handling

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -47,22 +47,20 @@ context_impl::context_impl(const std::vector<sycl::device> Devices,
       MSupportBufferLocationByDevices(NotChecked) {
   MPlatform = detail::getSyclObjImpl(MDevices[0].get_platform());
   std::vector<sycl::detail::pi::PiDevice> DeviceIds;
-  for (size_t I = 0, E = MDevices.size(); I != E; ++I) {
-    if (MDevices[I].has(aspect::ext_oneapi_is_composite)) {
+  for (const auto &D : MDevices) {
+    if (D.has(aspect::ext_oneapi_is_composite)) {
       // Component devices are considered to be descendent devices from a
       // composite device and therefore context created for a composite
       // device should also work for a component device.
       // In order to achieve that, we implicitly add all component devices to
       // the list if a composite device was passed by user to us.
-      std::vector<device> ComponentDevices =
-          MDevices[I]
-              .get_info<
-                  ext::oneapi::experimental::info::device::component_devices>();
+      std::vector<device> ComponentDevices = D.get_info<
+          ext::oneapi::experimental::info::device::component_devices>();
       for (const auto &CD : ComponentDevices)
         DeviceIds.push_back(getSyclObjImpl(CD)->getHandleRef());
     }
 
-    DeviceIds.push_back(getSyclObjImpl(MDevices[I])->getHandleRef());
+    DeviceIds.push_back(getSyclObjImpl(D)->getHandleRef());
   }
 
   if (getBackend() == backend::ext_oneapi_cuda) {

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -58,10 +58,8 @@ context_impl::context_impl(const std::vector<sycl::device> Devices,
           MDevices[I]
               .get_info<
                   ext::oneapi::experimental::info::device::component_devices>();
-      for (const auto &CD : ComponentDevices) {
+      for (const auto &CD : ComponentDevices)
         DeviceIds.push_back(getSyclObjImpl(CD)->getHandleRef());
-        MDevices.push_back(CD);
-      }
     }
 
     DeviceIds.push_back(getSyclObjImpl(MDevices[I])->getHandleRef());

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -8,6 +8,7 @@ add_sycl_unittest(ExtensionsTests OBJECT
   DeviceGlobal.cpp
   OneAPISubGroupMask.cpp
   USMP2P.cpp
+  CompositeDevice.cpp
 )
 
 add_subdirectory(CommandGraph)

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -104,7 +104,7 @@ TEST(CompositeDeviceTest, DescendentDeviceSupport) {
 
   auto CompositeDevice = RootDevice.get_info<
       sycl::ext::oneapi::experimental::info::device::composite_device>();
-  sycl::context Ctx2(CompositeDevice);
+  sycl::context CompositeDevContext(CompositeDevice);
   // To make sure that component devices an also be used within a context
   // created for a composite device, we expect them to be implicitly added to
   // the context under the hood.
@@ -124,4 +124,9 @@ TEST(CompositeDeviceTest, DescendentDeviceSupport) {
                             return D == reinterpret_cast<pi_device>(
                                             COMPONENT_DEVICE_B);
                           }));
+  // Even though under the hood we have created context for 3 devices,
+  // user-visible interface should only report the exact list of devices passed
+  // by user to the context constructor.
+  ASSERT_EQ(CompositeDevContext.get_devices().size(), 1);
+  ASSERT_EQ(CompositeDevContext.get_devices().front(), CompositeDevice);
 }

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -105,7 +105,7 @@ TEST(CompositeDeviceTest, DescendentDeviceSupport) {
   auto CompositeDevice = RootDevice.get_info<
       sycl::ext::oneapi::experimental::info::device::composite_device>();
   sycl::context CompositeDevContext(CompositeDevice);
-  // To make sure that component devices an also be used within a context
+  // To make sure that component devices can also be used within a context
   // created for a composite device, we expect them to be implicitly added to
   // the context under the hood.
   ASSERT_EQ(DevicesUsedInContextCreation.size(), 3u);

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -98,7 +98,7 @@ TEST(CompositeDeviceTest, DescendentDeviceSupport) {
   ASSERT_TRUE(RootDevice.has(sycl::aspect::ext_oneapi_is_component));
   sycl::context Ctx(RootDevice);
   // We expect to only see the passed device
-  ASSERT_EQ(DevicesUsedInContextCreation.size(), 1);
+  ASSERT_EQ(DevicesUsedInContextCreation.size(), 1u);
   ASSERT_EQ(DevicesUsedInContextCreation.front(),
             reinterpret_cast<pi_device>(COMPONENT_DEVICE_A));
 
@@ -108,7 +108,7 @@ TEST(CompositeDeviceTest, DescendentDeviceSupport) {
   // To make sure that component devices an also be used within a context
   // created for a composite device, we expect them to be implicitly added to
   // the context under the hood.
-  ASSERT_EQ(DevicesUsedInContextCreation.size(), 3);
+  ASSERT_EQ(DevicesUsedInContextCreation.size(), 3u);
   ASSERT_TRUE(std::any_of(DevicesUsedInContextCreation.begin(),
                           DevicesUsedInContextCreation.end(), [=](pi_device D) {
                             return D == reinterpret_cast<pi_device>(
@@ -127,6 +127,6 @@ TEST(CompositeDeviceTest, DescendentDeviceSupport) {
   // Even though under the hood we have created context for 3 devices,
   // user-visible interface should only report the exact list of devices passed
   // by user to the context constructor.
-  ASSERT_EQ(CompositeDevContext.get_devices().size(), 1);
+  ASSERT_EQ(CompositeDevContext.get_devices().size(), 1u);
   ASSERT_EQ(CompositeDevContext.get_devices().front(), CompositeDevice);
 }

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -1,0 +1,127 @@
+#include <sycl/sycl.hpp>
+
+#include <helpers/PiMock.hpp>
+
+#include <gtest/gtest.h>
+
+#include <algorithm>
+
+namespace {
+constexpr int COMPOSITE_DEVICE = 1;
+constexpr int COMPONENT_DEVICE_A = 2;
+constexpr int COMPONENT_DEVICE_B = 3;
+
+pi_result redefine_piDevicesGet(pi_platform platform, pi_device_type,
+                                pi_uint32 num_entries, pi_device *devices,
+                                pi_uint32 *num_devices) {
+  if (num_devices)
+    *num_devices = 2;
+  if (devices) {
+    if (num_entries > 0)
+      devices[0] = reinterpret_cast<pi_device>(COMPONENT_DEVICE_A);
+    if (num_entries > 1)
+      devices[1] = reinterpret_cast<pi_device>(COMPONENT_DEVICE_B);
+  }
+  return PI_SUCCESS;
+}
+
+pi_result after_piDeviceGetInfo(pi_device device, pi_device_info param_name,
+                                size_t param_value_size, void *param_value,
+                                size_t *param_value_size_ret) {
+  switch (param_name) {
+  case PI_EXT_ONEAPI_DEVICE_INFO_COMPOSITE_DEVICE:
+    if (param_value_size_ret)
+      *param_value_size_ret = sizeof(pi_device);
+    if (param_value) {
+      if (device == reinterpret_cast<pi_device>(COMPONENT_DEVICE_A) ||
+          device == reinterpret_cast<pi_device>(COMPONENT_DEVICE_B)) {
+        *static_cast<pi_device *>(param_value) =
+            reinterpret_cast<pi_device>(COMPOSITE_DEVICE);
+      } else
+        *static_cast<pi_device *>(param_value) = nullptr;
+    }
+
+    return PI_SUCCESS;
+
+  case PI_EXT_ONEAPI_DEVICE_INFO_COMPONENT_DEVICES:
+    if (device == reinterpret_cast<pi_device>(COMPOSITE_DEVICE)) {
+      if (param_value_size_ret)
+        *param_value_size_ret = 2 * sizeof(pi_device);
+      if (param_value) {
+        if (param_value_size >= sizeof(pi_device))
+          static_cast<pi_device *>(param_value)[0] =
+              reinterpret_cast<pi_device>(COMPONENT_DEVICE_A);
+        if (param_value_size >= 2 * sizeof(pi_device))
+          static_cast<pi_device *>(param_value)[1] =
+              reinterpret_cast<pi_device>(COMPONENT_DEVICE_B);
+      }
+
+    } else {
+      if (param_value_size_ret)
+        *param_value_size_ret = 0;
+    }
+
+    return PI_SUCCESS;
+
+  default:
+    return PI_SUCCESS;
+  }
+}
+
+thread_local std::vector<pi_device> DevicesUsedInContextCreation;
+
+pi_result after_piContextCreate(const pi_context_properties *,
+                                pi_uint32 num_devices, const pi_device *devices,
+                                void (*)(const char *, const void *, size_t,
+                                         void *),
+                                void *, pi_context *ret_context) {
+
+  DevicesUsedInContextCreation.assign(devices, devices + num_devices);
+
+  return PI_SUCCESS;
+}
+
+} // namespace
+
+TEST(CompositeDeviceTest, DescendentDeviceSupport) {
+  sycl::unittest::PiMock Mock(sycl::backend::ext_oneapi_level_zero);
+  Mock.redefine<sycl::detail::PiApiKind::piDevicesGet>(redefine_piDevicesGet);
+  Mock.redefineAfter<sycl::detail::PiApiKind::piDeviceGetInfo>(
+      after_piDeviceGetInfo);
+  Mock.redefineAfter<sycl::detail::PiApiKind::piContextCreate>(
+      after_piContextCreate);
+
+  sycl::platform Plt = Mock.getPlatform();
+  ASSERT_EQ(Plt.get_backend(), sycl::backend::ext_oneapi_level_zero);
+
+  sycl::device RootDevice = Plt.get_devices()[0];
+  ASSERT_TRUE(RootDevice.has(sycl::aspect::ext_oneapi_is_component));
+  sycl::context Ctx(RootDevice);
+  // We expect to only see the passed device
+  ASSERT_EQ(DevicesUsedInContextCreation.size(), 1);
+  ASSERT_EQ(DevicesUsedInContextCreation.front(),
+            reinterpret_cast<pi_device>(COMPONENT_DEVICE_A));
+
+  auto CompositeDevice = RootDevice.get_info<
+      sycl::ext::oneapi::experimental::info::device::composite_device>();
+  sycl::context Ctx2(CompositeDevice);
+  // To make sure that component devices an also be used within a context
+  // created for a composite device, we expect them to be implicitly added to
+  // the context under the hood.
+  ASSERT_EQ(DevicesUsedInContextCreation.size(), 3);
+  ASSERT_TRUE(std::any_of(DevicesUsedInContextCreation.begin(),
+                          DevicesUsedInContextCreation.end(), [=](pi_device D) {
+                            return D == reinterpret_cast<pi_device>(
+                                            COMPOSITE_DEVICE);
+                          }));
+  ASSERT_TRUE(std::any_of(DevicesUsedInContextCreation.begin(),
+                          DevicesUsedInContextCreation.end(), [=](pi_device D) {
+                            return D == reinterpret_cast<pi_device>(
+                                            COMPONENT_DEVICE_A);
+                          }));
+  ASSERT_TRUE(std::any_of(DevicesUsedInContextCreation.begin(),
+                          DevicesUsedInContextCreation.end(), [=](pi_device D) {
+                            return D == reinterpret_cast<pi_device>(
+                                            COMPONENT_DEVICE_B);
+                          }));
+}


### PR DESCRIPTION
According to `sycl_ext_oneapi_composite_device` documentation a component device is considered to be a descendent from a composite device it belongs to.

This implies that context created for a composite device work with component devices as well.

In order to achieve this, this patch changes `context_impl` constructor to include all component devices into context's device list if a composite device was passed by user to the constructor.