### PR TITLE
[SYCL][JIT] Load SYCL JIT lazily

### DIFF
--- a/sycl-fusion/jit-compiler/CMakeLists.txt
+++ b/sycl-fusion/jit-compiler/CMakeLists.txt
@@ -9,6 +9,8 @@ add_llvm_library(sycl-fusion
    lib/fusion/ModuleHelper.cpp
    lib/helper/ConfigHelper.cpp
 
+   SHARED
+
    DEPENDS
    intrinsics_gen
 
@@ -66,13 +68,11 @@ if("AMDGPU" IN_LIST LLVM_TARGETS_TO_BUILD)
   target_compile_definitions(sycl-fusion PRIVATE FUSION_JIT_SUPPORT_AMDGCN)
 endif()
 
-if (BUILD_SHARED_LIBS)
-  if(NOT MSVC AND NOT APPLE)
-    # Manage symbol visibility through the linker to make sure no LLVM symbols
-    # are exported and confuse the drivers.
-    set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
-    target_link_libraries(
-      sycl-fusion PRIVATE "-Wl,--version-script=${linker_script}")
-    set_target_properties(sycl-fusion PROPERTIES LINK_DEPENDS ${linker_script})
-  endif()
+if(NOT MSVC AND NOT APPLE)
+  # Manage symbol visibility through the linker to make sure no LLVM symbols
+  # are exported and confuse the drivers.
+  set(linker_script "${CMAKE_CURRENT_SOURCE_DIR}/ld-version-script.txt")
+  target_link_libraries(
+    sycl-fusion PRIVATE "-Wl,--version-script=${linker_script}")
+  set_target_properties(sycl-fusion PROPERTIES LINK_DEPENDS ${linker_script})
 endif()

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -54,11 +54,11 @@ private:
 extern "C" {
 
 FusionResult fuseKernels(View<SYCLKernelInfo> KernelInformation,
-                                const char *FusedKernelName,
-                                View<ParameterIdentity> Identities,
-                                BarrierFlags BarriersFlags,
-                                View<ParameterInternalization> Internalization,
-                                View<jit_compiler::JITConstant> JITConstants);
+                         const char *FusedKernelName,
+                         View<ParameterIdentity> Identities,
+                         BarrierFlags BarriersFlags,
+                         View<ParameterInternalization> Internalization,
+                         View<jit_compiler::JITConstant> JITConstants);
 
 /// Clear all previously set options.
 void resetJITConfiguration();

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -51,23 +51,22 @@ private:
   DynString ErrorMessage;
 };
 
-class KernelFusion {
+extern "C" {
 
-public:
-  static FusionResult
-  fuseKernels(View<SYCLKernelInfo> KernelInformation,
-              const char *FusedKernelName, View<ParameterIdentity> Identities,
-              BarrierFlags BarriersFlags,
-              View<ParameterInternalization> Internalization,
-              View<jit_compiler::JITConstant> JITConstants);
+FusionResult fuseKernels(View<SYCLKernelInfo> KernelInformation,
+                                const char *FusedKernelName,
+                                View<ParameterIdentity> Identities,
+                                BarrierFlags BarriersFlags,
+                                View<ParameterInternalization> Internalization,
+                                View<jit_compiler::JITConstant> JITConstants);
 
-  /// Clear all previously set options.
-  static void resetConfiguration();
+/// Clear all previously set options.
+void resetJITConfiguration();
 
-  /// Add an option to the configuration.
-  static void addToConfiguration(OptionStorage&& Opt);
+/// Add an option to the configuration.
+void addToJITConfiguration(OptionStorage &&Opt);
 
-};
+} // end of extern "C"
 
 } // namespace jit_compiler
 

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -64,14 +64,9 @@ public:
   /// Clear all previously set options.
   static void resetConfiguration();
 
-  /// Set \p Opt to the value built in-place by \p As.
-  template <typename Opt, typename... Args> static void set(Args &&...As) {
-    set(new Opt{std::forward<Args>(As)...});
-  }
+  /// Add an option to the configuration.
+  static void addToConfiguration(OptionStorage&& Opt);
 
