### PR TITLE
[CI] Fix permissions on nightly releases

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -129,6 +129,8 @@ jobs:
     if: ${{ github.ref_name == 'sycl' }}
     needs: [ubuntu2204_build, build-win]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
     - uses: actions/download-artifact@v4
       with:


### PR DESCRIPTION
Nightly packages haven't been published in a while and looking at the logs the job failed with 403.

The `softprops/action-gh-release` documentation says it needs `contents: write` permissions, which makes sense as it's creating a tag.