### PR TITLE
[GEN] Add `use-64bit-index` option to `-convert-gen-to-spirv`

### DIFF
--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -468,6 +468,11 @@ def GENToLLVMConversionPass : Pass<"convert-gen-to-llvm"> {
     This pass converts GEN dialect operations to LLVM dialect operations.
   }];
   let dependentDialects = ["LLVM::LLVMDialect"];
+  let options = [
+    Option<"indexBitwidth", "index-bitwidth", "unsigned",
+           /*default=kDeriveIndexBitwidthFromDataLayout*/"0",
+           "Bitwidth of the index type, 0 to use size of machine word">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Conversion/GENToLLVM/GENToLLVM.cpp
+++ b/mlir/lib/Conversion/GENToLLVM/GENToLLVM.cpp
@@ -248,7 +248,11 @@ struct GENToLLVMConversionPass final
   void runOnOperation() override {
     MLIRContext *context = &getContext();
     RewritePatternSet pattern(context);
+
     LowerToLLVMOptions options(context);
+    if (indexBitwidth != kDeriveIndexBitwidthFromDataLayout)
+      options.overrideIndexBitwidth(indexBitwidth);
+
     LLVMTypeConverter converter(context, options);
     LLVMConversionTarget target(*context);
 

--- a/mlir/test/Conversion/GENToLLVM/gen-to-llvm.mlir
+++ b/mlir/test/Conversion/GENToLLVM/gen-to-llvm.mlir
@@ -1,4 +1,7 @@
-// RUN: mlir-opt -pass-pipeline="builtin.module(func.func(convert-gen-to-llvm))" -split-input-file %s | FileCheck %s
+// RUN: mlir-opt -pass-pipeline="builtin.module(func.func(convert-gen-to-llvm))" -split-input-file %s \
+// RUN: | FileCheck --check-prefixes=CHECK-64,CHECK %s
+// RUN: mlir-opt -pass-pipeline="builtin.module(func.func(convert-gen-to-llvm{index-bitwidth=32}))" -split-input-file %s \
+// RUN: | FileCheck --check-prefixes=CHECK-32,CHECK %s
 
 // Same below, but using the `ConvertToLLVMPatternInterface` entry point
 // and the generic `convert-to-llvm` pass.
@@ -7,13 +10,17 @@
 func.func @gen_nd_range(%dim: i32) {
   // CHECK-LABEL: gen_nd_range
   // CHECK-SAME:              ([[DIM:%.*]]: i32)
-  // CHECK:         llvm.call @_Z12get_local_idj([[DIM]]) : (i32) -> i64
+  // CHECK-64:      llvm.call @_Z12get_local_idj([[DIM]]) : (i32) -> i64
+  // CHECK-32:      llvm.call @_Z12get_local_idj([[DIM]]) : (i32) -> i32
   %0 = gen.local_id %dim
-  // CHECK:         llvm.call @_Z12get_group_idj([[DIM]]) : (i32) -> i64
+  // CHECK-64:      llvm.call @_Z12get_group_idj([[DIM]]) : (i32) -> i64
+  // CHECK-32:      llvm.call @_Z12get_group_idj([[DIM]]) : (i32) -> i32
   %1 = gen.work_group_id %dim
-  // CHECK:         llvm.call @_Z14get_local_sizej([[DIM]]) : (i32) -> i64
+  // CHECK-64:      llvm.call @_Z14get_local_sizej([[DIM]]) : (i32) -> i64
+  // CHECK-32:      llvm.call @_Z14get_local_sizej([[DIM]]) : (i32) -> i32
   %2 = gen.work_group_size %dim
-  // CHECK:         llvm.call @_Z14get_num_groupsj([[DIM]]) : (i32) -> i64
+  // CHECK-64:      llvm.call @_Z14get_num_groupsj([[DIM]]) : (i32) -> i64
+  // CHECK-32:      llvm.call @_Z14get_num_groupsj([[DIM]]) : (i32) -> i32
   %3 = gen.num_work_groups %dim
   func.return
 }


### PR DESCRIPTION
Add option to control whether 32 or 64 bit integers are used.