### PR TITLE
[SYCL][COMPAT] util header split in math and util headers

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1048,16 +1048,6 @@ Functionality is provided to represent a pair of integers as a `double`.
 in the high & low 32-bits respectively. `cast_double_to_int` casts the high or
 low 32-bits back into an integer.
 
-`syclcompat::fast_length` provides a wrapper to SYCL's
-`fast_length(sycl::vec<float,N>)` that accepts arguments for a C++ array and a
-length.
-
-`vectorized_max` and `vectorized_min` are binary operations returning the
-max/min of two arguments, where each argument is treated as a `sycl::vec` type.
-`vectorized_isgreater` performs elementwise `isgreater`, treating each argument
-as a vector of elements, and returning `0` for vector components for which
-`isgreater` is false, and `-1` when true.
-
 `reverse_bits` reverses the bits of a 32-bit unsigned integer, `ffs` returns the
 position of the first least significant set bit in an integer.
 `byte_level_permute` returns a byte-permutation of two input unsigned integers,
@@ -1073,9 +1063,6 @@ functionality to `sycl::select_from_group`, `sycl::shift_group_left`,
 However, they provide an optional argument to represent the `logical_group` size
 (default 32).
 
-The functions `cmul`,`cdiv`,`cabs`, and `conj` define complex math operations
-which accept `sycl::vec<T,2>` arguments representing complex values.
-
 ```c++
 namespace syclcompat {
 
@@ -1083,50 +1070,26 @@ inline int cast_double_to_int(double d, bool use_high32 = true);
 
 inline double cast_ints_to_double(int high32, int low32);
 
-inline float fast_length(const float *a, int len);
-
-template <typename S, typename T> inline T vectorized_max(T a, T b);
-
-template <typename S, typename T> inline T vectorized_min(T a, T b);
-
-template <typename S, typename T> inline T vectorized_isgreater(T a, T b);
-
-template <>
-inline unsigned vectorized_isgreater<sycl::ushort2, unsigned>(unsigned a,
-                                                              unsigned b);
-
-template <typename T> inline T reverse_bits(T a);
-
 inline unsigned int byte_level_permute(unsigned int a, unsigned int b,
                                        unsigned int s);
 
-template <typename T> inline int ffs(T a);
+template <typename ValueT> inline int ffs(ValueT a);
 
-template <typename T>
-T select_from_sub_group(sycl::sub_group g, T x, int remote_local_id,
+template <typename ValueT>
+ValueT select_from_sub_group(sycl::sub_group g, ValueT x, int remote_local_id,
                         int logical_sub_group_size = 32);
 
-template <typename T>
-T shift_sub_group_left(sycl::sub_group g, T x, unsigned int delta,
+template <typename ValueT>
+ValueT shift_sub_group_left(sycl::sub_group g, ValueT x, unsigned int delta,
                        int logical_sub_group_size = 32);
 
-template <typename T>
-T shift_sub_group_right(sycl::sub_group g, T x, unsigned int delta,
+template <typename ValueT>
+ValueT shift_sub_group_right(sycl::sub_group g, ValueT x, unsigned int delta,
                         int logical_sub_group_size = 32);
 
-template <typename T>
-T permute_sub_group_by_xor(sycl::sub_group g, T x, unsigned int mask,
+template <typename ValueT>
+ValueT permute_sub_group_by_xor(sycl::sub_group g, ValueT x, unsigned int mask,
                            int logical_sub_group_size = 32);
-
-template <typename T>
-sycl::vec<T, 2> cmul(sycl::vec<T, 2> x, sycl::vec<T, 2> y);
-
-template <typename T>
-sycl::vec<T, 2> cdiv(sycl::vec<T, 2> x, sycl::vec<T, 2> y);
-
-template <typename T> T cabs(sycl::vec<T, 2> x);
-
-template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x);
 
 } // namespace syclcompat
 ```
