### PR TITLE
[CI][OSSF] Add default permissions to work flows

### DIFF
--- a/.github/workflows/sycl-aws.yml
+++ b/.github/workflows/sycl-aws.yml
@@ -1,5 +1,7 @@
 name: Start/Stop AWS instance
 
+permissions: read-all
+
 on:
   workflow_call:
     inputs:

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -21,6 +21,8 @@ on:
       - 'devops/scripts/install_build_tools.sh'
       - '.github/workflows/sycl-containers.yaml'
 
+permissions: read-all
+
 jobs:
   base_image_ubuntu2204:
     if: github.repository == 'intel/llvm'

--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -7,6 +7,8 @@ on:
         description: Matched filters
         value: ${{ jobs.need_check.outputs.filters }}
 
+permissions: read-all
+
 jobs:
   need_check:
     name: Decide which tests could be affected by the changes

--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -11,8 +11,13 @@ on:
     - 'clang/docs/**'
     - 'sycl/doc/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     if: github.repository == 'intel/llvm'
     steps:

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -103,6 +103,9 @@ on:
         options:
           - 3
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build + LIT

--- a/.github/workflows/sycl-linux-matrix-e2e-on-nightly.yml
+++ b/.github/workflows/sycl-linux-matrix-e2e-on-nightly.yml
@@ -10,6 +10,9 @@ on:
           Format: '{"VAR1":"VAL1","VAR2":"VAL2",...}'
         default: '{"LIT_FILTER":""}'
 
+permissions:
+  contents: read
+
 jobs:
   linux_e2e_on_nightly:
     name: E2E on Nightly

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -14,6 +14,9 @@ on:
     types:
       - completed
 
+permissions:
+  contents: read
+
 jobs:
   create-check:
     runs-on: [Linux, build]

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   detect_changes:
     uses: ./.github/workflows/sycl-detect-changes.yml

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -132,6 +132,9 @@ on:
           - false
           - true
 
+permissions:
+  contents: read
+
 jobs:
   run:
     name: ${{ inputs.name }}

--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -19,6 +19,9 @@ on:
         required: false
         default: ""
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   ubuntu2204_build:
     if: github.repository == 'intel/llvm'

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -19,6 +19,9 @@ on:
     - ./devops/actions/cleanup
     - ./devops/actions/cached_checkout
 
+permissions:
+  contents: read
+
 jobs:
   build-lin:
     name: Linux (Self build + shared libraries + no-assertions)

--- a/.github/workflows/sycl-stale-issues.yml
+++ b/.github/workflows/sycl-stale-issues.yml
@@ -4,8 +4,14 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   close-issues:
+    permissions:
+      issues: write  # for actions/stale to close stale issues
+      pull-requests: write  # for actions/stale to close stale PRs
     runs-on: ubuntu-20.04
     steps:
     - uses: actions/stale@v9

--- a/.github/workflows/sycl-sync-main.yml
+++ b/.github/workflows/sycl-sync-main.yml
@@ -3,8 +3,13 @@ name: main branch sync
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sync:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-20.04
     if: github.repository == 'intel/llvm'
     steps:

--- a/.github/workflows/sycl-update-gpu-driver.yml
+++ b/.github/workflows/sycl-update-gpu-driver.yml
@@ -5,8 +5,13 @@ on:
     - cron:  '0 3 * * 2'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   update_driver_linux:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-20.04
     if: github.repository == 'intel/llvm'
     steps:

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -50,6 +50,8 @@ on:
         type: choice
         options:
           - 3
+permissions:
+  contents: read
 
 jobs:
   build:

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -32,6 +32,10 @@ on:
         type: string
         default: '{}'
         required: False
+
+permissions:
+  contents: read
+
 jobs:
   run:
     name: ${{ inputs.name }}


### PR DESCRIPTION
per OSSF (https://securityscorecards.dev/viewer/?uri=github.com/intel/llvm) all workflows should have default top level permission set. Which we set to below as per recommendation

permissions:
  contents: read

then within actual jobs, when needed, we added additional privileges. 

These changes were generated by the recommended OSSF tool 

This PR changes those workflows created/owned by intel/llvm repo. Will do seperate PR for issues found in llvm/llvm-project inherited workflows. 