### PR TITLE
[SYCL][E2E] Stop skipping image_selection.cpp test.

### DIFF
--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: opencl, level-zero, gpu, ocloc
+// REQUIRES: (opencl || level-zero) && gpu && ocloc
 
 // Check the case when -fsycl-add-default-spec-consts-image option is used which
 // results in generation of two types of images: where specialization constants


### PR DESCRIPTION
Using `,` in requires is equivalent to `&&`, and a device can't support simultaneously `opencl` and `level-zero`, so this test was always skipped. This patch corrects this by requiring either `opencl` or `level-zero`, but not both simultaneously.