### PR TITLE
[SYCL] Add value_type alias to sycl::vec class

### DIFF
--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -518,7 +518,9 @@ template <typename T, typename Enable = void> struct RelConverter {
 template <typename T> class TryToGetElementType {
   static T check(...);
   template <typename A> static typename A::element_type check(const A &);
-  template <typename A> static typename A::value_type check(const A &);
+  template <typename A, typename = std::enable_if_t<!std::is_same_v<
+                            typename A::element_type, typename A::value_type>>>
+  static typename A::value_type check(const A &);
 
 public:
   using type = decltype(check(T()));

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -345,7 +345,7 @@ Requested alignment applied, limited at 64.")
 /// \ingroup sycl_api
 template <typename Type, int NumElements> class vec {
   using DataT = Type;
-
+  
   // This represent type of underlying value. There should be only one field
   // in the class, so vec<float, 16> should be equal to float16 in memory.
   using DataType = typename detail::VecStorage<DataT, NumElements>::DataType;
@@ -546,6 +546,7 @@ template <typename Type, int NumElements> class vec {
 
 public:
   using element_type = DataT;
+  using value_type = DataT;
   using rel_t = detail::rel_t<DataT>;
 
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -345,6 +345,7 @@ Requested alignment applied, limited at 64.")
 /// \ingroup sycl_api
 template <typename Type, int NumElements> class vec {
   using DataT = Type;
+
   // This represent type of underlying value. There should be only one field
   // in the class, so vec<float, 16> should be equal to float16 in memory.
   using DataType = typename detail::VecStorage<DataT, NumElements>::DataType;

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -345,7 +345,6 @@ Requested alignment applied, limited at 64.")
 /// \ingroup sycl_api
 template <typename Type, int NumElements> class vec {
   using DataT = Type;
-  
   // This represent type of underlying value. There should be only one field
   // in the class, so vec<float, 16> should be equal to float16 in memory.
   using DataType = typename detail::VecStorage<DataT, NumElements>::DataType;

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -548,7 +548,6 @@ public:
   using element_type = DataT;
   using value_type = DataT;
   using rel_t = detail::rel_t<DataT>;
-
 #ifdef __SYCL_DEVICE_ONLY__
 #if defined(__INTEL_PREVIEW_BREAKING_CHANGES)
   using vector_t =

--- a/sycl/test/regression/vec_value_type.cpp
+++ b/sycl/test/regression/vec_value_type.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx -fsycl -fsyntax-only %s
 #include <sycl/sycl.hpp>
-
+#include <type_traits>
 using namespace std;
 int main() {
   static_assert(is_same_v<sycl::vec<int, 1>::value_type, int>);

--- a/sycl/test/regression/vec_value_type.cpp
+++ b/sycl/test/regression/vec_value_type.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl %s
+#include <sycl/sycl.hpp>
+
+using namespace std;
+int main() {
+  static_assert(is_same_v<sycl::vec<int, 1>::value_type, int>);
+  static_assert(is_same_v<sycl::vec<float, 2>::value_type, float>);
+  static_assert(is_same_v<sycl::vec<double, 3>::value_type, double>);
+  static_assert(is_same_v<sycl::vec<sycl::half, 4>::value_type, sycl::half>);
+  return 0;
+}

--- a/sycl/test/regression/vec_value_type.cpp
+++ b/sycl/test/regression/vec_value_type.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl %s
+// RUN: %clangxx -fsycl -fsyntax-only %s
 #include <sycl/sycl.hpp>
 
 using namespace std;


### PR DESCRIPTION
This PR adds the value_type alias for the data type of a sycl::vec object as described in the spec.