### PR TITLE
[SYCL][Docs] Specify command_start meaning for profiling tags

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
@@ -157,10 +157,10 @@ This timestamp is between the `info::event_profiling::command_submit` and
 `info::event_profiling::command_end` timestamps.
 
 It is unspecified whether the event ever has the
-`info::event_command_status::running` status. Implementations are encouraged
-to transition the event directly from the "submitted" status to the "complete"
-status and are encouraged to set the "command_start" timestamp to the same value
-as the "command_end" timestamp.
+`info::event_command_status::running` status.
+Implementations are encouraged to transition the event directly from the
+"submitted" status to the "complete" status and are encouraged to set the
+"command_start" timestamp to the same value as the "command_end" timestamp.
 
 _Throws:_ A synchronous `exception` with the `errc::invalid` error code if the
 queue was not constructed with the `property::queue::enable_profiling` property

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
@@ -151,13 +151,16 @@ The event's `info::event_profiling::command_submit` timestamp reflects the
 time at which `submit_profiling_tag` is called.
 The event's `info::event_profiling::command_end` timestamp reflects the time
 at which the event enters the "complete" state.
+The event's `info::event_profiling::command_start` timestamp reflects the time
+that the profiling tag command starts executing. This timestamp is between
+the `info::event_profiling::command_submit` and
+`info::event_profiling::command_end` timestamps.
 
 It is unspecified whether the event ever has the
-`info::event_command_status::running` status, and the meaning of the
-`info::event_profiling::command_start` timestamp is also unspecified.
-Implementations are encouraged to transition the event directly from the
-"submitted" status to the "complete" status and are encouraged to set the
-"command_start" timestamp to the same value as the "command_end" timestamp.
+`info::event_command_status::running` status. Implementations are encouraged
+to transition the event directly from the "submitted" status to the "complete"
+status and are encouraged to set the "command_start" timestamp to the same value
+as the "command_end" timestamp.
 
 _Throws:_ A synchronous `exception` with the `errc::invalid` error code if the
 queue was not constructed with the `property::queue::enable_profiling` property

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
@@ -152,8 +152,8 @@ time at which `submit_profiling_tag` is called.
 The event's `info::event_profiling::command_end` timestamp reflects the time
 at which the event enters the "complete" state.
 The event's `info::event_profiling::command_start` timestamp reflects the time
-that the profiling tag command starts executing. This timestamp is between
-the `info::event_profiling::command_submit` and
+that the profiling tag command starts executing.
+This timestamp is between the `info::event_profiling::command_submit` and
 `info::event_profiling::command_end` timestamps.
 
 It is unspecified whether the event ever has the


### PR DESCRIPTION
This commit clarifies the meaning of command_start on profiling tags.