### PR TITLE
[SYCL] Remove all uses of `_be` suffix in testing

### DIFF
--- a/sycl/test/abi/pi_cuda_symbol_check.dump
+++ b/sycl/test/abi/pi_cuda_symbol_check.dump
@@ -5,7 +5,7 @@
 
 # RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir %python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %sycl_libs_dir/libpi_cuda.so
 # REQUIRES: linux
-# REQUIRES: cuda_be
+# REQUIRES: cuda
 # UNSUPPORTED: libcxx
 
 piContextCreate

--- a/sycl/test/abi/pi_hip_symbol_check.dump
+++ b/sycl/test/abi/pi_hip_symbol_check.dump
@@ -5,7 +5,7 @@
 
 # RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir %python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %sycl_libs_dir/libpi_hip.so
 # REQUIRES: linux
-# REQUIRES: hip_be
+# REQUIRES: hip
 # UNSUPPORTED: libcxx
 
 piContextCreate

--- a/sycl/test/abi/pi_nativecpu_symbol_check.dump
+++ b/sycl/test/abi/pi_nativecpu_symbol_check.dump
@@ -5,7 +5,7 @@
 
 # RUN: env LLVM_BIN_PATH=%llvm_build_bin_dir %python %sycl_tools_src_dir/abi_check.py --mode check_symbols --reference %s %sycl_libs_dir/libpi_native_cpu.so
 # REQUIRES: linux
-# REQUIRES: native_cpu_be
+# REQUIRES: native_cpu
 # UNSUPPORTED: libcxx
 
 piContextCreate

--- a/sycl/test/basic_tests/interop-backend-traits-cuda.cpp
+++ b/sycl/test/basic_tests/interop-backend-traits-cuda.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: cuda_be
+// REQUIRES: cuda
 // RUN: %clangxx -fsycl -fsyntax-only %s
 // RUN: %clangxx -fsycl -fsyntax-only -DUSE_CUDA_EXPERIMENTAL %s
 

--- a/sycl/test/basic_tests/interop-backend-traits-hip.cpp
+++ b/sycl/test/basic_tests/interop-backend-traits-hip.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
 // RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/interop-backend-traits-level-zero.cpp
+++ b/sycl/test/basic_tests/interop-backend-traits-level-zero.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: level_zero_be
+// REQUIRES: level_zero
 // RUN: %clangxx %fsycl-host-only -fsyntax-only %s
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/basic_tests/interop-backend-traits-opencl.cpp
+++ b/sycl/test/basic_tests/interop-backend-traits-opencl.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: opencl_be
+// REQUIRES: opencl
 // RUN: %clangxx -fsycl -fsyntax-only %s
 
 #include <CL/cl.h>

--- a/sycl/test/basic_tests/interop-hip.cpp
+++ b/sycl/test/basic_tests/interop-hip.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -D__SYCL_INTERNAL_API %s
 

--- a/sycl/test/check_device_code/hip/matrix/compile-query-hip-gfx90a.cpp
+++ b/sycl/test/check_device_code/hip/matrix/compile-query-hip-gfx90a.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
+
 // RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx90a %s -o compile-query-hip
 
 #include <iostream>

--- a/sycl/test/check_device_code/hip/matrix/compile-query-hip-gfx90a.cpp
+++ b/sycl/test/check_device_code/hip/matrix/compile-query-hip-gfx90a.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip
+// REQUIRES: hip_be
 // RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx90a %s -o compile-query-hip
 
 #include <iostream>

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-bfloat16-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-bfloat16-float-test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
+// XFAIL: hip
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-bfloat16-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-bfloat16-float-test.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip
+// REQUIRES: hip_be
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-double-double-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-double-double-test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
+// XFAIL: hip
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-double-double-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-double-double-test.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip
+// REQUIRES: hip_be
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-half-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-half-float-test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
+// XFAIL: hip
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-half-float-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-half-float-test.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip
+// REQUIRES: hip_be
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-int8-int32-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-int8-int32-test.cpp
@@ -1,4 +1,5 @@
-// REQUIRES: hip_be
+// REQUIRES: hip
+// XFAIL: hip
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/check_device_code/hip/matrix/matrix-hip-int8-int32-test.cpp
+++ b/sycl/test/check_device_code/hip/matrix/matrix-hip-int8-int32-test.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: hip
+// REQUIRES: hip_be
 
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=amd_gpu_gfx90a -S -Xclang -emit-llvm %s -o -| FileCheck %s
 

--- a/sycl/test/extensions/macro_cuda.cpp
+++ b/sycl/test/extensions/macro_cuda.cpp
@@ -1,6 +1,6 @@
 // This test checks presence of macros for available extensions.
 // RUN: %clangxx -fsycl -fsyntax-only %s
