### PR TITLE
[SYCL][SCLA] Emit warning on invalid default size value

### DIFF
--- a/clang/include/clang/Basic/DiagnosticGroups.td
+++ b/clang/include/clang/Basic/DiagnosticGroups.td
@@ -1360,6 +1360,7 @@ def SyclTarget : DiagGroup<"sycl-target">;
 def SyclFPGAMismatch : DiagGroup<"sycl-fpga-mismatch">;
 def SyclAspectMismatch : DiagGroup<"sycl-aspect-mismatch">;
 def SyclNativeCPUTargets: DiagGroup<"sycl-native-cpu-targets">;
+def SyclPrivateAllocaPositiveSize : DiagGroup<"sycl-private-alloca-positive-size">;
 
 // OpenACC warnings.
 def SourceUsesOpenACC : DiagGroup<"source-uses-openacc">;

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -199,8 +199,8 @@ def err_intel_sycl_alloca_no_size
     : Error<"__builtin_intel_sycl_alloca must be passed a specialization "
             "constant of integral value type as a template argument. Got %0">;
 def warn_intel_sycl_alloca_bad_default_value : Warning<
-    "__builtin_intel_sycl_alloca should be passed a specialization constant with "
-    "a default value of at least one as an argument. Got %0">,
+    "__builtin_intel_sycl_alloca expects a specialization constant with a "
+    "default value of at least one as an argument. Got %0">,
     InGroup<SyclPrivateAllocaPositiveSize>;
 
 // C99 variable-length arrays

--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -198,6 +198,10 @@ def err_intel_sycl_alloca_wrong_size
 def err_intel_sycl_alloca_no_size
     : Error<"__builtin_intel_sycl_alloca must be passed a specialization "
             "constant of integral value type as a template argument. Got %0">;
+def warn_intel_sycl_alloca_bad_default_value : Warning<
+    "__builtin_intel_sycl_alloca should be passed a specialization constant with "
+    "a default value of at least one as an argument. Got %0">,
+    InGroup<SyclPrivateAllocaPositiveSize>;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -7790,6 +7790,20 @@ bool Sema::CheckIntelSYCLPtrAnnotationBuiltinFunctionCall(unsigned BuiltinID,
   return false;
 }
 
