### PR TITLE
[UR][OpenCL] Revert urMemBufferCreate extension function lookup error

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -110,12 +110,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
 
   fetch_adapter_source(opencl
     ${UNIFIED_RUNTIME_REPO}
-    # Merge: e60c3c22 9287547e
+    # commit 85b7559033e329389452cb87615ad42fbb644d59 (HEAD -> main, origin/main, origin/HEAD)
+    # Merge: a7c202b4 5c300799
     # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Thu Apr 4 10:23:33 2024 +0200
-    #     Merge pull request #1448 from steffenlarsen/steffen/make_ext_func_fail_unsupported
-    #     [OpenCL] Make extension function lookup return unusupported error
-    3609afc7f8781f2eae5de74deaf50ba52b1bb344
+    # Date:   Tue Apr 9 14:06:49 2024 +0100
+    #     Merge pull request #1496 from steffenlarsen/steffen/revert_memory_lookup_error
+    #     [OpenCL] Revert urMemBufferCreate extension function lookup error
+    85b7559033e329389452cb87615ad42fbb644d59
   )
 
   fetch_adapter_source(cuda


### PR DESCRIPTION
Revert https://github.com/oneapi-src/unified-runtime/pull/1448, pulls in OpenCL adapter changes from https://github.com/oneapi-src/unified-runtime/pull/1496.