### PR TITLE
 [SYCL][E2E] Test bitreverse with default options

### DIFF
--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -25,13 +25,11 @@
 
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-// TODO FIXME  Change NOT_READY to RUN when llvm.bitreverse.* is supported.
-
 // Build without lowering explicitly disabled.
-// NOT_READY: %{build} -o %t.bitinstructions.out
+// RUN: %{build} -o %t.bitinstructions.out
 
 // Execution should still be correct.
-// NOT_READY: %{run} %t.bitinstructions.out
+// RUN: %{run} %t.bitinstructions.out
 
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i8"
 // CHECK-SPV: Name {{[0-9]+}} "llvm_bitreverse_i16"


### PR DESCRIPTION
Now that the SPIR-V extension SPV_KHR_bit_instructions is not enabled by default, it is safe to test bitreverse with default options.