### PR TITLE
[SYCL][Graph][HIP] Set minimum ROCm version for graphs

### DIFF
--- a/sycl/doc/design/CommandGraph.md
+++ b/sycl/doc/design/CommandGraph.md
@@ -405,8 +405,10 @@ The HIP backend offers a Graph managemenet API very similar to CUDA Graph
 feature for batching series of operations.
 The SYCL Graph HIP backend implementation is therefore very similar to that of CUDA.
 
+The minimum version of ROCm required to support `sycl_ext_oneapi_graph` is 5.5.1.
+
 UR commands (e.g. kernels) are mapped as graph nodes using the
-[HIP Management API](https://docs.amd.com/projects/HIP/en/docs-5.5.0/doxygen/html/group___graph.html).
+[HIP Management API](https://rocm.docs.amd.com/projects/HIP/en/docs-5.5.1/doxygen/html/group___graph.html).
 Synchronization between commands (UR sync-points) is implemented
 using graph dependencies.
 Executable HIP Graphs can be submitted to a HIP stream

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -82,13 +82,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit ed1f8bf618c88eaabea6bde0f6c06fc265f3b49f
-  # Merge: ca5c3421 69c43b45
-  # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Tue Mar 19 21:00:20 2024 +0000
-  #     Merge pull request #1326 from hdelan/refactor-guess-local-worksize
-  #     [CUDA][HIP] Fix bug in guess local worksize funcs and improve local worksize guessing in HIP adapter
-  set(UNIFIED_RUNTIME_TAG ed1f8bf618c88eaabea6bde0f6c06fc265f3b49f)
+  # commit  5f4dd113824e90522d813420932c14072dc3049d
+  # Merge:  ed1f8bf b551c77
+  # Author: Ewan Crawford <ewan@codeplay.com>
+  # Date:   Fri Mar 15 10:22:39 2024 +0000
+  #     Merge pull request #1447 from Bensuo/ewan/rocm_5_5_1
+  #     [HIP][CMDBUF] Require ROCm 5.5.1 for HIP command-buffers
+  set(UNIFIED_RUNTIME_TAG 5f4dd113824e90522d813420932c14072dc3049d)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
Tests UR PR https://github.com/oneapi-src/unified-runtime/pull/1447 that only reports support for UR command-buffers on ROCm 5.5.1 and later to work around HIP driver bugs related to HIP-Graph in earlier version.

This requirement is also explicitly mentioned in the design doc.