### PR TITLE
[CI] Redirect and fix email-check workflow

### DIFF
--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -28,7 +28,6 @@ jobs:
 
       - name: Validate author email
         if: ${{ endsWith(steps.author.outputs.EMAIL, 'noreply.github.com')  }}
-        uses: actions/github-script@v7
         env:
           COMMENT: >-
             ⚠️ We detected that you are using a GitHub private e-mail address to contribute to the repo.<br/>

--- a/.github/workflows/email-check.yaml
+++ b/.github/workflows/email-check.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   validate_email:
     runs-on: ubuntu-latest
-    if: github.repository == 'llvm/llvm-project'
+    if: github.repository == 'intel/llvm'
     steps:
       - name: Fetch LLVM sources
         uses: actions/checkout@v4


### PR DESCRIPTION
https://github.com/intel/llvm/commit/1bed6397a3c47eb3ca19b70f8d15a7860da0792d resolved a merge conflict in .github/workflows/email-check.yaml by reintroducing a removed "uses" key. However, this makes for an invalid configuration. This commit removes the invalid conflict resolution.

Additionally, it changes the check for repository in the workflow to require intel/llvm. This should make it run as part of our CI.