### PR TITLE
[Joint Matrix][E2E] Remove xfail for 2 tests

### DIFF
--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: matrix-xmx8
-// XFAIL:gpu
 
 // RUN: %{build} -mllvm -inline-threshold=2000 -ffp-model=precise -o %t.out -DMANUAL_UNROLL
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Matrix/XMX8/joint_matrix_int8_vnni.cpp
+++ b/sycl/test-e2e/Matrix/XMX8/joint_matrix_int8_vnni.cpp
@@ -10,12 +10,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: *
-
 #include "../common.hpp"
-
-using namespace sycl;
-using namespace sycl::ext::oneapi::experimental::matrix;
 
 #define SG_SZ 8
 constexpr size_t TN = 8;


### PR DESCRIPTION
Remove xfail for Matrix/XMX8/joint_matrix_bf16_fill_k_cache_unroll.cpp and XMX8/joint_matrix_int8_vnni.cpp

Resolves https://github.com/intel/llvm/issues/13593