### PR TITLE
[SPIR-V][Headers] Enable programs that include system headers on Windows for SPIRV32 and SPIRV64 targets

### DIFF
--- a/clang/lib/Basic/Targets.cpp
+++ b/clang/lib/Basic/Targets.cpp
@@ -698,15 +698,39 @@ std::unique_ptr<TargetInfo> AllocateTarget(const llvm::Triple &Triple,
     if (os != llvm::Triple::UnknownOS ||
         Triple.getEnvironment() != llvm::Triple::UnknownEnvironment)
       return nullptr;
-    return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);
+    llvm::Triple HT(Opts.HostTriple);
+    switch (HT.getOS()) {
+    case llvm::Triple::Win32:
+      switch (HT.getEnvironment()) {
+      default: // Assume MSVC for unknown environments
+      case llvm::Triple::MSVC:
+        assert(HT.getArch() == llvm::Triple::x86 &&
+               "Unsupported host architecture");
+        return std::make_unique<MicrosoftX86_32SPIRV32TargetInfo>(Triple, Opts);
+      }
+    default:
+      return std::make_unique<SPIRV32TargetInfo>(Triple, Opts);
+    }
   }
   case llvm::Triple::spirv64: {
     if (os != llvm::Triple::UnknownOS ||
         Triple.getEnvironment() != llvm::Triple::UnknownEnvironment)
       return nullptr;
-    return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);
+    llvm::Triple HT(Opts.HostTriple);
+    switch (HT.getOS()) {
+    case llvm::Triple::Win32:
+      switch (HT.getEnvironment()) {
+      default: // Assume MSVC for unknown environments
+      case llvm::Triple::MSVC:
+        assert(HT.getArch() == llvm::Triple::x86_64 &&
+               "Unsupported host architecture");
+        return std::make_unique<MicrosoftX86_64_SPIRV64TargetInfo>(Triple,
+                                                                   Opts);
+      }
+    default:
+      return std::make_unique<SPIRV64TargetInfo>(Triple, Opts);
+    }
   }
-
   case llvm::Triple::wasm32:
     if (Triple.getSubArch() != llvm::Triple::NoSubArch ||
         Triple.getVendor() != llvm::Triple::UnknownVendor ||

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -356,9 +356,9 @@ public:
     DoubleAlign = LongLongAlign = 64;
     IntMaxType = SignedLongLong;
     Int64Type = SignedLongLong;
-    SizeType = UnsignedLongLong;
-    PtrDiffType = SignedLongLong;
-    IntPtrType = SignedLongLong;
+    SizeType = UnsignedLong;
+    PtrDiffType = SignedLong;
+    IntPtrType = SignedLong;
     WCharType = UnsignedShort;
   }
 

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -356,9 +356,9 @@ public:
     DoubleAlign = LongLongAlign = 64;
     IntMaxType = SignedLongLong;
     Int64Type = SignedLongLong;
-    SizeType = UnsignedLong;
-    PtrDiffType = SignedLong;
-    IntPtrType = SignedLong;
+    SizeType = UnsignedLongLong;
+    PtrDiffType = SignedLongLong;
+    IntPtrType = SignedLongLong;
     WCharType = UnsignedShort;
   }
 
@@ -473,6 +473,97 @@ public:
 
   void getTargetDefines(const LangOptions &Opts,
                         MacroBuilder &Builder) const override;
