### PR TITLE
[SYCL][E2E] Pass -std=c++17 to the compiler provided via -fsycl-host-compiler

### DIFF
--- a/sycl/test-e2e/Complex/sycl_complex_include_order.cpp
+++ b/sycl/test-e2e/Complex/sycl_complex_include_order.cpp
@@ -3,9 +3,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %if linux %{ %{build} -DINCLUDE_BEFORE -fsycl-host-compiler=g++ -o %t.out %}
+// RUN: %if linux %{ %{build} -DINCLUDE_BEFORE -fsycl-host-compiler=g++ -fsycl-host-compiler-options="-std=c++17" -o %t.out %}
 // RUN: %if linux %{ %{run} %t.out %}
-// RUN: %if linux %{ %{build} -fsycl-host-compiler=g++ -o %t.out %}
+// RUN: %if linux %{ %{build} -fsycl-host-compiler=g++ -fsycl-host-compiler-options="-std=c++17" -o %t.out %}
 // RUN: %if linux %{ %{run} %t.out %}
 
 // RUN: %if windows %{ %{build} -DINCLUDE_BEFORE -fsycl-host-compiler=cl -fsycl-host-compiler-options="/std:c++17" -o %t.out %}


### PR DESCRIPTION
Author: Marcos Maronas <marcos.maronas@intel.com>