### PR TITLE
[SYCL][E2E][Joint Matrix] Switch most of Joint Matrix tests to use <sycl/detail/core.hpp>

### DIFF
--- a/sycl/include/sycl/ext/oneapi/matrix/matrix-intel.hpp
+++ b/sycl/include/sycl/ext/oneapi/matrix/matrix-intel.hpp
@@ -13,13 +13,15 @@
 
 #include <CL/__spirv/spirv_types.hpp>         // for MatrixLayout, MatrixUse
 #include <sycl/access/access.hpp>             // for address_space, decorated
+#include <sycl/builtins.hpp>                  // for fabs
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_ALWAYS_INLINE
 #include <sycl/detail/pi.h>                   // for PI_ERROR_INVALID_DEVICE
 #include <sycl/exception.hpp>                 // for runtime_error
 #include <sycl/ext/oneapi/bfloat16.hpp>       // for bfloat16
-#include <sycl/group.hpp>                     // for group
-#include <sycl/multi_ptr.hpp>                 // for multi_ptr
-#include <sycl/sub_group.hpp>                 // for sub_group
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp> // for annotated_ptr
+#include <sycl/group.hpp>     // for group
+#include <sycl/multi_ptr.hpp> // for multi_ptr
+#include <sycl/sub_group.hpp> // for sub_group
 
 #include <cstddef>     // for size_t
 #include <stdint.h>    // for uint32_t

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_half.cpp
@@ -15,7 +15,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_half.cpp
@@ -16,8 +16,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8_packed.cpp
@@ -15,7 +15,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_int8_packed.cpp
@@ -16,8 +16,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_ops_tf32.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_sizes.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/SG32/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/SG32/element_wise_all_sizes.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_apply_bf16.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16.cpp
@@ -13,7 +13,10 @@
 
 #include "../common.hpp"
 #include <iostream>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16.cpp
@@ -14,8 +14,6 @@
 #include "../common.hpp"
 #include <iostream>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
@@ -19,8 +19,6 @@
 #include "../common.hpp"
 #include <iostream>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
@@ -18,7 +18,10 @@
 
 #include "../common.hpp"
 #include <iostream>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_half.cpp
@@ -15,8 +15,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_half.cpp
@@ -14,7 +14,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
@@ -15,7 +15,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
@@ -16,8 +16,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
@@ -17,7 +17,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
@@ -18,8 +18,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
@@ -21,8 +21,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
@@ -20,7 +20,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_apply_bf16.cpp
@@ -13,8 +13,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_apply_bf16.cpp
@@ -12,7 +12,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/common.hpp
+++ b/sycl/test-e2e/Matrix/common.hpp
@@ -9,8 +9,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/common.hpp
+++ b/sycl/test-e2e/Matrix/common.hpp
@@ -8,7 +8,10 @@
 #include <cmath>
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/element_wise_abc_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_abc_impl.hpp
@@ -7,7 +7,10 @@
 //===----------------------------------------------------------------------===//
 
 #include <iostream>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/element_wise_abc_impl.hpp
+++ b/sycl/test-e2e/Matrix/element_wise_abc_impl.hpp
@@ -8,8 +8,6 @@
 
 #include <iostream>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_half.cpp
@@ -15,8 +15,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_half.cpp
@@ -14,7 +14,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8.cpp
@@ -13,8 +13,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8.cpp
@@ -12,7 +12,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
@@ -15,8 +15,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_int8_packed.cpp
@@ -14,7 +14,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::intel;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_ops_tf32.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_sizes.cpp
@@ -13,7 +13,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/element_wise_all_sizes.cpp
@@ -14,8 +14,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/get_coord_float_matC_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_float_matC_impl.hpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include <sycl/atomic_ref.hpp>
+#include <sycl/group_algorithm.hpp>
+
 constexpr size_t TM = 8;
 
 // clang-format off

--- a/sycl/test-e2e/Matrix/get_coord_int8_matA_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matA_impl.hpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include <sycl/group_algorithm.hpp>
 
 constexpr size_t TM = 8;
 constexpr size_t TK = 32;

--- a/sycl/test-e2e/Matrix/get_coord_int8_matB_impl.hpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matB_impl.hpp
@@ -5,6 +5,8 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include <sycl/group_algorithm.hpp>
+
 constexpr size_t TK = 32;
 constexpr size_t VF = 4;
 

--- a/sycl/test-e2e/Matrix/joint_matrix_annotated_ptr_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_annotated_ptr_impl.hpp
@@ -1,3 +1,5 @@
+#include <sycl/usm.hpp>
+
 #define TM 8
 #define TK 16
 

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_bf16.cpp
@@ -13,8 +13,6 @@
 #include <iostream>
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_bf16.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_bf16.cpp
@@ -12,7 +12,10 @@
 
 #include <iostream>
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
@@ -8,8 +8,6 @@
 
 #include <random>
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_impl.hpp
@@ -7,7 +7,11 @@
 //===-------------------------------------------------------------------------===//
 
 #include <random>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
+#include <sycl/usm.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/joint_matrix_colA_rowB_colC_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_colA_rowB_colC_impl.hpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <random>
+#include <sycl/usm.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
@@ -1,4 +1,5 @@
 #include <iostream>
+#include <sycl/usm.hpp>
 
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/joint_matrix_prefetch_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_prefetch_impl.hpp
@@ -1,3 +1,5 @@
+#include <sycl/usm.hpp>
+
 #define TM 8
 #define TK 16
 

--- a/sycl/test-e2e/Matrix/joint_matrix_transposeC_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_transposeC_impl.hpp
@@ -1,3 +1,5 @@
+#include <sycl/usm.hpp>
+
 using namespace sycl;
 using namespace sycl::ext::oneapi::experimental::matrix;
 

--- a/sycl/test-e2e/Matrix/runtime_query_pvc.cpp
+++ b/sycl/test-e2e/Matrix/runtime_query_pvc.cpp
@@ -3,8 +3,6 @@
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
-#include <sycl/builtins.hpp>
-#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl::ext::oneapi::experimental::matrix;

--- a/sycl/test-e2e/Matrix/runtime_query_pvc.cpp
+++ b/sycl/test-e2e/Matrix/runtime_query_pvc.cpp
@@ -2,7 +2,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp>
+#include <sycl/ext/oneapi/matrix/matrix.hpp>
 
 using namespace sycl::ext::oneapi::experimental::matrix;
 


### PR DESCRIPTION
Only updated tests related to Intel XMX (and tests common for Intel XMX and Intel AMX).
Updated matrix header file to make it self-contained.

This and other related changes for your reference and background: https://github.com/intel/llvm/pulls?q=is%3Apr+sycl%2Fdetail%2Fcore.hpp+