### PR TITLE
[MLIR][LLVM] Add `llvm.experimental.constrained.fptrunc` operation

### DIFF
--- a/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
+++ b/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
@@ -36,6 +36,19 @@ convertArithOverflowFlagsToLLVM(arith::IntegerOverflowFlags arithFlags);
 LLVM::IntegerOverflowFlagsAttr
 convertArithOverflowAttrToLLVM(arith::IntegerOverflowFlagsAttr flagsAttr);
 
+/// Maps arithmetic rounding enum vales to LLVM enum values.
+LLVM::RoundingMode
+convertArithRoundingModeToLLVM(arith::RoundingMode roundingMode);
+
+/// Creates an LLVM rounding mnode attribute from a given arithmetic rounding
+/// mode attribute.
+LLVM::RoundingModeAttr
+convertArithRoundingModeAttrToLLVM(arith::RoundingModeAttr roundingModeAttr);
+
+/// Return the default LLVM exception behavior attribute.
+LLVM::ExceptionBehaviorAttr
+getDefaultExceptionBehaviorAttr(MLIRContext *context);
+
 // Attribute converter that populates a NamedAttrList by removing the fastmath
 // attribute from the source operation attributes, and replacing it with an
 // equivalent LLVM fastmath attribute.
@@ -89,6 +102,39 @@ public:
 private:
   NamedAttrList convertedAttr;
 };
