### PR TITLE
[UR] Decouple adapter tags & bump OpenCL 3609afc7

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -60,12 +60,25 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   # fetch for a UR adapter, this allows development of adapters to be decoupled
   # from each other.
   #
+  # A separate content fetch will not be performed if:
+  # * The adapter name is not present in the SYCL_ENABLE_PLUGINS variable.
+  # * The repo and tag provided match the values of the
+  #   UNIFIED_RUNTIME_REPO/UNIFIED_RUNTIME_TAG variables
+  #
   # Args:
   #   * name - Must be the directory name of the adapter
   #   * repo - A valid Git URL of a Unified Runtime repo
   #   * tag - A valid Git branch/tag/commit in the Unified Runtime repo
   function(fetch_adapter_source name repo tag)
-    message(STATUS "Will fetch Unified Runtime ${name} adapter from ${repo} at ${tag}")
+    if(NOT ${name} IN_LIST SYCL_ENABLE_PLUGINS)
+      return()
+    endif()
+    if(repo STREQUAL UNIFIED_RUNTIME_REPO AND
+        tag STREQUAL UNIFIED_RUNTIME_TAG)
+      return()
+    endif()
+    message(STATUS
+      "Will fetch Unified Runtime ${name} adapter from ${repo} at ${tag}")
     set(fetch-name unified-runtime-${name})
     FetchContent_Declare(${fetch-name}
       GIT_REPOSITORY ${repo} GIT_TAG ${tag})
@@ -89,6 +102,36 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   #     Merge pull request #1432 from RossBrunton/ross/testfix
   #     [CTS] Don't segfault when failing to load a kernel
   set(UNIFIED_RUNTIME_TAG 03b71483168c091d08d86dec8b1f1c76bff19af5)
+
+  fetch_adapter_source(level_zero
+    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_TAG}
+  )
+
+  fetch_adapter_source(opencl
+    "https://github.com/oneapi-src/unified-runtime.git"
+    # Merge: e60c3c22 9287547e
+    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+    # Date:   Thu Apr 4 10:23:33 2024 +0200
+    #     Merge pull request #1448 from steffenlarsen/steffen/make_ext_func_fail_unsupported
+    #     [OpenCL] Make extension function lookup return unusupported error
+    3609afc7f8781f2eae5de74deaf50ba52b1bb344
+  )
+
+  fetch_adapter_source(cuda
+    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_TAG}
+  )
+
+  fetch_adapter_source(hip
+    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_TAG}
+  )
+
+  fetch_adapter_source(native_cpu
+    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_TAG}
+  )
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
This patch makes use of the recently introduced `fetch_adapter_source()` utility function to decouple fetching all UR adapter source in the event that a different repo/tag pair is used. To facilitate this `fetch_adapter_source()` was updated to only perform a fetch if the adapter name is present in the `SYCL_ENABLE_PLUGINS` variable and the repo/tag pair does not match the values set in the `UNFIED_RUNTIME_REPO` and `UNIFIED_RUNTIME_TAG` variables.

To exercise the newly decoupled adapter source mechanism the OpenCL adapter is bumped to 3609afc7.
