### PR TITLE
[ABI-Break][SYCL] Remove preview guards around bfloat16

### DIFF
--- a/sycl/include/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/sycl/detail/generic_type_lists.hpp
@@ -97,16 +97,8 @@ using scalar_vector_double_list =
 using double_list =
     tl_append<scalar_double_list, vector_double_list, marray_double_list>;
 
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
 using scalar_floating_list = tl_append<scalar_float_list, scalar_double_list,
                                        scalar_half_list, scalar_bfloat16_list>;
-#else
-// Presently, this is used only by builtins_legacy_scalar.hpp for defining math
-// funcs. bfloat16 provides its own scalar math definitions so we skip its
-// inclusion.
-using scalar_floating_list =
-    tl_append<scalar_float_list, scalar_double_list, scalar_half_list>;
-#endif
 
 using vector_floating_list = tl_append<vector_float_list, vector_double_list,
                                        vector_half_list, vector_bfloat16_list>;

--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -21,13 +21,6 @@ __devicelib_ConvertBF16ToFINTEL(const uint16_t &) noexcept;
 
 namespace sycl {
 inline namespace _V1 {
-
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-// forward declaration of sycl::isnan built-in.
-// extern __DPCPP_SYCL_EXTERNAL bool isnan(float a);
-bool isnan(float a);
-#endif
-
 namespace ext::oneapi {
 
 class bfloat16;
@@ -53,10 +46,6 @@ using Vec8StorageT = std::array<Bfloat16StorageT, 8>;
 using Vec16StorageT = std::array<Bfloat16StorageT, 16>;
 #endif
 } // namespace bf16
-
-#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
-inline bool float_is_nan(float x) { return x != x; }
-#endif
 } // namespace detail
 
 class bfloat16 {
@@ -77,13 +66,10 @@ public:
 
 private:
   static detail::Bfloat16StorageT from_float_fallback(const float &a) {
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-    if (sycl::isnan(a))
+    // We don't call sycl::isnan because we don't want a data type to depend on
+    // builtins.
+    if (a != a)
       return 0xffc1;
-#else
-    if (detail::float_is_nan(a))
-      return 0xffc1;
-#endif
 
     union {
       uint32_t intStorage;


### PR DESCRIPTION
Also reverts `isnan` check to non-preview implementation to avoid unnecessary dependecy of a data type on builtins.