+
+template <typename SourceOp, typename TargetOp,
+          std::enable_if_t<TargetOp::template hasTrait<
+                               LLVM::ExceptionBehaviorOpInterface::Trait>(),
+                           bool> = true>
+class AttrConverterConstrainedFPToLLVM {
+public:
+  AttrConverterConstrainedFPToLLVM(
+      SourceOp srcOp) { // Copy the source attributes.
+    convertedAttr = NamedAttrList{srcOp->getAttrs()};
+
+    if constexpr (TargetOp::template hasTrait<
+                      LLVM::RoundingModeOpInterface::Trait>()) {
+      // Get the name of the rounding mode attribute.
+      StringRef arithAttrName = srcOp.getRoundingModeAttrName();
+      // Remove the source attribute.
+      auto arithAttr = dyn_cast_if_present<arith::RoundingModeAttr>(
+          convertedAttr.erase(arithAttrName));
+      if (arithAttr) {
+        convertedAttr.set(TargetOp::getRoundingModeAttrName(),
+                          convertArithRoundingModeAttrToLLVM(arithAttr));
+      }
+    }
+    convertedAttr.set(TargetOp::getExceptionBehaviorAttrName(),
+                      getDefaultExceptionBehaviorAttr(srcOp->getContext()));
+  }
+
+  ArrayRef<NamedAttribute> getAttrs() const { return convertedAttr.getAttrs(); }
+
+private:
+  NamedAttrList convertedAttr;
+};
+
 } // namespace arith
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
+++ b/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
@@ -110,7 +110,8 @@ template <typename SourceOp, typename TargetOp,
 class AttrConverterConstrainedFPToLLVM {
 public:
   AttrConverterConstrainedFPToLLVM(
-      SourceOp srcOp) { // Copy the source attributes.
+      SourceOp srcOp) {
+    // Copy the source attributes.
     convertedAttr = NamedAttrList{srcOp->getAttrs()};
 
     if constexpr (TargetOp::template hasTrait<

--- a/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
+++ b/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
@@ -36,11 +36,11 @@ convertArithOverflowFlagsToLLVM(arith::IntegerOverflowFlags arithFlags);
 LLVM::IntegerOverflowFlagsAttr
 convertArithOverflowAttrToLLVM(arith::IntegerOverflowFlagsAttr flagsAttr);
 
-/// Maps arithmetic rounding enum vales to LLVM enum values.
+/// Maps arithmetic rounding enum values to LLVM enum values.
 LLVM::RoundingMode
 convertArithRoundingModeToLLVM(arith::RoundingMode roundingMode);
 
-/// Creates an LLVM rounding mnode attribute from a given arithmetic rounding
+/// Creates an LLVM rounding mode attribute from a given arithmetic rounding
 /// mode attribute.
 LLVM::RoundingModeAttr
 convertArithRoundingModeAttrToLLVM(arith::RoundingModeAttr roundingModeAttr);

--- a/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
+++ b/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
@@ -119,12 +119,11 @@ public:
       // Get the name of the rounding mode attribute.
       StringRef arithAttrName = srcOp.getRoundingModeAttrName();
       // Remove the source attribute.
-      auto arithAttr = dyn_cast_if_present<arith::RoundingModeAttr>(
-          convertedAttr.erase(arithAttrName));
-      if (arithAttr) {
-        convertedAttr.set(TargetOp::getRoundingModeAttrName(),
-                          convertArithRoundingModeAttrToLLVM(arithAttr));
-      }
+      auto arithAttr =
+          cast<arith::RoundingModeAttr>(convertedAttr.erase(arithAttrName));
+      // Set the target attribute.
+      convertedAttr.set(TargetOp::getRoundingModeAttrName(),
+                        convertArithRoundingModeAttrToLLVM(arithAttr));
     }
     convertedAttr.set(TargetOp::getExceptionBehaviorAttrName(),
                       getDefaultExceptionBehaviorAttr(srcOp->getContext()));

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -705,4 +705,56 @@ def FramePointerKindEnum : LLVM_EnumAttr<
   let cppNamespace = "::mlir::LLVM::framePointerKind";
 }
 
+//===----------------------------------------------------------------------===//
+// RoundingMode
+//===----------------------------------------------------------------------===//
+
+def RoundTowardZero
+    : LLVM_EnumAttrCase<"TowardZero", "towardzero", "TowardZero", 0>;
+def RoundNearestTiesToEven
+    : LLVM_EnumAttrCase<"NearestTiesToEven", "tonearest", "NearestTiesToEven", 1>;
+def RoundTowardPositive
+    : LLVM_EnumAttrCase<"TowardPositive", "upward", "TowardPositive", 2>;
+def RoundTowardNegative
+    : LLVM_EnumAttrCase<"TowardNegative", "downward", "TowardNegative", 3>;
+def RoundNearestTiesToAway
+    : LLVM_EnumAttrCase<"NearestTiesToAway", "tonearestaway", "NearestTiesToAway", 4>;
+def RoundDynamic
+    : LLVM_EnumAttrCase<"Dynamic", "dynamic", "Dynamic", 7>;
+def RoundInvalid // Needed as llvm::RoundingMode defines this.
+    : LLVM_EnumAttrCase<"Invalid", "invalid", "Invalid", -1>;
+
+// RoundingModeAttr should not be used in operations definitions.
+// Use ValidRoundingModeAttr instead.
+def RoundingModeAttr : LLVM_EnumAttr<
+    "RoundingMode",
+    "::llvm::RoundingMode",
+    "LLVM Rounding Mode",
+    [RoundTowardZero, RoundNearestTiesToEven, RoundTowardPositive,
+     RoundTowardNegative, RoundNearestTiesToAway, RoundDynamic, RoundInvalid]> {
+  let cppNamespace = "::mlir::LLVM";
+}
+
+def ValidRoundingModeAttr : ConfinedAttr<RoundingModeAttr, [IntMinValue<0>]>;
+
+//===----------------------------------------------------------------------===//
+// ExceptionBehavior
+//===----------------------------------------------------------------------===//
+
+def ExceptionBehaviorIgnore
+    : LLVM_EnumAttrCase<"Ignore", "ignore", "ebIgnore", 0>;
+def ExceptionBehaviorMayTrap
+    : LLVM_EnumAttrCase<"MayTrap", "maytrap", "ebMayTrap", 1>;
+def ExceptionBehaviorStrict
+    : LLVM_EnumAttrCase<"Strict", "strict", "ebStrict", 2>;
+
+def ExceptionBehaviorAttr : LLVM_EnumAttr<
+    "ExceptionBehavior",
+    "::llvm::fp::ExceptionBehavior",
+    "LLVM Exception Behavior",
+    [ExceptionBehaviorIgnore, ExceptionBehaviorMayTrap,
+     ExceptionBehaviorStrict]> {
+  let cppNamespace = "::mlir::LLVM";
+}
+
 #endif // LLVMIR_ENUMS

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMEnums.td
@@ -709,6 +709,8 @@ def FramePointerKindEnum : LLVM_EnumAttr<
 // RoundingMode
 //===----------------------------------------------------------------------===//
 
+// These values must match llvm::RoundingMode ones.
+// See llvm/include/llvm/ADT/FloatingPointMode.h.
 def RoundTowardZero
     : LLVM_EnumAttrCase<"TowardZero", "towardzero", "TowardZero", 0>;
 def RoundNearestTiesToEven
@@ -721,7 +723,8 @@ def RoundNearestTiesToAway
     : LLVM_EnumAttrCase<"NearestTiesToAway", "tonearestaway", "NearestTiesToAway", 4>;
 def RoundDynamic
     : LLVM_EnumAttrCase<"Dynamic", "dynamic", "Dynamic", 7>;
-def RoundInvalid // Needed as llvm::RoundingMode defines this.
+// Needed as llvm::RoundingMode defines this.
+def RoundInvalid
     : LLVM_EnumAttrCase<"Invalid", "invalid", "Invalid", -1>;
 
 // RoundingModeAttr should not be used in operations definitions.
@@ -741,6 +744,8 @@ def ValidRoundingModeAttr : ConfinedAttr<RoundingModeAttr, [IntMinValue<0>]>;
 // ExceptionBehavior
 //===----------------------------------------------------------------------===//
 
+// These values must match llvm::fp::ExceptionBehavior ones.
+// See llvm/include/llvm/IR/FPEnv.h.
 def ExceptionBehaviorIgnore
     : LLVM_EnumAttrCase<"Ignore", "ignore", "ebIgnore", 0>;
 def ExceptionBehaviorMayTrap

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMInterfaces.td
@@ -105,6 +105,74 @@ def IntegerOverflowFlagsInterface : OpInterface<"IntegerOverflowFlagsInterface">
   ];
 }
 
