### PR TITLE
[SYCL] Implement enqueue free functions extension

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp
@@ -76,12 +76,12 @@ template <typename LCRangeT, typename LCPropertiesT> struct LaunchConfigAccess {
 template <typename CommandGroupFunc>
 void submit(queue Q, CommandGroupFunc &&CGF) {
   // TODO: Use new submit without Events.
-  Q.submit(CGF);
+  Q.submit(std::forward<CommandGroupFunc>(CGF));
 }
 
 template <typename CommandGroupFunc>
 event submit_with_event(queue Q, CommandGroupFunc &&CGF) {
-  return Q.submit(CGF);
+  return Q.submit(std::forward<CommandGroupFunc>(CGF));
 }
 
 template <typename KernelName = sycl::detail::auto_name, typename KernelType>

--- a/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp
@@ -1,0 +1,327 @@
+//==------ enqueue_functions.hpp ------- SYCL enqueue free functions -------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <utility> // for std::forward
+
+#include <sycl/event.hpp>                            // for event
+#include <sycl/ext/oneapi/properties/properties.hpp> // for properties
+#include <sycl/handler.hpp>                          // for handler
+#include <sycl/nd_range.hpp>                         // for nd_range
+#include <sycl/queue.hpp>                            // for queue
+#include <sycl/range.hpp>                            // for range
+
+namespace sycl {
+inline namespace _V1 {
+namespace ext::oneapi::experimental {
+
+namespace detail {
+// Trait for identifying sycl::range and sycl::nd_range.
+template <typename RangeT> struct is_range_or_nd_range : std::false_type {};
+template <int Dimensions>
+struct is_range_or_nd_range<range<Dimensions>> : std::true_type {};
+template <int Dimensions>
+struct is_range_or_nd_range<nd_range<Dimensions>> : std::true_type {};
+
+template <typename RangeT>
+constexpr bool is_range_or_nd_range_v = is_range_or_nd_range<RangeT>::value;
+
+template <typename LCRangeT, typename LCPropertiesT> struct LaunchConfigAccess;
+} // namespace detail
+
+// Available only when Range is range or nd_range
+template <
+    typename RangeT, typename PropertiesT = empty_properties_t,
+    typename = std::enable_if_t<
+        ext::oneapi::experimental::detail::is_range_or_nd_range_v<RangeT>>>
+class launch_config {
+public:
+  launch_config(RangeT Range, PropertiesT Properties = {})
+      : MRange{Range}, MProperties{Properties} {}
+
+private:
+  RangeT MRange;
+  PropertiesT MProperties;
+
+  const RangeT &getRange() const noexcept { return MRange; }
+
+  const PropertiesT &getProperties() const noexcept { return MProperties; }
+
+  template <typename LCRangeT, typename LCPropertiesT>
+  friend struct detail::LaunchConfigAccess;
+};
+
+namespace detail {
+// Helper for accessing the members of launch_config.
+template <typename LCRangeT, typename LCPropertiesT> struct LaunchConfigAccess {
+  LaunchConfigAccess(const launch_config<LCRangeT, LCPropertiesT> &LaunchConfig)
+      : MLaunchConfig{LaunchConfig} {}
+
+  const launch_config<LCRangeT, LCPropertiesT> &MLaunchConfig;
+
+  const LCRangeT &getRange() const noexcept { return MLaunchConfig.getRange(); }
+
+  const LCPropertiesT &getProperties() const noexcept {
+    return MLaunchConfig.getProperties();
+  }
+};
+} // namespace detail
+
+template <typename CommandGroupFunc>
+void submit(queue Q, CommandGroupFunc &&CGF) {
+  // TODO: Use new submit without Events.
+  Q.submit(CGF);
+}
+
+template <typename CommandGroupFunc>
+event submit_with_event(queue Q, CommandGroupFunc &&CGF) {
+  return Q.submit(CGF);
+}
+
+template <typename KernelName = sycl::detail::auto_name, typename KernelType>
+void single_task(handler &CGH, const KernelType &KernelObj) {
+  CGH.single_task<KernelName>(KernelObj);
+}
+
+template <typename KernelName = sycl::detail::auto_name, typename KernelType>
+void single_task(queue Q, const KernelType &KernelObj) {
+  submit(Q, [&](handler &CGH) { single_task<KernelName>(CGH, KernelObj); });
+}
+
+template <typename... ArgsT>
+void single_task(handler &CGH, const kernel &KernelObj, ArgsT &&...Args) {
+  CGH.set_args<ArgsT...>(std::forward<ArgsT>(Args)...);
+  CGH.single_task(KernelObj);
+}
+
+template <typename... ArgsT>
+void single_task(queue Q, const kernel &KernelObj, ArgsT &&...Args) {
+  submit(Q, [&](handler &CGH) {
+    single_task(CGH, KernelObj, std::forward<ArgsT>(Args)...);
+  });
+}
+
+// TODO: Make overloads for scalar arguments for range.
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename KernelType, typename... ReductionsT>
+void parallel_for(handler &CGH, range<Dimensions> Range,
+                  const KernelType &KernelObj, ReductionsT &&...Reductions) {
+  CGH.parallel_for<KernelName>(Range, std::forward<ReductionsT>(Reductions)...,
+                               KernelObj);
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename KernelType, typename... ReductionsT>
+void parallel_for(queue Q, range<Dimensions> Range, const KernelType &KernelObj,
+                  ReductionsT &&...Reductions) {
+  submit(Q, [&](handler &CGH) {
+    parallel_for<KernelName>(CGH, Range, KernelObj,
+                             std::forward<ReductionsT>(Reductions)...);
+  });
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename Properties, typename KernelType, typename... ReductionsT>
+void parallel_for(handler &CGH,
+                  launch_config<range<Dimensions>, Properties> Config,
+                  const KernelType &KernelObj, ReductionsT &&...Reductions) {
+  ext::oneapi::experimental::detail::LaunchConfigAccess<range<Dimensions>,
+                                                        Properties>
+      ConfigAccess(Config);
+  CGH.parallel_for<KernelName>(ConfigAccess.getRange(),
+                               std::forward<ReductionsT>(Reductions)...,
+                               KernelObj);
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename Properties, typename KernelType, typename... ReductionsT>
+void parallel_for(queue Q, launch_config<range<Dimensions>, Properties> Config,
+                  const KernelType &KernelObj, ReductionsT &&...Reductions) {
+  submit(Q, [&](handler &CGH) {
+    parallel_for<KernelName>(CGH, Config, KernelObj,
+                             std::forward<ReductionsT>(Reductions)...);
+  });
+}
+
+template <int Dimensions, typename... ArgsT>
+void parallel_for(handler &CGH, range<Dimensions> Range,
+                  const kernel &KernelObj, ArgsT &&...Args) {
+  CGH.set_args<ArgsT...>(std::forward<ArgsT>(Args)...);
+  CGH.parallel_for(Range, KernelObj);
+}
+
+template <int Dimensions, typename... ArgsT>
+void parallel_for(queue Q, range<Dimensions> Range, const kernel &KernelObj,
+                  ArgsT &&...Args) {
+  submit(Q, [&](handler &CGH) {
+    parallel_for(CGH, Range, KernelObj, std::forward<ArgsT>(Args)...);
+  });
+}
+
+template <int Dimensions, typename Properties, typename... ArgsT>
+void parallel_for(handler &CGH,
+                  launch_config<range<Dimensions>, Properties> Config,
+                  const kernel &KernelObj, ArgsT &&...Args) {
+  ext::oneapi::experimental::detail::LaunchConfigAccess<range<Dimensions>,
+                                                        Properties>
+      ConfigAccess(Config);
+  CGH.set_args<ArgsT...>(std::forward<ArgsT>(Args)...);
+  CGH.parallel_for(ConfigAccess.getRange(), KernelObj);
+}
+
+template <int Dimensions, typename Properties, typename... ArgsT>
+void parallel_for(queue Q, launch_config<range<Dimensions>, Properties> Config,
+                  const kernel &KernelObj, ArgsT &&...Args) {
+  submit(Q, [&](handler &CGH) {
+    parallel_for(CGH, Config, KernelObj, std::forward<ArgsT>(Args)...);
+  });
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename KernelType, typename... ReductionsT>
+void nd_launch(handler &CGH, nd_range<Dimensions> Range,
+               const KernelType &KernelObj, ReductionsT &&...Reductions) {
+  CGH.parallel_for<KernelName>(Range, std::forward<ReductionsT>(Reductions)...,
+                               KernelObj);
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename KernelType, typename... ReductionsT>
+void nd_launch(queue Q, nd_range<Dimensions> Range, const KernelType &KernelObj,
+               ReductionsT &&...Reductions) {
+  submit(Q, [&](handler &CGH) {
+    nd_launch(CGH, Range, KernelObj, std::forward<ReductionsT>(Reductions)...);
+  });
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename Properties, typename KernelType, typename... ReductionsT>
+void nd_launch(handler &CGH,
+               launch_config<nd_range<Dimensions>, Properties> Config,
+               const KernelType &KernelObj, ReductionsT &&...Reductions) {
+
+  ext::oneapi::experimental::detail::LaunchConfigAccess<nd_range<Dimensions>,
+                                                        Properties>
+      ConfigAccess(Config);
+  CGH.parallel_for<KernelName>(ConfigAccess.getRange(),
+                               std::forward<ReductionsT>(Reductions)...,
+                               KernelObj);
+}
+
+template <typename KernelName = sycl::detail::auto_name, int Dimensions,
+          typename Properties, typename KernelType, typename... ReductionsT>
+void nd_launch(queue Q, launch_config<nd_range<Dimensions>, Properties> Config,
+               const KernelType &KernelObj, ReductionsT &&...Reductions) {
+  submit(Q, [&](handler &CGH) {
+    nd_launch(CGH, Config, KernelObj, std::forward<ReductionsT>(Reductions)...);
+  });
+}
+
+template <int Dimensions, typename... ArgsT>
+void nd_launch(handler &CGH, nd_range<Dimensions> Range,
+               const kernel &KernelObj, ArgsT &&...Args) {
+  CGH.set_args<ArgsT...>(std::forward<ArgsT>(Args)...);
+  CGH.parallel_for(Range, KernelObj);
+}
+
+template <int Dimensions, typename... ArgsT>
+void nd_launch(queue Q, nd_range<Dimensions> Range, const kernel &KernelObj,
+               ArgsT &&...Args) {
+  submit(Q, [&](handler &CGH) {
+    nd_launch(CGH, Range, KernelObj, std::forward<ArgsT>(Args)...);
+  });
+}
+
+template <int Dimensions, typename Properties, typename... ArgsT>
+void nd_launch(handler &CGH,
+               launch_config<nd_range<Dimensions>, Properties> Config,
+               const kernel &KernelObj, ArgsT &&...Args) {
+  ext::oneapi::experimental::detail::LaunchConfigAccess<nd_range<Dimensions>,
+                                                        Properties>
+      ConfigAccess(Config);
+  CGH.set_args<ArgsT...>(std::forward<ArgsT>(Args)...);
+  CGH.parallel_for(ConfigAccess.getRange(), KernelObj);
+}
+
+template <int Dimensions, typename Properties, typename... ArgsT>
+void nd_launch(queue Q, launch_config<nd_range<Dimensions>, Properties> Config,
+               const kernel &KernelObj, ArgsT &&...Args) {
+  submit(Q, [&](handler &CGH) {
+    nd_launch(CGH, Config, KernelObj, std::forward<ArgsT>(Args)...);
+  });
+}
+
+inline void memcpy(handler &CGH, void *Dest, const void *Src, size_t NumBytes) {
+  CGH.memcpy(Dest, Src, NumBytes);
+}
+
+inline void memcpy(queue Q, void *Dest, const void *Src, size_t NumBytes) {
+  submit(Q, [&](handler &CGH) { memcpy(CGH, Dest, Src, NumBytes); });
+}
+
+template <typename T>
+void copy(handler &CGH, const T *Src, T *Dest, size_t Count) {
+  CGH.copy<T>(Src, Dest, Count);
+}
+
+template <typename T> void copy(queue Q, const T *Src, T *Dest, size_t Count) {
+  submit(Q, [&](handler &CGH) { copy<T>(CGH, Src, Dest, Count); });
+}
+
+inline void memset(handler &CGH, void *Ptr, int Value, size_t NumBytes) {
+  CGH.memset(Ptr, Value, NumBytes);
+}
+
+inline void memset(queue Q, void *Ptr, int Value, size_t NumBytes) {
+  submit(Q, [&](handler &CGH) { memset(CGH, Ptr, Value, NumBytes); });
+}
+
+template <typename T>
+void fill(sycl::handler &CGH, T *Ptr, const T &Pattern, size_t Count) {
+  CGH.fill(Ptr, Pattern, Count);
+}
+
+template <typename T>
+void fill(sycl::queue Q, T *Ptr, const T &Pattern, size_t Count) {
+  submit(Q, [&](handler &CGH) { fill<T>(CGH, Ptr, Pattern, Count); });
+}
+
+inline void prefetch(handler &CGH, void *Ptr, size_t NumBytes) {
+  CGH.prefetch(Ptr, NumBytes);
+}
+
+inline void prefetch(queue Q, void *Ptr, size_t NumBytes) {
+  submit(Q, [&](handler &CGH) { prefetch(CGH, Ptr, NumBytes); });
+}
+
+inline void mem_advise(handler &CGH, void *Ptr, size_t NumBytes, int Advice) {
+  CGH.mem_advise(Ptr, NumBytes, Advice);
+}
+
+inline void mem_advise(queue Q, void *Ptr, size_t NumBytes, int Advice) {
+  submit(Q, [&](handler &CGH) { mem_advise(CGH, Ptr, NumBytes, Advice); });
+}
+
+inline void barrier(handler &CGH) { CGH.ext_oneapi_barrier(); }
+
+inline void barrier(queue Q) {
+  submit(Q, [&](handler &CGH) { barrier(CGH); });
+}
+
+inline void partial_barrier(handler &CGH, const std::vector<event> &Events) {
+  CGH.ext_oneapi_barrier(Events);
+}
+
+inline void partial_barrier(queue Q, const std::vector<event> &Events) {
+  submit(Q, [&](handler &CGH) { partial_barrier(CGH, Events); });
+}
+
+} // namespace ext::oneapi::experimental
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/enqueue_functions.hpp
@@ -10,12 +10,12 @@
 
 #include <utility> // for std::forward
 
-#include <sycl/event.hpp>                            // for event
-#include <sycl/ext/oneapi/properties/properties.hpp> // for properties
-#include <sycl/handler.hpp>                          // for handler
-#include <sycl/nd_range.hpp>                         // for nd_range
-#include <sycl/queue.hpp>                            // for queue
-#include <sycl/range.hpp>                            // for range
+#include <sycl/event.hpp>
+#include <sycl/ext/oneapi/properties/properties.hpp>
+#include <sycl/handler.hpp>
+#include <sycl/nd_range.hpp>
+#include <sycl/queue.hpp>
+#include <sycl/range.hpp>
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -88,6 +88,7 @@
 #include <sycl/ext/oneapi/experimental/builtins.hpp>
 #include <sycl/ext/oneapi/experimental/composite_device.hpp>
 #include <sycl/ext/oneapi/experimental/cuda/barrier.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
 #include <sycl/ext/oneapi/experimental/fixed_size_group.hpp>
 #include <sycl/ext/oneapi/experimental/opportunistic_group.hpp>
 #include <sycl/ext/oneapi/experimental/prefetch.hpp>

--- a/sycl/test-e2e/EnqueueFunctions/barrier.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/barrier.cpp
@@ -1,0 +1,54 @@
+// RUN: %{build} -o %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
+
+// Tests the enqueue free function barriers.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+int main() {
+  sycl::context Context;
+  sycl::queue Q1(Context, sycl::default_selector_v);
+
+  oneapiext::single_task(Q1, []() {});
+  oneapiext::single_task(Q1, []() {});
+
+  oneapiext::barrier(Q1);
+
+  oneapiext::single_task(Q1, []() {});
+  oneapiext::single_task(Q1, []() {});
+
+  oneapiext::barrier(Q1);
+
+  sycl::queue Q2(Context, sycl::default_selector_v);
+  sycl::queue Q3(Context, sycl::default_selector_v);
+
+  sycl::event Event1 = oneapiext::submit_with_event(
+      Q1, [&](sycl::handler &CGH) { oneapiext::single_task(CGH, []() {}); });
+
+  sycl::event Event2 = oneapiext::submit_with_event(
+      Q2, [&](sycl::handler &CGH) { oneapiext::single_task(CGH, []() {}); });
+
+  oneapiext::partial_barrier(Q3, {Event1, Event2});
+
+  oneapiext::single_task(Q3, []() {});
+
+  sycl::event Event3 = oneapiext::submit_with_event(
+      Q1, [&](sycl::handler &CGH) { oneapiext::single_task(CGH, []() {}); });
+
+  sycl::event Event4 = oneapiext::submit_with_event(
+      Q2, [&](sycl::handler &CGH) { oneapiext::single_task(CGH, []() {}); });
+
+  oneapiext::partial_barrier(Q3, {Event3, Event4});
+
+  oneapiext::single_task(Q3, []() {});
+
+  Q1.wait();
+
+  return 0;
+}
+
+// CHECK-COUNT-4:---> piEnqueueEventsWaitWithBarrier
+// CHECK-NOT:---> piEnqueueEventsWaitWithBarrier

--- a/sycl/test-e2e/EnqueueFunctions/common.hpp
+++ b/sycl/test-e2e/EnqueueFunctions/common.hpp
@@ -1,0 +1,50 @@
+#pragma once
+
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
+
+#include <iostream>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+auto constexpr CLSource = R"===(
+__kernel void KernelSingleTask(int num, int in, __global int *out) {
+  for (size_t i = 0; i < num; ++i)
+    out[i] = in;
+}
+__kernel void Kernel1D(int in, __global int *out) {
+  size_t i = get_global_id(0);
+  out[i] = in;
+}
+__kernel void Kernel2D(int in, __global int *out) {
+  size_t x = get_global_id(0);
+  size_t y = get_global_id(1);
+  size_t xs = get_global_size(0);
+  size_t i = x + y * xs;
+  out[i] = in;
+}
+__kernel void Kernel3D(int in, __global int *out) {
+  size_t x = get_global_id(0);
+  size_t y = get_global_id(1);
+  size_t z = get_global_id(2);
+  size_t xs = get_global_size(0);
+  size_t ys = get_global_size(1);
+  size_t i = x + y * xs + z * xs * ys;
+  out[i] = in;
+}
+)===";
+
+sycl::kernel_bundle<sycl::bundle_state::executable> CreateKB(sycl::queue Q) {
+  sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source> KBSource =
+      oneapiext::create_kernel_bundle_from_source(
+          Q.get_context(), oneapiext::source_language::opencl, CLSource);
+  return oneapiext::build(KBSource, {Q.get_device()});
+}
+
+int Check(int *Data, int Expected, size_t Index, std::string TestName) {
+  if (Data[Index] == Expected)
+    return 0;
+  std::cout << "Failed " << TestName << " at index " << Index << " : "
+            << Data[Index] << " != " << Expected << std::endl;
+  return 1;
+}

--- a/sycl/test-e2e/EnqueueFunctions/kernel_shortcut_with_kb.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_shortcut_with_kb.cpp
@@ -1,0 +1,155 @@
+// REQUIRES: usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function kernel shortcuts with sycl::kernel.
+// NOTE: This relies on the availability of an OpenCL C compiler being
+// available.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <iostream>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+
+  if (!oneapiext::is_source_kernel_bundle_supported(
+          Q.get_backend(), oneapiext::source_language::opencl)) {
+    std::cout
+        << "Backend does not support OpenCL C source kernel bundle extension: "
+        << Q.get_backend() << std::endl;
+    return 0;
+  }
+
+  auto KB = CreateKB(Q);
+
+  assert(KB.ext_oneapi_has_kernel("KernelSingleTask"));
+  assert(KB.ext_oneapi_has_kernel("Kernel1D"));
+  assert(KB.ext_oneapi_has_kernel("Kernel2D"));
+  assert(KB.ext_oneapi_has_kernel("Kernel3D"));
+
+  sycl::kernel KernelSingleTask = KB.ext_oneapi_get_kernel("KernelSingleTask");
+  sycl::kernel Kernel1D = KB.ext_oneapi_get_kernel("Kernel1D");
+  sycl::kernel Kernel2D = KB.ext_oneapi_get_kernel("Kernel2D");
+  sycl::kernel Kernel3D = KB.ext_oneapi_get_kernel("Kernel3D");
+
+  int *Memory = sycl::malloc_shared<int>(N, Q);
+
+  int Failed = 0;
+
+  // single_task shortcut
+  oneapiext::single_task(Q, KernelSingleTask, (int)N, 42, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 42, I, "single_task shortcut");
+
+  // 1D parallel_for shortcut
+  oneapiext::parallel_for(Q, sycl::range<1>{N}, Kernel1D, 43, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 43, I, "1D parallel_for shortcut");
+
+  // 2D parallel_for shortcut
+  oneapiext::parallel_for(Q, sycl::range<2>{8, N / 8}, Kernel2D, 44, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 44, I, "2D parallel_for shortcut");
+
+  // 3D parallel_for shortcut
+  oneapiext::parallel_for(Q, sycl::range<3>{8, 8, N / 64}, Kernel3D, 45,
+                          Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 45, I, "3D parallel_for shortcut");
+
+  // 1D nd_launch shortcut
+  oneapiext::nd_launch(Q, sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}},
+                       Kernel1D, 46, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 46, I, "1D nd_launch shortcut");
+
+  // 2D nd_launch shortcut
+  oneapiext::nd_launch(
+      Q, sycl::nd_range<2>{sycl::range<2>{8, N / 8}, sycl::range{8, 8}},
+      Kernel2D, 47, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 47, I, "2D nd_launch shortcut");
+
+  // 3D nd_launch shortcut
+  oneapiext::nd_launch(
+      Q, sycl::nd_range<3>{sycl::range<3>{8, 8, N / 64}, sycl::range{8, 8, 8}},
+      Kernel3D, 48, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 48, I, "3D nd_launch shortcut");
+
+  // 1D parallel_for shortcut with launch config
+  oneapiext::parallel_for(
+      Q, oneapiext::launch_config<sycl::range<1>>{sycl::range<1>{N}}, Kernel1D,
+      49, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed +=
+        Check(Memory, 49, I, "1D parallel_for shortcut with launch config");
+
+  // 2D parallel_for shortcut with launch config
+  oneapiext::parallel_for(
+      Q, oneapiext::launch_config<sycl::range<2>>{sycl::range<2>{8, N / 8}},
+      Kernel2D, 50, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed +=
+        Check(Memory, 50, I, "2D parallel_for shortcut with launch config");
+
+  // 3D parallel_for shortcut with launch config
+  oneapiext::parallel_for(
+      Q, oneapiext::launch_config<sycl::range<3>>{sycl::range<3>{8, 8, N / 64}},
+      Kernel3D, 51, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed +=
+        Check(Memory, 51, I, "3D parallel_for shortcut with launch config");
+
+  // 1D nd_launch shortcut with launch config
+  oneapiext::nd_launch(
+      Q,
+      oneapiext::launch_config<sycl::nd_range<1>>{
+          sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}},
+      Kernel1D, 52, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 52, I, "1D nd_launch shortcut with launch config");
+
+  // 2D nd_launch shortcut with launch config
+  oneapiext::nd_launch(
+      Q,
+      oneapiext::launch_config<sycl::nd_range<2>>{
+          sycl::nd_range<2>{sycl::range<2>{8, N / 8}, sycl::range{8, 8}}},
+      Kernel2D, 53, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 53, I, "2D nd_launch shortcut with launch config");
+
+  // 3D nd_launch shortcut with launch config
+  oneapiext::nd_launch(
+      Q,
+      oneapiext::launch_config<sycl::nd_range<3>>{sycl::nd_range<3>{
+          sycl::range<3>{8, 8, N / 64}, sycl::range{8, 8, 8}}},
+      Kernel3D, 54, Memory);
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 54, I, "3D nd_launch shortcut with launch config");
+
+  sycl::free(Memory, Q);
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/kernel_shortcuts.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_shortcuts.cpp
@@ -1,0 +1,138 @@
+// REQUIRES: usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function kernel shortcuts.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <iostream>
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+  int *Memory = sycl::malloc_shared<int>(N, Q);
+
+  int Failed = 0;
+
+  // single_task shortcut
+  oneapiext::single_task(Q, [=]() {
+    for (size_t I = 0; I < N; ++I)
+      Memory[I] = 42;
+  });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 42, I, "single_task shortcut");
+
+  // 1D parallel_for shortcut
+  oneapiext::parallel_for(Q, sycl::range<1>{N},
+                          [=](sycl::item<1> Item) { Memory[Item] = 43; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 43, I, "1D parallel_for shortcut");
+
+  // 2D parallel_for shortcut
+  oneapiext::parallel_for(Q, sycl::range<2>{8, N / 8}, [=](sycl::item<2> Item) {
+    Memory[Item.get_linear_id()] = 44;
+  });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 44, I, "2D parallel_for shortcut");
+
+  // 3D parallel_for shortcut
+  oneapiext::parallel_for(
+      Q, sycl::range<3>{8, 8, N / 64},
+      [=](sycl::item<3> Item) { Memory[Item.get_linear_id()] = 45; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 45, I, "3D parallel_for shortcut");
+
+  // 1D nd_launch shortcut
+  oneapiext::nd_launch(
+      Q, sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}},
+      [=](sycl::nd_item<1> Item) { Memory[Item.get_global_linear_id()] = 46; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 46, I, "1D nd_launch shortcut");
+
+  // 2D nd_launch shortcut
+  oneapiext::nd_launch(
+      Q, sycl::nd_range<2>{sycl::range<2>{8, N / 8}, sycl::range{8, 8}},
+      [=](sycl::nd_item<2> Item) { Memory[Item.get_global_linear_id()] = 47; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 47, I, "2D nd_launch shortcut");
+
+  // 3D nd_launch shortcut
+  oneapiext::nd_launch(
+      Q, sycl::nd_range<3>{sycl::range<3>{8, 8, N / 64}, sycl::range{8, 8, 8}},
+      [=](sycl::nd_item<3> Item) { Memory[Item.get_global_linear_id()] = 48; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 48, I, "3D nd_launch shortcut");
+
+  // 1D parallel_for shortcut with launch config
+  oneapiext::parallel_for(
+      Q, oneapiext::launch_config<sycl::range<1>>{sycl::range<1>{N}},
+      [=](sycl::item<1> Item) { Memory[Item] = 49; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed +=
+        Check(Memory, 49, I, "1D parallel_for shortcut with launch config");
+
+  // 2D parallel_for shortcut with launch config
+  oneapiext::parallel_for(
+      Q, oneapiext::launch_config<sycl::range<2>>{sycl::range<2>{8, N / 8}},
+      [=](sycl::item<2> Item) { Memory[Item.get_linear_id()] = 50; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed +=
+        Check(Memory, 50, I, "2D parallel_for shortcut with launch config");
+
+  // 3D parallel_for shortcut with launch config
+  oneapiext::parallel_for(
+      Q, oneapiext::launch_config<sycl::range<3>>{sycl::range<3>{8, 8, N / 64}},
+      [=](sycl::item<3> Item) { Memory[Item.get_linear_id()] = 51; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed +=
+        Check(Memory, 51, I, "3D parallel_for shortcut with launch config");
+
+  // 1D nd_launch shortcut with launch config
+  oneapiext::nd_launch(
+      Q,
+      oneapiext::launch_config<sycl::nd_range<1>>{
+          sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}},
+      [=](sycl::nd_item<1> Item) { Memory[Item.get_global_linear_id()] = 52; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 52, I, "1D nd_launch shortcut with launch config");
+
+  // 2D nd_launch shortcut with launch config
+  oneapiext::nd_launch(
+      Q,
+      oneapiext::launch_config<sycl::nd_range<2>>{
+          sycl::nd_range<2>{sycl::range<2>{8, N / 8}, sycl::range{8, 8}}},
+      [=](sycl::nd_item<2> Item) { Memory[Item.get_global_linear_id()] = 53; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 53, I, "2D nd_launch shortcut with launch config");
+
+  // 3D nd_launch shortcut with launch config
+  oneapiext::nd_launch(
+      Q,
+      oneapiext::launch_config<sycl::nd_range<3>>{sycl::nd_range<3>{
+          sycl::range<3>{8, 8, N / 64}, sycl::range{8, 8, 8}}},
+      [=](sycl::nd_item<3> Item) { Memory[Item.get_global_linear_id()] = 54; });
+  Q.wait();
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 54, I, "3D nd_launch shortcut with launch config");
+
+  sycl::free(Memory, Q);
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/kernel_submit.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_submit.cpp
@@ -1,0 +1,232 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function kernel submits.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <iostream>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+  int Memory[N] = {0};
+
+  int Failed = 0;
+
+  // single_task
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::single_task(CGH, [=]() {
+          for (size_t I = 0; I < N; ++I)
+            MemAcc[I] = 42;
+        });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 42, I, "single_task");
+
+  // 1D parallel_for
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, sycl::range<1>{N},
+                                [=](sycl::item<1> Item) { MemAcc[Item] = 43; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 43, I, "1D parallel_for");
+
+  // 2D parallel_for
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range,
+                                [=](sycl::item<2> Item) { MemAcc[Item] = 44; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 44, I, "2D parallel_for");
+
+  // 3D parallel_for
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range,
+                                [=](sycl::item<3> Item) { MemAcc[Item] = 45; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 45, I, "3D parallel_for");
+
+  // 1D nd_launch
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}},
+            [=](sycl::nd_item<1> Item) { MemAcc[Item.get_global_id()] = 46; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 46, I, "1D nd_launch");
+
+  // 2D nd_launch
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<2>{Range, sycl::range{8, 8}},
+            [=](sycl::nd_item<2> Item) { MemAcc[Item.get_global_id()] = 47; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 47, I, "2D nd_launch");
+
+  // 3D nd_launch
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<3>{Range, sycl::range{8, 8, 8}},
+            [=](sycl::nd_item<3> Item) { MemAcc[Item.get_global_id()] = 48; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 48, I, "3D nd_launch");
+
+  // 1D parallel_for with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(
+            CGH, oneapiext::launch_config<sycl::range<1>>{sycl::range<1>{N}},
+            [=](sycl::item<1> Item) { MemAcc[Item] = 49; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 49, I, "1D parallel_for with launch config");
+
+  // 2D parallel_for with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<2>>{Range},
+                                [=](sycl::item<2> Item) { MemAcc[Item] = 50; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 50, I, "2D parallel_for with launch config");
+
+  // 3D parallel_for with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<3>>{Range},
+                                [=](sycl::item<3> Item) { MemAcc[Item] = 51; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 51, I, "3D parallel_for with launch config");
+
+  // 1D nd_launch with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<1>>{
+                sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}},
+            [=](sycl::nd_item<1> Item) { MemAcc[Item.get_global_id()] = 52; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 52, I, "1D nd_launch with launch config");
+
+  // 2D nd_launch with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<2>>{
+                sycl::nd_range<2>{Range, sycl::range{8, 8}}},
+            [=](sycl::nd_item<2> Item) { MemAcc[Item.get_global_id()] = 53; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 53, I, "2D nd_launch with launch config");
+
+  // 3D nd_launch with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<3>>{
+                sycl::nd_range<3>{Range, sycl::range{8, 8, 8}}},
+            [=](sycl::nd_item<3> Item) { MemAcc[Item.get_global_id()] = 54; });
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 54, I, "3D nd_launch with launch config");
+
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/kernel_submit_with_event.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_submit_with_event.cpp
@@ -1,0 +1,232 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function kernel submits with event.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <iostream>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+  int Memory[N] = {0};
+
+  int Failed = 0;
+
+  // single_task
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::single_task(CGH, [=]() {
+          for (size_t I = 0; I < N; ++I)
+            MemAcc[I] = 42;
+        });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 42, I, "single_task");
+
+  // 1D parallel_for
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, sycl::range<1>{N},
+                                [=](sycl::item<1> Item) { MemAcc[Item] = 43; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 43, I, "1D parallel_for");
+
+  // 2D parallel_for
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range,
+                                [=](sycl::item<2> Item) { MemAcc[Item] = 44; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 44, I, "2D parallel_for");
+
+  // 3D parallel_for
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range,
+                                [=](sycl::item<3> Item) { MemAcc[Item] = 45; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 45, I, "3D parallel_for");
+
+  // 1D nd_launch
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}},
+            [=](sycl::nd_item<1> Item) { MemAcc[Item.get_global_id()] = 46; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 46, I, "1D nd_launch");
+
+  // 2D nd_launch
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<2>{Range, sycl::range{8, 8}},
+            [=](sycl::nd_item<2> Item) { MemAcc[Item.get_global_id()] = 47; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 47, I, "2D nd_launch");
+
+  // 3D nd_launch
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<3>{Range, sycl::range{8, 8, 8}},
+            [=](sycl::nd_item<3> Item) { MemAcc[Item.get_global_id()] = 48; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 48, I, "3D nd_launch");
+
+  // 1D parallel_for with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(
+            CGH, oneapiext::launch_config<sycl::range<1>>{sycl::range<1>{N}},
+            [=](sycl::item<1> Item) { MemAcc[Item] = 49; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 49, I, "1D parallel_for with launch config");
+
+  // 2D parallel_for with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<2>>{Range},
+                                [=](sycl::item<2> Item) { MemAcc[Item] = 50; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 50, I, "2D parallel_for with launch config");
+
+  // 3D parallel_for with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<3>>{Range},
+                                [=](sycl::item<3> Item) { MemAcc[Item] = 51; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 51, I, "3D parallel_for with launch config");
+
+  // 1D nd_launch with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<1>>{
+                sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}},
+            [=](sycl::nd_item<1> Item) { MemAcc[Item.get_global_id()] = 52; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 52, I, "1D nd_launch with launch config");
+
+  // 2D nd_launch with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<2>>{
+                sycl::nd_range<2>{Range, sycl::range{8, 8}}},
+            [=](sycl::nd_item<2> Item) { MemAcc[Item.get_global_id()] = 53; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 53, I, "2D nd_launch with launch config");
+
+  // 3D nd_launch with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<3>>{
+                sycl::nd_range<3>{Range, sycl::range{8, 8, 8}}},
+            [=](sycl::nd_item<3> Item) { MemAcc[Item.get_global_id()] = 54; });
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 54, I, "3D nd_launch with launch config");
+
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/kernel_submit_with_event_and_kb.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_submit_with_event_and_kb.cpp
@@ -1,0 +1,246 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function kernel submit_with_events with events and
+// sycl::kernel. NOTE: This relies on the availability of an OpenCL C compiler
+// being available.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <iostream>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+  int Memory[N] = {0};
+
+  if (!oneapiext::is_source_kernel_bundle_supported(
+          Q.get_backend(), oneapiext::source_language::opencl)) {
+    std::cout
+        << "Backend does not support OpenCL C source kernel bundle extension: "
+        << Q.get_backend() << std::endl;
+    return 0;
+  }
+
+  auto KB = CreateKB(Q);
+
+  assert(KB.ext_oneapi_has_kernel("KernelSingleTask"));
+  assert(KB.ext_oneapi_has_kernel("Kernel1D"));
+  assert(KB.ext_oneapi_has_kernel("Kernel2D"));
+  assert(KB.ext_oneapi_has_kernel("Kernel3D"));
+
+  sycl::kernel KernelSingleTask = KB.ext_oneapi_get_kernel("KernelSingleTask");
+  sycl::kernel Kernel1D = KB.ext_oneapi_get_kernel("Kernel1D");
+  sycl::kernel Kernel2D = KB.ext_oneapi_get_kernel("Kernel2D");
+  sycl::kernel Kernel3D = KB.ext_oneapi_get_kernel("Kernel3D");
+
+  int Failed = 0;
+
+  // single_task
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::single_task(CGH, KernelSingleTask, (int)N, 42, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 42, I, "single_task");
+
+  // 1D parallel_for
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, sycl::range<1>{N}, Kernel1D, 43, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 43, I, "1D parallel_for");
+
+  // 2D parallel_for
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range, Kernel2D, 44, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 44, I, "2D parallel_for");
+
+  // 3D parallel_for
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range, Kernel3D, 45, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 45, I, "3D parallel_for");
+
+  // 1D nd_launch
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}, Kernel1D,
+            46, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 46, I, "1D nd_launch");
+
+  // 2D nd_launch
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(CGH, sycl::nd_range<2>{Range, sycl::range{8, 8}},
+                             Kernel2D, 47, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 47, I, "2D nd_launch");
+
+  // 3D nd_launch
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(CGH,
+                             sycl::nd_range<3>{Range, sycl::range{8, 8, 8}},
+                             Kernel3D, 48, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 48, I, "3D nd_launch");
+
+  // 1D parallel_for with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(
+            CGH, oneapiext::launch_config<sycl::range<1>>{sycl::range<1>{N}},
+            Kernel1D, 49, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 49, I, "1D parallel_for with launch config");
+
+  // 2D parallel_for with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<2>>{Range},
+                                Kernel2D, 50, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 50, I, "2D parallel_for with launch config");
+
+  // 3D parallel_for with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<3>>{Range},
+                                Kernel3D, 51, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 51, I, "3D parallel_for with launch config");
+
+  // 1D nd_launch with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<1>>{
+                sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}},
+            Kernel1D, 52, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 52, I, "1D nd_launch with launch config");
+
+  // 2D nd_launch with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(CGH,
+                             oneapiext::launch_config<sycl::nd_range<2>>{
+                                 sycl::nd_range<2>{Range, sycl::range{8, 8}}},
+                             Kernel2D, 53, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 53, I, "2D nd_launch with launch config");
+
+  // 3D nd_launch with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<3>>{
+                sycl::nd_range<3>{Range, sycl::range{8, 8, 8}}},
+            Kernel3D, 54, MemAcc);
+      }).wait();
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 54, I, "3D nd_launch with launch config");
+
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/kernel_submit_with_kb.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/kernel_submit_with_kb.cpp
@@ -1,0 +1,246 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function kernel submits with sycl::kernel.
+// NOTE: This relies on the availability of an OpenCL C compiler being
+// available.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <iostream>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+  int Memory[N] = {0};
+
+  if (!oneapiext::is_source_kernel_bundle_supported(
+          Q.get_backend(), oneapiext::source_language::opencl)) {
+    std::cout
+        << "Backend does not support OpenCL C source kernel bundle extension: "
+        << Q.get_backend() << std::endl;
+    return 0;
+  }
+
+  auto KB = CreateKB(Q);
+
+  assert(KB.ext_oneapi_has_kernel("KernelSingleTask"));
+  assert(KB.ext_oneapi_has_kernel("Kernel1D"));
+  assert(KB.ext_oneapi_has_kernel("Kernel2D"));
+  assert(KB.ext_oneapi_has_kernel("Kernel3D"));
+
+  sycl::kernel KernelSingleTask = KB.ext_oneapi_get_kernel("KernelSingleTask");
+  sycl::kernel Kernel1D = KB.ext_oneapi_get_kernel("Kernel1D");
+  sycl::kernel Kernel2D = KB.ext_oneapi_get_kernel("Kernel2D");
+  sycl::kernel Kernel3D = KB.ext_oneapi_get_kernel("Kernel3D");
+
+  int Failed = 0;
+
+  // single_task
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::single_task(CGH, KernelSingleTask, (int)N, 42, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 42, I, "single_task");
+
+  // 1D parallel_for
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, sycl::range<1>{N}, Kernel1D, 43, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 43, I, "1D parallel_for");
+
+  // 2D parallel_for
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range, Kernel2D, 44, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 44, I, "2D parallel_for");
+
+  // 3D parallel_for
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH, Range, Kernel3D, 45, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 45, I, "3D parallel_for");
+
+  // 1D nd_launch
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH, sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}, Kernel1D,
+            46, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 46, I, "1D nd_launch");
+
+  // 2D nd_launch
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(CGH, sycl::nd_range<2>{Range, sycl::range{8, 8}},
+                             Kernel2D, 47, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 47, I, "2D nd_launch");
+
+  // 3D nd_launch
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(CGH,
+                             sycl::nd_range<3>{Range, sycl::range{8, 8, 8}},
+                             Kernel3D, 48, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 48, I, "3D nd_launch");
+
+  // 1D parallel_for with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(
+            CGH, oneapiext::launch_config<sycl::range<1>>{sycl::range<1>{N}},
+            Kernel1D, 49, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 49, I, "1D parallel_for with launch config");
+
+  // 2D parallel_for with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<2>>{Range},
+                                Kernel2D, 50, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 50, I, "2D parallel_for with launch config");
+
+  // 3D parallel_for with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::parallel_for(CGH,
+                                oneapiext::launch_config<sycl::range<3>>{Range},
+                                Kernel3D, 51, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 51, I, "3D parallel_for with launch config");
+
+  // 1D nd_launch with launch config
+  {
+    sycl::buffer<int, 1> MemBuf{Memory, sycl::range<1>{N}};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<1>>{
+                sycl::nd_range<1>{sycl::range<1>{N}, sycl::range{8}}},
+            Kernel1D, 52, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 52, I, "1D nd_launch with launch config");
+
+  // 2D nd_launch with launch config
+  {
+    sycl::range<2> Range{8, N / 8};
+    sycl::buffer<int, 2> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(CGH,
+                             oneapiext::launch_config<sycl::nd_range<2>>{
+                                 sycl::nd_range<2>{Range, sycl::range{8, 8}}},
+                             Kernel2D, 53, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 53, I, "2D nd_launch with launch config");
+
+  // 3D nd_launch with launch config
+  {
+    sycl::range<3> Range{8, 8, N / 64};
+    sycl::buffer<int, 3> MemBuf{Memory, Range};
+    {
+      oneapiext::submit(Q, [&](sycl::handler &CGH) {
+        sycl::accessor MemAcc{MemBuf, CGH, sycl::write_only};
+        oneapiext::nd_launch(
+            CGH,
+            oneapiext::launch_config<sycl::nd_range<3>>{
+                sycl::nd_range<3>{Range, sycl::range{8, 8, 8}}},
+            Kernel3D, 54, MemAcc);
+      });
+    }
+  }
+  for (size_t I = 0; I < N; ++I)
+    Failed += Check(Memory, 54, I, "3D nd_launch with launch config");
+
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/mem_advise.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/mem_advise.cpp
@@ -1,0 +1,40 @@
+// REQUIRES: usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
+
+// Tests the enqueue free function mem_advise.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::context Context;
+  sycl::queue Q(Context, sycl::default_selector_v);
+  int *Memory = sycl::malloc_shared<int>(N, Q);
+
+  constexpr size_t ChunkSize = N / 3;
+
+  oneapiext::mem_advise(Q, Memory, ChunkSize, 0);
+
+  oneapiext::submit(Q, [&](sycl::handler &CGH) {
+    oneapiext::mem_advise(CGH, Memory + ChunkSize, ChunkSize, 0);
+  });
+
+  sycl::event E = oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+    oneapiext::mem_advise(CGH, Memory + ChunkSize * 2, ChunkSize, 0);
+  });
+
+  E.wait();
+  Q.wait();
+  sycl::free(Memory, Q);
+
+  return 0;
+}
+
+// CHECK-COUNT-3:---> piextUSMEnqueueMemAdvise
+// CHECK-NOT:---> piextUSMEnqueueMemAdvise

