### PR TITLE
[SYCL][COMPAT] Added Vectorized binary and unary ops

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1206,6 +1206,8 @@ max/min of two arguments, where each argument is treated as a `sycl::vec` type.
 `vectorized_isgreater` performs elementwise `isgreater`, treating each argument
 as a vector of elements, and returning `0` for vector components for which
 `isgreater` is false, and `-1` when true.
+`vectorized_sum_abs_diff` calculates the absolute difference for two values
+without modulo overflow for vector types.
 
 The functions `cmul`,`cdiv`,`cabs`, and `conj` define complex math operations
 which accept `sycl::vec<T,2>` arguments representing complex values.
@@ -1242,7 +1244,8 @@ template <typename ValueT> inline ValueT reverse_bits(ValueT a);
 `vectorized_binary` computes the `BinaryOperation` for two operands,
 with each value treated as a vector type. `vectorized_unary` offers the same
 interface for operations with a single operand.
-The implemented `BinaryOperation`s are `abs_diff`, `add_sat`, `rhadd`, `hadd`, `maximum`, `minimum`, and `sub_sat`.
+The implemented `BinaryOperation`s are `abs_diff`, `add_sat`, `rhadd`, `hadd`,
+`maximum`, `minimum`, and `sub_sat`.
 
 ```cpp
 namespace syclcompat {

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1223,6 +1223,9 @@ template <>
 inline unsigned vectorized_isgreater<sycl::ushort2, unsigned>(unsigned a,
                                                               unsigned b);
 
+template <typename VecT>
+inline unsigned vectorized_sum_abs_diff(unsigned a, unsigned b);
+
 template <typename T>
 sycl::vec<T, 2> cmul(sycl::vec<T, 2> x, sycl::vec<T, 2> y);
 
@@ -1234,6 +1237,65 @@ template <typename T> T cabs(sycl::vec<T, 2> x);
 template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x);
 
 template <typename ValueT> inline ValueT reverse_bits(ValueT a);
+```
+
+`vectorized_binary` computes the `BinaryOperation` for two operands,
+with each value treated as a vector type. `vectorized_unary` offers the same
+interface for operations with a single operand.
+The implemented `BinaryOperation`s are `abs_diff`, `add_sat`, `rhadd`, `hadd`, `maximum`, `minimum`, and `sub_sat`.
+
+```cpp
+namespace syclcompat {
+  
+template <typename VecT, class UnaryOperation>
+inline unsigned vectorized_unary(unsigned a, const UnaryOperation unary_op);
+
+// A sycl::abs wrapper functor.
+struct abs {
+  template <typename ValueT> auto operator()(const ValueT x) const;
+};
+
+template <typename VecT, class BinaryOperation>
+inline unsigned vectorized_binary(unsigned a, unsigned b,
+                                  const BinaryOperation binary_op);
+
+// A sycl::abs_diff wrapper functor.
+struct abs_diff {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+// A sycl::add_sat wrapper functor.
+struct add_sat {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+// A sycl::rhadd wrapper functor.
+struct rhadd {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+// A sycl::hadd wrapper functor.
+struct hadd {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+// A sycl::max wrapper functor.
+struct maximum {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+// A sycl::min wrapper functor.
+struct minimum {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+// A sycl::sub_sat wrapper functor.
+struct sub_sat {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const;
+};
+
+} // namespace syclcompat
 ```
 
 ## Sample Code

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -47,6 +47,18 @@ namespace complex_namespace = sycl::ext::oneapi::experimental;
 template <typename ValueT>
 using complex_type = detail::complex_namespace::complex<ValueT>;
 
+template <typename VecT, class BinaryOperation, class = void>
+class vectorized_binary {
+public:
+  inline VecT operator()(VecT a, VecT b, const BinaryOperation binary_op) {
+    VecT v4;
+    for (size_t i = 0; i < v4.size(); ++i) {
+      v4[i] = binary_op(a[i], b[i]);
+    }
+    return v4;
+  }
+};
+
 } // namespace detail
 
 /// Compute fast_length for variable-length array
