### PR TITLE
[SYCL] Clear deprecated sycl::runtime_error #2 and deprecate default constructor for sycl::exception

### DIFF
--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -67,8 +67,8 @@ public:
 /// \ingroup sycl_api
 class __SYCL_EXPORT exception : public virtual std::exception {
 public:
-  __SYCL2020_DEPRECATED("The version of an exception constructor which takes "
-                        "no arguments is deprecated.")
+  __SYCL_DEPRECATED("The version of an exception constructor which takes "
+                    "no arguments is deprecated.")
   exception() = default;
   virtual ~exception();
 

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -67,7 +67,7 @@ public:
 /// \ingroup sycl_api
 class __SYCL_EXPORT exception : public virtual std::exception {
 public:
-  __SYCL_DEPRECATED("The version of an exception constructor which takes "
+  __SYCL_DEPRECATED("The version of the exception constructor that takes "
                     "no arguments is deprecated.")
   exception() = default;
   virtual ~exception();

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -63,8 +63,8 @@ backend convertBackend(pi_platform_backend PiBackend) {
   case PI_EXT_PLATFORM_BACKEND_NATIVE_CPU:
     return backend::ext_oneapi_native_cpu;
   }
-  throw sycl::runtime_error{"convertBackend: Unsupported backend",
-                            PI_ERROR_INVALID_OPERATION};
+  throw sycl::exception(sycl::errc::runtime,
+                        "convertBackend: Unsupported backend");
 }
 
 platform make_platform(pi_native_handle NativeHandle, backend Backend) {

--- a/sycl/source/detail/filter_selector_impl.cpp
+++ b/sycl/source/detail/filter_selector_impl.cpp
@@ -56,7 +56,7 @@ filter create_filter(const std::string &Input) {
   // There should only be up to 3 tokens.
   // BE:Device Type:Device Num
   if (Tokens.size() > 3)
-    throw sycl::runtime_error(Error, PI_ERROR_INVALID_VALUE);
+    throw sycl::exception(sycl::errc::runtime, Error);
 
   for (const std::string &Token : Tokens) {
     if (Token == "cpu" && !Result.DeviceType) {
@@ -77,10 +77,10 @@ filter create_filter(const std::string &Input) {
       try {
         Result.DeviceNum = std::stoi(Token);
       } catch (std::logic_error &) {
-        throw sycl::runtime_error(Error, PI_ERROR_INVALID_VALUE);
+        throw sycl::exception(sycl::errc::runtime, Error);
       }
     } else {
-      throw sycl::runtime_error(Error, PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(sycl::errc::runtime, Error);
     }
   }
 
@@ -144,9 +144,9 @@ int filter_selector_impl::operator()(const device &Dev) const {
 
   mNumDevicesSeen++;
   if ((mNumDevicesSeen == mNumTotalDevices) && !mMatchFound) {
-    throw sycl::runtime_error(
-        "Could not find a device that matches the specified filter(s)!",
-        PI_ERROR_DEVICE_NOT_FOUND);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Could not find a device that matches the specified filter(s)!");
   }
 
   return Score;

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -151,9 +151,9 @@ public:
         break;
       case bundle_state::input:
       case bundle_state::ext_oneapi_source:
-        throw sycl::runtime_error("Internal error. The target state should not "
-                                  "be input or ext_oneapi_source",
-                                  PI_ERROR_INVALID_OPERATION);
+        throw sycl::exception(sycl::errc::runtime,
+                              "Internal error. The target state should not "
+                              "be input or ext_oneapi_source");
         break;
       }
     }

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2033,10 +2033,9 @@ ProgramManager::compile(const device_image_plain &DeviceImage,
   if (InputImpl->get_bin_image_ref()->getFormat() !=
           PI_DEVICE_BINARY_TYPE_SPIRV &&
       Devs.size() > 1)
-    sycl::runtime_error(
-        "Creating a program from AOT binary for multiple device is not "
-        "supported",
-        PI_ERROR_INVALID_OPERATION);
+    sycl::exception(sycl::errc::runtime,
+                    "Creating a program from AOT binary for multiple device is "
+                    "not supported");
 
   // Device is not used when creating program from SPIRV, so passing only one
   // device is OK.
@@ -2227,10 +2226,9 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
     if (InputImpl->get_bin_image_ref()->getFormat() !=
             PI_DEVICE_BINARY_TYPE_SPIRV &&
         Devs.size() > 1)
-      sycl::runtime_error(
-          "Creating a program from AOT binary for multiple device is not "
-          "supported",
-          PI_ERROR_INVALID_OPERATION);
+      sycl::exception(sycl::errc::runtime,
+                      "Creating a program from AOT binary for multiple device "
+                      "is not supported");
 
     // Device is not used when creating program from SPIRV, so passing only one
     // device is OK.

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2033,7 +2033,7 @@ ProgramManager::compile(const device_image_plain &DeviceImage,
   if (InputImpl->get_bin_image_ref()->getFormat() !=
           PI_DEVICE_BINARY_TYPE_SPIRV &&
       Devs.size() > 1)
-    sycl::exception(sycl::errc::runtime,
+    sycl::exception(sycl::errc::feature_not_supported,
                     "Creating a program from AOT binary for multiple device is "
                     "not supported");
 
@@ -2226,7 +2226,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
     if (InputImpl->get_bin_image_ref()->getFormat() !=
             PI_DEVICE_BINARY_TYPE_SPIRV &&
         Devs.size() > 1)
-      sycl::exception(sycl::errc::runtime,
+      sycl::exception(sycl::errc::feature_not_supported,
                       "Creating a program from AOT binary for multiple device "
                       "is not supported");
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -2033,9 +2033,10 @@ ProgramManager::compile(const device_image_plain &DeviceImage,
   if (InputImpl->get_bin_image_ref()->getFormat() !=
           PI_DEVICE_BINARY_TYPE_SPIRV &&
       Devs.size() > 1)
-    sycl::exception(sycl::errc::feature_not_supported,
-                    "Creating a program from AOT binary for multiple device is "
-                    "not supported");
+    sycl::exception(
+        sycl::errc::feature_not_supported,
+        "Creating a program from AOT binary for multiple devices is "
+        "not supported");
 
   // Device is not used when creating program from SPIRV, so passing only one
   // device is OK.

--- a/sycl/source/detail/spec_constant_impl.cpp
+++ b/sycl/source/detail/spec_constant_impl.cpp
@@ -22,8 +22,7 @@ namespace detail {
 
 void spec_constant_impl::set(size_t Size, const void *Val) {
   if (0 == Size)
-    throw sycl::runtime_error("invalid spec constant size",
-                              PI_ERROR_INVALID_VALUE);
+    throw sycl::exception(sycl::errc::runtime, "invalid spec constant size");
   auto *BytePtr = reinterpret_cast<const char *>(Val);
   this->Bytes.assign(BytePtr, BytePtr + Size);
 }

--- a/sycl/source/detail/spec_constant_impl.cpp
+++ b/sycl/source/detail/spec_constant_impl.cpp
@@ -22,7 +22,7 @@ namespace detail {
 
 void spec_constant_impl::set(size_t Size, const void *Val) {
   if (0 == Size)
-    throw sycl::exception(sycl::errc::runtime, "invalid spec constant size");
+    throw sycl::exception(sycl::errc::invalid, "invalid spec constant size");
   auto *BytePtr = reinterpret_cast<const char *>(Val);
   this->Bytes.assign(BytePtr, BytePtr + Size);
 }

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -536,9 +536,9 @@ event handler::finalize() {
   }
 
   if (!CommandGroup)
-    throw sycl::runtime_error(
-        "Internal Error. Command group cannot be constructed.",
-        PI_ERROR_INVALID_OPERATION);
+    throw sycl::exception(
+        sycl::errc::runtime,
+        "Internal Error. Command group cannot be constructed.");
 
   // If there is a graph associated with the handler we are in the explicit
   // graph mode, so we store the CG instead of submitting it to the scheduler,

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -104,7 +104,7 @@ int main() {
   try {
     // pick something crazy
     device d9(filter_selector("gpu:999"));
-  } catch (const sycl::runtime_error &e) {
+  } catch (const sycl::exception &e) {
     const char *ErrorMesg =
         "Could not find a device that matches the specified filter(s)!";
     assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
@@ -114,7 +114,7 @@ int main() {
   try {
     // pick something crazy
     device d10(filter_selector("bob:gpu"));
-  } catch (const sycl::runtime_error &e) {
+  } catch (const sycl::exception &e) {
     const char *ErrorMesg = "Invalid filter string!";
     assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
            "filter_selector(\"bob:gpu\") unexpectedly selected a device");
@@ -123,7 +123,7 @@ int main() {
   try {
     // pick something crazy
     device d11(filter_selector("opencl:bob"));
-  } catch (const sycl::runtime_error &e) {
+  } catch (const sycl::exception &e) {
     const char *ErrorMesg = "Invalid filter string!";
     assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
            "filter_selector(\"opencl:bob\") unexpectedly selected a device");

--- a/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
+++ b/sycl/test-e2e/OnlineCompiler/online_compiler_OpenCL.cpp
@@ -26,15 +26,16 @@ sycl::kernel getSYCLKernelWithIL(sycl::queue &Queue,
       clCreateProgramWithIL(sycl::get_native<sycl::backend::opencl>(Context),
                             IL.data(), IL.size(), &Err);
   if (Err != CL_SUCCESS)
-    throw sycl::runtime_error("clCreateProgramWithIL() failed", Err);
+    throw sycl::exception(sycl::errc::runtime,
+                          "clCreateProgramWithIL() failed");
 
   Err = clBuildProgram(ClProgram, 0, nullptr, nullptr, nullptr, nullptr);
   if (Err != CL_SUCCESS)
-    throw sycl::runtime_error("clBuildProgram() failed", Err);
+    throw sycl::exception(sycl::errc::runtime, "clBuildProgram() failed");
 
   cl_kernel ClKernel = clCreateKernel(ClProgram, "my_kernel", &Err);
   if (Err != CL_SUCCESS)
-    throw sycl::runtime_error("clCreateKernel() failed", Err);
+    throw sycl::exception(sycl::errc::runtime, "clCreateKernel() failed");
 
   return sycl::make_kernel<sycl::backend::opencl>(ClKernel, Context);
 }

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -112,7 +112,7 @@ int main() {
   sycl::profiling_error pre;
   // expected-warning@+1 {{'feature_not_supported' is deprecated: use sycl::exception with sycl::errc::feature_not_supported instead.}}
   sycl::feature_not_supported fns;
-  // expected-warning@+1{{'exception' is deprecated: The version of an exception constructor which takes no arguments is deprecated.}}
+  // expected-warning@+1{{'exception' is deprecated: The version of the exception constructor that takes no arguments is deprecated.}}
   sycl::exception ex;
   // expected-warning@+1{{'get_cl_code' is deprecated: use sycl::exception.code() instead.}}
   ex.get_cl_code();

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -128,8 +128,8 @@ public:
       break;
     }
     default:
-      throw sycl::runtime_error("Unhandled type of command group",
-                                PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(sycl::errc::runtime,
+                            "Unhandled type of command group");
     }
 
     return CommandGroup;

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -283,8 +283,8 @@ public:
   }
 
   std::unique_ptr<sycl::detail::CG> finalize() {
-    throw sycl::runtime_error("Unhandled type of command group",
-                              PI_ERROR_INVALID_OPERATION);
+    throw sycl::exception(sycl::errc::runtime,
+                          "Unhandled type of command group");
 
     return nullptr;
   }
@@ -317,8 +317,8 @@ public:
       break;
     }
     default:
-      throw sycl::runtime_error("Unhandled type of command group",
-                                PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(sycl::errc::runtime,
+                            "Unhandled type of command group");
     }
 
     return CommandGroup;

--- a/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
+++ b/sycl/unittests/scheduler/StreamInitDependencyOnHost.cpp
@@ -38,8 +38,8 @@ public:
       break;
     }
     default:
-      throw sycl::runtime_error("Unhandled type of command group",
-                                PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(sycl::errc::runtime,
+                            "Unhandled type of command group");
     }
 
     return CommandGroup;
@@ -57,8 +57,8 @@ static bool ValidateDepCommandsTree(const detail::Command *Cmd,
                                     const detail::SYCLMemObjI *MemObj,
                                     size_t Depth = 0) {
   if (!Cmd || Depth >= DepCmdsTypes.size())
-    throw sycl::runtime_error("Command parameters are invalid",
-                              PI_ERROR_INVALID_VALUE);
+    throw sycl::exception(sycl::errc::runtime,
+                          "Command parameters are invalid");
 
   for (const detail::DepDesc &Dep : Cmd->MDeps) {
     if (Dep.MDepCommand &&


### PR DESCRIPTION
Replacing the second batch of sycl::runtime_error instances with sycl::exception. (Previous PR about this issue: https://github.com/intel/llvm/pull/13283) Also deprecating the default constructor for sycl::exception which no longer exist in SYCL 2020 spec.