### PR TITLE
[SYCL] Adjust GCC workaround and its scope

### DIFF
--- a/sycl/source/builtins/relational_functions.cpp
+++ b/sycl/source/builtins/relational_functions.cpp
@@ -71,17 +71,34 @@ REL_BUILTIN(ONE_ARG, isnormal)
 REL_BUILTIN(TWO_ARGS, isunordered)
 REL_BUILTIN_CUSTOM(TWO_ARGS, isordered,
                    ([](auto x, auto y) { return !sycl::isunordered(x, y); }))
-#if defined(__GNUC__) && !defined(__clang__)
+
+#define GCC_VERSION                                                            \
+  (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
+
+#if defined(__GNUC__) && !defined(__clang__) &&                                \
+    ((GCC_VERSION >= 100000 && GCC_VERSION < 110000) ||                        \
+     (GCC_VERSION >= 110000 && GCC_VERSION < 110500) ||                        \
+     (GCC_VERSION >= 120000 && GCC_VERSION < 120400) ||                        \
+     (GCC_VERSION >= 130000 && GCC_VERSION < 130300))
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112816
-#pragma GCC push_options
-#pragma GCC optimize("-O2")
+// The reproducers in that ticket only affect GCCs 10 to 13. Release
+// branches 11.5, 12.4, and 13.3 have been updated with the fix; release branch
+// 10 hasn't, so all GCCs 10.x are considered affected.
+#define GCC_PR112816_DISABLE_OPT                                               \
+  _Pragma("GCC push_options") _Pragma("GCC optimize(\"-O1\")")
+#define GCC_PR112816_RESTORE_OPT _Pragma("GCC pop_options")
+#else
+#define GCC_PR112816_DISABLE_OPT
+#define GCC_PR112816_RESTORE_OPT
 #endif
+
+GCC_PR112816_DISABLE_OPT
 
 REL_BUILTIN(ONE_ARG, signbit)
 
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC pop_options
-#endif
+GCC_PR112816_RESTORE_OPT
+
+#undef GCC_VERSION
 
 HOST_IMPL(bitselect, [](auto x, auto y, auto z) {
   using T0 = decltype(x);

--- a/sycl/source/builtins/relational_functions.cpp
+++ b/sycl/source/builtins/relational_functions.cpp
@@ -72,14 +72,14 @@ REL_BUILTIN(TWO_ARGS, isunordered)
 REL_BUILTIN_CUSTOM(TWO_ARGS, isordered,
                    ([](auto x, auto y) { return !sycl::isunordered(x, y); }))
 
-#define GCC_VERSION                                                            \
+#define _SYCL_BUILTINS_GCC_VER                                                 \
   (__GNUC__ * 10000 + __GNUC_MINOR__ * 100 + __GNUC_PATCHLEVEL__)
 
 #if defined(__GNUC__) && !defined(__clang__) &&                                \
-    ((GCC_VERSION >= 100000 && GCC_VERSION < 110000) ||                        \
-     (GCC_VERSION >= 110000 && GCC_VERSION < 110500) ||                        \
-     (GCC_VERSION >= 120000 && GCC_VERSION < 120400) ||                        \
-     (GCC_VERSION >= 130000 && GCC_VERSION < 130300))
+    ((_SYCL_BUILTINS_GCC_VER >= 100000 && _SYCL_BUILTINS_GCC_VER < 110000) ||  \
+     (_SYCL_BUILTINS_GCC_VER >= 110000 && _SYCL_BUILTINS_GCC_VER < 110500) ||  \
+     (_SYCL_BUILTINS_GCC_VER >= 120000 && _SYCL_BUILTINS_GCC_VER < 120400) ||  \
+     (_SYCL_BUILTINS_GCC_VER >= 130000 && _SYCL_BUILTINS_GCC_VER < 130300))
 // https://gcc.gnu.org/bugzilla/show_bug.cgi?id=112816
 // The reproducers in that ticket only affect GCCs 10 to 13. Release
 // branches 11.5, 12.4, and 13.3 have been updated with the fix; release branch
@@ -98,7 +98,9 @@ REL_BUILTIN(ONE_ARG, signbit)
 
 GCC_PR112816_RESTORE_OPT
 
-#undef GCC_VERSION
+#undef GCC_PR112816_RESTORE_OPT
+#undef GCC_PR112816_DISABLE_OPT
+#undef _SYCL_BUILTINS_GCC_VER
 
 HOST_IMPL(bitselect, [](auto x, auto y, auto z) {
   using T0 = decltype(x);


### PR DESCRIPTION
Previously we were hard-coding an -O2 optimization level for the 'signbit' builtin for all versions of GCC.

Despite this workaround, I found locally that I was unable to build with GCC versions 12.2, 12.3, and 13.2. Reducing the optimization level to -O1 allowed me to progress. This seems to follow the bug report already linked, which had test cases at -O2 which were also failing.

With this in mind, we can also restrict the GCC versions we apply the workaround to, so that more modern compilers should "just work" without us having to do anything. That should save someone having to investigate a performance report a year or so down the line...