### PR TITLE
[CI] Enable post commit for sycl-web pushes

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -6,6 +6,7 @@ on:
     - sycl
     - sycl-devops-pr/**
     - sycl-rel-**
+    - sycl-web
 
   pull_request:
     branches:


### PR DESCRIPTION
In we may get regressions almost every pulldown, we currently only
expose them when we create the pulldown PR. The pulldown may be delayed
if we get multiple failures.
This is to enable post commit CI to pushes to sycl-web so that we can
know the regressions ealier and may fix the regressions earlier to avoid
delay to pulldown.

This will just add 2-3 post commits run per day.

```
$git ld3 --merges --since 2023-01-01|grep 'Merge.*sycl-web'|wc
893   11747   76149
$ git ld3 --merges --since 2024-01-01|grep 'Merge.*sycl-web'|wc
131 1696 11014
$ git ld3 --merges --since 2024-02-01|grep 'Merge.*sycl-web'|wc
86 1113 7215
$ git ld3 --merges --since 2024-03-01|grep 'Merge.*sycl-web'|wc
53 692 4446

workdays since 2023-01-01 305
workdays since 2024-01-01 57
workdays since 2024-02-01 36
workdays since 2024-03-01 16

893/305 = 2.9
131/57 = 2.3
86/36 = 2.4
53/16 = 3.3
```