### PR TITLE
[WIP][DO NOT MERGE] temp fix to null programimpl. 

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2604,7 +2604,13 @@ pi_int32 enqueueImpKernel(
            Queue->get_context());
     Kernel = MSyclKernel->getHandleRef();
     auto SyclProg = MSyclKernel->getProgramImpl();
-    Program = SyclProg->getHandleRef();
+    if (SyclProg != nullptr) {
+      Program = SyclProg->getHandleRef();
+    } else {
+      DeviceImageImpl = MSyclKernel->getDeviceImage();
+      Program = DeviceImageImpl->get_program_ref();
+    }
+
     // Non-cacheable kernels use mutexes from kernel_impls.
     // TODO this can still result in a race condition if multiple SYCL
     // kernels are created with the same native handle. To address this,


### PR DESCRIPTION
ProgramImpl on kernel might be null, get from device image in that case. Investigation ongoing, but I wanted to put this up as workaround for @rdeodhar 