### PR TITLE
[SYCL][Driver] Add target DeviceConfigFile to DEPENDS of clangDriver

### DIFF
--- a/clang/lib/Driver/CMakeLists.txt
+++ b/clang/lib/Driver/CMakeLists.txt
@@ -98,6 +98,7 @@ add_clang_library(clangDriver
 
   DEPENDS
   ClangDriverOptions
+  DeviceConfigFile
 
   LINK_LIBS
   clangBasic


### PR DESCRIPTION
Fix `llvm/SYCLLowerIR/DeviceConfigFile.inc: No such file or directory` when compiling clang Driver.cpp
The inc file is generated by tablegen_target DeviceConfigFile.