### PR TITLE
[SYCL] Fix kernel->get_info() in the pre-C++11 ABI scenario

### DIFF
--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -15,9 +15,14 @@
 #include <sycl/detail/info_desc_helpers.hpp>  // for is_kernel_device_specif...
 #include <sycl/detail/owner_less_base.hpp>    // for OwnerLessBase
 #include <sycl/detail/pi.h>                   // for pi_native_handle
-#include <sycl/device.hpp>                    // for device
-#include <sycl/kernel_bundle_enums.hpp>       // for bundle_state
-#include <sycl/range.hpp>                     // for range
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#include <sycl/detail/string.hpp>
+#include <sycl/detail/string_view.hpp>
+#endif
+#include <sycl/detail/util.hpp>
+#include <sycl/device.hpp>              // for device
+#include <sycl/kernel_bundle_enums.hpp> // for bundle_state
+#include <sycl/range.hpp>               // for range
 
 #include <cstddef> // for size_t
 #include <memory>  // for shared_ptr, hash, opera...
@@ -137,7 +142,15 @@ public:
   ///
   /// \return depends on information being queried.
   template <typename Param>
-  typename detail::is_kernel_info_desc<Param>::return_type get_info() const;
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  typename detail::is_kernel_info_desc<Param>::return_type get_info() const {
+    return detail::convert_from_abi_neutral(get_info_impl<Param>());
+  }
+#else
+  detail::ABINeutralT_t<
+      typename detail::is_kernel_info_desc<Param>::return_type>
+  get_info() const;
+#endif
 
   /// Query device-specific information from the kernel object using the
   /// info::kernel_device_specific descriptor.
@@ -183,6 +196,12 @@ private:
   template <backend BackendName, class SyclObjectT>
   friend auto get_native(const SyclObjectT &Obj)
       -> backend_return_t<BackendName, SyclObjectT>;
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  template <typename Param>
+  typename detail::ABINeutralT_t<
+      typename detail::is_kernel_info_desc<Param>::return_type>
+  get_info_impl() const;
+#endif
 };
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -147,9 +147,7 @@ public:
     return detail::convert_from_abi_neutral(get_info_impl<Param>());
   }
 #else
-  detail::ABINeutralT_t<
-      typename detail::is_kernel_info_desc<Param>::return_type>
-  get_info() const;
+  typename detail::is_kernel_info_desc<Param>::return_type get_info() const;
 #endif
 
   /// Query device-specific information from the kernel object using the

--- a/sycl/source/kernel.cpp
+++ b/sycl/source/kernel.cpp
@@ -49,13 +49,24 @@ kernel::get_kernel_bundle() const {
 }
 
 template <typename Param>
-typename detail::is_kernel_info_desc<Param>::return_type
+detail::ABINeutralT_t<typename detail::is_kernel_info_desc<Param>::return_type>
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+kernel::get_info_impl() const {
+#else
 kernel::get_info() const {
-  return impl->get_info<Param>();
+#endif
+  return detail::convert_to_abi_neutral(impl->template get_info<Param>());
 }
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)              \
-  template __SYCL_EXPORT ReturnT kernel::get_info<info::kernel::Desc>() const;
+  template __SYCL_EXPORT detail::ABINeutralT_t<ReturnT>                        \
+  kernel::get_info_impl<info::kernel::Desc>() const;
+#else
+#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)              \
+  template __SYCL_EXPORT detail::ABINeutralT_t<ReturnT>                        \
+  kernel::get_info<info::kernel::Desc>() const;
+#endif
 
 #include <sycl/info/kernel_traits.def>
 

--- a/sycl/test-e2e/Basic/kernel_info.cpp
+++ b/sycl/test-e2e/Basic/kernel_info.cpp
@@ -2,7 +2,7 @@
 // RUN: %{run} %t.out
 //
 // Fail is flaky for level_zero, enable when fixed.
-// UNSUPPORTED: level_zero
+// NSUPPORTED: level_zero
 //
 
 //==--- kernel_info.cpp - SYCL kernel info test ----------------------------==//

--- a/sycl/test-e2e/Basic/kernel_info.cpp
+++ b/sycl/test-e2e/Basic/kernel_info.cpp
@@ -2,7 +2,7 @@
 // RUN: %{run} %t.out
 //
 // Fail is flaky for level_zero, enable when fixed.
-// NSUPPORTED: level_zero
+// UNSUPPORTED: level_zero
 //
 
 //==--- kernel_info.cpp - SYCL kernel info test ----------------------------==//


### PR DESCRIPTION
The get_info<> API returns a std::string which should be handled through detail::string, ABI-neutral way.