### PR TITLE
[SYCL][Graph] Fix potential issue with command buffer commands

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -655,7 +655,7 @@ sycl::detail::pi::PiExtSyncPoint exec_graph_impl::enqueueNodeDirect(
     findRealDeps(Deps, N.lock(), MPartitionNodes[Node]);
   }
   sycl::detail::pi::PiExtSyncPoint NewSyncPoint;
-  sycl::detail::pi::PiExtCommandBufferCommand NewCommand;
+  sycl::detail::pi::PiExtCommandBufferCommand NewCommand = 0;
   pi_int32 Res = sycl::detail::enqueueImpCommandBufferKernel(
       Ctx, DeviceImpl, CommandBuffer,
       *static_cast<sycl::detail::CGExecKernel *>((Node->MCommandGroup.get())),


### PR DESCRIPTION
- Fix uninitialized pointer values leading to trying to call piExtCommandBufferReleaseCommand on backends which don't support update, which may return as an unsupported feature. Initializing pointers to 0 prevents this call from happening.