### PR TITLE
[SYCL] Revise SYCL 2017 test cases for `*_group_size` attributes for usage under SYCL 2020

### DIFF
--- a/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -sycl-std=2017 -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -disable-llvm-passes -sycl-std=2020 -emit-llvm -o - %s | FileCheck %s
 
 #include "sycl.hpp"
 
@@ -49,9 +49,7 @@ int main() {
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2() #0 {{.*}} !max_work_group_size ![[NUM8:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3() #0 {{.*}} !max_work_group_size ![[NUM6:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0 {{.*}} !max_work_group_size ![[NUM2:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name5() #0 {{.*}} !max_work_group_size ![[NUM4:[0-9]+]]
 // CHECK: ![[NUM1]] = !{i32 1, i32 1, i32 1}
 // CHECK: ![[NUM8]] = !{i32 8, i32 8, i32 8}
 // CHECK: ![[NUM6]] = !{i32 6, i32 3, i32 1}
 // CHECK: ![[NUM2]] = !{i32 2, i32 2, i32 2}
-// CHECK: ![[NUM4]] = !{i32 4, i32 4, i32 4}

--- a/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/intel-max-work-group-size.cpp
@@ -21,9 +21,6 @@ public:
   [[intel::max_work_group_size(SIZE, SIZE1, SIZE2)]] void operator()() const {}
 };
 
-template <int N, int N1, int N2>
-[[intel::max_work_group_size(N, N1, N2)]] void func() {}
-
 int main() {
   q.submit([&](handler &h) {
     Foo boo;
@@ -37,10 +34,6 @@ int main() {
 
     Functor<2, 2, 2> f;
     h.single_task<class kernel_name4>(f);
-
-    h.single_task<class kernel_name5>([]() {
-      func<4, 4, 4>();
-    });
   });
   return 0;
 }

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -10,13 +10,9 @@ public:
   [[intel::reqd_sub_group_size(16)]] void operator()() const {}
 };
 
-[[intel::reqd_sub_group_size(8)]] void foo() {}
-
 class Functor8 {
 public:
-  void operator()() const {
-    foo();
-  }
+  [[intel::reqd_sub_group_size(8)]] void operator()() const {}
 };
 
 template <int SIZE>
@@ -25,30 +21,28 @@ public:
   [[intel::reqd_sub_group_size(SIZE)]] void operator()() const {}
 };
 
-template <int N>
-[[intel::reqd_sub_group_size(N)]] void func() {}
-
 int main() {
   q.submit([&](handler &h) {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
+
+    Functor8 f8;
+    h.single_task<class kernel_name2>(f8);
 
     h.single_task<class kernel_name3>(
         []() [[intel::reqd_sub_group_size(4)]]{});
 
     Functor2<2> f2;
     h.single_task<class kernel_name4>(f2);
-
-    h.single_task<class kernel_name5>([]() {
-      func<2>();
-    });
   });
   return 0;
 }
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE16:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE8:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE4:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE2:[0-9]+]]
 // CHECK: ![[SGSIZE16]] = !{i32 16}
+// CHECK: ![[SGSIZE8]] = !{i32 8}
 // CHECK: ![[SGSIZE4]] = !{i32 4}
 // CHECK: ![[SGSIZE2]] = !{i32 2}

--- a/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-sub-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -disable-llvm-passes -sycl-std=2017 -triple spir64-unknown-unknown -emit-llvm -o - %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -disable-llvm-passes -sycl-std=2020 -triple spir64-unknown-unknown -emit-llvm -o - %s | FileCheck %s
 
 #include "sycl.hpp"
 
@@ -33,9 +33,6 @@ int main() {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
-    Functor8 f8;
-    h.single_task<class kernel_name2>(f8);
-
     h.single_task<class kernel_name3>(
         []() [[intel::reqd_sub_group_size(4)]]{});
 
@@ -50,11 +47,8 @@ int main() {
 }
 
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE16:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE8:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE4:[0-9]+]]
 // CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE2:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name5() #0 {{.*}} !intel_reqd_sub_group_size ![[SGSIZE2]]
 // CHECK: ![[SGSIZE16]] = !{i32 16}
