### PR TITLE
[SYCL][Graph] Fix sycl-ls output for graph aspect

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -621,7 +621,6 @@ bool device_impl::has(aspect Aspect) const {
     }
 
     std::string_view ExtensionsString(Result.get());
-    std::cout << ExtensionsString;
     const bool Support =
         ExtensionsString.find("ur_exp_command_buffer") != std::string::npos;
 


### PR DESCRIPTION
Remove unnecessary output, which garbled sycl-ls verbose output like that:

`ext_intel_matrixcl_khr_il_program cl_khr_subgroups cl_intel_subgroups
cl_intel_subgroups_short cl_intel_required_subgroup_size cl_khr_fp16
cl_khr_fp64 cl_khr_int64_base_atomics cl_khr_int64_extended_atomics
cl_intel_bfloat16_conversions ur_exp_command_buffer
ur_exp_multi_device_compile  ext_oneapi_graph`

Expected was:
`ext_intel_matrix ext_oneapi_graph`