### PR TITLE
[SYCL] Fix WA for ocl query of CL_DEVICE_PROFILE 

### DIFF
--- a/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
@@ -6,8 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <sycl/detail/pi.hpp>          // getOsLibraryFuncAddress
-#include <sycl/exception.hpp>          // make_error_code
+#include <sycl/detail/pi.hpp> // getOsLibraryFuncAddress
+#include <sycl/exception.hpp> // make_error_code
 
 #include "kernel_compiler_opencl.hpp"
 
@@ -368,9 +368,11 @@ std::string OpenCLC_Profile(uint32_t IPVersion) {
     std::string result = InvokeOclocQuery(IPVersion, "CL_DEVICE_PROFILE");
     // NOTE: result has \n\n amended. Clean it up.
     // TODO: remove this once the ocloc query is fixed.
-    while (result.back() == '\n') {
-      result.pop_back();
-    }
+    result.erase(std::remove_if(result.begin(), result.end(),
+                                [](char c) {
+                                  return !std::isprint(c) || std::isspace(c);
+                                }),
+                 result.end());
 
     return result;
   } catch (sycl::exception &) {

--- a/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
@@ -9,8 +9,8 @@
 // REQUIRES: ocloc && (opencl || level_zero)
 // UNSUPPORTED: accelerator
 
-// Fails with opencl and level_zero on linux, enable when fixed.
-// XFAIL: opencl || (linux && level_zero)
+// Fails with level_zero on linux, enable when fixed.
+// XFAIL: (linux && level_zero)
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
@@ -48,11 +48,16 @@ int main() {
   assert(d.ext_oneapi_cl_profile() == "FULL_PROFILE" &&
          "unexpected cl_profile");
 
-  assert(syclex::opencl_c_1_0.major == 1 && syclex::opencl_c_1_0.minor == 0 && syclex::opencl_c_1_0.patch == 0);
-  assert(syclex::opencl_c_1_1.major == 1 && syclex::opencl_c_1_1.minor == 1 && syclex::opencl_c_1_1.patch == 0);
-  assert(syclex::opencl_c_1_2.major == 1 && syclex::opencl_c_1_2.minor == 2 && syclex::opencl_c_1_2.patch == 0);
-  assert(syclex::opencl_c_2_0.major == 2 && syclex::opencl_c_2_0.minor == 0 && syclex::opencl_c_2_0.patch == 0);
-  assert(syclex::opencl_c_3_0.major == 3 && syclex::opencl_c_3_0.minor == 0 && syclex::opencl_c_3_0.patch == 0);
+  assert(syclex::opencl_c_1_0.major == 1 && syclex::opencl_c_1_0.minor == 0 &&
+         syclex::opencl_c_1_0.patch == 0);
+  assert(syclex::opencl_c_1_1.major == 1 && syclex::opencl_c_1_1.minor == 1 &&
+         syclex::opencl_c_1_1.patch == 0);
+  assert(syclex::opencl_c_1_2.major == 1 && syclex::opencl_c_1_2.minor == 2 &&
+         syclex::opencl_c_1_2.patch == 0);
+  assert(syclex::opencl_c_2_0.major == 2 && syclex::opencl_c_2_0.minor == 0 &&
+         syclex::opencl_c_2_0.patch == 0);
+  assert(syclex::opencl_c_3_0.major == 3 && syclex::opencl_c_3_0.minor == 0 &&
+         syclex::opencl_c_3_0.patch == 0);
 
   return 0;
 }

--- a/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
@@ -9,9 +9,6 @@
 // REQUIRES: ocloc && (opencl || level_zero)
 // UNSUPPORTED: accelerator
 
-// Fails with level_zero on linux, enable when fixed.
-// XFAIL: (linux && level_zero)
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Improves kernel_compiler WA for CL_DEVICE_PROFILE query. 
Currently ocl query returns some extra symbols we want to eliminate from final result returned to user. 
Removes all special symbols now. To be removed once ocl query is fixed.