### PR TITLE
[SYCL][Bindless][Doc] Introduce SPIR-V spec for enabling bindless images on Intel devices

### DIFF
--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -101,7 +101,7 @@ OpConvertHandleToSamplerINTEL
 |======
 5+|[[OpConvertHandleToImageINTEL]]*OpConvertHandleToImageINTEL* +
  +
-Accepts an unsigned integer and converts to image type.
+Converts an unsigned integer pointed by _Operand_ to image type.
 
 Unsigned integer is either a 64 or 32 bit unsigned integer.
 Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
@@ -115,7 +115,7 @@ _Result type_ must be an `OpTypeImage`.
 |======
 5+|[[OpConvertHandleToSamplerINTEL]]*OpConvertHandleToSamplerINTEL* +
  +
-Accepts an unsigned integer and converts to sampler type.
+Converts an unsigned integer pointed by _Operand_ to sampler type.
 
 Unsigned integer is either a 64 or 32 bit unsigned integer.
 Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -103,8 +103,8 @@ OpConvertHandleToSamplerINTEL
  +
 Converts an unsigned integer pointed by _Operand_ to image type.
 
-Unsigned integer is either a 64 or 32 bit unsigned integer.
-Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
+Unsigned integer is either a 32 or 64 bit unsigned integer.
+Depending on if the addressing model is set to *Physical32* or *Physical64*.
 
 _Result type_ must be an `OpTypeImage`.
 
@@ -117,8 +117,8 @@ _Result type_ must be an `OpTypeImage`.
  +
 Converts an unsigned integer pointed by _Operand_ to sampler type.
 
-Unsigned integer is either a 64 or 32 bit unsigned integer.
-Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
+Unsigned integer is either a 32 or 64 bit unsigned integer.
+Depending on if the addressing model is set to *Physical32* or *Physical64*.
 
 _Result type_ must be an `OpTypeSampler`.
 

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -106,7 +106,7 @@ Accepts an unsigned integer and converts to image type.
 Unsigned integer is either a 64 or 32 bit unsigned integer.
 Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
 
-Return type must be an `OpTypeImage`.
+_Result type_ must be an `OpTypeImage`.
 
 | 4 | 6529 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
 |======
@@ -120,7 +120,7 @@ Accepts an unsigned integer and converts to sampler type.
 Unsigned integer is either a 64 or 32 bit unsigned integer.
 Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
 
