### PR TITLE
[SYCL][E2E] Add gpu-intel-pvc-vg LIT param

### DIFF
--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -258,6 +258,9 @@ configure specific single test execution in the command line:
  * **gpu-intel-pvc** - tells LIT infra that Intel GPU PVC is present in the
    system. It is developer / CI infra responsibility to make sure that the
    device is available in the system.
+ * **gpu-intel-pvc-vg** - tells LIT infra that Intel GPU PVC-VG is present in the
+   system. It is developer / CI infra responsibility to make sure that the
+   device is available in the system.
  * **extra_environment** - comma-separated list of variables with values to be
    added to test environment. Can be also set by LIT_EXTRA_ENVIRONMENT variable
    in cmake.

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -155,19 +155,22 @@ if lit_config.params.get("gpu-intel-dg1", False):
     config.available_features.add("gpu-intel-dg1")
 if lit_config.params.get("gpu-intel-dg2", False):
     config.available_features.add("gpu-intel-dg2")
-if lit_config.params.get("gpu-intel-pvc", False) or \
-   lit_config.params.get("gpu-intel-pvc-vg", False) :
-    if lit_config.params.get("gpu-intel-pvc", False):
-        config.available_features.add("gpu-intel-pvc")
-    else:
-        config.available_features.add("gpu-intel-pvc-vg")
+if lit_config.params.get("gpu-intel-pvc", False):
+    config.available_features.add("gpu-intel-pvc")
     config.available_features.add(
         "matrix-fp16"
-    )  # PVC/PVC-VG implies the support of FP16 matrix
+    )  # PVC implies the support of FP16 matrix
     config.available_features.add(
         "matrix-tf32"
-    )  # PVC/PVC-VG implies the support of TF32 matrix
-
+    )  # PVC implies the support of TF32 matrix
+if lit_config.params.get("gpu-intel-pvc-vg", False):
+    config.available_features.add("gpu-intel-pvc-vg")
+    config.available_features.add(
+        "matrix-fp16"
+    )  # PVC-VG implies the support of FP16 matrix
+    config.available_features.add(
+        "matrix-tf32"
+    )  # PVC-VG implies the support of TF32 matrix    
 if lit_config.params.get("matrix", False):
     config.available_features.add("matrix")
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -155,14 +155,18 @@ if lit_config.params.get("gpu-intel-dg1", False):
     config.available_features.add("gpu-intel-dg1")
 if lit_config.params.get("gpu-intel-dg2", False):
     config.available_features.add("gpu-intel-dg2")
-if lit_config.params.get("gpu-intel-pvc", False):
-    config.available_features.add("gpu-intel-pvc")
+if lit_config.params.get("gpu-intel-pvc", False) or \
+   lit_config.params.get("gpu-intel-pvc-vg", False) :
+    if lit_config.params.get("gpu-intel-pvc", False):
+        config.available_features.add("gpu-intel-pvc")
+    else:
+        config.available_features.add("gpu-intel-pvc-vg")
     config.available_features.add(
         "matrix-fp16"
-    )  # PVC implies the support of FP16 matrix
+    )  # PVC/PVC-VG implies the support of FP16 matrix
     config.available_features.add(
         "matrix-tf32"
-    )  # PVC implies the support of TF32 matrix
+    )  # PVC/PVC-VG implies the support of TF32 matrix
 
 if lit_config.params.get("matrix", False):
     config.available_features.add("matrix")


### PR DESCRIPTION
I chose `gpu-intel-pvc-vg` instead of `gpu-intel-pvcvg` to match the device_arch [here](https://github.com/intel/llvm/blob/a0cdd9f741c70e7586d7638b88e7b750eb2d540c/sycl/doc/UsersManual.md?plain=1#L51).