+};
+
+// x86-32 SPIRV32 Windows target
+class LLVM_LIBRARY_VISIBILITY WindowsX86_32SPIRV32TargetInfo
+    : public WindowsTargetInfo<SPIRV32TargetInfo> {
+public:
+  WindowsX86_32SPIRV32TargetInfo(const llvm::Triple &Triple,
+                                 const TargetOptions &Opts)
+      : WindowsTargetInfo<SPIRV32TargetInfo>(Triple, Opts) {
+    DoubleAlign = LongLongAlign = 64;
+    WCharType = UnsignedShort;
+  }
+
+  BuiltinVaListKind getBuiltinVaListKind() const override {
+    return TargetInfo::CharPtrBuiltinVaList;
+  }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    if (CC == CC_X86VectorCall)
+      // Permit CC_X86VectorCall which is used in Microsoft headers
+      return CCCR_OK;
+    return (CC == CC_SpirFunction || CC == CC_OpenCLKernel) ? CCCR_OK
+                                                            : CCCR_Warning;
+  }
+};
+
+// x86-32 SPIRV32 Windows Visual Studio target
+class LLVM_LIBRARY_VISIBILITY MicrosoftX86_32SPIRV32TargetInfo
+    : public WindowsX86_32SPIRV32TargetInfo {
+public:
+  MicrosoftX86_32SPIRV32TargetInfo(const llvm::Triple &Triple,
+                                   const TargetOptions &Opts)
+      : WindowsX86_32SPIRV32TargetInfo(Triple, Opts) {}
+
+  void getTargetDefines(const LangOptions &Opts,
+                        MacroBuilder &Builder) const override {
+    WindowsX86_32SPIRV32TargetInfo::getTargetDefines(Opts, Builder);
+    // The value of the following reflects processor type.
+    // 300=386, 400=486, 500=Pentium, 600=Blend (default)
+    // We lost the original triple, so we use the default.
+    // TBD should we keep these lines?  Copied from X86.h.
+    Builder.defineMacro("_M_IX86", "600");
+  }
+};
+
+// x86-64 SPIRV64 Windows target
+class LLVM_LIBRARY_VISIBILITY WindowsX86_64_SPIRV64TargetInfo
+    : public WindowsTargetInfo<SPIRV64TargetInfo> {
+public:
+  WindowsX86_64_SPIRV64TargetInfo(const llvm::Triple &Triple,
+                                  const TargetOptions &Opts)
+      : WindowsTargetInfo<SPIRV64TargetInfo>(Triple, Opts) {
+    LongWidth = LongAlign = 32;
+    DoubleAlign = LongLongAlign = 64;
+    IntMaxType = SignedLongLong;
+    Int64Type = SignedLongLong;
+    SizeType = UnsignedLongLong;
+    PtrDiffType = SignedLongLong;
+    IntPtrType = SignedLongLong;
+    WCharType = UnsignedShort;
+  }
+
+  BuiltinVaListKind getBuiltinVaListKind() const override {
+    return TargetInfo::CharPtrBuiltinVaList;
+  }
+
+  CallingConvCheckResult checkCallingConvention(CallingConv CC) const override {
+    if (CC == CC_X86VectorCall || CC == CC_X86RegCall)
+      // Permit CC_X86VectorCall which is used in Microsoft headers
+      // Permit CC_X86RegCall which is used to mark external functions with
+      // explicit simd or structure type arguments to pass them via registers.
+      return CCCR_OK;
+    return (CC == CC_SpirFunction || CC == CC_OpenCLKernel) ? CCCR_OK
+                                                            : CCCR_Warning;
+  }
+};
+
+// x86-64 SPIRV64 Windows Visual Studio target
+class LLVM_LIBRARY_VISIBILITY MicrosoftX86_64_SPIRV64TargetInfo
+    : public WindowsX86_64_SPIRV64TargetInfo {
+public:
+  MicrosoftX86_64_SPIRV64TargetInfo(const llvm::Triple &Triple,
+                                    const TargetOptions &Opts)
+      : WindowsX86_64_SPIRV64TargetInfo(Triple, Opts) {}
+
+  void getTargetDefines(const LangOptions &Opts,
+                        MacroBuilder &Builder) const override {
+    WindowsX86_64_SPIRV64TargetInfo::getTargetDefines(Opts, Builder);
+    Builder.defineMacro("_M_X64", "100");
+    Builder.defineMacro("_M_AMD64", "100");
+  }
 };
 
 } // namespace targets

