### PR TITLE
[SYCL] Remove print to cout from aspect check

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -621,7 +621,6 @@ bool device_impl::has(aspect Aspect) const {
     }
 
     std::string_view ExtensionsString(Result.get());
-    std::cout << ExtensionsString;
     const bool Support =
         ExtensionsString.find("ur_exp_command_buffer") != std::string::npos;
 


### PR DESCRIPTION
- Removes printing to cout from check for ext_oneapi_graph
- Caused garbled output when running sycl-ls and LIT