+def ExceptionBehaviorOpInterface : OpInterface<"ExceptionBehaviorOpInterface"> {
+  let description = [{
+    An interface for operations receiving an exception behavior attribute
+    controlling FP exception behavior.
+  }];
+
+  let cppNamespace = "::mlir::LLVM";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/        "Returns a ExceptionBehavior attribute for the operation",
+      /*returnType=*/  "ExceptionBehaviorAttr",
+      /*methodName=*/  "getExceptionBehaviorAttr",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        return op.getExceptionbehaviorAttr();
+      }]
+    >,  
+    StaticInterfaceMethod<
+      /*desc=*/        [{Returns the name of the ExceptionBehaviorAttr attribute
+                         for the operation}],
+      /*returnType=*/  "StringRef",
+      /*methodName=*/  "getExceptionBehaviorAttrName",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        return "exceptionbehavior";
+      }]
+    >
+  ];
+}
+
+def RoundingModeOpInterface : OpInterface<"RoundingModeOpInterface"> {
+  let description = [{
+    An interface for operations receiving a rounding mode attribute
+    controlling FP rounding mode.
+  }];
+
+  let cppNamespace = "::mlir::LLVM";
+
+  let methods = [
+    InterfaceMethod<
+      /*desc=*/        "Returns a RoundingMode attribute for the operation",
+      /*returnType=*/  "RoundingModeAttr",
+      /*methodName=*/  "getRoundingModeAttr",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        auto op = cast<ConcreteOp>(this->getOperation());
+        return op.getRoundingmodeAttr();
+      }]
+    >,
+    StaticInterfaceMethod<
+      /*desc=*/        [{Returns the name of the RoundingModeAttr attribute
+                         for the operation}],
+      /*returnType=*/  "StringRef",
+      /*methodName=*/  "getRoundingModeAttrName",
+      /*args=*/        (ins),
+      /*methodBody=*/  [{}],
+      /*defaultImpl=*/ [{
+        return "roundingmode";
+      }]
+    >,
+  ];
+}
+
 def BranchWeightOpInterface : OpInterface<"BranchWeightOpInterface"> {
   let description = [{
     An interface for operations that can carry branch weights metadata. It

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -332,8 +332,7 @@ class LLVM_ConstrainedIntr<string mnem, int numArgs, bit hasRoundingMode>
   let llvmBuilder = [{
     $res = LLVM::detail::createConstrainedIntrinsicCall(
       builder, moduleTranslation, &opInst, llvm::Intrinsic::experimental_constrained_}]
-       # mnem # ", "
-       # /*hasRoundingMode=*/!cond(!gt(hasRoundingMode, 0) : "true", true : "false")
+       # mnem
        # [{);
   }];
   let mlirBuilder = [{

--- a/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
+++ b/mlir/include/mlir/Dialect/LLVMIR/LLVMIntrinsicOps.td
@@ -311,6 +311,48 @@ def LLVM_InvariantEndOp : LLVM_ZeroResultIntrOp<"invariant.end", [2],
       "qualified(type($ptr))";
 }
 
+// Constrained Floating-Point Intrinsics
+
+class LLVM_ConstrainedIntr<string mnem, int numArgs, bit hasRoundingMode>
+    : LLVM_OneResultIntrOp<"experimental.constrained." # mnem,
+                           /*overloadedResults=*/[0],
+                           /*overloadedOperands=*/[0],
+                           /*traits=*/[Pure, DeclareOpInterfaceMethods<ExceptionBehaviorOpInterface>]
+                           # !cond(
+                               !gt(hasRoundingMode, 0) : [DeclareOpInterfaceMethods<RoundingModeOpInterface>],
+                               true : []),
+                           /*requiresFastmath=*/0,
+                           /*immArgPositions=*/[],
+                           /*immArgAttrNames=*/[]> {
+  dag regularArgs = !dag(ins, !listsplat(LLVM_Type, numArgs), !foreach(i, !range(numArgs), "arg_" #i));
+  dag attrArgs = !con(!cond(!gt(hasRoundingMode, 0) : (ins ValidRoundingModeAttr:$roundingmode),
+                            true : (ins)),
+                      (ins ExceptionBehaviorAttr:$exceptionbehavior));
+  let arguments = !con(regularArgs, attrArgs);
+  let llvmBuilder = [{
+    $res = LLVM::detail::createConstrainedIntrinsicCall(
+      builder, moduleTranslation, &opInst, llvm::Intrinsic::experimental_constrained_}]
+       # mnem # ", "
+       # /*hasRoundingMode=*/!cond(!gt(hasRoundingMode, 0) : "true", true : "false")
+       # [{);
+  }];
+  let mlirBuilder = [{
+    auto op = moduleImport.translateConstrainedIntrinsic(
+      $_location, $_resultType, llvmOperands,
+      $_qualCppClassName::getOperationName());
+    if (!op)
+      return failure();
+    $res = op;
+  }];
+}
+
+def LLVM_ConstrainedFPTruncIntr
+    : LLVM_ConstrainedIntr<"fptrunc", /*numArgs=*/1, /*hasRoundingMode=*/1> {
+  let assemblyFormat = [{
+    $arg_0 $roundingmode $exceptionbehavior attr-dict `:` type($arg_0) `to` type(results)
+  }];
+}
+
 // Intrinsics with multiple returns.
 
 class LLVM_ArithWithOverflowOp<string mnem>

--- a/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleImport.h
@@ -232,6 +232,11 @@ public:
                             SmallVectorImpl<Value> &valuesOut,
                             SmallVectorImpl<NamedAttribute> &attrsOut);
 
+  /// Import constrained intrinsic.
+  Value translateConstrainedIntrinsic(Location loc, Type type,
+                                      ArrayRef<llvm::Value *> llvmOperands,
+                                      StringRef opName);
+
 private:
   /// Clears the accumulated state before processing a new region.
   void clearRegionState() {

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -423,7 +423,7 @@ llvm::CallInst *createIntrinsicCall(
 
 llvm::CallInst *createConstrainedIntrinsicCall(
     llvm::IRBuilderBase &builder, ModuleTranslation &moduleTranslation,
-    Operation *intrOp, llvm::Intrinsic::ID intrinsic, bool hasRoundingMode);
+    Operation *intrOp, llvm::Intrinsic::ID intrinsic);
 
 } // namespace detail
 

--- a/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
+++ b/mlir/include/mlir/Target/LLVMIR/ModuleTranslation.h
@@ -421,6 +421,10 @@ llvm::CallInst *createIntrinsicCall(
     ArrayRef<unsigned> immArgPositions,
     ArrayRef<StringLiteral> immArgAttrNames);
 
+llvm::CallInst *createConstrainedIntrinsicCall(
+    llvm::IRBuilderBase &builder, ModuleTranslation &moduleTranslation,
+    Operation *intrOp, llvm::Intrinsic::ID intrinsic, bool hasRoundingMode);
+
 } // namespace detail
 
 } // namespace LLVM

