### PR TITLE
[libclc] Fix UB in double->int conversions

### DIFF
--- a/libclc/generic/lib/math/cosh.cl
+++ b/libclc/generic/lib/math/cosh.cl
@@ -132,7 +132,7 @@ _CLC_OVERLOAD _CLC_DEF double cosh(double x) {
     // z = cosh(y) = cosh(y0)cosh(dy) + sinh(y0)sinh(dy)
     // where sinh(y0) and cosh(y0) are tabulated above.
 
-    int ind = min((int)y, 36);
+    int ind = min((int)(long)y, 36);
     double dy = y - ind;
     double dy2 = dy * dy;
 

--- a/libclc/generic/lib/math/lgamma_r.cl
+++ b/libclc/generic/lib/math/lgamma_r.cl
@@ -447,7 +447,7 @@ _CLC_OVERLOAD _CLC_DEF double lgamma_r(double x, private int *ip) {
                 r += fma(-0.5, y, p / q);
         }
     } else if (absx < 8.0) {
-        int i = absx;
+        int i = (int)(long)absx;
         double y = absx - (double) i;
         double p = y * fma(y, fma(y, fma(y, fma(y, fma(y, fma(y, s6, s5), s4), s3), s2), s1), s0);
         double q = fma(y, fma(y, fma(y, fma(y, fma(y, fma(y, r6, r5), r4), r3), r2), r1), 1.0);

--- a/libclc/generic/lib/math/sinh.cl
+++ b/libclc/generic/lib/math/sinh.cl
@@ -132,7 +132,7 @@ _CLC_OVERLOAD _CLC_DEF double sinh(double x)
     // z = sinh(y) = sinh(y0)cosh(dy) + cosh(y0)sinh(dy)
     // where sinh(y0) and cosh(y0) are obtained from tables
 
-    int ind = min((int)y, 36);
+    int ind = min((int)(long)y, 36);
     double dy = y - ind;
     double dy2 = dy * dy;
 

--- a/libclc/generic/libspirv/math/clc_pow.cl
+++ b/libclc/generic/libspirv/math/clc_pow.cl
@@ -317,7 +317,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y)
         const double lnof2_by_64_tail = -4.359010638708991e-10;
 
         double temp = v * sixtyfour_by_lnof2;
-        int n = (int)(long)(temp);
+        int n = (int)(long)temp;
         double dn = (double)n;
         int j = n & 0x0000003f;
         int m = n >> 6;

--- a/libclc/generic/libspirv/math/clc_pow.cl
+++ b/libclc/generic/libspirv/math/clc_pow.cl
@@ -317,7 +317,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pow(double x, double y)
         const double lnof2_by_64_tail = -4.359010638708991e-10;
 
         double temp = v * sixtyfour_by_lnof2;
-        int n = (int)temp;
+        int n = (int)(long)(temp);
         double dn = (double)n;
         int j = n & 0x0000003f;
         int m = n >> 6;

--- a/libclc/generic/libspirv/math/clc_pown.cl
+++ b/libclc/generic/libspirv/math/clc_pown.cl
@@ -311,7 +311,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_pown(double x, int ny) {
     const double lnof2_by_64_tail = -4.359010638708991e-10;
 
     double temp = v * sixtyfour_by_lnof2;
-    int n = (int)temp;
+    int n = (int)(long)temp;
     double dn = (double)n;
     int j = n & 0x0000003f;
     int m = n >> 6;

--- a/libclc/generic/libspirv/math/clc_powr.cl
+++ b/libclc/generic/libspirv/math/clc_powr.cl
@@ -309,7 +309,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_powr(double x, double y) {
     const double lnof2_by_64_tail = -4.359010638708991e-10;
 
     double temp = v * sixtyfour_by_lnof2;
-    int n = (int)temp;
+    int n = (int)(long)temp;
     double dn = (double)n;
     int j = n & 0x0000003f;
     int m = n >> 6;

--- a/libclc/generic/libspirv/math/clc_rootn.cl
+++ b/libclc/generic/libspirv/math/clc_rootn.cl
@@ -317,7 +317,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
     const double lnof2_by_64_tail = -4.359010638708991e-10;
 
     double temp = v * sixtyfour_by_lnof2;
-    int n = (int)(long)(temp);
+    int n = (int)(long)temp;
     double dn = (double)n;
     int j = n & 0x0000003f;
     int m = n >> 6;

--- a/libclc/generic/libspirv/math/clc_rootn.cl
+++ b/libclc/generic/libspirv/math/clc_rootn.cl
@@ -295,7 +295,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
     double y_tail = y - y_head;
 
     double fnyh = as_double(as_long(dny) & 0xfffffffffff00000);
-    double fnyt = (double)(ny - (int)fnyh);
+    double fnyt = (double)(ny - (int)(long)fnyh);
     y_tail =
         __spirv_ocl_fma(-fnyt, y_head, __spirv_ocl_fma(-fnyh, y_head, 1.0)) /
         dny;
@@ -317,7 +317,7 @@ _CLC_DEF _CLC_OVERLOAD double __clc_rootn(double x, int ny) {
     const double lnof2_by_64_tail = -4.359010638708991e-10;
 
     double temp = v * sixtyfour_by_lnof2;
-    int n = (int)temp;
+    int n = (int)(long)(temp);
     double dn = (double)n;
     int j = n & 0x0000003f;
     int m = n >> 6;

--- a/libclc/generic/libspirv/math/lgamma_r.cl
+++ b/libclc/generic/libspirv/math/lgamma_r.cl
@@ -563,7 +563,7 @@ _CLC_OVERLOAD _CLC_DEF double __spirv_ocl_lgamma_r(double x, private int *ip) {
       r += __spirv_ocl_fma(-0.5, y, p / q);
     }
   } else if (absx < 8.0) {
-    int i = absx;
+    int i = (int)(long)absx;
     double y = absx - (double)i;
     double p =
         y *


### PR DESCRIPTION
While we have mostly been getting away with this, in certain circumstances (constant propagation, inlining) the compiler would be able to tell that the double cannot fit into the resulting integer type, which produces a poison value in LLVM IR.