### PR TITLE
[SYCL][COMPAT] Adds sycl::length wrapper to SYCLcompat

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1199,7 +1199,8 @@ static kernel_function_info get_kernel_function_info(const void *function);
 
 `syclcompat::fast_length` provides a wrapper to SYCL's
 `fast_length(sycl::vec<float,N>)` that accepts arguments for a C++ array and a
-length.
+length. `syclcompat::length` provides a templated version that wraps over
+`sycl::length`.
 
 `vectorized_max` and `vectorized_min` are binary operations returning the
 max/min of two arguments, where each argument is treated as a `sycl::vec` type.
@@ -1212,6 +1213,9 @@ which accept `sycl::vec<T,2>` arguments representing complex values.
 
 ```cpp
 inline float fast_length(const float *a, int len);
+
+template <typename ValueT>
+inline ValueT length(const ValueT *a, const int len);
 
 template <typename S, typename T> inline T vectorized_max(T a, T b);
 

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -73,6 +73,29 @@ inline float fast_length(const float *a, int len) {
   }
 }
 
+/// Calculate the square root of the input array.
+/// \param [in] a The array pointer
+/// \param [in] len Length of the array
+/// \returns The square root
+template <typename ValueT>
+inline ValueT length(const ValueT *a, const int len) {
+  switch (len) {
+  case 1:
+    return a[0];
+  case 2:
+    return sycl::length(sycl::vec<ValueT, 2>(a[0], a[1]));
+  case 3:
+    return sycl::length(sycl::vec<ValueT, 3>(a[0], a[1], a[2]));
+  case 4:
+    return sycl::length(sycl::vec<ValueT, 4>(a[0], a[1], a[2], a[3]));
+  default:
+    ValueT ret = 0;
+    for (int i = 0; i < len; ++i)
+      ret += a[i] * a[i];
+    return sycl::sqrt(ret);
+  }
+}
+
 /// Compute vectorized max for two values, with each value treated as a vector
 /// type \p S
 /// \param [in] S The type of the vector


### PR DESCRIPTION
Adds a templated wrapper to sycl::length in syclcompat, that wraps over `sycl::vec<ValueT,N>` up to N == 4, and calculates the length with N > 4.