### PR TITLE
[SYCL] fix persistent cache test

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
+++ b/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
@@ -13,7 +13,11 @@
 // Check the logs first.
 // RUN: %{build_cmd} -DVALUE=1 -o %t.out
 // RUN: rm -rf %t/cache_dir/*
-// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if windows %{ --check-prefixes=CHECK,CHECK-WIN %}
+// xUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if
+// windows %{ --check-prefixes=CHECK,CHECK-WIN %}
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 //
 // Now try to substitute the cached image and verify it is actually taken and
 // the code/binary there is executed.
@@ -30,7 +34,12 @@
 // Check the logs first.
 // RUN: %{build_cmd} -DVALUE=1 -o %t.out
 // RUN: rm -rf %t/cache_dir/*
-// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if windows %{ --check-prefixes=CHECK,CHECK-WIN %}
+// xUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if
+// windows %{ --check-prefixes=CHECK,CHECK-WIN %}
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
+
 //
 // Now try to substitute the cached image and verify it is actually taken and
 // the code/binary there is executed.
@@ -47,7 +56,11 @@
 // Check the logs first.
 // RUN: %{build_cmd} -DVALUE=1 -o %t.out
 // RUN: rm -rf %t/cache_dir/*
-// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if windows %{ --check-prefixes=CHECK,CHECK-WIN %}
+// xUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if
+// windows %{ --check-prefixes=CHECK,CHECK-WIN %}
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
+// RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 //
 // Now try to substitute the cached image and verify it is actually taken and
 // the code/binary there is executed.
@@ -59,9 +72,8 @@
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT1
 // ******************************
 
-// CHECK:     Code caching: device binary has been cached: [[BIN_FILE:.*]]
-// CHECK-WIN: Code caching: using cached device binary: [[BIN_FILE]]
-// CHECK-WIN: Code caching: using cached device binary: [[BIN_FILE]]
+// CHECK-CACHE-WRITE: Code caching: device binary has been cached: [[BIN_FILE:.*]]
+// CHECK-CACHE-READ: Code caching: using cached device binary
 
 // RESULT1: Result (0): 1
 // RESULT1: Result (1): 1

--- a/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
+++ b/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
@@ -13,8 +13,6 @@
 // Check the logs first.
 // RUN: %{build_cmd} -DVALUE=1 -o %t.out
 // RUN: rm -rf %t/cache_dir/*
-// xUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if
-// windows %{ --check-prefixes=CHECK,CHECK-WIN %}
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
@@ -34,8 +32,6 @@
 // Check the logs first.
 // RUN: %{build_cmd} -DVALUE=1 -o %t.out
 // RUN: rm -rf %t/cache_dir/*
-// xUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if
-// windows %{ --check-prefixes=CHECK,CHECK-WIN %}
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
@@ -56,8 +52,6 @@
 // Check the logs first.
 // RUN: %{build_cmd} -DVALUE=1 -o %t.out
 // RUN: rm -rf %t/cache_dir/*
-// xUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s %if
-// windows %{ --check-prefixes=CHECK,CHECK-WIN %}
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-WRITE
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s  --check-prefixes=CHECK-CACHE-READ

--- a/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
+++ b/sycl/test-e2e/KernelAndProgram/test_cache_jit_aot.cpp
@@ -66,7 +66,7 @@
 // RUN: %{cache_vars} %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --check-prefixes RESULT1
 // ******************************
 
-// CHECK-CACHE-WRITE: Code caching: device binary has been cached: [[BIN_FILE:.*]]
+// CHECK-CACHE-WRITE: Code caching: device binary has been cached
 // CHECK-CACHE-READ: Code caching: using cached device binary
 
 // RESULT1: Result (0): 1


### PR DESCRIPTION
On Windows the persistent cache is still working but the path string when writing is one mishmash of Linux and Win separators and on read a different mishmash for the same file.  Corrects this test on Win.

Also am expanding it to confirm write/reuse/reuse is working on both Lin and Win, not just Win.