### PR TITLE
[SYCL][E2E] Update expected output to work with Windows

### DIFF
--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -73,7 +73,7 @@ int main() {
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-DEFAULT-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-DEFAULT-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT: Default value of specialization constant was used.
 
@@ -82,7 +82,7 @@ int main() {
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-DEFAULT-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-DEFAULT-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT: New specialization constant value was set.
 
@@ -91,7 +91,7 @@ int main() {
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-DEFAULT-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-DEFAULT-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT: Default value of specialization constant was used.
 
@@ -100,7 +100,7 @@ int main() {
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-DEFAULT-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-DEFAULT-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT: New specialization constant value was set.
 
@@ -109,7 +109,7 @@ int main() {
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
-  // CHECK-ENABLED-NEXT:	<unknown> : 0
+  // CHECK-ENABLED-NEXT:	<unknown> : {{0+}}
   // CHECK-ENABLED-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-ENABLED: Default value of specialization constant was used.
 
@@ -118,7 +118,7 @@ int main() {
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
-  // CHECK-ENABLED-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-ENABLED-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-ENABLED-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-ENABLED: New specialization constant value was set.
 
@@ -127,7 +127,7 @@ int main() {
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
-  // CHECK-ENABLED-NEXT:	<unknown> : 0
+  // CHECK-ENABLED-NEXT:	<unknown> : {{0+}}
   // CHECK-ENABLED-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-ENABLED: Default value of specialization constant was used.
 
@@ -136,7 +136,7 @@ int main() {
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
-  // CHECK-ENABLED-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-ENABLED-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-ENABLED-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-ENABLED: New specialization constant value was set.
 
@@ -181,7 +181,7 @@ int main() {
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-NEXT:	<unknown> : 0x{{[0-9,a-f]+}}
+  // CHECK-DEFAULT-NEXT:	<unknown> : {{(0x)?[0-9,a-f,A-F]+}}
   // CHECK-DEFAULT-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT: Default value of specialization constant was used.
 
@@ -190,7 +190,7 @@ int main() {
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
   // CHECK-ENABLED-NEXT:	<unknown> : {{.*}}
-  // CHECK-ENABLED-NEXT:	<unknown> : 0
+  // CHECK-ENABLED-NEXT:	<unknown> : {{0+}}
   // CHECK-ENABLED-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-ENABLED: Default value of specialization constant was used.
 
@@ -223,7 +223,7 @@ int main() {
   // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : 0
+  // CHECK-DEFAULT-EXPLICIT-SET-NEXT:	<unknown> : {{0+}}
   // CHECK-DEFAULT-EXPLICIT-SET-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT-EXPLICIT-SET: Default value of specialization constant was used.
   std::cout << "Default value was explicitly set" << std::endl;
@@ -251,7 +251,7 @@ int main() {
   // CHECK-DEFAULT-BACK-TO-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-BACK-TO-DEFAULT-NEXT:	<unknown> : {{.*}}
   // CHECK-DEFAULT-BACK-TO-DEFAULT-NEXT:	<unknown> : {{.*}}
-  // CHECK-DEFAULT-BACK-TO-DEFAULT-NEXT:	<unknown> : 0
+  // CHECK-DEFAULT-BACK-TO-DEFAULT-NEXT:	<unknown> : {{0+}}
   // CHECK-DEFAULT-BACK-TO-DEFAULT-NEXT: ) ---> 	pi_result : PI_SUCCESS
   // CHECK-DEFAULT-BACK-TO-DEFAULT: Default value of specialization constant was used.
   std::cout << "Changed to new value and then default value was explicitly set"


### PR DESCRIPTION
`SYCL_PI_TRACE` log in Windows have some differences compared to Linux:

- Hexadecimal values don't start with `0x`, so this patch makes it optional.
- Hexadecimal values are printed with capital letters (A-F), so this patch accounts for that.
- Zero value is printed like `0000000000000000`, rather than simply `0` like in Linux. This patch accounts for that.