### PR TITLE
[test-e2e] Disable broken test part 2

### DIFF
--- a/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 
 // spir-v gen for legacy images at O0 not working
-// UNSUPPORTED: gpu-intel-dg2
+// UNSUPPORTED: true
 // This test is currently broken see https://github.com/intel/llvm/issues/13090
 
 // This test verifies that make_image is working for 1D, 2D and 3D images.


### PR DESCRIPTION
6246e20e40e10 wasn't enough, as the test still fails on Arc GPUs. Mark this as entirely unsupported until someone can properly fix the root cause as per https://github.com/intel/llvm/issues/13090

