### PR TITLE
[Driver][SYCL] Use LLVM-IR based device libraries for device linking

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5902,22 +5902,8 @@ class OffloadingActionBuilder final {
             Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
                                          Args.MakeArgString(LibName));
             auto *SYCLDeviceLibsInputAction =
-                C.MakeAction<InputAction>(*InputArg, types::TY_Object);
-            auto *SYCLDeviceLibsUnbundleAction =
-                C.MakeAction<OffloadUnbundlingJobAction>(
-                    SYCLDeviceLibsInputAction);
-
-            // We are using BoundArch="" here since the NVPTX bundles in
-            // the devicelib .o files do not contain any arch information
-            SYCLDeviceLibsUnbundleAction->registerDependentActionInfo(
-                TC, /*BoundArch=*/"", Action::OFK_SYCL);
-            OffloadAction::DeviceDependences Dep;
-            Dep.add(*SYCLDeviceLibsUnbundleAction, *TC, /*BoundArch=*/"",
-                    Action::OFK_SYCL);
-            auto *SYCLDeviceLibsDependenciesAction =
-                C.MakeAction<OffloadAction>(
-                    Dep, SYCLDeviceLibsUnbundleAction->getType());
-            DeviceLinkObjects.push_back(SYCLDeviceLibsDependenciesAction);
+                C.MakeAction<InputAction>(*InputArg, types::TY_LLVM_BC);
+            DeviceLinkObjects.push_back(SYCLDeviceLibsInputAction);
             if (!LibLocSelected)
               LibLocSelected = !LibLocSelected;
           }

--- a/clang/test/Driver/sycl-bfloat16-lib.cpp
+++ b/clang/test/Driver/sycl-bfloat16-lib.cpp
@@ -66,20 +66,20 @@
 // RUN:   --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=BFLOAT16-FALLBACK-FALLBACK
 
-// BFLOAT16-NOT:  clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-{{fallback|native}}-bfloat16.o" "-output={{.*}}libsycl-{{fallback|native}}-{{.*}}.o" "-unbundle"
+// BFLOAT16-NOT: llvm-link{{.*}} "{{.*}}libsycl-{{fallback|native}}-bfloat16.bc"
 
-// BFLOAT16-NATIVE: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_gen-unknown-unknown" "-input={{.*}}libsycl-native-bfloat16.o"
+// BFLOAT16-NATIVE: llvm-link{{.*}} "{{.*}}libsycl-native-bfloat16.bc"
 
-// BFLOAT16-FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-{{spir64_gen-|spir64-}}unknown-unknown" "-input={{.*}}libsycl-fallback-bfloat16.o"
+// BFLOAT16-FALLBACK: llvm-link{{.*}} "{{.*}}libsycl-fallback-bfloat16.bc"
 
-// BFLOAT16-NONE-NATIVE-NOT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}-bfloat16.o"
-// BFLOAT16-NONE-NATIVE: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_gen-unknown-unknown" "-input={{.*}}libsycl-native-bfloat16.o"
+// BFLOAT16-NONE-NATIVE-NOT: llvm-link{{.*}} "{{.*}}-bfloat16.bc"
+// BFLOAT16-NONE-NATIVE: llvm-link{{.*}} "{{.*}}libsycl-native-bfloat16.bc"
 
-// BFLOAT16-NONE-FALLBACK-NOT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}-bfloat16.o"
-// BFLOAT16-NONE-FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_gen-unknown-unknown" "-input={{.*}}libsycl-fallback-bfloat16.o"
+// BFLOAT16-NONE-FALLBACK-NOT: llvm-link{{.*}} "{{.*}}-bfloat16.bc"
+// BFLOAT16-NONE-FALLBACK: llvm-link{{.*}} "{{.*}}libsycl-fallback-bfloat16.bc"
 
-// BFLOAT16-FALLBACK-NATIVE: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-bfloat16.o" "-output={{.*}}libsycl-fallback-bfloat16-{{.*}}.o" "-unbundle"
-// BFLOAT16-FALLBACK-NATIVE: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_gen-unknown-unknown" "-input={{.*}}libsycl-native-bfloat16.o"
+// BFLOAT16-FALLBACK-NATIVE: llvm-link{{.*}} "{{.*}}libsycl-fallback-bfloat16.bc"
+// BFLOAT16-FALLBACK-NATIVE: {{.*}}libsycl-native-bfloat16.bc"
 
-// BFLOAT16-FALLBACK-FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-bfloat16.o" "-output={{.*}}libsycl-fallback-bfloat16-{{.*}}.o" "-unbundle"
-// BFLOAT16-FALLBACK-FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_gen-unknown-unknown" "-input={{.*}}libsycl-fallback-bfloat16.o"
+// BFLOAT16-FALLBACK-FALLBACK: llvm-link{{.*}} "{{.*}}libsycl-fallback-bfloat16.bc"
+// BFLOAT16-FALLBACK-FALLBACK: "{{.*}}libsycl-fallback-bfloat16.bc"

--- a/clang/test/Driver/sycl-device-lib.cpp
+++ b/clang/test/Driver/sycl-device-lib.cpp
@@ -8,123 +8,133 @@
 
 /// test behavior of device library default link and fno-sycl-device-lib-jit-link
 // RUN: %clangxx -fsycl %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
 // RUN: %clangxx -fsycl -fno-sycl-device-lib-jit-link %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
 // RUN: %clangxx -fsycl -fno-sycl-device-lib-jit-link %s -fsycl-device-lib=libc --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libm-fp32 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc,libm-fp32 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex.o" "-output={{.*}}libsycl-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex-fp64.o" "-output={{.*}}libsycl-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath.o" "-output={{.*}}libsycl-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath-fp64.o" "-output={{.*}}libsycl-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cassert.o" "-output={{.*}}libsycl-fallback-cassert-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cstring.o" "-output={{.*}}libsycl-fallback-cstring-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex.o" "-output={{.*}}libsycl-fallback-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex-fp64.o" "-output={{.*}}libsycl-fallback-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath.o" "-output={{.*}}libsycl-fallback-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.o" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_DEFAULT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_DEFAULT
+// SYCL_DEVICE_LIB_LINK_DEFAULT: llvm-link{{.*}} "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-complex.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-imf.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-imf-bf16.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-cassert.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-cstring.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-complex.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-imf.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_DEFAULT-SAME: "{{.*}}libsycl-fallback-imf-bf16.bc"
 
 /// ###########################################################################
 /// test sycl fallback device libraries are not linked by default
 // RUN: %clangxx -fsycl -fsycl-device-lib-jit-link %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_NO_FALLBACK
-// SYCL_DEVICE_LIB_NO_FALLBACK: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_NO_FALLBACK-NOT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-{{.*}}.o"
-// SYCL_DEVICE_LIB_NO_FALLBACK: llvm-link{{.*}}  "-only-needed"
+// SYCL_DEVICE_LIB_NO_FALLBACK: llvm-link{{.*}} "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_NO_FALLBACK-NOT: "{{.*}}libsycl-fallback-{{.*}}.bc"
 
 /// ###########################################################################
 /// test behavior of device library link with libm-fp64
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libm-fp64 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_WITH_FP64
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc,libm-fp64 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_WITH_FP64
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=all --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_WITH_FP64
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc,libm-fp32,libm-fp64 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_WITH_FP64
 // RUN: %clangxx -fsycl %s -fsycl-device-lib=libc,all --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex.o" "-output={{.*}}libsycl-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex-fp64.o" "-output={{.*}}libsycl-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath.o" "-output={{.*}}libsycl-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath-fp64.o" "-output={{.*}}libsycl-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cassert.o" "-output={{.*}}libsycl-fallback-cassert-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cstring.o" "-output={{.*}}libsycl-fallback-cstring-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex.o" "-output={{.*}}libsycl-fallback-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex-fp64.o" "-output={{.*}}libsycl-fallback-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath.o" "-output={{.*}}libsycl-fallback-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.o" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_WITH_FP64-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_WITH_FP64
