### PR TITLE
[SYCL][ESIMD][E2E] Re-enable dword_local_accessor_atomic_smoke.cpp on Windows

### DIFF
--- a/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/dword_local_accessor_atomic_smoke.cpp
@@ -8,8 +8,6 @@
 // This test checks DWORD local accessor atomic operations.
 //===----------------------------------------------------------------------===//
 // REQUIRES-INTEL-DRIVER: lin: 26690, win: 101.4576
-// TODO: disabled temporarily because of flaky issue.
-// UNSUPPORTED: windows
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //


### PR DESCRIPTION
I ran the test 2000 times on Linux and 500 times on Windows in latest syclos on Gen12 as well as fulsim and it never failed, it seems this isn't reproducible anymore.