### PR TITLE
[SYCL][COMPAT] Adding 2-byte and 4-bytes memset operations to headers

### DIFF
--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -410,8 +410,7 @@ memcpy(sycl::queue q, void *to_ptr, const void *from_ptr,
     }));
     break;
   default:
-    throw std::runtime_error("[SYCLcompat]"
-                             "memcpy: invalid direction value");
+    throw std::runtime_error("[SYCLcompat] memcpy: invalid direction value");
   }
   return event_list;
 }
@@ -783,8 +782,8 @@ static inline void memset_d32(void *dev_ptr, unsigned int value, size_t size,
 /// \param value Value to be set.
 /// \param size Number of bytes to be set to the value.
 /// \returns An event representing the memset operation.
-static sycl::event memset_async(void *dev_ptr, int value, size_t size,
-                                sycl::queue q = get_default_queue()) {
+static inline sycl::event memset_async(void *dev_ptr, int value, size_t size,
+                                       sycl::queue q = get_default_queue()) {
   return detail::memset(q, dev_ptr, value, size);
 }
 

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
@@ -128,27 +128,36 @@ void test_memcpy_q() {
   free(h_C);
 }
 
-void test_memset() {
+template <size_t memset_size_bits = 8> void test_memset_impl() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
+  // ValueT -> int for memset and memset_d32, short for memset_d16.
+  using ValueT = std::conditional_t<
+      memset_size_bits == 8 || memset_size_bits == 32, int,
+      std::conditional_t<memset_size_bits == 16, short, void>>;
+  static_assert(!std::is_void_v<ValueT>,
+                "memset tests only work for 8, 16 and 32 bits");
 
   constexpr int Num = 10;
-  int *h_A = (int *)malloc(Num * sizeof(int));
+  ValueT *h_A = (ValueT *)malloc(Num * sizeof(ValueT));
 
   for (int i = 0; i < Num; i++) {
     h_A[i] = 4;
   }
 
-  int *d_A = nullptr;
-
-  d_A = (int *)syclcompat::malloc(Num * sizeof(int));
+  ValueT *d_A = (ValueT *)syclcompat::malloc(Num * sizeof(ValueT));
   // hostA -> deviceA
-  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(int));
+  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(ValueT));
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset((void *)d_A, 0, (Num - 3) * sizeof(int));
+  if constexpr (memset_size_bits == 8)
+    syclcompat::memset((void *)d_A, 0, (Num - 3) * sizeof(ValueT));
+  else if constexpr (memset_size_bits == 16)
+    syclcompat::memset_d16((void *)d_A, 0, (Num - 3));
+  else if constexpr (memset_size_bits == 32)
+    syclcompat::memset_d32((void *)d_A, 0, (Num - 3));
 
   // deviceA -> hostA
-  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(int));
+  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(ValueT));
 
   syclcompat::free((void *)d_A);
 
@@ -165,28 +174,37 @@ void test_memset() {
   free(h_A);
 }
 
-void test_memset_q() {
+template <size_t memset_size_bits = 8> void test_memset_q_impl() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
+  // ValueT -> int for memset and memset_d32, short for memset_d16.
+  using ValueT = std::conditional_t<
+      memset_size_bits == 8 || memset_size_bits == 32, int,
+      std::conditional_t<memset_size_bits == 16, short, void>>;
+  static_assert(!std::is_void_v<ValueT>,
+                "memset tests only work for 8, 16 and 32 bits");
 
   sycl::queue q{{sycl::property::queue::in_order()}};
   constexpr int Num = 10;
-  int *h_A = (int *)malloc(Num * sizeof(int));
+  ValueT *h_A = (ValueT *)malloc(Num * sizeof(ValueT));
 
   for (int i = 0; i < Num; i++) {
     h_A[i] = 4;
   }
 
-  int *d_A = nullptr;
-
-  d_A = (int *)syclcompat::malloc(Num * sizeof(int), q);
+  ValueT *d_A = (ValueT *)syclcompat::malloc(Num * sizeof(ValueT), q);
   // hostA -> deviceA
-  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(int), q);
+  syclcompat::memcpy((void *)d_A, (void *)h_A, Num * sizeof(ValueT), q);
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset((void *)d_A, 0, (Num - 3) * sizeof(int), q);
+  if constexpr (memset_size_bits == 8)
+    syclcompat::memset((void *)d_A, 0, (Num - 3) * sizeof(ValueT), q);
+  else if constexpr (memset_size_bits == 16)
+    syclcompat::memset_d16((void *)d_A, 0, (Num - 3), q);
+  else if constexpr (memset_size_bits == 32)
+    syclcompat::memset_d32((void *)d_A, 0, (Num - 3), q);
 
   // deviceA -> hostA
-  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(int), q);
+  syclcompat::memcpy((void *)h_A, (void *)d_A, Num * sizeof(ValueT), q);
 
   syclcompat::free((void *)d_A, q);
 
@@ -201,6 +219,42 @@ void test_memset_q() {
   }
 
   free(h_A);
