### PR TITLE
[SYCL][Graph][Doc] Remove outdated limitation from spec

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1881,8 +1881,6 @@ if used in application code.
 
 . Using reductions in a graph node.
 . Using sycl streams in a graph node.
-. Profiling an event returned from graph submission with
-  `event::get_profiling_info()`.
 . Synchronization between multiple executions of the same command-buffer 
   must be handled in the host for level-zero backend, which may involve 
   extra latency for subsequent submissions.


### PR DESCRIPTION
Merged PR https://github.com/intel/llvm/pull/11324 introduced the ability to profile an executable graph submission. However, the specification limitation section was not updated to reflect this, which is addressed in this PR.