+// SYCL_DEVICE_LIB_LINK_WITH_FP64: llvm-link{{.*}} "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-complex.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-imf.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-imf-bf16.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-cassert.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-cstring.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-complex.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-imf.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_WITH_FP64-SAME: "{{.*}}libsycl-fallback-imf-bf16.bc"
 /// ###########################################################################
 
 /// test behavior of -fno-sycl-device-lib=libc
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libc --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex.o" "-output={{.*}}libsycl-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex-fp64.o" "-output={{.*}}libsycl-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath.o" "-output={{.*}}libsycl-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath-fp64.o" "-output={{.*}}libsycl-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex.o" "-output={{.*}}libsycl-fallback-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex-fp64.o" "-output={{.*}}libsycl-fallback-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath.o" "-output={{.*}}libsycl-fallback-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.o" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBC-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_LIBC
+// SYCL_DEVICE_LIB_LINK_NO_LIBC: llvm-link{{.*}}
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-NOT: "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC: "{{.*}}libsycl-complex.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-imf.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-imf-bf16.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-NOT: "{{.*}}libsycl-fallback-cassert.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-NOT: "{{.*}}libsycl-fallback-cstring.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-complex.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-imf.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBC-SAME: "{{.*}}libsycl-fallback-imf-bf16.bc"
 /// ###########################################################################
 
 /// test behavior of -fno-sycl-device-lib=libm-fp32,libm-fp64
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libm-fp32,libm-fp64 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cassert.o" "-output={{.*}}libsycl-fallback-cassert-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cstring.o" "-output={{.*}}libsycl-fallback-cstring-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_LIBM: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_LIBM
+// SYCL_DEVICE_LIB_LINK_NO_LIBM: llvm-link{{.*}} "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-complex.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-imf.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-imf-bf16.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-fallback-cassert.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-fallback-cstring.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-fallback-complex.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-fallback-complex-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-fallback-cmath.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-NOT: "{{.*}}libsycl-fallback-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-fallback-imf.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-fallback-imf-fp64.bc"
+// SYCL_DEVICE_LIB_LINK_NO_LIBM-SAME: "{{.*}}libsycl-fallback-imf-bf16.bc"
 /// ###########################################################################
 
 /// test behavior of disabling all device libraries
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libc,libm-fp32 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=all --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libc,all --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libm-fp32,all --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libm-fp64,all --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
 // RUN: %clangxx -fsycl %s -fno-sycl-device-lib=libc,all,libm-fp64,libm-fp32 --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB: {{.*}}clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB-NOT: libsycl-cmath
-// SYCL_DEVICE_LIB_UNBUNDLE_NO_DEVICE_LIB: {{.*}}llvm-link{{.*}} {{.*}} "--suppress-warnings"
+// RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB
+// SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB: {{.*}}clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"
+// SYCL_DEVICE_LIB_LINK_NO_DEVICE_LIB-NOT: libsycl-cmath.bc
 
 /// ###########################################################################
 
@@ -147,28 +157,27 @@
 // RUN:   | FileCheck %s -check-prefix=SYCL_LLVM_LINK_DEVICE_LIB
 // RUN: %clangxx -fsycl -save-temps %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_LLVM_LINK_DEVICE_LIB
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
+// RUN:   | FileCheck %s -check-prefix=SYCL_LLVM_LINK_DEVICE_LIB
 // SYCL_LLVM_LINK_DEVICE_LIB: llvm-link{{.*}}  "{{.*}}.bc" "-o" "{{.*}}.bc" "--suppress-warnings"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex.o" "-output={{.*}}libsycl-complex-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex-fp64.o" "-output={{.*}}libsycl-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath.o" "-output={{.*}}libsycl-cmath-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath-fp64.o" "-output={{.*}}libsycl-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cassert.o" "-output={{.*}}libsycl-fallback-cassert-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cstring.o" "-output={{.*}}libsycl-fallback-cstring-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex.o" "-output={{.*}}libsycl-fallback-complex-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex-fp64.o" "-output={{.*}}libsycl-fallback-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath.o" "-output={{.*}}libsycl-fallback-cmath-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.o" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-user-wrappers.o" "-output={{.*}}libsycl-itt-user-wrappers-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-compiler-wrappers.o" "-output={{.*}}libsycl-itt-compiler-wrappers-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-stubs.o" "-output={{.*}}libsycl-itt-stubs-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB-NEXT: llvm-link{{.*}} "-only-needed" "{{.*}}" "-o" "{{.*}}.bc" "--suppress-warnings"
+// SYCL_LLVM_LINK_DEVICE_LIB: llvm-link{{.*}} "-only-needed"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-crt.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-complex.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-complex-fp64.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-cmath.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-cmath-fp64.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-imf.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-imf-fp64.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-imf-bf16.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-cassert.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-cstring.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-complex.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-complex-fp64.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-cmath.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-cmath-fp64.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-imf.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-imf-fp64.bc"
+// SYCL_LLVM_LINK_DEVICE_LIB-SAME: "{{.*}}libsycl-fallback-imf-bf16.bc"
 
 /// ###########################################################################
 /// test llvm-link behavior for fno-sycl-device-lib
@@ -187,34 +196,6 @@
 // SYCL_LLVM_LINK_USER_ONLY_NEEDED: llvm-link{{.*}}  "-only-needed" "{{.*}}" "-o" "{{.*}}.bc" "--suppress-warnings"
 
 /// ###########################################################################
-/// test llvm-link behavior for linking device libraries
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %s --sysroot=%S/Inputs/SYCL -### 2>&1 \
-// RUN:   | FileCheck %s -check-prefix=SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT: llvm-link{{.*}}  "{{.*}}.bc" "-o" "{{.*}}.bc" "--suppress-warnings"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-complex.o" "-output={{.*}}libsycl-complex-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-complex-fp64.o" "-output={{.*}}libsycl-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-cmath.o" "-output={{.*}}libsycl-cmath-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-cmath-fp64.o" "-output={{.*}}libsycl-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-cassert.o" "-output={{.*}}libsycl-fallback-cassert-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-cstring.o" "-output={{.*}}libsycl-fallback-cstring-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex.o" "-output={{.*}}libsycl-fallback-complex-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex-fp64.o" "-output={{.*}}libsycl-fallback-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath.o" "-output={{.*}}libsycl-fallback-cmath-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.o" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-fallback-bfloat16.o" "-output={{.*}}libsycl-fallback-bfloat16-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-itt-user-wrappers.o" "-output={{.*}}libsycl-itt-user-wrappers-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-itt-compiler-wrappers.o" "-output={{.*}}libsycl-itt-compiler-wrappers-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64_x86_64-unknown-unknown" "-input={{.*}}libsycl-itt-stubs.o" "-output={{.*}}libsycl-itt-stubs-{{.*}}.o" "-unbundle"
-// SYCL_LLVM_LINK_DEVICE_LIB_SPIRV_CPU_AOT-NEXT: llvm-link{{.*}} "-only-needed" "{{.*}}" "-o" "{{.*}}.bc" "--suppress-warnings"
-
-/// ###########################################################################
 /// test behavior of libsycl-sanitizer.o linking when -fsanitize=address is available
 // RUN: %clangxx -fsycl %s --sysroot=%S/Inputs/SYCL -fsanitize=address -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_SANITIZER
@@ -228,29 +209,25 @@
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_LIB_SANITIZER
 // RUN: %clangxx -fsycl %s --sysroot=%S/Inputs/SYCL -Xarch_device "-fsanitize=address -DUSE_SYCL_DEVICE_ASAN" -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_ASAN_MACRO
-// SYCL_DEVICE_LIB_SANITIZER: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-crt.o" "-output={{.*}}libsycl-crt-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex.o" "-output={{.*}}libsycl-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex-fp64.o" "-output={{.*}}libsycl-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath.o" "-output={{.*}}libsycl-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-cmath-fp64.o" "-output={{.*}}libsycl-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf.o" "-output={{.*}}libsycl-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-fp64.o" "-output={{.*}}libsycl-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-imf-bf16.o" "-output={{.*}}libsycl-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cassert.o" "-output={{.*}}libsycl-fallback-cassert-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cstring.o" "-output={{.*}}libsycl-fallback-cstring-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex.o" "-output={{.*}}libsycl-fallback-complex-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-complex-fp64.o" "-output={{.*}}libsycl-fallback-complex-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath.o" "-output={{.*}}libsycl-fallback-cmath-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-cmath-fp64.o" "-output={{.*}}libsycl-fallback-cmath-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf.o" "-output={{.*}}libsycl-fallback-imf-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-fp64.o" "-output={{.*}}libsycl-fallback-imf-fp64-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-fallback-imf-bf16.o" "-output={{.*}}libsycl-fallback-imf-bf16-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-user-wrappers.o" "-output={{.*}}libsycl-itt-user-wrappers-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-compiler-wrappers.o" "-output={{.*}}libsycl-itt-compiler-wrappers-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-stubs.o" "-output={{.*}}libsycl-itt-stubs-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_LIB_SANITIZER-NEXT: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-sanitizer.o" "-output={{.*}}libsycl-sanitizer-{{.*}}.o" "-unbundle"
+// SYCL_DEVICE_LIB_SANITIZER: llvm-link{{.*}} "{{.*}}libsycl-crt.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-complex.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-complex-fp64.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-cmath.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-imf.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-imf-fp64.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-imf-bf16.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-cassert.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-cstring.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-complex.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-complex-fp64.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-cmath.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-cmath-fp64.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-imf.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-imf-fp64.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-fallback-imf-bf16.bc"
+// SYCL_DEVICE_LIB_SANITIZER-SAME: "{{.*}}libsycl-sanitizer.bc"
 // SYCL_DEVICE_ASAN_MACRO: "-cc1"
 // SYCL_DEVICE_ASAN_MACRO-SAME: "USE_SYCL_DEVICE_ASAN"
