### PR TITLE
[Driver][SYCL] Do not perform link step with -fsycl-link-targets

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5047,8 +5047,6 @@ class OffloadingActionBuilder final {
           // action or fat binary.
           SYCLDeviceActions.clear();
 
-          for (auto SDA : SYCLDeviceActions)
-            SYCLLinkBinaryList.push_back(SDA);
           if (WrapDeviceOnlyBinary)
             return ABRT_Success;
           auto *Link =
@@ -7512,9 +7510,12 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
   }
 
   // Add a link action if necessary.
+  // When offloading with -fsycl-link-targets, no link action is processed
+  // as we stop at the spirv-translation step.
   Arg *FinalPhaseArg;
   if (!UseNewOffloadingDriver &&
-      getFinalPhase(Args, &FinalPhaseArg) == phases::Link) {
+      getFinalPhase(Args, &FinalPhaseArg) == phases::Link &&
+      !Args.hasArg(options::OPT_fsycl_link_targets_EQ)) {
     if (LinkerInputs.empty() && DeviceAOTLinkerInputs.empty())
       OffloadBuilder->appendDeviceLinkActions(Actions);
 

--- a/clang/test/Driver/sycl-link-add-targets.cpp
+++ b/clang/test/Driver/sycl-link-add-targets.cpp
@@ -78,6 +78,14 @@
 // CHK-LINK-TARGETS-UB: 2: linker, {1}, image, (device-sycl)
 // CHK-LINK-TARGETS-UB: 3: llvm-spirv, {2}, image, (device-sycl)
 // CHK-LINK-TARGETS-UB: 4: offload, "device-sycl (spir64-unknown-unknown)" {3}, image
+// CHK-LINK-TARGETS-UB-NOT: offload
+
+// RUN: %clangxx -ccc-print-bindings --target=x86_64-unknown-linux-gnu \
+// RUN:          -fsycl -o checkme.out -fsycl-link-targets=spir64 %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK-LINK-TARGETS-BINDINGS %s
+// CHK-LINK-TARGETS-BINDINGS: "spir64-unknown-unknown" - "clang", inputs: [{{.*}}], output: "[[IR_OUTPUT_BC:.+\.bc]]"
+// CHK-LINK-TARGETS-BINDINGS: "spir64-unknown-unknown" - "SYCL::Linker", inputs: ["[[IR_OUTPUT_BC]]"], output: "[[LLVM_LINK_OUTPUT:.+\.out]]"
+// CHK-LINK-TARGETS-BINDINGS: "spir64-unknown-unknown" - "SPIR-V translator", inputs: ["[[LLVM_LINK_OUTPUT]]"], output: "checkme.out"
 
 /// Check -fsycl-link-targets=<triple> behaviors unbundle multiple objects
 // RUN:   touch %t-a.o


### PR DESCRIPTION
When using the -fsycl-link-targets option, we inadvertently were triggering the additional device linking steps that are performed for -fsycl-link.  Prevent this from happening.  Also do a little cleanup of some code that is not needed.