-Return type must be an `OpTypeSampler`.
+_Result type_ must be an `OpTypeSampler`.
 
 | 4 | 6530 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
 |======

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -1,0 +1,138 @@
+SPV_INTEL_bindless_images
+=========================
+
+== Name Strings
+
+SPV_INTEL_bindless_images
+
+== Contact
+
+To report problems with this extension, please open a new issue at:
+
+<https://github.com/intel/llvm/issues>
+
+== Contributors
+
+- Duncan Brawley, Codeplay
+- Przemek Malon, Codeplay
+- Peter Žužek, Codeplay
+- Chedy Najjar, Codeplay
+
+== Notice
+
+Copyright © Codeplay Software Limited. All rights reserved.
+
+== Status
+
+In Development
+
+== Version
+
+[width="40%",cols="25,25"]
+|========================================
+| Last Modified Date | 2024-02-23
+| Revision           | 6
+|========================================
+
+== Dependencies
+
+This extension is written against the SPIR-V Specification,
+Version 1.6 Revision 1.
+
+This extension requires SPIR-V 1.0.
+
+== Overview
+
+This extension adds support for bindless images.
+This is done by adding support for SPIR-V to convert unsigned integer handles to images/samplers.
+
+Bindless images are a feature that provides flexibility on how images are accessed and used, such as removing limitations on how many images can be accessed as well as potentially improving performance.
+This is an improvement on the legacy bound images model which is a holdover from binding slots in hardware which used to be limited in number.
+
+== Extension Name
+
+To use this extension within a SPIR-V module, the following *OpExtension* must be present in the module:
+
+----
+OpExtension "SPV_INTEL_bindless_images"
+----
+
+== New Capabilities
+
+This extension introduces a new capability:
+
+----
+BindlessImagesINTEL
+----
+
+== New Instructions
+
+Instructions added under *BindlessImagesINTEL* capability.
+
+----
+OpConvertHandleToImageINTEL
+OpConvertHandleToSamplerINTEL
+----
+
+== Token Number Assignments
+
+--
+[width="40%"]
+[cols="70%,30%"]
+[grid="rows"]
+|====
+|BindlessImagesINTEL                |6528
+|OpConvertHandleToImageINTEL        |6529
+|OpConvertHandleToSamplerINTEL      |6530
+|====
+--
+
+== Modifications to the SPIR-V Specification, Version 1.6
+
+[cols="2*1,3*2"]
+|======
+5+|[[OpConvertHandleToImageINTEL]]*OpConvertHandleToImageINTEL* +
+ +
+Accepts an unsigned integer and converts to image type.
+
+Unsigned integer is either a 64 or 32 bit unsigned integer.
+Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
+
+Return type must be an `OpTypeImage`.
+
+| 4 | 6529 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
+|======
+
+[cols="2*1,3*2"]
+|======
+5+|[[OpConvertHandleToSamplerINTEL]]*OpConvertHandleToSamplerINTEL* +
+ +
+Accepts an unsigned integer and converts to sampler type.
+
+Unsigned integer is either a 64 or 32 bit unsigned integer.
+Depending on whether *OpMemoryModel* is set to *Physical32* or *Physical64*.
+
+Return type must be an `OpTypeSampler`.
+
+| 4 | 6530 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
+|======
+
+
+== Issues
+
+None Yet.
+
+== Revision History
+
+[cols="5,15,15,70"]
+[grid="rows"]
+[options="header"]
+|========================================
+|Rev|Date|Author|Changes
+|1|2023-03-23|Duncan Brawley|*Initial public release*
+|2|2023-03-30|Duncan Brawley| Updated token assignments
+|3|2023-05-29|Duncan Brawley| Updated token assignments and fix capitalization
+|4|2023-06-13|Duncan Brawley| Remove need for OpHandleAddressingModeINTEL instruction
+|5|2024-02-23|Duncan Brawley| Remove OpConvertHandleToSampledImageINTEL instruction and clarify return types
+|========================================
+

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -1,3 +1,7 @@
+:capability_token: 6528
+:handle_to_image_token: 6529
+:handle_to_sampler_token: 6530
+
 SPV_INTEL_bindless_images
 =========================
 
@@ -33,7 +37,7 @@ In Development
 
 [width="40%",cols="25,25"]
 |========================================
-| Last Modified Date | 2024-02-23
+| Last Modified Date | 2024-03-25
 | Revision           | 6
 |========================================
 
@@ -89,9 +93,9 @@ OpConvertHandleToSamplerINTEL
 [cols="70%,30%"]
 [grid="rows"]
 |====
-|BindlessImagesINTEL                |6528
-|OpConvertHandleToImageINTEL        |6529
-|OpConvertHandleToSamplerINTEL      |6530
+|BindlessImagesINTEL                |{capability_token}
+|OpConvertHandleToImageINTEL        |{handle_to_image_token}
+|OpConvertHandleToSamplerINTEL      |{handle_to_sampler_token}
 |====
 --
 
@@ -111,7 +115,8 @@ Depending on if the addressing model is set to *Physical32* or *Physical64*.
 
 _Result type_ must be an `OpTypeImage`.
 
-| 4 | 6529 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
+| 4 | {handle_to_image_token} | '<id> Result Type' | 'Result <id>' |
+'<id> Operand'
 |======
 
 [cols="2*1,3*2"]
@@ -125,7 +130,8 @@ Depending on if the addressing model is set to *Physical32* or *Physical64*.
 
 _Result type_ must be an `OpTypeSampler`.
 
-| 4 | 6530 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
+| 4 | {handle_to_sampler_token} | '<id> Result Type' | 'Result <id>' |
+'<id> Operand'
 |======
 
 Modify Section 3.31, Capability, adding row to the capability table:
