### PR TITLE
[SYCL][FPGA] Allow tablegen handle mutually exclusive decl attrs (SYCLIntelRegister and SYCLIntelMemory)

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -2779,6 +2779,7 @@ def SYCLIntelForcePow2Depth : InheritableAttr {
   let Documentation = [SYCLIntelForcePow2DepthAttrDocs];
 }
 def : MutualExclusions<[SYCLIntelRegister, SYCLIntelForcePow2Depth]>;
+def : MutualExclusions<[SYCLIntelRegister, SYCLIntelMemory]>;
 
 def Naked : InheritableAttr {
   let Spellings = [GCC<"naked">, Declspec<"naked">];

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -7617,9 +7617,6 @@ static void handleSYCLIntelDoublePumpAttr(Sema &S, Decl *D,
 /// Handle the [[intel::fpga_memory]] attribute.
 /// This is incompatible with the [[intel::fpga_register]] attribute.
 static void handleSYCLIntelMemoryAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
-  if (checkAttrMutualExclusion<SYCLIntelRegisterAttr>(S, D, AL))
-    return;
-
   SYCLIntelMemoryAttr::MemoryKind Kind;
   if (AL.getNumArgs() == 0)
     Kind = SYCLIntelMemoryAttr::Default;
@@ -7665,19 +7662,6 @@ static void handleSYCLIntelMemoryAttr(Sema &S, Decl *D, const ParsedAttr &AL) {
   D->addAttr(::new (S.Context) SYCLIntelMemoryAttr(S.Context, AL, Kind));
 }
 
-/// Check for and diagnose attributes incompatible with register.
-/// return true if any incompatible attributes exist.
-static bool checkIntelFPGARegisterAttrCompatibility(Sema &S, Decl *D,
-                                                    const ParsedAttr &Attr) {
-  bool InCompat = false;
-  if (auto *MA = D->getAttr<SYCLIntelMemoryAttr>())
-    if (!MA->isImplicit() &&
-        checkAttrMutualExclusion<SYCLIntelMemoryAttr>(S, D, Attr))
-      InCompat = true;
-
-  return InCompat;
-}
-
 /// Handle the [[intel::fpga_register]] attribute.
 /// This is incompatible with most of the other memory attributes.
 static void handleSYCLIntelRegisterAttr(Sema &S, Decl *D,
@@ -7705,10 +7689,7 @@ static void handleSYCLIntelRegisterAttr(Sema &S, Decl *D,
     return;
   }
 
-  if (checkIntelFPGARegisterAttrCompatibility(S, D, A))
-    return;
-
-  handleSimpleAttribute<SYCLIntelRegisterAttr>(S, D, A);
+  D->addAttr(::new (S.Context) SYCLIntelRegisterAttr(S.Context, A));
 }
 
 /// Handle the [[intel::bankwidth]] and [[intel::numbanks]] attributes.

--- a/clang/test/SemaSYCL/intel-fpga-local.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-local.cpp
@@ -67,11 +67,17 @@ void diagnostics()
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_dpump[64];
 
-  //expected-error@+2{{attributes are not compatible}}
+  //expected-error@+2{{'fpga_memory' and 'fpga_register' attributes are not compatible}}
   [[intel::fpga_register]]
   [[intel::fpga_memory]]
   //expected-note@-2 {{conflicting attribute is here}}
   unsigned int reg_memory[64];
+
+  //expected-error@+2{{'fpga_register' and 'fpga_memory' attributes are not compatible}}
+  [[intel::fpga_memory]]
+  [[intel::fpga_register]]
+  //expected-note@-2 {{conflicting attribute is here}}
+  unsigned int reg_fp_memory[64];
 
   //expected-error@+2{{'bank_bits' and 'fpga_register' attributes are not compatible}}
   [[intel::fpga_register]]


### PR DESCRIPTION
This patch uses MutualExclusions tablegen support to allow us to remove a custom diagnostic checking codes with FPGA attributes: [[intel:fpga_register]] and [[intel::fpga_memory]].
