### PR TITLE
[CI] Fix docker push permission in nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -160,6 +160,8 @@ jobs:
   ubuntu2204_docker_build_push:
     if: github.repository == 'intel/llvm'
     runs-on: [Linux, build]
+    permissions:
+      packages: write
     needs: ubuntu2204_build
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
Similar to https://github.com/intel/llvm/pull/13245

This should fix the self-build issue reported in https://github.com/intel/llvm/issues/13225