### PR TITLE
[SYCL][Matrix] Enable tests on DG2 GPU

### DIFF
--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: matrix-xmx8
-// REQUIRES: TEMPORARY_DISBLED
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_ops_int8_packed.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: matrix-xmx8
-// REQUIRES: TEMPORARY_DISBLED
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes.cpp
@@ -8,10 +8,6 @@
 // REQUIRES: matrix-xmx8
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943
 
-// TODO: Currently fails and regularly times out on DG2. Re-enable when this has
-//       been addressed.
-// UNSUPPORTED: gpu-intel-dg2
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/element_wise_all_sizes_no_split.cpp
@@ -11,10 +11,6 @@
 // REQUIRES: matrix-xmx8
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943
 
-// TODO: Currently fails and regularly times out on DG2. Re-enable when this has
-//       been addressed.
-// UNSUPPORTED: gpu-intel-dg2
-
 // RUN: %{build} -fsycl-device-code-split=off -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
These tests should pass in the current environment on both A770 and A750.

Closes #11538.
Closes #11912.