### PR TITLE
[SYCL] Align assert ext name with libdevice implementation

### DIFF
--- a/sycl/include/sycl/detail/pi.h
+++ b/sycl/include/sycl/detail/pi.h
@@ -957,8 +957,7 @@ static const uint8_t PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL = 4;
 /// Extension to denote native support of assert feature by an arbitrary device
 /// piDeviceGetInfo call should return this extension when the device supports
 /// native asserts if supported extensions' names are requested
-#define PI_DEVICE_INFO_EXTENSION_DEVICELIB_ASSERT                              \
-  "cl_intel_devicelib_assert"
+#define PI_DEVICE_INFO_EXTENSION_DEVICELIB_ASSERT "cl_intel_devicelib_assert"
 
 /// Device binary image property set names recognized by the SYCL runtime.
 /// Name must be consistent with

--- a/sycl/include/sycl/detail/pi.h
+++ b/sycl/include/sycl/detail/pi.h
@@ -958,7 +958,7 @@ static const uint8_t PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL = 4;
 /// piDeviceGetInfo call should return this extension when the device supports
 /// native asserts if supported extensions' names are requested
 #define PI_DEVICE_INFO_EXTENSION_DEVICELIB_ASSERT                              \
-  "pi_ext_intel_devicelib_assert"
+  "cl_intel_devicelib_assert"
 
 /// Device binary image property set names recognized by the SYCL runtime.
 /// Name must be consistent with


### PR DESCRIPTION
In native assert design (https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/supported/sycl_ext_oneapi_assert.asciidoc), fallback implementation is used only when native support is not available for underlying device(OCL CPU/GPU, level 0 GPU). The fallback implementation for assert is provided via sycl device libraries and fallback mechanism requires that any underlying device which provides native assert should also expose 'cl_intel_devicelib_assert' extension for sycl runtime to check. Latest OCL cpu runtime has already provided native assert and expose this ext string, but we find the fallback implementation is still used instead of native version on OCL CPU device.
The reason is sycl runtime used a different string for checking: "pi_ext_intel_devicelib_assert", so this PR fixes it.