### PR TITLE
[NFC][SYCL] Set target restriction for LIT test:SemaSYCL/lb_sm_90.cpp

### DIFF
--- a/clang/test/SemaSYCL/lb_sm_90.cpp
+++ b/clang/test/SemaSYCL/lb_sm_90.cpp
@@ -1,5 +1,7 @@
 // RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -fsyntax-only -Wno-c++23-extensions -verify -S -o %t
 
+// REQUIRES: nvptx64-nvidia-cuda
+
 // Maximum work groups per multi-processor, mapped to maxclusterrank PTX
 // directive, is an SM_90 feature. Attributes need to be used in sequence:
 // max_work_group_size, min_work_groups_per_cu, max_work_groups_per_mp, warn on


### PR DESCRIPTION
Lit test SemaSYCL/lb_sm_90.cpp that requires nvptx target to be built in order to properly run. This patch adds this requirement to the test.

Driver tests were fixed on https://github.com/intel/llvm/pull/12505

Fixes https://github.com/intel/llvm/issues/12091