@@ -103,6 +115,40 @@ template <typename S, typename T> inline T vectorized_min(T a, T b) {
   v2 = sycl::min(v2, v3);
   v0 = v2.template as<sycl::vec<T, 1>>();
   return v0;
+}
+
+/// Compute vectorized unary operation for a value, with the value treated as a
+/// vector type \p VecT.
+/// \tparam [in] VecT The type of the vector
+/// \tparam [in] UnaryOperation The unary operation class
+/// \param [in] a The input value
+/// \returns The vectorized unary operation value of the input value
+template <typename VecT, class UnaryOperation>
+inline unsigned vectorized_unary(unsigned a, const UnaryOperation unary_op) {
+  sycl::vec<unsigned, 1> v0{a};
+  auto v1 = v0.as<VecT>();
+  auto v2 = unary_op(v1);
+  v0 = v2.template as<sycl::vec<unsigned, 1>>();
+  return v0;
+}
+
+/// Compute vectorized absolute difference for two values without modulo
+/// overflow, with each value treated as a vector type \p VecT.
+/// \tparam [in] VecT The type of the vector
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized absolute difference of the two values
+template <typename VecT>
+inline unsigned vectorized_sum_abs_diff(unsigned a, unsigned b) {
+  sycl::vec<unsigned, 1> v0{a}, v1{b};
+  auto v2 = v0.as<VecT>();
+  auto v3 = v1.as<VecT>();
+  auto v4 = sycl::abs_diff(v2, v3);
+  unsigned sum = 0;
+  for (size_t i = 0; i < v4.size(); ++i) {
+    sum += v4[i];
+  }
+  return sum;
 }
 
 /// Compute vectorized isgreater for two values, with each value treated as a
@@ -180,6 +226,88 @@ template <typename T> sycl::vec<T, 2> conj(sycl::vec<T, 2> x) {
   sycl::ext::oneapi::experimental::complex<T> t(x[0], x[1]);
   t = conj(t);
   return sycl::vec<T, 2>(t.real(), t.imag());
+}
+
+/// A sycl::abs wrapper functors.
+struct abs {
+  template <typename ValueT> auto operator()(const ValueT x) const {
+    return sycl::abs(x);
+  }
+};
+
+/// A sycl::abs_diff wrapper functors.
+struct abs_diff {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::abs_diff(x, y);
+  }
+};
+
+/// A sycl::add_sat wrapper functors.
+struct add_sat {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::add_sat(x, y);
+  }
+};
+
+/// A sycl::rhadd wrapper functors.
+struct rhadd {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::rhadd(x, y);
+  }
+};
+
+/// A sycl::hadd wrapper functors.
+struct hadd {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::hadd(x, y);
+  }
+};
+
+/// A sycl::max wrapper functors.
+struct maximum {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::max(x, y);
+  }
+};
+
+/// A sycl::min wrapper functors.
+struct minimum {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::min(x, y);
+  }
+};
+
+/// A sycl::sub_sat wrapper functors.
+struct sub_sat {
+  template <typename ValueT>
+  auto operator()(const ValueT x, const ValueT y) const {
+    return sycl::sub_sat(x, y);
+  }
+};
+
+/// Compute vectorized binary operation value for two values, with each value
+/// treated as a vector type \p VecT.
+/// \tparam [in] VecT The type of the vector
+/// \tparam [in] BinaryOperation The binary operation class
+/// \param [in] a The first value
+/// \param [in] b The second value
+/// \returns The vectorized binary operation value of the two values
+template <typename VecT, class BinaryOperation>
+inline unsigned vectorized_binary(unsigned a, unsigned b,
+                                  const BinaryOperation binary_op) {
+  sycl::vec<unsigned, 1> v0{a}, v1{b};
+  auto v2 = v0.as<VecT>();
+  auto v3 = v1.as<VecT>();
+  auto v4 =
+      detail::vectorized_binary<VecT, BinaryOperation>()(v2, v3, binary_op);
+  v0 = v4.template as<sycl::vec<unsigned, 1>>();
+  return v0;
 }
 
 } // namespace syclcompat

--- a/sycl/test-e2e/syclcompat/common.hpp
+++ b/sycl/test-e2e/syclcompat/common.hpp
@@ -25,6 +25,8 @@
 #include <sycl/half_type.hpp>
 #include <tuple>
 
+constexpr double ERROR_TOLERANCE = 1e-5;
+
 // Typed call helper
 // Iterates over all types and calls Functor f for each of them
 template <typename tuple, typename Functor>

--- a/sycl/test-e2e/syclcompat/math/math_complex.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_complex.cpp
@@ -35,13 +35,15 @@
 // RUN: %{run} %t.out
 
 #include <complex>
