### PR TITLE
[SYCL] Update clangd test after queue.hpp change in PR#13241

### DIFF
--- a/clang-tools-extra/clangd/test/sycl.test
+++ b/clang-tools-extra/clangd/test/sycl.test
@@ -25,11 +25,11 @@
 # CHECK-NEXT:        "range": {
 # CHECK-NEXT:          "end": {
 # CHECK-NEXT:            "character": 16,
-# CHECK-NEXT:            "line": 124
+# CHECK-NEXT:            "line": 116
 # CHECK-NEXT:          },
 # CHECK-NEXT:          "start": {
 # CHECK-NEXT:            "character": 11,
-# CHECK-NEXT:            "line": 124
+# CHECK-NEXT:            "line": 116
 # CHECK-NEXT:          }
 # CHECK-NEXT:        },
 # CHECK-NEXT:        "uri": "file://{{.*}}/include/sycl/queue.hpp"


### PR DESCRIPTION
Line number of the queue constructor changed after https://github.com/intel/llvm/pull/13241