### PR TITLE
[libclc] Several little QOL improvements to libclc-remangler

### DIFF
--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -963,7 +963,7 @@ int main(int argc, const char **argv) {
 
   // Use a default Compilation DB instead of the build one, as it might contain
   // toolchain specific options, not compatible with clang.
-  FixedCompilationDatabase Compilations("/", std::vector<std::string>());
+  FixedCompilationDatabase Compilations(".", std::vector<std::string>());
   ClangTool Tool(Compilations, ExpectedParser->getSourcePathList());
 
   LibCLCRemanglerActionFactory LRAF{};

--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -845,7 +845,7 @@ private:
   }
 
   bool remangleFunction(Function &Func, llvm::Module *M) {
-    if (!Func.getName().startswith("_Z"))
+    if (!Func.getName().starts_with("_Z"))
       return true;
 
     std::string const MangledName = Func.getName().str();

--- a/libclc/utils/libclc-remangler/LibclcRemangler.cpp
+++ b/libclc/utils/libclc-remangler/LibclcRemangler.cpp
@@ -777,12 +777,17 @@ public:
 
   void Initialize(ASTContext &C) override {
     ASTCtx = &C;
-    SMDiagnostic Err;
     std::unique_ptr<MemoryBuffer> const Buff = ExitOnErr(
         errorOrToExpected(MemoryBuffer::getFileOrSTDIN(InputIRFilename)));
+
+    SMDiagnostic Err;
     std::unique_ptr<llvm::Module> const M =
-        ExitOnErr(Expected<std::unique_ptr<llvm::Module>>(
-            parseIR(Buff.get()->getMemBufferRef(), Err, LLVMCtx)));
+        parseIR(Buff.get()->getMemBufferRef(), Err, LLVMCtx);
+
+    if (!M) {
+      Err.print("libclc-remangler", errs());
+      exit(1);
+    }
 
     handleModule(M.get());
   }


### PR DESCRIPTION
I've bunched these together as I don't think any are controversial and it seems a waste of time to review each independently.

-----

[libclc] Update deprecated method use in remangler

llvm::StringRef::startswith -> llvm::StringRef::starts_with

-----

[libclc] Fix up improper use of ExitOnError

ExitOnError takes a llvm::Expected, but we were passing it the result of
llvm::parseIR - std::unique_ptr<llvm::Module> - which, even when null, is
not an error condition. Thus invalid IR input was silently being
accepted until it would segfault on accessing the module.

-----


[libclc] Open remangler file system at PWD, not root

I don't think there's any reason to open it at root. Opening it at the
current working directory is more intuitive for developers using
relative paths for input/output files.

Previously "--input-ir foo.ll" would try and open "/foo.ll", which
depending on the system is likely a permissions error, or a missing
file, or even an unintended file.

-----