-// SYCL_DEVICE_ASAN_MACRO: llvm-link{{.*}}
-// SYCL_DEVICE_ASAN_MACRO:  clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-sanitizer.o" "-output={{.*}}libsycl-sanitizer-{{.*}}.o" "-unbundle"
-// SYCL_DEVICE_ASAN_MACRO: llvm-link{{.*}} "-only-needed" "{{.*}}" "-o" "{{.*}}.bc" "--suppress-warnings"
+// SYCL_DEVICE_ASAN_MACRO: llvm-link{{.*}} "-only-needed"
+// SYCL_DEVICE_ASAN_MACRO-SAME: "{{.*}}libsycl-sanitizer.bc"

--- a/clang/test/Driver/sycl-early-device-link.cpp
+++ b/clang/test/Driver/sycl-early-device-link.cpp
@@ -29,32 +29,26 @@
 // CREATE_IMAGE_PHASES: 0: input, "[[INPUT:.+\.cpp]]", c++, (device-sycl)
 // CREATE_IMAGE_PHASES: 1: preprocessor, {0}, c++-cpp-output, (device-sycl)
 // CREATE_IMAGE_PHASES: 2: compiler, {1}, ir, (device-sycl)
-// CREATE_IMAGE_PHASES: 3: input, "{{.*libsycl-itt-user-wrappers.o.*}}", object
-// CREATE_IMAGE_PHASES: 4: clang-offload-unbundler, {3}, object
-// CREATE_IMAGE_PHASES: 5: offload, " (spir64_gen-unknown-unknown)" {4}, object
-// CREATE_IMAGE_PHASES: 6: input, "{{.*libsycl-itt-compiler-wrappers.o.*}}", object
-// CREATE_IMAGE_PHASES: 7: clang-offload-unbundler, {6}, object
-// CREATE_IMAGE_PHASES: 8: offload, " (spir64_gen-unknown-unknown)" {7}, object
-// CREATE_IMAGE_PHASES: 9: input, "{{.*libsycl-itt-stubs.o.*}}", object
-// CREATE_IMAGE_PHASES: 10: clang-offload-unbundler, {9}, object
-// CREATE_IMAGE_PHASES: 11: offload, " (spir64_gen-unknown-unknown)" {10}, object
-// CREATE_IMAGE_PHASES: 12: linker, {5, 8, 11}, ir, (device-sycl)
-// CREATE_IMAGE_PHASES: 13: linker, {2, 12}, ir, (device-sycl)
-// CREATE_IMAGE_PHASES: 14: sycl-post-link, {13}, tempfiletable, (device-sycl)
-// CREATE_IMAGE_PHASES: 15: file-table-tform, {14}, tempfilelist, (device-sycl)
-// CREATE_IMAGE_PHASES: 16: llvm-spirv, {15}, tempfilelist, (device-sycl)
-// CREATE_IMAGE_PHASES: 17: backend-compiler, {16}, image, (device-sycl)
-// CREATE_IMAGE_PHASES: 18: file-table-tform, {14, 17}, tempfiletable, (device-sycl)
-// CREATE_IMAGE_PHASES: 19: clang-offload-wrapper, {18}, object, (device-sycl)
-// CREATE_IMAGE_PHASES: 20: offload, "device-sycl (spir64_gen-unknown-unknown)" {19}, object
-// CREATE_IMAGE_PHASES: 21: input, "[[INPUT]]", c++, (host-sycl)
-// CREATE_IMAGE_PHASES: 22: append-footer, {21}, c++, (host-sycl)
-// CREATE_IMAGE_PHASES: 23: preprocessor, {22}, c++-cpp-output, (host-sycl)
-// CREATE_IMAGE_PHASES: 24: offload, "host-sycl (x86_64-unknown-linux-gnu)" {23}, "device-sycl (spir64_gen-unknown-unknown)" {19}, c++-cpp-output
-// CREATE_IMAGE_PHASES: 25: compiler, {24}, ir, (host-sycl)
-// CREATE_IMAGE_PHASES: 26: backend, {25}, assembler, (host-sycl)
-// CREATE_IMAGE_PHASES: 27: assembler, {26}, object, (host-sycl)
-// CREATE_IMAGE_PHASES: 28: clang-offload-bundler, {20, 27}, object, (host-sycl)
+// CREATE_IMAGE_PHASES: 3: input, "{{.*}}libsycl-itt-user-wrappers.bc", ir, (device-sycl)
+// CREATE_IMAGE_PHASES: 4: input, "{{.*}}libsycl-itt-compiler-wrappers.bc", ir, (device-sycl)
+// CREATE_IMAGE_PHASES: 5: input, "{{.*}}libsycl-itt-stubs.bc", ir, (device-sycl)
+// CREATE_IMAGE_PHASES: 6: linker, {3, 4, 5}, ir, (device-sycl)
+// CREATE_IMAGE_PHASES: 7: linker, {2, 6}, ir, (device-sycl)
+// CREATE_IMAGE_PHASES: 8: sycl-post-link, {7}, tempfiletable, (device-sycl)
+// CREATE_IMAGE_PHASES: 9: file-table-tform, {8}, tempfilelist, (device-sycl)
+// CREATE_IMAGE_PHASES: 10: llvm-spirv, {9}, tempfilelist, (device-sycl)
+// CREATE_IMAGE_PHASES: 11: backend-compiler, {10}, image, (device-sycl)
+// CREATE_IMAGE_PHASES: 12: file-table-tform, {8, 11}, tempfiletable, (device-sycl)
+// CREATE_IMAGE_PHASES: 13: clang-offload-wrapper, {12}, object, (device-sycl)
+// CREATE_IMAGE_PHASES: 14: offload, "device-sycl (spir64_gen-unknown-unknown)" {13}, object
+// CREATE_IMAGE_PHASES: 15: input, "[[INPUT]]", c++, (host-sycl)
+// CREATE_IMAGE_PHASES: 16: append-footer, {15}, c++, (host-sycl)
+// CREATE_IMAGE_PHASES: 17: preprocessor, {16}, c++-cpp-output, (host-sycl)
+// CREATE_IMAGE_PHASES: 18: offload, "host-sycl (x86_64-unknown-linux-gnu)" {17}, "device-sycl (spir64_gen-unknown-unknown)" {13}, c++-cpp-output
+// CREATE_IMAGE_PHASES: 19: compiler, {18}, ir, (host-sycl)
+// CREATE_IMAGE_PHASES: 20: backend, {19}, assembler, (host-sycl)
+// CREATE_IMAGE_PHASES: 21: assembler, {20}, object, (host-sycl)
+// CREATE_IMAGE_PHASES: 22: clang-offload-bundler, {14, 21}, object, (host-sycl)
 
 // Use of -fno-sycl-rdc -c with non-AOT should not perform the device link.
 // RUN: %clangxx -c -fno-sycl-rdc -fsycl -fsycl-targets=spir64 \
@@ -88,32 +82,26 @@
 // JIT_AOT_PHASES: 4: input, "[[INPUT]]", c++, (device-sycl)
 // JIT_AOT_PHASES: 5: preprocessor, {4}, c++-cpp-output, (device-sycl)
 // JIT_AOT_PHASES: 6: compiler, {5}, ir, (device-sycl)