@@ -1191,7 +1154,7 @@ int get_sycl_language_version();
 } // namespace syclcompat
 ```
 
-#### Kernel Helper Functions
+### Kernel Helper Functions
 
 Kernel helper functions provide a structure `kernel_function_info` to keep SYCL
 kernel information, and provide a utility function `get_kernel_function_info()`
@@ -1210,6 +1173,47 @@ static void get_kernel_function_info(kernel_function_info *kernel_info,
                                      const void *function);
 static kernel_function_info get_kernel_function_info(const void *function);
 } // namespace syclcompat
+```
+
+### Math Functions
+
+`syclcompat::fast_length` provides a wrapper to SYCL's
+`fast_length(sycl::vec<float,N>)` that accepts arguments for a C++ array and a
+length.
+
+`vectorized_max` and `vectorized_min` are binary operations returning the
+max/min of two arguments, where each argument is treated as a `sycl::vec` type.
+`vectorized_isgreater` performs elementwise `isgreater`, treating each argument
+as a vector of elements, and returning `0` for vector components for which
+`isgreater` is false, and `-1` when true.
+
+The functions `cmul`,`cdiv`,`cabs`, and `conj` define complex math operations
+which accept `sycl::vec<T,2>` arguments representing complex values.
+
+```cpp
+inline float fast_length(const float *a, int len);
+
+template <typename S, typename T> inline T vectorized_max(T a, T b);
+
+template <typename S, typename T> inline T vectorized_min(T a, T b);
+
+template <typename S, typename T> inline T vectorized_isgreater(T a, T b);
+
+template <>
+inline unsigned vectorized_isgreater<sycl::ushort2, unsigned>(unsigned a,
+                                                              unsigned b);
+
+template <typename T>
+sycl::vec<T, 2> cmul(sycl::vec<T, 2> x, sycl::vec<T, 2> y);
+
+template <typename T>
+sycl::vec<T, 2> cdiv(sycl::vec<T, 2> x, sycl::vec<T, 2> y);
+
+template <typename T> T cabs(sycl::vec<T, 2> x);
+
+template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x);
+
+template <typename ValueT> inline ValueT reverse_bits(ValueT a);
 ```
 
 ## Sample Code
