### PR TITLE
[SYCL] Add missing aliases to swizzles

### DIFF
--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1793,7 +1793,7 @@ public:
   using value_type = DataT;
 
 #ifdef __SYCL_DEVICE_ONLY__
-  using vector_t = typename VecT::vector_t;
+  using vector_t = typename vec_t::vector_t;
 #endif // __SYCL_DEVICE_ONLY__
 
   const DataT &operator[](int i) const {

--- a/sycl/include/sycl/types.hpp
+++ b/sycl/include/sycl/types.hpp
@@ -1790,6 +1790,11 @@ class SwizzleOp {
 
 public:
   using element_type = DataT;
+  using value_type = DataT;
+
+#ifdef __SYCL_DEVICE_ONLY__
+  using vector_t = typename VecT::vector_t;
+#endif // __SYCL_DEVICE_ONLY__
 
   const DataT &operator[](int i) const {
     std::array<int, getNumElements()> Idxs{Indexes...};

--- a/sycl/test/basic_tests/vectors/swizzle_aliases.cpp
+++ b/sycl/test/basic_tests/vectors/swizzle_aliases.cpp
@@ -10,7 +10,7 @@ int main() {
     static_assert(std::is_same_v<decltype(X.swizzle<0>())::value_type, int>);
 #ifdef __SYCL_DEVICE_ONLY__
     static_assert(std::is_same_v<decltype(X.swizzle<0>())::vector_t,
-                                 decltype(X)::vector_t>);
+                                 sycl::vec<int, 1>::vector_t>);
 #endif // __SYCL_DEVICE_ONLY__
   });
   return 0;

--- a/sycl/test/basic_tests/vectors/swizzle_aliases.cpp
+++ b/sycl/test/basic_tests/vectors/swizzle_aliases.cpp
@@ -1,0 +1,17 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+
+#include <sycl/sycl.hpp>
+
+int main() {
+  sycl::queue Q;
+  Q.single_task([]() {
+    sycl::vec<int, 4> X{1};
+    static_assert(std::is_same_v<decltype(X.swizzle<0>())::element_type, int>);
+    static_assert(std::is_same_v<decltype(X.swizzle<0>())::value_type, int>);
+#ifdef __SYCL_DEVICE_ONLY__
+    static_assert(std::is_same_v<decltype(X.swizzle<0>())::vector_t,
+                                 decltype(X)::vector_t>);
+#endif // __SYCL_DEVICE_ONLY__
+  });
+  return 0;
+}


### PR DESCRIPTION
Vector swizzles are currently missing the value_type and vector_t aliases, as should be inherited from vec. This commit adds these aliases.