### PR TITLE
[CUDA][HIP] Enable user_defined_reductions for cuda and hip.

### DIFF
--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//
-// UNSUPPORTED: cuda || hip
 
 #include <complex>
 #include <numeric>


### PR DESCRIPTION
This patch enables user_defined_reductions.cpp for cuda and hip.
It's been verified that the test is now supported for cuda and hip now, this closes https://github.com/intel/llvm/issues/12613