### PR TITLE
[SYCL][E2E] Don't use fp64 aspect in the test that doesn't need it

### DIFF
--- a/sycl/test-e2e/Regression/nop_event_profiling.cpp
+++ b/sycl/test-e2e/Regression/nop_event_profiling.cpp
@@ -21,7 +21,7 @@ int main() {
       sycl::nd_range<3>(sycl::range<3>(1, 1, 16) * sycl::range<3>(1, 1, 16),
                         sycl::range<3>(1, 1, 16)),
       [=](sycl::nd_item<3> item_ct1) {
-        double d = 123;
+        int d = 123;
         for (int i = 0; i < 10000; i++) {
           d = d * i;
         }


### PR DESCRIPTION
Test is failing on devices without fp64 aspect.
Test doesn't actually need to use double type.