### PR TITLE
[SYCL][SCLA] Throw `sycl::exception` with `feature_not_supported` error code

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/alloca.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/alloca.hpp
@@ -61,18 +61,18 @@ __SYCL_BUILTIN_ALIAS(__builtin_intel_sycl_alloca_with_align)
 template <typename ElementType, auto &SizeSpecName,
           access::decorated DecorateAddress>
 private_ptr<ElementType, DecorateAddress> private_alloca(kernel_handler &kh) {
-  throw feature_not_supported("sycl::ext::oneapi::experimental::private_alloca "
-                              "is not supported on host",
-                              PI_ERROR_INVALID_OPERATION);
+  throw exception(sycl::errc::feature_not_supported,
+                  "sycl::ext::oneapi::experimental::private_alloca is not "
+                  "supported on host");
 }
 
 template <typename ElementType, std::size_t Alignment, auto &SizeSpecName,
           access::decorated DecorateAddress>
 private_ptr<ElementType, DecorateAddress>
 aligned_private_alloca(kernel_handler &kh) {
-  throw feature_not_supported("sycl::ext::oneapi::experimental::aligned_"
-                              "private_alloca is not supported on host",
-                              PI_ERROR_INVALID_OPERATION);
+  throw exception(sycl::errc::feature_not_supported,
+                  "sycl::ext::oneapi::experimental::aligned_private_alloca is "
+                  "not supported on host");
 }
 
 #endif // __SYCL_DEVICE_ONLY__

--- a/sycl/test-e2e/PrivateAlloca/private_alloca_host.cpp
+++ b/sycl/test-e2e/PrivateAlloca/private_alloca_host.cpp
@@ -11,24 +11,33 @@
 
 constexpr sycl::specialization_id<int> size(10);
 
-template <typename Func> static void test(Func f) {
+template <typename Func>
+static void test(std::string_view expectedMessage, Func f) {
   try {
     f();
   } catch (sycl::exception &e) {
     assert(e.code() == sycl::errc::feature_not_supported &&
            "Unexpected error code");
+    assert(std::string_view{e.what()} == expectedMessage &&
+           "Unexpected error message");
   }
 }
 
 int main() {
+  using namespace std::literals;
+
   std::array<uint8_t, sizeof(sycl::kernel_handler)> h;
   auto &kh = *reinterpret_cast<sycl::kernel_handler *>(h.data());
-  test([&kh]() {
-    sycl::ext::oneapi::experimental::aligned_private_alloca<
-        float, alignof(double), size, sycl::access::decorated::no>(kh);
-  });
-  test([&kh]() {
-    sycl::ext::oneapi::experimental::private_alloca<
-        float, size, sycl::access::decorated::no>(kh);
-  });
+  test(
+      "sycl::ext::oneapi::experimental::aligned_private_alloca is not supported on host"sv,
+      [&kh]() {
+        sycl::ext::oneapi::experimental::aligned_private_alloca<
+            float, alignof(double), size, sycl::access::decorated::no>(kh);
+      });
+  test(
+      "sycl::ext::oneapi::experimental::private_alloca is not supported on host"sv,
+      [&kh]() {
+        sycl::ext::oneapi::experimental::private_alloca<
+            float, size, sycl::access::decorated::no>(kh);
+      });
 }


### PR DESCRIPTION
Throw a `sycl::exception` with `feature_not_supported` error code instead of an instance of the deprecated `sycl::feature_not_supported` on `[aligned_]private_alloca` use on host.