### PR TITLE
[UR][L0][Image] Set ZeImageDesc member of _ur_image in release build …

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -104,8 +104,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG a7c202b49aff130f60da0c03916d08bb22b91aa0)
 
   fetch_adapter_source(level_zero
-    ${UNIFIED_RUNTIME_REPO}
-    ${UNIFIED_RUNTIME_TAG}
+    https://github.com/wenju-he/unified-runtime.git
+    0497923ac9f29b10d84182f56e011266377a8563
   )
 
   fetch_adapter_source(opencl

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -95,17 +95,17 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 758c61490442456933e3957aac568e13287429eb
-  # Merge: e2b5b7fa e2e44728
+  # commit 6ccaf38708cfa614ab7f9b34c351826cd74028f2
+  # Merge: 0eab26c7 0497923a
   # Author: aarongreig <aaron.greig@codeplay.com>
-  # Date:   Wed Apr 10 16:15:45 2024 +0100
-  #    Merge pull request #1483 from nrspruit/fix_inorder_lists_reuse
-  #    [L0] Fix regular in order command list reuse given inorder queue
-  set(UNIFIED_RUNTIME_TAG 758c61490442456933e3957aac568e13287429eb)
+  # Date:   Fri Apr 12 10:22:00 2024 +0100
+  #    Merge pull request #1498 from wenju-he/ZeImageDesc-urMemImageCreateWithNativeHandle
+  #    [L0][Image] Set ZeImageDesc member of _ur_image in release build for legacy image
+  set(UNIFIED_RUNTIME_TAG 6ccaf38708cfa614ab7f9b34c351826cd74028f2)
 
   fetch_adapter_source(level_zero
-    https://github.com/wenju-he/unified-runtime.git
-    0497923ac9f29b10d84182f56e011266377a8563
+    ${UNIFIED_RUNTIME_REPO}
+    ${UNIFIED_RUNTIME_TAG}
   )
 
   fetch_adapter_source(opencl

--- a/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
+++ b/sycl/test-e2e/Plugin/interop-level-zero-image.cpp
@@ -3,8 +3,7 @@
 // RUN: %{run} %t.out
 
 // spir-v gen for legacy images at O0 not working
-// UNSUPPORTED: true
-// This test is currently broken see https://github.com/intel/llvm/issues/13090
+// UNSUPPORTED: O0
 
 // This test verifies that make_image is working for 1D, 2D and 3D images.
 // We instantiate an image with L0, set its body, then use a host accessor to


### PR DESCRIPTION
…for legacy image

- reenable the image interop test with fix to image interop in release builds
- precommit PR for https://github.com/oneapi-src/unified-runtime/pull/1498