### PR TITLE
sycl-rel_5_2_0: [CUDA][LIBCLC] Implement RC11 seq_cst for PTX6.0 (#12516)

### DIFF
--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_add.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_add.cl
@@ -71,6 +71,13 @@ Memory order is stored in the lowest 5 bits */                                  
                                                ADDR_SPACE, ADDR_SPACE_NV)                                                                                     \
         }                                                                                                                                                     \
         break;                                                                                                                                                \
+      case SequentiallyConsistent:                                                                                                                            \
+        if (__clc_nvvm_reflect_arch() >= 700) {                                                                                                               \
+          __CLC_NVVM_FENCE_SC_SM70()                                                                                                                          \
+          __CLC_NVVM_ATOMIC_IMPL_ORDER(double, double, d, add, ADDR_SPACE,                                                                                    \
+                                       ADDR_SPACE_NV, _acq_rel)                                                                                               \
+          break;                                                                                                                                              \
+        }                                                                                                                                                     \
       }                                                                                                                                                       \
       __builtin_trap();                                                                                                                                       \
       __builtin_unreachable();                                                                                                                                \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_cmpxchg.cl
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <atomic_helpers.h>
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
@@ -120,6 +121,13 @@ Memory order is stored in the lowest 5 bits */                                 \
             TYPE, TYPE_NV, TYPE_MANGLED_NV, OP, ADDR_SPACE, ADDR_SPACE_NV)     \
       }                                                                        \
       break;                                                                   \
+    case SequentiallyConsistent:                                               \
+      if (__clc_nvvm_reflect_arch() >= 700) {                                  \
+        __CLC_NVVM_FENCE_SC_SM70()                                             \
+        __CLC_NVVM_ATOMIC_CAS_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV, OP,   \
+                                         ADDR_SPACE, ADDR_SPACE_NV, _acq_rel)  \
+        break;                                                                 \
+      }                                                                        \
     }                                                                          \
     __builtin_trap();                                                          \
     __builtin_unreachable();                                                   \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_load.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_load.cl
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <atomic_helpers.h>
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
@@ -53,6 +54,12 @@ Memory order is stored in the lowest 5 bits */                                 \
       case Acquire:                                                            \
         __CLC_NVVM_ATOMIC_LOAD_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV,      \
                                           ADDR_SPACE, ADDR_SPACE_NV, _acquire) \
+        break;                                                                 \
+      case SequentiallyConsistent:                                             \
+        __CLC_NVVM_FENCE_SC_SM70()                                             \
+        __CLC_NVVM_ATOMIC_LOAD_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV,      \
+                                          ADDR_SPACE, ADDR_SPACE_NV, _acquire) \
+        break;                                                                 \
       }                                                                        \
     } else {                                                                   \
       TYPE_NV res = __nvvm_volatile_ld##ADDR_SPACE_NV##TYPE_MANGLED_NV(        \

--- a/libclc/ptx-nvidiacl/libspirv/atomic/atomic_store.cl
+++ b/libclc/ptx-nvidiacl/libspirv/atomic/atomic_store.cl
@@ -6,6 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+#include <atomic_helpers.h>
 #include <spirv/spirv.h>
 #include <spirv/spirv_types.h>
 
@@ -54,6 +55,13 @@ Memory order is stored in the lowest 5 bits */                                 \
         __CLC_NVVM_ATOMIC_STORE_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV,     \
                                            ADDR_SPACE, ADDR_SPACE_NV,          \
                                            _release)                           \
+        break;                                                                 \
+      case SequentiallyConsistent:                                             \
+        __CLC_NVVM_FENCE_SC_SM70()                                             \
+        __CLC_NVVM_ATOMIC_STORE_IMPL_ORDER(TYPE, TYPE_NV, TYPE_MANGLED_NV,     \
+                                           ADDR_SPACE, ADDR_SPACE_NV,          \
+                                           _release)                           \
+        break;                                                                 \
       }                                                                        \
     } else {                                                                   \
       switch (order) {                                                         \

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -57,13 +57,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit ec634ff05b067d7922ec45059dda94665e5dcd9b
-  # Merge: 418ad535 8714b853
-  # Author: Piotr Balcer <piotr.balcer@intel.com>
-  # Date:   Thu Mar 14 15:52:52 2024 +0100
-  #     Merge pull request #1438 from PatKamin/disable-fuzztests
-  #     Disable fuzz tests on ubuntu-22.04 runner
-  set(UNIFIED_RUNTIME_TAG ec634ff05b067d7922ec45059dda94665e5dcd9b)
+  # commit 09be0881b727fadb1c04b38c00d2562d7dc6875f
+  # Merge: bb589ca8 e9f855d4
+  # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+  # Date:   Thu Mar 14 22:10:28 2024 +0000
+  #     Merge pull request #1429 from nrspruit/l0_p2p_device_query
+  #     [L0] Support for urUsmP2PPeerAccessGetInfoExp to query p2p access info
+  set(UNIFIED_RUNTIME_TAG 09be0881b727fadb1c04b38c00d2562d7dc6875f)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -57,13 +57,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 09be0881b727fadb1c04b38c00d2562d7dc6875f
-  # Merge: bb589ca8 e9f855d4
+  # commit 29ee45c4451a682f744146cc9dbeb2617ecdd6b3
+  # Merge: db4b0c14 4f5d005a
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Thu Mar 14 22:10:28 2024 +0000
-  #     Merge pull request #1429 from nrspruit/l0_p2p_device_query
-  #     [L0] Support for urUsmP2PPeerAccessGetInfoExp to query p2p access info
-  set(UNIFIED_RUNTIME_TAG 09be0881b727fadb1c04b38c00d2562d7dc6875f)
+  # Date:   Mon Mar 18 12:14:26 2024 +0000
+  #     Merge pull request #1291 from JackAKirk/cuda-seq-cst-b
+  #     [CUDA] Report that devices with cc >= sm_70 support seq_cst
+  set(UNIFIED_RUNTIME_TAG 29ee45c4451a682f744146cc9dbeb2617ecdd6b3)
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)
     set(UNIFIED_RUNTIME_REPO "${SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO}")


### PR DESCRIPTION
Cherry-pick for sycl-rel_5_2_0 depends on https://github.com/intel/llvm/pull/13401

Implement `seq_cst` RC11/ptx6.0 memory consistency for CUDA backend.

See https://dl.acm.org/doi/pdf/10.1145/3297858.3304043 and
https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#memory-consistency-model
for full details. Requires sm_70 or above. With this PR there is now a
complete mapping between SYCL memory consistency model capabilities and
the official CUDA model, fully exploiting CUDA capabilities when
possible on supported arches.

This makes the SYCL-CTS atomic_ref tests fully pass for sm_70 on the
cuda backend.

Fixes https://github.com/intel/llvm/issues/11208

Depends on https://github.com/intel/llvm/pull/12907

---------

Signed-off-by: JackAKirk <jack.kirk@codeplay.com>
