### PR TITLE
[CI] Use same image name but different tag

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -68,7 +68,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/${{ github.repository }}/${{ matrix.file }}-${{ github.sha }}
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}-${{ matrix.tags }}${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tags }}
           build-args: ${{ matrix.build_args }}
 

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -69,6 +69,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.file }}-${{ github.sha }}
-            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ github.tags }}
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tags }}
           build-args: ${{ matrix.build_args }}
 

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -35,25 +35,25 @@ jobs:
         include:
           - name: Base Ubuntu 22.04 Docker image
             file: ubuntu2204_base
-            tags: latest
+            tag: latest
             build_args: ""
           - name: Build Ubuntu Docker image
             file: ubuntu2204_build
-            tags: latest
+            tag: latest
             build_args: ""
           - name: Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
-            tags: latest
+            tag: latest
             build_args: "use_latest=false"
           - name: Intel Drivers Ubuntu 22.04 Docker image with dev IGC
             file: ubuntu2204_intel_drivers
-            tags: devigc
+            tag: devigc
             build_args: |
                   "use_latest=false"
                   "use_igc_dev=true"
           - name: Intel Drivers (unstable) Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
-            tags: unstable
+            tag: unstable
             build_args: "use_latest=true"
     steps:
       - name: Checkout
@@ -67,8 +67,8 @@ jobs:
           file: ${{ matrix.file }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          tags: |
-            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tags }}-${{ github.sha }}
-            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tags }}
+          tag: |
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}-${{ github.sha }}
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}
           build-args: ${{ matrix.build_args }}
 

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -68,7 +68,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/${{ github.repository }}/${{ matrix.file }}-${{ matrix.tags }}${{ github.sha }}
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tags }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tags }}
           build-args: ${{ matrix.build_args }}
 

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -47,13 +47,13 @@ jobs:
             build_args: "use_latest=false"
           - name: Intel Drivers Ubuntu 22.04 Docker image with dev IGC
             file: ubuntu2204_intel_drivers
-            tags: ubuntu2204_intel_drivers_devigc
+            tags: ubuntu2204_intel_drivers:devigc
             build_args: |
                   "use_latest=false"
                   "use_igc_dev=true"
           - name: Intel Drivers (unstable) Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
-            tags: ubuntu2204_intel_drivers_unstable
+            tags: ubuntu2204_intel_drivers:unstable
             build_args: "use_latest=true"
     steps:
       - name: Checkout
@@ -69,6 +69,6 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.tags }}-${{ github.sha }}
-            ghcr.io/${{ github.repository }}/${{ matrix.tags }}:latest
+            ghcr.io/${{ github.repository }}/${{ contains(matrix.tags, ':') && matrix.tags || format('{0}:latest', matrix.tags) }}
           build-args: ${{ matrix.build_args }}
 

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -67,7 +67,7 @@ jobs:
           file: ${{ matrix.file }}
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
-          tag: |
+          tags: |
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}
           build-args: ${{ matrix.build_args }}

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -35,25 +35,25 @@ jobs:
         include:
           - name: Base Ubuntu 22.04 Docker image
             file: ubuntu2204_base
-            tags: ubuntu2204_base
+            tags: latest
             build_args: ""
           - name: Build Ubuntu Docker image
             file: ubuntu2204_build
-            tags: ubuntu2204_build
+            tags: latest
             build_args: ""
           - name: Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
-            tags: ubuntu2204_intel_drivers
+            tags: latest
             build_args: "use_latest=false"
           - name: Intel Drivers Ubuntu 22.04 Docker image with dev IGC
             file: ubuntu2204_intel_drivers
-            tags: ubuntu2204_intel_drivers:devigc
+            tags: devigc
             build_args: |
                   "use_latest=false"
                   "use_igc_dev=true"
           - name: Intel Drivers (unstable) Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
-            tags: ubuntu2204_intel_drivers:unstable
+            tags: unstable
             build_args: "use_latest=true"
     steps:
       - name: Checkout
@@ -68,7 +68,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
           tags: |
-            ghcr.io/${{ github.repository }}/${{ matrix.tags }}-${{ github.sha }}
-            ghcr.io/${{ github.repository }}/${{ contains(matrix.tags, ':') && matrix.tags || format('{0}:latest', matrix.tags) }}
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}-${{ github.sha }}
+            ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ github.tags }}
           build-args: ${{ matrix.build_args }}
 


### PR DESCRIPTION
When we push the built docker image with tags, it will be stored in github as a package.
The default package is private.
When we create name image names,  they are all private by default.
Hence we can't access `_unstable` or `_devigc` images after refactoring. 

See https://github.com/intel/llvm/actions/runs/8574917864/job/23502927206?pr=13305

> /usr/bin/docker pull "ghcr.io/intel/llvm/ubuntu2204_intel_drivers_devigc:latest"
>   Error response from daemon: Head "https://ghcr.io/v2/intel/llvm/ubuntu2204_intel_drivers_devigc/manifests/latest": unauthorized
>   Warning: Docker pull failed with exit code 1, back off 2.664 seconds before retry."

Also the package permission control is in github org level, not in repo level, 
so even the repo admin can't mark them as public.

To avoid applying for more public images from org level, 
we can use same images but different tags for our images, as the existing images have been marked as public.