### PR TITLE
[CI] Fix sycl-nightly workflow

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -33,6 +33,7 @@ jobs:
             image: ghcr.io/intel/llvm/ubuntu2204_build:latest
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: ext_oneapi_hip:gpu
+            tests_selector: e2e
 
           - name: Intel L0 GPU
             runner: '["Linux", "gen12"]'
@@ -40,6 +41,7 @@ jobs:
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: ext_oneapi_level_zero:gpu
             reset_gpu: true
+            tests_selector: e2e
 
           - name: Intel OCL GPU
             runner: '["Linux", "gen12"]'
@@ -47,30 +49,35 @@ jobs:
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: opencl:gpu
             reset_gpu: true
+            tests_selector: e2e
 
           - name: OCL CPU (AMD)
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001
             target_devices: opencl:cpu
+            tests_selector: e2e
 
           - name: OCL CPU (Intel/GEN12)
             runner: '["Linux", "gen12"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001 --privileged --cap-add SYS_ADMIN
             target_devices: opencl:cpu
+            tests_selector: e2e
 
           - name: OCL CPU (Intel/Arc)
             runner: '["Linux", "arc"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001
             target_devices: opencl:cpu
+            tests_selector: e2e
 
           - name: Self-hosted CUDA
             runner: '["Linux", "cuda"]'
             image: ghcr.io/intel/llvm/ubuntu2204_build:latest
             image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
             target_devices: ext_oneapi_cuda:gpu
+            tests_selector: e2e
 
           - name: SYCL-CTS
             runner: '["cts-cpu"]'


### PR DESCRIPTION
E2E are ignored since we added "tests_selector: cts"