### PR TITLE
[SYCL][NFC] Rename IsLargeGRF to Is256GRF

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -284,22 +284,22 @@ appendCompileOptionsForGRFSizeProperties(std::string &CompileOpts,
   // The mutual exclusivity of these properties should have been checked in
   // sycl-post-link.
   assert(!RegAllocModeProp || !GRFSizeProp);
-  bool IsLargeGRF = false;
+  bool Is256GRF = false;
   bool IsAutoGRF = false;
   if (RegAllocModeProp) {
     uint32_t RegAllocModePropVal =
         DeviceBinaryProperty(RegAllocModeProp).asUint32();
-    IsLargeGRF = RegAllocModePropVal ==
-                 static_cast<uint32_t>(register_alloc_mode_enum::large);
+    Is256GRF = RegAllocModePropVal ==
+               static_cast<uint32_t>(register_alloc_mode_enum::large);
     IsAutoGRF = RegAllocModePropVal ==
                 static_cast<uint32_t>(register_alloc_mode_enum::automatic);
   } else {
     assert(GRFSizeProp);
     uint32_t GRFSizePropVal = DeviceBinaryProperty(GRFSizeProp).asUint32();
-    IsLargeGRF = GRFSizePropVal == 256;
+    Is256GRF = GRFSizePropVal == 256;
     IsAutoGRF = GRFSizePropVal == 0;
   }
-  if (IsLargeGRF) {
+  if (Is256GRF) {
     if (!CompileOpts.empty())
       CompileOpts += " ";
     // This option works for both LO AND OCL backends.


### PR DESCRIPTION
After https://github.com/intel/llvm/commit/370aa2a0171199d07f70096fb396810137f26e50 
grf_size control values changed to 128 and 256 values instead of values like "small", "large".


> 2) Adds two new kernel properties
> `sycl::ext::intel::experimental::grf_size` and
> `sycl::ext::intel::experimental::grf_size_automatic`, as per the spec.
> `grf_size` adds the `sycl-grf-size` metadata with a value of the
> template parameter **(`128` or `256`)**. `grf_size_automatic` adds the
> `sycl-grf-size` metadata with a value of `0`.

and user is expected to specify value like this:
syclex::properties kernel_properties{intelex::grf_size<128>};
syclex::properties kernel_properties{intelex::grf_size<256>};
