### PR TITLE
[SYCL][CMake] Build sycl-toolchain by default

### DIFF
--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -343,7 +343,7 @@ add_custom_target( sycl-runtime-libraries
   DEPENDS ${SYCL_RT_LIBS}
 )
 
-add_custom_target( sycl-toolchain
+add_custom_target( sycl-toolchain ALL
   DEPENDS sycl-runtime-libraries
           sycl-compiler
           sycl-ls


### PR DESCRIPTION
In compile.py we are using -t sycl-toolchain to build the sycl
toolchain. However, sycl-toolchain is not added by default target.
So when I configure the project , then build the default target,
eg: `ninja`
some of the libs eg: libdevice will not be built even if they are in the
"LLVM_ENABLE_PROJECTS" list.

eg: One of the typical failures are missing sycl-devicelib-host.

```
/iusers/jinsongj/llvm/build/bin/clang++   -fsycl -fsycl-targets=spir64 /iusers/jinsongj/llvm/sycl/test-e2e/Matrix/XMX8/element_wise_abc.cpp

$ /iusers/jinsongj/llvm/build/bin/clang++   -fsycl -fsycl-targets=spir64 /iusers/jinsongj/llvm/sycl/test-e2e/Matrix/XMX8/element_wise_abc.cpp
/usr/bin/ld: cannot find -lsycl-devicelib-host: No such file or directory
clang++: error: linker command failed with exit code 1 (use -v to see invocation)
```
So I have to run `ninja sycl-toolchain` again to build sycl toolchain.

Since sycl branch is for sycl-toolchain, I think we should enable
building sycl-toolchain by default.
