### PR TITLE
[SYCL][libdevice] Build for spirv64 on Linux

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -20,8 +20,16 @@ string(CONCAT sycl_targets_opt
   "spir64_x86_64-unknown-unknown,"
   "spir64_gen-unknown-unknown,"
   "spir64_fpga-unknown-unknown,"
-  "spir64-unknown-unknown,"
-  "spirv64-unknown-unknown")
+  "spir64-unknown-unknown")
+
+if (NOT WIN32)
+  # Don't build for spirv64 on Windows due to
+  # some type size difference issues.
+  # Build on once Windows once internal tracker is fixed.
+  string(APPEND
+    sycl_targets_opt
+    ",spirv64-unknown-unknown")
+endif()
 
 set(compile_opts
   # suppress an error about SYCL_EXTERNAL being used for

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -20,7 +20,8 @@ string(CONCAT sycl_targets_opt
   "spir64_x86_64-unknown-unknown,"
   "spir64_gen-unknown-unknown,"
   "spir64_fpga-unknown-unknown,"
-  "spir64-unknown-unknown")
+  "spir64-unknown-unknown,"
+  "spirv64-unknown-unknown")
 
 set(compile_opts
   # suppress an error about SYCL_EXTERNAL being used for


### PR DESCRIPTION
Otherwise we will hit problems with compiling with `-fsycl-targets=spirv64`.

Eventually we will need to expand this for the non-JIT `spirv64` targets, but those aren't supported today. 

We only build on Linux today because of ptrdiff_t size differences causing compiler errors on Windows.

Found this also while working on thinLTO.