--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -513,7 +513,6 @@ public:
     // The value of the following reflects processor type.
     // 300=386, 400=486, 500=Pentium, 600=Blend (default)
     // We lost the original triple, so we use the default.
-    // TBD should we keep these lines?  Copied from X86.h.
     Builder.defineMacro("_M_IX86", "600");
   }
 };

--- a/clang/test/CodeGenCUDASPIRV/copy-aggregate-byval.cu
+++ b/clang/test/CodeGenCUDASPIRV/copy-aggregate-byval.cu
@@ -2,7 +2,7 @@
 // destructor, copy constructor or move constructor defined by user.
 
 // RUN: %clang -emit-llvm --cuda-device-only --offload=spirv32 \
-// RUN:   -nocudalib -nocudainc %s -o %t.bc -c 2>&1
+// RUN:   --target=i386-pc-windows-msvc -nocudalib -nocudainc %s -o %t.bc -c 2>&1
 // RUN: llvm-dis %t.bc -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll
 

--- a/clang/test/CodeGenCUDASPIRV/kernel-argument.cu
+++ b/clang/test/CodeGenCUDASPIRV/kernel-argument.cu
@@ -2,7 +2,7 @@
 
 
 // RUN: %clang -emit-llvm --cuda-device-only --offload=spirv32 \
-// RUN:   -nocudalib -nocudainc %s -o %t.bc -c 2>&1
+// RUN:   --target=i386-pc-windows-msvc -nocudalib -nocudainc %s -o %t.bc -c 2>&1
 // RUN: llvm-dis %t.bc -o %t.ll
 // RUN: FileCheck %s --input-file=%t.ll
 

--- a/clang/test/SemaSYCL/mangle-kernel.cpp
+++ b/clang/test/SemaSYCL/mangle-kernel.cpp
@@ -1,6 +1,9 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -aux-triple x86_64-pc-windows-msvc -I %S/../Headers/Inputs/include/ -ast-dump %s | FileCheck %s --check-prefix=CHECK-64-WIN
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -aux-triple x86_64-unknown-linux-gnu -I %S/../Headers/Inputs/include/ -ast-dump %s | FileCheck %s --check-prefix=CHECK-64-LIN
 // RUN: %clang_cc1 -fsycl-is-device -triple spir-unknown-linux -I %S/../Headers/Inputs/include/ -ast-dump %s | FileCheck %s --check-prefix=CHECK-32
+// RUN: %clang_cc1 -fsycl-is-device -triple spirv64-unknown-unknown -aux-triple x86_64-pc-windows-msvc -I %S/../Headers/Inputs/include/ -ast-dump %s | FileCheck %s --check-prefix=CHECK-64-WIN
+// RUN: %clang_cc1 -fsycl-is-device -triple spirv64-unknown-unknown -aux-triple x86_64-unknown-linux-gnu -I %S/../Headers/Inputs/include/ -ast-dump %s | FileCheck %s --check-prefix=CHECK-64-LIN
+// RUN: %clang_cc1 -fsycl-is-device -triple spirv32-unknown-unknown -I %S/../Headers/Inputs/include/ -ast-dump %s | FileCheck %s --check-prefix=CHECK-32
 #include "Inputs/sycl.hpp"
 #include <stdlib.h>
 

--- a/clang/test/SemaSYCL/msvc-fixes-x86.cpp
+++ b/clang/test/SemaSYCL/msvc-fixes-x86.cpp
@@ -1,0 +1,8 @@
+// This test verifies that the correct macros are predefined.
+// This test verifies that __builtin_va_list is processed without errors.
+// RUN: %clang_cc1 -fsycl-is-device -triple spir-unknown-unknown -aux-triple i386-pc-windows-msvc  -fsyntax-only -E -dM -o - | FileCheck -match-full-lines %s --check-prefix=CHECK-MS64
+// RUN: %clang_cc1 -fsycl-is-device -triple spirv32-unknown-unknown -aux-triple i386-pc-windows-msvc  -fsyntax-only -E -dM -o - | FileCheck -match-full-lines %s --check-prefix=CHECK-MS64
+// CHECK-MS64: #define _M_IX86 600
+void foo(__builtin_va_list bvl) {
+  char * VaList = bvl;
+}

