### PR TITLE
[SYCL] Add alternative to deprecated barrier() function for sub-group

### DIFF
--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -558,8 +558,8 @@ struct sub_group {
 
   /* --- synchronization functions --- */
   __SYCL_DEPRECATED(
-              "Sub-group barrier with no arguments is deprecated."
-              "Use sycl::group_barrier with the sub-group as the argument instead.")
+      "Sub-group barrier with no arguments is deprecated."
+      "Use sycl::group_barrier with the sub-group as the argument instead.")
   void barrier() const {
 #ifdef __SYCL_DEVICE_ONLY__
     __spirv_ControlBarrier(

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -576,7 +576,7 @@ struct sub_group {
 
   __SYCL_DEPRECATED(
       "Sub-group barrier accepting fence_space is deprecated."
-      "Use sycl::group_barrier with the sub-group as the argument.")
+      "Use sycl::group_barrier with the sub-group as the argument instead.")
   void barrier(access::fence_space accessSpace) const {
 #ifdef __SYCL_DEVICE_ONLY__
     int32_t flags = sycl::detail::getSPIRVMemorySemanticsMask(accessSpace);

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -557,8 +557,9 @@ struct sub_group {
   }
 
   /* --- synchronization functions --- */
-  __SYCL_DEPRECATED("Sub-group barrier with no arguments is deprecated."
-                    "Use sycl::group_barrier with the sub-group as the argument instead.")
+  __SYCL_DEPRECATED(
+              "Sub-group barrier with no arguments is deprecated."
+              "Use sycl::group_barrier with the sub-group as the argument instead.")
   void barrier() const {
 #ifdef __SYCL_DEVICE_ONLY__
     __spirv_ControlBarrier(

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -557,7 +557,8 @@ struct sub_group {
   }
 
   /* --- synchronization functions --- */
-  __SYCL_DEPRECATED("Sub-group barrier with no arguments is deprecated.")
+  __SYCL_DEPRECATED("Sub-group barrier with no arguments is deprecated."
+                    "Use sycl::group_barrier with the sub-group as the argument instead.")
   void barrier() const {
 #ifdef __SYCL_DEVICE_ONLY__
     __spirv_ControlBarrier(

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -574,8 +574,9 @@ struct sub_group {
 #endif
   }
 
-  __SYCL_DEPRECATED("Sub-group barrier accepting fence_space is deprecated."
-                    "Use barrier() without a fence_space instead.")
+  __SYCL_DEPRECATED(
+      "Sub-group barrier accepting fence_space is deprecated."
+      "Use sycl::group_barrier with the sub-group as the argument.")
   void barrier(access::fence_space accessSpace) const {
 #ifdef __SYCL_DEVICE_ONLY__
     int32_t flags = sycl::detail::getSPIRVMemorySemanticsMask(accessSpace);


### PR DESCRIPTION
Add an alternative in the deprecation message for barrier() method on a sub-group. This should help clients move closer to conformant code.