### PR TITLE
[GEN] Add `use-64bit-index` option to `-convert-gen-to-spirv`

### DIFF
--- a/mlir/include/mlir/Conversion/GENToSPIRV/GENToSPIRV.h
+++ b/mlir/include/mlir/Conversion/GENToSPIRV/GENToSPIRV.h
@@ -23,8 +23,6 @@ class RewritePatternSet;
 namespace GEN {
 void populateGENToSPIRVPatterns(SPIRVTypeConverter &typeConverter,
                                 RewritePatternSet &patterns);
-
-std::unique_ptr<OperationPass<>> createConvertGENToSPIRVPass();
 } // namespace GEN
 } // namespace mlir
 

--- a/mlir/include/mlir/Conversion/Passes.td
+++ b/mlir/include/mlir/Conversion/Passes.td
@@ -477,8 +477,12 @@ def GENToLLVMConversionPass : Pass<"convert-gen-to-llvm"> {
 
 def ConvertGENToSPIRV : Pass<"convert-gen-to-spirv"> {
   let summary = "Convert GEN dialect to SPIR-V dialect";
-  let constructor = "mlir::GEN::createConvertGENToSPIRVPass()";
   let dependentDialects = ["spirv::SPIRVDialect"];
+  let options = [
+    Option<"use64bitIndex", "use-64bit-index",
+           "bool", /*default=*/"false",
+           "Use 64-bit integers to convert index types">,
+  ];
 }
 
 //===----------------------------------------------------------------------===//

--- a/mlir/lib/Conversion/GENToSPIRV/GENToSPIRV.cpp
+++ b/mlir/lib/Conversion/GENToSPIRV/GENToSPIRV.cpp
@@ -106,13 +106,17 @@ void mlir::GEN::populateGENToSPIRVPatterns(SPIRVTypeConverter &converter,
 namespace {
 struct ConvertGENToSPIRVPass
     : public impl::ConvertGENToSPIRVBase<ConvertGENToSPIRVPass> {
+  using Base::Base;
+
   void runOnOperation() override {
     Operation *op = getOperation();
     spirv::TargetEnvAttr targetAttr = spirv::lookupTargetEnvOrDefault(op);
     std::unique_ptr<SPIRVConversionTarget> target =
         SPIRVConversionTarget::get(targetAttr);
 
-    SPIRVTypeConverter typeConverter(targetAttr);
+    SPIRVConversionOptions options;
+    options.use64bitIndex = this->use64bitIndex;
+    SPIRVTypeConverter typeConverter(targetAttr, options);
 
     // Fail hard when there are any remaining GEN ops.
     target->addIllegalDialect<GEN::GENDialect>();
@@ -125,7 +129,3 @@ struct ConvertGENToSPIRVPass
   }
 };
 } // namespace
-
-std::unique_ptr<OperationPass<>> mlir::GEN::createConvertGENToSPIRVPass() {
-  return std::make_unique<ConvertGENToSPIRVPass>();
-}

--- a/mlir/test/Conversion/GENToSPIRV/gen-to-spirv.mlir
+++ b/mlir/test/Conversion/GENToSPIRV/gen-to-spirv.mlir
@@ -1,28 +1,54 @@
-// RUN: mlir-opt -convert-gen-to-spirv -split-input-file %s | FileCheck %s
+// RUN: mlir-opt -convert-gen-to-spirv -split-input-file %s | FileCheck %s --check-prefixes=CHECK,CHECK-32
+// RUN: mlir-opt -convert-gen-to-spirv=use-64bit-index=true -split-input-file %s | FileCheck %s --check-prefixes=CHECK,CHECK-64
 
-// CHECK-DAG:     spirv.GlobalVariable @__spirv_BuiltInNumWorkgroups built_in("NumWorkgroups") : !spirv.ptr<vector<3xi32>, Input>
-// CHECK-DAG:     spirv.GlobalVariable @__spirv_BuiltInWorkgroupSize built_in("WorkgroupSize") : !spirv.ptr<vector<3xi32>, Input>
-// CHECK-DAG:     spirv.GlobalVariable @__spirv_BuiltInWorkgroupId built_in("WorkgroupId") : !spirv.ptr<vector<3xi32>, Input>
-// CHECK-DAG:     spirv.GlobalVariable @__spirv_BuiltInLocalInvocationId built_in("LocalInvocationId") : !spirv.ptr<vector<3xi32>, Input>
+module attributes {
+  spirv.target_env = #spirv.target_env<#spirv.vce<v1.0, [Int64], []>, #spirv.resource_limits<>>
+} {
+// CHECK-32-DAG:     spirv.GlobalVariable @__spirv_BuiltInNumWorkgroups built_in("NumWorkgroups") : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32-DAG:     spirv.GlobalVariable @__spirv_BuiltInWorkgroupSize built_in("WorkgroupSize") : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32-DAG:     spirv.GlobalVariable @__spirv_BuiltInWorkgroupId built_in("WorkgroupId") : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32-DAG:     spirv.GlobalVariable @__spirv_BuiltInLocalInvocationId built_in("LocalInvocationId") : !spirv.ptr<vector<3xi32>, Input>
+
+// CHECK-64-DAG:     spirv.GlobalVariable @__spirv_BuiltInNumWorkgroups built_in("NumWorkgroups") : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64-DAG:     spirv.GlobalVariable @__spirv_BuiltInWorkgroupSize built_in("WorkgroupSize") : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64-DAG:     spirv.GlobalVariable @__spirv_BuiltInWorkgroupId built_in("WorkgroupId") : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64-DAG:     spirv.GlobalVariable @__spirv_BuiltInLocalInvocationId built_in("LocalInvocationId") : !spirv.ptr<vector<3xi64>, Input>
 
 // CHECK-LABEL:   func.func @gen_nd_range(
 // CHECK-SAME:                            %[[VAL_0:.*]]: i32) {
 func.func @gen_nd_range(%dim: i32) {
-// CHECK:           %[[VAL_1:.*]] = spirv.mlir.addressof @__spirv_BuiltInLocalInvocationId : !spirv.ptr<vector<3xi32>, Input>
-// CHECK:           %[[VAL_2:.*]] = spirv.Load "Input" %[[VAL_1]] : vector<3xi32>
-// CHECK:           %[[VAL_3:.*]] = spirv.VectorExtractDynamic %[[VAL_2]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+// CHECK-32:           %[[VAL_1:.*]] = spirv.mlir.addressof @__spirv_BuiltInLocalInvocationId : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_2:.*]] = spirv.Load "Input" %[[VAL_1]] : vector<3xi32>
+// CHECK-32:           %[[VAL_3:.*]] = spirv.VectorExtractDynamic %[[VAL_2]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+
+// CHECK-64:           %[[VAL_1:.*]] = spirv.mlir.addressof @__spirv_BuiltInLocalInvocationId : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_2:.*]] = spirv.Load "Input" %[[VAL_1]] : vector<3xi64>
+// CHECK-64:           %[[VAL_3:.*]] = spirv.VectorExtractDynamic %[[VAL_2]]{{\[}}%[[VAL_0]]] : vector<3xi64>, i32
   %0 = gen.local_id %dim
-// CHECK:           %[[VAL_4:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupId : !spirv.ptr<vector<3xi32>, Input>
-// CHECK:           %[[VAL_5:.*]] = spirv.Load "Input" %[[VAL_4]] : vector<3xi32>
-// CHECK:           %[[VAL_6:.*]] = spirv.VectorExtractDynamic %[[VAL_5]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+// CHECK-32:           %[[VAL_4:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupId : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_5:.*]] = spirv.Load "Input" %[[VAL_4]] : vector<3xi32>
+// CHECK-32:           %[[VAL_6:.*]] = spirv.VectorExtractDynamic %[[VAL_5]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+
+// CHECK-64:           %[[VAL_4:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupId : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_5:.*]] = spirv.Load "Input" %[[VAL_4]] : vector<3xi64>
+// CHECK-64:           %[[VAL_6:.*]] = spirv.VectorExtractDynamic %[[VAL_5]]{{\[}}%[[VAL_0]]] : vector<3xi64>, i32
   %1 = gen.work_group_id %dim
-// CHECK:           %[[VAL_7:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupSize : !spirv.ptr<vector<3xi32>, Input>
-// CHECK:           %[[VAL_8:.*]] = spirv.Load "Input" %[[VAL_7]] : vector<3xi32>
-// CHECK:           %[[VAL_9:.*]] = spirv.VectorExtractDynamic %[[VAL_8]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+// CHECK-32:           %[[VAL_7:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupSize : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_8:.*]] = spirv.Load "Input" %[[VAL_7]] : vector<3xi32>
+// CHECK-32:           %[[VAL_9:.*]] = spirv.VectorExtractDynamic %[[VAL_8]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+
+// CHECK-64:           %[[VAL_7:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupSize : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_8:.*]] = spirv.Load "Input" %[[VAL_7]] : vector<3xi64>
+// CHECK-64:           %[[VAL_9:.*]] = spirv.VectorExtractDynamic %[[VAL_8]]{{\[}}%[[VAL_0]]] : vector<3xi64>, i32
   %2 = gen.work_group_size %dim
-// CHECK:           %[[VAL_10:.*]] = spirv.mlir.addressof @__spirv_BuiltInNumWorkgroups : !spirv.ptr<vector<3xi32>, Input>
-// CHECK:           %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
-// CHECK:           %[[VAL_12:.*]] = spirv.VectorExtractDynamic %[[VAL_11]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+// CHECK-32:           %[[VAL_10:.*]] = spirv.mlir.addressof @__spirv_BuiltInNumWorkgroups : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+// CHECK-32:           %[[VAL_12:.*]] = spirv.VectorExtractDynamic %[[VAL_11]]{{\[}}%[[VAL_0]]] : vector<3xi32>, i32
+
+// CHECK-64:           %[[VAL_10:.*]] = spirv.mlir.addressof @__spirv_BuiltInNumWorkgroups : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi64>
+// CHECK-64:           %[[VAL_12:.*]] = spirv.VectorExtractDynamic %[[VAL_11]]{{\[}}%[[VAL_0]]] : vector<3xi64>, i32
   %3 = gen.num_work_groups %dim
   func.return
+}
 }


### PR DESCRIPTION
Add option to choose `i64` as `index` type in GEN to SPIR-V conversion.