### PR TITLE
[SYCL] Remove preview guard from a few tests

### DIFF
--- a/sycl/test/basic_tests/handler/handler_generic_lambda_interface.cpp
+++ b/sycl/test/basic_tests/handler/handler_generic_lambda_interface.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsyntax-only -Xclang -verify %s -I %sycl_include
-// RUN: %if preview-breaking-changes-supported %{%clangxx -fsycl -fsyntax-only -Xclang -verify %s -I %sycl_include -fpreview-breaking-changes -DPREVIEW_BREAKING_CHANGES%}
+// RUN: %if preview-breaking-changes-supported %{ %clangxx -fsycl -fsyntax-only -Xclang -verify %s -I %sycl_include -fpreview-breaking-changes %}
 // expected-no-diagnostics
 //==--------------- handler_generic_lambda_interface.cpp -------------------==//
 //

--- a/sycl/test/basic_tests/handler/parallel_for_arg_restrictions.cpp
+++ b/sycl/test/basic_tests/handler/parallel_for_arg_restrictions.cpp
@@ -1,5 +1,5 @@
 // RUN: %clangxx -fsycl -fsyntax-only -ferror-limit=0 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning,error %s
-// RUN: %if preview-breaking-changes-supported %{%clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -ferror-limit=0 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning,error %s -DPREVIEW_BREAKING_CHANGES%}
+// RUN: %if preview-breaking-changes-supported %{%clangxx -fsycl -fpreview-breaking-changes -fsyntax-only -ferror-limit=0 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning,error %s %}
 
 // Tests the requirements on the first argument in a kernel lambda.
 // TODO: Some of the behavior is currently guarded behind the
@@ -19,8 +19,6 @@ template <int Dims> struct ConvertibleFromNDItem {
 int main() {
   sycl::queue Q;
 
-// TODO: Remove this when the guarded behavior is promoted.
-#ifdef PREVIEW_BREAKING_CHANGES
   // ND-range parallel_for with item.
   Q.submit([&](sycl::handler &CGH) {
     // expected-error@sycl/handler.hpp:* {{Kernel argument of a sycl::parallel_for with sycl::nd_range must be either sycl::nd_item or be convertible from sycl::nd_item}}
@@ -88,7 +86,6 @@ int main() {
     CGH.parallel_for(sycl::range{1}, [=](sycl::item<1> it, sycl::item<1> it,
                                          kernel_handler kh) {});
   });
-#endif // PREVIEW_BREAKING_CHANGES
 
   // Range parallel_for with nd_item.
   Q.submit([&](sycl::handler &CGH) {


### PR DESCRIPTION
All pre-existing preview features have been uplifted to be available by default.