### PR TITLE
[SYCL-WEB][Test] Avoid hardcoding function attr number

### DIFF
--- a/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
+++ b/clang/test/CodeGenSYCL/check-direct-attribute-propagation.cpp
@@ -317,7 +317,7 @@ int main() {
 
     // Test attribute is not propagated.
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name32() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}Functor10{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) #{{.*}} comdat align 2
     // CHECK-NOT: noalias
     // CHECK-SAME: {
     // CHECK: define {{.*}}spir_func void @_Z4foo8v()
@@ -325,12 +325,12 @@ int main() {
     h.single_task<class kernel_name32>(f10);
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name33() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}Foo8{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #2 comdat align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}Foo8{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #{{.*}} comdat align 2
     Foo8 boo8;
     h.single_task<class kernel_name33>(boo8);
 
     // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name34() #0{{.*}} !kernel_arg_buffer_location ![[NUM]]
-    // CHECK: define {{.*}}spir_func void @{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #3 align 2
+    // CHECK: define {{.*}}spir_func void @{{.*}}(ptr addrspace(4) noalias noundef align 1 dereferenceable_or_null(1) %this) #{{.*}} align 2
     h.single_task<class kernel_name34>(
         []() [[intel::kernel_args_restrict]]{});
 


### PR DESCRIPTION
The function attribute number is not test point
hardcoding them is causing maintainece effort in pulldown.

eg:
* c68953ecd974 - (2023-11-30) [SYCL] Update CodeGenSYCL test due to attr change - sys_ce_bb

and
newly failure due to b433076fcbacba8a3b91446390bbea5843322bcd