-// JIT_AOT_PHASES: 7: input, "{{.*libsycl-itt-user-wrappers.o.*}}", object
-// JIT_AOT_PHASES: 8: clang-offload-unbundler, {7}, object
-// JIT_AOT_PHASES: 9: offload, " (spir64_gen-unknown-unknown)" {8}, object
-// JIT_AOT_PHASES: 10: input, "{{.*libsycl-itt-compiler-wrappers.o.*}}", object
-// JIT_AOT_PHASES: 11: clang-offload-unbundler, {10}, object
-// JIT_AOT_PHASES: 12: offload, " (spir64_gen-unknown-unknown)" {11}, object
-// JIT_AOT_PHASES: 13: input, "{{.*libsycl-itt-stubs.o.*}}", object
-// JIT_AOT_PHASES: 14: clang-offload-unbundler, {13}, object
-// JIT_AOT_PHASES: 15: offload, " (spir64_gen-unknown-unknown)" {14}, object
-// JIT_AOT_PHASES: 16: linker, {9, 12, 15}, ir, (device-sycl)
-// JIT_AOT_PHASES: 17: linker, {6, 16}, ir, (device-sycl)
-// JIT_AOT_PHASES: 18: sycl-post-link, {17}, tempfiletable, (device-sycl)
-// JIT_AOT_PHASES: 19: file-table-tform, {18}, tempfilelist, (device-sycl)
-// JIT_AOT_PHASES: 20: llvm-spirv, {19}, tempfilelist, (device-sycl)
-// JIT_AOT_PHASES: 21: backend-compiler, {20}, image, (device-sycl)
-// JIT_AOT_PHASES: 22: file-table-tform, {18, 21}, tempfiletable, (device-sycl)
-// JIT_AOT_PHASES: 23: clang-offload-wrapper, {22}, object, (device-sycl)
-// JIT_AOT_PHASES: 24: offload, "device-sycl (spir64_gen-unknown-unknown)" {23}, object
-// JIT_AOT_PHASES: 25: input, "[[INPUT]]", c++, (host-sycl)
-// JIT_AOT_PHASES: 26: append-footer, {25}, c++, (host-sycl)
-// JIT_AOT_PHASES: 27: preprocessor, {26}, c++-cpp-output, (host-sycl)
-// JIT_AOT_PHASES: 28: offload, "host-sycl (x86_64-unknown-linux-gnu)" {27}, "device-sycl (spir64_gen-unknown-unknown)" {23}, c++-cpp-output
-// JIT_AOT_PHASES: 29: compiler, {28}, ir, (host-sycl)
-// JIT_AOT_PHASES: 30: backend, {29}, assembler, (host-sycl)
-// JIT_AOT_PHASES: 31: assembler, {30}, object, (host-sycl)
-// JIT_AOT_PHASES: 32: clang-offload-bundler, {3, 24, 31}, object, (host-sycl)
+// JIT_AOT_PHASES: 7: input, "{{.*}}libsycl-itt-user-wrappers.bc", ir, (device-sycl)
+// JIT_AOT_PHASES: 8: input, "{{.*}}libsycl-itt-compiler-wrappers.bc", ir, (device-sycl)
+// JIT_AOT_PHASES: 9: input, "{{.*}}libsycl-itt-stubs.bc", ir, (device-sycl)
+// JIT_AOT_PHASES: 10: linker, {7, 8, 9}, ir, (device-sycl)
+// JIT_AOT_PHASES: 11: linker, {6, 10}, ir, (device-sycl)
+// JIT_AOT_PHASES: 12: sycl-post-link, {11}, tempfiletable, (device-sycl)
+// JIT_AOT_PHASES: 13: file-table-tform, {12}, tempfilelist, (device-sycl)
+// JIT_AOT_PHASES: 14: llvm-spirv, {13}, tempfilelist, (device-sycl)
+// JIT_AOT_PHASES: 15: backend-compiler, {14}, image, (device-sycl)
+// JIT_AOT_PHASES: 16: file-table-tform, {12, 15}, tempfiletable, (device-sycl)
+// JIT_AOT_PHASES: 17: clang-offload-wrapper, {16}, object, (device-sycl)
+// JIT_AOT_PHASES: 18: offload, "device-sycl (spir64_gen-unknown-unknown)" {17}, object
+// JIT_AOT_PHASES: 19: input, "[[INPUT]]", c++, (host-sycl)
+// JIT_AOT_PHASES: 20: append-footer, {19}, c++, (host-sycl)
+// JIT_AOT_PHASES: 21: preprocessor, {20}, c++-cpp-output, (host-sycl)
+// JIT_AOT_PHASES: 22: offload, "host-sycl (x86_64-unknown-linux-gnu)" {21}, "device-sycl (spir64_gen-unknown-unknown)" {17}, c++-cpp-output
+// JIT_AOT_PHASES: 23: compiler, {22}, ir, (host-sycl)
+// JIT_AOT_PHASES: 24: backend, {23}, assembler, (host-sycl)
+// JIT_AOT_PHASES: 25: assembler, {24}, object, (host-sycl)
+// JIT_AOT_PHASES: 26: clang-offload-bundler, {3, 18, 25}, object, (host-sycl)
 
 // Consume object and library that contain final device images.
 // RUN: %clangxx -fsycl --target=x86_64-unknown-linux-gnu -### \

--- a/clang/test/Driver/sycl-force-target.cpp
+++ b/clang/test/Driver/sycl-force-target.cpp
@@ -18,7 +18,7 @@
 // CHECK_FORCE_TARGET: clang-offload-bundler{{.*}} "-type=o" "-targets=host-{{.*}},sycl-spir64-unknown-unknown" "-input={{.*}}" "-output={{.*}}" "-output=[[DEVICEOBJECTOUT:.+]]" "-unbundle" "-allow-missing-bundles"
 // CHECK_FORCE_TARGET: spirv-to-ir-wrapper{{.*}} "[[DEVICEOBJECTOUT]]" "-o" "[[DEVICEOBJECTBC:.+\.bc]]"
 // CHECK_FORCE_TARGET: llvm-link{{.*}} "[[DEVICEOBJECTBC]]"{{.*}} "-o" "[[DEVICEOBJLINKED:.+\.bc]]" "--suppress-warnings"
-// CHECK_FORCE_TARGET: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-complex{{.*}}" "-output={{.*}}libsycl-complex-{{.*}}" "-unbundle"
+// CHECK_FORCE_TARGET: llvm-link{{.*}} "{{.*}}libsycl-complex{{.*}}"
 // CHECK_FORCE_TARGET_GEN: llvm-foreach{{.*}} {{.*}}ocloc{{.*}}
 // CHECK_FORCE_TARGET_CPU: llvm-foreach{{.*}} {{.*}}opencl-aot{{.*}}
 

--- a/clang/test/Driver/sycl-instrumentation.c
+++ b/clang/test/Driver/sycl-instrumentation.c
@@ -14,10 +14,10 @@
 // RUN: | FileCheck -check-prefixes=CHECK-SPIRV %s
 
 // CHECK-SPIRV: "-cc1"{{.*}} "-fsycl-is-device"{{.*}} "-fsycl-instrument-device-code"
-// CHECK-SPIRV: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-user-wrappers.{{o|obj}}" "-output={{.*}}libsycl-itt-user-wrappers-{{.*}}.{{o|obj}}" "-unbundle"
-// CHECK-SPIRV: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-compiler-wrappers.{{o|obj}}" "-output={{.*}}libsycl-itt-compiler-wrappers-{{.*}}.{{o|obj}}" "-unbundle"
-// CHECK-SPIRV: clang-offload-bundler{{.*}} "-type=o" "-targets=sycl-spir64-unknown-unknown" "-input={{.*}}libsycl-itt-stubs.{{o|obj}}" "-output={{.*}}libsycl-itt-stubs-{{.*}}.{{o|obj}}" "-unbundle"
-// CHECK-SPIRV: llvm-link{{.*}} "-only-needed" "{{.*}}" "-o" "{{.*}}.bc" "--suppress-warnings"
+// CHECK-SPIRV: llvm-link{{.*}} "-only-needed"
+// CHECK-SPIRV-SAME: "{{.*}}libsycl-itt-user-wrappers.bc"
+// CHECK-SPIRV-SAME: "{{.*}}libsycl-itt-compiler-wrappers.bc"
+// CHECK-SPIRV-SAME: "{{.*}}libsycl-itt-stubs.bc"
 // CHECK-HOST-NOT: "-cc1"{{.*}} "-fsycl-is-host"{{.*}} "-fsycl-instrument-device-code"
 
 // RUN: %clangxx -fsycl -fno-sycl-instrument-device-code -fsycl-targets=spir64 -### %s 2>&1 \
