### PR TITLE
[SYCL] kernel_compiler opencl query fix

### DIFF
--- a/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
@@ -255,9 +255,9 @@ std::string InvokeOclocQuery(uint32_t IPVersion, const char *identifier) {
   // Gather the results.
   for (uint32_t i = 0; i < NumOutputs; i++) {
     if (!strcmp(OutputNames[i], "stdout.log")) {
-      const char *LogText = reinterpret_cast<const char *>(Outputs[i]);
-      if (LogText != nullptr && LogText[0] != '\0') {
-        QueryLog.append(LogText);
+      if (OutputLengths[i] > 0) {
+        const char *LogText = reinterpret_cast<const char *>(Outputs[i]);
+        QueryLog.append(LogText, OutputLengths[i]);
       }
     }
   }


### PR DESCRIPTION
This should have been gotten with https://github.com/intel/llvm/pull/13214  but was accidentally overlooked. Errors discovered by sanitization. 