### PR TITLE
[SYCL][Doc] Correct range-rounding link

### DIFF
--- a/sycl/doc/EnvironmentVariables.md
+++ b/sycl/doc/EnvironmentVariables.md
@@ -280,4 +280,4 @@ variables in production code.</span>
 `(*) Note: Any means this environment variable is effective when set to any non-null value.`
 
 [xpti]: https://github.com/intel/llvm/blob/sycl/xptifw/doc/XPTI_Framework.md
-[range-rounding]: https://github.com/intel/llvm/blob/sycl/doc/design/ParallelForRangeRounding.md
+[range-rounding]: https://github.com/intel/llvm/blob/sycl/sycl/doc/design/ParallelForRangeRounding.md


### PR DESCRIPTION
Just try to fix a broken link found when reading https://intel.github.io/llvm-docs/EnvironmentVariables.html