### PR TITLE
[SYCL][COMPAT] Extended device_info properties.

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -852,7 +852,7 @@ class device_ext : public sycl::device {
   int get_max_work_group_size() const;
   int get_mem_base_addr_align() const;
   size_t get_global_mem_size() const;
-  void get_memory_info(size_t &free_memory, size_t &total_memory);
+  void get_memory_info(size_t &free_memory, size_t &total_memory) const;
 
   void get_device_info(device_info &out) const;
   device_info get_device_info() const;
@@ -869,7 +869,7 @@ class device_ext : public sycl::device {
   sycl::context get_context();
 
   void
-  has_capability_or_fail(const std::initializer_list<sycl::aspect> &props);
+  has_capability_or_fail(const std::initializer_list<sycl::aspect> &props) const;
 };
 
 } // syclcompat

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -629,7 +629,7 @@ public:
     return *_devs[dev_id];
   }
   device_ext &cpu_device() const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     if (_cpu_device == -1) {
       throw std::runtime_error("[SYCLcompat] No valid cpu device");
     } else {
@@ -637,12 +637,12 @@ public:
     }
   }
   device_ext &get_device(unsigned int id) const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     check_id(id);
     return *_devs[id];
   }
   unsigned int current_device_id() const {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     auto it = _thread2dev_map.find(get_tid());
     if (it != _thread2dev_map.end())
       return it->second;
@@ -653,7 +653,7 @@ public:
   /// \param [in] id The id of the device which can
   /// be obtained through get_device_id(const sycl::device).
   void select_device(unsigned int id) {
-    std::lock_guard<std::recursive_mutex> lock(m_mutex);
+    std::lock_guard<std::mutex> lock(m_mutex);
     check_id(id);
     _thread2dev_map[get_tid()] = id;
   }
@@ -693,7 +693,7 @@ public:
   dev_mgr &operator=(dev_mgr &&) = delete;
 
 private:
-  mutable std::recursive_mutex m_mutex;
+  mutable std::mutex m_mutex;
 
   dev_mgr() {
     sycl::device default_device = sycl::device(sycl::default_selector_v);

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -81,6 +81,8 @@ using event_ptr = sycl::event *;
 
 using queue_ptr = sycl::queue *;
 
+using device_ptr = char *;
+
 /// Destroy \p event pointed memory.
 ///
 /// \param event Pointer to the sycl::event address.
@@ -91,26 +93,27 @@ public:
   // get interface
   const char *get_name() const { return _name; }
   char *get_name() { return _name; }
-  template <typename WorkItemSizesTy = sycl::id<3>,
-            std::enable_if_t<std::is_same_v<WorkItemSizesTy, sycl::id<3>> ||
+  template <typename WorkItemSizesTy = sycl::range<3>,
+            std::enable_if_t<std::is_same_v<WorkItemSizesTy, sycl::range<3>> ||
                                  std::is_same_v<WorkItemSizesTy, int *>,
                              int> = 0>
   auto get_max_work_item_sizes() const {
-    if constexpr (std::is_same_v<WorkItemSizesTy, sycl::id<3>>)
+    if constexpr (std::is_same_v<WorkItemSizesTy, sycl::range<3>>)
       return _max_work_item_sizes;
     else
       return _max_work_item_sizes_i;
   }
-  template <typename WorkItemSizesTy = sycl::id<3>,
-            std::enable_if_t<std::is_same_v<WorkItemSizesTy, sycl::id<3>> ||
+  template <typename WorkItemSizesTy = sycl::range<3>,
+            std::enable_if_t<std::is_same_v<WorkItemSizesTy, sycl::range<3>> ||
                                  std::is_same_v<WorkItemSizesTy, int *>,
                              int> = 0>
   auto get_max_work_item_sizes() {
-    if constexpr (std::is_same_v<WorkItemSizesTy, sycl::id<3>>)
+    if constexpr (std::is_same_v<WorkItemSizesTy, sycl::range<3>>)
       return _max_work_item_sizes;
     else
       return _max_work_item_sizes_i;
   }
+  bool get_host_unified_memory() const { return _host_unified_memory; }
   int get_major_version() const { return _major; }
   int get_minor_version() const { return _minor; }
   int get_integrated() const { return _integrated; }
@@ -120,6 +123,9 @@ public:
   int get_max_sub_group_size() const { return _max_sub_group_size; }
   int get_max_work_items_per_compute_unit() const {
     return _max_work_items_per_compute_unit;
+  }
+  int get_max_register_size_per_work_group() const {
+    return _max_register_size_per_work_group;
   }
   template <typename NDRangeSizeTy = size_t *,
             std::enable_if_t<std::is_same_v<NDRangeSizeTy, size_t *> ||
@@ -143,14 +149,43 @@ public:
   }
   size_t get_global_mem_size() const { return _global_mem_size; }
   size_t get_local_mem_size() const { return _local_mem_size; }
+  /// Returns the maximum clock rate of device's global memory in kHz. If
+  /// compiler does not support this API then returns default value 3200000 kHz.
+  unsigned int get_memory_clock_rate() const { return _memory_clock_rate; }
+  /// Returns the maximum bus width between device and memory in bits. If
+  /// compiler does not support this API then returns default value 64 bits.
+  unsigned int get_memory_bus_width() const { return _memory_bus_width; }
+  uint32_t get_device_id() const { return _device_id; }
+  std::array<unsigned char, 16> get_uuid() const { return _uuid; }
+  /// Returns global memory cache size in bytes.
+  unsigned int get_global_mem_cache_size() const {
+    return _global_mem_cache_size;
+  }
+
   // set interface
   void set_name(const char *name) {
-    std::strncpy(_name, name, device_info::NAME_BUFFER_SIZE);
+    size_t length = strlen(name);
+    if (length < device_info::NAME_BUFFER_SIZE) {
+      std::memcpy(_name, name, length + 1);
+    } else {
+      std::memcpy(_name, name, device_info::NAME_BUFFER_SIZE - 1);
+      _name[255] = '\0';
+    }
   }
-  void set_max_work_item_sizes(const sycl::id<3> max_work_item_sizes) {
+  void set_max_work_item_sizes(const sycl::range<3> max_work_item_sizes) {
     _max_work_item_sizes = max_work_item_sizes;
     for (int i = 0; i < 3; ++i)
       _max_work_item_sizes_i[i] = max_work_item_sizes[i];
+  }
+  [[deprecated]] void
+  set_max_work_item_sizes(const sycl::id<3> max_work_item_sizes) {
+    for (int i = 0; i < 3; ++i) {
+      _max_work_item_sizes[i] = max_work_item_sizes[i];
+      _max_work_item_sizes_i[i] = max_work_item_sizes[i];
+    }
+  }
+  void set_host_unified_memory(bool host_unified_memory) {
+    _host_unified_memory = host_unified_memory;
   }
   void set_major_version(int major) { _major = major; }
   void set_minor_version(int minor) { _minor = minor; }
@@ -181,25 +216,49 @@ public:
       _max_nd_range_size_i[i] = max_nd_range_size[i];
     }
   }