--- a/mlir/lib/Conversion/ArithCommon/AttrToLLVMConverter.cpp
+++ b/mlir/lib/Conversion/ArithCommon/AttrToLLVMConverter.cpp
@@ -55,3 +55,37 @@ LLVM::IntegerOverflowFlagsAttr mlir::arith::convertArithOverflowAttrToLLVM(
   return LLVM::IntegerOverflowFlagsAttr::get(
       flagsAttr.getContext(), convertArithOverflowFlagsToLLVM(arithFlags));
 }
+
+LLVM::RoundingMode
+mlir::arith::convertArithRoundingModeToLLVM(arith::RoundingMode roundingMode) {
+  // Sorted array
+  constexpr std::array<std::pair<arith::RoundingMode, LLVM::RoundingMode>, 5>
+      values{
+          {{arith::RoundingMode::tonearesteven,
+            LLVM::RoundingMode::NearestTiesToEven},
+           {arith::RoundingMode::downward, LLVM::RoundingMode::TowardNegative},
+           {arith::RoundingMode::upward, LLVM::RoundingMode::TowardPositive},
+           {arith::RoundingMode::towardzero, LLVM::RoundingMode::TowardZero},
+           {arith::RoundingMode::tonearestaway,
+            LLVM::RoundingMode::NearestTiesToAway}}};
+  auto *found = llvm::lower_bound(
+      values, roundingMode, [](const auto &entry, arith::RoundingMode value) {
+        return entry.first < value;
+      });
+  assert(found != values.end());
+  return found->second;
+}
+
+LLVM::RoundingModeAttr mlir::arith::convertArithRoundingModeAttrToLLVM(
+    arith::RoundingModeAttr roundingModeAttr) {
+  arith::RoundingMode roundingMode = roundingModeAttr.getValue();
+  return LLVM::RoundingModeAttr::get(
+      roundingModeAttr.getContext(),
+      convertArithRoundingModeToLLVM(roundingMode));
+}
+
+LLVM::ExceptionBehaviorAttr
+mlir::arith::getDefaultExceptionBehaviorAttr(MLIRContext *context) {
+  return LLVM::ExceptionBehaviorAttr::get(context,
+                                          LLVM::ExceptionBehavior::Ignore);
+}

