### PR TITLE
Fix AST lit failures.

### DIFF
--- a/clang/include/clang/Basic/FPOptions.def
+++ b/clang/include/clang/Basic/FPOptions.def
@@ -28,6 +28,6 @@ OPTION(FPEvalMethod, LangOptions::FPEvalMethodKind, 2, AllowApproxFunc)
 OPTION(Float16ExcessPrecision, LangOptions::ExcessPrecisionKind, 2, FPEvalMethod)
 OPTION(BFloat16ExcessPrecision, LangOptions::ExcessPrecisionKind, 2, Float16ExcessPrecision)
 OPTION(FPAccuracy, LangOptions::FPAccuracyKind, 3, BFloat16ExcessPrecision)
-OPTION(MathErrno, bool, 1, BFloat16ExcessPrecision)
+OPTION(MathErrno, bool, 1, FPAccuracy)
 OPTION(ComplexRange, LangOptions::ComplexRangeKind, 2, MathErrno)
 #undef OPTION


### PR DESCRIPTION
Let MathErrno reference the previous item FPAccuracy.
Fix:
Clang::AST/ast-dump-fpfeatures.cpp
Clang::AST/ast-dump-fpfeatures.m
Clang::AST/ast-dump-late-parsing.cpp