### PR TITLE
[DeviceSanitizer] Strip off pointer casts and inbounds GEPs

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1328,7 +1328,7 @@ static bool isUnsupportedSPIRAccess(Value *Addr, Function *Func) {
   }
 
   // All the rest address spaces: skip SPIR-V built-in varibles
-  auto *OrigValue = Addr->stripPointerCasts();
+  auto *OrigValue = Addr->stripInBoundsOffsets();
   return OrigValue->getName().starts_with("__spirv_BuiltIn");
 }
 

--- a/llvm/test/Instrumentation/AddressSanitizer/spir_skip_builtin.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/spir_skip_builtin.ll
@@ -1,0 +1,17 @@
+; RUN: opt < %s -passes=asan -asan-instrumentation-with-call-threshold=0 -asan-stack=0 -asan-globals=0 -S | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+@__spirv_BuiltInGlobalInvocationId = external addrspace(1) constant <3 x i64>
+
+; Function Attrs: sanitize_address
+define spir_kernel void @_ZTSN4sycl3_V16detail19__pf_kernel_wrapperIZZ4mainENKUlRNS0_7handlerEE_clES4_E19bufferByRange2_initEE() #0 {
+entry:
+  ; CHECK-NOT: {{ __asan_load8.*__spirv_BuiltInGlobalInvocationId }}
+  %0 = load i64, ptr addrspace(1) getelementptr inbounds (i8, ptr addrspace(1) @__spirv_BuiltInGlobalInvocationId, i64 8), align 8
+  ret void
+}
+
+attributes #0 = { sanitize_address }
+


### PR DESCRIPTION
Disable device sanitizer instrument following case:
%0 = load i64, ptr addrspace(1) getelementptr inbounds (i8,
  ptr addrspace(1) @__spirv_BuiltInGlobalInvocationId, i64 8)