--- a/mlir/lib/Conversion/ArithCommon/AttrToLLVMConverter.cpp
+++ b/mlir/lib/Conversion/ArithCommon/AttrToLLVMConverter.cpp
@@ -58,22 +58,18 @@ LLVM::IntegerOverflowFlagsAttr mlir::arith::convertArithOverflowAttrToLLVM(
 
 LLVM::RoundingMode
 mlir::arith::convertArithRoundingModeToLLVM(arith::RoundingMode roundingMode) {
-  // Sorted array
-  constexpr std::array<std::pair<arith::RoundingMode, LLVM::RoundingMode>, 5>
-      values{
-          {{arith::RoundingMode::tonearesteven,
-            LLVM::RoundingMode::NearestTiesToEven},
-           {arith::RoundingMode::downward, LLVM::RoundingMode::TowardNegative},
-           {arith::RoundingMode::upward, LLVM::RoundingMode::TowardPositive},
-           {arith::RoundingMode::towardzero, LLVM::RoundingMode::TowardZero},
-           {arith::RoundingMode::tonearestaway,
-            LLVM::RoundingMode::NearestTiesToAway}}};
-  auto *found = llvm::lower_bound(
-      values, roundingMode, [](const auto &entry, arith::RoundingMode value) {
-        return entry.first < value;
-      });
-  assert(found != values.end());
-  return found->second;
+  switch (roundingMode) {
+  case arith::RoundingMode::tonearesteven:
+    return LLVM::RoundingMode::NearestTiesToEven;
+  case arith::RoundingMode::downward:
+    return LLVM::RoundingMode::TowardNegative;
+  case arith::RoundingMode::upward:
+    return LLVM::RoundingMode::TowardPositive;
+  case arith::RoundingMode::towardzero:
+    return LLVM::RoundingMode::TowardZero;
+  case arith::RoundingMode::tonearestaway:
+    return LLVM::RoundingMode::NearestTiesToAway;
+  }
 }
 
 LLVM::RoundingModeAttr mlir::arith::convertArithRoundingModeAttrToLLVM(

--- a/mlir/lib/Target/LLVMIR/ModuleImport.cpp
+++ b/mlir/lib/Target/LLVMIR/ModuleImport.cpp
@@ -1258,6 +1258,91 @@ LogicalResult ModuleImport::convertIntrinsicArguments(
   return success();
 }
 
+static RoundingModeAttr metadataToRoundingMode(Builder &builder,
+                                               llvm::Metadata *metadata) {
+  auto *mdstr = dyn_cast<llvm::MDString>(metadata);
+  if (!mdstr)
+    return {};
+  std::optional<llvm::RoundingMode> optLLVM =
+      llvm::convertStrToRoundingMode(mdstr->getString());
+  if (!optLLVM)
+    return {};
+  return builder.getAttr<RoundingModeAttr>(
+      convertRoundingModeFromLLVM(*optLLVM));
+}
+
+static ExceptionBehaviorAttr
+metadataToExceptionBehavior(Builder &builder, llvm::Metadata *metadata) {
+  auto *mdstr = dyn_cast<llvm::MDString>(metadata);
+  if (!mdstr)
+    return {};
+  std::optional<llvm::fp::ExceptionBehavior> optLLVM =
+      llvm::convertStrToExceptionBehavior(mdstr->getString());
+  if (!optLLVM)
+    return {};
+  return builder.getAttr<ExceptionBehaviorAttr>(
+      convertExceptionBehaviorFromLLVM(*optLLVM));
+}
+
+static void
+splitMetadataAndValues(ArrayRef<llvm::Value *> inputs,
+                       SmallVectorImpl<llvm::Value *> &values,
+                       SmallVectorImpl<llvm::Metadata *> &metadata) {
+  for (llvm::Value *in : inputs) {
+    if (auto *mdval = dyn_cast<llvm::MetadataAsValue>(in)) {
+      metadata.push_back(mdval->getMetadata());
+    } else {
+      values.push_back(in);
+    }
+  }
+}
+
+Value ModuleImport::translateConstrainedIntrinsic(
+    Location loc, Type type, ArrayRef<llvm::Value *> llvmOperands,
+    StringRef opName) {
+  // Split metadata values from regular ones.
+  SmallVector<llvm::Value *> values;
+  SmallVector<llvm::Metadata *> metadata;
+  splitMetadataAndValues(llvmOperands, values, metadata);
+
+  // Expect 1 or 2 metadata values.
+  assert((metadata.size() == 1 || metadata.size() == 2) &&
+         "Unexpected number of arguments");
+
+  SmallVector<Value> mlirOperands;
+  SmallVector<NamedAttribute> mlirAttrs;
+  if (failed(
+          convertIntrinsicArguments(values, {}, {}, mlirOperands, mlirAttrs))) {
+    return {};
+  }
+
+  // Create operation as usual.
+  StringAttr opNameAttr = builder.getStringAttr(opName);
+  Operation *op =
+      builder.create(loc, opNameAttr, mlirOperands, type, mlirAttrs);
+
+  // Set exception behavior attribute.
+  auto exceptionBehaviorOp = cast<LLVM::ExceptionBehaviorOpInterface>(op);
+  auto attr = metadataToExceptionBehavior(builder, metadata.back());
+  if (!attr)
+    return {};
+  op->setAttr(exceptionBehaviorOp.getExceptionBehaviorAttrName(), attr);
+
+  // If avaialbe, set rounding mode attribute.
+  if (auto roundingModeOp = dyn_cast<LLVM::RoundingModeOpInterface>(op)) {
+    assert(metadata.size() > 1 && "Unexpected number of arguments");
+    // rounding_mode present
+    auto attr = metadataToRoundingMode(builder, metadata[0]);
+    if (!attr)
+      return {};
+    roundingModeOp->setAttr(roundingModeOp.getRoundingModeAttrName(), attr);
+  } else {
+    assert(metadata.size() == 1 && "Unexpected number of arguments");
+  }
+
+  return op->getResult(0);
+}
+
 IntegerAttr ModuleImport::matchIntegerAttr(llvm::Value *value) {
   IntegerAttr integerAttr;
   FailureOr<Value> converted = convertValue(value);

--- a/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
+++ b/mlir/test/Conversion/ArithToLLVM/arith-to-llvm.mlir
@@ -289,6 +289,22 @@ func.func @fptrunc_vector(%arg0 : vector<2xf32>, %arg1 : vector<2xf64>) {
   return
 }
 
+// CHECK-LABEL: experimental_constrained_fptrunc
+func.func @experimental_constrained_fptrunc(%arg0 : f64) {
+// CHECK-NEXT: = llvm.intr.experimental.constrained.fptrunc {{.*}} tonearest ignore : f64 to f32
+  %0 = arith.truncf %arg0 tonearesteven : f64 to f32
+// CHECK-NEXT: = llvm.intr.experimental.constrained.fptrunc {{.*}} downward ignore : f64 to f32
+  %1 = arith.truncf %arg0 downward : f64 to f32
+// CHECK-NEXT: = llvm.intr.experimental.constrained.fptrunc {{.*}} upward ignore : f64 to f32
+  %2 = arith.truncf %arg0 upward : f64 to f32
+// CHECK-NEXT: = llvm.intr.experimental.constrained.fptrunc {{.*}} towardzero ignore : f64 to f32
+  %3 = arith.truncf %arg0 towardzero : f64 to f32
+// CHECK-NEXT: = llvm.intr.experimental.constrained.fptrunc {{.*}} tonearestaway ignore : f64 to f32
+  %4 = arith.truncf %arg0 tonearestaway : f64 to f32
+  return
+}
+
+
 // Check sign and zero extension and truncation of integers.
 // CHECK-LABEL: @integer_extension_and_truncation
 func.func @integer_extension_and_truncation(%arg0 : i3) {

--- a/mlir/test/Dialect/LLVMIR/roundtrip.mlir
+++ b/mlir/test/Dialect/LLVMIR/roundtrip.mlir
@@ -647,3 +647,22 @@ llvm.func @experimental_noalias_scope_decl() {
   llvm.intr.experimental.noalias.scope.decl #alias_scope
   llvm.return
 }
+
+// CHECK-LABEL: @experimental_constrained_fptrunc
+llvm.func @experimental_constrained_fptrunc(%in: f64) -> f32 {
+  // CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} towardzero ignore : f64 to f32
+  %0 = llvm.intr.experimental.constrained.fptrunc %in towardzero ignore : f64 to f32
+  // CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} tonearest maytrap : f64 to f32
+  %1 = llvm.intr.experimental.constrained.fptrunc %in tonearest maytrap : f64 to f32
+  // CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} upward strict : f64 to f32
+  %2 = llvm.intr.experimental.constrained.fptrunc %in upward strict : f64 to f32
+  // CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} downward ignore : f64 to f32
+  %3 = llvm.intr.experimental.constrained.fptrunc %in downward ignore : f64 to f32
+  // CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} tonearestaway ignore : f64 to f32
+  %4 = llvm.intr.experimental.constrained.fptrunc %in tonearestaway ignore : f64 to f32
+  %tmp0 = llvm.fadd %0, %1 : f32
+  %tmp1 = llvm.fadd %2, %3 : f32
+  %tmp2 = llvm.fadd %tmp0, %tmp1 : f32
+  %res = llvm.fadd %tmp2, %4 : f32
+  llvm.return %res : f32
+}

--- a/mlir/test/Target/LLVMIR/Import/intrinsic.ll
+++ b/mlir/test/Target/LLVMIR/Import/intrinsic.ll
@@ -894,6 +894,23 @@ define float @ssa_copy(float %0) {
   ret float %2
 }
 
+; CHECK-LABEL: experimental_constrained_fptrunc
+define void @experimental_constrained_fptrunc(double %s, <4 x double> %v) {
+  ; CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} towardzero ignore : f64 to f32
+  %1 = call float @llvm.experimental.constrained.fptrunc.f32.f64(double %s, metadata !"round.towardzero", metadata !"fpexcept.ignore")
+  ; CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} tonearest maytrap : f64 to f32
+  %2 = call float @llvm.experimental.constrained.fptrunc.f32.f64(double %s, metadata !"round.tonearest", metadata !"fpexcept.maytrap")
+  ; CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} upward strict : f64 to f32
+  %3 = call float @llvm.experimental.constrained.fptrunc.f32.f64(double %s, metadata !"round.upward", metadata !"fpexcept.strict")
+  ; CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} downward ignore : f64 to f32
+  %4 = call float @llvm.experimental.constrained.fptrunc.f32.f64(double %s, metadata !"round.downward", metadata !"fpexcept.ignore")
+  ; CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} tonearestaway ignore : f64 to f32
+  %5 = call float @llvm.experimental.constrained.fptrunc.f32.f64(double %s, metadata !"round.tonearestaway", metadata !"fpexcept.ignore")
+  ; CHECK: llvm.intr.experimental.constrained.fptrunc %{{.*}} tonearestaway ignore : vector<4xf64> to vector<4xf16>
+  %6 = call <4 x half> @llvm.experimental.constrained.fptrunc.v4f16.v4f64(<4 x double> %v, metadata !"round.tonearestaway", metadata !"fpexcept.ignore")
+  ret void
+}
+
 declare float @llvm.fmuladd.f32(float, float, float)
 declare <8 x float> @llvm.fmuladd.v8f32(<8 x float>, <8 x float>, <8 x float>)
 declare float @llvm.fma.f32(float, float, float)
