### PR TITLE
[SYCL][E2E] Enable image_selection.cpp for level zero.

### DIFF
--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: (opencl || level-zero) && gpu && ocloc
+// REQUIRES: (opencl || level_zero) && gpu && ocloc
 
 // Check the case when -fsycl-add-default-spec-consts-image option is used which
 // results in generation of two types of images: where specialization constants


### PR DESCRIPTION
`image_selection.cpp` test was skipped for level zero backend because the proper spelling is `level_zero` (underscore) rather than `level-zero` (dash). This patch corrects such an error.