### PR TITLE
[SYCL][COMPAT] defs.hpp update with Windows macros. SYCLCOMPAT_CHECK_ERROR added.

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1182,9 +1182,8 @@ expressions that might throw `sycl::exception` and `std::runtime_error`.
 If no exceptions are thrown, it returns `syclcompat::error_code::SUCCESS`.
 If a `sycl::exception` is caught, it returns `syclcompat::error_code::BACKEND_ERROR`.
 If a `std::runtime_error` exception is caught,
-`syclcompat::error_code::DEFAULT_ERROR` is returned instead.
-For both cases, it prints the error message to the standard
-error stream.
+`syclcompat::error_code::DEFAULT_ERROR` is returned instead. For both cases, it
+prints the error message to the standard error stream.
 
 ``` c++
 namespace syclcompat {
@@ -1215,7 +1214,7 @@ template <int Arg> class syclcompat_kernel_scalar;
 #endif
 
 namespace syclcompat {
-enum error_code { SUCCESS = 0, DEFAULT_ERROR = 999 };
+enum error_code { SUCCESS = 0, BACKEND_ERROR = 1, DEFAULT_ERROR = 999 };
 }
 
 #define SYCLCOMPAT_CHECK_ERROR(expr)

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1178,10 +1178,13 @@ kernel names during machine translation.
 SYCL spec supported by the current SYCL compiler.
 
 The `SYCLCOMPAT_CHECK_ERROR` macro encapsulates an error-handling mechanism for
-expressions that might throw `sycl::exception`. If no exceptions are thrown, it
-returns `syclcompat::error_code::SUCCESS`. If an exception is caught, it prints
-the error message to the standard error stream and returns
-`syclcompat::error_code::DEFAULT_ERROR`.
+expressions that might throw `sycl::exception` and `std::runtime_error`.
+If no exceptions are thrown, it returns `syclcompat::error_code::SUCCESS`.
+If a `sycl::exception` is caught, it returns `syclcompat::error_code::BACKEND_ERROR`.
+If a `std::runtime_error` exception is caught,
+`syclcompat::error_code::DEFAULT_ERROR` is returned instead.
+For both cases, it prints the error message to the standar
+d error stream.
 
 ``` c++
 namespace syclcompat {

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1183,8 +1183,8 @@ If no exceptions are thrown, it returns `syclcompat::error_code::SUCCESS`.
 If a `sycl::exception` is caught, it returns `syclcompat::error_code::BACKEND_ERROR`.
 If a `std::runtime_error` exception is caught,
 `syclcompat::error_code::DEFAULT_ERROR` is returned instead.
-For both cases, it prints the error message to the standar
-d error stream.
+For both cases, it prints the error message to the standard
+error stream.
 
 ``` c++
 namespace syclcompat {

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1177,16 +1177,45 @@ kernel names during machine translation.
 `get_sycl_language_version` returns an integer representing the version of the
 SYCL spec supported by the current SYCL compiler.
 
+The `SYCLCOMPAT_CHECK_ERROR` macro encapsulates an error-handling mechanism for
+expressions that might throw `sycl::exception`. If no exceptions are thrown, it
+returns `syclcompat::error_code::SUCCESS`. If an exception is caught, it prints
+the error message to the standard error stream and returns
+`syclcompat::error_code::DEFAULT_ERROR`.
+
 ``` c++
 namespace syclcompat {
 
-#define __sycl_compat_align__(n) __attribute__((aligned(n)))
-#define __sycl_compat_inline__ __inline__ __attribute__((always_inline))
+template <class... Args> class syclcompat_kernel_name;
+template <int Arg> class syclcompat_kernel_scalar;
 
-#define __sycl_compat_noinline__ __attribute__((noinline))
+#if defined(_MSC_VER)
+#define __syclcompat_align__(n) __declspec(align(n))
+#define __syclcompat_inline__ __forceinline
+#else
+#define __syclcompat_align__(n) __attribute__((aligned(n)))
+#define __syclcompat_inline__ __inline__ __attribute__((always_inline))
+#endif
 
-template <class... Args> class sycl_compat_kernel_name;
-template <int Arg> class sycl_compat_kernel_scalar;
+#if defined(_MSC_VER)
+#define __syclcompat_noinline__ __declspec(noinline)
+#else
+#define __syclcompat_noinline__ __attribute__((noinline))
+#endif
+
+#define SYCLCOMPAT_COMPATIBILITY_TEMP (600)
+
+#ifdef _WIN32
+#define SYCLCOMPAT_EXPORT __declspec(dllexport)
+#else
+#define SYCLCOMPAT_EXPORT
+#endif
+
+namespace syclcompat {
+enum error_code { SUCCESS = 0, DEFAULT_ERROR = 999 };
+}
+
+#define SYCLCOMPAT_CHECK_ERROR(expr)
 
 int get_sycl_language_version();
 

--- a/sycl/include/syclcompat/defs.hpp
+++ b/sycl/include/syclcompat/defs.hpp
@@ -56,7 +56,7 @@ template <int Arg> class syclcompat_kernel_scalar;
 #endif
 
 namespace syclcompat {
-enum error_code { SUCCESS = 0, DEFAULT_ERROR = 999 };
+enum error_code { SUCCESS = 0, BACKEND_ERROR = 1, DEFAULT_ERROR = 999 };
 }
 
 #define SYCLCOMPAT_CHECK_ERROR(expr)                                           \
@@ -65,6 +65,9 @@ enum error_code { SUCCESS = 0, DEFAULT_ERROR = 999 };
       expr;                                                                    \
       return syclcompat::error_code::SUCCESS;                                  \
     } catch (sycl::exception const &e) {                                       \
+      std::cerr << e.what() << std::endl;                                      \
+      return syclcompat::error_code::BACKEND_ERROR;                            \
+    } catch (std::runtime_error const &e) {                                    \
       std::cerr << e.what() << std::endl;                                      \
       return syclcompat::error_code::DEFAULT_ERROR;                            \
     }                                                                          \

--- a/sycl/include/syclcompat/defs.hpp
+++ b/sycl/include/syclcompat/defs.hpp
@@ -32,12 +32,44 @@
 
 #pragma once
 
-template <class... Args> class sycl_compat_kernel_name;
-template <int Arg> class sycl_compat_kernel_scalar;
+#include <iostream>
 
-#define __sycl_compat_align__(n) alignas(n)
-#define __sycl_compat_inline__ __inline__ __attribute__((always_inline))
+template <class... Args> class syclcompat_kernel_name;
+template <int Arg> class syclcompat_kernel_scalar;
 
-#define __sycl_compat_noinline__ __attribute__((noinline))
+#if defined(_MSC_VER)
+#define __syclcompat_align__(n) __declspec(align(n))
+#define __syclcompat_inline__ __forceinline
+#else
+#define __syclcompat_align__(n) __attribute__((aligned(n)))
+#define __syclcompat_inline__ __inline__ __attribute__((always_inline))
+#endif
 
-#define SYCL_COMPAT_COMPATIBILITY_TEMP (600)
+#if defined(_MSC_VER)
+#define __syclcompat_noinline__ __declspec(noinline)
+#else
+#define __syclcompat_noinline__ __attribute__((noinline))
+#endif
+
+#define SYCLCOMPAT_COMPATIBILITY_TEMP (600)
+
+#ifdef _WIN32
+#define SYCLCOMPAT_EXPORT __declspec(dllexport)
+#else
+#define SYCLCOMPAT_EXPORT
+#endif
+
+namespace syclcompat {
+enum error_code { SUCCESS = 0, DEFAULT_ERROR = 999 };
+}
+
+#define SYCLCOMPAT_CHECK_ERROR(expr)                                           \
+  [&]() {                                                                      \
+    try {                                                                      \
+      expr;                                                                    \
+      return syclcompat::error_code::SUCCESS;                                  \
+    } catch (sycl::exception const &e) {                                       \
+      std::cerr << e.what() << std::endl;                                      \
+      return syclcompat::error_code::DEFAULT_ERROR;                            \
+    }                                                                          \
+  }()

--- a/sycl/include/syclcompat/defs.hpp
+++ b/sycl/include/syclcompat/defs.hpp
@@ -40,14 +40,10 @@ template <int Arg> class syclcompat_kernel_scalar;
 #if defined(_MSC_VER)
 #define __syclcompat_align__(n) __declspec(align(n))
 #define __syclcompat_inline__ __forceinline
+#define __syclcompat_noinline__ __declspec(noinline)
 #else
 #define __syclcompat_align__(n) __attribute__((aligned(n)))
 #define __syclcompat_inline__ __inline__ __attribute__((always_inline))
-#endif
-
-#if defined(_MSC_VER)
-#define __syclcompat_noinline__ __declspec(noinline)
-#else
 #define __syclcompat_noinline__ __attribute__((noinline))
 #endif
 

--- a/sycl/test-e2e/syclcompat/defs.cpp
+++ b/sycl/test-e2e/syclcompat/defs.cpp
@@ -45,14 +45,20 @@ void test_align() {
 void test_check_error() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  auto error_throw = []() {
+  auto sycl_error_throw = []() {
     throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
                           "Expected invalid exception in test_check_error");
   };
 
+  auto runtime_error_throw = []() {
+    throw std::runtime_error("Expected invalid exception in test_check_error");
+  };
+
   assert(syclcompat::error_code::SUCCESS == SYCLCOMPAT_CHECK_ERROR());
+  assert(syclcompat::error_code::BACKEND_ERROR ==
+         SYCLCOMPAT_CHECK_ERROR(sycl_error_throw()));
   assert(syclcompat::error_code::DEFAULT_ERROR ==
-         SYCLCOMPAT_CHECK_ERROR(error_throw()));
+         SYCLCOMPAT_CHECK_ERROR(runtime_error_throw()));
 }
 
 int main() {

--- a/sycl/test-e2e/syclcompat/defs.cpp
+++ b/sycl/test-e2e/syclcompat/defs.cpp
@@ -17,22 +17,47 @@
  *  Defs.cpp
  *
  *  Description:
- *     __sycl_compat_align__ tests
+ *     Syclcompat macros tests
  **************************************************************************/
 
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <cassert>
+#include <iostream>
+
+#include <sycl/sycl.hpp>
+
 #include <syclcompat/defs.hpp>
 
-int main() {
-  struct __sycl_compat_align__(16) {
+void test_align() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  constexpr std::size_t expected_size = 16;
+  struct __syclcompat_align__(expected_size) {
     int a;
     char c;
   }
   s;
-  assert(sizeof(s) == 16);
+  assert(sizeof(s) == expected_size);
+}
+
+void test_check_error() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  auto error_throw = []() {
+    throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
+                          "Expected invalid exception in test_check_error");
+  };
+
+  assert(syclcompat::error_code::SUCCESS == SYCLCOMPAT_CHECK_ERROR());
+  assert(syclcompat::error_code::DEFAULT_ERROR ==
+         SYCLCOMPAT_CHECK_ERROR(error_throw()));
+}
+
+int main() {
+  test_align();
+  test_check_error();
 
   return 0;
 }


### PR DESCRIPTION
This PR:
- unifies the names of the definitions in `defs.hpp` from `sycl_compat` to `syclcompat`
- extends definitions to work with MSVC
- Adds a macro to handle error codes from expressions that could throw `sycl::exception`.