### PR TITLE
[HIP] Mark assert tests unsupported / 2dmem tests Xfail.

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_kernels_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels_ndebug.cpp
@@ -1,3 +1,5 @@
+// https://github.com/intel/llvm/issues/7634
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -DNDEBUG %S/assert_in_kernels.cpp -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 //

--- a/sycl/test-e2e/Assert/assert_in_one_kernel_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_one_kernel_ndebug.cpp
@@ -1,3 +1,5 @@
+// https://github.com/intel/llvm/issues/7634
+// UNSUPPORTED: hip
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -DNDEBUG  %S/assert_in_one_kernel.cpp -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 //

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_dhost.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
@@ -13,6 +13,8 @@
 // Temporarily disabled until the failure is addressed.
 // For HIP see https://github.com/intel/llvm/issues/10157.
 // UNSUPPORTED: (level_zero && windows) || hip
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_dhost.cpp
@@ -11,6 +11,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_host.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_host.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/fill2d.cpp
+++ b/sycl/test-e2e/USM/memops2d/fill2d.cpp
@@ -8,6 +8,8 @@
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_device.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_dhost.cpp
@@ -11,6 +11,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_host.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_dhost.cpp
@@ -12,6 +12,8 @@
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memset2d.cpp
+++ b/sycl/test-e2e/USM/memops2d/memset2d.cpp
@@ -8,6 +8,8 @@
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// Certain rocm versions fail due to driver bug.
+// XFAIL: hip_amd
 
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
- Mark all assert tests on hip unsupported
Due to https://github.com/ROCm/HIP/issues/3368
- Mark some 2dmem tests Xfail: We can track which rocm versions they pass for. Some rocm versions don't support 2d mem operations.

The two assert tests were originally missed because they are flaky and didnt fail in https://github.com/intel/llvm/issues/7634
But the assert problem on hip rdna2 cards such as the CI in intel/llvm (see https://github.com/ROCm/HIP/issues/3368#issuecomment-1855925476) appears to affect all basic use of assert, and they are leading to timeouts currently https://github.com/intel/llvm/pull/12909