### PR TITLE
[CI][SYCL-CTS] Ensure link/test runs are parallel

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -309,7 +309,8 @@ jobs:
         -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
         $CMAKE_EXTRA_ARGS
         # Ignore errors so that if one category build fails others still have a
-        # chance to finish and be executed at the run stage.
+        # chance to finish and be executed at the run stage. Note that
+        # "test_conformance" target skips building "test_all" executable.
         ninja -C build-cts -k0 $( [ -n "$CTS_TESTS_TO_BUILD" ] && echo "$CTS_TESTS_TO_BUILD" || echo "test_conformance")
 
     - name: SYCL CTS List devices
@@ -339,11 +340,9 @@ jobs:
         # Run each test category separately so that
         #  - crash on one would not affect others
         #  - multiple tests could be run in parallel
-        # test_all contains all categories, so skip it
-        which time timeout
         mkdir logs
         find build-cts/bin/ -type f -print | \
-          xargs -t -I % -P 8 sh -c 'log=logs/$(basename %).log ; echo % >$log ; % >>$log 2>&1 ; ret=$? ; echo "exit code: $ret" >>$log ; exit $ret'
+          xargs -t -I % -P 8 sh -c 'log=logs/$(basename %).log ; echo % >$log ; date >>$log ; timeout 60m % >>$log 2>&1 ; ret=$? ; echo "exit code: $ret" >>$log ; date >>$log  ; exit $ret'
         ret=$?
 
         for f in logs/* ; do

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -310,7 +310,7 @@ jobs:
         $CMAKE_EXTRA_ARGS
         # Ignore errors so that if one category build fails others still have a
         # chance to finish and be executed at the run stage.
-        ninja -C build-cts -k0 $( [[ -n "$CTS_TESTS_TO_BUILD" ]] && echo "$CTS_TESTS_TO_BUILD" || echo "test_conformance")
+        ninja -C build-cts -k0 $( [ -n "$CTS_TESTS_TO_BUILD" ] && echo "$CTS_TESTS_TO_BUILD" || echo "test_conformance")
 
     - name: SYCL CTS List devices
       # Proceed with execution even if the 'build' step did not succeed.

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -118,7 +118,7 @@ on:
           Suggested variables: for E2E tests - LIT_FILTER, LIT_FILTER_OUT.
           LIT_OPTS won't work as we redefine it as part of this workflow.
 
-          For SYCL CTS - CTS_TEST_ARGS that will be passed as an argument to the
+          For SYCL CTS - CTS_TESTS_TO_BUILD that will be passed as an argument to the
           test_all executable.
 
           Format: '{"VAR1":"VAL1","VAR2":"VAL2",...}'
@@ -310,7 +310,7 @@ jobs:
         $CMAKE_EXTRA_ARGS
         # Ignore errors so that if one category build fails others still have a
         # chance to finish and be executed at the run stage.
-        ninja -C build-cts -k0
+        ninja -C build-cts -k0 $( [[ -n "$CTS_TESTS_TO_BUILD" ]] && echo "$CTS_TESTS_TO_BUILD" || echo "test_conformance")
 
     - name: SYCL CTS List devices
       # Proceed with execution even if the 'build' step did not succeed.
@@ -340,9 +340,10 @@ jobs:
         #  - crash on one would not affect others
         #  - multiple tests could be run in parallel
         # test_all contains all categories, so skip it
+        which time timeout
         mkdir logs
-        find build-cts/bin/ ! -name 'test_all' -print | \
-          xargs -t -I % -P 8 sh -c 'log=logs/$(basename %).log ; echo % >$log ; /usr/bin/time -p timeout 10s % >>$log 2>&1 ; ret=$? ; echo "exit code: $ret" >>$log ; exit $ret'
+        find build-cts/bin/ -print | \
+          xargs -t -I % -P 8 sh -c 'log=logs/$(basename %).log ; echo % >$log ; % >>$log 2>&1 ; ret=$? ; echo "exit code: $ret" >>$log ; exit $ret'
         ret=$?
 
         for f in logs/* ; do

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -118,8 +118,8 @@ on:
           Suggested variables: for E2E tests - LIT_FILTER, LIT_FILTER_OUT.
           LIT_OPTS won't work as we redefine it as part of this workflow.
 
-          For SYCL CTS - CTS_TESTS_TO_BUILD that will be passed as an argument to the
-          test_all executable.
+          For SYCL CTS - CTS_TESTS_TO_BUILD to specify which categories to
+          build.
 
           Format: '{"VAR1":"VAL1","VAR2":"VAL2",...}'
         default: '{}'

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -342,7 +342,7 @@ jobs:
         # test_all contains all categories, so skip it
         which time timeout
         mkdir logs
-        find build-cts/bin/ -print | \
+        find build-cts/bin/ -type f -print | \
           xargs -t -I % -P 8 sh -c 'log=logs/$(basename %).log ; echo % >$log ; % >>$log 2>&1 ; ret=$? ; echo "exit code: $ret" >>$log ; exit $ret'
         ret=$?
 

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -351,6 +351,10 @@ jobs:
           echo "::endgroup::"
         done
 
+        echo "::group::Fails:"
+        grep 'exit code: [^0]' -r logs
+        echo "::endgroup::"
+
         grep 'exit code: [^0]' -r logs >> $GITHUB_STEP_SUMMARY
 
         exit $ret

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -300,10 +300,6 @@ jobs:
       if: inputs.tests_selector == 'cts'
       env:
         CMAKE_EXTRA_ARGS: ${{ inputs.extra_cmake_args }}
-      # Continue execution if some category fails to build.
-      shell: bash {0}
-      # Compile each binary individually; if a failure occurs during the
-      # 'test_all' build, the entire build will be affected.
       run: |
         cmake -GNinja -B./build-cts -S./khronos_sycl_cts -DCMAKE_CXX_COMPILER=$(which clang++) \
         -DSYCL_IMPLEMENTATION=DPCPP \
@@ -311,30 +307,10 @@ jobs:
         -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
         -DSYCL_CTS_MEASURE_BUILD_TIMES=ON \
         -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
-        $CMAKE_EXTRA_ARGS | tee "cmake_output.txt"
-
-        # Get names of all added test-categories:
-        categories=$(grep -o '^-- Adding test: test_[a-zA-Z0-9_]*' "./cmake_output.txt" | sed 's/^-- Adding test: //')
-
-        number_of_test_categories=$(echo $categories | wc -w)
-        iteration=1
-        failed_to_build=""
-
-        for i in $categories; do
-          echo "::group::Building $i ($iteration of $number_of_test_categories)"
-          ninja -C build-cts $i
-          [ $? -ne 0 ] && failed_to_build+=$i'\n'
-          echo "::endgroup::"
-          ((iteration++))
-        done
-
-        if [ -n "$failed_to_build" ]; then
-          echo -e "Failed to build:\n$failed_to_build"
-          echo -e "Failed to build:\n$failed_to_build" >> $GITHUB_STEP_SUMMARY
-          exit 1
-        fi
-
-        exit 0
+        $CMAKE_EXTRA_ARGS
+        # Ignore errors so that if one category build fails others still have a
+        # chance to finish and be executed at the run stage.
+        ninja -C build-cts -k0
 
     - name: SYCL CTS List devices
       # Proceed with execution even if the 'build' step did not succeed.

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -336,19 +336,21 @@ jobs:
       # https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#custom-shell
       shell: bash {0}
       run: |
-        failed_suites=""
+        # Run each test category separately so that
+        #  - crash on one would not affect others
+        #  - multiple tests could be run in parallel
+        # test_all contains all categories, so skip it
+        mkdir logs
+        find build-cts/bin/ ! -name 'test_all' -print | \
+          xargs -t -I % -P 8 sh -c 'log=logs/$(basename %).log ; echo % >$log ; /usr/bin/time -p timeout 10s % >>$log 2>&1 ; ret=$? ; echo "exit code: $ret" >>$log ; exit $ret'
+        ret=$?
 
-        for i in `ls -1 ./build-cts/bin`; do
-          echo "::group::Running $i"
-          build-cts/bin/$i
-          [ $? -ne 0 ] && failed_suites+=$i'\n'
+        for f in logs/* ; do
+          echo "::group::$f"
+          cat $f
           echo "::endgroup::"
         done
 
-        if [ -n "$failed_suites" ]; then
-          echo -e "Failed suite(s): $failed_suites"
-          echo -e "Failed suite(s): $failed_suites" >> $GITHUB_STEP_SUMMARY
-          exit 1
-        fi
+        grep 'exit code: [^0]' -r logs >> $GITHUB_STEP_SUMMARY
 
-        exit 0
+        exit $ret


### PR DESCRIPTION
https://github.com/intel/llvm/pull/13421 reduced parellization when trying to avoid early build failouts. Use `ninja`'s `-k0` to do the same without undesired side effects. Also run individual tests in parallel as well.