### PR TITLE
[CI][OSSF] Allow package write in sycl-container build

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -28,6 +28,8 @@ jobs:
     if: github.repository == 'intel/llvm'
     name: Base Ubuntu 22.04 Docker image
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -47,6 +49,8 @@ jobs:
     if: github.repository == 'intel/llvm'
     name: Build Ubuntu Docker image
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -69,6 +73,8 @@ jobs:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers Ubuntu 22.04 Docker image
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     needs: base_image_ubuntu2204
     steps:
       - name: Checkout
@@ -107,6 +113,8 @@ jobs:
     if: github.repository == 'intel/llvm'
     name: Intel Drivers (unstable) Ubuntu 22.04 Docker image
     runs-on: ubuntu-22.04
+    permissions:
+      packages: write
     needs: base_image_ubuntu2204
     steps:
       - name: Checkout


### PR DESCRIPTION
After https://github.com/intel/llvm/pull/13173 , we are not able to push container images.
See https://github.com/intel/llvm/actions/runs/8485593107/job/23250649681

```
------
 > pushing ghcr.io/intel/llvm/ubuntu2204_base:2f03ef85fee5e867c8250d535f561f2e52e5260c with docker:
------
ERROR: denied: installation not allowed to Write organization package
Error: buildx failed with: ERROR: denied: installation not allowed to Write organization package
```

We need to update the docker images, so need to write packages.

Push permission tested through non PR workflow run here: https://github.com/intel/llvm/actions/runs/8516878870