-// REQUIRES: cuda_be
+// REQUIRES: cuda
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/extensions/macro_hip.cpp
+++ b/sycl/test/extensions/macro_hip.cpp
@@ -1,6 +1,6 @@
 // This test checks presence of macros for available extensions.
 // RUN: %clangxx -fsycl -fsyntax-only %s
-// REQUIRES: hip_be
+// REQUIRES: hip
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/lit.cfg.py
+++ b/sycl/test/lit.cfg.py
@@ -144,20 +144,20 @@ config.substitutions.append(("%sycl_triple", triple))
 
 additional_flags = config.sycl_clang_extra_flags.split(" ")
 
-if config.cuda_be == "ON":
-    config.available_features.add("cuda_be")
+if config.cuda == "ON":
+    config.available_features.add("cuda")
 
-if config.hip_be == "ON":
-    config.available_features.add("hip_be")
+if config.hip == "ON":
+    config.available_features.add("hip")
 
-if config.opencl_be == "ON":
-    config.available_features.add("opencl_be")
+if config.opencl == "ON":
+    config.available_features.add("opencl")
 
-if config.level_zero_be == "ON":
-    config.available_features.add("level_zero_be")
+if config.level_zero == "ON":
+    config.available_features.add("level_zero")
 
-if config.native_cpu_be == "ON":
-    config.available_features.add("native_cpu_be")
+if config.native_cpu == "ON":
+    config.available_features.add("native_cpu")
 
 if config.native_cpu_ock == "ON":
     config.available_features.add("native_cpu_ock")

--- a/sycl/test/lit.site.cfg.py.in
+++ b/sycl/test/lit.site.cfg.py.in
@@ -26,11 +26,11 @@ config.llvm_enable_projects = "@LLVM_ENABLE_PROJECTS@"
 config.sycl_threads_lib = '@SYCL_THREADS_LIB@'
 config.sycl_use_libcxx = '@SYCL_USE_LIBCXX@'
 config.extra_environment = lit_config.params.get("extra_environment", "@LIT_EXTRA_ENVIRONMENT@")
-config.cuda_be = '@SYCL_BUILD_PI_CUDA@'
-config.hip_be = '@SYCL_BUILD_PI_HIP@'
-config.opencl_be = '@SYCL_BUILD_PI_OPENCL@'
-config.level_zero_be = '@SYCL_BUILD_PI_LEVEL_ZERO@'
-config.native_cpu_be = '@SYCL_BUILD_NATIVE_CPU@'
+config.cuda = '@SYCL_BUILD_PI_CUDA@'
+config.hip = '@SYCL_BUILD_PI_HIP@'
+config.opencl = '@SYCL_BUILD_PI_OPENCL@'
+config.level_zero = '@SYCL_BUILD_PI_LEVEL_ZERO@'
+config.native_cpu = '@SYCL_BUILD_NATIVE_CPU@'
 config.native_cpu_ock = '@NATIVECPU_USE_OCK@'
 config.sycl_preview_lib_enabled = '@SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB@'
 

--- a/sycl/test/native_cpu/atomic-base.cpp
+++ b/sycl/test/native_cpu/atomic-base.cpp
@@ -1,6 +1,6 @@
 // Simple test that checks that we can run a simple applications that uses
 // builtins
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 #include <sycl/sycl.hpp>

--- a/sycl/test/native_cpu/call_host_func.cpp
+++ b/sycl/test/native_cpu/call_host_func.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 // This test is needed since we need to make sure that there no

--- a/sycl/test/native_cpu/check-pi-output.cpp
+++ b/sycl/test/native_cpu/check-pi-output.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu  %s -o %t
 // RUN: env SYCL_PI_TRACE=1 ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t | FileCheck %s
 

--- a/sycl/test/native_cpu/driver-fsycl.cpp
+++ b/sycl/test/native_cpu/driver-fsycl.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/example-sycl-application.cpp
+++ b/sycl/test/native_cpu/example-sycl-application.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/global-id-range.cpp
+++ b/sycl/test/native_cpu/global-id-range.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/globaloffsetchecks.cpp
+++ b/sycl/test/native_cpu/globaloffsetchecks.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 

--- a/sycl/test/native_cpu/link-noinline.cpp
+++ b/sycl/test/native_cpu/link-noinline.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu -fno-inline -O0  %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/local-id-range.cpp
+++ b/sycl/test/native_cpu/local-id-range.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/local_basic.cpp
+++ b/sycl/test/native_cpu/local_basic.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 #include <sycl/sycl.hpp>

