### PR TITLE
[NFC][SYCL][E2E] Drop Annotated_arg_ptr/common.hpp

### DIFF
--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_arg.cpp
@@ -2,7 +2,11 @@
 // RUN: %{run} %t.out
 // REQUIRES: aspect-usm_shared_allocations
 
-#include "common.hpp"
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl::ext::intel::experimental;
 
 struct test {
   int a;

--- a/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/annotated_ptr.cpp
@@ -2,7 +2,11 @@
 // RUN: %{run} %t.out
 // REQUIRES: aspect-usm_shared_allocations
 
-#include "common.hpp"
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+using namespace sycl::ext::oneapi::experimental;
+using namespace sycl::ext::intel::experimental;
 
 struct test {
   int a;

--- a/sycl/test-e2e/Annotated_arg_ptr/common.hpp
+++ b/sycl/test-e2e/Annotated_arg_ptr/common.hpp
@@ -1,7 +1,0 @@
-#pragma once
-
-#include <sycl/sycl.hpp>
-
-using namespace sycl;
-using namespace sycl::ext::oneapi::experimental;
-using namespace sycl::ext::intel::experimental;


### PR DESCRIPTION
It didn't bring any readability benefits.