+  void set_memory_clock_rate(unsigned int memory_clock_rate) {
+    _memory_clock_rate = memory_clock_rate;
+  }
+  void set_memory_bus_width(unsigned int memory_bus_width) {
+    _memory_bus_width = memory_bus_width;
+  }
+  void
+  set_max_register_size_per_work_group(int max_register_size_per_work_group) {
+    _max_register_size_per_work_group = max_register_size_per_work_group;
+  }
+  void set_device_id(uint32_t device_id) { _device_id = device_id; }
+  void set_uuid(std::array<unsigned char, 16> uuid) { _uuid = std::move(uuid); }
+  void set_global_mem_cache_size(unsigned int global_mem_cache_size) {
+    _global_mem_cache_size = global_mem_cache_size;
+  }
 
 private:
   constexpr static size_t NAME_BUFFER_SIZE = 256;
 
   char _name[device_info::NAME_BUFFER_SIZE];
-  sycl::id<3> _max_work_item_sizes;
+  sycl::range<3> _max_work_item_sizes;
   int _max_work_item_sizes_i[3];
+  bool _host_unified_memory = false;
   int _major;
   int _minor;
   int _integrated = 0;
   int _frequency;
+  // Set estimated value 3200000 kHz as default value.
+  unsigned int _memory_clock_rate = 3200000;
+  // Set estimated value 64 bits as default value.
+  unsigned int _memory_bus_width = 64;
+  unsigned int _global_mem_cache_size;
   int _max_compute_units;
   int _max_work_group_size;
   int _max_sub_group_size;
   int _max_work_items_per_compute_unit;
+  int _max_register_size_per_work_group;
   size_t _global_mem_size;
   size_t _local_mem_size;
   size_t _max_nd_range_size[3];
   int _max_nd_range_size_i[3];
+  uint32_t _device_id;
+  std::array<unsigned char, 16> _uuid;
 };
 
 /// device extension
@@ -211,15 +270,16 @@ public:
     sycl::event::wait(_events);
     _queues.clear();
   }
-  device_ext(const sycl::device &base) : sycl::device(base), _ctx(*this) {
+  device_ext(const sycl::device &base, bool print_on_async_exceptions = false,
+             bool in_order = true)
+      : sycl::device(base), _ctx(*this) {
     if (!this->has(sycl::aspect::usm_device_allocations)) {
       throw std::invalid_argument(
           "Device does not support device USM allocations");
     }
-    _queues.push_back(
-        std::make_shared<sycl::queue>(_ctx, base, detail::exception_handler,
-                                      sycl::property::queue::in_order()));
-    _saved_queue = _default_queue = _queues[0].get();
+    // calls create_queue since we don't have a locked m_mutex
+    _saved_queue = _default_queue =
+        create_queue(print_on_async_exceptions, in_order);
   }
 
   bool is_native_host_atomic_supported() { return false; }
@@ -235,11 +295,59 @@ public:
     return get_device_info().get_max_compute_units();
   }
 
