### PR TITLE
[SYCL][Bindless][E2E] fix missing scope when using equal_vec function

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/mipmaps.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/mipmaps.cpp
@@ -200,7 +200,8 @@ bool run_sycl(sycl::range<NDims> globalSize, sycl::range<NDims> localSize,
             bindless_helpers::init_vector<DType, NChannels>(y +
                                                             (width / 2 * x));
 
-        if (!equal_vec<DType, NChannels>(out[j + (width * i)], expected)) {
+        if (!bindless_helpers::equal_vec<DType, NChannels>(out[j + (width * i)],
+                                                           expected)) {
           mismatch = true;
           validated = false;
         }


### PR DESCRIPTION
* fix missed scope for `equal_vec` in Vulkan interop `mipmaps.cpp` test.