### PR TITLE
[SYCL] Fix issues regarding deprecated SYCL 1.2.1 exception types

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_filter_selector.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_filter_selector.asciidoc
@@ -21,7 +21,7 @@ Backend:DeviceType:RelativeDeviceNumber
 
 Every element of the triple is optional, but a filter must contain at least one component. 
 
-`Backend` specifies the desired backend for the wanted devices. `DeviceType` specifies the type of the desired device.  `RelativeDeviceNumber` refers to the number of device that matches any other requirements, starting from `0`, which means "the first device that matches the requirements".  Incorrect input will result in an a `runtime_error` being thrown.
+`Backend` specifies the desired backend for the wanted devices. `DeviceType` specifies the type of the desired device.  `RelativeDeviceNumber` refers to the number of device that matches any other requirements, starting from `0`, which means "the first device that matches the requirements".  Incorrect input will result in an exception with errc::runtime error code being thrown.
 
 .Supported Backends
 [width=25%]

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -136,9 +136,8 @@ protected:
             const char *WhatArg);
 };
 
-class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::runtime instead.") runtime_error
-    : public exception {
+class __SYCL_DEPRECATED("use sycl::exception with sycl::errc::runtime instead.")
+    runtime_error : public exception {
 public:
   runtime_error() : exception(make_error_code(errc::runtime)) {}
 
@@ -156,8 +155,8 @@ protected:
   runtime_error(std::error_code Ec) : exception(Ec) {}
 };
 
-class __SYCL2020_DEPRECATED("use sycl::exception with sycl::errc::kernel or "
-                            "errc::kernel_argument instead.") kernel_error
+class __SYCL_DEPRECATED("use sycl::exception with sycl::errc::kernel or "
+                        "errc::kernel_argument instead.") kernel_error
     : public runtime_error {
 public:
   kernel_error() : runtime_error(make_error_code(errc::kernel)) {}
@@ -169,7 +168,7 @@ public:
       : runtime_error(make_error_code(errc::kernel), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with sycl::errc::accessor instead.") accessor_error
     : public runtime_error {
 public:
@@ -182,7 +181,7 @@ public:
       : runtime_error(make_error_code(errc::accessor), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with sycl::errc::nd_range instead.") nd_range_error
     : public runtime_error {
 public:
@@ -195,9 +194,8 @@ public:
       : runtime_error(make_error_code(errc::nd_range), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::event instead.") event_error
-    : public runtime_error {
+class __SYCL_DEPRECATED("use sycl::exception with sycl::errc::event instead.")
+    event_error : public runtime_error {
 public:
   event_error() : runtime_error(make_error_code(errc::event)) {}
 
@@ -208,7 +206,7 @@ public:
       : runtime_error(make_error_code(errc::event), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.")
     invalid_parameter_error : public runtime_error {
 public:
@@ -222,7 +220,7 @@ public:
       : runtime_error(make_error_code(errc::kernel_argument), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.") device_error
     : public exception {
 public:
@@ -241,7 +239,7 @@ protected:
       : exception(Ec, Msg, PIErr) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.")
     compile_program_error : public device_error {
 public:
@@ -254,7 +252,7 @@ public:
       : device_error(make_error_code(errc::build), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.")
     link_program_error : public device_error {
 public:
@@ -267,7 +265,7 @@ public:
       : device_error(make_error_code(errc::build), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.")
     invalid_object_error : public device_error {
 public:
@@ -280,7 +278,7 @@ public:
       : device_error(make_error_code(errc::invalid), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with sycl::errc::memory_allocation instead.")
     memory_allocation_error : public device_error {
 public:
@@ -294,7 +292,7 @@ public:
       : device_error(make_error_code(errc::memory_allocation), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with sycl::errc::platform instead.") platform_error
     : public device_error {
 public:
@@ -307,7 +305,7 @@ public:
       : device_error(make_error_code(errc::platform), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with sycl::errc::profiling instead.") profiling_error
     : public device_error {
 public:
@@ -320,7 +318,7 @@ public:
       : device_error(make_error_code(errc::profiling), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
+class __SYCL_DEPRECATED(
     "use sycl::exception with sycl::errc::feature_not_supported instead.")
     feature_not_supported : public device_error {
 public:

--- a/sycl/include/sycl/ext/oneapi/backend/hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/backend/hip.hpp
@@ -16,10 +16,8 @@ inline namespace _V1 {
 template <>
 inline backend_return_t<backend::ext_oneapi_hip, device>
 get_native<backend::ext_oneapi_hip, device>(const device &Obj) {
-  // TODO swap with SYCL 2020 exception when in ABI-break window
   if (Obj.get_backend() != backend::ext_oneapi_hip) {
-    throw sycl::runtime_error(errc::backend_mismatch, "Backends mismatch",
-                              PI_ERROR_INVALID_OPERATION);
+    throw sycl::exception(errc::backend_mismatch, "Backends mismatch");
   }
   // HIP uses a 32-bit int instead of an opaque pointer like other backends,
   // so we need a specialization with static_cast instead of reinterpret_cast.

--- a/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
@@ -49,8 +49,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fabs(T x) {
   return __clc_fabs(x);
 #else
   (void)x;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "bf16 is not supported on host device.");
 #endif
 }
 template <typename T>
@@ -60,8 +60,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmin(T x, T y) {
 #else
   (void)x;
   (void)y;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "bf16 is not supported on host device.");
 #endif
 }
 template <typename T>
@@ -71,8 +71,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmax(T x, T y) {
 #else
   (void)x;
   (void)y;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "bf16 is not supported on host device.");
 #endif
 }
 template <typename T>
@@ -83,8 +83,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fma(T x, T y, T z) {
   (void)x;
   (void)y;
   (void)z;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "bf16 is not supported on host device.");
 #endif
 }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/ballot_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/ballot_group.hpp
@@ -11,7 +11,7 @@
 #include <sycl/aspects.hpp>
 #include <sycl/detail/pi.h>            // for PI_ERROR_INVALID_DEVICE
 #include <sycl/detail/type_traits.hpp> // for is_group, is_user_cons...
-#include <sycl/exception.hpp>          // for runtime_error
+#include <sycl/exception.hpp>          // for exception
 #include <sycl/ext/oneapi/experimental/non_uniform_groups.hpp> // for GetMask
 #include <sycl/ext/oneapi/sub_group_mask.hpp> // for sub_group_mask
 #include <sycl/id.hpp>                        // for id
@@ -48,8 +48,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return (Predicate) ? 1 : 0;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -57,8 +58,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return sycl::detail::CallerPositionInMask(Mask);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -66,8 +68,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return 2;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -75,8 +78,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return Mask.count();
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -84,8 +88,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -93,8 +98,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -102,8 +108,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -111,8 +118,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -121,8 +129,9 @@ public:
     uint32_t Lowest = static_cast<uint32_t>(Mask.find_low()[0]);
     return __spirv_SubgroupLocalInvocationId() == Lowest;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -164,8 +173,8 @@ get_ballot_group(Group group, bool predicate) {
 #endif
 #else
   (void)predicate;
-  throw runtime_error("Non-uniform groups are not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Non-uniform groups are not supported on host device.");
 #endif
 }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/fixed_size_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/fixed_size_group.hpp
@@ -11,7 +11,7 @@
 #include <sycl/aspects.hpp>
 #include <sycl/detail/pi.h>            // for PI_ERROR_INVALID_DEVICE
 #include <sycl/detail/type_traits.hpp> // for is_fixed_size_group, is_group
-#include <sycl/exception.hpp>          // for runtime_error
+#include <sycl/exception.hpp>          // for exception
 #include <sycl/ext/oneapi/sub_group_mask.hpp> // for sub_group_mask
 #include <sycl/id.hpp>                        // for id
 #include <sycl/memory_enums.hpp>              // for memory_scope
@@ -48,8 +48,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return __spirv_SubgroupLocalInvocationId() / PartitionSize;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -57,8 +58,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return __spirv_SubgroupLocalInvocationId() % PartitionSize;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -66,8 +68,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return __spirv_SubgroupSize() / PartitionSize;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -75,8 +78,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return PartitionSize;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -84,8 +88,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -93,8 +98,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -102,8 +108,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -111,8 +118,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -120,8 +128,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return get_local_linear_id() == 0;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -166,8 +175,8 @@ get_fixed_size_group(Group group) {
   return fixed_size_group<PartitionSize, sycl::sub_group>();
 #endif
 #else
-  throw runtime_error("Non-uniform groups are not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Non-uniform groups are not supported on host device.");
 #endif
 }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/opportunistic_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/opportunistic_group.hpp
@@ -11,7 +11,7 @@
 #include <sycl/aspects.hpp>
 #include <sycl/detail/pi.h>                   // for PI_ERROR_INVALID_DEVICE
 #include <sycl/detail/type_traits.hpp>        // for is_group, is_user_cons...
-#include <sycl/exception.hpp>                 // for runtime_error
+#include <sycl/exception.hpp>                 // for exception
 #include <sycl/ext/oneapi/sub_group_mask.hpp> // for sub_group_mask
 #include <sycl/id.hpp>                        // for id
 #include <sycl/memory_enums.hpp>              // for memory_scope
@@ -47,8 +47,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<id_type>(0);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -56,8 +57,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return sycl::detail::CallerPositionInMask(Mask);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -65,8 +67,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return 1;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -74,8 +77,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return Mask.count();
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -83,8 +87,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -92,8 +97,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -101,8 +107,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -110,8 +117,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -120,8 +128,9 @@ public:
     uint32_t Lowest = static_cast<uint32_t>(Mask.find_low()[0]);
     return __spirv_SubgroupLocalInvocationId() == Lowest;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -154,8 +163,8 @@ inline opportunistic_group get_opportunistic_group() {
   return opportunistic_group(mask);
 #endif
 #else
-  throw runtime_error("Non-uniform groups are not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Non-uniform groups are not supported on host device.");
 #endif
 }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/root_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/root_group.hpp
@@ -116,8 +116,8 @@ void group_barrier(ext::oneapi::experimental::root_group<dimensions> G,
 #else
   (void)G;
   (void)FenceScope;
-  throw sycl::runtime_error("Barriers are not supported on host device",
-                            PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Barriers are not supported on host device");
 #endif
 }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/tangle_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/tangle_group.hpp
@@ -11,7 +11,7 @@
 #include <sycl/aspects.hpp>
 #include <sycl/detail/pi.h>                   // for PI_ERROR_INVALID_DEVICE
 #include <sycl/detail/type_traits.hpp>        // for is_group, is_user_cons...
-#include <sycl/exception.hpp>                 // for runtime_error
+#include <sycl/exception.hpp>                 // for exception
 #include <sycl/ext/oneapi/sub_group_mask.hpp> // for sub_group_mask
 #include <sycl/id.hpp>                        // for id
 #include <sycl/memory_enums.hpp>              // for memory_scope
@@ -46,8 +46,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<id_type>(0);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -55,8 +56,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return sycl::detail::CallerPositionInMask(Mask);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -64,8 +66,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return 1;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -73,8 +76,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return Mask.count();
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -82,8 +86,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -91,8 +96,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_id()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -100,8 +106,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_group_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -109,8 +116,9 @@ public:
 #ifdef __SYCL_DEVICE_ONLY__
     return static_cast<linear_id_type>(get_local_range()[0]);
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -119,8 +127,9 @@ public:
     uint32_t Lowest = static_cast<uint32_t>(Mask.find_low()[0]);
     return __spirv_SubgroupLocalInvocationId() == Lowest;
 #else
-    throw runtime_error("Non-uniform groups are not supported on host device.",
-                        PI_ERROR_INVALID_DEVICE);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Non-uniform groups are not supported on host device.");
 #endif
   }
 
@@ -156,8 +165,8 @@ get_tangle_group(Group group) {
   return tangle_group<sycl::sub_group>(0);
 #endif
 #else
-  throw runtime_error("Non-uniform groups are not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Non-uniform groups are not supported on host device.");
 #endif
 
 } // namespace this_kernel

--- a/sycl/include/sycl/ext/oneapi/experimental/user_defined_reductions.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/user_defined_reductions.hpp
@@ -36,8 +36,8 @@ T reduce_over_group_impl(GroupHelper group_helper, T x, size_t num_elements,
   std::ignore = x;
   std::ignore = num_elements;
   std::ignore = binary_op;
-  throw runtime_error("Group algorithms are not supported on host.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Group algorithms are not supported on host.");
 #endif
 }
 } // namespace detail
@@ -54,8 +54,8 @@ reduce_over_group(GroupHelper group_helper, T x, BinaryOperation binary_op) {
       group_helper, x, group_helper.get_group().get_local_linear_range(),
       binary_op);
 #else
-  throw runtime_error("Group algorithms are not supported on host.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Group algorithms are not supported on host.");
 #endif
 }
 
@@ -73,8 +73,8 @@ reduce_over_group(GroupHelper group_helper, V x, T init,
   return binary_op(init, reduce_over_group(group_helper, x, binary_op));
 #else
   std::ignore = group_helper;
-  throw runtime_error("Group algorithms are not supported on host.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Group algorithms are not supported on host.");
 #endif
 }
 
@@ -110,8 +110,8 @@ joint_reduce(GroupHelper group_helper, Ptr first, Ptr last,
   std::ignore = first;
   std::ignore = last;
   std::ignore = binary_op;
-  throw runtime_error("Group algorithms are not supported on host.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Group algorithms are not supported on host.");
 #endif
 }
 
@@ -130,8 +130,8 @@ joint_reduce(GroupHelper group_helper, Ptr first, Ptr last, T init,
 #else
   std::ignore = group_helper;
   std::ignore = last;
-  throw runtime_error("Group algorithms are not supported on host.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw sycl::exception(sycl::errc::runtime,
+                        "Group algorithms are not supported on host.");
 #endif
 }
 } // namespace ext::oneapi::experimental

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -128,7 +128,7 @@ device select_device(DSelectorInvocableType DeviceSelectorInvocable,
     Message += Acc;
   }
   Message += Suffix;
-  throw sycl::runtime_error(Message, PI_ERROR_DEVICE_NOT_FOUND);
+  throw sycl::exception(sycl::errc::runtime, Message);
 }
 
 // select_device(selector)

--- a/sycl/test-e2e/Config/device_selector.cpp
+++ b/sycl/test-e2e/Config/device_selector.cpp
@@ -20,7 +20,7 @@ int main() {
   RejectEverything Selector;
   try {
     sycl::device Device(Selector);
-  } catch (sycl::runtime_error &E) {
+  } catch (sycl::exception &E) {
     return 0;
   }
   std::cerr << "Error. A device is found." << std::endl;

--- a/sycl/test-e2e/Scheduler/MultipleDevices.cpp
+++ b/sycl/test-e2e/Scheduler/MultipleDevices.cpp
@@ -101,7 +101,7 @@ int main() {
     queue MyQueue1(CPUSelector);
     queue MyQueue2(CPUSelector);
     Result &= multidevice_test(MyQueue1, MyQueue2);
-  } catch (sycl::runtime_error &) {
+  } catch (sycl::exception &) {
     std::cout << "Skipping CPU and CPU" << std::endl;
   }
 
@@ -109,7 +109,7 @@ int main() {
     queue MyQueue1(CPUSelector);
     queue MyQueue2(GPUSelector);
     Result &= multidevice_test(MyQueue1, MyQueue2);
-  } catch (sycl::runtime_error &) {
+  } catch (sycl::exception &) {
     std::cout << "Skipping CPU and GPU" << std::endl;
   } catch (sycl::compile_program_error &) {
     std::cout << "Skipping CPU and GPU" << std::endl;
@@ -119,7 +119,7 @@ int main() {
     queue MyQueue1(GPUSelector);
     queue MyQueue2(GPUSelector);
     Result &= multidevice_test(MyQueue1, MyQueue2);
-  } catch (sycl::runtime_error &) {
+  } catch (sycl::exception &) {
     std::cout << "Skipping GPU and GPU" << std::endl;
   } catch (sycl::compile_program_error &) {
     std::cout << "Skipping CPU and GPU" << std::endl;


### PR DESCRIPTION
Some exception types in SYCL 1.2.1 no longer exist in SYCL 2020 spec but they are marked as "SYCL-2020 deprecated" in our code with a large quantity of usages. They should be replaced with sycl::Exception. For example:
`throw runtime_error("--ERROR MESSAGE--", PI_ERROR_INVALID_DEVICE);`
should be replaced with
`throw sycl::exception(sycl::errc::runtime, "--ERROR MESSAGE--");`

In this PR: change deprecation type macros for deprecated exception types and replace the first batch of sycl::runtime_error instances with sycl::exception.

List of such exception types:
runtime_error
kernel_error
accessor_error
nd_range_error
event_error
invalid_parameter_error
device_error
compile_program_error
link_program_error
invalid_object_error
memory_allocation_error
platform_error
profiling_error
feature_not_supported