### PR TITLE
[SYCL][DeviceSanitizer] Use -asan-constructor-kind=none to disable ctor/dtor

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1152,6 +1152,9 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
       CmdArgs.push_back("-asan-instrumentation-with-call-threshold=0");
 
       CmdArgs.push_back("-mllvm");
+      CmdArgs.push_back("-asan-constructor-kind=none");
+
+      CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-asan-stack=0");
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-asan-globals=0");

--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1151,6 +1151,7 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-asan-instrumentation-with-call-threshold=0");
 
+      // asan initialization is done in unified runtime rather than in ctor.
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-asan-constructor-kind=none");
 

--- a/clang/test/Driver/sycl-device-sanitizer.cpp
+++ b/clang/test/Driver/sycl-device-sanitizer.cpp
@@ -5,6 +5,7 @@
 // SYCL-ASAN-SAME: -fsanitize-address-use-after-return=never
 // SYCL-ASAN-SAME: -fno-sanitize-address-use-after-scope
 // SYCL-ASAN-SAME: "-mllvm" "-asan-instrumentation-with-call-threshold=0"
+// SYCL-ASAN-SAME: "-mllvm" "-asan-constructor-kind=none"
 // SYCL-ASAN-SAME: "-mllvm" "-asan-stack=0"
 // SYCL-ASAN-SAME: "-mllvm" "-asan-globals=0"
 

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -2911,12 +2911,6 @@ bool ModuleAddressSanitizer::instrumentModule(Module &M) {
     }
   }
 
-  // SPIR kernel needn't AsanCtorFunction & AsanDtorFunction
-  if (TargetTriple.isSPIR()) {
-    AsanCtorFunction = nullptr;
-    AsanDtorFunction = nullptr;
-  }
-
   const uint64_t Priority = GetCtorAndDtorPriority(TargetTriple);
 
   // Put the constructor and destructor in comdat if both

--- a/sycl/test/check_device_code/device_asan_no_ctor.cpp
+++ b/sycl/test/check_device_code/device_asan_no_ctor.cpp
@@ -1,0 +1,22 @@
+// REQUIRES: linux
+// RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -Xarch_device -fsanitize=address -emit-llvm %s -S -o %t.ll
+// RUN: FileCheck %s --input-file %t.ll
+
+// CHECK-NOT: asan.module_ctor
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+int main() {
+  sycl::queue queue;
+  {
+    queue.submit([&](sycl::handler &cgh) {
+      cgh.single_task<class t>([=]() {
+      });
+    });
+    queue.wait();
+  }
+
+  return 0;
+}

--- a/sycl/test/check_device_code/device_asan_no_ctor.cpp
+++ b/sycl/test/check_device_code/device_asan_no_ctor.cpp
@@ -11,10 +11,8 @@ using namespace sycl;
 int main() {
   sycl::queue queue;
   {
-    queue.submit([&](sycl::handler &cgh) {
-      cgh.single_task<class t>([=]() {
-      });
-    });
+    queue.submit(
+        [&](sycl::handler &cgh) { cgh.single_task<class t>([=]() {}); });
     queue.wait();
   }
 

--- a/sycl/test/check_device_code/device_asan_no_ctor.cpp
+++ b/sycl/test/check_device_code/device_asan_no_ctor.cpp
@@ -2,6 +2,9 @@
 // RUN: %clangxx -fsycl-device-only -fno-sycl-early-optimizations -Xarch_device -fsanitize=address -emit-llvm %s -S -o %t.ll
 // RUN: FileCheck %s --input-file %t.ll
 
+// Check asan ctor is not generated since device asan initialization is done in
+// unified runtime rather than in ctor.
+
 // CHECK-NOT: asan.module_ctor
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
The removed code fails to prevent ctor/dtor generation.