### PR TITLE
[SYCL][XPTI] Fix Coverity issues by disabling copy constructors

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -81,6 +81,7 @@ struct DemangleHandle {
   char *p;
   DemangleHandle(char *ptr) : p(ptr) {}
 
+  DemangleHandle(const DemangleHandle &) = delete;
   DemangleHandle &operator=(const DemangleHandle &) = delete;
 
   ~DemangleHandle() { std::free(p); }

--- a/xpti/src/xpti_proxy.cpp
+++ b/xpti/src/xpti_proxy.cpp
@@ -100,6 +100,7 @@ public:
     tryToEnable();
   }
 
+  ProxyLoader(const ProxyLoader &) = delete;
   ProxyLoader &operator=(const ProxyLoader &) = delete;
 
   ~ProxyLoader() {


### PR DESCRIPTION
Coverity is complaining about `ProxyLoader` and `DemangleHandle` classes not having a copy constructor, even though these classes destroy/free resources in their destructor. If these classes are copy-constructed, this may cause use-after-free errors.

This PR fixes this by disallowing copy constructors in these classes - we don't use them in the code anyway.