--- a/sycl/test/native_cpu/multi-devices-swap.cpp
+++ b/sycl/test/native_cpu/multi-devices-swap.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: native_cpu_be
-// REQUIRES: opencl_be
+// REQUIRES: native_cpu
+// REQUIRES: opencl
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu,spir64 %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/multi-devices.cpp
+++ b/sycl/test/native_cpu/multi-devices.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: native_cpu_be
-// REQUIRES: opencl_be
+// REQUIRES: native_cpu
+// REQUIRES: opencl
 // RUN: %clangxx -fsycl -fsycl-targets=spir64,native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/multiple_tu.cpp
+++ b/sycl/test/native_cpu/multiple_tu.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 //RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -c -o %t_main.o
 //RUN: %clangxx -fsycl -fsycl-targets=native_cpu %S/Inputs/init.cpp -c -o %t_init.o
 //RUN: %clangxx -fsycl -fsycl-targets=native_cpu %S/Inputs/plusone.cpp -c -o %t_plusone.o

--- a/sycl/test/native_cpu/no-dead-arg.cpp
+++ b/sycl/test/native_cpu/no-dead-arg.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu -O1 -fsycl-dead-args-optimization %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/no-opt.cpp
+++ b/sycl/test/native_cpu/no-opt.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu -g -O0 -o %t %s
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" SYCL_DEVICE_ALLOWLIST="BackendName:native_cpu" %t

--- a/sycl/test/native_cpu/no_kernels.cpp
+++ b/sycl/test/native_cpu/no_kernels.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/native_cpu/readwrite_rectops.cpp
+++ b/sycl/test/native_cpu/readwrite_rectops.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 

--- a/sycl/test/native_cpu/scalar_args.cpp
+++ b/sycl/test/native_cpu/scalar_args.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 #include <sycl/sycl.hpp>

--- a/sycl/test/native_cpu/sycl-external-static.cpp
+++ b/sycl/test/native_cpu/sycl-external-static.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // Check that kernel can call a SYCL_EXTERNAL function defined in a
 // static library.
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu -DSOURCE1 %s -c -o %t1.o

--- a/sycl/test/native_cpu/sycl-external.cpp
+++ b/sycl/test/native_cpu/sycl-external.cpp
@@ -1,6 +1,6 @@
 // Test1 - check that kernel can call a SYCL_EXTERNAL function defined in a
 // different object file.
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu -DSOURCE1 %s -c -o %t1.o
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu -DSOURCE2 %s -c -o %t2.o
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %t1.o %t2.o -o %t

--- a/sycl/test/native_cpu/unnamed.cpp
+++ b/sycl/test/native_cpu/unnamed.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 #include <sycl/sycl.hpp>

--- a/sycl/test/native_cpu/unused-regression.cpp
+++ b/sycl/test/native_cpu/unused-regression.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 #include <sycl/sycl.hpp>

--- a/sycl/test/native_cpu/user-defined-private-type.cpp
+++ b/sycl/test/native_cpu/user-defined-private-type.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 #include <functional>

--- a/sycl/test/native_cpu/user-defined-type.cpp
+++ b/sycl/test/native_cpu/user-defined-type.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 #include <functional>

--- a/sycl/test/native_cpu/usm_basic.cpp
+++ b/sycl/test/native_cpu/usm_basic.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR=native_cpu:cpu %t
 #include <sycl/sycl.hpp>

--- a/sycl/test/native_cpu/vector-add.cpp
+++ b/sycl/test/native_cpu/vector-add.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: native_cpu_be
+// REQUIRES: native_cpu
 // RUN: %clangxx -fsycl -fsycl-targets=native_cpu %s -o %t
 // RUN: env ONEAPI_DEVICE_SELECTOR="native_cpu:cpu" %t
 

--- a/sycl/test/regression/multi_targeting.cpp
+++ b/sycl/test/regression/multi_targeting.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: cuda || hip_be
+// REQUIRES: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple,spir64 %s -o -
 // RUN: %clangxx -fsycl -fsycl-targets=spir64,%sycl_triple %s -o -
 //


### PR DESCRIPTION
The `_be` suffix was used in sycl/test to identify support for lots of
different backends. For instance: `hip_be`, `cuda_be` etc.

sycl/test-e2e used the same backend identifiers but without the `_be`
suffix. This has caused some confusion, allowing tests to be added to
sycl/test that do not use the `_be` suffix, meaning they are considered
UNSUPPORTED for all backends.

This patch removes all uses of the `_be` suffix in sycl/test, so that
the backend support is aligned with the keywords used in sycl/test-e2e.
Some tests that were not running for any backends now fail, so they are
marked XFAIL.