@@ -134,7 +140,7 @@ Modify Section 3.31, Capability, adding row to the capability table:
 [options="header"]
 |====
 2+^| Capability ^| Implicitly Declares
-| 6528 | BindlessImagesINTEL |
+| {capability_token} | BindlessImagesINTEL |
 |====
 
 
@@ -156,5 +162,8 @@ None Yet.
                               instruction
 |5|2024-02-23|Duncan Brawley| Remove OpConvertHandleToSampledImageINTEL
                               instruction and clarify return types
+|6|2024-03-25|Duncan Brawley| Wording/formatting improvements, clarify sections
+                              edited, make capability addition explicit and
+                              substitute instruction numbers            
 |========================================
 

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -95,7 +95,10 @@ OpConvertHandleToSamplerINTEL
 |====
 --
 
-== Modifications to the SPIR-V Specification, Version 1.6
+== Modifications to the SPIR-V Specification, Version 1.6, Revision 2
+
+Modify Section 3.49.10, Image Instructions, adding to the end of the list of
+instructions:
 
 [cols="2*1,3*2"]
 |======

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -128,6 +128,15 @@ _Result type_ must be an `OpTypeSampler`.
 | 4 | 6530 | '<id> Result Type' | 'Result <id>' | '<id> Operand'
 |======
 
+Modify Section 3.31, Capability, adding row to the capability table:
+
+[width="40%"]
+[options="header"]
+|====
+2+^| Capability ^| Implicitly Declares
+| 6528 | BindlessImagesINTEL |
+|====
+
 
 == Issues
 

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -47,14 +47,19 @@ This extension requires SPIR-V 1.0.
 == Overview
 
 This extension adds support for bindless images.
-This is done by adding support for SPIR-V to convert unsigned integer handles to images/samplers.
+This is done by adding support for SPIR-V to convert unsigned integer handles to
+images/samplers.
 
-Bindless images are a feature that provides flexibility on how images are accessed and used, such as removing limitations on how many images can be accessed as well as potentially improving performance.
-This is an improvement on the legacy bound images model which is a holdover from binding slots in hardware which used to be limited in number.
+Bindless images are a feature that provides flexibility on how images are
+accessed and used, such as removing limitations on how many images can be
+accessed as well as potentially improving performance.
+This is an improvement on the legacy bound images model which is a holdover from
+binding slots in hardware which used to be limited in number.
 
 == Extension Name
 
-To use this extension within a SPIR-V module, the following *OpExtension* must be present in the module:
+To use this extension within a SPIR-V module, the following *OpExtension* must
+be present in the module:
 
 ----
 OpExtension "SPV_INTEL_bindless_images"
@@ -135,7 +140,9 @@ None Yet.
 |1|2023-03-23|Duncan Brawley|*Initial public release*
 |2|2023-03-30|Duncan Brawley| Updated token assignments
 |3|2023-05-29|Duncan Brawley| Updated token assignments and fix capitalization
-|4|2023-06-13|Duncan Brawley| Remove need for OpHandleAddressingModeINTEL instruction
-|5|2024-02-23|Duncan Brawley| Remove OpConvertHandleToSampledImageINTEL instruction and clarify return types
+|4|2023-06-13|Duncan Brawley| Remove need for OpHandleAddressingModeINTEL 
+                              instruction
+|5|2024-02-23|Duncan Brawley| Remove OpConvertHandleToSampledImageINTEL
+                              instruction and clarify return types
 |========================================
 

--- a/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
+++ b/sycl/doc/design/spirv-extensions/SPV_INTEL_bindless_images.asciidoc
@@ -17,6 +17,9 @@ To report problems with this extension, please open a new issue at:
 - Przemek Malon, Codeplay
 - Peter Žužek, Codeplay
 - Chedy Najjar, Codeplay
+- Sean Stirling, Codeplay
+- Isaac Ault, Codeplay
+- Victor Lomuller, Codeplay
 
 == Notice
 


### PR DESCRIPTION
Create a new extension to enable SPIR-V to support handle conversion to image and sampler types for the bindless images extension.