+  /// Return the maximum clock frequency of this device in KHz.
   int get_max_clock_frequency() const {
     return get_device_info().get_max_clock_frequency();
   }
 
   int get_integrated() const { return get_device_info().get_integrated(); }
+
+  int get_max_sub_group_size() const {
+    return get_device_info().get_max_sub_group_size();
+  }
+
+  int get_max_register_size_per_work_group() const {
+    return get_device_info().get_max_register_size_per_work_group();
+  }
+
+  int get_max_work_group_size() const {
+    return get_device_info().get_max_work_group_size();
+  }
+
+  int get_mem_base_addr_align() const {
+    return get_info<sycl::info::device::mem_base_addr_align>();
+  }
+
+  size_t get_global_mem_size() const {
+    return get_device_info().get_global_mem_size();
+  }
+
+  /// Get the number of bytes of free and total memory on the SYCL device.
+  /// \param [out] free_memory The number of bytes of free memory on the SYCL
+  /// device.
+  /// \param [out] total_memory The number of bytes of total memory on the SYCL
+  /// device.
+  void get_memory_info(size_t &free_memory, size_t &total_memory) {
+#if (defined(__SYCL_COMPILER_VERSION) && __SYCL_COMPILER_VERSION >= 20221105)
+    if (!has(sycl::aspect::ext_intel_free_memory)) {
+      std::cerr << "get_memory_info: ext_intel_free_memory is not supported."
+                << std::endl;
+      free_memory = 0;
+    } else {
+      free_memory = get_info<sycl::ext::intel::info::device::free_memory>();
+    }
+#else
+    std::cerr << "get_memory_info: ext_intel_free_memory is not supported."
+              << std::endl;
+    free_memory = 0;
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma message("Querying the number of bytes of free memory is not supported")
+#else
+#warning "Querying the number of bytes of free memory is not supported"
+#endif
+#endif
+    total_memory = get_device_info().get_global_mem_size();
+  }
 
   void get_device_info(device_info &out) const {
     device_info prop;
@@ -270,6 +378,35 @@ public:
     prop.set_global_mem_size(get_info<sycl::info::device::global_mem_size>());
     prop.set_local_mem_size(get_info<sycl::info::device::local_mem_size>());
 
+#if (defined(SYCL_EXT_INTEL_DEVICE_INFO) && SYCL_EXT_INTEL_DEVICE_INFO >= 6)
+    if (has(sycl::aspect::ext_intel_memory_clock_rate)) {
+      unsigned int tmp =
+          get_info<sycl::ext::intel::info::device::memory_clock_rate>();
+      if (tmp != 0)
+        prop.set_memory_clock_rate(1000 * tmp);
+    }
+    if (has(sycl::aspect::ext_intel_memory_bus_width)) {
+      prop.set_memory_bus_width(
+          get_info<sycl::ext::intel::info::device::memory_bus_width>());
+    }
+    if (has(sycl::aspect::ext_intel_device_id)) {
+      prop.set_device_id(get_info<sycl::ext::intel::info::device::device_id>());
+    }
+    if (has(sycl::aspect::ext_intel_device_info_uuid)) {
+      prop.set_uuid(get_info<sycl::ext::intel::info::device::uuid>());
+    }
+#elif defined(_MSC_VER) && !defined(__clang__)
+#pragma message("get_device_info: querying memory_clock_rate and \
+memory_bus_width are not supported by the compiler used. \
+Use 3200000 kHz as memory_clock_rate default value. \
+Use 64 bits as memory_bus_width default value.")
+#else
+#warning "get_device_info: querying memory_clock_rate and \
+memory_bus_width are not supported by the compiler used. \
+Use 3200000 kHz as memory_clock_rate default value. \
+Use 64 bits as memory_bus_width default value."
+#endif
+
     size_t max_sub_group_size = 1;
     std::vector<size_t> sub_group_sizes =
         get_info<sycl::info::device::sub_group_sizes>();
@@ -286,6 +423,12 @@ public:
     int max_nd_range_size[] = {0x7FFFFFFF, 0x7FFFFFFF, 0x7FFFFFFF};
     prop.set_max_nd_range_size(max_nd_range_size);
 
+    // Estimates max register size per work group, feel free to update the value
+    // according to device properties.
+    prop.set_max_register_size_per_work_group(65536);
+
+    prop.set_global_mem_cache_size(
+        get_info<sycl::info::device::global_mem_cache_size>());
     out = prop;
   }
 
@@ -295,7 +438,7 @@ public:
     return prop;
   }
 
