### PR TITLE
[SYCL] Fix a hang with invalid values of ONEAPI_DEVICE_SELECTOR

### DIFF
--- a/sycl/test-e2e/OneapiDeviceSelector/illegal_input_hang.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/illegal_input_hang.cpp
@@ -1,0 +1,18 @@
+// RUN: %{build} -o %t.out
+// RUN: env ONEAPI_DEVICE_SELECTOR=":" %{run-unfiltered-devices} %t.out
+#include <sycl/detail/core.hpp>
+#include <vector>
+
+// Check that the application does not hang when we attempt
+// to initialize plugins multiple times with invalid values
+// of ONEAPI_DEVICE_SELECTOR.
+int main() {
+  for (int I = 0; I < 3; ++I) {
+    try {
+      std::vector<sycl::platform> pl = sycl::platform::get_platforms();
+    } catch (std::exception const &e) {
+    }
+  }
+
+  return 0;
+}


### PR DESCRIPTION
There's a gcc std::call_once bug that leads to a hang when the function passed to it throws an exception: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=66146 Replace std::call_once with a static variable workaround until this is fixed.