### PR TITLE
Fix a build failure shown in HIP backend in multi_ptr_null_relational_operators.cpp test

### DIFF
--- a/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
+++ b/sycl/test-e2e/Basic/multi_ptr_null_relational_operators.cpp
@@ -36,7 +36,7 @@ void nullptrRelationalOperatorTest() {
           if constexpr (address_space ==
                         sycl::access::address_space::local_space) {
             sycl::local_accessor<int, 1> locAcc(1, cgh);
-            cgh.parallel_for(sycl::nd_range<1>{1, 1}, [=](sycl::id<1>) {
+            cgh.parallel_for(sycl::nd_range<1>{1, 1}, [=](sycl::nd_item<1>) {
               locAcc[0] = 1;
               multi_ptr_t mp(locAcc);
               check(mp, dev_acc);


### PR DESCRIPTION
- change `sycl::id<1>` to `sycl::nd_item<1>` in a parallel_for with `sycl::nd_range`, which caused a build error in HIP backend.