### PR TITLE
[SYCL][E2E] Add llvm-lit.py to LIT binary names

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -28,7 +28,7 @@ find_package(Vulkan)
 
 if(NOT LLVM_LIT)
   find_program(LLVM_LIT
-               NAMES llvm-lit lit.py lit
+               NAMES llvm-lit.py llvm-lit lit.py lit
                PATHS "${LLVM_MAIN_SRC_DIR}/utils/lit"
                DOC "Path to lit.py")
 endif()


### PR DESCRIPTION
On windows the lit setup in the bin directory is `llvm-lit.py`, this helps CMake find it.