### PR TITLE
[UR] Use UNIFIED_RUNTIME_REPO for adapter source fetches

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -104,12 +104,12 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG 065bf2dd97b58a4ceeb2fb83eed1df9319e61c59)
 
   fetch_adapter_source(level_zero
-    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_REPO}
     ${UNIFIED_RUNTIME_TAG}
   )
 
   fetch_adapter_source(opencl
-    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_REPO}
     # Merge: e60c3c22 9287547e
     # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
     # Date:   Thu Apr 4 10:23:33 2024 +0200
@@ -119,17 +119,17 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   )
 
   fetch_adapter_source(cuda
-    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_REPO}
     ${UNIFIED_RUNTIME_TAG}
   )
 
   fetch_adapter_source(hip
-    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_REPO}
     ${UNIFIED_RUNTIME_TAG}
   )
 
   fetch_adapter_source(native_cpu
-    "https://github.com/oneapi-src/unified-runtime.git"
+    ${UNIFIED_RUNTIME_REPO}
     ${UNIFIED_RUNTIME_TAG}
   )
 


### PR DESCRIPTION
Following up from #13278 change the calls to `fetch_adapter_source()` to use the `UNIFIED_RUNTIME_REPO` variable by default. This should ensure that existing UR testing PR's are using the intended fork.