+static llvm::APSInt getSYCLAllocaDefaultSize(const ASTContext &Ctx,
+                                             const VarDecl *VD) {
+  assert(VD && "Expecting valid declaration");
+  APValue *SpecializationId = VD->evaluateValue();
+  assert(SpecializationId && "Expecting value");
+  assert(SpecializationId->getKind() == APValue::ValueKind::Struct &&
+         "Expecting specialization_id struct");
+  assert(SpecializationId->getStructNumFields() == 1 &&
+         "Expecting single field for default value");
+  APValue Default = SpecializationId->getStructField(0);
+  assert(Default.isInt() && "Expecting default integer value");
+  return Default.getInt();
+}
+
 bool Sema::CheckIntelSYCLAllocaBuiltinFunctionCall(unsigned, CallExpr *Call) {
   assert(getLangOpts().SYCLIsDevice &&
          "Builtin can only be used in SYCL device code");
@@ -7854,7 +7868,7 @@ bool Sema::CheckIntelSYCLAllocaBuiltinFunctionCall(unsigned, CallExpr *Call) {
   }
 
   // Check size is passed as a specialization constant
-  constexpr auto CheckSize = [](const ASTContext &Ctx,
+  const auto CheckSize = [this](const ASTContext &Ctx, SourceLocation Loc,
                                 const TemplateArgumentList *CST) {
     QualType Ty = CST->get(1).getNonTypeTemplateArgumentType();
     if (Ty.isNull() || !Ty->isReferenceType())
@@ -7865,10 +7879,17 @@ bool Sema::CheckIntelSYCLAllocaBuiltinFunctionCall(unsigned, CallExpr *Call) {
     const TemplateArgumentList &TAL =
         cast<ClassTemplateSpecializationDecl>(Ty->getAsCXXRecordDecl())
             ->getTemplateArgs();
-    return !TAL.get(0).getAsType()->isIntegralType(Ctx);
+    if (!TAL.get(0).getAsType()->isIntegralType(Ctx))
+      return true;
+    llvm::APSInt DefaultSize =
+        getSYCLAllocaDefaultSize(Ctx, cast<VarDecl>(CST->get(1).getAsDecl()));
+    if (DefaultSize < 1)
+      Diag(Loc, diag::warn_intel_sycl_alloca_bad_default_value)
+          << DefaultSize.getSExtValue();
+    return false;
   };
   const TemplateArgumentList *CST = FD->getTemplateSpecializationArgs();
-  if (CheckSize(getASTContext(), CST)) {
+  if (CheckSize(getASTContext(), Loc, CST)) {
     TemplateArgument TA = CST->get(1);
     QualType Ty = TA.getNonTypeTemplateArgumentType();
     if (Ty.isNull())

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -7794,13 +7794,14 @@ static llvm::APSInt getSYCLAllocaDefaultSize(const ASTContext &Ctx,
                                              const VarDecl *VD) {
   assert(VD && "Expecting valid declaration");
   APValue *SpecializationId = VD->evaluateValue();
-  assert(SpecializationId && "Expecting value");
+  assert(SpecializationId && "Expecting a non-null SpecializationId");
   assert(SpecializationId->getKind() == APValue::ValueKind::Struct &&
-         "Expecting specialization_id struct");
+         "Expecting SpecializationId to be of kind Struct");
   assert(SpecializationId->getStructNumFields() == 1 &&
-         "Expecting single field for default value");
+         "Expecting SpecializationId to have a single field for the default "
+         "value");
   APValue Default = SpecializationId->getStructField(0);
-  assert(Default.isInt() && "Expecting default integer value");
+  assert(Default.isInt() && "Expecting the default value to be an integer");
   return Default.getInt();
 }
 

--- a/clang/test/CodeGenSYCL/builtin-alloca.cpp
+++ b/clang/test/CodeGenSYCL/builtin-alloca.cpp
@@ -16,7 +16,7 @@ struct myStruct {
 };
 
 constexpr sycl::specialization_id<size_t> size(1);
-constexpr sycl::specialization_id<int> intSize(-1);
+constexpr sycl::specialization_id<int> intSize(1);
 
 // For each call, we should generate a chain of: 'call @llvm.sycl.alloca.<ty>' + ('addrspacecast') + 'store'.
 // The 'addrspacecast' will only appear when the pointer is not decorated, i.e., `DecorateAddress == sycl::access::decorated::no`.

--- a/clang/test/SemaSYCL/builtin-alloca-errors-device.cpp
+++ b/clang/test/SemaSYCL/builtin-alloca-errors-device.cpp
@@ -7,8 +7,15 @@
 #include "Inputs/sycl.hpp"
 #include "Inputs/private_alloca.hpp"
 
+constexpr int ten() { return 10; }
+
 constexpr sycl::specialization_id<size_t> size(1);
 constexpr sycl::specialization_id<float> badsize(1);
+constexpr sycl::specialization_id<size_t> zero;
+constexpr sycl::specialization_id<int> negative(-1);
+constexpr sycl::specialization_id<int> negative_expr(1 - ten());
+
+constexpr const sycl::specialization_id<int> &negative_expr_ref = negative_expr;
 
 struct wrapped_int { int a; };
 
@@ -116,4 +123,13 @@ void test(sycl::kernel_handler &h) {
 
   // expected-error@+1 {{__builtin_intel_sycl_alloca must be passed a specialization constant of integral value type as a template argument. Got 'const sycl::specialization_id<float> &'}}
   sycl::ext::oneapi::experimental::private_alloca<float, badsize, sycl::access::decorated::yes>(h);
+
+  // expected-warning@+1 {{__builtin_intel_sycl_alloca should be passed a specialization constant with a default value of at least one as an argument. Got 0}}
+  sycl::ext::oneapi::experimental::private_alloca<float, zero, sycl::access::decorated::yes>(h);
+
+  // expected-warning@+1 {{__builtin_intel_sycl_alloca should be passed a specialization constant with a default value of at least one as an argument. Got -1}}
+  sycl::ext::oneapi::experimental::private_alloca<float, negative, sycl::access::decorated::yes>(h);
+
+  // expected-warning@+1 {{__builtin_intel_sycl_alloca should be passed a specialization constant with a default value of at least one as an argument. Got -9}}
+  sycl::ext::oneapi::experimental::private_alloca<float, negative_expr_ref, sycl::access::decorated::yes>(h);
 }

--- a/clang/test/SemaSYCL/builtin-alloca-errors-device.cpp
+++ b/clang/test/SemaSYCL/builtin-alloca-errors-device.cpp
@@ -124,12 +124,12 @@ void test(sycl::kernel_handler &h) {
   // expected-error@+1 {{__builtin_intel_sycl_alloca must be passed a specialization constant of integral value type as a template argument. Got 'const sycl::specialization_id<float> &'}}
   sycl::ext::oneapi::experimental::private_alloca<float, badsize, sycl::access::decorated::yes>(h);
 
-  // expected-warning@+1 {{__builtin_intel_sycl_alloca should be passed a specialization constant with a default value of at least one as an argument. Got 0}}
+  // expected-warning@+1 {{__builtin_intel_sycl_alloca expects a specialization constant with a default value of at least one as an argument. Got 0}}
   sycl::ext::oneapi::experimental::private_alloca<float, zero, sycl::access::decorated::yes>(h);
 
-  // expected-warning@+1 {{__builtin_intel_sycl_alloca should be passed a specialization constant with a default value of at least one as an argument. Got -1}}
+  // expected-warning@+1 {{__builtin_intel_sycl_alloca expects a specialization constant with a default value of at least one as an argument. Got -1}}
   sycl::ext::oneapi::experimental::private_alloca<float, negative, sycl::access::decorated::yes>(h);
 
-  // expected-warning@+1 {{__builtin_intel_sycl_alloca should be passed a specialization constant with a default value of at least one as an argument. Got -9}}
+  // expected-warning@+1 {{__builtin_intel_sycl_alloca expects a specialization constant with a default value of at least one as an argument. Got -9}}
   sycl::ext::oneapi::experimental::private_alloca<float, negative_expr_ref, sycl::access::decorated::yes>(h);
 }

--- a/clang/test/SemaSYCL/builtin-alloca.cpp
+++ b/clang/test/SemaSYCL/builtin-alloca.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -triple spir64-unknown-unknown -verify -Wpedantic                  %s
+// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -triple spir64-unknown-unknown -verify -Wpedantic %s
 
 // Test verification of __builtin_intel_sycl_alloca when used in different valid ways.
 
@@ -15,7 +15,7 @@ struct myStruct {
 };
 
 constexpr sycl::specialization_id<size_t> size(1);
-constexpr sycl::specialization_id<int> intSize(-1);
+constexpr sycl::specialization_id<int> intSize(1);
 constexpr sycl::specialization_id<unsigned short> shortSize(1);
 
 void basic_test(sycl::kernel_handler &kh) {


### PR DESCRIPTION
According to the extension specification:

> *`SizeSpecName` must have a default value of at least 1* and not be
set to a value less than 1 during program execution. Violation of these conditions results in undefined behavior.

Warn users on default values lesser than 1 used for `private_alloca` sizes.