-
 #include <iostream>
+
 #include <sycl/sycl.hpp>
 #include <syclcompat.hpp>
 
+#include "../common.hpp"
+
 template <typename T> bool check(T x, float *e) {
-  float precision = 0.001f;
+  float precision = ERROR_TOLERANCE;
   if ((x.x() - e[0] < precision) && (x.x() - e[0] > -precision) &&
       (x.y() - e[1] < precision) && (x.y() - e[1] > -precision)) {
     return true;
@@ -50,7 +52,7 @@ template <typename T> bool check(T x, float *e) {
 }
 
 template <> bool check<float>(float x, float *e) {
-  float precision = 0.001f;
+  float precision = ERROR_TOLERANCE;
   if ((x - e[0] < precision) && (x - e[0] > -precision)) {
     return true;
   }
@@ -58,7 +60,7 @@ template <> bool check<float>(float x, float *e) {
 }
 
 template <> bool check<double>(double x, float *e) {
-  float precision = 0.001f;
+  float precision = ERROR_TOLERANCE;
   if ((x - e[0] < precision) && (x - e[0] > -precision)) {
     return true;
   }

--- a/sycl/test-e2e/syclcompat/math/math_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/math/math_fixt.hpp
@@ -86,7 +86,7 @@ template <typename ValueT> struct should_skip {
     else                                                                       \
       assert(fabs(RESULT - EXPECTED) < ERROR_TOLERANCE);                       \
   } else if constexpr (contained_is_floating_point_v<ResultT>) {               \
-    for (size_t i = 0; i < RESULT->size(); i++)                                \
+    for (size_t i = 0; i < RESULT.size(); i++)                                 \
       assert(fabs(RESULT[i] - EXPECTED[i]) < ERROR_TOLERANCE);                 \
   } else {                                                                     \
     static_assert(0, "Math_fixt.hpp should not have arrived here.");           \

--- a/sycl/test-e2e/syclcompat/math/math_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/math/math_fixt.hpp
@@ -1,0 +1,186 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat
+ *
+ *  math_fixt.hpp
+ *
+ *  Description:
+ *     Fixtures and helpers for to tests the math functionalities
+ **************************************************************************/
+
+#pragma once
+
+#include <type_traits>
+
+#include <sycl/sycl.hpp>
+#include <syclcompat.hpp>
+
+#include "../common.hpp"
+
+template <typename Container, typename ValueT, typename = void>
+static constexpr bool contained_is_same_v = false;
+
+template <typename Container, typename ValueT>
+static constexpr bool contained_is_same_v<
+    Container, ValueT, std::void_t<typename Container::value_type>> =
+    std::is_same_v<typename Container::value_type, ValueT>;
+
+template <typename Container, typename = void>
+static constexpr bool contained_is_integral_v = false;
+
+template <typename Container>
+static constexpr bool contained_is_integral_v<
+    Container, std::void_t<typename Container::value_type>> =
+    std::is_integral_v<typename Container::value_type>;
+
+template <typename Container, typename = void>
+static constexpr bool contained_is_floating_point_v = false;
+
+template <typename Container>
+static constexpr bool contained_is_floating_point_v<
+    Container, std::void_t<typename Container::value_type>> =
+    std::is_floating_point_v<typename Container::value_type> ||
+    std::is_same_v<typename Container::value_type, sycl::half>;
+
+template <typename ValueT> struct should_skip {
+  bool operator()(const sycl::device &dev) const {
+    if constexpr (std::is_same_v<ValueT, double> ||
+                  contained_is_same_v<ValueT, double>) {
+      if (!dev.has(sycl::aspect::fp64)) {
+        std::cout << "  sycl::aspect::fp64 not supported by the SYCL device."
+                  << std::endl;
+        return true;
+      }
+    }
+    if constexpr (std::is_same_v<ValueT, sycl::half> ||
+                  contained_is_same_v<ValueT, sycl::half>) {
+      if (!dev.has(sycl::aspect::fp16)) {
+        std::cout << "  sycl::aspect::fp16 not supported by the SYCL device."
+                  << std::endl;
+        return true;
+      }
+    }
+    return false;
+  }
+};
+
+#define CHECK(ResultT, RESULT_PTR, EXPECTED)                                   \
+  if constexpr (std::is_integral_v<ResultT>) {                                 \
+    assert(*RESULT_PTR == EXPECTED);                                           \
+  } else if constexpr (std::is_floating_point_v<ResultT> ||                    \
+                       std::is_same_v<ResultT, sycl::half>) {                  \
+    if (sycl::isnan(*RESULT_PTR))                                              \
+      assert(sycl::isnan(EXPECTED));                                           \
+    else                                                                       \
+      assert(fabs(*RESULT_PTR - EXPECTED) < ERROR_TOLERANCE);                  \
+  } else if constexpr (contained_is_floating_point_v<ResultT>) {               \
+    for (size_t i = 0; i < RESULT_PTR->size(); i++)                            \
+      assert(fabs((*RESULT_PTR)[i] - EXPECTED[i]) < ERROR_TOLERANCE);          \
+  } else {                                                                     \
+    static_assert(0, "Math_fixt.hpp should not have arrived here.");           \
+  }
+
+class OpTestLauncher {
+protected:
+  syclcompat::dim3 grid_;
+  syclcompat::dim3 threads_;
+  bool skip_;
+
+public:
+  OpTestLauncher(const syclcompat::dim3 &grid, const syclcompat::dim3 &threads,
+                 const bool skip)
+      : grid_{grid}, threads_{threads}, skip_{skip} {}
+};
+
+// Templated ResultT to support both arithmetic and boolean operators
+template <typename ValueT, typename ValueU,
+          typename ResultT = std::common_type_t<ValueT, ValueU>>
+class BinaryOpTestLauncher : OpTestLauncher {
+protected:
+  ValueT *op1_;
+  ValueU *op2_;
+  ResultT *res_;
+
+public:
+  BinaryOpTestLauncher(const syclcompat::dim3 &grid,
+                       const syclcompat::dim3 &threads,
+                       const size_t data_size = 1)
+      : OpTestLauncher{
+            grid, threads,
+            should_skip<ValueT>()(syclcompat::get_current_device())} {
+    if (skip_)
+      return;
+    op1_ = syclcompat::malloc_shared<ValueT>(data_size);
+    op2_ = syclcompat::malloc_shared<ValueU>(data_size);
+    res_ = syclcompat::malloc_shared<ResultT>(data_size);
+  };
+
+  virtual ~BinaryOpTestLauncher() {
+    if (skip_)
+      return;
+    syclcompat::free(op1_);
+    syclcompat::free(op2_);
+    syclcompat::free(res_);
+  }
+
+  template <auto Kernel>
+  void launch_test(ValueT op1, ValueU op2, ResultT expected) {
+    if (skip_)
+      return;
+    *op1_ = op1;
+    *op2_ = op2;
+    syclcompat::launch<Kernel>(grid_, threads_, op1_, op2_, res_);
+    syclcompat::wait();
+
+    CHECK(ResultT, res_, expected);
+  };
+};
+
+template <typename ValueT, typename ResultT = ValueT>
+class UnaryOpTestLauncher : OpTestLauncher {
+protected:
+  ValueT *op_;
+  ValueT *res_;
+
+public:
+  UnaryOpTestLauncher(const syclcompat::dim3 &grid,
+                      const syclcompat::dim3 &threads,
+                      const size_t data_size = 1)
+      : OpTestLauncher{
+            grid, threads,
+            should_skip<ValueT>()(syclcompat::get_current_device())} {
+    if (skip_)
+      return;
+    op_ = syclcompat::malloc_shared<ValueT>(data_size);
+    res_ = syclcompat::malloc_shared<ValueT>(data_size);
+  };
+
+  virtual ~UnaryOpTestLauncher() {
+    if (skip_)
+      return;
+    syclcompat::free(op_);
+    syclcompat::free(res_);
+  }
+
+  template <auto Kernel> void launch_test(ValueT op, ResultT expected) {
+    if (skip_)
+      return;
+    *op_ = op;
+    syclcompat::launch<Kernel>(grid_, threads_, op_, res_);
+    syclcompat::wait();
+
+    CHECK(ResultT, res_, expected);
+  }
+};

--- a/sycl/test-e2e/syclcompat/math/math_vectorized.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized.cpp
@@ -1,0 +1,106 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  math_vectorized.cpp
+ *
+ *  Description:
+ *    math helpers for vectorized operations and fp16 operations
+ **************************************************************************/
+
+// REQUIRES: aspect-fp16
+
+// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <syclcompat/math.hpp>
+
+#include "../common.hpp"
+#include "math_fixt.hpp"
+
+template <typename BinaryOp, typename ValueT>
+void vectorized_binary_kernel(ValueT *a, ValueT *b, unsigned *r) {
+  unsigned ua = static_cast<unsigned>(*a);
+  unsigned ub = static_cast<unsigned>(*b);
+  *r = syclcompat::vectorized_binary<sycl::short2>(ua, ub, BinaryOp());
+}
+
+template <typename BinaryOp, typename ValueT>
+void test_vectorized_binary(ValueT op1, ValueT op2, unsigned expected) {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr syclcompat::dim3 grid{1};
+  constexpr syclcompat::dim3 threads{1};
+
+  BinaryOpTestLauncher<ValueT, ValueT, unsigned>(grid, threads)
+      .template launch_test<vectorized_binary_kernel<BinaryOp, ValueT>>(
+          op1, op2, expected);
+}
+
+template <typename UnaryOp, typename ValueT>
+void vectorized_unary_kernel(ValueT *a, unsigned *r) {
+  unsigned ua = static_cast<unsigned>(*a);
+  *r = syclcompat::vectorized_unary<sycl::short2>(ua, UnaryOp());
+}
+
+template <typename UnaryOp, typename ValueT>
+void test_vectorized_unary(ValueT op1, unsigned expected) {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr syclcompat::dim3 grid{1};
+  constexpr syclcompat::dim3 threads{1};
+
+  UnaryOpTestLauncher<ValueT, unsigned>(grid, threads)
+      .template launch_test<vectorized_unary_kernel<UnaryOp, ValueT>>(op1,
+                                                                      expected);
+}
+
+template <typename ValueT>
+void vectorized_sum_abs_diff_kernel(ValueT *a, ValueT *b, unsigned *r) {
+  unsigned ua = static_cast<unsigned>(*a);
+  unsigned ub = static_cast<unsigned>(*b);
+
+  *r = syclcompat::vectorized_sum_abs_diff<sycl::short2>(ua, ub);
+}
+
+template <typename ValueT>
+void test_vectorized_sum_abs_diff(ValueT op1, ValueT op2, unsigned expected) {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr syclcompat::dim3 grid{1};
+  constexpr syclcompat::dim3 threads{1};
+
+  BinaryOpTestLauncher<ValueT, ValueT, unsigned>(grid, threads)
+      .template launch_test<vectorized_sum_abs_diff_kernel<ValueT>>(op1, op2,
+                                                                    expected);
+}
+
+int main() {
+  test_vectorized_binary<syclcompat::abs_diff, uint32_t>(0x00010002, 0x00040002,
+                                                         0x00030000);
+  test_vectorized_binary<syclcompat::add_sat, uint32_t>(0x00020002, 0xFFFDFFFF,
+                                                        0xFFFF0001);
+  test_vectorized_binary<syclcompat::rhadd, uint32_t>(0x00010008, 0x00020001,
+                                                      0x00020005);
+  test_vectorized_binary<syclcompat::hadd, uint32_t>(0x00010003, 0x00020005,
+                                                     0x00010004);
+  test_vectorized_binary<syclcompat::maximum, uint32_t>(0x0FFF0000, 0x00000FFF,
+                                                        0x0FFF0FFF);
+  test_vectorized_binary<syclcompat::minimum, uint32_t>(0x0FFF0000, 0x00000FFF,
+                                                        0x00000000);
+  test_vectorized_binary<syclcompat::sub_sat, uint32_t>(0xFFFB0005, 0x00030008,
+                                                        0xFFF8FFFD);
+  test_vectorized_unary<syclcompat::abs, uint32_t>(0xFFFBFFFD, 0x00050003);
+  test_vectorized_sum_abs_diff<uint32_t>(0x00010002, 0x00040002, 0x00000003);
+
+  return 0;
+}


### PR DESCRIPTION
This PR adds multiple binary and unary ops through callable structs:

- abs 
- abs_diff 
- add_sat
- rhadd 
- hadd 
- maximum
- minimum
- sub_sat

It also adds `vectorized_sum_abs_diff`.

To facilitate testing, it also incorporates a set of fixtures/helper classes to simplify future additions to math.hpp