### PR TITLE
[SYCL][COMPAT] Removed sycl/sycl.hpp include

### DIFF
--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -35,6 +35,7 @@
 #define SYCL_EXT_ONEAPI_COMPLEX
 #endif
 
+#include <sycl/ext/oneapi/experimental/bfloat16_math.hpp>
 #include <sycl/ext/oneapi/experimental/complex/complex.hpp>
 
 namespace syclcompat {

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -31,8 +31,6 @@
 
 #pragma once
 
-#include <sycl/sycl.hpp>
-
 #ifndef SYCL_EXT_ONEAPI_COMPLEX
 #define SYCL_EXT_ONEAPI_COMPLEX
 #endif

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -34,7 +34,7 @@
 #include <cassert>
 #include <type_traits>
 
-#include <sycl/sycl.hpp>
+#include <sycl/atomic_ref.hpp>
 
 #include <syclcompat/math.hpp>
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
@@ -72,13 +72,9 @@ void test_cast_value() {
   d_out_data = (double *)sycl::malloc_device(mem_size, q);
   q.memcpy(d_out_data, h_out_data, mem_size).wait();
 
-  auto range =
-      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1));
-  q.submit([&](sycl::handler &cgh) {
-    cgh.parallel_for(range, [=](sycl::nd_item<3> item_ct1) {
-      test_kernel_cast_value(d_out_data);
-    });
-  });
+  q.parallel_for(
+      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
+      [=](sycl::nd_item<3> item_ct1) { test_kernel_cast_value(d_out_data); });
 
   q.memcpy(h_out_data, d_out_data, mem_size).wait();
 

--- a/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
@@ -44,7 +44,7 @@ double cast_value(const double &val) {
   int lo = syclcompat::cast_double_to_int(val, false);
   int hi = syclcompat::cast_double_to_int(val);
   return syclcompat::cast_ints_to_double(hi, lo);
-  }
+}
 
 void test_kernel_cast_value(double *g_odata) {
   double a = 1.12123515e-25f;

--- a/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
@@ -44,7 +44,7 @@ double cast_value(const double &val) {
   int lo = syclcompat::cast_double_to_int(val, false);
   int hi = syclcompat::cast_double_to_int(val);
   return syclcompat::cast_ints_to_double(hi, lo);
-}
+  }
 
 void test_kernel_cast_value(double *g_odata) {
   double a = 1.12123515e-25f;
@@ -72,9 +72,13 @@ void test_cast_value() {
   d_out_data = (double *)sycl::malloc_device(mem_size, q);
   q.memcpy(d_out_data, h_out_data, mem_size).wait();
 
-  q.parallel_for(
-      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1)),
-      [=](sycl::nd_item<3> item_ct1) { test_kernel_cast_value(d_out_data); });
+  auto range =
+      sycl::nd_range<3>(sycl::range<3>(1, 1, 1), sycl::range<3>(1, 1, 1));
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(range, [=](sycl::nd_item<3> item_ct1) {
+      test_kernel_cast_value(d_out_data);
+    });
+  });
 
   q.memcpy(h_out_data, d_out_data, mem_size).wait();
 


### PR DESCRIPTION
In line with other recent PRs, the objective is to improve compilation times and be clear about dependencies from each header. 

Will be retained as draft until all current opened PRs for the util and math headers are merged as these pending PRs may require to include additional header files.