### PR TITLE
[SYCL][ESIMD] Use old intrinsic for named_barrier_signal for now 

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -494,6 +494,8 @@ public:
         {"dpasw", {"dpasw", {a(0), a(1), a(2), t(0)}}},
         {"dpasw_nosrc0", {"dpasw.nosrc0", {a(0), a(1), t(0)}}},
         {"nbarrier", {"nbarrier", {a(0), a(1), a(2)}}},
+	{"raw_send_nbarrier_signal",
+         {"raw.send.noresult", {a(0), ai1(4), a(1), a(2), a(3)}}},
         {"nbarrier_arrive", {"nbarrier.arrive", {a(0), a(1), a(2), a(3)}}},
         {"lsc_load_slm",
          {"lsc.load.slm",

--- a/llvm/test/SYCLLowerIR/esimd_lower_nbarriers.ll
+++ b/llvm/test/SYCLLowerIR/esimd_lower_nbarriers.ll
@@ -1,0 +1,21 @@
+; RUN: opt < %s -passes=LowerESIMD -S | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: convergent norecurse mustprogress
+define dso_local spir_kernel void @_ZTSZ6calleriE12kernel_esimd() !sycl_explicit_simd !3 {
+entry:
+; CHECK: call void @llvm.genx.nbarrier(i8 0, i8 2, i8 0)
+  call spir_func void @_Z16__esimd_nbarrierhhh(i8 zeroext 0, i8 zeroext 2, i8 zeroext 0)
+
+; CHECK: call void @llvm.genx.raw.send.noresult.i1.v8i32(i32 0, i1 true, i32 3, i32 33554436, <8 x i32> <i32 0, i32 0, i32 67371008, i32 0, i32 0, i32 0, i32 0, i32 0>)
+  call spir_func void @_Z32__esimd_raw_send_nbarrier_signalIjLi8EEvjjjN2cl4sycl5INTEL3gpu6detail11vector_typeIT_XT0_EE4typeEt(i32 0, i32 3, i32 33554436, <8 x i32> <i32 0, i32 0, i32 67371008, i32 0, i32 0, i32
+0, i32 0, i32 0>, i16 zeroext 1)
+
+  ret void
+}
+!3 = !{}
+
+declare dso_local spir_func void @_Z16__esimd_nbarrierhhh(i8 zeroext, i8 zeroext, i8 zeroext) local_unnamed_addr #1
+declare dso_local spir_func void @_Z32__esimd_raw_send_nbarrier_signalIjLi8EEvjjjN2cl4sycl5INTEL3gpu6detail11vector_typeIT_XT0_EE4typeEt(i32, i32, i32, <8 x i32>, i16 zeroext)

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -41,6 +41,27 @@ __ESIMD_INTRIN void __esimd_nbarrier(uint8_t mode, uint8_t id,
 /// @param count  - number of named barriers
 __ESIMD_INTRIN void __esimd_nbarrier_init(uint8_t count) __ESIMD_INTRIN_END;
 
+/// Raw send signal to perform signal operation on named barriers
+/// Available only on PVC
+/// @tparam Ty  - message element type
+///
+/// @tparam N  - message length
+///
+/// @param is_sendc  - is sendc
+///
+/// @param extended_descriptor  - extended message descriptor
+///
+/// @param descriptor  - message descriptor
+///
+/// @param msg_var  - source operand of send message
+///
+/// @param pred  - predicate for enabled channels
+template <typename Ty, int N>
+__ESIMD_INTRIN void __esimd_raw_send_nbarrier_signal(
+    uint32_t is_sendc, uint32_t extended_descriptor, uint32_t descriptor,
+    __ESIMD_DNS::vector_type_t<Ty, N> msg_var,
+    uint16_t pred = 1) __ESIMD_INTRIN_END;
+
 /// Perform signal operation on named barriers
 /// Available only on PVC
 /// @param id - barrier id

--- a/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/memory.hpp
@@ -395,8 +395,22 @@ __ESIMD_API void named_barrier_signal(uint8_t barrier_id,
                                       uint32_t num_consumers) {
   __esimd_fence(__ESIMD_NS::fence_mask::global_coherent_fence |
                 __ESIMD_NS::fence_mask::local_barrier);
+#ifdef __ESIMD_USE_NEW_NAMED_BARRIER_INTRIN
   __esimd_nbarrier_arrive(barrier_id, producer_consumer_mode, num_producers,
                           num_consumers);
+#else
+  constexpr uint32_t gateway = 3;
+  constexpr uint32_t barrier = 4;
+  constexpr uint32_t descriptor = 1 << 25 | // Message length: 1 register
+                                  0 << 12 | // Fence Data Ports: No fence
+                                  barrier;  // Barrier subfunction
+
+  __ESIMD_DNS::vector_type_t<uint32_t, 8> payload = 0;
+  payload[2] = (num_consumers & 0xff) << 24 | (num_producers & 0xff) << 16 |
+               producer_consumer_mode << 14 | (barrier_id & 0b11111) << 0;
+  __esimd_raw_send_nbarrier_signal<uint32_t, 8>(
+      0 /*sendc*/, gateway, descriptor, payload, 1 /*pred*/);
+#endif
 }
 
 /// Create explicit scoreboard dependency to avoid device code motion

--- a/sycl/test/esimd/nbarriers.cpp
+++ b/sycl/test/esimd/nbarriers.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -c -fsycl-device-only -Xclang -emit-llvm %s -o - 2>&1 | FileCheck %s
+// RUN: %clangxx -D__ESIMD_USE_NEW_NAMED_BARRIER_INTRIN -fsycl -c -fsycl-device-only -Xclang -emit-llvm %s -o - 2>&1 | FileCheck %s
 
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
Need a new driver supporting the new intrinsic.