### PR TITLE
[SYCL][COMPAT] Added helpers for occupancy calculation in Intel GPUs

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -52,7 +52,7 @@ Specifically, this library depends on the following SYCL extensions:
 
 If available, the following extensions extend SYCLcompat functionality:
 
-* [sycl_ext_intel_device_info](../extensions/supported/sycl_ext_intel_device_info.md) \[Optional\]
+* [sycl_ext_intel_device_info](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md) \[Optional\]
 
 ## Usage
 

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1159,7 +1159,7 @@ inline int calculate_max_active_wg_per_xecore(int *num_wg, int wg_size,
                                               bool used_large_grf = false);
 
 inline int calculate_max_potential_wg(int *num_wg, int *wg_size,
-                                      int max_ws_size_for_device_code,
+                                      int max_wg_size_for_device_code,
                                       int slm_size = 0, int sg_size = 32,
                                       bool used_barrier = false,
                                       bool used_large_grf = false);

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -50,6 +50,10 @@ Specifically, this library depends on the following SYCL extensions:
     ../extensions/supported/sycl_ext_oneapi_enqueue_barrier.asciidoc)
 * [sycl_ext_oneapi_usm_device_read_only](../extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc)
 
+If available, the following extensions extend SYCLcompat functionality:
+
+* [sycl_ext_intel_device_info](../extensions/supported/sycl_ext_intel_device_info.md) \[Optional\]
+
 ## Usage
 
 All functionality is available under the `syclcompat::` namespace, imported