-  void reset() {
+  void reset(bool print_on_async_exceptions = false, bool in_order = true) {
     std::lock_guard<std::mutex> lock(m_mutex);
     // The queues are shared_ptrs and the ref counts of the shared_ptrs increase
     // only in wait_and_throw(). If there is no other thread calling
@@ -303,11 +446,10 @@ public:
     // all commands executing on the queue to complete. It isn't possible to
     // destroy a queue immediately. This is a synchronization point in SYCL.
     _queues.clear();
-    // create new default queue.
-    _queues.push_back(
-        std::make_shared<sycl::queue>(_ctx, *this, detail::exception_handler,
-                                      sycl::property::queue::in_order()));
-    _saved_queue = _default_queue = _queues.front().get();
+    // create new default queue
+    // calls create_queue_impl since we already have a locked m_mutex
+    _saved_queue = _default_queue =
+        create_queue_impl(print_on_async_exceptions, in_order);
   }
 
   void set_default_queue(const sycl::queue &q) {
@@ -331,22 +473,12 @@ public:
     // Guard the destruct of current_queues to make sure the ref count is safe.
     lock.lock();
   }
-  queue_ptr create_queue(bool print_on_async_exceptions = false,
-                         bool in_order = true) {
+  sycl::queue *create_queue(bool print_on_async_exceptions = false,
+                            bool in_order = true) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    sycl::property_list prop = {};
-    if (in_order) {
-      prop = {sycl::property::queue::in_order()};
-    }
-    if (print_on_async_exceptions) {
-      _queues.push_back(std::make_shared<sycl::queue>(
-          _ctx, *this, detail::exception_handler, prop));
-    } else {
-      _queues.push_back(std::make_shared<sycl::queue>(_ctx, *this, prop));
-    }
-    return _queues.back().get();
+    return create_queue_impl(print_on_async_exceptions, in_order);
   }
-  void destroy_queue(queue_ptr &queue) {
+  void destroy_queue(sycl::queue *&queue) {
     std::lock_guard<std::mutex> lock(m_mutex);
     _queues.erase(
         std::remove_if(_queues.begin(), _queues.end(),
@@ -356,17 +488,84 @@ public:
         _queues.end());
     queue = nullptr;
   }
-  void set_saved_queue(queue_ptr q) {
+  void set_saved_queue(sycl::queue *q) {
     std::lock_guard<std::mutex> lock(m_mutex);
     _saved_queue = q;
   }
-  queue_ptr get_saved_queue() const {
+  sycl::queue *get_saved_queue() const {
     std::lock_guard<std::mutex> lock(m_mutex);
     return _saved_queue;
   }
   sycl::context get_context() const { return _ctx; }
 
+  /// Util function to check whether a device supports some kinds of
+  /// sycl::aspect.
+  void
+  has_capability_or_fail(const std::initializer_list<sycl::aspect> &props) {
+    for (const auto &it : props) {
+      if (has(it))
+        continue;
+      switch (it) {
+      case sycl::aspect::fp64:
+        throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
+                              "[SYCLcompat] 'double' is not supported in '" +
+                                  get_info<sycl::info::device::name>() +
+                                  "' device");
+        break;
+      case sycl::aspect::fp16:
+        throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
+                              "[SYCLcompat] 'half' is not supported in '" +
+                                  get_info<sycl::info::device::name>() +
+                                  "' device");
+        break;
+      default:
+#define __SYCL_ASPECT(ASPECT, ID)                                              \
+  case sycl::aspect::ASPECT:                                                   \
+    return #ASPECT;
+#define __SYCL_ASPECT_DEPRECATED(ASPECT, ID, MESSAGE) __SYCL_ASPECT(ASPECT, ID)
+#define __SYCL_ASPECT_DEPRECATED_ALIAS(ASPECT, ID, MESSAGE)
+        auto getAspectNameStr = [](sycl::aspect AspectNum) -> std::string {
+          switch (AspectNum) {
+#include <sycl/info/aspects.def>
+#include <sycl/info/aspects_deprecated.def>
+          default:
+            return "unknown aspect";
+          }
+        };
+#undef __SYCL_ASPECT_DEPRECATED_ALIAS
+#undef __SYCL_ASPECT_DEPRECATED
+#undef __SYCL_ASPECT
+        throw sycl::exception(sycl::make_error_code(sycl::errc::runtime),
+                              "[SYCLcompat] '" + getAspectNameStr(it) +
+                                  "' is not supported in '" +
+                                  get_info<sycl::info::device::name>() +
+                                  "' device");
+      }
+      break;
+    }
+  }
+
 private:
+  /// Caller should only be done from functions where the resource \p m_mutex
+  /// has been acquired.
+  queue_ptr create_queue_impl(bool print_on_async_exceptions = false,
+                              bool in_order = true) {
+    sycl::property_list prop = {};
+    if (in_order) {
+      prop = {sycl::property::queue::in_order()};
+    }
+#ifdef SYCLCOMPAT_PROFILING_ENABLED
+    prop.push_back(sycl::property::queue::enable_profiling());
+#endif
+    if (print_on_async_exceptions) {
+      _queues.push_back(std::make_shared<sycl::queue>(
+          _ctx, *this, detail::exception_handler, prop));
+    } else {
+      _queues.push_back(std::make_shared<sycl::queue>(_ctx, *this, prop));
+    }
+    return _queues.back().get();
+  }
+
   void get_version(int &major, int &minor) const {
     // Version string has the following format:
     // a. OpenCL<space><major.minor><space><vendor-specific-information>
@@ -430,7 +629,7 @@ public:
     return *_devs[dev_id];
   }
   device_ext &cpu_device() const {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     if (_cpu_device == -1) {
       throw std::runtime_error("[SYCLcompat] No valid cpu device");
     } else {
@@ -438,19 +637,23 @@ public:
     }
   }
   device_ext &get_device(unsigned int id) const {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     check_id(id);
     return *_devs[id];
   }
   unsigned int current_device_id() const {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     auto it = _thread2dev_map.find(get_tid());
     if (it != _thread2dev_map.end())
       return it->second;
     return _default_device_id;
   }
+
+  /// Select device with a device ID.
+  /// \param [in] id The id of the device which can
+  /// be obtained through get_device_id(const sycl::device).
   void select_device(unsigned int id) {
-    std::lock_guard<std::mutex> lock(m_mutex);
+    std::lock_guard<std::recursive_mutex> lock(m_mutex);
     check_id(id);
     _thread2dev_map[get_tid()] = id;
   }
@@ -467,6 +670,18 @@ public:
     return id;
   }
 
+  /// Select device with a Device Selector
+  /// \param selector device selector to get the device id from. Defaults to
+  /// sycl::gpu_selector_v
+  template <class DeviceSelector>
+  std::enable_if_t<
+      std::is_invocable_r_v<int, DeviceSelector, const sycl::device &>>
+  select_device(const DeviceSelector &selector = sycl::gpu_selector_v) {
+    sycl::device selected_device = sycl::device(selector);
+    unsigned int selected_device_id = get_device_id(selected_device);
+    select_device(selected_device_id);
+  }
+
   /// Returns the instance of device manager singleton.
   static dev_mgr &instance() {
     static dev_mgr d_m;
@@ -478,7 +693,8 @@ public:
   dev_mgr &operator=(dev_mgr &&) = delete;
 
 private:
-  mutable std::mutex m_mutex;
+  mutable std::recursive_mutex m_mutex;
+
   dev_mgr() {
     sycl::device default_device = sycl::device(sycl::default_selector_v);
     _devs.push_back(std::make_shared<device_ext>(default_device));
@@ -574,6 +790,17 @@ static inline device_ext &cpu_device() {
 static inline unsigned int select_device(unsigned int id) {
   detail::dev_mgr::instance().select_device(id);
   return id;
+}
+
+template <class DeviceSelector>
+static inline std::enable_if_t<
+    std::is_invocable_r_v<int, DeviceSelector, const sycl::device &>>
+select_device(const DeviceSelector &selector = sycl::gpu_selector_v) {
+  detail::dev_mgr::instance().select_device(selector);
+}
+
+static inline unsigned int get_device_id(const sycl::device &dev) {
+  return detail::dev_mgr::instance().get_device_id(dev);
 }
 
 } // namespace syclcompat

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -476,7 +476,7 @@ Use 64 bits as memory_bus_width default value."
     lock.lock();
   }
   queue_ptr create_queue(bool print_on_async_exceptions = false,
-                            bool in_order = true) {
+                         bool in_order = true) {
     std::lock_guard<std::mutex> lock(m_mutex);
     return create_queue_impl(print_on_async_exceptions, in_order);
   }

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -36,6 +36,44 @@
 
 #include "device_fixt.hpp"
 
+
+  /*
+    Device Tests
+  */
+void test_at_least_one_device() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  assert(dtf.get_n_devices() > 0);
+}
+
+  // Check the device returned matches the device ID
+void test_matches_id() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  assert(syclcompat::get_device(syclcompat::get_current_device_id()) ==
+         syclcompat::get_current_device());
+}
+
+  // Check error on insufficient devices
+void test_not_enough_devices() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  try {
+    syclcompat::select_device(dtf.get_n_devices());
+  } catch (std::runtime_error const &e) {
+    std::cout << "Expected SYCL exception caught: " << e.what();
+  }
+}
+
+  // Check the default context matches default queue's context
+void test_default_context() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  assert(dtf.get_queue().get_context() == syclcompat::get_default_context());
+}
+
+  /*
+    Queue Tests
+  */
 void test_set_default_queue() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
