### PR TITLE
[ABI-Break][SYCL] Remove `sycl::make_unique_ptr`

### DIFF
--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -105,19 +105,3 @@
 #include <sycl/ext/oneapi/sub_group.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 #include <sycl/ext/oneapi/weak_object.hpp>
-
-#if !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
-namespace sycl {
-inline namespace _V1 {
-// This wasn't put into "detail" so we can't just drop it outsdie ABI-breaking
-// window. DO NOT USE.
-template <typename T, typename... ArgsT>
-__SYCL_DEPRECATED(
-    "sycl::make_unique_ptr was never supposed to be anything other than "
-    "an implementation detail. Use std::make_unique instead.")
-std::unique_ptr<T> make_unique_ptr(ArgsT &&...Args) {
-  return std::unique_ptr<T>(new T(std::forward<ArgsT>(Args)...));
-}
-} // namespace _V1
-} // namespace sycl
-#endif


### PR DESCRIPTION
Not used, was faiting for an ABI breaking window to be removed.