### PR TITLE
Revert "[SYCL][Driver] Link with sycl libs at link step of clang-cl -fsycl (#12793)"

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -135,23 +135,18 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-defaultlib:oldnames");
   }
 
-  if ((Args.hasArg(options::OPT_fsycl) &&
+  if ((!C.getDriver().IsCLMode() && Args.hasArg(options::OPT_fsycl) &&
        !Args.hasArg(options::OPT_nolibsycl)) ||
       Args.hasArg(options::OPT_fsycl_host_compiler_EQ)) {
     CmdArgs.push_back(Args.MakeArgString(std::string("-libpath:") +
                                          TC.getDriver().Dir + "/../lib"));
-    if (!Args.hasArg(options::OPT__SLASH_MDd) &&
-        !isDependentLibAdded(Args, "msvcrtd")) {
+    // When msvcrtd is added via --dependent-lib, we add the sycld
+    // equivalent.  Do not add the -defaultlib as it conflicts.
+    if (!isDependentLibAdded(Args, "msvcrtd")) {
       if (Args.hasArg(options::OPT_fpreview_breaking_changes))
         CmdArgs.push_back("-defaultlib:sycl" SYCL_MAJOR_VERSION "-preview.lib");
       else
         CmdArgs.push_back("-defaultlib:sycl" SYCL_MAJOR_VERSION ".lib");
-    } else {
-      if (Args.hasArg(options::OPT_fpreview_breaking_changes))
-        CmdArgs.push_back("-defaultlib:sycl" SYCL_MAJOR_VERSION
-                          "-previewd.lib");
-      else
-        CmdArgs.push_back("-defaultlib:sycl" SYCL_MAJOR_VERSION "d.lib");
     }
     CmdArgs.push_back("-defaultlib:sycl-devicelib-host.lib");
   }

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -486,7 +486,7 @@
 // RUN: %clang -fsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
 // RUN: %clang_cl -fsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-CL %s
 // CHECK-LINK-SYCL-CL: "--dependent-lib=sycl{{[0-9]*}}"
-// CHECK-LINK-SYCL-CL: "-defaultlib:sycl{{[0-9]*}}.lib"
+// CHECK-LINK-SYCL-CL-NOT: "-defaultlib:sycl{{[0-9]*}}.lib"
 // CHECK-LINK-SYCL: "-defaultlib:sycl{{[0-9]*}}.lib"
 
 /// Check no SYCL runtime is linked with -nolibsycl
@@ -837,16 +837,3 @@
 // FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK: --dependent-lib=sycl{{[0-9]*}}-previewd
 // FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK-NOT: -defaultlib:sycl{{[0-9]*}}.lib
 // FSYCL-PREVIEW-BREAKING-CHANGES-DEBUG-CHECK-NOT: -defaultlib:sycl{{[0-9]*}}-preview.lib
-
-
-/// Check that at link step of "clang-cl -fsycl" we pull in sycl.lib even if at the compilation step sycl libraries were not provided (this is possible if user compiles manually without -fsycl by provided paths to the headers).
-// RUN: %clang_cl -### -fsycl -nolibsycl -target x86_64-unknown-windows-msvc -c %s 2>&1 | FileCheck -check-prefix FSYCL-CL-COMPILE-NOLIBS-CHECK %s
-// RUN: %clang_cl -### -fsycl %s 2>&1 | FileCheck -check-prefix FSYCL-CL-LINK-CHECK %s
-// FSYCL-CL-COMPILE-NOLIBS-CHECK-NOT: "--dependent-lib=sycl{{[0-9]*}}"
-// FSYCL-CL-LINK-CHECK: "-defaultlib:sycl{{[0-9]*}}.lib"
-
-/// Check that at link step of "clang-cl -fsycl /MDd" we pull in sycld.lib even if at the compilation step sycl libraries were not provided (this is possible if user compiles manually without -fsycl by provided paths to the headers).
-// RUN: %clang_cl -### -fsycl -nolibsycl /MDd -target x86_64-unknown-windows-msvc -c %s 2>&1 | FileCheck -check-prefix FSYCL-CL-COMPILE-NOLIBS-MDd-CHECK %s
-// RUN: %clang_cl -### -fsycl /MDd %s 2>&1 | FileCheck -check-prefix FSYCL-CL-LINK--MDd-CHECK %s
-// FSYCL-CL-COMPILE-NOLIBS-MDd-CHECK-NOT: "--dependent-lib=sycl{{[0-9]*}}d"
-// FSYCL-CL-LINK--MDd-CHECK: "-defaultlib:sycl{{[0-9]*}}d.lib"


### PR DESCRIPTION
This reverts commit d6eecfa0e709ec280db6c15fa84d9f573e6a9d42.

This was commit was trying to cover the scenario:
```
clang-cl -I[path to sycl headers] sycl_program.cpp 
clang-cl -fsycl sycl_program.obj
```
and automatically link with sycl library at link step in such case.

But problem is that at link step there is no way to know if -fsycl -MDd option was used at compile step or not.
if -fsycl -MDd is used at compilation step then driver adds --dependent-lib=msvcrtd --dependent-lib=sycl7d options:
`clang-cl -fsycl -MDd  sycl_program.cpp  # --dependent-lib=msvcrtd --dependent-lib=sycl7d`
If then user links the program like this (without  -MDd):
`clang-cl -fsycl sycl_program.obj` then we will also link with sycl7 library (release version) which will cause a problem.
Because at link step we don't know if we need to use debug of release version of the library.


So, from my understanding this case:
```
clang-cl -I[path to sycl headers] sycl_program.cpp 
clang-cl -fsycl sycl_program.obj
```
can't be supported and needs to be considered as user's mistake.