@@ -26,4 +26,4 @@
 // RUN: | FileCheck -check-prefixes=CHECK-NONPASSED %s
 
 // CHECK-NONPASSED-NOT: "-fsycl-instrument-device-code"
-// CHECK-NONPASSED-NOT: "-input={{.*}}libsycl-itt-{{.*}}.{{o|obj}}"
+// CHECK-NONPASSED-NOT: llvm-link{{.*}} {{.*}}libsycl-itt-{{.*}}.bc"

--- a/clang/test/Driver/sycl-no-rdc-fat-archive.cpp
+++ b/clang/test/Driver/sycl-no-rdc-fat-archive.cpp
@@ -12,21 +12,19 @@
 // CHECK: 1: input, "{{.*}}_lib.a", archive
 // CHECK: 2: clang-offload-unbundler, {1}, tempfilelist
 // CHECK: 3: spirv-to-ir-wrapper, {2}, tempfilelist, (device-sycl)
-// CHECK: 4: input, "{{.*}}libsycl-crt{{.*}}", object
-// CHECK: 5: clang-offload-unbundler, {4}, object
-// CHECK: 6: offload, " (spir64-unknown-unknown)" {5}, object
-// CHECK: 64: linker, {6, {{.*}}}, ir, (device-sycl)
-// CHECK: 65: linker, {3, 64}, ir, (device-sycl)
-// CHECK: 66: foreach, {3, 65}, ir, (device-sycl)
-// CHECK: 67: file-table-tform, {3, 66}, tempfilelist, (device-sycl)
-// CHECK: 68: sycl-post-link, {67}, tempfiletable, (device-sycl)
-// CHECK: 69: foreach, {67, 68}, tempfiletable, (device-sycl)
-// CHECK: 70: file-table-tform, {69}, tempfilelist, (device-sycl)
-// CHECK: 71: file-table-tform, {69}, tempfilelist, (device-sycl)
-// CHECK: 72: foreach, {67, 71}, tempfilelist, (device-sycl)
-// CHECK: 73: file-table-tform, {72}, tempfilelist, (device-sycl)
-// CHECK: 74: llvm-spirv, {73}, tempfilelist, (device-sycl)
-// CHECK: 75: file-table-tform, {70, 74}, tempfiletable, (device-sycl)
-// CHECK: 76: clang-offload-wrapper, {75}, object, (device-sycl)
-// CHECK: 77: offload, "device-sycl (spir64-unknown-unknown)" {76}, object
-// CHECK: 78: linker, {0, 77}, image, (host-sycl)
+// CHECK: 4: input, "{{.*}}libsycl-crt.bc", ir, (device-sycl)
+// CHECK: 24: linker, {4, {{.*}}}, ir, (device-sycl)
+// CHECK: 25: linker, {3, 24}, ir, (device-sycl)
+// CHECK: 26: foreach, {3, 25}, ir, (device-sycl)
+// CHECK: 27: file-table-tform, {3, 26}, tempfilelist, (device-sycl)
+// CHECK: 28: sycl-post-link, {27}, tempfiletable, (device-sycl)
+// CHECK: 29: foreach, {27, 28}, tempfiletable, (device-sycl)
+// CHECK: 30: file-table-tform, {29}, tempfilelist, (device-sycl)
+// CHECK: 31: file-table-tform, {29}, tempfilelist, (device-sycl)
+// CHECK: 32: foreach, {27, 31}, tempfilelist, (device-sycl)
+// CHECK: 33: file-table-tform, {32}, tempfilelist, (device-sycl)
+// CHECK: 34: llvm-spirv, {33}, tempfilelist, (device-sycl)
+// CHECK: 35: file-table-tform, {30, 34}, tempfiletable, (device-sycl)
+// CHECK: 36: clang-offload-wrapper, {35}, object, (device-sycl)
+// CHECK: 37: offload, "device-sycl (spir64-unknown-unknown)" {36}, object
+// CHECK: 38: linker, {0, 37}, image, (host-sycl)

--- a/clang/test/Driver/sycl-no-rdc.cpp
+++ b/clang/test/Driver/sycl-no-rdc.cpp
@@ -11,22 +11,20 @@
 // CHECK: 13: input, "{{.*}}2.cpp", c++, (device-sycl)
 // CHECK: 14: preprocessor, {13}, c++-cpp-output, (device-sycl)
 // CHECK: 15: compiler, {14}, ir, (device-sycl)
-// CHECK: 20: input, {{.*}}libsycl-crt{{.*}}, object
-// CHECK: 21: clang-offload-unbundler, {20}, object
-// CHECK: 22: offload, " (spir64-unknown-unknown)" {21}, object
-// CHECK: 80: linker, {22, {{.*}}}, ir, (device-sycl)
-// CHECK: 81: linker, {5, 80}, ir, (device-sycl)
-// CHECK: 82: sycl-post-link, {81}, tempfiletable, (device-sycl)
-// CHECK: 83: file-table-tform, {82}, tempfilelist, (device-sycl)
-// CHECK: 84: llvm-spirv, {83}, tempfilelist, (device-sycl)
-// CHECK: 85: file-table-tform, {82, 84}, tempfiletable, (device-sycl)
-// CHECK: 86: clang-offload-wrapper, {85}, object, (device-sycl)
-// CHECK: 87: offload, "device-sycl (spir64-unknown-unknown)" {86}, object
-// CHECK: 88: linker, {15, 80}, ir, (device-sycl)
-// CHECK: 89: sycl-post-link, {88}, tempfiletable, (device-sycl)
-// CHECK: 90: file-table-tform, {89}, tempfilelist, (device-sycl)
-// CHECK: 91: llvm-spirv, {90}, tempfilelist, (device-sycl)
-// CHECK: 92: file-table-tform, {89, 91}, tempfiletable, (device-sycl)
-// CHECK: 93: clang-offload-wrapper, {92}, object, (device-sycl)
-// CHECK: 94: offload, "device-sycl (spir64-unknown-unknown)" {93}, object
-// CHECK: 95: linker, {9, 19, 87, 94}, image, (host-sycl)
+// CHECK: 20: input, "{{.*}}libsycl-crt.bc", ir, (device-sycl)
+// CHECK: 40: linker, {20, {{.*}}}, ir, (device-sycl)
+// CHECK: 41: linker, {5, 40}, ir, (device-sycl)
+// CHECK: 42: sycl-post-link, {41}, tempfiletable, (device-sycl)
+// CHECK: 43: file-table-tform, {42}, tempfilelist, (device-sycl)
+// CHECK: 44: llvm-spirv, {43}, tempfilelist, (device-sycl)
+// CHECK: 45: file-table-tform, {42, 44}, tempfiletable, (device-sycl)
+// CHECK: 46: clang-offload-wrapper, {45}, object, (device-sycl)
+// CHECK: 47: offload, "device-sycl (spir64-unknown-unknown)" {46}, object
+// CHECK: 48: linker, {15, 40}, ir, (device-sycl)
+// CHECK: 49: sycl-post-link, {48}, tempfiletable, (device-sycl)
+// CHECK: 50: file-table-tform, {49}, tempfilelist, (device-sycl)
+// CHECK: 51: llvm-spirv, {50}, tempfilelist, (device-sycl)
+// CHECK: 52: file-table-tform, {49, 51}, tempfiletable, (device-sycl)
+// CHECK: 53: clang-offload-wrapper, {52}, object, (device-sycl)
+// CHECK: 54: offload, "device-sycl (spir64-unknown-unknown)" {53}, object
+// CHECK: 55: linker, {9, 19, 47, 54}, image, (host-sycl)

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -38,7 +38,7 @@
 // RUN:          --sysroot=%S/Inputs/SYCL -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS %s
 // WRAPPER_OPTIONS: clang-linker-wrapper{{.*}} "--triple=spir64"
-// WRAPPER_OPTIONS-SAME: "-sycl-device-libraries=libsycl-crt.o,libsycl-complex.o,libsycl-complex-fp64.o,libsycl-cmath.o,libsycl-cmath-fp64.o,libsycl-imf.o,libsycl-imf-fp64.o,libsycl-imf-bf16.o,libsycl-itt-user-wrappers.o,libsycl-itt-compiler-wrappers.o,libsycl-itt-stubs.o"
+// WRAPPER_OPTIONS-SAME: "-sycl-device-libraries=libsycl-crt.bc,libsycl-complex.bc,libsycl-complex-fp64.bc,libsycl-cmath.bc,libsycl-cmath-fp64.bc,libsycl-imf.bc,libsycl-imf-fp64.bc,libsycl-imf-bf16.bc,libsycl-itt-user-wrappers.bc,libsycl-itt-compiler-wrappers.bc,libsycl-itt-stubs.bc"
 // WRAPPER_OPTIONS-SAME: "-sycl-device-library-location={{.*}}/lib"
 
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \

