### PR TITLE
[SYCL][E2E] Split vector scalar operator ordering test

### DIFF
--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order.hpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order.hpp
@@ -1,13 +1,8 @@
-// REQUIRES: preview-breaking-changes-supported
-// RUN: %{build} -fpreview-breaking-changes -o %t.out
-// RUN: %{run} %t.out
+// Header with helper macros for testing vec binary operators.
 
-// This test currently fails on AMD HIP due to an unresolved memcmp function.
-// XFAIL: hip_amd
+#pragma once
 
-// Checks scalar/vec operator ordering.
-
-#include <sycl.hpp>
+#include <sycl/sycl.hpp>
 
 template <typename T>
 using rel_t = std::conditional_t<
@@ -101,50 +96,3 @@ bool CheckResult(sycl::vec<T1, N> V, T2 Ref) {
   CHECK(Q, C, T, 4, IS_RELOP, OP)                                              \
   CHECK(Q, C, T, 8, IS_RELOP, OP)                                              \
   CHECK(Q, C, T, 16, IS_RELOP, OP)
-
-// NOTE: For the sake of compile-time we pick only a few operators per category.
-#define CHECK_SIZES_AND_COMMON_OPS(Q, C, T)                                    \
-  CHECK_SIZES(Q, Failures, T, false, *)                                        \
-  CHECK_SIZES(Q, Failures, T, true, &&)                                        \
-  CHECK_SIZES(Q, Failures, T, true, ==)                                        \
-  CHECK_SIZES(Q, Failures, T, true, <)                                         \
-  CHECK_SIZES(Q, Failures, T, true, >=)
-#define CHECK_SIZES_AND_INT_ONLY_OPS(Q, C, T)                                  \
-  CHECK_SIZES(Q, Failures, T, false, %)                                        \
-  CHECK_SIZES(Q, Failures, T, false, >>)                                       \
-  CHECK_SIZES(Q, Failures, T, false, ^)
-
-int main() {
-  sycl::queue Q;
-  int Failures = 0;
-
-  // Check operators on types with requirements if they are supported.
-  if (Q.get_device().has(sycl::aspect::fp16)) {
-    CHECK_SIZES_AND_COMMON_OPS(Q, Failures, sycl::half);
-  }
-  if (Q.get_device().has(sycl::aspect::fp64)) {
-    CHECK_SIZES_AND_COMMON_OPS(Q, Failures, double);
-  }
-
-  // Check all operators without requirements.
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, float);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int8_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int16_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int64_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint8_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint64_t);
-
-  // Check integer only operators.
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int8_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int16_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int32_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int64_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint8_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint16_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint32_t);
-  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint64_t);
-  return Failures;
-}

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_arith.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_arith.cpp
@@ -1,0 +1,53 @@
+// REQUIRES: preview-breaking-changes-supported
+// RUN: %{build} -fpreview-breaking-changes -o %t.out
+// RUN: %{run} %t.out
+
+// This test currently fails on AMD HIP due to an unresolved memcmp function.
+// XFAIL: hip_amd
+
+// Checks scalar/vec arithmetic operator ordering.
+
+#include "vec_binary_scalar_order.hpp"
+
+#define CHECK_SIZES_AND_COMMON_OPS(Q, C, T)                                    \
+  CHECK_SIZES(Q, Failures, T, false, +)                                        \
+  CHECK_SIZES(Q, Failures, T, false, -)                                        \
+  CHECK_SIZES(Q, Failures, T, false, /)                                        \
+  CHECK_SIZES(Q, Failures, T, false, *)
+#define CHECK_SIZES_AND_INT_ONLY_OPS(Q, C, T)                                  \
+  CHECK_SIZES(Q, Failures, T, false, %)
+
+int main() {
+  sycl::queue Q;
+  int Failures = 0;
+
+  // Check operators on types with requirements if they are supported.
+  if (Q.get_device().has(sycl::aspect::fp16)) {
+    CHECK_SIZES_AND_COMMON_OPS(Q, Failures, sycl::half);
+  }
+  if (Q.get_device().has(sycl::aspect::fp64)) {
+    CHECK_SIZES_AND_COMMON_OPS(Q, Failures, double);
+  }
+
+  // Check all operators without requirements.
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, float);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int8_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int16_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int32_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, int64_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint8_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint16_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint32_t);
+  CHECK_SIZES_AND_COMMON_OPS(Q, Failures, uint64_t);
+
+  // Check integer only operators.
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int8_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int16_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int32_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, int64_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint8_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint16_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint32_t);
+  CHECK_SIZES_AND_INT_ONLY_OPS(Q, Failures, uint64_t);
+  return Failures;
+}

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_bitwise.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_bitwise.cpp
@@ -1,0 +1,33 @@
+// REQUIRES: preview-breaking-changes-supported
+// RUN: %{build} -fpreview-breaking-changes -o %t.out
+// RUN: %{run} %t.out
+
+// This test currently fails on AMD HIP due to an unresolved memcmp function.
+// XFAIL: hip_amd
+
+// Checks scalar/vec bitwise operator ordering.
+
+#include "vec_binary_scalar_order.hpp"
+
+#define CHECK_SIZES_AND_OPS(Q, C, T)                                           \
+  CHECK_SIZES(Q, Failures, T, false, >>)                                       \
+  CHECK_SIZES(Q, Failures, T, false, <<)                                       \
+  CHECK_SIZES(Q, Failures, T, false, &)                                        \
+  CHECK_SIZES(Q, Failures, T, false, |)                                        \
+  CHECK_SIZES(Q, Failures, T, false, ^)
+
+int main() {
+  sycl::queue Q;
+  int Failures = 0;
+
+  // Check operators.
+  CHECK_SIZES_AND_OPS(Q, Failures, int8_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int16_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int32_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int64_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint8_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint16_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint32_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint64_t);
+  return Failures;
+}

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_logical.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_logical.cpp
@@ -1,0 +1,39 @@
+// REQUIRES: preview-breaking-changes-supported
+// RUN: %{build} -fpreview-breaking-changes -o %t.out
+// RUN: %{run} %t.out
+
+// This test currently fails on AMD HIP due to an unresolved memcmp function.
+// XFAIL: hip_amd
+
+// Checks scalar/vec logical operator ordering.
+
+#include "vec_binary_scalar_order.hpp"
+
+#define CHECK_SIZES_AND_OPS(Q, C, T)                                           \
+  CHECK_SIZES(Q, Failures, T, true, &&)                                        \
+  CHECK_SIZES(Q, Failures, T, true, ||)
+
+int main() {
+  sycl::queue Q;
+  int Failures = 0;
+
+  // Check operators on types with requirements if they are supported.
+  if (Q.get_device().has(sycl::aspect::fp16)) {
+    CHECK_SIZES_AND_OPS(Q, Failures, sycl::half);
+  }
+  if (Q.get_device().has(sycl::aspect::fp64)) {
+    CHECK_SIZES_AND_OPS(Q, Failures, double);
+  }
+
+  // Check all operators without requirements.
+  CHECK_SIZES_AND_OPS(Q, Failures, float);
+  CHECK_SIZES_AND_OPS(Q, Failures, int8_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int16_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int32_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int64_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint8_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint16_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint32_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint64_t);
+  return Failures;
+}

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_relational.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_relational.cpp
@@ -1,0 +1,44 @@
+// REQUIRES: preview-breaking-changes-supported
+// RUN: %{build} -fpreview-breaking-changes -o %t.out
+// RUN: %{run} %t.out
+
+// This test currently fails on AMD HIP due to an unresolved memcmp function.
+// XFAIL: hip_amd
+
+// Checks scalar/vec relational operator ordering.
+
+#include "vec_binary_scalar_order.hpp"
+
+// NOTE: For the sake of compile-time we pick only a few operators per category.
+#define CHECK_SIZES_AND_OPS(Q, C, T)                                           \
+  CHECK_SIZES(Q, Failures, T, true, ==)                                        \
+  CHECK_SIZES(Q, Failures, T, true, !=)                                        \
+  CHECK_SIZES(Q, Failures, T, true, <)                                         \
+  CHECK_SIZES(Q, Failures, T, true, >)                                         \
+  CHECK_SIZES(Q, Failures, T, true, <=)                                        \
+  CHECK_SIZES(Q, Failures, T, true, >=)
+
+int main() {
+  sycl::queue Q;
+  int Failures = 0;
+
+  // Check operators on types with requirements if they are supported.
+  if (Q.get_device().has(sycl::aspect::fp16)) {
+    CHECK_SIZES_AND_OPS(Q, Failures, sycl::half);
+  }
+  if (Q.get_device().has(sycl::aspect::fp64)) {
+    CHECK_SIZES_AND_OPS(Q, Failures, double);
+  }
+
+  // Check all operators without requirements.
+  CHECK_SIZES_AND_OPS(Q, Failures, float);
+  CHECK_SIZES_AND_OPS(Q, Failures, int8_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int16_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int32_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, int64_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint8_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint16_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint32_t);
+  CHECK_SIZES_AND_OPS(Q, Failures, uint64_t);
+  return Failures;
+}


### PR DESCRIPTION
This commit splits the vec_binary_scalar_order test to improve coverage and reduce the compile-time overhead.