### PR TITLE
[CI] Clarify that SYCL CTS nightly testing is on OpenCL CPU

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -312,6 +312,8 @@ jobs:
 
     - name: SYCL CTS List devices
       if: inputs.tests_selector == 'cts'
+      env:
+        ONEAPI_DEVICE_SELECTOR: ${{ inputs.target_devices }}
       run: |
         ./build-cts/bin/test_all --list-devices
 

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -81,7 +81,7 @@ jobs:
             target_devices: ext_oneapi_cuda:gpu
             tests_selector: e2e
 
-          - name: SYCL-CTS
+          - name: SYCL-CTS on OCL CPU
             runner: '["Linux", "gen12"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN


### PR DESCRIPTION
Right now it is extremely confusing because the name is shown as SYCL CTS on Gen12 machine, basically implying that tests are run on GPU. And gpu device is shown as selected in the list of devices. 
This confusion may cost somebody a lot of time trying to reproduce issue on wrong backend when analyzing nightly failures.