@@ -47,156 +85,164 @@ void test_set_default_queue() {
   assert(*dev_.default_queue() != old_default_queue);
 }
 
-int main() {
-  /*
-    Device Tests
-  */
-  std::cout << "Testing AtLeastOneDevice" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    assert(dtf.get_n_devices() > 0);
-  }
+void test_make_in_order_queue() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  sycl::queue q = syclcompat::get_default_queue();
+  assert(q.is_in_order());
+}
 
-  // Check the device returned matches the device ID
-  std::cout << "Testing MatchesID" << std::endl;
-  {
-    assert(syclcompat::get_device(syclcompat::get_current_device_id()) ==
-           syclcompat::get_current_device());
-  }
-
-  // Check error on insufficient devices
-  std::cout << "Testing NotEnoughDevices" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    try {
-      syclcompat::select_device(dtf.get_n_devices());
-    } catch (std::runtime_error const &e) {
-      std::cout << "Expected SYCL exception caught: " << e.what();
-    }
-  }
-
-  // Check the default context matches default queue's context
-  std::cout << "Testing DefaultContext" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    assert(dtf.get_queue().get_context() == syclcompat::get_default_context());
-  }
-
-  /*
-    Queue Tests
-  */
-  std::cout << "Testing MakeInOrderQueue" << std::endl;
-  {
-    sycl::queue q = syclcompat::get_default_queue();
-    assert(q.is_in_order());
-  }
-
-  std::cout << "Testing CheckDefaultDevice" << std::endl;
-  {
-    sycl::queue q = syclcompat::get_default_queue();
-    assert(q.get_device() == sycl::device{sycl::default_selector_v});
-  }
+void test_check_default_device() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  sycl::queue q = syclcompat::get_default_queue();
+  assert(q.get_device() == sycl::device{sycl::default_selector_v});
+}
 
   // Check behaviour of in order & out of order queue construction
