### PR TITLE
[OpenCL] Config dependent-load flag to exclude CWD from DLL search path

### DIFF
--- a/opencl/opencl-aot/CMakeLists.txt
+++ b/opencl/opencl-aot/CMakeLists.txt
@@ -12,6 +12,11 @@ set(OPENCL_AOT_PROJECT_NAME opencl-aot)
 
 add_llvm_tool(${OPENCL_AOT_PROJECT_NAME} ${TARGET_SOURCES})
 
+if (WIN32)
+  # 0x2000: exclude CWD from DLL loading path
+  target_link_options(${OPENCL_AOT_PROJECT_NAME} PRIVATE "/DEPENDENTLOADFLAG:0x2000")
+endif()
+
 if(NOT MSVC)
   # FIXME: when built with clang it produces a warning.
   target_compile_options(${OPENCL_AOT_PROJECT_NAME} PRIVATE "-Wno-unused-parameter")


### PR DESCRIPTION
This change is to avoid DLL hijacking security issue.