### PR TITLE
[CI] Fix status (update-check) permission for sycl cuda e2e

### DIFF
--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -20,6 +20,8 @@ permissions:
 jobs:
   create-check:
     runs-on: [Linux, build]
+    permissions:
+      statuses: write
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -77,6 +77,8 @@ jobs:
     needs: [create-check, e2e-cuda]
     if: always()
     runs-on: [Linux, build]
+    permissions:
+      statuses: write
     steps:
       - uses: actions/github-script@v7
         with:

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -15,7 +15,7 @@ on:
       - completed
 
 permissions:
-  contents: read
+  contents: read-all
 
 jobs:
   create-check:

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -14,8 +14,7 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
+permissions: write-all
 
 jobs:
   create-check:

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -15,12 +15,13 @@ on:
       - completed
 
 permissions:
-  contents: read-all
+  contents: read
 
 jobs:
   create-check:
     runs-on: [Linux, build]
     permissions:
+      checks: write
       statuses: write
     steps:
       - uses: actions/github-script@v7
@@ -80,6 +81,7 @@ jobs:
     if: always()
     runs-on: [Linux, build]
     permissions:
+      checks: write
       statuses: write
     steps:
       - uses: actions/github-script@v7

--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -14,7 +14,8 @@ on:
     types:
       - completed
 
-permissions: write-all
+permissions:
+  contents: read
 
 jobs:
   create-check:


### PR DESCRIPTION
The update-check started to fail 2 months ago in https://github.com/intel/llvm/actions/runs/8461500755.

Last CUDA e2e success was https://github.com/intel/llvm/actions/runs/8460746056 2 months ago!!
So looks like a problem caused by #13173 again..
