### PR TITLE
[SYCL][ClangLinkerWrapper] Support single or double dash for SYCL options

### DIFF
--- a/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
+++ b/clang/tools/clang-linker-wrapper/LinkerWrapperOpts.td
@@ -137,29 +137,29 @@ def libpath : Joined<["/", "-", "/?", "-?"], "libpath:">, Flags<[HelpHidden]>;
 def wholearchive_flag : Joined<["/", "-", "/?", "-?"], "wholearchive">, Flags<[HelpHidden]>;
 
 // Options to specify SYCL device library files
-def sycl_device_lib_EQ : CommaJoined<["-"], "sycl-device-libraries=">,
+def sycl_device_lib_EQ : CommaJoined<["--", "-"], "sycl-device-libraries=">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"A comma separated list of device libraries that are linked during the device link.">;
-def sycl_device_library_location_EQ : Joined<["-"],
+def sycl_device_library_location_EQ : Joined<["--", "-"],
   "sycl-device-library-location=">, Flags<[WrapperOnlyOption]>,
   HelpText<"Location of SYCL device library files">;
 
 // Options for SYCL backends and linker options for shared libraries.
 def sycl_backend_compile_options_EQ :
-  Joined<["-"], "sycl-backend-compile-options">,
+  Joined<["--", "-"], "sycl-backend-compile-options">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"Options that are passed to the backend of target device compiler">;
 def sycl_target_link_options_EQ :
-  Joined<["-"], "sycl-target-link-options">,
+  Joined<["--", "-"], "sycl-target-link-options">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"Options that are passed to target linker during a linking of shared device code.">;
 
 // Special option to pass in sycl-post-link options
-def sycl_post_link_options_EQ : Joined<["-"], "sycl-post-link-options=">,
+def sycl_post_link_options_EQ : Joined<["--", "-"], "sycl-post-link-options=">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"Options that will control sycl-post-link step">;
 
 // Special option to pass in llvm-spirv options
-def llvm_spirv_options_EQ : Joined<["-"], "llvm-spirv-options=">,
+def llvm_spirv_options_EQ : Joined<["--", "-"], "llvm-spirv-options=">,
   Flags<[WrapperOnlyOption]>,
   HelpText<"Options that will control llvm-spirv step">;


### PR DESCRIPTION
Many other upstream options in the same file do this, and right now we have a few options that don't work because the driver passes the wrong dashes. We could fix the driver, but just simplify the whole thing.