### PR TITLE
[SYCL][E2E] Ensure lowering of llvm.bitreverse for 2/4-bit scalars is functionally correct

### DIFF
--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -130,12 +130,12 @@ template <typename TYPE> void do_scalar_bitreverse_test() {
   queue q;
 
   // calculate bitlength
-  int bitlength=0;
-  TYPE t=1;
+  int bitlength = 0;
+  TYPE t = 1;
   do {
     ++bitlength;
-    t<<=1;
-  } while(t);
+    t <<= 1;
+  } while (t);
 
   TYPE *Input = (TYPE *)malloc_shared(sizeof(TYPE) * NUM_TESTS, q.get_device(),
                                       q.get_context());
@@ -153,8 +153,9 @@ template <typename TYPE> void do_scalar_bitreverse_test() {
   q.wait();
   for (unsigned i = 0; i < NUM_TESTS; i++)
     if (Output[i] != reference_reverse(Input[i], bitlength)) {
-      std::cerr << "Failed for scalar " << std::hex << static_cast<uint64_t>(Input[i])
-                << " bitlength=" << bitlength << "\n";
+      std::cerr << "Failed for scalar " << std::hex
+                << static_cast<uint64_t>(Input[i]) << " bitlength=" << bitlength
+                << "\n";
 
       exit(-1);
     }

--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -2,7 +2,8 @@
 
 // UNSUPPORTED: hip || cuda
 
-// TODO: Remove XFAIL after fixing https://github.com/intel/intel-graphics-compiler/issues/330
+// TODO: Remove XFAIL after fixing
+// https://github.com/intel/intel-graphics-compiler/issues/330
 // XFAIL: gpu-intel-gen12
 
 // Make dump directory.

--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -2,6 +2,9 @@
 
 // UNSUPPORTED: hip || cuda
 
+// TODO: Remove XFAIL after fixing https://github.com/intel/intel-graphics-compiler/issues/330
+// XFAIL: gpu-intel-gen12
+
 // Make dump directory.
 // RUN: rm -rf %t.spvdir && mkdir %t.spvdir
 

--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -31,6 +31,8 @@
 // Execution should still be correct.
 // RUN: %{run} %t.bitinstructions.out
 
+// CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i2"
+// CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i4"
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i8"
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i16"
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i32"
@@ -56,6 +58,8 @@
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_v16i16"
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_v16i32"
 
+// CHECK-SPV: LinkageAttributes "llvm_bitreverse_i2" Export
+// CHECK-SPV: LinkageAttributes "llvm_bitreverse_i4" Export
 // CHECK-SPV: LinkageAttributes "llvm_bitreverse_i8" Export
 // CHECK-SPV: LinkageAttributes "llvm_bitreverse_i16" Export
 // CHECK-SPV: LinkageAttributes "llvm_bitreverse_i32" Export
@@ -125,6 +129,14 @@ template <class T> class BitreverseTest;
 template <typename TYPE> void do_scalar_bitreverse_test() {
   queue q;
 
+  // calculate bitlength
+  int bitlength=0;
+  TYPE t=1;
+  do {
+    ++bitlength;
+    t<<=1;
+  } while(t);
+
   TYPE *Input = (TYPE *)malloc_shared(sizeof(TYPE) * NUM_TESTS, q.get_device(),
                                       q.get_context());
   TYPE *Output = (TYPE *)malloc_shared(sizeof(TYPE) * NUM_TESTS, q.get_device(),
@@ -140,9 +152,10 @@ template <typename TYPE> void do_scalar_bitreverse_test() {
   });
   q.wait();
   for (unsigned i = 0; i < NUM_TESTS; i++)
-    if (Output[i] != reference_reverse(Input[i], sizeof(TYPE) * 8)) {
-      std::cerr << "Failed for scalar " << std::hex << Input[i]
-                << " sizeof=" << sizeof(TYPE) << "\n";
+    if (Output[i] != reference_reverse(Input[i], bitlength)) {
+      std::cerr << "Failed for scalar " << std::hex << static_cast<uint64_t>(Input[i])
+                << " bitlength=" << bitlength << "\n";
+
       exit(-1);
     }
 
@@ -184,6 +197,12 @@ template <typename VTYPE> void do_vector_bitreverse_test() {
   free(Output, q.get_context());
 }
 
+using uint2_t = _BitInt(2);
+using uint4_t = _BitInt(4);
+
+// Vectors of uint2_t and uint4_t not allowed.
+// Vector elements must be at least as wide as CHAR_BIT
+
 using uint8_t2 = uint8_t __attribute__((ext_vector_type(2)));
 using uint16_t2 = uint16_t __attribute__((ext_vector_type(2)));
 using uint32_t2 = uint32_t __attribute__((ext_vector_type(2)));
@@ -212,6 +231,8 @@ using uint64_t16 = uint64_t __attribute__((ext_vector_type(16)));
 int main() {
   srand(2024);
 
+  do_scalar_bitreverse_test<uint2_t>();
+  do_scalar_bitreverse_test<uint4_t>();
   do_scalar_bitreverse_test<uint8_t>();
   do_scalar_bitreverse_test<uint16_t>();
   do_scalar_bitreverse_test<uint32_t>();

--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -1,4 +1,5 @@
-// Test that llvm.bitreverse is lowered correctly by llvm-spirv for 2/4-bit types.
+// Test that llvm.bitreverse is lowered correctly by llvm-spirv for 2/4-bit
+// types.
 
 // UNSUPPORTED: hip || cuda
 

--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -1,0 +1,120 @@
+// Test that llvm.bitreverse is lowered correctly by llvm-spirv for 2/4-bit types.
+
+// UNSUPPORTED: hip || cuda
+
+// TODO: Remove XFAIL after fixing
+// https://github.com/intel/intel-graphics-compiler/issues/330
+// XFAIL: gpu
+
+// Make dump directory.
+// RUN: rm -rf %t.spvdir && mkdir %t.spvdir
+
+// Ensure that SPV_KHR_bit_instructions is disabled so that translator
+// will lower llvm.bitreverse.* intrinsics instead of relying on SPIRV
+// BitReverse instruction.
+// Also build executable with SPV dump.
+// RUN: %{build} -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir
+
+// Rename SPV file to explictly known filename.
+// RUN: mv %t.spvdir/*.spv %t.spvdir/dump.spv
+
+// Convert to text.
+// RUN: llvm-spirv -to-text %t.spvdir/dump.spv
+
+// Check that all lowerings are done by llvm-spirv.
+// RUN: cat %t.spvdir/dump.spt | FileCheck %s --check-prefix CHECK-SPV --implicit-check-not=BitReverse
+
+// Execute to ensure lowering has correct functionality.
+// RUN: %{run} %t.out
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+// Build without lowering explicitly disabled.
+// RUN: %{build} -o %t.bitinstructions.out
+
+// Execution should still be correct.
+// RUN: %{run} %t.bitinstructions.out
+
+// CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i2"
+// CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i4"
+
+// CHECK-SPV: LinkageAttributes "llvm_bitreverse_i2" Export
+// CHECK-SPV: LinkageAttributes "llvm_bitreverse_i4" Export
+
+#include "common.hpp"
+#include <iostream>
+#include <string.h>
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+template <typename TYPE>
+__attribute__((optnone, noinline)) TYPE reference_reverse(TYPE a,
+                                                          const int bitlength) {
+  TYPE ret = 0;
+  for (auto i = 0; i < bitlength; i++) {
+    ret <<= 1;
+    ret |= a & 0x1;
+    a >>= 1;
+  }
+  return ret;
+}
+
+template <typename TYPE>
+__attribute__((noinline)) TYPE reverse(TYPE a, int bitlength) {
+  return __builtin_elementwise_bitreverse(a);
+}
+
+template <class T> class BitreverseTest;
+
+#define NUM_TESTS 1024
+
+template <typename TYPE> void do_scalar_bitreverse_test() {
+  queue q;
+
+  // calculate bitlength
+  int bitlength = 0;
+  TYPE t = 1;
+  do {
+    ++bitlength;
+    t <<= 1;
+  } while (t);
+
+  TYPE *Input = (TYPE *)malloc_shared(sizeof(TYPE) * NUM_TESTS, q.get_device(),
+                                      q.get_context());
+  TYPE *Output = (TYPE *)malloc_shared(sizeof(TYPE) * NUM_TESTS, q.get_device(),
+                                       q.get_context());
+
+  for (unsigned i = 0; i < NUM_TESTS; i++)
+    Input[i] = get_rand<TYPE>();
+  q.submit([=](handler &cgh) {
+    cgh.single_task<BitreverseTest<TYPE>>([=]() {
+      for (unsigned i = 0; i < NUM_TESTS; i++)
+        Output[i] = reverse(Input[i], sizeof(TYPE) * 8);
+    });
+  });
+  q.wait();
+  for (unsigned i = 0; i < NUM_TESTS; i++)
+    if (Output[i] != reference_reverse(Input[i], bitlength)) {
+      std::cerr << "Failed for scalar " << std::hex
+                << static_cast<uint64_t>(Input[i]) << " bitlength=" << bitlength
+                << "\n";
+
+      exit(-1);
+    }
+
+  free(Input, q.get_context());
+  free(Output, q.get_context());
+}
+
+using uint2_t = _BitInt(2);
+using uint4_t = _BitInt(4);
+
+int main() {
+  srand(2024);
+
+  do_scalar_bitreverse_test<uint2_t>();
+  do_scalar_bitreverse_test<uint4_t>();
+
+  return 0;
+}


### PR DESCRIPTION
Ensure that lowering of llvm.bitreverse.i2/i4 by llvm-spirv is functionally correct.