### PR TITLE
[Driver][SYCL] Update visibility of option to allow for clang-cl usage

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -3913,12 +3913,12 @@ def fsycl_device_code_split_esimd : Flag<["-"], "fsycl-device-code-split-esimd">
 def fno_sycl_device_code_split_esimd : Flag<["-"], "fno-sycl-device-code-split-esimd">,
   Visibility<[ClangOption, CLOption, DXCOption]>, HelpText<"do not split ESIMD and SYCL device code into separate device binary images. Has effect only for SPIR-based targets. (experimental)">;
 defm sycl_add_default_spec_consts_image : BoolOptionWithoutMarshalling<"f", "sycl-add-default-spec-consts-image",
-  PosFlag<SetTrue, [], [ClangOption],
+  PosFlag<SetTrue, [], [ClangOption, CLOption],
            "Generates a copy of every device image that uses a specialization constant and "
            "replaces all usages of specialization constant with default values specified by specialization_id. "
            "If a device image doesn't use a specialization constant at all then no copy is generated. "
            "This option is only useful if used in conjunction with Ahead of Time Compilation (-fsycl-target command line option).">,
-  NegFlag<SetFalse, [], [ClangOption],
+  NegFlag<SetFalse, [], [ClangOption, CLOption],
            "Turns off generation of device image where all specialization constant usages are replaced "
            "with default values.">
 >;

--- a/clang/test/Driver/sycl-add-default-spec-consts-image.cpp
+++ b/clang/test/Driver/sycl-add-default-spec-consts-image.cpp
@@ -2,6 +2,7 @@
 
 // Check usages when warning should be issued.
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image 2>&1 %s | FileCheck %s -check-prefix=CHECK-NON-AOT
+// RUN: %clang_cl -### -fsycl -fsycl-add-default-spec-consts-image 2>&1 %s | FileCheck %s -check-prefix=CHECK-NON-AOT
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image -fsycl-targets=spir64 2>&1 %s | FileCheck %s -check-prefix=CHECK-NON-AOT
 // CHECK-NON-AOT: warning: -fsycl-add-default-spec-consts-image flag has an effect only in Ahead of Time Compilation mode (AOT).
 
@@ -20,4 +21,5 @@
 
 
 // RUN: %clang -### -fsycl -fno-sycl-add-default-spec-consts-image -fsycl-targets=spir64_gen 2>&1  %s | FileCheck %s -check-prefix=CHECK-NO-ADD
+// RUN: %clang_cl -### -fsycl -fno-sycl-add-default-spec-consts-image -fsycl-targets=spir64_gen 2>&1  %s | FileCheck %s -check-prefix=CHECK-NO-ADD
 // CHECK-NO-ADD-NOT: {{.*}}sycl-post-link{{.*}} "-generate-device-image-default-spec-consts"


### PR DESCRIPTION
The -fsycl-add-default-spec-consts-image was added to only be used from the clang and clang++ command lines.  Update this to also allow for clang-cl usage, better matching the other fsycl based options.