### PR TITLE
[CI] Add cron job to update IGC dev driver only

### DIFF
--- a/.github/workflows/sycl-update-gpu-driver.yml
+++ b/.github/workflows/sycl-update-gpu-driver.yml
@@ -3,7 +3,13 @@ name: Update GPU driver
 on:
   schedule:
     - cron:  '0 3 * * 2'
+    - cron:  '0 3 * * 1,4'
   workflow_dispatch:
+    inputs:
+      dayofweek:
+        description: 'Override the day of the week (e.g., 1 for Monday, 2 for Tuesday, etc.)'
+        required: false
+        default: '2'
 
 permissions: read-all
 
@@ -15,9 +21,25 @@ jobs:
     if: github.repository == 'intel/llvm'
     steps:
     - uses: actions/checkout@v4
+    - name: Determine parameters based on the day of the week
+      run: |
+        if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          # Use the input dayofweek when manually triggered
+          DAY_OF_WEEK="${{ github.event.inputs.dayofweek }}"
+        else
+          # Use the current day of the week when triggered by a schedule
+          DAY_OF_WEEK=$(date +%u)
+        fi
+
+        if [ "$DAY_OF_WEEK" = "2" ]; then
+          PARAM=""
+        else
+          PARAM="--igc-dev-only"
+        fi
+        echo "PARAM=$PARAM" >> $GITHUB_ENV
     - name: Update dependencies file
       run: |
-        version="$(python3 devops/scripts/update_drivers.py linux)"
+        version="$(python3 devops/scripts/update_drivers.py $PARAM linux)"
         echo 'NEW_DRIVER_VERSION='$version >> $GITHUB_ENV
     - name: Create Pull Request
       env:

--- a/devops/scripts/update_drivers.py
+++ b/devops/scripts/update_drivers.py
@@ -3,6 +3,7 @@ import json
 import sys
 import os
 import re
+import argparse
 
 
 def get_latest_release(repo):
@@ -28,7 +29,20 @@ def get_artifacts_download_url(repo, name):
     return json.loads(artifacts)["artifacts"][0]["archive_download_url"]
 
 
-def uplift_linux_igfx_driver(config, platform_tag):
+def uplift_linux_igfx_driver(config, platform_tag,igc_dev_only):
+
+    igc_dev = get_latest_workflow_runs("intel/intel-graphics-compiler", "build-IGC")
+    igcdevver = igc_dev["head_sha"][:7]
+    config[platform_tag]["igc_dev"]["github_tag"] = "igc-dev-" + igcdevver
+    config[platform_tag]["igc_dev"]["version"] = igcdevver
+    config[platform_tag]["igc_dev"]["updated_at"] = igc_dev["updated_at"]
+    config[platform_tag]["igc_dev"]["url"] = get_artifacts_download_url(
+        "intel/intel-graphics-compiler", "IGC_Ubuntu22.04_llvm14_clang-" + igcdevver
+    )
+
+    if(igc_dev_only):
+        return config
+
     compute_runtime = get_latest_release('intel/compute-runtime')
 
     config[platform_tag]['compute_runtime']['github_tag'] = compute_runtime['tag_name']
@@ -46,15 +60,6 @@ def uplift_linux_igfx_driver(config, platform_tag):
                 config[platform_tag]['igc']['url'] = 'https://github.com/intel/intel-graphics-compiler/releases/tag/igc-' + ver
                 break
 
-    igc_dev = get_latest_workflow_runs("intel/intel-graphics-compiler", "build-IGC")
-    igcdevver = igc_dev["head_sha"][:7]
-    config[platform_tag]["igc_dev"]["github_tag"] = "igc-dev-" + igcdevver
-    config[platform_tag]["igc_dev"]["version"] = igcdevver
-    config[platform_tag]["igc_dev"]["updated_at"] = igc_dev["updated_at"]
-    config[platform_tag]["igc_dev"]["url"] = get_artifacts_download_url(
-        "intel/intel-graphics-compiler", "IGC_Ubuntu22.04_llvm14_clang-" + igcdevver
-    )
-
     cm = get_latest_release('intel/cm-compiler')
     config[platform_tag]['cm']['github_tag'] = cm['tag_name']
     config[platform_tag]['cm']['version'] = cm['tag_name'].replace('cmclang-', '')
@@ -68,22 +73,28 @@ def uplift_linux_igfx_driver(config, platform_tag):
     return config
 
 
-def main(platform_tag):
+def main(platform_tag, igc_dev_only):
     script = os.path.dirname(os.path.realpath(__file__))
     config_name = os.path.join(script, '..', 'dependencies.json')
     config = {}
 
     with open(config_name, "r") as f:
         config = json.loads(f.read())
-        config = uplift_linux_igfx_driver(config, platform_tag)
+        config = uplift_linux_igfx_driver(config, platform_tag, igc_dev_only)
 
     with open(config_name, "w") as f:
         json.dump(config, f, indent=2)
         f.write('\n')
 
+    if(igc_dev_only):
+        return config[platform_tag]["igc_dev"]["github_tag"]
+
     return config[platform_tag]['compute_runtime']['version']
 
 
 if __name__ == '__main__':
-    platform_tag = sys.argv[1] if len(sys.argv) > 1 else "ERROR_PLATFORM"
-    sys.stdout.write(main(platform_tag) + '\n')
+    parser = argparse.ArgumentParser()
+    parser.add_argument('platform_tag')
+    parser.add_argument('--igc-dev-only', action='store_true')
+    args = parser.parse_args()
+    sys.stdout.write(main(args.platform_tag, args.igc_dev_only) + '\n')


### PR DESCRIPTION
We have weekly cron job to update the IGC drivers. 
However, the igc dev driver use CI driver from intel-graphic-compiler repo, the CI artifacts will be deleted if the build is 1 week or older,  so we need to update the igc dev driver more frequently, eg: at least twice a week to make sure that the driver we use are new enough, or else we will fail to download the artifacts when doing install_driver test or updating the `devigc` docker contains.

This is to add cron jobs to update igc dev driver only.

Tested: https://github.com/intel/llvm/actions/runs/8695012724