-  std::cout << "Testing QueuePropOrder" << std::endl;
-  {
-    sycl::queue q_create_def{syclcompat::create_queue()};
-    assert(q_create_def.is_in_order());
-    sycl::queue q_in_order{syclcompat::create_queue(false, true)};
-    assert(q_in_order.is_in_order());
-    sycl::queue q_out_order{syclcompat::create_queue(false, false)};
-    assert(!q_out_order.is_in_order());
-  }
+void test_create_queue_arguments() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  sycl::queue q_create_def{syclcompat::create_queue()};
+  assert(q_create_def.is_in_order());
+  sycl::queue q_in_order{syclcompat::create_queue(false, true)};
+  assert(q_in_order.is_in_order());
+  sycl::queue q_out_order{syclcompat::create_queue(false, false)};
+  assert(!q_out_order.is_in_order());
+}
 
   /*
     Device Extension Tests
   */
-  std::cout << "Testing DeviceExtAPI" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    dev_.is_native_host_atomic_supported();
-    dev_.get_major_version();
-    dev_.get_minor_version();
-    dev_.get_max_compute_units();
-    dev_.get_max_clock_frequency();
-    dev_.get_integrated();
-    syclcompat::device_info Info;
-    dev_.get_device_info(Info);
-    Info = dev_.get_device_info();
-    dev_.reset();
-    auto QueuePtr = dev_.default_queue();
-    dev_.queues_wait_and_throw();
-    QueuePtr = dev_.create_queue();
-    dev_.destroy_queue(QueuePtr);
-    QueuePtr = dev_.create_queue();
-    dev_.set_saved_queue(QueuePtr);
-    QueuePtr = dev_.get_saved_queue();
-    auto Context = dev_.get_context();
-  }
+void test_device_ext_api() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  dev_.is_native_host_atomic_supported();
+  dev_.get_major_version();
+  dev_.get_minor_version();
+  dev_.get_max_compute_units();
+  dev_.get_max_clock_frequency();
+  dev_.get_integrated();
+  syclcompat::device_info Info;
+  dev_.get_device_info(Info);
+  Info = dev_.get_device_info();
+  dev_.reset();
+  auto QueuePtr = dev_.default_queue();
+  dev_.queues_wait_and_throw();
+  QueuePtr = dev_.create_queue();
+  dev_.destroy_queue(QueuePtr);
+  QueuePtr = dev_.create_queue();
+  dev_.set_saved_queue(QueuePtr);
+  QueuePtr = dev_.get_saved_queue();
+  auto Context = dev_.get_context();
+}
 
-  std::cout << "Testing DefaultSavedQueue" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    assert(*dev_.default_queue() == *dev_.get_saved_queue());
-  }
+void test_default_saved_queue() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  assert(*dev_.default_queue() == *dev_.get_saved_queue());
+}
 
-  std::cout << "Testing SavedQueue" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    auto q = *dev_.create_queue();
-    dev_.set_saved_queue(&q);
-    assert(q == *dev_.get_saved_queue());
-  }
+void test_saved_queue() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  auto q = *dev_.create_queue();
+  dev_.set_saved_queue(&q);
+  assert(q == *dev_.get_saved_queue());
+}
 
   // Check reset() resets the queues etc
-  std::cout << "Testing Reset" << std::endl;
-  {
-    DeviceExtFixt dev_ext;
-    auto &dev_ = dev_ext.get_dev_ext();
-    auto q = *dev_.create_queue();
-    dev_.set_saved_queue(&q);
-    dev_.reset();
-    assert(q != *dev_.get_saved_queue());
-  }
+void test_reset() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+  auto q = *dev_.create_queue();
+  dev_.set_saved_queue(&q);
+  dev_.reset();
+  assert(q != *dev_.get_saved_queue());
+}
 