@@ -1117,6 +1121,8 @@ ValueT permute_sub_group_by_xor(sycl::sub_group g, ValueT x, unsigned int mask,
 The function `experimental::nd_range_barrier` synchronizes work items from all
 work groups within a SYCL kernel. This is not officially supported by the SYCL
 spec, and so should be used with caution.
+`experimental::calculate_max_active_wg_per_xecore` and
+`experimental::calculate_max_potential_wg` are used for occupancy calculation.
 
 ```c++
 namespace syclcompat {
@@ -1145,6 +1151,18 @@ public:
   uint32_t get_local_linear_range() const;
   uint32_t get_group_linear_range() const;
 };
+
+inline int calculate_max_active_wg_per_xecore(int *num_wg, int wg_size,
+                                              int slm_size = 0,
+                                              int sg_size = 32,
+                                              bool used_barrier = false,
+                                              bool used_large_grf = false);
+
+inline int calculate_max_potential_wg(int *num_wg, int *wg_size,
+                                      int max_ws_size_for_device_code,
+                                      int slm_size = 0, int sg_size = 32,
+                                      bool used_barrier = false,
+                                      bool used_large_grf = false);
 
 } // namespace experimental
 } // namespace syclcompat

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -497,7 +497,7 @@ inline int calculate_max_active_wg_per_xecore(int *num_wg, int wg_size,
 /// https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/GPU-Occupancy-Calculator
 /// \param [out] num_wg Work-group number.
 /// \param [out] wg_size Work-group size.
-/// \param [in] max_ws_size_for_device_code The maximum working work-group size
+/// \param [in] max_wg_size_for_device_code The maximum working work-group size
 /// for current device code logic. Zero means no limitation.
 /// \param [in] slm_size Share local memory size.
 /// \param [in] sg_size Sub-group size.
@@ -505,17 +505,17 @@ inline int calculate_max_active_wg_per_xecore(int *num_wg, int wg_size,
 /// \param [in] used_large_grf Whether large General Register File is used.
 /// \return Returns 0.
 inline int calculate_max_potential_wg(int *num_wg, int *wg_size,
-                                      int max_ws_size_for_device_code,
+                                      int max_wg_size_for_device_code,
                                       int slm_size = 0, int sg_size = 32,
                                       bool used_barrier = false,
                                       bool used_large_grf = false) {
   sycl::device &dev = syclcompat::get_current_device();
   size_t max_wg_size = dev.get_info<sycl::info::device::max_work_group_size>();
-  if (max_ws_size_for_device_code == 0 ||
-      max_ws_size_for_device_code >= max_wg_size)
+  if (max_wg_size_for_device_code == 0 ||
+      max_wg_size_for_device_code >= max_wg_size)
     *wg_size = (int)max_wg_size;
   else
-    *wg_size = max_ws_size_for_device_code;
+    *wg_size = max_wg_size_for_device_code;
   calculate_max_active_wg_per_xecore(num_wg, *wg_size, slm_size, sg_size,
                                      used_barrier, used_large_grf);
   std::uint32_t num_ss = 1;

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -404,5 +404,130 @@ public:
   }
 };
 
+// The original source of the functions calculate_max_active_wg_per_xecore and
+// calculate_max_potential_wg were under the license below:
+//
+// Copyright (C) Intel Corporation
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+/// This function is used for occupancy calculation, it computes the max active
+/// work-group number per Xe-Core. Ref to
+/// https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/GPU-Occupancy-Calculator
+/// \param [out] num_wg Active work-group number.
+/// \param [in] wg_size Work-group size.
+/// \param [in] slm_size Share local memory size.
+/// \param [in] sg_size Sub-group size.
+/// \param [in] used_barrier Whether barrier is used.
+/// \param [in] used_large_grf Whether large General Register File is used.
+/// \return If no error, returns 0.
+/// If \p wg_size exceeds the max work-group size, the max work-group size will
+/// be used instead of \p wg_size and returns -1.
+inline int calculate_max_active_wg_per_xecore(int *num_wg, int wg_size,
+                                              int slm_size = 0,
+                                              int sg_size = 32,
+                                              bool used_barrier = false,
+                                              bool used_large_grf = false) {
+  int ret = 0;
+  const int slm_size_per_xe_core = 64 * 1024;
+  const int max_barrier_registers = 32;
+  syclcompat::device_ext &dev = syclcompat::get_current_device();
+
+  size_t max_wg_size = dev.get_info<sycl::info::device::max_work_group_size>();
+  if (wg_size > max_wg_size) {
+    wg_size = max_wg_size;
+    ret = -1;
+  }
+
+  int num_threads_ss = 56;
+  int max_num_wg = 56;
+  if (dev.has(sycl::aspect::ext_intel_gpu_eu_count_per_subslice) &&
+      dev.has(sycl::aspect::ext_intel_gpu_hw_threads_per_eu)) {
+    auto eu_count =
+        dev.get_info<sycl::info::device::ext_intel_gpu_eu_count_per_subslice>();
+    auto threads_count =
+        dev.get_info<sycl::ext::intel::info::device::gpu_hw_threads_per_eu>();
+    num_threads_ss = eu_count * threads_count;
+    max_num_wg = eu_count * threads_count;
+  }
+
+  if (used_barrier) {
+    max_num_wg = max_barrier_registers;
+  }
+
+  // Calculate num_wg_slm
+  int num_wg_slm = 0;
+  if (slm_size == 0) {
+    num_wg_slm = max_num_wg;
+  } else {
+    num_wg_slm = std::floor((float)slm_size_per_xe_core / slm_size);
+  }
+
+  // Calculate num_wg_threads
+  if (used_large_grf)
+    num_threads_ss = num_threads_ss / 2;
+  int num_threads = std::ceil((float)wg_size / sg_size);
+  int num_wg_threads = std::floor((float)num_threads_ss / num_threads);
+
+  // Calculate num_wg
+  *num_wg = std::min(num_wg_slm, num_wg_threads);
+  *num_wg = std::min(*num_wg, max_num_wg);
+  return ret;
+}
+
+/// This function is used for occupancy calculation, it computes the work-group
+/// number and the work-group size which achieves the maximum occupancy of the
+/// device potentially. Ref to
+/// https://github.com/oneapi-src/oneAPI-samples/tree/master/Tools/GPU-Occupancy-Calculator
+/// \param [out] num_wg Work-group number.
+/// \param [out] wg_size Work-group size.
+/// \param [in] max_ws_size_for_device_code The maximum working work-group size
+/// for current device code logic. Zero means no limitation.
+/// \param [in] slm_size Share local memory size.
+/// \param [in] sg_size Sub-group size.
+/// \param [in] used_barrier Whether barrier is used.
+/// \param [in] used_large_grf Whether large General Register File is used.
+/// \return Returns 0.
+inline int calculate_max_potential_wg(int *num_wg, int *wg_size,
+                                      int max_ws_size_for_device_code,
+                                      int slm_size = 0, int sg_size = 32,
+                                      bool used_barrier = false,
+                                      bool used_large_grf = false) {
+  sycl::device &dev = syclcompat::get_current_device();
+  size_t max_wg_size = dev.get_info<sycl::info::device::max_work_group_size>();
+  if (max_ws_size_for_device_code == 0 ||
+      max_ws_size_for_device_code >= max_wg_size)
+    *wg_size = (int)max_wg_size;
+  else
+    *wg_size = max_ws_size_for_device_code;
+  calculate_max_active_wg_per_xecore(num_wg, *wg_size, slm_size, sg_size,
+                                     used_barrier, used_large_grf);
+  std::uint32_t num_ss = 1;
+  if (dev.has(sycl::aspect::ext_intel_gpu_slices) &&
+      dev.has(sycl::aspect::ext_intel_gpu_subslices_per_slice)) {
+    num_ss =
+        dev.get_info<sycl::ext::intel::info::device::gpu_slices>() *
+        dev.get_info<sycl::ext::intel::info::device::gpu_subslices_per_slice>();
+  }
+  num_wg[0] = num_ss * num_wg[0];
+  return 0;
+}
+
 } // namespace experimental
 } // namespace syclcompat

--- a/sycl/test-e2e/syclcompat/util/util_occupancy_calculation.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_occupancy_calculation.cpp
@@ -1,0 +1,76 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  util_occupancy_calculation.cpp
+ *
+ *  Description:
+ *    max_potential_wg and max_active_wg tests
+ **************************************************************************/
+
+// The original source was under the license below:
+// ====--- util_calculate_max_active_wg_per_xecore.cpp ----- *- C++ -* ----===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+// ===---------------------------------------------------------------------===//
+
+// REQUIRES: gpu
+// REQUIRES: level_zero || opencl
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <syclcompat/util.hpp>
+
+// These tests only check the API, not the functionality itself.
+void test_calculate_max_active_wg_per_xecore() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  int num_blocks;
+  int block_size = 128;
+  size_t dynamic_shared_memory_size = 0;
+  int sg_size = 32;
+  bool used_barrier = true;
+  bool used_large_grf = true;
+  syclcompat::experimental::calculate_max_active_wg_per_xecore(
+      &num_blocks, block_size, dynamic_shared_memory_size, sg_size,
+      used_barrier, used_large_grf);
+}
+
+void test_calculate_max_potential_wg() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  int num_blocks;
+  int block_size = 128;
+  size_t dynamic_shared_memory_size = 0;
+  int sg_size = 32;
+  bool used_barrier = true;
+  bool used_large_grf = true;
+
+  int block_size_limit = 0;
+  syclcompat::experimental::calculate_max_potential_wg(
+      &num_blocks, &block_size, block_size_limit, dynamic_shared_memory_size,
+      sg_size, used_barrier, used_large_grf);
+}
+
+int main() {
+  test_calculate_max_active_wg_per_xecore();
+  test_calculate_max_potential_wg();
+
+  return 0;
+}


### PR DESCRIPTION
Adds helpers to calculate the occupancy of the GPU

Testing currently only addresses API.