### PR TITLE
[SYCL] Silence warnings for `#warning` directive in `CL/sycl.hpp`

### DIFF
--- a/sycl/include/CL/sycl.hpp
+++ b/sycl/include/CL/sycl.hpp
@@ -9,7 +9,10 @@
 #pragma once
 
 #if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
 #warning "CL/sycl.hpp is deprecated, use sycl/sycl.hpp"
+#pragma clang diagnostic pop
 #endif
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -1,6 +1,6 @@
 // RUN: %clangxx %fsycl-host-only -fsyntax-only -ferror-limit=0 -sycl-std=2020 -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
 
-// expected-warning@sycl/CL/sycl.hpp:12 {{CL/sycl.hpp is deprecated, use sycl/sycl.hpp}}
+// expected-warning@sycl/CL/sycl.hpp:* {{CL/sycl.hpp is deprecated, use sycl/sycl.hpp}}
 #include <CL/sycl.hpp>
 #include <sycl/ext/intel/experimental/online_compiler.hpp>
 

--- a/sycl/unittests/SYCL2020/AtomicFenceCapabilities.cpp
+++ b/sycl/unittests/SYCL2020/AtomicFenceCapabilities.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <gtest/gtest.h>
 #include <helpers/PiMock.hpp>
 

--- a/sycl/unittests/SYCL2020/AtomicMemoryScopeCapabilities.cpp
+++ b/sycl/unittests/SYCL2020/AtomicMemoryScopeCapabilities.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <gtest/gtest.h>
 #include <helpers/PiMock.hpp>
 

--- a/sycl/unittests/queue/DeviceCheck.cpp
+++ b/sycl/unittests/queue/DeviceCheck.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#include <CL/sycl.hpp>
+#include <sycl/sycl.hpp>
 #include <detail/config.hpp>
 #include <detail/device_impl.hpp>
 #include <gtest/gtest.h>


### PR DESCRIPTION
Fixes https://github.com/intel/llvm/issues/13592. Also update unittests not to use the deprecated header file.