+}
+
+void test_memset() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 8;
+  test_memset_impl<memset_size_in_bits>();
+}
+
+void test_memset_d16() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 16;
+  test_memset_impl<memset_size_in_bits>();
+}
+
+void test_memset_d32() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 32;
+  test_memset_impl<memset_size_in_bits>();
+}
+
+void test_memset_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 8;
+  test_memset_q_impl<memset_size_in_bits>();
+}
+
+void test_memset_d16_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 16;
+  test_memset_q_impl<memset_size_in_bits>();
+}
+
+void test_memset_d32_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 32;
+  test_memset_q_impl<memset_size_in_bits>();
 }
 
 template <typename T> void test_memcpy_t() {
@@ -480,6 +534,10 @@ int main() {
   test_memcpy_q();
   test_memset();
   test_memset_q();
+  test_memset_d16();
+  test_memset_d16_q();
+  test_memset_d32();
+  test_memset_d32_q();
   test_constant_memcpy();
   test_constant_memcpy_q();
 

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -244,25 +244,36 @@ void test_memcpy_async_pitched_q() {
   syclcompat::free((void *)d_data, q);
 }
 
-void test_memset_async() {
+template <size_t memset_size_bits = 8> void test_memset_async_impl() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
+  // ValueT -> int for memset and memset_d32, short for memset_d16.
+  using ValueT = std::conditional_t<
+      memset_size_bits == 8 || memset_size_bits == 32, int,
+      std::conditional_t<memset_size_bits == 16, short, void>>;
+  static_assert(!std::is_void_v<ValueT>,
+                "memset tests only work for 8, 16 and 32 bits");
 
   int Num = 10;
-  int *h_A = (int *)malloc(Num * sizeof(int));
+  ValueT *h_A = (ValueT *)malloc(Num * sizeof(ValueT));
 
   for (int i = 0; i < Num; i++) {
     h_A[i] = 4;
   }
 
-  int *d_A = (int *)syclcompat::malloc(Num * sizeof(int));
+  ValueT *d_A = (ValueT *)syclcompat::malloc(Num * sizeof(ValueT));
   // hostA -> deviceA
-  syclcompat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(int));
+  syclcompat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(ValueT));
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(int));
+  if constexpr (memset_size_bits == 8)
+    syclcompat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(ValueT));
+  else if constexpr (memset_size_bits == 16)
+    syclcompat::memset_d16_async((void *)d_A, 0, (Num - 3));
+  else if constexpr (memset_size_bits == 32)
+    syclcompat::memset_d32_async((void *)d_A, 0, (Num - 3));
 
   // deviceA -> hostA
-  syclcompat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(int));
+  syclcompat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(ValueT));
 
   syclcompat::get_default_queue().wait_and_throw();
 
@@ -281,26 +292,37 @@ void test_memset_async() {
   free(h_A);
 }
 
-void test_memset_async_q() {
+template <size_t bits = 8> void test_memset_async_q_impl() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
+  // int for memset and memset_d32, short for memset_d16.
+  using ValueT =
+      std::conditional_t<bits == 8 || bits == 32, int,
+                         std::conditional_t<bits == 16, short, void>>;
+  static_assert(!std::is_void_v<ValueT>,
+                "memset tests only work for 8, 16 and 32 bits");
 
   sycl::queue q{{sycl::property::queue::in_order()}};
   int Num = 10;
-  int *h_A = (int *)malloc(Num * sizeof(int));
+  ValueT *h_A = (ValueT *)malloc(Num * sizeof(ValueT));
 
   for (int i = 0; i < Num; i++) {
     h_A[i] = 4;
   }
 
-  int *d_A = (int *)syclcompat::malloc(Num * sizeof(int), q);
+  ValueT *d_A = (ValueT *)syclcompat::malloc(Num * sizeof(ValueT), q);
   // hostA -> deviceA
-  syclcompat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(int), q);
+  syclcompat::memcpy_async((void *)d_A, (void *)h_A, Num * sizeof(ValueT), q);
 
   // set d_A[0,..., 6] = 0
-  syclcompat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(int), q);
+  if constexpr (bits == 8)
+    syclcompat::memset_async((void *)d_A, 0, (Num - 3) * sizeof(ValueT), q);
+  else if constexpr (bits == 16)
+    syclcompat::memset_d16_async((void *)d_A, 0, (Num - 3), q);
+  else if constexpr (bits == 32)
+    syclcompat::memset_d32_async((void *)d_A, 0, (Num - 3), q);
 
   // deviceA -> hostA
-  syclcompat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(int), q);
+  syclcompat::memcpy_async((void *)h_A, (void *)d_A, Num * sizeof(ValueT), q);
   q.wait_and_throw();
   syclcompat::free((void *)d_A, q);
 
@@ -315,6 +337,42 @@ void test_memset_async_q() {
   }
 
   free(h_A);
+}
+
+void test_memset_async() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 8;
+  test_memset_async_impl<memset_size_in_bits>();
+}
+
+void test_memset_d16_async() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 16;
+  test_memset_async_impl<memset_size_in_bits>();
+}
+
+void test_memset_d32_async() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 32;
+  test_memset_async_impl<memset_size_in_bits>();
+}
+
+void test_memset_async_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 8;
+  test_memset_async_q_impl<memset_size_in_bits>();
+}
+
+void test_memset_d16_async_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 16;
+  test_memset_async_q_impl<memset_size_in_bits>();
+}
+
+void test_memset_d32_async_q() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  constexpr size_t memset_size_in_bits = 32;
+  test_memset_async_q_impl<memset_size_in_bits>();
 }
 
 template <typename T> void test_memcpy_async_t_q() {
@@ -610,6 +668,10 @@ int main() {
   test_memcpy_async_pitched_q();
   test_memset_async();
   test_memset_async_q();
+  test_memset_d16_async();
+  test_memset_d16_async_q();
+  test_memset_d32_async();
+  test_memset_d32_async_q();
   test_constant_memcpy_async();
   test_constant_memcpy_async_q();
 


### PR DESCRIPTION
This PR replaces #11340

This PR extends the memory header to include 2 byte and 4 byte memsets.
- memset remains unchanged.
  - 2D / 3D memsets are templated and wrap `sycl::fill`. Functionality remains unchanged as it is exposed through `detail::memset<unsigned char>`, equivalent to what we had before.
- memset_d16 and memset_d32 calls are added wrapped around `sycl::fill`  using 2-byte and 4-byte datatypes

Added tests for memset_d16 and memset_d32.