### PR TITLE
[CI] Fix bad OSSF recomendations 

### DIFF
--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -11,8 +11,7 @@ on:
     - 'clang/docs/**'
     - 'sycl/doc/**'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/sycl-linux-build.yml
+++ b/.github/workflows/sycl-linux-build.yml
@@ -103,8 +103,7 @@ on:
         options:
           - 3
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/sycl-linux-matrix-e2e-on-nightly.yml
+++ b/.github/workflows/sycl-linux-matrix-e2e-on-nightly.yml
@@ -10,8 +10,7 @@ on:
           Format: '{"VAR1":"VAL1","VAR2":"VAL2",...}'
         default: '{"LIT_FILTER":""}'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   linux_e2e_on_nightly:

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -29,8 +29,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   detect_changes:

--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -19,8 +19,7 @@ on:
         required: false
         default: ""
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -5,8 +5,7 @@ on:
   schedule:
     - cron: '0 3 * * *'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   ubuntu2204_build:

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -19,8 +19,7 @@ on:
     - ./devops/actions/cleanup
     - ./devops/actions/cached_checkout
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build-lin:

--- a/.github/workflows/sycl-stale-issues.yml
+++ b/.github/workflows/sycl-stale-issues.yml
@@ -4,8 +4,7 @@ on:
   schedule:
     - cron: '30 1 * * *'
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   close-issues:

--- a/.github/workflows/sycl-sync-main.yml
+++ b/.github/workflows/sycl-sync-main.yml
@@ -3,8 +3,7 @@ name: main branch sync
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   sync:

--- a/.github/workflows/sycl-update-gpu-driver.yml
+++ b/.github/workflows/sycl-update-gpu-driver.yml
@@ -5,8 +5,7 @@ on:
     - cron:  '0 3 * * 2'
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   update_driver_linux:

--- a/.github/workflows/sycl-windows-build.yml
+++ b/.github/workflows/sycl-windows-build.yml
@@ -50,8 +50,7 @@ on:
         type: choice
         options:
           - 3
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   build:

--- a/.github/workflows/sycl-windows-precommit.yml
+++ b/.github/workflows/sycl-windows-precommit.yml
@@ -23,8 +23,7 @@ on:
     - 'devops/containers/**'
     - 'devops/actions/build_container/**'
 
-permissions:
-  contents: read
+permissions: read-all
 
 concurrency:
   #  Cancel a currently running workflow from the same PR, branch or tag.

--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -33,8 +33,7 @@ on:
         default: '{}'
         required: False
 
-permissions:
-  contents: read
+permissions: read-all
 
 jobs:
   run:


### PR DESCRIPTION
the OSSF tool sucks and don't use its recommended default settings. It suggested permissions content:read as default, but that broke most of our workflows, instead use the GitHub recommended

permissions: read-all