### PR TITLE
[SYCL] [NATIVECPU] Select right libclc file for native cpu

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5855,7 +5855,7 @@ class OffloadingActionBuilder final {
         LibraryPaths.emplace_back(WithInstallPath.c_str());
 
         // Select libclc variant based on target triple
-        std::string LibSpirvTargetName = "builtins.link.libspirv-";
+        std::string LibSpirvTargetName = "libspirv-";
         LibSpirvTargetName.append(TC->getTripleString() + ".bc");
 
         for (StringRef LibraryPath : LibraryPaths) {

--- a/sycl/test/check_device_code/native_cpu/sycl-native-cpu-libclc.cpp
+++ b/sycl/test/check_device_code/native_cpu/sycl-native-cpu-libclc.cpp
@@ -1,0 +1,5 @@
+// TODO: move this to clang/Driver once Native CPU is enabled in CI
+// REQUIRES: native_cpu
+// RUN: %clang -### -fsycl -fsycl-targets=native_cpu -target x86_64-unknown-linux-gnu %s 2> %t.ncpu.out
+// RUN: FileCheck %s --input-file %t.ncpu.out
+// CHECK: libspirv-x86_64-unknown-linux-gnu.bc


### PR DESCRIPTION
This PR makes it so we select the right module for `libclc` when compiling for Native CPU.