-  std::cout << "Testing DeviceInfoAPI" << std::endl;
-  {
-    syclcompat::device_info Info;
-    const char *Name = "DEVNAME";
-    Info.set_name(Name);
-    sycl::id<3> max_work_item_sizes;
-    Info.set_max_work_item_sizes(max_work_item_sizes);
-    Info.set_major_version(1);
-    Info.set_minor_version(1);
-    Info.set_integrated(1);
-    Info.set_max_clock_frequency(1000);
-    Info.set_max_compute_units(32);
-    Info.set_global_mem_size(1000);
-    Info.set_local_mem_size(1000);
-    Info.set_max_work_group_size(32);
-    Info.set_max_sub_group_size(16);
-    Info.set_max_work_items_per_compute_unit(16);
-    int SizeArray[3] = {1, 2, 3};
-    Info.set_max_nd_range_size(SizeArray);
+void test_reset_arguments() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-    assert(!strcmp(Info.get_name(), Name));
-    assert(Info.get_max_work_item_sizes() == max_work_item_sizes);
-    assert(Info.get_minor_version() == 1);
-    assert(Info.get_integrated() == 1);
-    assert(Info.get_max_clock_frequency() == 1000);
-    assert(Info.get_max_compute_units() == 32);
-    assert(Info.get_max_work_group_size() == 32);
-    assert(Info.get_max_sub_group_size() == 16);
-    assert(Info.get_max_work_items_per_compute_unit() == 16);
-    assert(Info.get_max_nd_range_size()[0] == SizeArray[0]);
-    assert(Info.get_max_nd_range_size()[1] == SizeArray[1]);
-    assert(Info.get_max_nd_range_size()[2] == SizeArray[2]);
-    assert(Info.get_global_mem_size() == 1000);
-    assert(Info.get_local_mem_size() == 1000);
-  }
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+
+  dev_.reset(false, false);
+  assert(!dev_.get_saved_queue()->is_in_order());
+
+  dev_.reset(false, true);
+  assert(dev_.get_saved_queue()->is_in_order());
+}
+
+void test_device_info_api() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  syclcompat::device_info Info;
+  const char *Name = "DEVNAME";
+  std::array<unsigned char, 16> uuid;
+  uuid.fill('0');
+  sycl::range<3> max_work_item_sizes;
+
+  Info.set_name(Name);
+  Info.set_max_work_item_sizes(max_work_item_sizes);
+  Info.set_major_version(1);
+  Info.set_minor_version(1);
+  Info.set_integrated(1);
+  Info.set_max_clock_frequency(1000);
+  Info.set_max_compute_units(32);
+  Info.set_global_mem_size(1000);
+  Info.set_local_mem_size(1000);
+  Info.set_max_work_group_size(32);
+  Info.set_max_sub_group_size(16);
+  Info.set_max_work_items_per_compute_unit(16);
+  int SizeArray[3] = {1, 2, 3};
+  Info.set_max_nd_range_size(SizeArray);
+
+  Info.set_host_unified_memory(true);
+  Info.set_memory_clock_rate(1000);
+  Info.set_max_register_size_per_work_group(1000);
+  Info.set_device_id(0);
+  Info.set_uuid(uuid);
+  Info.set_global_mem_cache_size(1000);
+
+  assert(!strcmp(Info.get_name(), Name));
+  assert(Info.get_max_work_item_sizes() == max_work_item_sizes);
+  assert(Info.get_minor_version() == 1);
+  assert(Info.get_integrated() == 1);
+  assert(Info.get_max_clock_frequency() == 1000);
+  assert(Info.get_max_compute_units() == 32);
+  assert(Info.get_max_work_group_size() == 32);
+  assert(Info.get_max_sub_group_size() == 16);
+  assert(Info.get_max_work_items_per_compute_unit() == 16);
+  assert(Info.get_max_nd_range_size()[0] == SizeArray[0]);
+  assert(Info.get_max_nd_range_size()[1] == SizeArray[1]);
+  assert(Info.get_max_nd_range_size()[2] == SizeArray[2]);
+  assert(Info.get_global_mem_size() == 1000);
+  assert(Info.get_local_mem_size() == 1000);
+
+  uuid.fill('0'); // set_uuid uses std::move
+  assert(Info.get_host_unified_memory());
+  assert(Info.get_memory_clock_rate() == 1000);
+  assert(Info.get_max_register_size_per_work_group() == 1000);
+  assert(Info.get_device_id() == 0);
+  assert(Info.get_uuid() == uuid);
+  assert(Info.get_global_mem_cache_size() == 1000);
+}
+
+int main() {
+  test_at_least_one_device();
+  test_matches_id();
+  test_not_enough_devices();
+  test_set_default_queue();
+  test_default_context();
+  test_make_in_order_queue();
+  test_check_default_device();
+  test_create_queue_arguments();
+  test_device_ext_api();
+  test_default_saved_queue();
+  test_saved_queue();
+  test_reset();
+  test_device_info_api();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -36,44 +36,6 @@
 
 #include "device_fixt.hpp"
 
-
-  /*
-    Device Tests
-  */
-void test_at_least_one_device() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  DeviceTestsFixt dtf;
-  assert(dtf.get_n_devices() > 0);
-}
-
-  // Check the device returned matches the device ID
-void test_matches_id() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  assert(syclcompat::get_device(syclcompat::get_current_device_id()) ==
-         syclcompat::get_current_device());
-}
-
-  // Check error on insufficient devices
-void test_not_enough_devices() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  DeviceTestsFixt dtf;
-  try {
-    syclcompat::select_device(dtf.get_n_devices());
-  } catch (std::runtime_error const &e) {
-    std::cout << "Expected SYCL exception caught: " << e.what();
-  }
-}
-
-  // Check the default context matches default queue's context
-void test_default_context() {
-  std::cout << __PRETTY_FUNCTION__ << std::endl;
-  DeviceTestsFixt dtf;
-  assert(dtf.get_queue().get_context() == syclcompat::get_default_context());
-}
-
-  /*
-    Queue Tests
-  */
 void test_set_default_queue() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
