### PR TITLE
[SYCL][NFC] Remove legacy SYCL_EXT_ONEAPI_MATRIX_VERSION usages

### DIFF
--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_opt_kernel_feature.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_opt_kernel_feature.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: matrix-xmx8
 
-// RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Test checks that exception will be thrown in case matrix parameters are

--- a/sycl/test-e2e/Matrix/joint_matrix_opt_kernel_feature.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_opt_kernel_feature.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: matrix
 
-// RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Test checks that exception will be thrown in case matrix parameters are

--- a/sycl/test-e2e/Matrix/joint_matrix_opt_kernel_feature_unsupported_hw.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_opt_kernel_feature_unsupported_hw.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: gpu-intel-gen12, gpu
 
-// RUN: %{build} -o %t.out -DSYCL_EXT_ONEAPI_MATRIX_VERSION=4
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Test checks that exception will be thrown in case object of joint_matrix type


### PR DESCRIPTION
This macro and its usages were removed here: https://github.com/intel/llvm/pull/11813
