### PR TITLE
[E2E][Bindless] XFAIL broken read_norm_types test

### DIFF
--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -1,5 +1,6 @@
 // REQUIRES: linux
 // REQUIRES: cuda
+// XFAIL: *
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
XFAIL the read_norm_types test as it is currently broken until an appropriate fix is figured out.