### PR TITLE
[SYCL][ESIMD][E2E] Include cmath in srnd.cpp

### DIFF
--- a/sycl/test-e2e/ESIMD/srnd.cpp
+++ b/sycl/test-e2e/ESIMD/srnd.cpp
@@ -14,6 +14,7 @@
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/sycl.hpp>
 
+#include <cmath>
 #include <iostream>
 
 using namespace sycl;


### PR DESCRIPTION
We didn't catch this in CI because it's a PVC only test.