### PR TITLE
[SYCL][E2E] Disable TaskSequence/* tests on Linux

### DIFF
--- a/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
+++ b/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: re-enable the test when compfail below is fixed:
-// # | llvm-foreach: Segmentation fault (core dumped)
-// # | clang++: error: fpga compiler command failed with exit code 254 (use -v to see invocation)
+// FIXME: failure in post-commit, re-enable when fixed:
 // UNSUPPORTED: linux
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence

--- a/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
+++ b/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
@@ -6,6 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: re-enable the test when compfail below is fixed:
+// # | llvm-foreach: Segmentation fault (core dumped)
+// # | clang++: error: fpga compiler command failed with exit code 254 (use -v to see invocation)
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
+++ b/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/mult-and-add.cpp
+++ b/sycl/test-e2e/TaskSequence/mult-and-add.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
+++ b/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/producer-consumer.cpp
+++ b/sycl/test-e2e/TaskSequence/producer-consumer.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
+++ b/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
They fail in post-commit