--- a/clang/test/SemaSYCL/msvc-fixes.cpp
+++ b/clang/test/SemaSYCL/msvc-fixes.cpp
@@ -1,8 +1,26 @@
+// This test verifies that the correct macros are predefined.
+// This test checks that sizes of different types are as expected.
+// This test verifies that __builtin_va_list is processed without errors.
+//
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-windows -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -verify %s
 // RUN: %clang_cc1 -fsycl-is-device -triple spirv64-unknown-unknown -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -verify %s
 // expected-no-diagnostics
-
+// RUN: %clang_cc1 -fsycl-is-device -triple spirv64-unknown-unknown -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -E -dM -o - | FileCheck -match-full-lines %s --check-prefix=CHECK-MS64
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -E -dM -o - | FileCheck -match-full-lines %s --check-prefix=CHECK-MS64
+// CHECK-MS64: #define _M_AMD64 100
+// CHECK-MS64: #define _M_X64 100
+typedef __PTRDIFF_TYPE__ ptrdiff_t;
+typedef __SIZE_TYPE__ size_t;
+typedef __INT64_TYPE__ int64_t;
+typedef __INTMAX_TYPE__ intmax_t;
 void foo(__builtin_va_list bvl) {
   char * VaList = bvl;
-  static_assert(sizeof(wchar_t) == 2, "sizeof wchar is 2 on Windows");
+  static_assert(sizeof(long) == 4, "sizeof long is 4 on Windows (x86_64)");
+  static_assert(sizeof(double) == 8, "sizeof double is 8 on Windows (x86_64)");
+  static_assert(sizeof(intmax_t) == 8, "sizeof intmax_t is 8 on Windows (x86_64)");
+  static_assert(sizeof(int64_t) == 8, "sizeof int64_t is 8 on Windows (x86_64)");
+  static_assert(sizeof(size_t) == 8, "sizeof size_t is 8 on Windows (x86_64)");
+  static_assert(sizeof(ptrdiff_t) == 8, "sizeof ptrdiff_t is 8 on Windows (x86_64)");
+  static_assert(sizeof(int *) == 8, "sizeof IntPtr is 8 on Windows (x86_64)");
+  static_assert(sizeof(wchar_t) == 2, "sizeof wchar is 2 on Windows (x86_64)");
 }

--- a/clang/test/SemaSYCL/msvc-fixes.cpp
+++ b/clang/test/SemaSYCL/msvc-fixes.cpp
@@ -1,4 +1,5 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-windows -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spirv64-unknown-unknown -aux-triple x86_64-pc-windows-msvc  -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 void foo(__builtin_va_list bvl) {


### PR DESCRIPTION
This is text from OpenCL SPIR Spec 2.0 (https://registry.khronos.org/SPIR/specs/spir_spec-2.0.pdf)

The OpenCL size_t, ptrdiff_t,uintptr_t, intptr_t, atomic_size_t, atomic_ptrdiff_t, atomic_uintptr_t and atomic_intptr_t data types are mapped to LLVM i32 when the device address width is equal to 32 bits and to LLVM i64 when the device address width is equal 64 bits.

After some analysis though, I see that the windows os based customizations made for the SPIR target (https://github.com/intel/llvm/pull/325) are necessary for successful compilation on windows.
Also, they do not seem to be violating the spec. It's just that 'long' and 'long long' mean different things on windows and linux. On 64-bit linux, long type has 8 bytes, but on 64-bit windows, long type has 4 bytes.
Hence, I have extended the SPIR target changes to the SPIR-V target as well. 
This PR extends those changes for SPIRV32 and SPIRV64 targets and added appropriate tests as well.

We would eventually want to submit this (and PR #325) upstream. 

Thanks