### PR TITLE
[SYCL] Fix descendent device support for composite/component devices

### DIFF
--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -186,8 +186,17 @@ public:
       return hasDevice(Device);
 
     while (!hasDevice(Device)) {
-      if (Device->isRootDevice())
+      if (Device->isRootDevice()) {
+        if (Device->has(aspect::ext_oneapi_is_component)) {
+          // Component devices should be implicitly usable in context created
+          // for a composite device they belong to.
+          auto CompositeDevice = Device->get_info<
+              ext::oneapi::experimental::info::device::composite_device>();
+          return hasDevice(detail::getSyclObjImpl(CompositeDevice));
+        }
+
         return false;
+      }
       Device = detail::getSyclObjImpl(
           Device->get_info<info::device::parent_device>());
     }


### PR DESCRIPTION
Fixed a case where it was not possible to create a queue for a component device using context for a composite device.