@@ -1311,7 +1315,7 @@ int main(int argc, char **argv) {
 
   // Check output
   for (size_t i = 0; i < n_points; i++) {
-    assert(h_Y[i] - h_expected[i] < 1e6);
+    assert(h_Y[i] - h_expected[i] < 1e-6);
   }
 
   // Clean up memory

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -1,0 +1,185 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCL compatibility extension
+ *
+ *  math.hpp
+ *
+ *  Description:
+ *    math utilities for the SYCL compatibility extension.
+ **************************************************************************/
+
+// The original source was under the license below:
+//==---- math.hpp ---------------------------------*- C++ -*----------------==//
+//
+// Copyright (C) Intel Corporation
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+// See https://llvm.org/LICENSE.txt for license information.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/sycl.hpp>
+
+#ifndef SYCL_EXT_ONEAPI_COMPLEX
+#define SYCL_EXT_ONEAPI_COMPLEX
+#endif
+
+#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
+
+namespace syclcompat {
+namespace detail {
+
+namespace complex_namespace = sycl::ext::oneapi::experimental;
+
+template <typename ValueT>
+using complex_type = detail::complex_namespace::complex<ValueT>;
+
+} // namespace detail
+
+/// Compute fast_length for variable-length array
+/// \param [in] a The array
+/// \param [in] len Length of the array
+/// \returns The computed fast_length
+inline float fast_length(const float *a, int len) {
+  switch (len) {
+  case 1:
+    return sycl::fast_length(a[0]);
+  case 2:
+    return sycl::fast_length(sycl::float2(a[0], a[1]));
+  case 3:
+    return sycl::fast_length(sycl::float3(a[0], a[1], a[2]));
+  case 4:
+    return sycl::fast_length(sycl::float4(a[0], a[1], a[2], a[3]));
+  case 0:
+    return 0;
+  default:
+    float f = 0;
+    for (int i = 0; i < len; ++i)
+      f += a[i] * a[i];
+    return sycl::sqrt(f);
+  }
+}
+
+/// Compute vectorized max for two values, with each value treated as a vector
+/// type \p S
+/// \param [in] S The type of the vector
+/// \param [in] T The type of the original values
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized max of the two values
+template <typename S, typename T> inline T vectorized_max(T a, T b) {
+  sycl::vec<T, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<S>();
+  auto v3 = v1.template as<S>();
+  v2 = sycl::max(v2, v3);
+  v0 = v2.template as<sycl::vec<T, 1>>();
+  return v0;
+}
+
+/// Compute vectorized min for two values, with each value treated as a vector
+/// type \p S
+/// \param [in] S The type of the vector
+/// \param [in] T The type of the original values
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized min of the two values
+template <typename S, typename T> inline T vectorized_min(T a, T b) {
+  sycl::vec<T, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<S>();
+  auto v3 = v1.template as<S>();
+  v2 = sycl::min(v2, v3);
+  v0 = v2.template as<sycl::vec<T, 1>>();
+  return v0;
+}
+
+/// Compute vectorized isgreater for two values, with each value treated as a
+/// vector type \p S
+/// \param [in] S The type of the vector
+/// \param [in] T The type of the original values
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized greater than of the two values
+template <typename S, typename T> inline T vectorized_isgreater(T a, T b) {
+  sycl::vec<T, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<S>();
+  auto v3 = v1.template as<S>();
+  auto v4 = sycl::isgreater(v2, v3);
+  v0 = v4.template as<sycl::vec<T, 1>>();
+  return v0;
+}
+
+/// Compute vectorized isgreater for two unsigned int values, with each value
+/// treated as a vector of two unsigned short
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized greater than of the two values
+template <>
+inline unsigned vectorized_isgreater<sycl::ushort2, unsigned>(unsigned a,
+                                                              unsigned b) {
+  sycl::vec<unsigned, 1> v0{a}, v1{b};
+  auto v2 = v0.template as<sycl::ushort2>();
+  auto v3 = v1.template as<sycl::ushort2>();
+  sycl::ushort2 v4;
+  v4[0] = v2[0] > v3[0];
+  v4[1] = v2[1] > v3[1];
+  v0 = v4.template as<sycl::vec<unsigned, 1>>();
+  return v0;
+}
+
+/// Computes the multiplication of two complex numbers.
+/// \tparam T Complex element type
+/// \param [in] x The first input complex number
+/// \param [in] y The second input complex number
+/// \returns The result
+template <typename T>
+sycl::vec<T, 2> cmul(sycl::vec<T, 2> x, sycl::vec<T, 2> y) {
+  sycl::ext::oneapi::experimental::complex<T> t1(x[0], x[1]), t2(y[0], y[1]);
+  t1 = t1 * t2;
+  return sycl::vec<T, 2>(t1.real(), t1.imag());
+}
+
+/// Computes the division of two complex numbers.
+/// \tparam T Complex element type
+/// \param [in] x The first input complex number
+/// \param [in] y The second input complex number
+/// \returns The result
+template <typename T>
+sycl::vec<T, 2> cdiv(sycl::vec<T, 2> x, sycl::vec<T, 2> y) {
+  sycl::ext::oneapi::experimental::complex<T> t1(x[0], x[1]), t2(y[0], y[1]);
+  t1 = t1 / t2;
+  return sycl::vec<T, 2>(t1.real(), t1.imag());
+}
+
+/// Computes the magnitude of a complex number.
+/// \tparam T Complex element type
+/// \param [in] x The input complex number
+/// \returns The result
+template <typename T> T cabs(sycl::vec<T, 2> x) {
+  sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
+  return abs(t);
+}
+
+/// Computes the complex conjugate of a complex number.
+/// \tparam T Complex element type
+/// \param [in] x The input complex number
+/// \returns The result
+template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x) {
+  sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
+  t = conj(t);
+  return sycl::vec<T, 2>(t.real(), t.imag());
+}
+
+} // namespace syclcompat