@@ -1120,3 +1137,5 @@ declare void @llvm.assume(i1)
 declare float @llvm.ssa.copy.f32(float returned)
 declare <vscale x 4 x float> @llvm.vector.insert.nxv4f32.v4f32(<vscale x 4 x float>, <4 x float>, i64)
 declare <4 x float> @llvm.vector.extract.v4f32.nxv4f32(<vscale x 4 x float>, i64)
+declare <4 x half> @llvm.experimental.constrained.fptrunc.v4f16.v4f64(<4 x double>, metadata, metadata)
+declare float @llvm.experimental.constrained.fptrunc.f32.f64(double, metadata, metadata)

--- a/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
+++ b/mlir/test/Target/LLVMIR/llvmir-intrinsics.mlir
@@ -964,6 +964,35 @@ llvm.func @ssa_copy(%arg: f32) -> f32 {
   llvm.return %0 : f32
 }
 
+// CHECK-LABEL: @experimental_constrained_fptrunc
+llvm.func @experimental_constrained_fptrunc(%s: f64, %v: vector<4xf32>) {
+  // CHECK: call float @llvm.experimental.constrained.fptrunc.f32.f64(
+  // CHECK: metadata !"round.towardzero"
+  // CHECK: metadata !"fpexcept.ignore"
+  %0 = llvm.intr.experimental.constrained.fptrunc %s towardzero ignore : f64 to f32
+  // CHECK: call float @llvm.experimental.constrained.fptrunc.f32.f64(
+  // CHECK: metadata !"round.tonearest"
+  // CHECK: metadata !"fpexcept.maytrap"
+  %1 = llvm.intr.experimental.constrained.fptrunc %s tonearest maytrap : f64 to f32
+  // CHECK: call float @llvm.experimental.constrained.fptrunc.f32.f64(
+  // CHECK: metadata !"round.upward"
+  // CHECK: metadata !"fpexcept.strict"
+  %2 = llvm.intr.experimental.constrained.fptrunc %s upward strict : f64 to f32
+  // CHECK: call float @llvm.experimental.constrained.fptrunc.f32.f64(
+  // CHECK: metadata !"round.downward"
+  // CHECK: metadata !"fpexcept.ignore"
+  %3 = llvm.intr.experimental.constrained.fptrunc %s downward ignore : f64 to f32
+  // CHECK: call float @llvm.experimental.constrained.fptrunc.f32.f64(
+  // CHECK: metadata !"round.tonearestaway"
+  // CHECK: metadata !"fpexcept.ignore"
+  %4 = llvm.intr.experimental.constrained.fptrunc %s tonearestaway ignore : f64 to f32
+  // CHECK: call <4 x half> @llvm.experimental.constrained.fptrunc.v4f16.v4f32(
+  // CHECK: metadata !"round.upward"
+  // CHECK: metadata !"fpexcept.strict"
+  %5 = llvm.intr.experimental.constrained.fptrunc %v upward strict : vector<4xf32> to vector<4xf16>
+  llvm.return
+}
+
 // Check that intrinsics are declared with appropriate types.
 // CHECK-DAG: declare float @llvm.fma.f32(float, float, float)
 // CHECK-DAG: declare <8 x float> @llvm.fma.v8f32(<8 x float>, <8 x float>, <8 x float>) #0
@@ -1120,6 +1149,8 @@ llvm.func @ssa_copy(%arg: f32) -> f32 {
 // CHECK-DAG: declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture)
 // CHECK-DAG: declare ptr @llvm.invariant.start.p0(i64 immarg, ptr nocapture)
 // CHECK-DAG: declare void @llvm.invariant.end.p0(ptr, i64 immarg, ptr nocapture)
+// CHECK-DAG: declare float @llvm.experimental.constrained.fptrunc.f32.f64(double, metadata, metadata)
+// CHECK-DAG: declare <4 x half> @llvm.experimental.constrained.fptrunc.v4f16.v4f32(<4 x float>, metadata, metadata)
 
 // CHECK-DAG: declare float @llvm.ssa.copy.f32(float returned)
 // CHECK-DAG: declare ptr @llvm.stacksave.p0()


### PR DESCRIPTION
Add operation mapping to the LLVM
`llvm.experimental.constrained.fptrunc.*` intrinsic.

The new operation implements the new
`LLVM::ExceptionBehaviorOpInterface` and
`LLVM::RoundingModeOpInterface` interfaces.

Add translation to LLVM IR and conversion from `arith.truncf` receiving the optional `rounding_mode` attribute.