--- a/clang/test/Driver/sycl-offload-nvptx.cpp
+++ b/clang/test/Driver/sycl-offload-nvptx.cpp
@@ -54,28 +54,22 @@
 // CHK-PHASES-NO-CC: 8: backend, {7}, assembler, (host-sycl)
 // CHK-PHASES-NO-CC: 9: assembler, {8}, object, (host-sycl)
 // CHK-PHASES-NO-CC: 10: linker, {5}, ir, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 11: input, "{{.*}}libsycl-itt-user-wrappers.o", object
-// CHK-PHASES-NO-CC: 12: clang-offload-unbundler, {11}, object
-// CHK-PHASES-NO-CC: 13: offload, " (nvptx64-nvidia-cuda)" {12}, object
-// CHK-PHASES-NO-CC: 14: input, "{{.*}}libsycl-itt-compiler-wrappers.o", object
-// CHK-PHASES-NO-CC: 15: clang-offload-unbundler, {14}, object
-// CHK-PHASES-NO-CC: 16: offload, " (nvptx64-nvidia-cuda)" {15}, object
-// CHK-PHASES-NO-CC: 17: input, "{{.*}}libsycl-itt-stubs.o", object
-// CHK-PHASES-NO-CC: 18: clang-offload-unbundler, {17}, object
-// CHK-PHASES-NO-CC: 19: offload, " (nvptx64-nvidia-cuda)" {18}, object
-// CHK-PHASES-NO-CC: 20: input, "{{.*}}nvidiacl{{.*}}", ir, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 21: input, "{{.*}}libdevice{{.*}}", ir, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 22: linker, {10, 13, 16, 19, 20, 21}, ir, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 23: sycl-post-link, {22}, ir, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 24: file-table-tform, {23}, ir, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 25: backend, {24}, assembler, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 26: assembler, {25}, object, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 27: linker, {25, 26}, cuda-fatbin, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 28: foreach, {24, 27}, cuda-fatbin, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 29: file-table-tform, {23, 28}, tempfiletable, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 30: clang-offload-wrapper, {29}, object, (device-sycl, sm_50)
-// CHK-PHASES-NO-CC: 31: offload, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {30}, object
-// CHK-PHASES-NO-CC: 32: linker, {9, 31}, image, (host-sycl)
+// CHK-PHASES-NO-CC: 11: input, "{{.*}}libsycl-itt-user-wrappers.bc", ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 12: input, "{{.*}}libsycl-itt-compiler-wrappers.bc", ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 13: input, "{{.*}}libsycl-itt-stubs.bc", ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 14: input, "{{.*}}nvidiacl{{.*}}", ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 15: input, "{{.*}}libdevice{{.*}}", ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 16: linker, {10, 11, 12, 13, 14, 15}, ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 17: sycl-post-link, {16}, ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 18: file-table-tform, {17}, ir, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 19: backend, {18}, assembler, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 20: assembler, {19}, object, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 21: linker, {19, 20}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 22: foreach, {18, 21}, cuda-fatbin, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 23: file-table-tform, {17, 22}, tempfiletable, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 24: clang-offload-wrapper, {23}, object, (device-sycl, sm_50)
+// CHK-PHASES-NO-CC: 25: offload, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {24}, object
+// CHK-PHASES-NO-CC: 26: linker, {9, 25}, image, (host-sycl)
 //
 /// Check phases specifying a compute capability.
 // RUN: %clangxx -ccc-print-phases --sysroot=%S/Inputs/SYCL -std=c++11 \
@@ -99,28 +93,22 @@
 // CHK-PHASES: 8: backend, {7}, assembler, (host-sycl)
 // CHK-PHASES: 9: assembler, {8}, object, (host-sycl)
 // CHK-PHASES: 10: linker, {5}, ir, (device-sycl, sm_35)
