### PR TITLE
sycl-rel_5_2_0: Add non-null check before accessing pointer (#83459)

### DIFF
--- a/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
+++ b/llvm/lib/Target/AMDGPU/SIFoldOperands.cpp
@@ -1054,6 +1054,7 @@ void SIFoldOperands::foldOperand(
       // Don't fold if OpToFold doesn't hold an aligned register.
       const TargetRegisterClass *RC =
           TRI->getRegClassForReg(*MRI, OpToFold.getReg());
+      assert(RC);
       if (TRI->hasVectorRegisters(RC) && OpToFold.getSubReg()) {
         unsigned SubReg = OpToFold.getSubReg();
         if (const TargetRegisterClass *SubRC =


### PR DESCRIPTION
Cherry-pick static analysis fix: https://github.com/llvm/llvm-project/pull/83459

Add a check if RC is not null to ensure that a consecutive access is safe.

A static analyzer flagged this issue since hasVectorRegisters potentially dereferences RC.