-// CHECK: ![[SGSIZE8]] = !{i32 8}
 // CHECK: ![[SGSIZE4]] = !{i32 4}
 // CHECK: ![[SGSIZE2]] = !{i32 2}

--- a/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
+++ b/clang/test/CodeGenSYCL/reqd-work-group-size.cpp
@@ -18,29 +18,6 @@ public:
   [[sycl::reqd_work_group_size(32, 16, 16)]] void operator()() const {}
 };
 
-[[sycl::reqd_work_group_size(8)]] void f8() {}
-[[sycl::reqd_work_group_size(8, 1)]] void f8x1() {}
-[[sycl::reqd_work_group_size(8, 1, 1)]] void f8x1x1() {}
-
-class Functor1D {
-public:
-  void operator()() const {
-    f8();
-  }
-};
-class Functor2D {
-public:
-  void operator()() const {
-    f8x1();
-  }
-};
-class Functor3D {
-public:
-  void operator()() const {
-    f8x1x1();
-  }
-};
-
 template <int SIZE>
 class FunctorTemp1D {
 public:
@@ -57,87 +34,59 @@ public:
   [[sycl::reqd_work_group_size(SIZE, SIZE1, SIZE2)]] void operator()() const {}
 };
 
-template <int N>
-[[sycl::reqd_work_group_size(N)]] void func1D() {}
-template <int N, int N1>
-[[sycl::reqd_work_group_size(N, N1)]] void func2D() {}
-template <int N, int N1, int N2>
-[[sycl::reqd_work_group_size(N, N1, N2)]] void func3D() {}
-
 int main() {
   q.submit([&](handler &h) {
     Functor32x16x16 f32x16x16;
-    h.single_task<class kernel_name7>(f32x16x16);
+    h.single_task<class kernel_name1>(f32x16x16);
 
-    Functor3D f3d;
-    h.single_task<class kernel_name8>(f3d);
-
-    h.single_task<class kernel_name9>(
+    h.single_task<class kernel_name2>(
         []() [[sycl::reqd_work_group_size(8, 8, 8)]]{});
 
     FunctorTemp3D<2, 2, 2> ft3d;
-    h.single_task<class kernel_name10>(ft3d);
+    h.single_task<class kernel_name3>(ft3d);
 
-    h.single_task<class kernel_name11>([]() {
-      func3D<8, 4, 4>();
-    });
-
-    h.single_task<class kernel_name12>(
+    h.single_task<class kernel_name4>(
         []() [[sycl::reqd_work_group_size(1, 8, 2)]]{});
 
     Functor32x16 f32x16;
-    h.single_task<class kernel_name13>(f32x16);
+    h.single_task<class kernel_name5>(f32x16);
 
-    Functor2D f2d;
-    h.single_task<class kernel_name14>(f2d);
-
-    h.single_task<class kernel_name15>(
+    h.single_task<class kernel_name6>(
         []() [[sycl::reqd_work_group_size(8, 8)]]{});
 
     FunctorTemp2D<2, 2> ft2d;
-    h.single_task<class kernel_name16>(ft2d);
+    h.single_task<class kernel_name7>(ft2d);
 
-    h.single_task<class kernel_name17>([]() {
-      func2D<8, 4>();
-    });
-
-    h.single_task<class kernel_name18>(
+    h.single_task<class kernel_name8>(
         []() [[sycl::reqd_work_group_size(1, 8)]]{});
 
     Functor32 f32;
-    h.single_task<class kernel_name19>(f32);
+    h.single_task<class kernel_name9>(f32);
 
-    Functor1D f1d;
-    h.single_task<class kernel_name20>(f1d);
-
-    h.single_task<class kernel_name21>(
+    h.single_task<class kernel_name10>(
         []() [[sycl::reqd_work_group_size(8)]]{});
 
     FunctorTemp1D<2> ft1d;
-    h.single_task<class kernel_name22>(ft1d);
+    h.single_task<class kernel_name11>(ft1d);
 
-    h.single_task<class kernel_name23>([]() {
-      func1D<8>();
-    });
-
-    h.single_task<class kernel_name24>(
+    h.single_task<class kernel_name12>(
         []() [[sycl::reqd_work_group_size(1)]]{});
   });
   return 0;
 }
 
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name7() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D32:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name9() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D88:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name10() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D22:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name12() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D2:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name13() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D32:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name15() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D88:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name16() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D22:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name18() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D2:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name19() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D32:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name21() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D8:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name22() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D22:[0-9]+]]
-// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name24() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name1() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D32:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name2() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D88:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name3() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D22:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name4() #0 {{.*}} !reqd_work_group_size ![[WGSIZE3D2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name5() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D32:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name6() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D88:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name7() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D22:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name8() #0 {{.*}} !reqd_work_group_size ![[WGSIZE2D2:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name9() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D32:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name10() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D8:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name11() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D22:[0-9]+]]
+// CHECK: define {{.*}}spir_kernel void @{{.*}}kernel_name12() #0 {{.*}} !reqd_work_group_size ![[WGSIZE1D2:[0-9]+]]
 // CHECK: ![[WGSIZE3D32]] = !{i32 16, i32 16, i32 32}
 // CHECK: ![[WGSIZE3D88]] = !{i32 8, i32 8, i32 8}
 // CHECK: ![[WGSIZE3D22]] = !{i32 2, i32 2, i32 2}

--- a/clang/test/SemaSYCL/intel-max-work-group-size-ast.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -triple spir64 | FileCheck %s
 
 // The test checks support and functionality of [[intel:::max_work_group_size()]] attribute.
 #include "sycl.hpp"
@@ -95,20 +95,6 @@ int main() {
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
     h.single_task<class test_kernel2>(
         []() [[intel::max_work_group_size(8, 8, 8)]] {});
-
-    // CHECK-LABEL: FunctionDecl {{.*}}test_kernel3
-    // CHECK:       SYCLIntelMaxWorkGroupSizeAttr
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    h.single_task<class test_kernel3>(
-        []() { func_do_not_ignore(); });
 
     // Ignore duplicate attribute.
     h.single_task<class test_kernel10>(

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -Wno-sycl-2020-compat -ast-dump %s | FileCheck %s
 
-// Test for AST of reqd_work_group_size kernel attribute in SYCL 1.2.1.
+// Test for AST of reqd_work_group_size kernel attribute in SYCL 2020.
 
 #include "sycl.hpp"
 
@@ -106,14 +106,6 @@ int main() {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-    // CHECK: SYCLReqdWorkGroupSizeAttr
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    Functor f;
-    h.single_task<class kernel_name2>(f);
-
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
     // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
@@ -156,34 +148,6 @@ int main() {
     h.single_task<class kernel_name5>([]() [[sycl::reqd_work_group_size(32, 32, 32)]] {
       f32x32x32();
     });
-
-    // CHECK:  FunctionDecl {{.*}} {{.*}}kernel_name6
-    // CHECK:  SYCLIntelNoGlobalWorkOffsetAttr
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK: SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK: SYCLReqdWorkGroupSizeAttr
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    h.single_task<class kernel_name6>(
-        []() { func1(); });
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
@@ -65,8 +65,6 @@ int check() {
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
 
-[[sycl::reqd_work_group_size(4)]] void f4() {}
-
 class Functor16 {
 public:
   [[sycl::reqd_work_group_size(16)]] void operator()() const {}
@@ -75,13 +73,6 @@ public:
 class Functor16x16x16 {
 public:
   [[sycl::reqd_work_group_size(16, 16, 16)]] void operator()() const {}
-};
-
-class Functor {
-public:
-  void operator()() const {
-    f4();
-  }
 };
 
 class FunctorAttr {
@@ -106,7 +97,7 @@ int main() {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
     // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 16
@@ -118,9 +109,9 @@ int main() {
     // CHECK-NEXT:  value: Int 16
     // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
     Functor16x16x16 f16x16x16;
-    h.single_task<class kernel_name3>(f16x16x16);
+    h.single_task<class kernel_name2>(f16x16x16);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
     // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 128
@@ -132,9 +123,9 @@ int main() {
     // CHECK-NEXT:  value: Int 128
     // CHECK-NEXT:  IntegerLiteral{{.*}}128{{$}}
     FunctorAttr fattr;
-    h.single_task<class kernel_name4>(fattr);
+    h.single_task<class kernel_name3>(fattr);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
     // CHECK: SYCLReqdWorkGroupSizeAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 32
@@ -145,7 +136,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 32
     // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
-    h.single_task<class kernel_name5>([]() [[sycl::reqd_work_group_size(32, 32, 32)]] {
+    h.single_task<class kernel_name4>([]() [[sycl::reqd_work_group_size(32, 32, 32)]] {
       f32x32x32();
     });
   });

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
@@ -8,11 +8,6 @@ using namespace sycl;
 queue q;
 
 [[sycl::reqd_work_group_size(4)]] void f4() {}
-[[sycl::reqd_work_group_size(32)]] void f32() {}
-[[sycl::reqd_work_group_size(16)]] void f16() {}
-[[sycl::reqd_work_group_size(16, 16)]] void f16x16() {}
-
-[[sycl::reqd_work_group_size(32, 32)]] void f32x32() {}
 [[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {}
 
 [[intel::reqd_work_group_size(4, 2, 9)]] void unknown() {} // expected-warning{{unknown attribute 'reqd_work_group_size' ignored}}
@@ -36,30 +31,15 @@ int main() {
     Functor8 f8;
     h.single_task<class kernel_name1>(f8);
 
-    h.single_task<class kernel_name2>([]() {
-      f4();
-      f32();
-    });
-
-    h.single_task<class kernel_name3>([]() {
-      f16();
-      f16x16();
-    });
-
-    h.single_task<class kernel_name4>([]() {
-      f32x32x32();
-      f32x32();
-    });
-
     // expected-error@+1 {{expected variable name or 'this' in lambda capture list}}
-    h.single_task<class kernel_name5>([[sycl::reqd_work_group_size(32, 32, 32)]][]() {
+    h.single_task<class kernel_name2>([[sycl::reqd_work_group_size(32, 32, 32)]][]() {
       f32x32x32();
     });
 
-    h.single_task<class kernel_name6>(
+    h.single_task<class kernel_name3>(
         []() { func2(); });
 
-    h.single_task<class kernel_name7>(
+    h.single_task<class kernel_name4>(
         []() { func3(); });
   });
   return 0;

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-device.cpp
@@ -1,26 +1,25 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -Wno-sycl-2020-compat -fsyntax-only -verify %s
 
-// The test checks support and functionality of reqd_work_group_size kernel attribute in SYCL 2017.
+// The test checks support and functionality of reqd_work_group_size kernel attribute in SYCL 2020.
 
 #include "sycl.hpp"
 
 using namespace sycl;
 queue q;
 
-[[sycl::reqd_work_group_size(4)]] void f4() {} // expected-note {{conflicting attribute is here}}
-// expected-note@-1 {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(32)]] void f32() {} // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(16)]] void f16() {}      // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(16, 16)]] void f16x16() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(4)]] void f4() {}
+[[sycl::reqd_work_group_size(32)]] void f32() {}
+[[sycl::reqd_work_group_size(16)]] void f16() {}
+[[sycl::reqd_work_group_size(16, 16)]] void f16x16() {}
 
-[[sycl::reqd_work_group_size(32, 32)]] void f32x32() {}      // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(32, 32)]] void f32x32() {}
+[[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {}
 
 [[intel::reqd_work_group_size(4, 2, 9)]] void unknown() {} // expected-warning{{unknown attribute 'reqd_work_group_size' ignored}}
 
-class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+class Functor8 {
 public:
-  [[sycl::reqd_work_group_size(8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
+  [[sycl::reqd_work_group_size(8)]] void operator()() const {
     f4();
   }
 };
@@ -37,17 +36,17 @@ int main() {
     Functor8 f8;
     h.single_task<class kernel_name1>(f8);
 
-    h.single_task<class kernel_name2>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name2>([]() {
       f4();
       f32();
     });
 
-    h.single_task<class kernel_name3>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name3>([]() {
       f16();
       f16x16();
     });
 
-    h.single_task<class kernel_name4>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name4>([]() {
       f32x32x32();
       f32x32();
     });

--- a/clang/test/SemaSYCL/intel-work-group-size-hint-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-work-group-size-hint-ast-device.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -Wno-sycl-2020-compat -ast-dump %s | FileCheck %s
 
-// Test for AST of work_group_size_hint kernel attribute in SYCL 1.2.1.
+// Test for AST of work_group_size_hint kernel attribute in SYCL 2020.
 
 #include "sycl.hpp"
 
@@ -106,14 +106,6 @@ int main() {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-    // CHECK: SYCLWorkGroupSizeHintAttr
-    // CHECK-NEXT:  ConstantExpr{{.*}}'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    Functor f;
-    h.single_task<class kernel_name2>(f);
-
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
     // CHECK: SYCLWorkGroupSizeHintAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
@@ -156,34 +148,6 @@ int main() {
     h.single_task<class kernel_name5>([]() [[sycl::work_group_size_hint(8, 16, 32)]] {
       f8x16x32();
     });
-
-    // CHECK:  FunctionDecl {{.*}} {{.*}}kernel_name6
-    // CHECK:  SYCLIntelNoGlobalWorkOffsetAttr
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK: SYCLIntelMaxWorkGroupSizeAttr {{.*}} Inherited
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 4
-    // CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 6
-    // CHECK-NEXT:  IntegerLiteral{{.*}}6{{$}}
-    // CHECK: SYCLWorkGroupSizeHintAttr
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 2
-    // CHECK-NEXT:  IntegerLiteral{{.*}}2{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 1
-    // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-    // CHECK-NEXT:  ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT:  value: Int 3
-    // CHECK-NEXT:  IntegerLiteral{{.*}}3{{$}}
-    h.single_task<class kernel_name6>(
-        []() { func1(); });
   });
   return 0;
 }

--- a/clang/test/SemaSYCL/intel-work-group-size-hint-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-work-group-size-hint-ast-device.cpp
@@ -65,8 +65,6 @@ int check() {
 // CHECK-NEXT: NonTypeTemplateParmDecl {{.*}}
 // CHECK-NEXT: IntegerLiteral{{.*}}8{{$}}
 
-[[sycl::work_group_size_hint(4)]] void f4() {}
-
 class Functor16 {
 public:
   [[sycl::work_group_size_hint(16)]] void operator()() const {}
@@ -75,13 +73,6 @@ public:
 class Functor32x16x8 {
 public:
   [[sycl::work_group_size_hint(32, 16, 8)]] void operator()() const {}
-};
-
-class Functor {
-public:
-  void operator()() const {
-    f4();
-  }
 };
 
 class FunctorAttr {
@@ -106,7 +97,7 @@ int main() {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
     // CHECK: SYCLWorkGroupSizeHintAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 32
@@ -118,9 +109,9 @@ int main() {
     // CHECK-NEXT:  value: Int 8
     // CHECK-NEXT:  IntegerLiteral{{.*}}8{{$}}
     Functor32x16x8 f32x16x8;
-    h.single_task<class kernel_name3>(f32x16x8);
+    h.single_task<class kernel_name2>(f32x16x8);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
     // CHECK: SYCLWorkGroupSizeHintAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 128
@@ -132,9 +123,9 @@ int main() {
     // CHECK-NEXT:  value: Int 512
     // CHECK-NEXT:  IntegerLiteral{{.*}}512{{$}}
     FunctorAttr fattr;
-    h.single_task<class kernel_name4>(fattr);
+    h.single_task<class kernel_name3>(fattr);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
     // CHECK: SYCLWorkGroupSizeHintAttr
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 8
@@ -145,7 +136,7 @@ int main() {
     // CHECK-NEXT:  ConstantExpr{{.*}}'int'
     // CHECK-NEXT:  value: Int 32
     // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
-    h.single_task<class kernel_name5>([]() [[sycl::work_group_size_hint(8, 16, 32)]] {
+    h.single_task<class kernel_name4>([]() [[sycl::work_group_size_hint(8, 16, 32)]] {
       f8x16x32();
     });
   });

--- a/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -Wno-sycl-2020-compat -ast-dump %s | FileCheck %s
 
 // The test checks AST of [[intel::reqd_sub_group_size()]] attribute.
 
@@ -55,14 +55,6 @@ int main() {
     // CHECK-NEXT: IntegerLiteral{{.*}}16{{$}}
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
-
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-    // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
-    // CHECK-NEXT: ConstantExpr {{.*}} 'int'
-    // CHECK-NEXT: value: Int 4
-    // CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-    Functor f;
-    h.single_task<class kernel_name2>(f);
 
     // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
     // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size

--- a/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
@@ -14,13 +14,6 @@ public:
   [[intel::reqd_sub_group_size(16)]] void operator()() const {}
 };
 
-class Functor {
-public:
-  void operator()() const {
-    foo();
-  }
-};
-
 // Test that checks template parameter support on member function of class template.
 template <int SIZE>
 class KernelFunctor {
@@ -56,27 +49,27 @@ int main() {
     Functor16 f16;
     h.single_task<class kernel_name1>(f16);
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
     // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
     // CHECK-NEXT: ConstantExpr {{.*}} 'int'
     // CHECK-NEXT: value: Int 2
     // CHECK-NEXT: IntegerLiteral{{.*}}2{{$}}
-    h.single_task<class kernel_name3>([]() [[intel::reqd_sub_group_size(2)]] {});
+    h.single_task<class kernel_name2>([]() [[intel::reqd_sub_group_size(2)]] {});
 
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name3
     // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
     // CHECK-NEXT: ConstantExpr {{.*}} 'int'
     // CHECK-NEXT: value: Int 4
     // CHECK-NEXT: IntegerLiteral{{.*}}4{{$}}
-    h.single_task<class kernel_name4>([]() [[intel::reqd_sub_group_size(4)]] { foo(); });
-    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
+    h.single_task<class kernel_name3>([]() [[intel::reqd_sub_group_size(4)]] { foo(); });
+    // CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
     // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
     // CHECK-NEXT: ConstantExpr {{.*}} 'int'
     // CHECK-NEXT: value: Int 6
     // CHECK-NEXT: IntegerLiteral{{.*}}6{{$}}
-    h.single_task<class kernel_name5>([]() [[intel::reqd_sub_group_size(6)]] {});
+    h.single_task<class kernel_name4>([]() [[intel::reqd_sub_group_size(6)]] {});
 
-    // CHECK: FunctionDecl {{.*}}kernel_name_6
+    // CHECK: FunctionDecl {{.*}}kernel_name5
     // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
     // CHECK-NEXT: ConstantExpr{{.*}}'int'
     // CHECK-NEXT: value: Int 10
@@ -84,11 +77,11 @@ int main() {
     // CHECK-NEXT: NonTypeTemplateParmDecl
     // CHECK-NEXT: IntegerLiteral {{.*}} 'int' 10
     KernelFunctor<10> f2;
-    h.single_task<class kernel_name_6>(f2);
+    h.single_task<class kernel_name5>(f2);
 
     // Ignore duplicate attribute.
-    h.single_task<class kernel_name_7>(
-        // CHECK: FunctionDecl {{.*}}kernel_name_7
+    h.single_task<class kernel_name6>(
+        // CHECK: FunctionDecl {{.*}}kernel_name6
         // CHECK: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
         // CHECK-NEXT: ConstantExpr {{.*}} 'int'
         // CHECK-NEXT: value: Int 8

--- a/clang/test/SemaSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size.cpp
@@ -5,30 +5,12 @@
 #include "sycl.hpp"
 
 using namespace sycl;
-queue q;
-
-[[intel::reqd_sub_group_size(4)]] void foo() {} 
-[[intel::reqd_sub_group_size(32)]] void baz() {} 
-
-class Functor8 {
-public:
-  [[intel::reqd_sub_group_size(8)]] void operator()() const { 
-    foo();
-  }
-};
 
 int main() {
-  q.submit([&](handler &h) {
-    Functor8 f8;
-    h.single_task<class kernel_name1>(f8);
-
-    h.single_task<class kernel_name2>([]() {
-      foo();
-      baz();
-    });
-  });
   return 0;
 }
+
+
 [[intel::reqd_sub_group_size(16)]] SYCL_EXTERNAL void B();
 [[intel::reqd_sub_group_size(16)]] void A() {
 }

--- a/clang/test/SemaSYCL/reqd-sub-group-size.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -sycl-std=2017 -Wno-sycl-2017-compat -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -sycl-std=2020 -Wno-sycl-2020-compat -verify -pedantic %s
 
 // The test checks functionality of [[intel::reqd_sub_group_size()]] attribute on SYCL kernel.
 
@@ -7,13 +7,12 @@
 using namespace sycl;
 queue q;
 
-[[intel::reqd_sub_group_size(4)]] void foo() {} // expected-note {{conflicting attribute is here}}
-// expected-note@-1 {{conflicting attribute is here}}
-[[intel::reqd_sub_group_size(32)]] void baz() {} // expected-note {{conflicting attribute is here}}
+[[intel::reqd_sub_group_size(4)]] void foo() {} 
+[[intel::reqd_sub_group_size(32)]] void baz() {} 
 
-class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+class Functor8 {
 public:
-  [[intel::reqd_sub_group_size(8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
+  [[intel::reqd_sub_group_size(8)]] void operator()() const { 
     foo();
   }
 };
@@ -23,7 +22,7 @@ int main() {
     Functor8 f8;
     h.single_task<class kernel_name1>(f8);
 
-    h.single_task<class kernel_name2>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name2>([]() {
       foo();
       baz();
     });

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -1,21 +1,20 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -sycl-std=2017 -Wno-sycl-2017-compat -verify -DTRIGGER_ERROR %s
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -sycl-std=2020 -Wno-sycl-2020-compat -verify -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -Wno-sycl-2020-compat -ast-dump %s | FileCheck %s
 
-// Test for AST of reqd_work_group_size kernel attribute in SYCL 1.2.1.
+// Test for AST of reqd_work_group_size kernel attribute in SYCL 2020.
 #include "sycl.hpp"
 
 using namespace sycl;
 queue q;
 
-[[sycl::reqd_work_group_size(4, 1, 1)]] void f4x1x1() {} // expected-note {{conflicting attribute is here}}
-// expected-note@-1 {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(32, 1, 1)]] void f32x1x1() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(4, 1, 1)]] void f4x1x1() {}
+[[sycl::reqd_work_group_size(32, 1, 1)]] void f32x1x1() {}
 
-[[sycl::reqd_work_group_size(16, 1, 1)]] void f16x1x1() {} // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(16, 16, 1)]] void f16x16x1() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(16, 1, 1)]] void f16x1x1() {}
+[[sycl::reqd_work_group_size(16, 16, 1)]] void f16x16x1() {}
 
-[[sycl::reqd_work_group_size(32, 32, 1)]] void f32x32x1() {} // expected-note {{conflicting attribute is here}}
-[[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {} // expected-note {{conflicting attribute is here}}
+[[sycl::reqd_work_group_size(32, 32, 1)]] void f32x32x1() {}
+[[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {}
 
 // No diagnostic because the attributes are synonyms with identical behavior.
 [[sycl::reqd_work_group_size(4, 4, 4)]] void four1();
@@ -62,9 +61,9 @@ public:
   [[sycl::reqd_work_group_size(16, 16, 16)]] void operator()() const {}
 };
 
-class Functor8 { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+class Functor8 {
 public:
-  [[sycl::reqd_work_group_size(1, 1, 8)]] void operator()() const { // expected-note {{conflicting attribute is here}}
+  [[sycl::reqd_work_group_size(1, 1, 8)]] void operator()() const {
     f4x1x1();
   }
 };
@@ -98,17 +97,17 @@ int main() {
     Functor32 f32;
     h.single_task<class kernel_name1>(f32);
 
-    h.single_task<class kernel_name7>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name7>([]() {
       f4x1x1();
       f32x1x1();
     });
 
-    h.single_task<class kernel_name8>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name8>([]() {
       f16x1x1();
       f16x16x1();
     });
 
-    h.single_task<class kernel_name9>([]() { // expected-error {{conflicting attributes applied to a SYCL kernel}}
+    h.single_task<class kernel_name9>([]() {
       f32x32x32();
       f32x32x1();
     });
@@ -132,17 +131,6 @@ int main() {
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 16
 // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
-// CHECK-NEXT:  ConstantExpr{{.*}}'int'
-// CHECK-NEXT:  value: Int 1
-// CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-// CHECK-NEXT:  ConstantExpr{{.*}}'int'
-// CHECK-NEXT:  value: Int 1
-// CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}
-// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name2
-// CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
-// CHECK-NEXT:  ConstantExpr{{.*}}'int'
-// CHECK-NEXT:  value: Int 4
-// CHECK-NEXT:  IntegerLiteral{{.*}}4{{$}}
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 1
 // CHECK-NEXT:  IntegerLiteral{{.*}}1{{$}}

--- a/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
+++ b/clang/test/SemaSYCL/reqd-work-group-size-device.cpp
@@ -8,12 +8,6 @@ using namespace sycl;
 queue q;
 
 [[sycl::reqd_work_group_size(4, 1, 1)]] void f4x1x1() {}
-[[sycl::reqd_work_group_size(32, 1, 1)]] void f32x1x1() {}
-
-[[sycl::reqd_work_group_size(16, 1, 1)]] void f16x1x1() {}
-[[sycl::reqd_work_group_size(16, 16, 1)]] void f16x16x1() {}
-
-[[sycl::reqd_work_group_size(32, 32, 1)]] void f32x32x1() {}
 [[sycl::reqd_work_group_size(32, 32, 32)]] void f32x32x32() {}
 
 // No diagnostic because the attributes are synonyms with identical behavior.
@@ -61,13 +55,6 @@ public:
   [[sycl::reqd_work_group_size(16, 16, 16)]] void operator()() const {}
 };
 
-class Functor8 {
-public:
-  [[sycl::reqd_work_group_size(1, 1, 8)]] void operator()() const {
-    f4x1x1();
-  }
-};
-
 class Functor {
 public:
   void operator()() const {
@@ -86,40 +73,22 @@ int main() {
     Functor16x16x16 f16x16x16;
     h.single_task<class kernel_name3>(f16x16x16);
 
-    h.single_task<class kernel_name5>([]() [[sycl::reqd_work_group_size(32, 32, 32), sycl::reqd_work_group_size(32, 32, 32)]] {
+    h.single_task<class kernel_name4>([]() [[sycl::reqd_work_group_size(32, 32, 32), sycl::reqd_work_group_size(32, 32, 32)]] {
       f32x32x32();
     });
 
 #ifdef TRIGGER_ERROR
-    Functor8 f8;
-    h.single_task<class kernel_name6>(f8);
-
     Functor32 f32;
     h.single_task<class kernel_name1>(f32);
 
-    h.single_task<class kernel_name7>([]() {
-      f4x1x1();
-      f32x1x1();
-    });
-
-    h.single_task<class kernel_name8>([]() {
-      f16x1x1();
-      f16x16x1();
-    });
-
-    h.single_task<class kernel_name9>([]() {
-      f32x32x32();
-      f32x32x1();
-    });
-
     // expected-error@+1 {{expected variable name or 'this' in lambda capture list}}
-    h.single_task<class kernel_name10>([[sycl::reqd_work_group_size(32, 32, 32)]][]() {
+    h.single_task<class kernel_name5>([[sycl::reqd_work_group_size(32, 32, 32)]][]() {
       f32x32x32();
     });
 
 #endif
     // Ignore duplicate attribute.
-    h.single_task<class test_kernel11>(
+    h.single_task<class kernel_name6>(
         []() [[sycl::reqd_work_group_size(2, 2, 2),
                sycl::reqd_work_group_size(2, 2, 2)]] {});
   });
@@ -148,7 +117,7 @@ int main() {
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 16
 // CHECK-NEXT:  IntegerLiteral{{.*}}16{{$}}
-// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name5
+// CHECK: FunctionDecl {{.*}} {{.*}}kernel_name4
 // CHECK: SYCLReqdWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 32
@@ -160,7 +129,7 @@ int main() {
 // CHECK-NEXT:  value: Int 32
 // CHECK-NEXT:  IntegerLiteral{{.*}}32{{$}}
 //
-// CHECK: FunctionDecl {{.*}}test_kernel11
+// CHECK: FunctionDecl {{.*}}kernel_name6
 // CHECK: SYCLReqdWorkGroupSizeAttr
 // CHECK-NEXT:  ConstantExpr{{.*}}'int'
 // CHECK-NEXT:  value: Int 2


### PR DESCRIPTION
Revise these SYCL 2017 (i.e. SYCL 1.2.1) tests so that they can run under SYCL 2020 mode before merging https://github.com/intel/llvm/pull/13411.