-// CHK-PHASES: 11: input, "{{.*}}libsycl-itt-user-wrappers.o", object
-// CHK-PHASES: 12: clang-offload-unbundler, {11}, object
-// CHK-PHASES: 13: offload, " (nvptx64-nvidia-cuda)" {12}, object
-// CHK-PHASES: 14: input, "{{.*}}libsycl-itt-compiler-wrappers.o", object
-// CHK-PHASES: 15: clang-offload-unbundler, {14}, object
-// CHK-PHASES: 16: offload, " (nvptx64-nvidia-cuda)" {15}, object
-// CHK-PHASES: 17: input, "{{.*}}libsycl-itt-stubs.o", object
-// CHK-PHASES: 18: clang-offload-unbundler, {17}, object
-// CHK-PHASES: 19: offload, " (nvptx64-nvidia-cuda)" {18}, object
-// CHK-PHASES: 20: input, "{{.*}}nvidiacl{{.*}}", ir, (device-sycl, sm_35)
-// CHK-PHASES: 21: input, "{{.*}}libdevice{{.*}}", ir, (device-sycl, sm_35)
-// CHK-PHASES: 22: linker, {10, 13, 16, 19, 20, 21}, ir, (device-sycl, sm_35)
-// CHK-PHASES: 23: sycl-post-link, {22}, ir, (device-sycl, sm_35)
-// CHK-PHASES: 24: file-table-tform, {23}, ir, (device-sycl, sm_35)
-// CHK-PHASES: 25: backend, {24}, assembler, (device-sycl, sm_35)
-// CHK-PHASES: 26: assembler, {25}, object, (device-sycl, sm_35)
-// CHK-PHASES: 27: linker, {25, 26}, cuda-fatbin, (device-sycl, sm_35)
-// CHK-PHASES: 28: foreach, {24, 27}, cuda-fatbin, (device-sycl, sm_35)
-// CHK-PHASES: 29: file-table-tform, {23, 28}, tempfiletable, (device-sycl, sm_35)
-// CHK-PHASES: 30: clang-offload-wrapper, {29}, object, (device-sycl, sm_35)
-// CHK-PHASES: 31: offload, "device-sycl (nvptx64-nvidia-cuda:sm_35)" {30}, object
-// CHK-PHASES: 32: linker, {9, 31}, image, (host-sycl)
+// CHK-PHASES: 11: input, "{{.*}}libsycl-itt-user-wrappers.bc", ir, (device-sycl, sm_35)
+// CHK-PHASES: 12: input, "{{.*}}libsycl-itt-compiler-wrappers.bc", ir, (device-sycl, sm_35)
+// CHK-PHASES: 13: input, "{{.*}}libsycl-itt-stubs.bc", ir, (device-sycl, sm_35)
+// CHK-PHASES: 14: input, "{{.*}}nvidiacl{{.*}}", ir, (device-sycl, sm_35)
+// CHK-PHASES: 15: input, "{{.*}}libdevice{{.*}}", ir, (device-sycl, sm_35)
+// CHK-PHASES: 16: linker, {10, 11, 12, 13, 14, 15}, ir, (device-sycl, sm_35)
+// CHK-PHASES: 17: sycl-post-link, {16}, ir, (device-sycl, sm_35)
+// CHK-PHASES: 18: file-table-tform, {17}, ir, (device-sycl, sm_35)
+// CHK-PHASES: 19: backend, {18}, assembler, (device-sycl, sm_35)
+// CHK-PHASES: 20: assembler, {19}, object, (device-sycl, sm_35)
+// CHK-PHASES: 21: linker, {19, 20}, cuda-fatbin, (device-sycl, sm_35)
+// CHK-PHASES: 22: foreach, {18, 21}, cuda-fatbin, (device-sycl, sm_35)
+// CHK-PHASES: 23: file-table-tform, {17, 22}, tempfiletable, (device-sycl, sm_35)
+// CHK-PHASES: 24: clang-offload-wrapper, {23}, object, (device-sycl, sm_35)
+// CHK-PHASES: 25: offload, "device-sycl (nvptx64-nvidia-cuda:sm_35)" {24}, object
+// CHK-PHASES: 26: linker, {9, 25}, image, (host-sycl)
 
 /// Check calling preprocessor only
 // RUN: %clangxx -E -fsycl -fsycl-targets=nvptx64-nvidia-cuda -ccc-print-phases %s 2>&1 \

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -2,12 +2,16 @@ set(obj_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
 if (MSVC)
   set(lib-suffix obj)
   set(spv_binary_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
+  set(bc_binary_dir "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
   set(install_dest_spv bin)
+  set(install_dest_bc bin)
   set(devicelib_host_static sycl-devicelib-host.lib)
 else()
   set(lib-suffix o)
   set(spv_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
+  set(bc_binary_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}")
   set(install_dest_spv lib${LLVM_LIBDIR_SUFFIX})
+  set(install_dest_bc lib${LLVM_LIBDIR_SUFFIX})
   set(devicelib_host_static libsycl-devicelib-host.a)
 endif()
 set(install_dest_lib lib${LLVM_LIBDIR_SUFFIX})
@@ -62,10 +66,12 @@ endif()
 
 add_custom_target(libsycldevice-obj)
 add_custom_target(libsycldevice-spv)
+add_custom_target(libsycldevice-bc)
 
 add_custom_target(libsycldevice DEPENDS
   libsycldevice-obj
-  libsycldevice-spv)
+  libsycldevice-spv
+  libsycldevice-bc)
 
 function(add_devicelib_obj obj_filename)
   cmake_parse_arguments(OBJ  "" "" "SRC;DEP;EXTRA_ARGS" ${ARGN})
@@ -105,10 +111,31 @@ function(add_devicelib_spv spv_filename)
           COMPONENT libsycldevice)
 endfunction()
 
-function(add_fallback_devicelib fallback_filename)
-  cmake_parse_arguments(FB "" "" "SRC;DEP;EXTRA_ARGS" ${ARGN})
-  add_devicelib_spv(${fallback_filename} SRC ${FB_SRC} DEP ${FB_DEP} EXTRA_ARGS ${FB_EXTRA_ARGS})
-  add_devicelib_obj(${fallback_filename} SRC ${FB_SRC} DEP ${FB_DEP} EXTRA_ARGS ${FB_EXTRA_ARGS})
+function(add_devicelib_bc bc_filename)
+  cmake_parse_arguments(BC  "" "" "SRC;DEP;EXTRA_ARGS" ${ARGN})
+  set(devicelib-bc-file ${bc_binary_dir}/${bc_filename}.bc)
+  add_custom_command(OUTPUT ${devicelib-bc-file}
+                     COMMAND ${clang} -fsycl-device-only
+                             -fsycl-device-obj=llvmir ${compile_opts}
+                             ${BC_EXTRA_ARGS}
+                             ${CMAKE_CURRENT_SOURCE_DIR}/${BC_SRC}
+                             -o ${devicelib-bc-file}
+                     MAIN_DEPENDENCY ${BC_SRC}
+                     DEPENDS ${BC_DEP}
+                     VERBATIM)
+  set(devicelib-bc-target ${bc_filename}-bc)
+  add_custom_target(${devicelib-bc-target} DEPENDS ${devicelib-bc-file})
+  add_dependencies(libsycldevice-bc ${devicelib-bc-target})
+  install(FILES ${devicelib-bc-file}
+          DESTINATION ${install_dest_bc}
+          COMPONENT libsycldevice)
+endfunction()
+
+function(add_devicelib filename)
+  cmake_parse_arguments(DL "" "" "SRC;DEP;EXTRA_ARGS" ${ARGN})
+  add_devicelib_spv(${filename} SRC ${DL_SRC} DEP ${DL_DEP} EXTRA_ARGS ${DL_EXTRA_ARGS})
+  add_devicelib_bc(${filename} SRC ${DL_SRC} DEP ${DL_DEP} EXTRA_ARGS ${DL_EXTRA_ARGS})
+  add_devicelib_obj(${filename} SRC ${DL_SRC} DEP ${DL_DEP} EXTRA_ARGS ${DL_EXTRA_ARGS})
 endfunction()
 
 set(crt_obj_deps wrapper.h device.h spirv_vars.h sycl-compiler)
@@ -121,33 +148,33 @@ if (NOT MSVC)
   set(sanitizer_obj_deps device.h atomic.hpp spirv_vars.h include/sanitizer_device_utils.hpp include/spir_global_var.hpp sycl-compiler)
 endif()
 
-add_devicelib_obj(libsycl-itt-stubs SRC itt_stubs.cpp DEP ${itt_obj_deps})
-add_devicelib_obj(libsycl-itt-compiler-wrappers SRC itt_compiler_wrappers.cpp DEP ${itt_obj_deps})
-add_devicelib_obj(libsycl-itt-user-wrappers SRC itt_user_wrappers.cpp DEP ${itt_obj_deps})
+add_devicelib(libsycl-itt-stubs SRC itt_stubs.cpp DEP ${itt_obj_deps})
+add_devicelib(libsycl-itt-compiler-wrappers SRC itt_compiler_wrappers.cpp DEP ${itt_obj_deps})
+add_devicelib(libsycl-itt-user-wrappers SRC itt_user_wrappers.cpp DEP ${itt_obj_deps})
 
-add_devicelib_obj(libsycl-crt SRC crt_wrapper.cpp DEP ${crt_obj_deps})
-add_devicelib_obj(libsycl-complex SRC complex_wrapper.cpp DEP ${complex_obj_deps})
-add_devicelib_obj(libsycl-complex-fp64 SRC complex_wrapper_fp64.cpp DEP ${complex_obj_deps} )
-add_devicelib_obj(libsycl-cmath SRC cmath_wrapper.cpp DEP ${cmath_obj_deps})
-add_devicelib_obj(libsycl-cmath-fp64 SRC cmath_wrapper_fp64.cpp DEP ${cmath_obj_deps} )
-add_devicelib_obj(libsycl-imf SRC imf_wrapper.cpp DEP ${imf_obj_deps})
-add_devicelib_obj(libsycl-imf-fp64 SRC imf_wrapper_fp64.cpp DEP ${imf_obj_deps})
-add_devicelib_obj(libsycl-imf-bf16 SRC imf_wrapper_bf16.cpp DEP ${imf_obj_deps})
-add_devicelib_obj(libsycl-bfloat16 SRC bfloat16_wrapper.cpp DEP ${cmath_obj_deps} )
+add_devicelib(libsycl-crt SRC crt_wrapper.cpp DEP ${crt_obj_deps})
+add_devicelib(libsycl-complex SRC complex_wrapper.cpp DEP ${complex_obj_deps})
+add_devicelib(libsycl-complex-fp64 SRC complex_wrapper_fp64.cpp DEP ${complex_obj_deps} )
+add_devicelib(libsycl-cmath SRC cmath_wrapper.cpp DEP ${cmath_obj_deps})
+add_devicelib(libsycl-cmath-fp64 SRC cmath_wrapper_fp64.cpp DEP ${cmath_obj_deps} )
+add_devicelib(libsycl-imf SRC imf_wrapper.cpp DEP ${imf_obj_deps})
+add_devicelib(libsycl-imf-fp64 SRC imf_wrapper_fp64.cpp DEP ${imf_obj_deps})
+add_devicelib(libsycl-imf-bf16 SRC imf_wrapper_bf16.cpp DEP ${imf_obj_deps})
+add_devicelib(libsycl-bfloat16 SRC bfloat16_wrapper.cpp DEP ${cmath_obj_deps} )
 if(MSVC)
-  add_devicelib_obj(libsycl-msvc-math SRC msvc_math.cpp DEP ${cmath_obj_deps})
+  add_devicelib(libsycl-msvc-math SRC msvc_math.cpp DEP ${cmath_obj_deps})
 else()
-  add_devicelib_obj(libsycl-sanitizer SRC sanitizer_utils.cpp DEP ${sanitizer_obj_deps} EXTRA_ARGS -fno-sycl-instrument-device-code)
+  add_devicelib(libsycl-sanitizer SRC sanitizer_utils.cpp DEP ${sanitizer_obj_deps} EXTRA_ARGS -fno-sycl-instrument-device-code)
 endif()
 
-add_fallback_devicelib(libsycl-fallback-cassert SRC fallback-cassert.cpp DEP ${crt_obj_deps} EXTRA_ARGS -fno-sycl-instrument-device-code)
-add_fallback_devicelib(libsycl-fallback-cstring SRC fallback-cstring.cpp DEP ${crt_obj_deps})
-add_fallback_devicelib(libsycl-fallback-complex SRC fallback-complex.cpp DEP ${complex_obj_deps})
-add_fallback_devicelib(libsycl-fallback-complex-fp64 SRC fallback-complex-fp64.cpp DEP ${complex_obj_deps} )
-add_fallback_devicelib(libsycl-fallback-cmath SRC fallback-cmath.cpp DEP ${cmath_obj_deps})
-add_fallback_devicelib(libsycl-fallback-cmath-fp64 SRC fallback-cmath-fp64.cpp DEP ${cmath_obj_deps})
-add_fallback_devicelib(libsycl-fallback-bfloat16 SRC fallback-bfloat16.cpp DEP ${bfloat16_obj_deps})
-add_fallback_devicelib(libsycl-native-bfloat16 SRC bfloat16_wrapper.cpp DEP ${bfloat16_obj_deps})
+add_devicelib(libsycl-fallback-cassert SRC fallback-cassert.cpp DEP ${crt_obj_deps} EXTRA_ARGS -fno-sycl-instrument-device-code)
+add_devicelib(libsycl-fallback-cstring SRC fallback-cstring.cpp DEP ${crt_obj_deps})
+add_devicelib(libsycl-fallback-complex SRC fallback-complex.cpp DEP ${complex_obj_deps})
+add_devicelib(libsycl-fallback-complex-fp64 SRC fallback-complex-fp64.cpp DEP ${complex_obj_deps} )
+add_devicelib(libsycl-fallback-cmath SRC fallback-cmath.cpp DEP ${cmath_obj_deps})
+add_devicelib(libsycl-fallback-cmath-fp64 SRC fallback-cmath-fp64.cpp DEP ${cmath_obj_deps})
+add_devicelib(libsycl-fallback-bfloat16 SRC fallback-bfloat16.cpp DEP ${bfloat16_obj_deps})
+add_devicelib(libsycl-native-bfloat16 SRC bfloat16_wrapper.cpp DEP ${bfloat16_obj_deps})
 
 file(MAKE_DIRECTORY ${obj_binary_dir}/libdevice)
 set(imf_fallback_src_dir ${obj_binary_dir}/libdevice)
@@ -206,6 +233,15 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-imf.spv
                    DEPENDS ${imf_fallback_fp32_deps} get_imf_fallback_fp32 sycl-compiler
                    VERBATIM)
 
+add_custom_command(OUTPUT ${bc_binary_dir}/libsycl-fallback-imf.bc
+                   COMMAND ${clang} -fsycl-device-only -fsycl-device-obj=llvmir
+                           ${compile_opts} -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
+                           ${imf_fp32_fallback_src}
+                           -o ${bc_binary_dir}/libsycl-fallback-imf.bc
+                   DEPENDS ${imf_fallback_fp32_deps} get_imf_fallback_fp32
+                           sycl-compiler
+                   VERBATIM)
+
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf.${lib-suffix}
                    COMMAND ${clang} -fsycl -c
                            ${compile_opts} ${sycl_targets_opt}
@@ -229,6 +265,15 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-imf-fp64.spv
                            ${imf_fp64_fallback_src}
                            -o ${spv_binary_dir}/libsycl-fallback-imf-fp64.spv
                    DEPENDS ${imf_fallback_fp64_deps} get_imf_fallback_fp64 sycl-compiler
+                   VERBATIM)
+
+add_custom_command(OUTPUT ${bc_binary_dir}/libsycl-fallback-imf-fp64.bc
+                   COMMAND ${clang} -fsycl-device-only -fsycl-device-obj=llvmir
+                           ${compile_opts} -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
+                           ${imf_fp64_fallback_src}
+                           -o ${bc_binary_dir}/libsycl-fallback-imf-fp64.bc
+                   DEPENDS ${imf_fallback_fp64_deps} get_imf_fallback_fp64
+                           sycl-compiler
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf-fp64.${lib-suffix}
@@ -256,6 +301,15 @@ add_custom_command(OUTPUT ${spv_binary_dir}/libsycl-fallback-imf-bf16.spv
                    DEPENDS ${imf_fallback_bf16_deps} get_imf_fallback_bf16 sycl-compiler
                    VERBATIM)
 
+add_custom_command(OUTPUT ${bc_binary_dir}/libsycl-fallback-imf-bf16.bc
+                   COMMAND ${clang} -fsycl-device-only -fsycl-device-obj=llvmir
+                           ${compile_opts} -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
+                           ${imf_bf16_fallback_src}
+                           -o ${bc_binary_dir}/libsycl-fallback-imf-bf16.bc
+                   DEPENDS ${imf_fallback_bf16_deps} get_imf_fallback_bf16
+                           sycl-compiler
+                   VERBATIM)
+
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf-bf16.${lib-suffix}
                    COMMAND ${clang} -fsycl -c -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
                            ${compile_opts} ${sycl_targets_opt}
@@ -273,21 +327,27 @@ add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-bf16-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_target(imf_fallback_fp32_spv DEPENDS ${spv_binary_dir}/libsycl-fallback-imf.spv)
+add_custom_target(imf_fallback_fp32_bc DEPENDS ${bc_binary_dir}/libsycl-fallback-imf.bc)
 add_custom_target(imf_fallback_fp32_obj DEPENDS ${obj_binary_dir}/libsycl-fallback-imf.${lib-suffix})
 add_custom_target(imf_fallback_fp32_host_obj DEPENDS ${obj_binary_dir}/fallback-imf-fp32-host.${lib-suffix})
 add_dependencies(libsycldevice-spv imf_fallback_fp32_spv)
+add_dependencies(libsycldevice-bc imf_fallback_fp32_bc)
 add_dependencies(libsycldevice-obj imf_fallback_fp32_obj)
 
 add_custom_target(imf_fallback_fp64_spv DEPENDS ${spv_binary_dir}/libsycl-fallback-imf-fp64.spv)
+add_custom_target(imf_fallback_fp64_bc DEPENDS ${bc_binary_dir}/libsycl-fallback-imf-fp64.bc)
 add_custom_target(imf_fallback_fp64_obj DEPENDS ${obj_binary_dir}/libsycl-fallback-imf-fp64.${lib-suffix})
 add_custom_target(imf_fallback_fp64_host_obj DEPENDS ${obj_binary_dir}/fallback-imf-fp64-host.${lib-suffix})
 add_dependencies(libsycldevice-spv imf_fallback_fp64_spv)
+add_dependencies(libsycldevice-bc imf_fallback_fp64_bc)
 add_dependencies(libsycldevice-obj imf_fallback_fp64_obj)
 
 add_custom_target(imf_fallback_bf16_spv DEPENDS ${spv_binary_dir}/libsycl-fallback-imf-bf16.spv)
+add_custom_target(imf_fallback_bf16_bc DEPENDS ${bc_binary_dir}/libsycl-fallback-imf-bf16.bc)
 add_custom_target(imf_fallback_bf16_obj DEPENDS ${obj_binary_dir}/libsycl-fallback-imf-bf16.${lib-suffix})
 add_custom_target(imf_fallback_bf16_host_obj DEPENDS ${obj_binary_dir}/fallback-imf-bf16-host.${lib-suffix})
 add_dependencies(libsycldevice-spv imf_fallback_bf16_spv)
+add_dependencies(libsycldevice-bc imf_fallback_bf16_bc)
 add_dependencies(libsycldevice-obj imf_fallback_bf16_obj)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/imf-fp32-host.${lib-suffix}
@@ -337,6 +397,12 @@ install(FILES ${spv_binary_dir}/libsycl-fallback-imf.spv
               ${spv_binary_dir}/libsycl-fallback-imf-fp64.spv
               ${spv_binary_dir}/libsycl-fallback-imf-bf16.spv
         DESTINATION ${install_dest_spv}
+        COMPONENT libsycldevice)
+
+install(FILES ${bc_binary_dir}/libsycl-fallback-imf.bc
+              ${bc_binary_dir}/libsycl-fallback-imf-fp64.bc
+              ${bc_binary_dir}/libsycl-fallback-imf-bf16.bc
+        DESTINATION ${install_dest_bc}
         COMPONENT libsycldevice)
 
 install(FILES ${obj_binary_dir}/libsycl-fallback-imf.${lib-suffix}


### PR DESCRIPTION
This change represents 2 changes.
1.  Update the build to create LLVM-IR based device libraries.

This is done by using the existing -fsycl-device-only functionality to create the device libraries that are used during device link.

2.  Update the compiler driver to use the LLVM-IR based device libraries.

When performing the device linking instead of performing a full unbundle of the device libraries and using the device binary that was extracted.

This streamlines the device linking behaviors, completely removing the cumbersome unbundling step from the process, freeing up a number of exteral tool calls.