### PR TITLE
[SYCL] Declare __devicelib_assert_read only when fallback assert is enabled

### DIFF
--- a/sycl/include/sycl/detail/assert_happened.hpp
+++ b/sycl/include/sycl/detail/assert_happened.hpp
@@ -10,7 +10,7 @@
 
 #include <cstdint> // for uint64_t, int32_t
 
-#ifdef __SYCL_DEVICE_ONLY__
+#if defined(__SYCL_DEVICE_ONLY__) && __SYCL_USE_FALLBACK_ASSERT
 // Reads Flag of AssertHappened on device
 __DPCPP_SYCL_EXTERNAL __attribute__((weak)) extern "C" void
 __devicelib_assert_read(void *);

--- a/sycl/include/sycl/detail/defines_elementary.hpp
+++ b/sycl/include/sycl/detail/defines_elementary.hpp
@@ -81,6 +81,13 @@
 static_assert(__cplusplus >= 201703L,
               "DPCPP does not support C++ version earlier than C++17.");
 
+// Helper macro to identify if fallback assert is needed
+#if defined(SYCL_FALLBACK_ASSERT)
+#define __SYCL_USE_FALLBACK_ASSERT SYCL_FALLBACK_ASSERT
+#else
+#define __SYCL_USE_FALLBACK_ASSERT 0
+#endif
+
 #if defined(_WIN32) && !defined(_DLL) && !defined(__SYCL_DEVICE_ONLY__)
 // SYCL library is designed such a way that STL objects cross DLL boundary,
 // which is guaranteed to work properly only when the application uses the same

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -65,14 +65,6 @@
 #define _KERNELFUNCPARAM(a) const KernelType &a
 #endif
 
-// Helper macro to identify if fallback assert is needed
-// FIXME remove __NVPTX__ condition once devicelib supports CUDA
-#if defined(SYCL_FALLBACK_ASSERT)
-#define __SYCL_USE_FALLBACK_ASSERT SYCL_FALLBACK_ASSERT
-#else
-#define __SYCL_USE_FALLBACK_ASSERT 0
-#endif
-
 namespace sycl {
 inline namespace _V1 {
 
@@ -3011,4 +3003,3 @@ event submitAssertCapture(queue &Self, event &Event, queue *SecondaryQueue,
 } // namespace sycl
 #endif // __SYCL_USE_FALLBACK_ASSERT
 
-#undef __SYCL_USE_FALLBACK_ASSERT

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -3002,4 +3002,3 @@ event submitAssertCapture(queue &Self, event &Event, queue *SecondaryQueue,
 } // namespace _V1
 } // namespace sycl
 #endif // __SYCL_USE_FALLBACK_ASSERT
-


### PR DESCRIPTION
Try to reland PR: https://github.com/intel/llvm/pull/5698

Author: Sergei Kanaev, s-kanaev