### PR TITLE
[SYCL][Graph] Bump UR commit for in-order L0 optimization

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -95,23 +95,17 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit b37fa2c4b09a49839a83228f687c811595fce3fd
-  # Merge: c7fade0d f61e81e9
+  # commit 7371150b3a525d9c69a0790f9abf59089eb0c46c
+  # Merge: cb44d9ab bb45b7c5
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Tue Apr 23 16:17:41 2024 +0100
-  #    Merge pull request #1544 from kbenzie/benie/l0-fix-rhel-error
-  #    [L0] Add missing <iomanip> include
-  set(UNIFIED_RUNTIME_TAG b37fa2c4b09a49839a83228f687c811595fce3fd)
+  # Date:   Fri Apr 26 15:44:19 2024 +0100
+  #    Merge pull request #1442 from Bensuo/ben/optimize-cmdbuffer-submission
+  #    [EXP][Command-Buffer] Optimize L0 command buffer submission
+  set(UNIFIED_RUNTIME_TAG 7371150b3a525d9c69a0790f9abf59089eb0c46c)
 
   fetch_adapter_source(level_zero
     ${UNIFIED_RUNTIME_REPO}
-    # commit f4a94976f880de64d0c144abb1080a8262c158f3
-    # Merge: ee075703 39fcb2be
-    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Fri Apr 26 11:50:56 2024 +0100
-    #     Merge pull request #1370 from winstonzhang-intel/counter-based-events
-    #     [L0] Support for counter-based events using L0 driver
-    f4a94976f880de64d0c144abb1080a8262c158f3
+    ${UNIFIED_RUNTIME_TAG}
   )
 
   fetch_adapter_source(opencl
@@ -120,15 +114,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   )
 
   fetch_adapter_source(cuda
-    "https://github.com/oneapi-src/unified-runtime.git"
-    # commit 7fcfe3ad8882fee23d83fa0fc4c4c944262a9ea3
-    # Merge: b37fa2c4 f9fb1167
-    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Wed Apr 24 10:38:00 2024 +0100
-    #     Merge pull request #1265 from cppchedy/chedy/device-to-device-copy
-    #
-    #     [Bindless][Exp] Add support for device to device copies between CuArrays
-    7fcfe3ad8882fee23d83fa0fc4c4c944262a9ea3
+    ${UNIFIED_RUNTIME_REPO}
+    ${UNIFIED_RUNTIME_TAG}
   )
 
   fetch_adapter_source(hip
@@ -138,13 +125,7 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
 
   fetch_adapter_source(native_cpu
     ${UNIFIED_RUNTIME_REPO}
-    # commit 37242e39480d8bb73cb8cc3a54152edab43fd85b
-    # Merge: 48facdd6 56ffd291
-    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Thu Apr 25 10:23:31 2024 +0100
-    #     Merge pull request #1518 from PietroGhg/pietro/coverity
-    #     [NATIVECPU] Address coverity warnings in threadpool implementation
-    37242e39480d8bb73cb8cc3a54152edab43fd85b
+    ${UNIFIED_RUNTIME_TAG}
   )
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -4496,6 +4496,8 @@ piextCommandBufferCreate(pi_context Context, pi_device Device,
   ur_device_handle_t UrDevice = reinterpret_cast<ur_device_handle_t>(Device);
   ur_exp_command_buffer_desc_t UrDesc;
   UrDesc.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC;
+  UrDesc.isInOrder = ur_bool_t(false);
+  UrDesc.enableProfiling = ur_bool_t(true);
   UrDesc.isUpdatable = Desc->is_updatable;
   ur_exp_command_buffer_handle_t *UrCommandBuffer =
       reinterpret_cast<ur_exp_command_buffer_handle_t *>(RetCommandBuffer);


### PR DESCRIPTION
- Bumps commit only and includes minimal pi2ur changes for new descriptor members
- In-order path not currently used, enable profiling by default (match previous behaviour)

UR PR: https://github.com/oneapi-src/unified-runtime/pull/1442