--- a/sycl/test-e2e/EnqueueFunctions/memops.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/memops.cpp
@@ -1,0 +1,131 @@
+// REQUIRES: usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// Tests the enqueue free function memory operations.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+#include "common.hpp"
+
+#include <algorithm>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+
+int main() {
+  sycl::queue Q;
+
+  int Failed = 0;
+
+  // Shortcuts.
+  {
+    int *Memory1 = sycl::malloc_shared<int>(N, Q);
+    int *Memory2 = sycl::malloc_shared<int>(N, Q);
+    std::fill(Memory1, Memory1 + N, 42);
+    std::fill(Memory2, Memory2 + N, 24);
+
+    oneapiext::fill(Q, Memory1, 1, N - 20);
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory1, (I < N - 20 ? 1 : 42), I, "fill shortcut");
+
+    oneapiext::memcpy(Q, Memory2, Memory1, N * sizeof(int));
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, Memory1[I], I, "memcpy shortcut");
+
+    oneapiext::memset(Q, Memory2, 0, (N - 10) * sizeof(int));
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, (I < N - 10 ? 0 : 42), I, "memset shortcut");
+
+    oneapiext::copy(Q, Memory1, Memory2, N);
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, Memory1[I], I, "copy shortcut");
+
+    sycl::free(Memory1, Q);
+    sycl::free(Memory2, Q);
+  }
+
+  // Submit without event.
+  {
+    int *Memory1 = sycl::malloc_shared<int>(N, Q);
+    int *Memory2 = sycl::malloc_shared<int>(N, Q);
+    std::fill(Memory1, Memory1 + N, 42);
+    std::fill(Memory2, Memory2 + N, 24);
+
+    oneapiext::submit(Q, [&](sycl::handler &CGH) {
+      oneapiext::fill(CGH, Memory1, 1, N - 20);
+    });
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory1, (I < N - 20 ? 1 : 42), I, "fill without event");
+
+    oneapiext::submit(Q, [&](sycl::handler &CGH) {
+      oneapiext::memcpy(CGH, Memory2, Memory1, N * sizeof(int));
+    });
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, Memory1[I], I, "memcpy without event");
+
+    oneapiext::submit(Q, [&](sycl::handler &CGH) {
+      oneapiext::memset(CGH, Memory2, 0, (N - 10) * sizeof(int));
+    });
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed +=
+          Check(Memory2, (I < N - 10 ? 0 : 42), I, "memset without event");
+
+    oneapiext::submit(Q, [&](sycl::handler &CGH) {
+      oneapiext::copy(CGH, Memory1, Memory2, N);
+    });
+    Q.wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, Memory1[I], I, "copy without event");
+
+    sycl::free(Memory1, Q);
+    sycl::free(Memory2, Q);
+  }
+
+  // Submit with event.
+  {
+    int *Memory1 = sycl::malloc_shared<int>(N, Q);
+    int *Memory2 = sycl::malloc_shared<int>(N, Q);
+    std::fill(Memory1, Memory1 + N, 42);
+    std::fill(Memory2, Memory2 + N, 24);
+
+    oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+      oneapiext::fill(CGH, Memory1, 1, N - 20);
+    }).wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory1, (I < N - 20 ? 1 : 42), I, "fill with event");
+
+    oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+      oneapiext::memcpy(CGH, Memory2, Memory1, N * sizeof(int));
+    }).wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, Memory1[I], I, "memcpy with event");
+
+    oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+      oneapiext::memset(CGH, Memory2, 0, (N - 10) * sizeof(int));
+    }).wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, (I < N - 10 ? 0 : 42), I, "memset with event");
+
+    oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+      oneapiext::copy(CGH, Memory1, Memory2, N);
+    }).wait();
+    for (size_t I = 0; I < N; ++I)
+      Failed += Check(Memory2, Memory1[I], I, "copy with event");
+
+    sycl::free(Memory1, Q);
+    sycl::free(Memory2, Q);
+  }
+
+  return Failed;
+}

