### PR TITLE
[SYCL] Handle PI_EVENT_STATUS_QUEUED return value

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -110,13 +110,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
 
   fetch_adapter_source(opencl
     ${UNIFIED_RUNTIME_REPO}
-    # commit 85b7559033e329389452cb87615ad42fbb644d59 (HEAD -> main, origin/main, origin/HEAD)
-    # Merge: a7c202b4 5c300799
+    # commit 0d2a972c71ba4dd5935478c7b7124a372a1eeca0
+    # Merge: ac89abfe 44aef877
     # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Tue Apr 9 14:06:49 2024 +0100
-    #     Merge pull request #1496 from steffenlarsen/steffen/revert_memory_lookup_error
-    #     [OpenCL] Revert urMemBufferCreate extension function lookup error
-    85b7559033e329389452cb87615ad42fbb644d59
+    # Date:   Thu Apr 11 10:24:19 2024 +0100
+    #     Merge pull request #1440 from fabiomestre/fabio/opencl_remove_queued_hack
+    #     [OPENCL] Remove EVENT_STATUS_QUEUED workaround
+    0d2a972c71ba4dd5935478c7b7124a372a1eeca0
   )
 
   fetch_adapter_source(cuda

--- a/sycl/source/detail/event_info.hpp
+++ b/sycl/source/detail/event_info.hpp
@@ -40,6 +40,16 @@ typename Param::return_type get_event_info(sycl::detail::pi::PiEvent Event,
   // TODO catch an exception and put it to list of asynchronous exceptions
   Plugin->call<PiApiKind::piEventGetInfo>(Event, PiInfoCode<Param>::value,
                                           sizeof(Result), &Result, nullptr);
+
+  // If the status is PI_EVENT_QUEUED We need to change it since QUEUE is
+  // not a valid status in sycl.
+  if constexpr (std::is_same<Param,
+                             info::event::command_execution_status>::value) {
+    Result = static_cast<pi_event_status>(Result) == PI_EVENT_QUEUED
+                 ? sycl::info::event_command_status::submitted
+                 : Result;
+  }
+
   return Result;
 }
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/9944 introduced a hack in the OpenCL PI plugin which maps PI_EVENT_QUEUED to PI_EVENT_SUBMITTED. This hack is problematic because it will make SYCL-RT assume that an event has been flushed when it might not have been. At the moment, this could result in buggy behaviour on the OpenCL backend when using multiple queues. The OpenCL specification states:

> "To use event objects that refer to commands enqueued in a command-queue as event objects to wait on by commands enqueued in a different command-queue, the application must call a clFlush or any blocking commands that perform an implicit flush of the command-queue where the commands that refer to these event objects are enqueued."

This PR, moves the mapping from UR to `get_event_info()` inside sycl-rt which avoids the issue because it is a separate code path from `flush_if_needed()`

Corresponding UR PR: https://github.com/oneapi-src/unified-runtime/pull/1440