### PR TITLE
[UR][L0] fix ze commands matching in level_zero_eager_init.cpp

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_eager_init.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_eager_init.cpp
@@ -7,9 +7,9 @@
 // heavy L0 initialization in the hot reportable path.
 //
 // CHECK-LABEL: HOT HOT HOT
-// CHECK-NOT: zeCommandQueueCreate
-// CHECK-NOT: zeCommandListCreate
-// CHECK-NOT: zeFenceCreate
+// CHECK-NOT: ZE ---> zeCommandQueueCreate
+// CHECK-NOT: ZE ---> zeCommandListCreate
+// CHECK-NOT: ZE ---> zeFenceCreate
 //
 
 #include <CL/sycl.hpp>


### PR DESCRIPTION
If the test is run with UR_L0_LEAKS_DEBUG var set, UR will print ze call count summary. This summary can cause the test to fail as it will contain zeCommandQueueCreate, etc.

Fix this by making CHECK-NOT only match output generated by UR_L0_DEBUG.