### PR TITLE
[MLIR][Arith] Fix Arith to LLVM build errors and warnings

### DIFF
--- a/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
+++ b/mlir/include/mlir/Conversion/ArithCommon/AttrToLLVMConverter.h
@@ -103,12 +103,14 @@ private:
   NamedAttrList convertedAttr;
 };
 
-template <typename SourceOp, typename TargetOp,
-          std::enable_if_t<TargetOp::template hasTrait<
-                               LLVM::ExceptionBehaviorOpInterface::Trait>(),
-                           bool> = true>
+template <typename SourceOp, typename TargetOp>
 class AttrConverterConstrainedFPToLLVM {
 public:
+  static_assert(
+      TargetOp::template hasTrait<LLVM::ExceptionBehaviorOpInterface::Trait>(),
+      "Target constrained FP operations must implement "
+      "LLVM::ExceptionBehaviorOpInterface");
+
   AttrConverterConstrainedFPToLLVM(
       SourceOp srcOp) {
     // Copy the source attributes.

--- a/mlir/lib/Conversion/ArithCommon/AttrToLLVMConverter.cpp
+++ b/mlir/lib/Conversion/ArithCommon/AttrToLLVMConverter.cpp
@@ -70,6 +70,7 @@ mlir::arith::convertArithRoundingModeToLLVM(arith::RoundingMode roundingMode) {
   case arith::RoundingMode::tonearestaway:
     return LLVM::RoundingMode::NearestTiesToAway;
   }
+  llvm_unreachable("Invalid rounding mode");
 }
 
 LLVM::RoundingModeAttr mlir::arith::convertArithRoundingModeAttrToLLVM(

--- a/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
+++ b/mlir/lib/Conversion/ArithToLLVM/ArithToLLVM.cpp
@@ -34,12 +34,15 @@ namespace {
 /// \tparam SourceOp is the source operation; \tparam TargetOp, the operation it
 /// will lower to; \tparam AttrConvert is the attribute conversion to convert
 /// the rounding mode attribute.
-template <
-    typename SourceOp, typename TargetOp, bool Constrained,
-    template <typename, typename> typename AttrConvert = AttrConvertPassThrough,
-    std::enable_if_t<
-        SourceOp::template hasTrait<arith::ArithRoundingModeInterface::Trait>(),
-        bool> = true>
+template <typename SourceOp, typename TargetOp, bool Constrained,
+          template <typename, typename> typename AttrConvert =
+              AttrConvertPassThrough,
+          // Target constrained operations must implement the
+          // ExceptionBehaviorOpInterface.
+          std::enable_if_t<!Constrained ||
+                               TargetOp::template hasTrait<
+                                   LLVM::ExceptionBehaviorOpInterface::Trait>(),
+                           bool> = true>
 struct ConstrainedVectorConvertToLLVMPattern
     : public VectorConvertToLLVMPattern<SourceOp, TargetOp, AttrConvert> {
   using VectorConvertToLLVMPattern<SourceOp, TargetOp,


### PR DESCRIPTION
Errors:

- Fixed build errors with some Clang versions due to mismatch in template parameters number. Changed compile time checks to enforce the target operation implements `LLVM::ExceptionBehaviorOpInterface` and drop `arith::ArithRoundingModeInterface` check for source operation.

Warnings:

- Added `llvm_unreachable` after switch statement in `convertArithRoundingModeToLLVM`.