### PR TITLE
[GEN] Make GEN implement `ConvertToLLVMPatternInterface`

### DIFF
--- a/mlir/include/mlir/Conversion/GENToLLVM/GENToLLVM.h
+++ b/mlir/include/mlir/Conversion/GENToLLVM/GENToLLVM.h
@@ -1,4 +1,4 @@
-//===- GENToLLVMPass.h - GEN to LLVM dialect conversion ---------*- C++ -*-===//
+//===- GENToLLVM.h - GEN to LLVM dialect conversion -------------*- C++ -*-===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,27 +6,27 @@
 //
 //===----------------------------------------------------------------------===//
 
-#ifndef MLIR_CONVERSION_GENTOLLVM_GENTOLLVMPASS_H
-#define MLIR_CONVERSION_GENTOLLVM_GENTOLLVMPASS_H
+#ifndef MLIR_CONVERSION_GENTOLLVM_GENTOLLVM_H
+#define MLIR_CONVERSION_GENTOLLVM_GENTOLLVM_H
 
-#include "mlir/Pass/Pass.h"
 #include <memory>
 
 namespace mlir {
 
+class DialectRegistry;
 class LLVMTypeConverter;
 class RewritePatternSet;
 class Pass;
 
-#define GEN_PASS_DECL_CONVERTGENTOLLVM
+#define GEN_PASS_DECL_GENTOLLVMCONVERSIONPASS
 #include "mlir/Conversion/Passes.h.inc"
 
 namespace GEN {
 void populateGENToLLVMConversionPatterns(LLVMTypeConverter &converter,
                                          RewritePatternSet &patterns);
 
-std::unique_ptr<Pass> createConvertGENToLLVM();
+void registerConvertGENToLLVMInterface(DialectRegistry &registry);
 } // namespace GEN
 } // namespace mlir
 
-#endif // MLIR_CONVERSION_GENTOLLVM_GENTOLLVMPASS_H
+#endif // MLIR_CONVERSION_GENTOLLVM_GENTOLLVM_H

--- a/mlir/include/mlir/Conversion/Passes.h
+++ b/mlir/include/mlir/Conversion/Passes.h
@@ -33,7 +33,7 @@
 #include "mlir/Conversion/FuncToEmitC/FuncToEmitCPass.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVMPass.h"
 #include "mlir/Conversion/FuncToSPIRV/FuncToSPIRVPass.h"
