### PR TITLE
[SYCL][SCLA] Error out on AOT compilation of `[aligned_]private_alloca`

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -198,6 +198,9 @@ def warn_intel_sycl_alloca_bad_default_value : Warning<
     "__builtin_intel_sycl_alloca%select{|_with_align}0 expects a specialization "
     "constant with a default value of at least one as an argument. Got %1">,
     InGroup<SyclPrivateAllocaPositiveSize>;
+def note_intel_sycl_alloca_aot
+    : Note<"__builtin_intel_sycl_alloca%select{|_with_align}0 cannot be AOT "
+           "compiled">;
 
 // C99 variable-length arrays
 def ext_vla : Extension<"variable length arrays are a C99 feature">,

--- a/clang/lib/Sema/SemaChecking.cpp
+++ b/clang/lib/Sema/SemaChecking.cpp
@@ -3022,6 +3022,12 @@ Sema::CheckBuiltinFunctionCall(FunctionDecl *FDecl, unsigned BuiltinID,
           << "SYCL device";
       return ExprError();
     }
+    if (getASTContext().getTargetInfo().getTriple().isSPIRAOT()) {
+      Diag(TheCall->getBeginLoc(), diag::err_builtin_target_unsupported);
+      Diag(TheCall->getBeginLoc(), diag::note_intel_sycl_alloca_aot)
+          << (BuiltinID == Builtin::BI__builtin_intel_sycl_alloca_with_align);
+      return ExprError();
+    }
     if (CheckIntelSYCLAllocaBuiltinFunctionCall(BuiltinID, TheCall))
       return ExprError();
     break;

--- a/clang/test/SemaSYCL/builtin-alloca-aot.cpp
+++ b/clang/test/SemaSYCL/builtin-alloca-aot.cpp
@@ -1,0 +1,37 @@
+// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -triple spir64_x86_64 -verify %s
+// RUN: %clang_cc1 -fsyntax-only -fsycl-is-device -triple spir64_gen -verify %s
+
+// Test clang emits correct errors on 'private_alloca' used on an AOT SPIR target.
+
+#include <stddef.h>
+
+#include "Inputs/sycl.hpp"
+#include "Inputs/private_alloca.hpp"
+
+struct myStruct {
+  int a;
+  int b;
+};
+
+constexpr sycl::specialization_id<size_t> size(1);
+constexpr sycl::specialization_id<int> intSize(1);
+constexpr sycl::specialization_id<unsigned short> shortSize(1);
+
+void basic_test(sycl::kernel_handler &kh) {
+  // expected-error@+2 {{builtin is not supported on this target}}
+  // expected-note@+1 {{__builtin_intel_sycl_alloca cannot be AOT compiled}}
+  sycl::ext::oneapi::experimental::private_alloca<
+    int, size, sycl::access::decorated::yes>(kh);
+  // expected-error@+2 {{builtin is not supported on this target}}
+  // expected-note@+1 {{__builtin_intel_sycl_alloca cannot be AOT compiled}}
+  sycl::ext::oneapi::experimental::private_alloca<
+    float, intSize, sycl::access::decorated::no>(kh);
+  // expected-error@+2 {{builtin is not supported on this target}}
+  // expected-note@+1 {{__builtin_intel_sycl_alloca cannot be AOT compiled}}
+  sycl::ext::oneapi::experimental::private_alloca<
+    myStruct, shortSize, sycl::access::decorated::legacy>(kh);
+  // expected-error@+2 {{builtin is not supported on this target}}
+  // expected-note@+1 {{__builtin_intel_sycl_alloca_with_align cannot be AOT compiled}}
+  sycl::ext::oneapi::experimental::aligned_private_alloca<
+    myStruct, alignof(myStruct) * 2, shortSize, sycl::access::decorated::legacy>(kh);
+}

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_private_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_private_alloca.asciidoc
@@ -51,6 +51,9 @@ change incompatibly in future versions of {dpcpp} without prior notice.
 *Shipping software products should not rely on APIs defined in this
 specification.*
 
+The {dpcpp} implementation of this experimental extension cannot be used in AOT
+mode as it requires JIT specialization of kernels.
+
 == Backend support status
 
 The APIs in this extension may be used only on a device that has
@@ -292,4 +295,5 @@ private_alloca(const specialization_constant<std::size_t> &size);
 |========================================
 |Rev|Date|Authors|Changes
 |1|2024-02-08|Victor Lomüller, Lukas Sommer, Victor Perez, Julian Oppermann, Tadej Ciglaric, Romain Biessy|*Initial draft*
+|1|2024-04-22|Victor Perez|*Add AOT clarification*
 |========================================

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_private_alloca.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_private_alloca.asciidoc
@@ -295,5 +295,5 @@ private_alloca(const specialization_constant<std::size_t> &size);
 |========================================
 |Rev|Date|Authors|Changes
 |1|2024-02-08|Victor Lomüller, Lukas Sommer, Victor Perez, Julian Oppermann, Tadej Ciglaric, Romain Biessy|*Initial draft*
-|1|2024-04-22|Victor Perez|*Add AOT clarification*
+|2|2024-04-22|Victor Lomüller, Lukas Sommer, Victor Perez, Julian Oppermann, Tadej Ciglaric, Romain Biessy|*Add AOT clarification*
 |========================================


### PR DESCRIPTION
`sycl_ext_oneapi_private_alloca` needs JIT compilation to function properly. Aspects cannot rely on querying whether a kernel is AOT compiled or not, so we just error out at compile time.