### PR TITLE
[SYCL][JIT] Ignore clang diagnostic on entry point

### DIFF
--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -53,6 +53,9 @@ private:
 
 extern "C" {
 
+#ifdef __clang__
+#pragma clang diagnostic ignored "-Wreturn-type-c-linkage"
+#endif // __clang__
 FusionResult fuseKernels(View<SYCLKernelInfo> KernelInformation,
                          const char *FusedKernelName,
                          View<ParameterIdentity> Identities,


### PR DESCRIPTION
Deactivate Clang warning for the entry point, as we know the entry point will be used from C++ code.