### PR TITLE
Revert "Map FPFastMathModeINTEL on SPV_INTEL_fp_fast_math_mode (#2360)"

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.h
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVEntry.h
@@ -904,8 +904,6 @@ public:
       return ExtensionID::SPV_INTEL_fast_composite;
     case internal::CapabilitySubgroupRequirementsINTEL:
       return ExtensionID::SPV_INTEL_subgroup_requirements;
-    case CapabilityFPFastMathModeINTEL:
-      return ExtensionID::SPV_INTEL_fp_fast_math_mode;
     default:
       return {};
     }

--- a/llvm-spirv/test/extensions/INTEL/SPV_INTEL_fp_fast_math_mode/fp_contract_reassoc_fast_mode.ll
+++ b/llvm-spirv/test/extensions/INTEL/SPV_INTEL_fp_fast_math_mode/fp_contract_reassoc_fast_mode.ll
@@ -5,14 +5,12 @@
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o - | FileCheck %s --check-prefix=CHECK-LLVM
  
 ; CHECK-SPIRV-ON: 2 Capability FPFastMathModeINTEL
-; CHECK-SPIRV-ON: SPV_INTEL_fp_fast_math_mode
 ; CHECK-SPIRV-ON: 3 Name [[mu:[0-9]+]] "mul"
 ; CHECK-SPIRV-ON: 3 Name [[su:[0-9]+]] "sub"
 ; CHECK-SPIRV-ON-DAG: 4 Decorate [[mu]] FPFastMathMode 65536
 ; CHECK-SPIRV-ON-DAG: 4 Decorate [[su]] FPFastMathMode 131072
 
 ; CHECK-SPIRV-OFF-NOT: 2 Capability FPFastMathModeINTEL
-; CHECK-SPIRV-OFF-NOT: SPV_INTEL_fp_fast_math_mode
 ; CHECK-SPIRV-OFF: 3 Name [[mu:[0-9]+]] "mul"
 ; CHECK-SPIRV-OFF: 3 Name [[su:[0-9]+]] "sub"
 ; CHECK-SPIRV-OFF-NOT: 4 Decorate [[mu]] FPFastMathMode 65536


### PR DESCRIPTION
This reverts commit 339c1c6024e284a6becfc0abfbb1d3d63fa6527d.

It's a good-tiny fix, but we have to revert it for now.