-private:
-  /// Take ownership of \p Option and include it in the current configuration.
-  static void set(OptionPtrBase *Option);
 };
 
 } // namespace jit_compiler

--- a/sycl-fusion/jit-compiler/include/Options.h
+++ b/sycl-fusion/jit-compiler/include/Options.h
@@ -27,10 +27,7 @@ public:
 
 class OptionStorage {
 public:
-  ~OptionStorage() {
-    if (Storage)
-      delete Storage;
-  }
+  ~OptionStorage() { delete Storage; }
 
   OptionStorage() : Storage{nullptr} {}
 

--- a/sycl-fusion/jit-compiler/include/Options.h
+++ b/sycl-fusion/jit-compiler/include/Options.h
@@ -20,10 +20,48 @@ protected:
   explicit OptionPtrBase(OptionID Id) : Id(Id) {}
 
 public:
+  virtual ~OptionPtrBase() = default;
+
   const OptionID Id;
 };
 
-template <OptionID ID, typename T> struct OptionBase : public OptionPtrBase {
+class OptionStorage {
+public:
+  ~OptionStorage() {
+    if (Storage)
+      delete Storage;
+  }
+
+  OptionStorage() : Storage{nullptr} {}
+
+  OptionStorage(const OptionStorage &) = delete;
+  OptionStorage &operator=(const OptionStorage &) = delete;
+
+  OptionStorage(OptionStorage &&Other) : Storage{Other.Storage} {
+    Other.Storage = nullptr;
+  }
+
+  OptionStorage &operator=(OptionStorage &&Other) {
+    Storage = Other.Storage;
+    Other.Storage = nullptr;
+    return *this;
+  }
+
+  OptionPtrBase *get() const { return Storage; }
+
+  template <typename OptionT, typename... Args>
+  static OptionStorage makeOption(Args &&...As) {
+    return OptionStorage(new OptionT(std::forward<Args>(As)...));
+  }
+
+private:
+  OptionPtrBase *Storage;
+
+  OptionStorage(OptionPtrBase *Store) : Storage{Store} {}
+};
+
+template <typename OptionT, OptionID ID, typename T>
+struct OptionBase : public OptionPtrBase {
   static constexpr OptionID Id = ID;
   using ValueType = T;
 
@@ -31,21 +69,27 @@ template <OptionID ID, typename T> struct OptionBase : public OptionPtrBase {
   explicit OptionBase(Args &&...As)
       : OptionPtrBase{ID}, Value{std::forward<Args>(As)...} {}
 
+  template <typename... Args> static OptionStorage set(Args &&...As) {
+    return OptionStorage::makeOption<OptionT>(std::forward<Args>(As)...);
+  }
+
   T Value;
 };
 
 namespace option {
 
-struct JITEnableVerbose : public OptionBase<OptionID::VerboseOutput, bool> {
+struct JITEnableVerbose
+    : public OptionBase<JITEnableVerbose, OptionID::VerboseOutput, bool> {
   using OptionBase::OptionBase;
 };
 
-struct JITEnableCaching : public OptionBase<OptionID::EnableCaching, bool> {
+struct JITEnableCaching
+    : public OptionBase<JITEnableCaching, OptionID::EnableCaching, bool> {
   using OptionBase::OptionBase;
 };
 
 struct JITTargetInfo
-    : public OptionBase<OptionID::TargetDeviceInfo, TargetInfo> {
+    : public OptionBase<JITTargetInfo, OptionID::TargetDeviceInfo, TargetInfo> {
   using OptionBase::OptionBase;
 };
 

--- a/sycl-fusion/jit-compiler/ld-version-script.txt
+++ b/sycl-fusion/jit-compiler/ld-version-script.txt
@@ -1,7 +1,6 @@
 {
   global:
-    /* Export everything from jit_compiler namespace */
-    _ZN12jit_compiler*;
+    /* Export the library entry points */
     fuseKernels;
     resetJITConfiguration;
     addToJITConfiguration;

--- a/sycl-fusion/jit-compiler/ld-version-script.txt
+++ b/sycl-fusion/jit-compiler/ld-version-script.txt
@@ -2,6 +2,9 @@
   global:
     /* Export everything from jit_compiler namespace */
     _ZN12jit_compiler*;
+    fuseKernels;
+    resetJITConfiguration;
+    addToJITConfiguration;
 
   local:
     *;

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -70,12 +70,11 @@ static bool isTargetFormatSupported(BinaryFormat TargetFormat) {
   }
 }
 
-extern "C" FusionResult fuseKernels(View<SYCLKernelInfo> KernelInformation,
-                         const char *FusedKernelName,
-                         View<ParameterIdentity> Identities,
-                         BarrierFlags BarriersFlags,
-                         View<ParameterInternalization> Internalization,
-                         View<jit_compiler::JITConstant> Constants) {
+extern "C" FusionResult
+fuseKernels(View<SYCLKernelInfo> KernelInformation, const char *FusedKernelName,
+            View<ParameterIdentity> Identities, BarrierFlags BarriersFlags,
+            View<ParameterInternalization> Internalization,
+            View<jit_compiler::JITConstant> Constants) {
 
   std::vector<std::string> KernelsToFuse;
   llvm::transform(KernelInformation, std::back_inserter(KernelsToFuse),

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -70,11 +70,12 @@ static bool isTargetFormatSupported(BinaryFormat TargetFormat) {
   }
 }
 
-FusionResult KernelFusion::fuseKernels(
-    View<SYCLKernelInfo> KernelInformation, const char *FusedKernelName,
-    View<ParameterIdentity> Identities, BarrierFlags BarriersFlags,
-    View<ParameterInternalization> Internalization,
-    View<jit_compiler::JITConstant> Constants) {
+extern "C" FusionResult fuseKernels(View<SYCLKernelInfo> KernelInformation,
+                         const char *FusedKernelName,
+                         View<ParameterIdentity> Identities,
+                         BarrierFlags BarriersFlags,
+                         View<ParameterInternalization> Internalization,
+                         View<jit_compiler::JITConstant> Constants) {
 
   std::vector<std::string> KernelsToFuse;
   llvm::transform(KernelInformation, std::back_inserter(KernelsToFuse),
@@ -191,8 +192,8 @@ FusionResult KernelFusion::fuseKernels(
   return FusionResult{FusedKernelInfo};
 }
 
-void KernelFusion::resetConfiguration() { ConfigHelper::reset(); }
+extern "C" void resetJITConfiguration() { ConfigHelper::reset(); }
 
-void KernelFusion::addToConfiguration(OptionStorage&& Opt){
+extern "C" void addToJITConfiguration(OptionStorage &&Opt) {
   ConfigHelper::getConfig().set(std::move(Opt));
 }

--- a/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-fusion/jit-compiler/lib/KernelFusion.cpp
@@ -193,6 +193,6 @@ FusionResult KernelFusion::fuseKernels(
 
 void KernelFusion::resetConfiguration() { ConfigHelper::reset(); }
 
-void KernelFusion::set(OptionPtrBase *Option) {
-  ConfigHelper::getConfig().set(Option);
+void KernelFusion::addToConfiguration(OptionStorage&& Opt){
+  ConfigHelper::getConfig().set(std::move(Opt));
 }

--- a/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
+++ b/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
@@ -29,7 +29,7 @@ public:
     return static_cast<const OptionBase<Opt, Opt::Id, T> *>(ConfigValue)->Value;
   }
 
-  void set(OptionStorage&& Option) {
+  void set(OptionStorage &&Option) {
     auto ID = Option.get()->Id;
     OptionValues[ID] = std::move(Option);
   }

--- a/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
+++ b/sycl-fusion/jit-compiler/lib/helper/ConfigHelper.h
@@ -26,15 +26,16 @@ public:
     if (!ConfigValue) {
       return T{};
     }
-    return static_cast<const OptionBase<Opt::Id, T> *>(ConfigValue)->Value;
+    return static_cast<const OptionBase<Opt, Opt::Id, T> *>(ConfigValue)->Value;
   }
 
-  void set(OptionPtrBase *Option) {
-    OptionValues[Option->Id] = std::unique_ptr<OptionPtrBase>(Option);
+  void set(OptionStorage&& Option) {
+    auto ID = Option.get()->Id;
+    OptionValues[ID] = std::move(Option);
   }
 
 private:
-  std::unordered_map<OptionID, std::unique_ptr<OptionPtrBase>> OptionValues;
+  std::unordered_map<OptionID, OptionStorage> OptionValues;
 
   const OptionPtrBase *get(OptionID ID) const {
     const auto Iter = OptionValues.find(ID);

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -141,12 +141,18 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
   )
 
   if(SYCL_ENABLE_KERNEL_FUSION)
-    target_link_libraries(${LIB_NAME} PRIVATE sycl-fusion)
-    target_link_libraries(${LIB_OBJ_NAME} PRIVATE sycl-fusion)
-    if (BUILD_SHARED_LIBS)
-     set_property(GLOBAL APPEND PROPERTY SYCL_TOOLCHAIN_INSTALL_COMPONENTS
+    if(NOT DEFINED LLVM_EXTERNAL_SYCL_FUSION_SOURCE_DIR)
+      message(FATAL_ERROR "Undefined LLVM_EXTERNAL_SYCL_FUSION_SOURCE_DIR variable: Must be set when SYCL fusion is enabled")
+    endif()
+    set(SYCL_FUSION_INCLUDE_DIRS 
+        ${LLVM_EXTERNAL_SYCL_FUSION_SOURCE_DIR}/common/include
+        ${LLVM_EXTERNAL_SYCL_FUSION_SOURCE_DIR}/jit-compiler/include)
+    add_dependencies(${LIB_NAME} sycl-fusion)
+    add_dependencies(${LIB_OBJ_NAME} sycl-fusion)
+    target_include_directories(${LIB_NAME} PRIVATE ${SYCL_FUSION_INCLUDE_DIRS})
+    target_include_directories(${LIB_OBJ_NAME} PRIVATE ${SYCL_FUSION_INCLUDE_DIRS})
+    set_property(GLOBAL APPEND PROPERTY SYCL_TOOLCHAIN_INSTALL_COMPONENTS
        sycl-fusion)
-    endif (BUILD_SHARED_LIBS)
   endif(SYCL_ENABLE_KERNEL_FUSION)
 
   find_package(Threads REQUIRED)

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <detail/device_impl.hpp>
+#include <detail/jit_compiler.hpp>
 #include <detail/platform_impl.hpp>
 #include <detail/platform_util.hpp>
 #include <detail/plugin.hpp>
@@ -1152,6 +1153,11 @@ struct get_device_info_impl<
     bool, ext::codeplay::experimental::info::device::supports_fusion> {
   static bool get(const DeviceImplPtr &Dev) {
 #if SYCL_EXT_CODEPLAY_KERNEL_FUSION
+    // If the JIT library can't be loaded or entry points in the JIT library
+    // can't be resolved, fusion is not available.
+    if (!jit_compiler::get_instance().isAvailable()) {
+      return false;
+    }
     // Currently fusion is only supported for SPIR-V based backends,
     // CUDA and HIP.
     if (Dev->getBackend() == backend::opencl) {

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -856,15 +856,16 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   ::jit_compiler::KernelFusion::resetConfiguration();
   bool DebugEnabled =
       detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() > 0;
-  ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITEnableVerbose>(
-      DebugEnabled);
-  ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITEnableCaching>(
-      detail::SYCLConfig<detail::SYCL_ENABLE_FUSION_CACHING>::get());
+  ::jit_compiler::KernelFusion::addToConfiguration(
+      ::jit_compiler::option::JITEnableVerbose::set(DebugEnabled));
+  ::jit_compiler::KernelFusion::addToConfiguration(
+      ::jit_compiler::option::JITEnableCaching::set(
+          detail::SYCLConfig<detail::SYCL_ENABLE_FUSION_CACHING>::get()));
 
   ::jit_compiler::TargetInfo TargetInfo = getTargetInfo(Queue);
   ::jit_compiler::BinaryFormat TargetFormat = TargetInfo.getFormat();
-  ::jit_compiler::KernelFusion::set<::jit_compiler::option::JITTargetInfo>(
-      std::move(TargetInfo));
+  ::jit_compiler::KernelFusion::addToConfiguration(
+      ::jit_compiler::option::JITTargetInfo::set(std::move(TargetInfo)));
 
   using ::jit_compiler::View;
   auto FusionResult = ::jit_compiler::KernelFusion::fuseKernels(

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -23,10 +23,8 @@ inline namespace _V1 {
 namespace detail {
 
 using FuseKernelsFuncT = decltype(::jit_compiler::fuseKernels) *;
-using ResetConfigFuncT =
-    decltype(::jit_compiler::resetJITConfiguration) *;
-using AddToConfigFuncT =
-    decltype(::jit_compiler::addToJITConfiguration) *;
+using ResetConfigFuncT = decltype(::jit_compiler::resetJITConfiguration) *;
+using AddToConfigFuncT = decltype(::jit_compiler::addToJITConfiguration) *;
 
 static inline void printPerformanceWarning(const std::string &Message) {
   if (detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() > 0) {
@@ -60,8 +58,8 @@ bool jit_compiler::isAvailable() {
       return false;
     }
 
-    this->FuseKernelsHandle = sycl::detail::pi::getOsLibraryFuncAddress(
-        LibraryPtr, "fuseKernels");
+    this->FuseKernelsHandle =
+        sycl::detail::pi::getOsLibraryFuncAddress(LibraryPtr, "fuseKernels");
     if (!this->FuseKernelsHandle) {
       printPerformanceWarning(
           "Cannot resolve JIT library function entry point");

--- a/sycl/source/detail/jit_compiler.hpp
+++ b/sycl/source/detail/jit_compiler.hpp
@@ -37,6 +37,8 @@ public:
   fuseKernels(QueueImplPtr Queue, std::vector<ExecCGCommand *> &InputKernels,
               const property_list &);
 
+  bool isAvailable();
+
   static jit_compiler &get_instance() {
     static jit_compiler instance{};
     return instance;
@@ -62,6 +64,12 @@ private:
 
   // Manages the lifetime of the PI structs for device binaries.
   std::vector<DeviceBinariesCollection> JITDeviceBinaries;
+
+  // Handles to the entry points of the lazily loaded JIT library.
+  using raw_function_handle = void *;
+  raw_function_handle FuseKernelsHandle = nullptr;
+  raw_function_handle ResetConfigHandle = nullptr;
+  raw_function_handle AddToConfigHandle = nullptr;
 };
 
 } // namespace detail


### PR DESCRIPTION
So far, the SYCL JIT library, used e.g. to implement the kernel fusion extension, was linked directly into `libsycl`.

This led to a significant increase in library binary size of `libsycl`. To avoid the corresponding startup overhead, in particular if applications do not use the kernel fusion extension, this PR implement lazy loading of the JIT library. 

Instead of linking the library into `libsycl`, the JIT library is built as a standalone shared library (`libsycl-fusion.so`). This library is only loaded at runtime on the first use of the JIT compiler and applications not using a feature that requires the JIT will not load the library at all. 

The dynamic loading happens through `dlopen` and `dlsym`, through existing functionality provided by PI and also used for the SYCL online compiler and kernel compiler.

This PR also includes necessary changes to the interface of the JIT library to allow dynamic loading, mainly changing interface entry points to `extern "C"` and changing the options interface to not require template functions.