### PR TITLE
[SYCL] Fix multi_ptr relational operators customised for nullptr.

### DIFF
--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -1546,70 +1546,80 @@ template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator==(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
                 std::nullptr_t) {
-  return lhs.get() == nullptr;
+  return lhs.get() ==
+         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator==(std::nullptr_t,
                 const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
-  return rhs.get() == nullptr;
+  return rhs.get() ==
+         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator>(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
                std::nullptr_t) {
-  return lhs.get() != nullptr;
+  return lhs.get() >
+         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator>(std::nullptr_t,
-               const multi_ptr<ElementType, Space, DecorateAddress> &) {
-  return false;
+               const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
+  return multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get() >
+         rhs.get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
-bool operator<(const multi_ptr<ElementType, Space, DecorateAddress> &,
+bool operator<(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
                std::nullptr_t) {
-  return false;
+  return lhs.get() <
+         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator<(std::nullptr_t,
                const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
-  return rhs.get() != nullptr;
+  return multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get() <
+         rhs.get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
-bool operator>=(const multi_ptr<ElementType, Space, DecorateAddress> &,
+bool operator>=(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
                 std::nullptr_t) {
-  return true;
+  return lhs.get() >=
+         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator>=(std::nullptr_t,
                 const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
-  return rhs.get() == nullptr;
+  return multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get() >=
+         rhs.get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator<=(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
                 std::nullptr_t) {
-  return lhs.get() == nullptr;
+  return lhs.get() <=
+         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator<=(std::nullptr_t,
-                const multi_ptr<ElementType, Space, DecorateAddress> &) {
-  return true;
+                const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
+  return multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get() <=
+         rhs.get();
 }
 
 } // namespace _V1

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -1546,16 +1546,14 @@ template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator==(const multi_ptr<ElementType, Space, DecorateAddress> &lhs,
                 std::nullptr_t) {
-  return lhs.get() ==
-         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
+  return lhs.get() == nullptr;
 }
 
 template <typename ElementType, access::address_space Space,
           access::decorated DecorateAddress>
 bool operator==(std::nullptr_t,
                 const multi_ptr<ElementType, Space, DecorateAddress> &rhs) {
-  return rhs.get() ==
-         multi_ptr<ElementType, Space, DecorateAddress>(nullptr).get();
+  return rhs.get() == nullptr;
 }
 
 template <typename ElementType, access::address_space Space,

--- a/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
@@ -1,55 +1,86 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/multi_ptr.hpp>
 
-template <typename multi_ptr_t> void nullptrRelationalOperatorTest() {
-  constexpr int OUTPUT_SIZE = 8;
-  bool output[OUTPUT_SIZE];
+template <typename T, typename AccessorType,
+          sycl::access::address_space address_space,
+          sycl::access::decorated decorated>
+void check(sycl::multi_ptr<T, address_space, decorated> &mp,
+           AccessorType &dev_acc) {
+  using multi_ptr_t = sycl::multi_ptr<T, address_space, decorated>;
+  multi_ptr_t null_mp;
+  dev_acc[0] = nullptr == null_mp;
+  dev_acc[0] += nullptr != mp;
+  dev_acc[0] += std::less<multi_ptr_t>()(nullptr, mp) == nullptr < mp;
+  dev_acc[0] += std::less<multi_ptr_t>()(mp, nullptr) == mp < nullptr;
+  dev_acc[0] += std::less_equal<multi_ptr_t>()(nullptr, mp) == nullptr <= mp;
+  dev_acc[0] += std::less_equal<multi_ptr_t>()(mp, nullptr) == mp <= nullptr;
+  dev_acc[0] += std::greater<multi_ptr_t>()(nullptr, mp) == nullptr > mp;
+  dev_acc[0] += std::greater<multi_ptr_t>()(mp, nullptr) == mp > nullptr;
+  dev_acc[0] += std::greater_equal<multi_ptr_t>()(nullptr, mp) == nullptr >= mp;
+  dev_acc[0] += std::greater_equal<multi_ptr_t>()(mp, nullptr) == mp >= nullptr;
+}
+
+template <typename T, sycl::access::address_space address_space,
+          sycl::access::decorated decorated>
+void nullptrRelationalOperatorTest() {
+  using multi_ptr_t = sycl::multi_ptr<int, address_space, decorated>;
   try {
     sycl::queue queue;
-    sycl::buffer<bool, 1> buf(output, sycl::range<1>(OUTPUT_SIZE));
+    sycl::buffer<int, 1> buf(1);
     queue
         .submit([&](sycl::handler &cgh) {
           auto dev_acc = buf.get_access<sycl::access::mode::write>(cgh);
-          sycl::local_accessor<bool, 1> locAcc(1, cgh);
-          cgh.parallel_for(sycl::nd_range<1>{1, 1}, [=](sycl::id<1>) {
-            locAcc[0] = 10;
-            multi_ptr_t mp(locAcc);
-            dev_acc[0] = std::less<multi_ptr_t>()(nullptr, mp) == nullptr < mp;
-            dev_acc[1] = std::less<multi_ptr_t>()(mp, nullptr) == mp < nullptr;
-            dev_acc[2] =
-                std::less_equal<multi_ptr_t>()(nullptr, mp) == nullptr <= mp;
-            dev_acc[3] =
-                std::less_equal<multi_ptr_t>()(mp, nullptr) == mp <= nullptr;
-            dev_acc[4] =
-                std::greater<multi_ptr_t>()(nullptr, mp) == nullptr > mp;
-            dev_acc[5] =
-                std::greater<multi_ptr_t>()(mp, nullptr) == mp > nullptr;
-            dev_acc[6] =
-                std::greater_equal<multi_ptr_t>()(nullptr, mp) == nullptr >= mp;
-            dev_acc[7] =
-                std::greater_equal<multi_ptr_t>()(mp, nullptr) == mp >= nullptr;
-          });
+          if constexpr (address_space ==
+                        sycl::access::address_space::local_space) {
+            sycl::local_accessor<int, 1> locAcc(1, cgh);
+            cgh.parallel_for(sycl::nd_range<1>{1, 1}, [=](sycl::id<1>) {
+              locAcc[0] = 1;
+              multi_ptr_t mp(locAcc);
+              check(mp, dev_acc);
+            });
+          } else if constexpr (address_space ==
+                               sycl::access::address_space::private_space) {
+            cgh.single_task([=] {
+              T priv_arr[1];
+              sycl::multi_ptr<T, address_space, decorated> mp =
+                  sycl::address_space_cast<address_space, decorated>(priv_arr);
+              check(mp, dev_acc);
+            });
+          } else {
+            cgh.single_task([=] {
+              multi_ptr_t mp(dev_acc);
+              check(mp, dev_acc);
+            });
+          }
         })
         .wait_and_throw();
+    assert(sycl::host_accessor{buf}[0] == 10);
   } catch (sycl::exception e) {
     std::cout << "SYCL exception caught: " << e.what();
     return;
   }
-  for (int index = 0; index < OUTPUT_SIZE; ++index) {
-    assert(output[index] && "Unexpected relational operator result.");
-  }
 }
 
 int main() {
-  using multi_ptr_yes =
-      sycl::multi_ptr<bool, sycl::access::address_space::local_space,
-                      sycl::access::decorated::yes>;
-  using multi_ptr_no =
-      sycl::multi_ptr<bool, sycl::access::address_space::local_space,
-                      sycl::access::decorated::no>;
-  nullptrRelationalOperatorTest<multi_ptr_yes>();
-  nullptrRelationalOperatorTest<multi_ptr_no>();
+  nullptrRelationalOperatorTest<bool, sycl::access::address_space::local_space,
+                                sycl::access::decorated::yes>();
+  nullptrRelationalOperatorTest<bool, sycl::access::address_space::local_space,
+                                sycl::access::decorated::no>();
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::global_space,
+                                sycl::access::decorated::yes>();
+  nullptrRelationalOperatorTest<bool, sycl::access::address_space::global_space,
+                                sycl::access::decorated::no>();
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::generic_space,
+                                sycl::access::decorated::yes>();
+  nullptrRelationalOperatorTest<bool,
+                                sycl::access::address_space::generic_space,
+                                sycl::access::decorated::no>();
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::private_space,
+                                sycl::access::decorated::yes>();
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::private_space,
+                                sycl::access::decorated::no>();
   return 0;
 }

--- a/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
@@ -1,0 +1,55 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+
+template <typename multi_ptr_t> void nullptrRelationalOperatorTest() {
+  constexpr int OUTPUT_SIZE = 8;
+  bool output[OUTPUT_SIZE];
+  try {
+    sycl::queue queue;
+    sycl::buffer<bool, 1> buf(output, sycl::range<1>(OUTPUT_SIZE));
+    queue
+        .submit([&](sycl::handler &cgh) {
+          auto dev_acc = buf.get_access<sycl::access::mode::write>(cgh);
+          sycl::local_accessor<bool, 1> locAcc(1, cgh);
+          cgh.parallel_for(sycl::nd_range<1>{1, 1}, [=](sycl::id<1>) {
+            locAcc[0] = 10;
+            multi_ptr_t mp(locAcc);
+            dev_acc[0] = std::less<multi_ptr_t>()(nullptr, mp) == nullptr < mp;
+            dev_acc[1] = std::less<multi_ptr_t>()(mp, nullptr) == mp < nullptr;
+            dev_acc[2] =
+                std::less_equal<multi_ptr_t>()(nullptr, mp) == nullptr <= mp;
+            dev_acc[3] =
+                std::less_equal<multi_ptr_t>()(mp, nullptr) == mp <= nullptr;
+            dev_acc[4] =
+                std::greater<multi_ptr_t>()(nullptr, mp) == nullptr > mp;
+            dev_acc[5] =
+                std::greater<multi_ptr_t>()(mp, nullptr) == mp > nullptr;
+            dev_acc[6] =
+                std::greater_equal<multi_ptr_t>()(nullptr, mp) == nullptr >= mp;
+            dev_acc[7] =
+                std::greater_equal<multi_ptr_t>()(mp, nullptr) == mp >= nullptr;
+          });
+        })
+        .wait_and_throw();
+  } catch (sycl::exception e) {
+    std::cout << "SYCL exception caught: " << e.what();
+    return;
+  }
+  for (int index = 0; index < OUTPUT_SIZE; ++index) {
+    assert(output[index] && "Unexpected relational operator result.");
+  }
+}
+
+int main() {
+  using multi_ptr_yes =
+      sycl::multi_ptr<bool, sycl::access::address_space::local_space,
+                      sycl::access::decorated::yes>;
+  using multi_ptr_no =
+      sycl::multi_ptr<bool, sycl::access::address_space::local_space,
+                      sycl::access::decorated::no>;
+  nullptrRelationalOperatorTest<multi_ptr_yes>();
+  nullptrRelationalOperatorTest<multi_ptr_no>();
+  return 0;
+}

--- a/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
@@ -65,18 +65,17 @@ void nullptrRelationalOperatorTest() {
 }
 
 int main() {
-  nullptrRelationalOperatorTest<bool, sycl::access::address_space::local_space,
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::local_space,
                                 sycl::access::decorated::yes>();
-  nullptrRelationalOperatorTest<bool, sycl::access::address_space::local_space,
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::local_space,
                                 sycl::access::decorated::no>();
   nullptrRelationalOperatorTest<int, sycl::access::address_space::global_space,
                                 sycl::access::decorated::yes>();
-  nullptrRelationalOperatorTest<bool, sycl::access::address_space::global_space,
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::global_space,
                                 sycl::access::decorated::no>();
   nullptrRelationalOperatorTest<int, sycl::access::address_space::generic_space,
                                 sycl::access::decorated::yes>();
-  nullptrRelationalOperatorTest<bool,
-                                sycl::access::address_space::generic_space,
+  nullptrRelationalOperatorTest<int, sycl::access::address_space::generic_space,
                                 sycl::access::decorated::no>();
   nullptrRelationalOperatorTest<int, sycl::access::address_space::private_space,
                                 sycl::access::decorated::yes>();


### PR DESCRIPTION
`multi_ptr` relational operators taking a `std::nullptr_t` are written in a way that assume it is the lowest possible value
(example https://github.com/intel/llvm/blob/sycl/sycl/include/sycl/multi_ptr.hpp#L1575). However the C++ specs states there is no ordering requirement (https://eel.is/c++draft/expr.rel#4.3).

In practice, this is causing issues in the CUDA and AMDGPU backend. For instance, in CUDA the nullptr in the local address space is a non `0` value and `0` in this address space is the root of the allocated local memory.