### PR TITLE
[SYCL] Fix compilation of joint_matrix_apply_two_matrices.cpp

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_apply_two_matrices_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_two_matrices_impl.hpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+#include <sycl/detail/core.hpp>
+#include <sycl/usm.hpp>
+
 template <typename Tc, typename Ta, size_t M, size_t N>
 bool apply_verify(Tc *C, Tc *D, Ta *A, Ta *Ar) {
   for (size_t i = 0; i < M; i++)

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_two_matrices_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_two_matrices_impl.hpp
@@ -5,7 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-#include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 
 template <typename Tc, typename Ta, size_t M, size_t N>


### PR DESCRIPTION
https://github.com/intel/llvm/commit/7fb3b20688c64761e73a0797a12c6df5c1f6da0a replaces `#include <sycl/sycl.hpp>` to `#include <sycl/detail/core.hpp>` in common.hpp. core.hpp doesn't include usm.hpp, used in the header file modified by this patch.