### PR TITLE
[SYCL][E2E] Allow setting amd_arch through a parameter

### DIFF
--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -184,8 +184,10 @@ Defaults to AMD if no value is given. Supported values are:
  - **AMD**    - for HIP to target AMD GPUs
  - **NVIDIA** - for HIP to target NVIDIA GPUs
  
- ***AMD_ARCH*** - flag must be set for when using HIP AMD triple.
- For example it may be set to "gfx906".
+***AMD_ARCH*** - flag may be set for when using HIP AMD triple. For example it
+may be set to "gfx906". Otherwise must be provided via the ***amd_arch*** LIT
+parameter (e.g., ***--param amd_arch=gfx906***) at runtime via the command line
+or via the ***LIT_OPTS*** environment variable.
 
 ***GPU_AOT_TARGET_OPTS*** - defines additional options which are passed to AOT
 compilation command line for GPU device. If not specified "-device *" value

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -464,9 +464,10 @@ if "cuda:gpu" in config.sycl_devices:
 if "hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":
     if not config.amd_arch:
         lit_config.error(
-            "Cannot run tests for HIP without an offload-arch. Please " +
-            "specify one via the 'amd_arch' parameter or 'AMD_ARCH' CMake "
-            "variable.")
+            "Cannot run tests for HIP without an offload-arch. Please "
+            + "specify one via the 'amd_arch' parameter or 'AMD_ARCH' CMake "
+            + "variable."
+        )
     llvm_config.with_system_environment("ROCM_PATH")
     config.available_features.add("hip_amd")
     arch_flag = (

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -462,6 +462,11 @@ if "cuda:gpu" in config.sycl_devices:
 
 # FIXME: This needs to be made per-device as well, possibly with a helper.
 if "hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":
+    if not config.amd_arch:
+        lit_config.error(
+            "Cannot run tests for HIP without an offload-arch. Please " +
+            "specify one via the 'amd_arch' parameter or 'AMD_ARCH' CMake "
+            "variable.")
     llvm_config.with_system_environment("ROCM_PATH")
     config.available_features.add("hip_amd")
     arch_flag = (

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -29,7 +29,7 @@ config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
 config.sycl_devices = lit_config.params.get("sycl_devices", "@SYCL_TEST_E2E_TARGETS@").split(';')
 
 config.hip_platform = "@HIP_PLATFORM@"
-config.amd_arch = "@AMD_ARCH@"
+config.amd_arch = lit_config.params.get("amd_arch", "@AMD_ARCH@")
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
 config.extra_environment = lit_config.params.get("extra_environment", "@LIT_EXTRA_ENVIRONMENT@")
 config.cxx_flags = "@SYCL_E2E_CLANG_CXX_FLAGS@"


### PR DESCRIPTION
Also provide a more helpful error message when it is not provided.

This should make it more intuitive and easier to test multiple different architectures without having to reconfigure CMake.