-#include "mlir/Conversion/GENToLLVM/GENToLLVMPass.h"
+#include "mlir/Conversion/GENToLLVM/GENToLLVM.h"
 #include "mlir/Conversion/GENToSPIRV/GENToSPIRV.h"
 #include "mlir/Conversion/GPUCommon/GPUCommonPass.h"
 #include "mlir/Conversion/GPUToGENX/GPUToGENXPass.h"

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -462,12 +462,11 @@ def ConvertFuncToSPIRV : Pass<"convert-func-to-spirv"> {
 // GENToLLVM
 //===----------------------------------------------------------------------===//
 
-def ConvertGENToLLVM : Pass<"convert-gen-to-llvm", "ModuleOp"> {
+def GENToLLVMConversionPass : Pass<"convert-gen-to-llvm"> {
   let summary = "Convert the GEN dialect to the LLVM dialect";
   let description = [{
     This pass converts GEN dialect operations to LLVM dialect operations.
   }];
-  let constructor = "mlir::GEN::createConvertGENToLLVM()";
   let dependentDialects = ["LLVM::LLVMDialect"];
 }
 

--- a/mlir/include/mlir/InitAllExtensions.h
+++ b/mlir/include/mlir/InitAllExtensions.h
@@ -18,6 +18,7 @@
 #include "mlir/Conversion/ComplexToLLVM/ComplexToLLVM.h"
 #include "mlir/Conversion/ControlFlowToLLVM/ControlFlowToLLVM.h"
 #include "mlir/Conversion/FuncToLLVM/ConvertFuncToLLVM.h"
+#include "mlir/Conversion/GENToLLVM/GENToLLVM.h"
 #include "mlir/Conversion/IndexToLLVM/IndexToLLVM.h"
 #include "mlir/Conversion/MathToLLVM/MathToLLVM.h"
 #include "mlir/Conversion/MemRefToLLVM/MemRefToLLVM.h"
@@ -59,6 +60,7 @@ inline void registerAllExtensions(DialectRegistry &registry) {
   registerConvertComplexToLLVMInterface(registry);
   cf::registerConvertControlFlowToLLVMInterface(registry);
   func::registerAllExtensions(registry);
+  GEN::registerConvertGENToLLVMInterface(registry);
   registerConvertFuncToLLVMInterface(registry);
   index::registerConvertIndexToLLVMInterface(registry);
   registerConvertMathToLLVMInterface(registry);

--- a/mlir/lib/Conversion/GENToLLVM/CMakeLists.txt
+++ b/mlir/lib/Conversion/GENToLLVM/CMakeLists.txt
@@ -1,5 +1,5 @@
 add_mlir_conversion_library(MLIRGENToLLVM
-  GENToLLVMPass.cpp
+  GENToLLVM.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${MLIR_MAIN_INCLUDE_DIR}/mlir/Conversion/GENToLLVM

--- a/mlir/lib/Conversion/GENToLLVM/GENToLLVM.cpp
+++ b/mlir/lib/Conversion/GENToLLVM/GENToLLVM.cpp
@@ -266,7 +266,7 @@ struct GENToLLVMConversionPass final
 //===----------------------------------------------------------------------===//
 
 namespace {
-/// Implement the interface to convert MemRef to LLVM.
+/// Implement the interface to convert GEN to LLVM.
 struct GENToLLVMDialectInterface : public ConvertToLLVMPatternInterface {
   using ConvertToLLVMPatternInterface::ConvertToLLVMPatternInterface;
 

--- a/mlir/lib/Conversion/GENToLLVM/GENToLLVM.cpp
+++ b/mlir/lib/Conversion/GENToLLVM/GENToLLVM.cpp
@@ -1,4 +1,4 @@
-//===- GENToLLVMPass.cpp - MLIR GEN to LLVM dialect conversion ------------===//
+//===- GENToLLVM.cpp - MLIR GEN to LLVM dialect conversion ----------------===//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include "mlir/Conversion/GENToLLVM/GENToLLVMPass.h"
+#include "mlir/Conversion/GENToLLVM/GENToLLVM.h"
 
 #include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
 #include "mlir/Conversion/LLVMCommon/ConversionTarget.h"
@@ -27,7 +27,7 @@
 #include "llvm/Support/ErrorHandling.h"
 
 namespace mlir {
-#define GEN_PASS_DEF_CONVERTGENTOLLVM
+#define GEN_PASS_DEF_GENTOLLVMCONVERSIONPASS
 #include "mlir/Conversion/Passes.h.inc"
 } // namespace mlir
 
@@ -241,8 +241,8 @@ struct SubGroupShuffleLowering
 //===----------------------------------------------------------------------===//
 
 namespace {
-struct ConvertGENToLLVM final
-    : public impl::ConvertGENToLLVMBase<ConvertGENToLLVM> {
+struct GENToLLVMConversionPass final
+    : public impl::GENToLLVMConversionPassBase<GENToLLVMConversionPass> {
   using Base::Base;
 
   void runOnOperation() override {
@@ -259,8 +259,32 @@ struct ConvertGENToLLVM final
       signalPassFailure();
   }
 };
-
 } // namespace
+
+//===----------------------------------------------------------------------===//
+// ConvertToLLVMPatternInterface implementation
+//===----------------------------------------------------------------------===//
+
+namespace {
+/// Implement the interface to convert MemRef to LLVM.
+struct GENToLLVMDialectInterface : public ConvertToLLVMPatternInterface {
+  using ConvertToLLVMPatternInterface::ConvertToLLVMPatternInterface;
+
+  /// Hook for derived dialect interface to provide conversion patterns
+  /// and mark dialect legal for the conversion target.
+  void populateConvertToLLVMConversionPatterns(
+      ConversionTarget &target, LLVMTypeConverter &typeConverter,
+      RewritePatternSet &patterns) const final {
+    GEN::populateGENToLLVMConversionPatterns(typeConverter, patterns);
+  }
+};
+} // namespace
+
+void mlir::GEN::registerConvertGENToLLVMInterface(DialectRegistry &registry) {
+  registry.addExtension(+[](MLIRContext *ctx, GEN::GENDialect *dialect) {
+    dialect->addInterfaces<GENToLLVMDialectInterface>();
+  });
+}
 
 //===----------------------------------------------------------------------===//
 // Pattern Population and Registration
@@ -273,8 +297,4 @@ void mlir::GEN::populateGENToLLVMConversionPatterns(
                GEN3DNDRangeLowering<GEN::WorkGroupSizeOp>,
                GEN3DNDRangeLowering<GEN::NumWorkGroupsOp>, GENBarrierLowering,
                SubGroupShuffleLowering>(converter);
-}
-
-std::unique_ptr<Pass> mlir::GEN::createConvertGENToLLVM() {
-  return std::make_unique<ConvertGENToLLVM>();
 }

--- a/mlir/lib/Dialect/GEN/IR/GENDialect.cpp
+++ b/mlir/lib/Dialect/GEN/IR/GENDialect.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 #include "mlir/Dialect/GEN/IR/GENDialect.h"
+
+#include "mlir/Conversion/ConvertToLLVM/ToLLVMInterface.h"
 #include "mlir/Dialect/GEN/IR/GENOps.h"
 #include "mlir/Dialect/LLVMIR/LLVMDialect.h"
 #include "mlir/IR/Builders.h"
@@ -39,4 +41,5 @@ void GENDialect::initialize() {
 #define GET_ATTRDEF_LIST
 #include "mlir/Dialect/GEN/IR/GENOpsAttrDefs.cpp.inc"
       >();
+  declarePromisedInterface<GENDialect, ConvertToLLVMPatternInterface>();
 }

--- a/mlir/test/Conversion/GENToLLVM/gen-to-llvm.mlir
+++ b/mlir/test/Conversion/GENToLLVM/gen-to-llvm.mlir
@@ -1,29 +1,33 @@
-// RUN: mlir-opt -convert-gen-to-llvm -split-input-file %s | FileCheck %s
+// RUN: mlir-opt -pass-pipeline="builtin.module(func.func(convert-gen-to-llvm))" -split-input-file %s | FileCheck %s
 
-llvm.func @gen_nd_range(%dim: i32) {
+// Same below, but using the `ConvertToLLVMPatternInterface` entry point
+// and the generic `convert-to-llvm` pass.
+// RUN: mlir-opt --convert-to-llvm="filter-dialects=gen" --split-input-file %s | FileCheck %s
+
+func.func @gen_nd_range(%dim: i32) {
   // CHECK-LABEL: gen_nd_range
-  // CHECK-SAME:              (%[[DIM:.*]]: i32)
-  // CHECK:         llvm.call @_Z12get_local_idj(%[[DIM]]) : (i32) -> i64
+  // CHECK-SAME:              ([[DIM:%.*]]: i32)
+  // CHECK:         llvm.call @_Z12get_local_idj([[DIM]]) : (i32) -> i64
   %0 = gen.local_id %dim
-  // CHECK:         llvm.call @_Z12get_group_idj(%[[DIM]]) : (i32) -> i64
+  // CHECK:         llvm.call @_Z12get_group_idj([[DIM]]) : (i32) -> i64
   %1 = gen.work_group_id %dim
-  // CHECK:         llvm.call @_Z14get_local_sizej(%[[DIM]]) : (i32) -> i64
+  // CHECK:         llvm.call @_Z14get_local_sizej([[DIM]]) : (i32) -> i64
   %2 = gen.work_group_size %dim
-  // CHECK:         llvm.call @_Z14get_num_groupsj(%[[DIM]]) : (i32) -> i64
+  // CHECK:         llvm.call @_Z14get_num_groupsj([[DIM]]) : (i32) -> i64
   %3 = gen.num_work_groups %dim
-  llvm.return
+  func.return
 }
 
 // -----
 
 // CHECK: llvm.func spir_funccc @_Z7barrierj(i32) attributes {passthrough = ["convergent"]}
 
-llvm.func @gen.barrier() {
+func.func @gen.barrier() {
   // CHECK-LABEL: gen.barrier
   // CHECK: [[CST:%.*]] = llvm.mlir.constant(1 : i32) : i32
   // CHECK: llvm.call @_Z7barrierj([[CST]]) {passthrough = ["convergent"]} : (i32) -> ()
   gen.barrier
-  llvm.return
+  func.return
 }
 
 // -----
@@ -39,47 +43,49 @@ llvm.func @gen.barrier() {
 // CHECK-DAG: llvm.func spir_funccc @_Z20sub_group_shuffle_upij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
 // CHECK-DAG: llvm.func spir_funccc @_Z21sub_group_shuffle_xorij(i32, i32) -> i32 attributes {passthrough = ["convergent"]}
 
-llvm.func @gen.sub_group_shuffle() {
+func.func @gen.sub_group_shuffle() {
   // CHECK-LABEL: gen.sub_group_shuffle
-  %0 = llvm.mlir.constant(0 : i32) : i32
-  // CHECK: [[ZERO:%.*]] = llvm.mlir.constant(0 : i32) : i32
+  %c0_i32 = arith.constant 0 : i32
+  %c0_i8 = arith.constant 0 : i8
+  %c0_i16 = arith.constant 0 : i16
+  %c0_i64 = arith.constant 0 : i64
+  %cst = arith.constant 0.000000e+00 : f64
+  %cst_0 = arith.constant 0.000000e+00 : f16
+  %cst_1 = arith.constant 0.000000e+00 : f32
+
+  // CHECK-DAG: [[ZERO:%.*]] = arith.constant 0 : i32
+  // CHECK-DAG: [[ZERO1:%.*]] = arith.constant 0 : i8
+  // CHECK-DAG: [[ZERO2:%.*]] = arith.constant 0 : i16
+  // CHECK-DAG: [[ZERO3:%.*]] = arith.constant 0 : i64
+  // CHECK-DAG: [[ZERO4:%.*]] = arith.constant 0.000000e+00 : f16
+  // CHECK-DAG: [[ZERO5:%.*]] = arith.constant 0.000000e+00 : f32
+  // CHECK-DAG: [[ZERO6:%.*]] = arith.constant 0.000000e+00 : f64
+
   // CHECK: llvm.call @_Z21sub_group_shuffle_xorij([[ZERO]], [[ZERO]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
   // CHECK: llvm.call @_Z20sub_group_shuffle_upij([[ZERO]], [[ZERO]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
   // CHECK: llvm.call @_Z22sub_group_shuffle_downij([[ZERO]], [[ZERO]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
   // CHECK: llvm.call @_Z17sub_group_shuffleij([[ZERO]], [[ZERO]]) {passthrough = ["convergent"]} : (i32, i32) -> i32
-  %1 = gen.sub_group_shuffle xor %0, %0 : i32
-  %2 = gen.sub_group_shuffle up %0, %0 : i32
-  %3 = gen.sub_group_shuffle down %0, %0 : i32
-  %4 = gen.sub_group_shuffle idx %0, %0 : i32
+  %0 = gen.sub_group_shuffle xor %c0_i32, %c0_i32 : i32
+  %1 = gen.sub_group_shuffle up %c0_i32, %c0_i32 : i32
+  %2 = gen.sub_group_shuffle down %c0_i32, %c0_i32 : i32
+  %3 = gen.sub_group_shuffle idx %c0_i32, %c0_i32 : i32
 
-  // CHECK: [[ZERO1:%.*]] = llvm.mlir.constant(0 : i8) : i8
   // CHECK: llvm.call @_Z21sub_group_shuffle_xorcj([[ZERO1]], [[ZERO]]) {passthrough = ["convergent"]} : (i8, i32) -> i8
-  %5 = llvm.mlir.constant(0 : i8) : i8
-  %6 = gen.sub_group_shuffle xor %5, %0 : i8
+  %4 = gen.sub_group_shuffle xor %c0_i8, %c0_i32 : i8
 
-  // CHECK: [[ZERO2:%.*]] = llvm.mlir.constant(0 : i16) : i16
   // CHECK: llvm.call @_Z21sub_group_shuffle_xorsj([[ZERO2]], [[ZERO]]) {passthrough = ["convergent"]} : (i16, i32) -> i16
-  %7 = llvm.mlir.constant(0 : i16) : i16
-  %8 = gen.sub_group_shuffle xor %7, %0 : i16
+  %5 = gen.sub_group_shuffle xor %c0_i16, %c0_i32 : i16
 
-  // CHECK: [[ZERO3:%.*]] = llvm.mlir.constant(0 : i64) : i64
   // CHECK: llvm.call @_Z21sub_group_shuffle_xorlj([[ZERO3]], [[ZERO]]) {passthrough = ["convergent"]} : (i64, i32) -> i64
-  %9 = llvm.mlir.constant(0 : i64) : i64
-  %10 = gen.sub_group_shuffle xor %9, %0 : i64
+  %6 = gen.sub_group_shuffle xor %c0_i64, %c0_i32 : i64
 
-  // CHECK: [[ZERO4:%.*]] = llvm.mlir.constant(0.000000e+00 : f16) : f16
   // CHECK: llvm.call @_Z21sub_group_shuffle_xorDhj([[ZERO4]], [[ZERO]]) {passthrough = ["convergent"]} : (f16, i32) -> f16
-  %11 = llvm.mlir.constant(0.0 : f16) : f16
-  %12 = gen.sub_group_shuffle xor %11, %0 : f16
+  %7 = gen.sub_group_shuffle xor %cst_0, %c0_i32 : f16
 
-  // CHECK: [[ZERO5:%.*]] = llvm.mlir.constant(0.000000e+00 : f32) : f32
   // CHECK: llvm.call @_Z21sub_group_shuffle_xorfj([[ZERO5]], [[ZERO]]) {passthrough = ["convergent"]} : (f32, i32) -> f32
-  %13 = llvm.mlir.constant(0.0 : f32) : f32
-  %14 = gen.sub_group_shuffle xor %13, %0 : f32
+  %8 = gen.sub_group_shuffle xor %cst_1, %c0_i32 : f32
 
-  // CHECK: [[ZERO6:%.*]] = llvm.mlir.constant(0.000000e+00 : f64) : f64
   // CHECK: llvm.call @_Z21sub_group_shuffle_xordj([[ZERO6]], [[ZERO]]) {passthrough = ["convergent"]} : (f64, i32) -> f64
-  %15 = llvm.mlir.constant(0.0 : f64) : f64
-  %16 = gen.sub_group_shuffle xor %15, %0 : f64
-  llvm.return
+  %9 = gen.sub_group_shuffle xor %cst, %c0_i32 : f64
+  func.return
 }


### PR DESCRIPTION
Make GEN implement `ConvertToLLVMPatternInterface` so it can be converted to LLVM using the `-convert-to-llvm` pass.

Also make some improvements to `-convert-gen-to-llvm`:

- Rename files and classes to match other dialects;
- Make it a `OperationPass<>` so it can be run using any operation as its root;
- Leverage MLIR TableGen infrastructure to define constructor instead of doing it manually;
- Use operations from dialects other than `llvm` in conversion tests.