### PR TITLE
[SYCL][CODEOWNERS][Graph] Update Graph Unittest codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -134,7 +134,7 @@ sycl/include/sycl/detail/native_cpu.hpp @intel/dpcpp-nativecpu-pi-reviewers
 sycl/include/sycl/ext/oneapi/experimental/graph.hpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.cpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.hpp @intel/sycl-graphs-reviewers
-sycl/unittests/Extensions/CommandGraph.cpp @intel/sycl-graphs-reviewers
+sycl/unittests/Extensions/CommandGraph/ @intel/sycl-graphs-reviewers
 sycl/doc/design/CommandGraph.md @intel/sycl-graphs-reviewers
 sycl/test-e2e/Graph @intel/sycl-graphs-reviewers
 sycl/doc/extensions/**/sycl_ext_oneapi_graph.asciidoc @intel/sycl-graphs-reviewers


### PR DESCRIPTION
Merged PR https://github.com/intel/llvm/pull/12837 split `CommandGraph.cpp` into a directory of files, however this was not reflected in the CODEOWNERS file.