### PR TITLE
[SYCL] Remove `sycl::abs` FP overload

### DIFF
--- a/sycl/include/sycl/detail/builtins/math_functions.inc
+++ b/sycl/include/sycl/detail/builtins/math_functions.inc
@@ -511,11 +511,5 @@ template <typename T> detail::builtin_enable_nan_t<T> nan(T x) {
 }
 #endif
 
-template <typename T>
-__SYCL_DEPRECATED("abs for floating point types is non-standard and has been "
-                  "deprecated. Please use fabs instead.")
-detail::builtin_enable_math_allow_scalar_t<T> abs(T x) {
-  return fabs(x);
-}
 } // namespace _V1
 } // namespace sycl

--- a/sycl/test-e2e/Basic/sycl_2020_images/common.hpp
+++ b/sycl/test-e2e/Basic/sycl_2020_images/common.hpp
@@ -267,7 +267,10 @@ template <typename T, int Dims> bool AllTrue(const vec<T, Dims> &Vec) {
 template <typename T, int Dims>
 bool ApproxEq(const vec<T, Dims> &LHS, const vec<T, Dims> &RHS,
               T Precision = 0.1) {
-  return AllTrue(sycl::abs(LHS - RHS) <= Precision);
+  if constexpr (std::is_integral_v<T>)
+    return AllTrue(sycl::abs(LHS - RHS) <= Precision);
+  else
+    return AllTrue(sycl::fabs(LHS - RHS) <= Precision);
 }
 
 template <typename T, int Dims>

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -139,9 +139,6 @@ int main() {
   sycl::byte B;
   (void)B;
 
-  // expected-warning@+1{{abs for floating point types is non-standard and has been deprecated. Please use fabs instead.}}
-  sycl::abs(0.0f);
-
   // expected-warning@+1{{'image_support' is deprecated: deprecated in SYCL 2020, use device::has(aspect::ext_intel_legacy_image) to query for SYCL 1.2.1 image support}}
   using IS = sycl::info::device::image_support;
   // expected-warning@+1{{'max_constant_buffer_size' is deprecated: deprecated in SYCL 2020}}


### PR DESCRIPTION
It's not provided by the SYCL 2020 specification and has been marked as deprecated some time ago.