@@ -85,6 +47,43 @@ void test_set_default_queue() {
   assert(*dev_.default_queue() != old_default_queue);
 }
 
+/*
+  Device Tests
+*/
+void test_at_least_one_device() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  assert(dtf.get_n_devices() > 0);
+}
+
+// Check the device returned matches the device ID
+void test_matches_id() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  assert(syclcompat::get_device(syclcompat::get_current_device_id()) ==
+         syclcompat::get_current_device());
+}
+
+// Check error on insufficient devices
+void test_not_enough_devices() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  try {
+    syclcompat::select_device(dtf.get_n_devices());
+  } catch (std::runtime_error const &e) {
+    std::cout << "Expected SYCL exception caught: " << e.what();
+  }
+}
+
+// Check the default context matches default queue's context
+void test_default_context() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceTestsFixt dtf;
+  assert(dtf.get_queue().get_context() == syclcompat::get_default_context());
+}
+
+/*
+  Queue Tests
+*/
 void test_make_in_order_queue() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   sycl::queue q = syclcompat::get_default_queue();
@@ -97,7 +96,7 @@ void test_check_default_device() {
   assert(q.get_device() == sycl::device{sycl::default_selector_v});
 }
 
-  // Check behaviour of in order & out of order queue construction
+// Check behaviour of in order & out of order queue construction
 void test_create_queue_arguments() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   sycl::queue q_create_def{syclcompat::create_queue()};
@@ -108,9 +107,9 @@ void test_create_queue_arguments() {
   assert(!q_out_order.is_in_order());
 }
 
-  /*
-    Device Extension Tests
-  */
+/*
+  Device Extension Tests
+*/
 void test_device_ext_api() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   DeviceExtFixt dev_ext;
@@ -151,7 +150,7 @@ void test_saved_queue() {
   assert(q == *dev_.get_saved_queue());
 }
 
-  // Check reset() resets the queues etc
+// Check reset() resets the queues etc
 void test_reset() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   DeviceExtFixt dev_ext;

--- a/sycl/test-e2e/syclcompat/device/device_threaded.cpp
+++ b/sycl/test-e2e/syclcompat/device/device_threaded.cpp
@@ -38,34 +38,39 @@
 
 #include "device_fixt.hpp"
 
-int main() {
-  // Check a thread is able to select a non-default device
-  std::cout << "Testing DeviceSelect" << std::endl;
-  {
-    DeviceTestsFixt dtf;
-    if (dtf.get_n_devices() > 1) {
-      constexpr unsigned int TARGET_DEV = 1;
-      unsigned int thread_dev_id{};
-      std::thread other_thread{[&]() {
-        syclcompat::select_device(TARGET_DEV);
-        thread_dev_id = syclcompat::get_current_device_id();
-      }};
-      other_thread.join();
-      assert(thread_dev_id == TARGET_DEV);
-    } else {
-      std::cout << "  Skipping, only doable with multiple devices" << std::endl;
-    }
-  }
+// Check a thread is able to select a non-default device
+void test_device_select() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  // Check multiple threads get same device by default
-  std::cout << "Testing Threads" << std::endl;
-  {
+  DeviceTestsFixt dtf;
+  if (dtf.get_n_devices() > 1) {
+    constexpr unsigned int TARGET_DEV = 1;
     unsigned int thread_dev_id{};
-    std::thread other_thread{
-        [&]() { thread_dev_id = syclcompat::get_current_device_id(); }};
+    std::thread other_thread{[&]() {
+      syclcompat::select_device(TARGET_DEV);
+      thread_dev_id = syclcompat::get_current_device_id();
+    }};
     other_thread.join();
-    assert(thread_dev_id == syclcompat::get_current_device_id());
+    assert(thread_dev_id == TARGET_DEV);
+  } else {
+    std::cout << "  Skipping, only doable with multiple devices" << std::endl;
   }
+}
+
+// Check multiple threads get same device by default
+void test_threads() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  unsigned int thread_dev_id{};
+  std::thread other_thread{
+      [&]() { thread_dev_id = syclcompat::get_current_device_id(); }};
+  other_thread.join();
+  assert(thread_dev_id == syclcompat::get_current_device_id());
+}
+
+int main() {
+  test_device_select();
+  test_threads();
 
   return 0;
 }


### PR DESCRIPTION
- Adds multiple properties to syclcompat's device_info class.
- Usage of `sycl::id` deprecated in favour of `sycl::range`.
- Refactored queue creation, implementation moved to a private method. 
- Device name truncated if it's name exceeds the maximum buffer size (256 by default).

Minor:
- Updated format of device tests to match the current test style used for other headers. 