### PR TITLE
[CI] Install driver when doing tests for dependencies-igc-dev.json update

### DIFF
--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -57,6 +57,8 @@ jobs:
             drivers:
               - devops/dependencies.json
               - devops/scripts/install_drivers.sh
+            devigccfg:
+              - devops/dependencies-igc-dev.json
             perf-tests:
               - sycl/test-e2e/PerformanceTests/**
             esimd:

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -90,7 +90,10 @@ jobs:
             image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
             target_devices: ext_oneapi_level_zero:gpu;opencl:gpu
             reset_gpu: true
-            install_drivers: ${{ contains(needs.detect_changes.outputs.filters, 'drivers') }}
+            install_drivers: >-
+              ${{ contains(needs.detect_changes.outputs.filters, 'drivers') ||
+              contains(needs.detect_changes.outputs.filters, 'devigccfg') }}
+            use_dev_igc: ${{ contains(needs.detect_changes.outputs.filters, 'devigccfg') }}
             extra_lit_opts: --param matrix-xmx8=True --param gpu-intel-dg2=True
             env: '{"LIT_FILTER":${{ needs.determine_arc_tests.outputs.arc_tests }} }'
     uses: ./.github/workflows/sycl-linux-run-tests.yml
@@ -102,7 +105,7 @@ jobs:
       target_devices: ${{ matrix.target_devices }}
       reset_gpu: ${{ matrix.reset_gpu }}
       install_drivers: ${{ matrix.install_drivers }}
-
+      use_dev_igc: ${{ matrix.use_dev_igc }}
       extra_lit_opts: ${{ matrix.extra_lit_opts }}
       env: ${{ matrix.env || '{}' }}
 


### PR DESCRIPTION
When we are doing dependencies-igc-dev.json update,
we will rebuild the docker image, but we can't use that image
immediately in the same CI for testing.

So we need to run the test by using the install driver option.