--- a/sycl/include/syclcompat/syclcompat.hpp
+++ b/sycl/include/syclcompat/syclcompat.hpp
@@ -29,5 +29,6 @@
 #include <syclcompat/id_query.hpp>
 #include <syclcompat/kernel.hpp>
 #include <syclcompat/launch.hpp>
+#include <syclcompat/math.hpp>
 #include <syclcompat/memory.hpp>
 #include <syclcompat/util.hpp>

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -31,14 +31,12 @@
 
 #pragma once
 
-#define SYCL_EXT_ONEAPI_COMPLEX
-
 #include <cassert>
-#include <complex>
-#include <sycl/ext/oneapi/experimental/complex/complex.hpp>
-#include <sycl/sycl.hpp>
 #include <type_traits>
 
+#include <sycl/sycl.hpp>
+
+#include <syclcompat/math.hpp>
 #include <syclcompat/memory.hpp>
 
 namespace syclcompat {
@@ -48,23 +46,23 @@ template <typename T> struct DataType {
   using T2 = T;
 };
 template <typename T> struct DataType<sycl::vec<T, 2>> {
-  using T2 = sycl::ext::oneapi::experimental::complex<T>;
+  using T2 = detail::complex_type<T>;
 };
 
 inline void matrix_mem_copy(void *to_ptr, const void *from_ptr, int to_ld,
                             int from_ld, int rows, int cols, int elem_size,
-                            sycl::queue queue = get_default_queue(),
+                            sycl::queue queue = syclcompat::get_default_queue(),
                             bool async = false) {
   if (to_ptr == from_ptr && to_ld == from_ld) {
     return;
   }
 
   if (to_ld == from_ld) {
-    size_t cpoy_size = elem_size * ((cols - 1) * to_ld + rows);
+    size_t copy_size = elem_size * ((cols - 1) * (size_t)to_ld + rows);
     if (async)
-      detail::memcpy(queue, (void *)to_ptr, (void *)from_ptr, cpoy_size);
+      detail::memcpy(queue, (void *)to_ptr, (void *)from_ptr, copy_size);
     else
-      detail::memcpy(queue, (void *)to_ptr, (void *)from_ptr, cpoy_size).wait();
+      detail::memcpy(queue, (void *)to_ptr, (void *)from_ptr, copy_size).wait();
   } else {
     if (async)
       detail::memcpy(queue, to_ptr, from_ptr, elem_size * to_ld,
@@ -117,96 +115,6 @@ inline double cast_ints_to_double(int high32, int low32) {
   sycl::int2 v0{high32, low32};
   auto v1 = v0.as<sycl::vec<double, 1>>();
   return v1;
-}
-
-/// Compute fast_length for variable-length array
-/// \param [in] a The array
-/// \param [in] len Length of the array
-/// \returns The computed fast_length
-inline float fast_length(const float *a, int len) {
-  switch (len) {
-  case 1:
-    return sycl::fast_length(a[0]);
-  case 2:
-    return sycl::fast_length(sycl::float2(a[0], a[1]));
-  case 3:
-    return sycl::fast_length(sycl::float3(a[0], a[1], a[2]));
-  case 4:
-    return sycl::fast_length(sycl::float4(a[0], a[1], a[2], a[3]));
-  case 0:
-    return 0;
-  default:
-    float f = 0;
-    for (int i = 0; i < len; ++i)
-      f += a[i] * a[i];
-    return sycl::sqrt(f);
-  }
-}
-
-/// Compute vectorized max for two values, with each value treated as a vector
-/// type \p S
-/// \param [in] S The type of the vector
-/// \param [in] T The type of the original values
-/// \param [in] a The first value
-/// \param [in] b The second value
-/// \returns The vectorized max of the two values
-template <typename S, typename T> inline T vectorized_max(T a, T b) {
-  sycl::vec<T, 1> v0{a}, v1{b};
-  auto v2 = v0.template as<S>();
-  auto v3 = v1.template as<S>();
-  v2 = sycl::max(v2, v3);
-  v0 = v2.template as<sycl::vec<T, 1>>();
-  return v0;
-}
-
-/// Compute vectorized min for two values, with each value treated as a vector
-/// type \p S
-/// \param [in] S The type of the vector
-/// \param [in] T The type of the original values
-/// \param [in] a The first value
-/// \param [in] b The second value
-/// \returns The vectorized min of the two values
-template <typename S, typename T> inline T vectorized_min(T a, T b) {
-  sycl::vec<T, 1> v0{a}, v1{b};
-  auto v2 = v0.template as<S>();
-  auto v3 = v1.template as<S>();
-  v2 = sycl::min(v2, v3);
-  v0 = v2.template as<sycl::vec<T, 1>>();
-  return v0;
-}
-
-/// Compute vectorized isgreater for two values, with each value treated as a
-/// vector type \p S
-/// \param [in] S The type of the vector
-/// \param [in] T The type of the original values
-/// \param [in] a The first value
-/// \param [in] b The second value
-/// \returns The vectorized greater than of the two values
-template <typename S, typename T> inline T vectorized_isgreater(T a, T b) {
-  sycl::vec<T, 1> v0{a}, v1{b};
-  auto v2 = v0.template as<S>();
-  auto v3 = v1.template as<S>();
-  auto v4 = sycl::isgreater(v2, v3);
-  v0 = v4.template as<sycl::vec<T, 1>>();
-  return v0;
-}
-
-/// Compute vectorized isgreater for two unsigned int values, with each value
-/// treated as a vector of two unsigned short
-/// \param [in] a The first value
-/// \param [in] b The second value
-/// \returns The vectorized greater than of the two values
-template <>
-inline unsigned vectorized_isgreater<sycl::ushort2, unsigned>(unsigned a,
-                                                              unsigned b) {
-  sycl::vec<unsigned, 1> v0{a}, v1{b};
-  auto v2 = v0.template as<sycl::ushort2>();
-  auto v3 = v1.template as<sycl::ushort2>();
-  sycl::ushort2 v4;
-  v4[0] = v2[0] > v3[0];
-  v4[1] = v2[1] > v3[1];
-  v0 = v4.template as<sycl::vec<unsigned, 1>>();
-  return v0;
 }
 
 /// Reverse the bit order of an unsigned integer
@@ -359,49 +267,6 @@ T permute_sub_group_by_xor(sycl::sub_group g, T x, unsigned int mask,
                                  target_offset < logical_sub_group_size
                                      ? start_index + target_offset
                                      : id);
-}
-
-/// Computes the multiplication of two complex numbers.
-/// \tparam T Complex element type
-/// \param [in] x The first input complex number
-/// \param [in] y The second input complex number
-/// \returns The result
-template <typename T>
-sycl::vec<T, 2> cmul(sycl::vec<T, 2> x, sycl::vec<T, 2> y) {
-  sycl::ext::oneapi::experimental::complex<T> t1(x[0], x[1]), t2(y[0], y[1]);
-  t1 = t1 * t2;
-  return sycl::vec<T, 2>(t1.real(), t1.imag());
-}
-
-/// Computes the division of two complex numbers.
-/// \tparam T Complex element type
-/// \param [in] x The first input complex number
-/// \param [in] y The second input complex number
-/// \returns The result
-template <typename T>
-sycl::vec<T, 2> cdiv(sycl::vec<T, 2> x, sycl::vec<T, 2> y) {
-  sycl::ext::oneapi::experimental::complex<T> t1(x[0], x[1]), t2(y[0], y[1]);
-  t1 = t1 / t2;
-  return sycl::vec<T, 2>(t1.real(), t1.imag());
-}
-
-/// Computes the magnitude of a complex number.
-/// \tparam T Complex element type
-/// \param [in] x The input complex number
-/// \returns The result
-template <typename T> T cabs(sycl::vec<T, 2> x) {
-  sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
-  return abs(t);
-}
-
-/// Computes the complex conjugate of a complex number.
-/// \tparam T Complex element type
-/// \param [in] x The input complex number
-/// \returns The result
-template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x) {
-  sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
-  t = conj(t);
-  return sycl::vec<T, 2>(t.real(), t.imag());
 }
 
 /// Inherited from the original SYCLomatic compatibility headers.

--- a/sycl/test-e2e/syclcompat/math/math_complex.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_complex.cpp
@@ -144,7 +144,7 @@ void kernel_div(int *result) {
   auto a1 = syclcompat::cdiv(d1, d2);
   r = r && check(a1, expect);
 
-  auto a2 = syclcompat::conj(f1);
+  auto a2 = syclcompat::cdiv(f1, f2);
   r = r && check(a2, expect + 2);
 
   *result = r;

--- a/sycl/test-e2e/syclcompat/math/math_complex.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_complex.cpp
@@ -14,7 +14,7 @@
  *
  *  SYCLcompat API
  *
- *  util_complex.cpp
+ *  math_complex.cpp
  *
  *  Description:
  *    Complex operations tests
@@ -40,30 +40,26 @@
 #include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 
-template <typename T> bool check(T x, float e[], int &index) {
+template <typename T> bool check(T x, float *e) {
   float precision = 0.001f;
-  if ((x.x() - e[index] < precision) && (x.x() - e[index] > -precision) &&
-      (x.y() - e[index + 1] < precision) &&
-      (x.y() - e[index + 1] > -precision)) {
-    index += 2;
+  if ((x.x() - e[0] < precision) && (x.x() - e[0] > -precision) &&
+      (x.y() - e[1] < precision) && (x.y() - e[1] > -precision)) {
     return true;
   }
   return false;
 }
 
-template <> bool check<float>(float x, float e[], int &index) {
+template <> bool check<float>(float x, float *e) {
   float precision = 0.001f;
-  if ((x - e[index] < precision) && (x - e[index] > -precision)) {
-    index++;
+  if ((x - e[0] < precision) && (x - e[0] > -precision)) {
     return true;
   }
   return false;
 }
 
-template <> bool check<double>(double x, float e[], int &index) {
+template <> bool check<double>(double x, float *e) {
   float precision = 0.001f;
-  if ((x - e[index] < precision) && (x - e[index] > -precision)) {
-    index++;
+  if ((x - e[0] < precision) && (x - e[0] > -precision)) {
     return true;
   }
   return false;
@@ -96,19 +92,16 @@ void kernel_abs(int *result) {
   sycl::double2 d1, d2;
 
   f1 = sycl::float2(1.8, -2.7);
-  f2 = sycl::float2(-3.6, 4.5);
   d1 = sycl::double2(5.4, -6.3);
-  d2 = sycl::double2(-7.2, 8.1);
 
-  int index = 0;
   bool r = true;
   float expect[2] = {8.297590, 3.244996};
 
   auto a1 = syclcompat::cabs(d1);
-  r = r && check(a1, expect, index);
+  r = r && check(a1, expect);
 
   auto a2 = syclcompat::cabs(f1);
-  r = r && check(a2, expect, index);
+  r = r && check(a2, expect + 1);
 
   *result = r;
 }
@@ -123,15 +116,14 @@ void kernel_conj(int *result) {
   d1 = sycl::double2(5.4, -6.3);
   d2 = sycl::double2(-7.2, 8.1);
 
-  int index = 0;
   bool r = true;
   float expect[4] = {5.400000, 6.300000, 1.800000, 2.700000};
 
   auto a1 = syclcompat::conj(d1);
-  r = r && check(a1, expect, index);
+  r = r && check(a1, expect);
 
   auto a2 = syclcompat::conj(f1);
-  r = r && check(a2, expect, index);
+  r = r && check(a2, expect + 2);
 
   *result = r;
 }
@@ -146,15 +138,14 @@ void kernel_div(int *result) {
   d1 = sycl::double2(5.4, -6.3);
   d2 = sycl::double2(-7.2, 8.1);
 
-  int index = 0;
   bool r = true;
   float expect[4] = {-0.765517, 0.013793, -0.560976, 0.048780};
 
   auto a1 = syclcompat::cdiv(d1, d2);
-  r = r && check(a1, expect, index);
+  r = r && check(a1, expect);
 
-  auto a2 = syclcompat::cdiv(f1, f2);
-  r = r && check(a2, expect, index);
+  auto a2 = syclcompat::conj(f1);
+  r = r && check(a2, expect + 2);
 
   *result = r;
 }
@@ -169,15 +160,14 @@ void kernel_mul(int *result) {
   d1 = sycl::double2(5.4, -6.3);
   d2 = sycl::double2(-7.2, 8.1);
 
-  int index = 0;
   bool r = true;
   float expect[4] = {12.150000, 89.100000, 5.670001, 17.820000};
 
   auto a1 = syclcompat::cmul(d1, d2);
-  r = r && check(a1, expect, index);
+  r = r && check(a1, expect);
 
   auto a2 = syclcompat::cmul(f1, f2);
-  r = r && check(a2, expect, index);
+  r = r && check(a2, expect + 2);
 
   *result = r;
 }

--- a/sycl/test-e2e/syclcompat/math/math_complex_datatype.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_complex_datatype.cpp
@@ -14,7 +14,7 @@
  *
  *  SYCLcompat API
  *
- *  util_complex_datatype.cpp
+ *  math_complex_datatype.cpp
  *
  *  Description:
  *    Complex operations tests
@@ -33,6 +33,7 @@
 // RUN: %{run} %t.out
 
 #include <iostream>
+#include <syclcompat/math.hpp>
 #include <syclcompat/util.hpp>
 
 void test_datatype() {

--- a/sycl/test-e2e/syclcompat/math/math_fast_length_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_fast_length_test.cpp
@@ -14,7 +14,7 @@
  *
  *  SYCLcompat API
  *
- *  util_fast_length_test.cpp
+ *  math_fast_length_test.cpp
  *
  *  Description:
  *    Fast length tests

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
@@ -14,7 +14,7 @@
  *
  *  SYCLcompat API
  *
- *  util_vectorized_isgreater_test.cpp
+ *  math_vectorized_isgreater_test.cpp
  *
  *  Description:
  *    vectorized_isgreater tests

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_max_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_max_test.cpp
@@ -14,14 +14,14 @@
  *
  *  SYCLcompat API
  *
- *  util_vectorized_min_test.cpp
+ *  math_vectorized_max_test.cpp
  *
  *  Description:
- *    vectorized_min tests
+ *    vectorized_max tests
  **************************************************************************/
 
 // The original source was under the license below:
-// ====------ UtilVectorizedMinTest.cpp---------- -*- C++ -* ----===////
+// ====------ UtilVectorizedMaxTest.cpp---------- -*- C++ -* ----===////
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -36,7 +36,7 @@
 #include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 
-void test_kernel_vect_min(unsigned int vect_count, unsigned int *input_1,
+void test_kernel_vect_max(unsigned int vect_count, unsigned int *input_1,
                           unsigned int *input_2, unsigned int *output,
                           sycl::nd_item<3> item_ct1) {
 
@@ -45,11 +45,11 @@ void test_kernel_vect_min(unsigned int vect_count, unsigned int *input_1,
 
   if (index < vect_count) {
     output[index] =
-        syclcompat::vectorized_min<sycl::char4>(input_1[index], input_2[index]);
+        syclcompat::vectorized_max<sycl::char4>(input_1[index], input_2[index]);
   }
 }
 
-void test_vec_min() {
+void test_vec_max() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
@@ -86,7 +86,7 @@ void test_vec_min() {
         sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3),
                           sycl::range<3>(1, 1, 3)),
         [=](sycl::nd_item<3> item_ct1) {
-          test_kernel_vect_min(num_data, d_in_data_1, d_in_data_2, d_out_data,
+          test_kernel_vect_max(num_data, d_in_data_1, d_in_data_2, d_out_data,
                                item_ct1);
         });
   });
@@ -94,7 +94,7 @@ void test_vec_min() {
 
   q_ct1->memcpy(h_out_data, d_out_data, mem_size).wait();
 
-  unsigned int ref_data[num_data] = {0, 1, 2, 3, 2, 1, 0};
+  unsigned int ref_data[num_data] = {6, 5, 4, 3, 4, 5, 6};
   for (unsigned int i = 0; i < num_data; i++) {
     if (h_out_data[i] != ref_data[i])
       exit(-1);
@@ -108,7 +108,7 @@ void test_vec_min() {
 }
 
 int main() {
-  test_vec_min();
+  test_vec_max();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_min_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_min_test.cpp
@@ -14,14 +14,14 @@
  *
  *  SYCLcompat API
  *
- *  util_vectorized_max_test.cpp
+ *  math_vectorized_min_test.cpp
  *
  *  Description:
- *    vectorized_max tests
+ *    vectorized_min tests
  **************************************************************************/
 
 // The original source was under the license below:
-// ====------ UtilVectorizedMaxTest.cpp---------- -*- C++ -* ----===////
+// ====------ UtilVectorizedMinTest.cpp---------- -*- C++ -* ----===////
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -36,7 +36,7 @@
 #include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 
-void test_kernel_vect_max(unsigned int vect_count, unsigned int *input_1,
+void test_kernel_vect_min(unsigned int vect_count, unsigned int *input_1,
                           unsigned int *input_2, unsigned int *output,
                           sycl::nd_item<3> item_ct1) {
 
@@ -45,11 +45,11 @@ void test_kernel_vect_max(unsigned int vect_count, unsigned int *input_1,
 
   if (index < vect_count) {
     output[index] =
-        syclcompat::vectorized_max<sycl::char4>(input_1[index], input_2[index]);
+        syclcompat::vectorized_min<sycl::char4>(input_1[index], input_2[index]);
   }
 }
 
-void test_vec_max() {
+void test_vec_min() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
@@ -86,7 +86,7 @@ void test_vec_max() {
         sycl::nd_range<3>(sycl::range<3>(1, 1, 3) * sycl::range<3>(1, 1, 3),
                           sycl::range<3>(1, 1, 3)),
         [=](sycl::nd_item<3> item_ct1) {
-          test_kernel_vect_max(num_data, d_in_data_1, d_in_data_2, d_out_data,
+          test_kernel_vect_min(num_data, d_in_data_1, d_in_data_2, d_out_data,
                                item_ct1);
         });
   });
@@ -94,7 +94,7 @@ void test_vec_max() {
 
   q_ct1->memcpy(h_out_data, d_out_data, mem_size).wait();
 
-  unsigned int ref_data[num_data] = {6, 5, 4, 3, 4, 5, 6};
+  unsigned int ref_data[num_data] = {0, 1, 2, 3, 2, 1, 0};
   for (unsigned int i = 0; i < num_data; i++) {
     if (h_out_data[i] != ref_data[i])
       exit(-1);
@@ -108,7 +108,7 @@ void test_vec_max() {
 }
 
 int main() {
-  test_vec_max();
+  test_vec_min();
 
   return 0;
 }


### PR DESCRIPTION
This PR prepares SYCLcompat to receive multiple PRs containing updates to the helper headers.

It will substitute the previous opened PR as it grew in scope too much, as in case of issues it would be difficult to track and resolve effectively the problem.

Edit: Previous PR was https://github.com/intel/llvm/pull/11267