### PR TITLE
[SYCL][COMPAT] match_any and match_all over sub group support

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1072,6 +1072,8 @@ low 32-bits back into an integer.
 position of the first least significant set bit in an integer.
 `byte_level_permute` returns a byte-permutation of two input unsigned integers,
 with bytes selected according to a third unsigned integer argument.
+`match_all_over_sub_group` and `match_any_over_sub_group` allows comparison of values
+across work-items within a sub-group.
 
 There is also an `experimental::logical_group` class which allows
 `sycl::sub_group`s to be further subdivided into 'logical' groups to perform
@@ -1094,6 +1096,14 @@ inline unsigned int byte_level_permute(unsigned int a, unsigned int b,
                                        unsigned int s);
 
 template <typename ValueT> inline int ffs(ValueT a);
+
+template <typename T>
+unsigned int match_any_over_sub_group(sycl::sub_group g, unsigned member_mask,
+                                      T value);
+
+template <typename T>
+unsigned int match_all_over_sub_group(sycl::sub_group g, unsigned member_mask,
+                                      T value, int *pred);
 
 template <typename ValueT>
 ValueT select_from_sub_group(sycl::sub_group g, ValueT x, int remote_local_id,

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -279,6 +279,77 @@ inline int get_sycl_language_version() {
 #endif
 }
 
+/// The function match_any_over_sub_group conducts a comparison of values
+/// across work-items within a sub-group. match_any_over_sub_group return a mask
+/// in which some bits are set to 1, indicating that the \p value provided by
+/// the work-item represented by these bits are equal. The n-th bit of mask
+/// representing the work-item with id n. The parameter \p member_mask
+/// indicating the work-items participating the call.
+/// \tparam T Input value type
+/// \param [in] g Input sub_group
+/// \param [in] member_mask Input mask
+/// \param [in] value Input value
+/// \returns The result
+template <typename T>
+unsigned int match_any_over_sub_group(sycl::sub_group g, unsigned member_mask,
+                                      T value) {
+  static_assert(std::is_arithmetic_v<T>, "Value type must be arithmetic type.");
+  if (!member_mask) {
+    return 0;
+  }
+  unsigned int id = g.get_local_linear_id();
+  unsigned int flag = 0, result = 0, reduce_result = 0;
+  unsigned int bit_index = 0x1 << id;
+  bool is_participate = member_mask & bit_index;
+  T broadcast_value = 0;
+  bool matched = false;
+  while (flag != member_mask) {
+    broadcast_value =
+        sycl::select_from_group(g, value, sycl::ctz((~flag & member_mask)));
+    reduce_result = sycl::reduce_over_group(
+        g, is_participate ? (broadcast_value == value ? bit_index : 0) : 0,
+        sycl::plus<>());
+    flag |= reduce_result;
+    matched = reduce_result & bit_index;
+    result = matched * reduce_result + (1 - matched) * result;
+  }
+  return result;
+}
+
+/// The function match_all_over_sub_group conducts a comparison of values
+/// across work-items within a sub-group. match_all_over_sub_group return \p
+/// member_mask and predicate \p pred will be set to 1 if all \p value that
+/// provided by each work-item in \p member_mask are equal, otherwise return 0
+/// and the predicate \p pred will be set to 0. The n-th bit of \p member_mask
+/// representing the work-item with id n. The parameter \p member_mask
+/// indicating the work-items participating the call.
+/// \tparam T Input value type
+/// \param [in] g Input sub_group
+/// \param [in] member_mask Input mask
+/// \param [in] value Input value
+/// \param [out] pred Output predicate
+/// \returns The result
+template <typename T>
+unsigned int match_all_over_sub_group(sycl::sub_group g, unsigned member_mask,
+                                      T value, int *pred) {
+  static_assert(std::is_arithmetic_v<T>, "Value type must be arithmetic type.");
+  if (!member_mask) {
+    return 0;
+  }
+  unsigned int id = g.get_local_linear_id();
+  unsigned int bit_index = 0x1 << id;
+  bool is_participate = member_mask & bit_index;
+  T broadcast_value = sycl::select_from_group(g, value, sycl::ctz(member_mask));
+  unsigned int reduce_result = sycl::reduce_over_group(
+      g,
+      (member_mask & bit_index) ? (broadcast_value == value ? bit_index : 0)
+                                : 0,
+      sycl::plus<>());
+  bool all_equal = (reduce_result == member_mask);
+  *pred = is_participate & all_equal;
+  return (is_participate & all_equal) * member_mask;
+}
+
 namespace experimental {
 /// Synchronize work items from all work groups within a SYCL kernel.
 /// \param [in] item:  Represents a work group.

--- a/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
@@ -40,7 +40,7 @@ constexpr unsigned int NUM_TESTS = 3;
 constexpr unsigned int SUBGROUP_SIZE = 32;
 constexpr unsigned int DATA_SIZE = NUM_TESTS * SUBGROUP_SIZE;
 
-void test_select_from_sub_group() {
+void test_match_all_over_group() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   constexpr syclcompat::dim3 grid{1};
@@ -102,7 +102,6 @@ void test_select_from_sub_group() {
   syclcompat::memcpy<int>(pred, d_pred, DATA_SIZE);
 
   for (int i = 0; i < DATA_SIZE; ++i) {
-    std::cout << "expected[" << i << "] = " << expected[i] << std::endl;
     assert(output[i] == expected[i]);
     assert(pred[i] == expected_pred[i]);
   }
@@ -113,7 +112,7 @@ void test_select_from_sub_group() {
 }
 
 int main() {
-  test_select_from_sub_group();
+  test_match_all_over_group();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
@@ -37,7 +37,7 @@
 #include <syclcompat.hpp>
 
 constexpr unsigned int NUM_TESTS = 3;
-constexpr unsigned int SUBGROUP_SIZE = 16;
+constexpr unsigned int SUBGROUP_SIZE = 32;
 constexpr unsigned int DATA_SIZE = NUM_TESTS * SUBGROUP_SIZE;
 
 void test_select_from_sub_group() {
@@ -47,9 +47,13 @@ void test_select_from_sub_group() {
   constexpr syclcompat::dim3 threads{SUBGROUP_SIZE};
 
   unsigned int input[DATA_SIZE] = {
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,  // #1
-      0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,  // #2
-      0, 0, 0, 0, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1}; // #3
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, // #1
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1, // #2
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+      0, 0, 0, 0, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1, // #3
+      1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  };
   unsigned int output[DATA_SIZE];
   int pred[DATA_SIZE];
   unsigned int *d_input = syclcompat::malloc<unsigned int>(DATA_SIZE);
@@ -58,17 +62,26 @@ void test_select_from_sub_group() {
 
   unsigned int member_mask = 0x00FF;
   unsigned int expected[DATA_SIZE] = {
-      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF,
-      0,      0,      0,      0,      0,      0,      0,      0, // #1
-      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF,
-      0,      0,      0,      0,      0,      0,      0,      0, // #2
+      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, // #1
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, // #2
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0,      0,      0,      0,      0,      0,      0,      0,
       0,      0,      0,      0,      0,      0,      0,      0,
       0,      0,      0,      0,      0,      0,      0,      0, // #3
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0,      0,      0,      0,      0,      0,      0,      0,
   };
   unsigned int expected_pred[DATA_SIZE] = {
       1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, // #1
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, // #2
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // #3
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
   };
 
   syclcompat::memcpy<unsigned int>(d_input, input, DATA_SIZE);
@@ -89,6 +102,7 @@ void test_select_from_sub_group() {
   syclcompat::memcpy<int>(pred, d_pred, DATA_SIZE);
 
   for (int i = 0; i < DATA_SIZE; ++i) {
+    std::cout << "expected[" << i << "] = " << expected[i] << std::endl;
     assert(output[i] == expected[i]);
     assert(pred[i] == expected_pred[i]);
   }

--- a/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
@@ -1,0 +1,105 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  util_match_all_over_group.cpp
+ *
+ *  Description:
+ *    util_match_all_over_group tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilSelectFromSubGroup.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+#include <syclcompat.hpp>
+
+constexpr unsigned int NUM_TESTS = 3;
+constexpr unsigned int SUBGROUP_SIZE = 16;
+constexpr unsigned int DATA_SIZE = NUM_TESTS * SUBGROUP_SIZE;
+
+void test_select_from_sub_group() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{1};
+  constexpr syclcompat::dim3 threads{SUBGROUP_SIZE};
+
+  unsigned int input[DATA_SIZE] = {
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1,  // #1
+      0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1, 1, 1,  // #2
+      0, 0, 0, 0, 2, 2, 2, 2, 1, 1, 1, 1, 1, 1, 1, 1}; // #3
+  unsigned int output[DATA_SIZE];
+  int pred[DATA_SIZE];
+  unsigned int *d_input = syclcompat::malloc<unsigned int>(DATA_SIZE);
+  unsigned int *d_output = syclcompat::malloc<unsigned int>(DATA_SIZE);
+  int *d_pred = syclcompat::malloc<int>(DATA_SIZE);
+
+  unsigned int member_mask = 0x00FF;
+  unsigned int expected[DATA_SIZE] = {
+      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF,
+      0,      0,      0,      0,      0,      0,      0,      0, // #1
+      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF,
+      0,      0,      0,      0,      0,      0,      0,      0, // #2
+      0,      0,      0,      0,      0,      0,      0,      0,
+      0,      0,      0,      0,      0,      0,      0,      0, // #3
+  };
+  unsigned int expected_pred[DATA_SIZE] = {
+      1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, // #1
+      1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, // #2
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // #3
+  };
+
+  syclcompat::memcpy<unsigned int>(d_input, input, DATA_SIZE);
+  syclcompat::memset(d_output, 0, DATA_SIZE * sizeof(unsigned int));
+  syclcompat::memset(d_pred, 1, DATA_SIZE * sizeof(int));
+
+  sycl::queue q = syclcompat::get_default_queue();
+  q.parallel_for(
+      sycl::nd_range<1>(threads.size(), threads.size()),
+      [=](sycl::nd_item<1> item) [[intel::reqd_sub_group_size(SUBGROUP_SIZE)]] {
+        for (auto id = item.get_global_linear_id(); id < DATA_SIZE;
+             id += SUBGROUP_SIZE)
+          d_output[id] = syclcompat::match_all_over_sub_group(
+              item.get_sub_group(), member_mask, d_input[id], &d_pred[id]);
+      });
+  q.wait_and_throw();
+  syclcompat::memcpy<unsigned int>(output, d_output, DATA_SIZE);
+  syclcompat::memcpy<int>(pred, d_pred, DATA_SIZE);
+
+  for (int i = 0; i < DATA_SIZE; ++i) {
+    assert(output[i] == expected[i]);
+    assert(pred[i] == expected_pred[i]);
+  }
+
+  syclcompat::free(d_input);
+  syclcompat::free(d_output);
+  syclcompat::free(d_pred);
+}
+
+int main() {
+  test_select_from_sub_group();
+
+  return 0;
+}

--- a/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
@@ -36,8 +36,8 @@
 #include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 
-#define DATA_SIZE 64
-#define SUBGROUP_SIZE 16
+#define DATA_SIZE 128
+#define SUBGROUP_SIZE 32
 
 void test_select_from_sub_group() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
@@ -46,23 +46,37 @@ void test_select_from_sub_group() {
   constexpr syclcompat::dim3 threads{DATA_SIZE};
 
   unsigned int input[DATA_SIZE] = {
-      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1,
-      1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
-      3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
+      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #1
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #2
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #3
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #4
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+  };
   unsigned int output[DATA_SIZE];
   unsigned int *d_input = syclcompat::malloc<unsigned int>(DATA_SIZE);
   unsigned int *d_output = syclcompat::malloc<unsigned int>(DATA_SIZE);
 
   unsigned int member_mask = 0x0FFF;
   unsigned int expected[DATA_SIZE] = {
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
-      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
-      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
-      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
-      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #1
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #2
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #3
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #4
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      //
   };
 
   syclcompat::memcpy<unsigned int>(d_input, input, DATA_SIZE);

--- a/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
@@ -36,24 +36,23 @@
 #include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 
-#define DATA_SIZE 128
-#define SUBGROUP_SIZE 32
+constexpr unsigned int NUM_TESTS = 3;
+constexpr unsigned int SUBGROUP_SIZE = 32;
+constexpr unsigned int DATA_SIZE = NUM_TESTS * SUBGROUP_SIZE;
 
-void test_select_from_sub_group() {
+void test_match_any_over_group() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   constexpr syclcompat::dim3 grid{1};
   constexpr syclcompat::dim3 threads{DATA_SIZE};
 
   unsigned int input[DATA_SIZE] = {
-      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #1
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #2
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #3
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
-      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, // Subgroup #4
-      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4,
+      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, // Subgroup #1
+      0, 0, 0, 0, 0, 0, 0, 0, 2, 2, 2, 2, 2, 2, 2, 2,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, // Subgroup #2
+      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+      4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, 4, // Subgroup #3
   };
   unsigned int output[DATA_SIZE];
   unsigned int *d_input = syclcompat::malloc<unsigned int>(DATA_SIZE);
@@ -61,22 +60,18 @@ void test_select_from_sub_group() {
 
   unsigned int member_mask = 0x0FFF;
   unsigned int expected[DATA_SIZE] = {
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #1
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, //
       0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
       0,      0,      0,      0,      0,      0,      0,      0,      //
-      0,      0,      0,      0,      0,      0,      0,      0,      //
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #2
+      0,      0,      0,      0,      0,      0,      0,      0,      // #1
+      0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, 0x00FF, //
       0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
       0,      0,      0,      0,      0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      // #2
+      0x0FFF, 0x0FFF, 0x0FFF, 0x0FFF, 0x0FFF, 0x0FFF, 0x0FFF, 0x0FFF, //
+      0x0FFF, 0x0FFF, 0x0FFF, 0x0FFF, 0,      0,      0,      0,      //
       0,      0,      0,      0,      0,      0,      0,      0,      //
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #3
-      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
-      0,      0,      0,      0,      0,      0,      0,      0,      //
-      0,      0,      0,      0,      0,      0,      0,      0,      //
-      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0, // #4
-      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,      //
-      0,      0,      0,      0,      0,      0,      0,      0,      //
-      0,      0,      0,      0,      0,      0,      0,      0,      //
+      0,      0,      0,      0,      0,      0,      0,      0,      // #3
   };
 
   syclcompat::memcpy<unsigned int>(d_input, input, DATA_SIZE);
@@ -100,7 +95,7 @@ void test_select_from_sub_group() {
 }
 
 int main() {
-  test_select_from_sub_group();
+  test_match_any_over_group();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
@@ -1,0 +1,92 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  util_match_any_over_group.cpp
+ *
+ *  Description:
+ *    util_match_any_over_group tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====------ UtilSelectFromSubGroup.cpp---------- -*- C++ -* ----===////
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//
+// ===----------------------------------------------------------------------===//
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+#include <syclcompat.hpp>
+
+#define DATA_SIZE 64
+#define SUBGROUP_SIZE 16
+
+void test_select_from_sub_group() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr syclcompat::dim3 grid{1};
+  constexpr syclcompat::dim3 threads{DATA_SIZE};
+
+  unsigned int input[DATA_SIZE] = {
+      0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1,
+      1, 1, 2, 2, 2, 2, 3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2,
+      3, 3, 3, 3, 0, 0, 0, 0, 1, 1, 1, 1, 2, 2, 2, 2, 3, 3, 3, 3};
+  unsigned int output[DATA_SIZE];
+  unsigned int *d_input = syclcompat::malloc<unsigned int>(DATA_SIZE);
+  unsigned int *d_output = syclcompat::malloc<unsigned int>(DATA_SIZE);
+
+  unsigned int member_mask = 0x0FFF;
+  unsigned int expected[DATA_SIZE] = {
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
+      0x000F, 0x000F, 0x000F, 0x000F, 0x00F0, 0x00F0, 0x00F0, 0x00F0,
+      0x0F00, 0x0F00, 0x0F00, 0x0F00, 0,      0,      0,      0,
+  };
+
+  syclcompat::memcpy<unsigned int>(d_input, input, DATA_SIZE);
+  sycl::queue q = syclcompat::get_default_queue();
+  q.parallel_for(
+      sycl::nd_range<1>(grid.size() * threads.size(), threads.size()),
+      [=](sycl::nd_item<1> item) [[intel::reqd_sub_group_size(SUBGROUP_SIZE)]] {
+        auto id = item.get_global_linear_id();
+        d_output[id] = syclcompat::match_any_over_sub_group(
+            item.get_sub_group(), member_mask, d_input[id]);
+      });
+  q.wait_and_throw();
+  syclcompat::memcpy<unsigned int>(output, d_output, DATA_SIZE);
+
+  for (int i = 0; i < DATA_SIZE; ++i) {
+    assert(output[i] == expected[i]);
+  }
+
+  syclcompat::free(d_input);
+  syclcompat::free(d_output);
+}
+
+int main() {
+  test_select_from_sub_group();
+
+  return 0;
+}


### PR DESCRIPTION
Added support to match_any_over_sub_group and match_all_over_sub_group functions to compare values across work-items withing a sub-group. 