### PR TITLE
[SYCL] Move ext_oneapi_memcpy2d impl into dedicated header

### DIFF
--- a/sycl/include/sycl/ext/oneapi/memcpy2d.hpp
+++ b/sycl/include/sycl/ext/oneapi/memcpy2d.hpp
@@ -1,0 +1,281 @@
+//==----- memcpy2d.hpp --- SYCL 2D memcpy extension ------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+#pragma once
+
+#include <sycl/handler.hpp>
+#include <sycl/queue.hpp>
+#include <sycl/usm/usm_enums.hpp>
+#include <sycl/usm/usm_pointer_info.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+template <typename T, typename>
+void handler::ext_oneapi_memcpy2d(void *Dest, size_t DestPitch, const void *Src,
+                                  size_t SrcPitch, size_t Width,
+                                  size_t Height) {
+  throwIfGraphAssociated<
+      ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
+          sycl_ext_oneapi_memcpy2d>();
+  throwIfActionIsCreated();
+  if (Width > DestPitch)
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Destination pitch must be greater than or equal "
+                          "to the width specified in 'ext_oneapi_memcpy2d'");
+  if (Width > SrcPitch)
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Source pitch must be greater than or equal "
+                          "to the width specified in 'ext_oneapi_memcpy2d'");
+
+  // Get the type of the pointers.
+  context Ctx = detail::createSyclObjFromImpl<context>(getContextImplPtr());
+  usm::alloc SrcAllocType = get_pointer_type(Src, Ctx);
+  usm::alloc DestAllocType = get_pointer_type(Dest, Ctx);
+  bool SrcIsHost =
+      SrcAllocType == usm::alloc::unknown || SrcAllocType == usm::alloc::host;
+  bool DestIsHost =
+      DestAllocType == usm::alloc::unknown || DestAllocType == usm::alloc::host;
+
+  // Do the following:
+  // 1. If both are host, use host_task to copy.
+  // 2. If either pointer is host or the backend supports native memcpy2d, use
+  //    special command.
+  // 3. Otherwise, launch a kernel for copying.
+  if (SrcIsHost && DestIsHost) {
+    commonUSMCopy2DFallbackHostTask<T>(Src, SrcPitch, Dest, DestPitch, Width,
+                                       Height);
+  } else if (SrcIsHost || DestIsHost || supportsUSMMemcpy2D()) {
+    ext_oneapi_memcpy2d_impl(Dest, DestPitch, Src, SrcPitch, Width, Height);
+  } else {
+    commonUSMCopy2DFallbackKernel<T>(Src, SrcPitch, Dest, DestPitch, Width,
+                                     Height);
+  }
+}
+
+template <typename T>
+void handler::ext_oneapi_copy2d(const T *Src, size_t SrcPitch, T *Dest,
+                                size_t DestPitch, size_t Width, size_t Height) {
+  if (Width > DestPitch)
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Destination pitch must be greater than or equal "
+                          "to the width specified in 'ext_oneapi_copy2d'");
+  if (Width > SrcPitch)
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Source pitch must be greater than or equal "
+                          "to the width specified in 'ext_oneapi_copy2d'");
+
+  // Get the type of the pointers.
+  context Ctx = detail::createSyclObjFromImpl<context>(getContextImplPtr());
+  usm::alloc SrcAllocType = get_pointer_type(Src, Ctx);
+  usm::alloc DestAllocType = get_pointer_type(Dest, Ctx);
+  bool SrcIsHost =
+      SrcAllocType == usm::alloc::unknown || SrcAllocType == usm::alloc::host;
+  bool DestIsHost =
+      DestAllocType == usm::alloc::unknown || DestAllocType == usm::alloc::host;
+
+  // Do the following:
+  // 1. If both are host, use host_task to copy.
+  // 2. If either pointer is host or of the backend supports native memcpy2d,
+  //    use special command.
+  // 3. Otherwise, launch a kernel for copying.
+  if (SrcIsHost && DestIsHost) {
+    commonUSMCopy2DFallbackHostTask<T>(Src, SrcPitch, Dest, DestPitch, Width,
+                                       Height);
+  } else if (SrcIsHost || DestIsHost || supportsUSMMemcpy2D()) {
+    ext_oneapi_memcpy2d_impl(Dest, DestPitch * sizeof(T), Src,
+                             SrcPitch * sizeof(T), Width * sizeof(T), Height);
+  } else {
+    commonUSMCopy2DFallbackKernel<T>(Src, SrcPitch, Dest, DestPitch, Width,
+                                     Height);
+  }
+}
+
+template <typename T, typename>
+void handler::ext_oneapi_memset2d(void *Dest, size_t DestPitch, int Value,
+                                  size_t Width, size_t Height) {
+  throwIfActionIsCreated();
+  if (Width > DestPitch)
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Destination pitch must be greater than or equal "
+                          "to the width specified in 'ext_oneapi_memset2d'");
+  T CharVal = static_cast<T>(Value);
+
+  context Ctx = detail::createSyclObjFromImpl<context>(getContextImplPtr());
+  usm::alloc DestAllocType = get_pointer_type(Dest, Ctx);
+
+  // If the backends supports 2D fill we use that. Otherwise we use a fallback
+  // kernel. If the target is on host we will always do the operation on host.
+  if (DestAllocType == usm::alloc::unknown || DestAllocType == usm::alloc::host)
+    commonUSMFill2DFallbackHostTask(Dest, DestPitch, CharVal, Width, Height);
+  else if (supportsUSMMemset2D())
+    ext_oneapi_memset2d_impl(Dest, DestPitch, Value, Width, Height);
+  else
+    commonUSMFill2DFallbackKernel(Dest, DestPitch, CharVal, Width, Height);
+}
+
+template <typename T>
+void handler::ext_oneapi_fill2d(void *Dest, size_t DestPitch, const T &Pattern,
+                                size_t Width, size_t Height) {
+  throwIfActionIsCreated();
+  static_assert(is_device_copyable<T>::value,
+                "Pattern must be device copyable");
+  if (Width > DestPitch)
+    throw sycl::exception(sycl::make_error_code(errc::invalid),
+                          "Destination pitch must be greater than or equal "
+                          "to the width specified in 'ext_oneapi_fill2d'");
+
+  context Ctx = detail::createSyclObjFromImpl<context>(getContextImplPtr());
+  usm::alloc DestAllocType = get_pointer_type(Dest, Ctx);
+
+  // If the backends supports 2D fill we use that. Otherwise we use a fallback
+  // kernel. If the target is on host we will always do the operation on host.
+  if (DestAllocType == usm::alloc::unknown || DestAllocType == usm::alloc::host)
+    commonUSMFill2DFallbackHostTask(Dest, DestPitch, Pattern, Width, Height);
+  else if (supportsUSMFill2D())
+    ext_oneapi_fill2d_impl(Dest, DestPitch, &Pattern, sizeof(T), Width, Height);
+  else
+    commonUSMFill2DFallbackKernel(Dest, DestPitch, Pattern, Width, Height);
+}
+
+template <typename T, typename>
+event queue::ext_oneapi_memcpy2d(void *Dest, size_t DestPitch, const void *Src,
+                                 size_t SrcPitch, size_t Width, size_t Height,
+                                 event DepEvent,
+                                 const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvent);
+        CGH.ext_oneapi_memcpy2d<T>(Dest, DestPitch, Src, SrcPitch, Width,
+                                   Height);
+      },
+      CodeLoc);
+}
+
+template <typename T, typename>
+event queue::ext_oneapi_memcpy2d(void *Dest, size_t DestPitch, const void *Src,
+                                 size_t SrcPitch, size_t Width, size_t Height,
+                                 const std::vector<event> &DepEvents,
+                                 const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvents);
+        CGH.ext_oneapi_memcpy2d<T>(Dest, DestPitch, Src, SrcPitch, Width,
+                                   Height);
+      },
+      CodeLoc);
+}
+
+template <typename T>
+event queue::ext_oneapi_copy2d(const T *Src, size_t SrcPitch, T *Dest,
+                               size_t DestPitch, size_t Width, size_t Height,
+                               const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.ext_oneapi_copy2d<T>(Src, SrcPitch, Dest, DestPitch, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T>
+event queue::ext_oneapi_copy2d(const T *Src, size_t SrcPitch, T *Dest,
+                               size_t DestPitch, size_t Width, size_t Height,
+                               event DepEvent,
+                               const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvent);
+        CGH.ext_oneapi_copy2d<T>(Src, SrcPitch, Dest, DestPitch, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T>
+event queue::ext_oneapi_copy2d(const T *Src, size_t SrcPitch, T *Dest,
+                               size_t DestPitch, size_t Width, size_t Height,
+                               const std::vector<event> &DepEvents,
+                               const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvents);
+        CGH.ext_oneapi_copy2d<T>(Src, SrcPitch, Dest, DestPitch, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T, typename>
+event queue::ext_oneapi_memset2d(void *Dest, size_t DestPitch, int Value,
+                                 size_t Width, size_t Height,
+                                 const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.ext_oneapi_memset2d<T>(Dest, DestPitch, Value, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T, typename>
+event queue::ext_oneapi_memset2d(void *Dest, size_t DestPitch, int Value,
+                                 size_t Width, size_t Height, event DepEvent,
+                                 const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvent);
+        CGH.ext_oneapi_memset2d<T>(Dest, DestPitch, Value, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T, typename>
+event queue::ext_oneapi_memset2d(void *Dest, size_t DestPitch, int Value,
+                                 size_t Width, size_t Height,
+                                 const std::vector<event> &DepEvents,
+                                 const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvents);
+        CGH.ext_oneapi_memset2d<T>(Dest, DestPitch, Value, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T>
+event queue::ext_oneapi_fill2d(void *Dest, size_t DestPitch, const T &Pattern,
+                               size_t Width, size_t Height,
+                               const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.ext_oneapi_fill2d<T>(Dest, DestPitch, Pattern, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T>
+event queue::ext_oneapi_fill2d(void *Dest, size_t DestPitch, const T &Pattern,
+                               size_t Width, size_t Height, event DepEvent,
+                               const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvent);
+        CGH.ext_oneapi_fill2d<T>(Dest, DestPitch, Pattern, Width, Height);
+      },
+      CodeLoc);
+}
+
+template <typename T>
+event queue::ext_oneapi_fill2d(void *Dest, size_t DestPitch, const T &Pattern,
+                               size_t Width, size_t Height,
+                               const std::vector<event> &DepEvents,
+                               const detail::code_location &CodeLoc) {
+  return submit(
+      [=](handler &CGH) {
+        CGH.depends_on(DepEvents);
+        CGH.ext_oneapi_fill2d<T>(Dest, DestPitch, Pattern, Width, Height);
+      },
+      CodeLoc);
+}
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -849,15 +849,7 @@ public:
   event ext_oneapi_memcpy2d(
       void *Dest, size_t DestPitch, const void *Src, size_t SrcPitch,
       size_t Width, size_t Height, event DepEvent,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvent);
-          CGH.ext_oneapi_memcpy2d<T>(Dest, DestPitch, Src, SrcPitch, Width,
-                                     Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Copies data from one 2D memory region to another, both pointed by
   /// USM pointers.
@@ -884,15 +876,7 @@ public:
   event ext_oneapi_memcpy2d(
       void *Dest, size_t DestPitch, const void *Src, size_t SrcPitch,
       size_t Width, size_t Height, const std::vector<event> &DepEvents,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvents);
-          CGH.ext_oneapi_memcpy2d<T>(Dest, DestPitch, Src, SrcPitch, Width,
-                                     Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Copies data from one 2D memory region to another, both pointed by
   /// USM pointers.
@@ -913,14 +897,7 @@ public:
   event ext_oneapi_copy2d(
       const T *Src, size_t SrcPitch, T *Dest, size_t DestPitch, size_t Width,
       size_t Height,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.ext_oneapi_copy2d<T>(Src, SrcPitch, Dest, DestPitch, Width,
-                                   Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Copies data from one 2D memory region to another, both pointed by
   /// USM pointers.
@@ -942,15 +919,7 @@ public:
   event ext_oneapi_copy2d(
       const T *Src, size_t SrcPitch, T *Dest, size_t DestPitch, size_t Width,
       size_t Height, event DepEvent,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvent);
-          CGH.ext_oneapi_copy2d<T>(Src, SrcPitch, Dest, DestPitch, Width,
-                                   Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Copies data from one 2D memory region to another, both pointed by
   /// USM pointers.
@@ -973,15 +942,7 @@ public:
   event ext_oneapi_copy2d(
       const T *Src, size_t SrcPitch, T *Dest, size_t DestPitch, size_t Width,
       size_t Height, const std::vector<event> &DepEvents,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvents);
-          CGH.ext_oneapi_copy2d<T>(Src, SrcPitch, Dest, DestPitch, Width,
-                                   Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Width or \param Height is zero. An
@@ -1003,13 +964,7 @@ public:
             typename = std::enable_if_t<std::is_same_v<T, unsigned char>>>
   event ext_oneapi_memset2d(
       void *Dest, size_t DestPitch, int Value, size_t Width, size_t Height,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.ext_oneapi_memset2d<T>(Dest, DestPitch, Value, Width, Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Width or \param Height is zero. An
@@ -1033,14 +988,7 @@ public:
   event ext_oneapi_memset2d(
       void *Dest, size_t DestPitch, int Value, size_t Width, size_t Height,
       event DepEvent,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvent);
-          CGH.ext_oneapi_memset2d<T>(Dest, DestPitch, Value, Width, Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Width or \param Height is zero. An
@@ -1065,14 +1013,7 @@ public:
   event ext_oneapi_memset2d(
       void *Dest, size_t DestPitch, int Value, size_t Width, size_t Height,
       const std::vector<event> &DepEvents,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvents);
-          CGH.ext_oneapi_memset2d<T>(Dest, DestPitch, Value, Width, Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Width or \param Height is zero. An
@@ -1091,13 +1032,7 @@ public:
   event ext_oneapi_fill2d(
       void *Dest, size_t DestPitch, const T &Pattern, size_t Width,
       size_t Height,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.ext_oneapi_fill2d<T>(Dest, DestPitch, Pattern, Width, Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Width or \param Height is zero. An
@@ -1117,14 +1052,7 @@ public:
   event ext_oneapi_fill2d(
       void *Dest, size_t DestPitch, const T &Pattern, size_t Width,
       size_t Height, event DepEvent,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvent);
-          CGH.ext_oneapi_fill2d<T>(Dest, DestPitch, Pattern, Width, Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Fills the memory pointed by a USM pointer with the value specified.
   /// No operations is done if \param Width or \param Height is zero. An
@@ -1145,14 +1073,7 @@ public:
   event ext_oneapi_fill2d(
       void *Dest, size_t DestPitch, const T &Pattern, size_t Width,
       size_t Height, const std::vector<event> &DepEvents,
-      const detail::code_location &CodeLoc = detail::code_location::current()) {
-    return submit(
-        [=](handler &CGH) {
-          CGH.depends_on(DepEvents);
-          CGH.ext_oneapi_fill2d<T>(Dest, DestPitch, Pattern, Width, Height);
-        },
-        CodeLoc);
-  }
+      const detail::code_location &CodeLoc = detail::code_location::current());
 
   /// Copies data from a USM memory region to a device_global.
   /// Throws an exception if the copy operation intends to write outside the

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -98,6 +98,7 @@
 #include <sycl/ext/oneapi/group_local_memory.hpp>
 #include <sycl/ext/oneapi/kernel_properties/properties.hpp>
 #include <sycl/ext/oneapi/matrix/matrix.hpp>
+#include <sycl/ext/oneapi/memcpy2d.hpp>
 #include <sycl/ext/oneapi/owner_less.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/ext/oneapi/properties/property_value.hpp>

--- a/sycl/include/sycl/usm.hpp
+++ b/sycl/include/sycl/usm.hpp
@@ -7,14 +7,14 @@
 // ===--------------------------------------------------------------------=== //
 #pragma once
 
-#include <sycl/builtins.hpp>      // for max
-#include <sycl/context.hpp>       // for context
-#include <sycl/detail/common.hpp> // for code_location
-#include <sycl/detail/export.hpp> // for __SYCL_EXPORT
-#include <sycl/device.hpp>        // for device
-#include <sycl/property_list.hpp> // for property_list
-#include <sycl/queue.hpp>         // for queue
-#include <sycl/usm/usm_enums.hpp> // for alloc
+#include <sycl/builtins.hpp>
+#include <sycl/context.hpp>
+#include <sycl/detail/common.hpp>
+#include <sycl/detail/export.hpp>
+#include <sycl/device.hpp>
+#include <sycl/property_list.hpp>
+#include <sycl/queue.hpp>
+#include <sycl/usm/usm_pointer_info.hpp>
 
 #include <algorithm> // for max
 #include <cstddef>   // for size_t

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -15,6 +15,9 @@
 #include <detail/queue_impl.hpp>
 #include <detail/xpti_registry.hpp>
 
+#include <sycl/usm/usm_enums.hpp>
+#include <sycl/usm/usm_pointer_info.hpp>
+
 #include <algorithm>
 #include <cassert>
 #include <cstring>

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -14,8 +14,8 @@
 #include <sycl/detail/pi.hpp>
 #include <sycl/device.hpp>
 #include <sycl/ext/intel/experimental/usm_properties.hpp>
-#include <sycl/usm.hpp>
 #include <sycl/ext/oneapi/memcpy2d.hpp>
+#include <sycl/usm.hpp>
 
 #include <array>
 #include <cassert>

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -15,6 +15,7 @@
 #include <sycl/device.hpp>
 #include <sycl/ext/intel/experimental/usm_properties.hpp>
 #include <sycl/usm.hpp>
+#include <sycl/ext/oneapi/memcpy2d.hpp>
 
 #include <array>
 #include <cassert>

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -29,6 +29,8 @@
 #include <sycl/info/info_desc.hpp>
 #include <sycl/stream.hpp>
 
+#include <sycl/ext/oneapi/memcpy2d.hpp>
+
 namespace sycl {
 inline namespace _V1 {
 

--- a/sycl/test-e2e/USM/memops2d/memops2d_utils.hpp
+++ b/sycl/test-e2e/USM/memops2d/memops2d_utils.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/memcpy2d.hpp>
 #include <sycl/usm.hpp>
 
 using namespace sycl;


### PR DESCRIPTION
`handler.hpp`/`queue.hpp` now contain declarations of the methods only,
definitions have been moved into a dedicated file. That way these
headers (and subsequently `sycl/detail/core.hpp`) don't need to depend on
`sycl/usm/*.hpp` headers.
