### PR TITLE
[SYCL] ensuring ZEX_NUMBER_OF_CCS is only used on COMPOSITE hierarchy mode

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -4,11 +4,10 @@
 // RUN: %{build} -o %t.out
 
 // TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
-// which is the
-//        new default on PVC.  Once it is supported, we'll test on both.
-//        In the interim, these are the environment vars that must be set to get
-//        cslice or the extra level of partition_by_affinity_domain with the
-//        "EXPOSE_" env var.
+// which is the new default on PVC.  Once it is supported, we'll test on both.
+// In the interim, these are the environment vars that must be set to get cslice
+// or the extra level of partition_by_affinity_domain with the "EXPOSE_" env
+// var.
 // DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
 
 // RUN: %{setup_env} env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -3,18 +3,26 @@
 
 // RUN: %{build} -o %t.out
 
-// RUN: env ZEX_NUMBER_OF_CCS=0:4 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+// TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
+// which is the
+//        new default on PVC.  Once it is supported, we'll test on both.
+//        In the interim, these are the environment vars that must be set to get
+//        cslice or the extra level of partition_by_affinity_domain with the
+//        "EXPOSE_" env var.
+// DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
 
-// RUN: env SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
-// RUN:   ZEX_NUMBER_OF_CCS=0:4 UR_L0_DEBUG=1 %{run} %t.out  2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+// RUN: %{setup_env} env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+
+// RUN: %{setup_env} env SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
+// RUN:  UR_L0_DEBUG=1 %{run} %t.out  2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
 // Same, but without using immediate commandlists:
 
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 ZEX_NUMBER_OF_CCS=0:4 \
+// RUN: %{setup_env} env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0  \
 // RUN:   UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
-// RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
-// RUN:   ZEX_NUMBER_OF_CCS=0:4 UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+// RUN: %{setup_env} env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 \
+// RUN:  UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -3,11 +3,10 @@
 // RUN: %{build} -o %t.out
 
 // TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
-// which is the
-//        new default on PVC.  Once it is supported, we'll test on both.
-//        In the interim, these are the environment vars that must be set to get
-//        cslice or the extra level of partition_by_affinity_domain with the
-//        "EXPOSE_" env var.
+// which is the new default on PVC.  Once it is supported, we'll test on both.
+// In the interim, these are the environment vars that must be set to get cslice
+// or the extra level of partition_by_affinity_domain with the "EXPOSE_" env
+// var.
 // DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
 
 // RUN: %{setup_env} env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -1,10 +1,19 @@
 // REQUIRES: aspect-ext_intel_device_id
 // REQUIRES: level_zero
 // RUN: %{build} -o %t.out
-// RUN: env ZEX_NUMBER_OF_CCS=0:4 env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+
+// TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
+// which is the
+//        new default on PVC.  Once it is supported, we'll test on both.
+//        In the interim, these are the environment vars that must be set to get
+//        cslice or the extra level of partition_by_affinity_domain with the
+//        "EXPOSE_" env var.
+// DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
+
+// RUN: %{setup_env} env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 //
 // Same with Immediate CommandLists
-// RUN: env SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 env ZEX_NUMBER_OF_CCS=0:4 env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
+// RUN: %{setup_env} env SYCL_PI_LEVEL_ZERO_EXPOSE_CSLICE_IN_AFFINITY_PARTITIONING=1 env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK-PVC
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
@@ -3,10 +3,9 @@
 // RUN: %{build} %level_zero_options -o %t.out
 
 // TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
-// which is the
-//        new default on PVC.  Once it is supported, we'll test on both.
-//        In the interim, these are the environment vars that must be used in
-//        conjunction with ZEX_NUMBER_OF_CCS
+// which is the new default on PVC.  Once it is supported, we'll test on both.
+// In the interim, these are the environment vars that must be used in
+// conjunction with ZEX_NUMBER_OF_CCS
 // DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
 
 // RUN: %{setup_env} env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s

--- a/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
@@ -1,8 +1,16 @@
 // REQUIRES:  gpu-intel-pvc, level_zero
 
 // RUN: %{build} %level_zero_options -o %t.out
-// RUN: env UR_L0_DEBUG=1 env ZEX_NUMBER_OF_CCS=0:4  %{run} %t.out 2>&1 | FileCheck %s
-// RUN: env ZEX_NUMBER_OF_CCS=0:4 %{run} %t.out
+
+// TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
+// which is the
+//        new default on PVC.  Once it is supported, we'll test on both.
+//        In the interim, these are the environment vars that must be used in
+//        conjunction with ZEX_NUMBER_OF_CCS
+// DEFINE: %{setup_env} = env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE ZE_AFFINITY_MASK=0 ZEX_NUMBER_OF_CCS=0:4
+
+// RUN: %{setup_env} env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
+// RUN: %{setup_env} %{run} %t.out
 
 // Check that queues created on sub-sub-devices are going to specific compute
 // engines:


### PR DESCRIPTION
ZEX_NUMBER_OF_CCS not yet working in FLAT mode, the new default on PVC. Shoring up the tests in the interim.