### PR TITLE
[SYCL][E2E] Fix checks for assertion tests on Windows

### DIFF
--- a/sycl/test-e2e/Assert/assert_in_kernels_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels_win.cpp
@@ -8,12 +8,12 @@
 // CHECK-NOT:  One shouldn't see this message
 // FIXME Windows version prints '(null)' instead of '<unknown func>' once in a
 // while for some insane reason.
-// CHECK:      {{.*}}assert_in_kernels.hpp:27: {{<unknown func>|(null)}}: {{.*}} [{{[0,2]}},0,0], {{.*}} [0,0,0]
+// CHECK:      {{.*}}assert_in_kernels.hpp:27: {{<unknown func>|\(null\)}}: {{.*}} [{{[0,2]}},0,0], {{.*}} [0,0,0]
 // CHECK-SAME: Assertion `Buf[wiID] == 0 && "from assert statement"` failed.
 // CHECK-NOT:  test aborts earlier, one shouldn't see this message
 // CHECK-NOT:  The test ended.
 //
-// CHECK-ACC-NOT: {{.*}}assert_in_kernels.hpp:27: {{<unknown func>|(null)}}: {{.*}} [{{[0,2]}},0,0], {{.*}} [0,0,0]
+// CHECK-ACC-NOT: {{.*}}assert_in_kernels.hpp:27: {{<unknown func>|\(null\)}}: {{.*}} [{{[0,2]}},0,0], {{.*}} [0,0,0]
 // CHECK-ACC: The test ended.
 
 #include "assert_in_kernels.hpp"

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
@@ -8,10 +8,10 @@
 // CHECK-NOT:  this message from calculus
 // FIXME Windows version prints '(null)' instead of '<unknown func>' once in a
 // while for some insane reason.
-// CHECK:      {{.*}}assert_in_multiple_tus.hpp:22: {{<unknown func>|(null)}}: {{.*}} [5,0,0],
+// CHECK:      {{.*}}assert_in_multiple_tus.hpp:22: {{<unknown func>|\(null\)}}: {{.*}} [5,0,0],
 // CHECK-SAME: {{.*}} [1,0,0] Assertion `X && "Nil in result"` failed.
 // CHECK-NOT:  this message from file2
 // CHECK-NOT:  The test ended.
 //
-// CHECK-ACC-NOT: {{.*}}assert_in_multiple_tus.hpp:22: {{<unknown func>|(null)}}: {{.*}} [5,0,0],
+// CHECK-ACC-NOT: {{.*}}assert_in_multiple_tus.hpp:22: {{<unknown func>|\(null\)}}: {{.*}} [5,0,0],
 // CHECK-ACC: The test ended.

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_win.cpp
@@ -7,12 +7,12 @@
 //
 // FIXME Windows version prints '(null)' instead of '<unknown func>' once in a
 // while for some insane reason.
-// CHECK:      {{.*}}kernels_in_file2.cpp:15: {{<unknown func>|(null)}}: {{.*}} [5,0,0], {{.*}} [1,0,0]
+// CHECK:      {{.*}}kernels_in_file2.cpp:15: {{<unknown func>|\(null\)}}: {{.*}} [5,0,0], {{.*}} [1,0,0]
 // CHECK-SAME: Assertion `X && "this message from calculus"` failed.
 // CHECK-NOT:  this message from file2
 // CHECK-NOT:  The test ended.
 //
-// CHECK-ACC-NOT: {{.*}}kernels_in_file2.cpp:15: {{<unknown func>|(null)}}: {{.*}} [5,0,0], {{.*}} [1,0,0]
+// CHECK-ACC-NOT: {{.*}}kernels_in_file2.cpp:15: {{<unknown func>|\(null\)}}: {{.*}} [5,0,0], {{.*}} [1,0,0]
 // CHECK-ACC: The test ended.
 
 #include "assert_in_multiple_tus.hpp"

--- a/sycl/test-e2e/Assert/assert_in_one_kernel_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_one_kernel_win.cpp
@@ -7,11 +7,11 @@
 //
 // FIXME Windows version prints '(null)' instead of '<unknown func>' once in a
 // while for some insane reason.
-// CHECK:      {{.*}}assert_in_one_kernel.hpp:12: {{<unknown func>|(null)}}: {{.*}} [{{[0-3]}},0,0], {{.*}} [0,0,0]
+// CHECK:      {{.*}}assert_in_one_kernel.hpp:12: {{<unknown func>|\(null\)}}: {{.*}} [{{[0-3]}},0,0], {{.*}} [0,0,0]
 // CHECK-SAME: Assertion `Buf[wiID] != 0 && "from assert statement"` failed.
 // CHECK-NOT:  The test ended.
 //
-// CHECK-ACC-NOT: {{.*}}assert_in_one_kernel.hpp:12: {{<unknown func>|(null)}}: {{.*}} [{{[0-3]}},0,0], {{.*}} [0,0,0]
+// CHECK-ACC-NOT: {{.*}}assert_in_one_kernel.hpp:12: {{<unknown func>|\(null\)}}: {{.*}} [{{[0-3]}},0,0], {{.*}} [0,0,0]
 // CHECK-ACC:  The test ended.
 
 #include "assert_in_one_kernel.hpp"

--- a/sycl/test-e2e/Assert/assert_in_simultaneous_kernels_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneous_kernels_win.cpp
@@ -16,11 +16,11 @@
 //
 // FIXME Windows version prints '(null)' instead of '<unknown func>' once in a
 // while for some insane reason.
-// CHECK:      {{.*}}assert_in_simultaneous_kernels.hpp:16: {{<unknown func>|(null)}}: global id: [9,7,0], local id: [0,0,0]
+// CHECK:      {{.*}}assert_in_simultaneous_kernels.hpp:16: {{<unknown func>|\(null\)}}: global id: [9,7,0], local id: [0,0,0]
 // CHECK-SAME: Assertion `false && "from assert statement"` failed.
 // CHECK-NOT:  The test ended.
 //
-// CHECK-ACC-NOT: {{.*}}assert_in_simultaneous_kernels.hpp:16: {{<unknown func>|(null)}}: global id: [9,7,0], local id: [0,0,0]
+// CHECK-ACC-NOT: {{.*}}assert_in_simultaneous_kernels.hpp:16: {{<unknown func>|\(null\)}}: global id: [9,7,0], local id: [0,0,0]
 // CHECK-ACC:  The test ended.
 
 #include "assert_in_simultaneous_kernels.hpp"


### PR DESCRIPTION
"(" and ")" must be escaped.