--- a/sycl/test-e2e/EnqueueFunctions/prefetch.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/prefetch.cpp
@@ -1,0 +1,39 @@
+// REQUIRES: usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
+
+// Tests the enqueue free function prefetch.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/usm.hpp>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+constexpr size_t N = 1024;
+constexpr size_t ChunkSize = N / 3;
+
+int main() {
+  sycl::context Context;
+  sycl::queue Q(Context, sycl::default_selector_v);
+  int *Memory = sycl::malloc_shared<int>(N, Q);
+
+  oneapiext::prefetch(Q, Memory, ChunkSize);
+
+  oneapiext::submit(Q, [&](sycl::handler &CGH) {
+    oneapiext::prefetch(CGH, Memory + ChunkSize, ChunkSize);
+  });
+
+  sycl::event E = oneapiext::submit_with_event(Q, [&](sycl::handler &CGH) {
+    oneapiext::prefetch(CGH, Memory + ChunkSize * 2, ChunkSize);
+  });
+
+  E.wait();
+  Q.wait();
+  sycl::free(Memory, Q);
+
+  return 0;
+}
+
+// CHECK-COUNT-3:---> piextUSMEnqueuePrefetch
+// CHECK-NOT:---> piextUSMEnqueuePrefetch


### PR DESCRIPTION
This commit implements the [sycl_ext_oneapi_enqueue_functions](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_enqueue_functions.asciidoc) extension with enqueue free functions.

Optimization for avoiding event creation will happen in a follow-up patch.