### PR TITLE
Disable TaskSequence e2e tests until FPGA Emulator implementation available

### DIFF
--- a/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
+++ b/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// XFAIL: *
 
-// REQUIRES: aspect-ext_intel_fpga_task_sequence
+// REQUIRES: accelerator && aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
+++ b/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// XFAIL: *
 
-// REQUIRES: aspect-ext_intel_fpga_task_sequence
+// REQUIRES: accelerator && aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/TaskSequence/mult-and-add.cpp
+++ b/sycl/test-e2e/TaskSequence/mult-and-add.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// XFAIL: *
 
-// REQUIRES: aspect-ext_intel_fpga_task_sequence
+// REQUIRES: accelerator && aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
+++ b/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// XFAIL: *
 
-// REQUIRES: aspect-ext_intel_fpga_task_sequence
+// REQUIRES: accelerator && aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/TaskSequence/producer-consumer.cpp
+++ b/sycl/test-e2e/TaskSequence/producer-consumer.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// XFAIL: *
 
-// REQUIRES: aspect-ext_intel_fpga_task_sequence
+// REQUIRES: accelerator && aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
+++ b/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
@@ -7,9 +7,9 @@
 //===----------------------------------------------------------------------===//
 
 // FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// XFAIL: *
 
-// REQUIRES: aspect-ext_intel_fpga_task_sequence
+// REQUIRES: accelerator && aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 #include "common.hpp"


### PR DESCRIPTION
Tests fail on windows as well due to lack of emulator implementation, was only disabled on linux to pass post-commit. Disable completely and reenable after emulator implementation upstreamed.