### PR TITLE
Revert "[CI] Add timeout limit for SYCL-CTS"

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -307,9 +307,6 @@ jobs:
       if: inputs.tests_selector == 'cts'
       env:
         ONEAPI_DEVICE_SELECTOR: ${{ inputs.target_devices }}
-      # This job takes ~100min usually. But sometimes some test isn't
-      # responding, so the job reaches the 360min limit. Setting a lower one.
-      timeout-minutes: 150
       # By-default GitHub actions execute the "run" shell script with -e option,
       # so the execution terminates if any command returns a non-zero status.
       # Since we're using a loop to run all test-binaries separately, some test
@@ -343,7 +340,6 @@ jobs:
         done
         if [ -n "$status" ]; then
           echo "Failed suite(s): $failed_suites"
-          echo "Failed suite(s): $failed_suites" >> $GITHUB_STEP_SUMMARY
           exit 1
         fi
         exit 0


### PR DESCRIPTION
Reverts intel/llvm#13335

The changes are seemingly not related to the failures, but the hope is that triggering CI with this revert will give us a better picture of whether the failures are related or comes from outside forces.