### PR TITLE
[SYCL] Fix Arg Type for the preview mode

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1368,8 +1368,7 @@ private:
     verifyUsedKernelBundle(detail::KernelInfo<NameT>::getName());
     using LambdaArgType =
         sycl::detail::lambda_arg_type<KernelType, nd_item<Dims>>;
-#if defined(SYCL2020_CONFORMANT_APIS) ||                                       \
-    defined(__INTEL_PREVIEW_BREAKING_CHANGES)
+#if defined(SYCL2020_CONFORMANT_APIS)
     static_assert(
         std::is_convertible_v<sycl::nd_item<Dims>, LambdaArgType>,
         "Kernel argument of a sycl::parallel_for with sycl::nd_range "


### PR DESCRIPTION
We already check if the arg type if convertible to nd_item in the struct TransformUserItemType properly.
We should not assume it is always convertible in the preview mode.