### PR TITLE
[ESIMD] Use 1-element mask for load_2d()/store_2d()/prefetch_2d()

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -1056,7 +1056,7 @@ template <typename Ty, __ESIMD_NS::cache_hint L1H, __ESIMD_NS::cache_hint L2H,
           uint8_t NBlocks, int BlockWidth, int BlockHeight, bool Transformed,
           int N>
 __ESIMD_INTRIN __ESIMD_DNS::vector_type_t<Ty, N>
-__esimd_lsc_load2d_stateless(__ESIMD_DNS::simd_mask_storage_t<N> Pred,
+__esimd_lsc_load2d_stateless(__ESIMD_DNS::simd_mask_storage_t<1> Pred,
                              uintptr_t Ptr, int SurfaceWidth, int SurfaceHeight,
                              int SurfacePitch, int X, int Y) __ESIMD_INTRIN_END;
 
@@ -1089,7 +1089,7 @@ template <typename Ty, __ESIMD_NS::cache_hint L1H, __ESIMD_NS::cache_hint L2H,
           uint8_t NBlocks, int BlockWidth, int BlockHeight, bool Transformed,
           int N>
 __ESIMD_INTRIN void __esimd_lsc_prefetch2d_stateless(
-    __ESIMD_DNS::simd_mask_storage_t<N> Pred, uintptr_t Ptr, int SurfaceWidth,
+    __ESIMD_DNS::simd_mask_storage_t<1> Pred, uintptr_t Ptr, int SurfaceWidth,
     int SurfaceHeight, int SurfacePitch, int X, int Y) __ESIMD_INTRIN_END;
 
 /// 2D USM pointer block store.
@@ -1126,7 +1126,7 @@ template <typename Ty, __ESIMD_NS::cache_hint L1H, __ESIMD_NS::cache_hint L2H,
           uint8_t NBlocks, int BlockWidth, int BlockHeight, bool Transformed,
           int N>
 __ESIMD_INTRIN void __esimd_lsc_store2d_stateless(
-    __ESIMD_DNS::simd_mask_storage_t<N> Pred, uintptr_t Ptr, int SurfaceWidth,
+    __ESIMD_DNS::simd_mask_storage_t<1> Pred, uintptr_t Ptr, int SurfaceWidth,
     int SurfaceHeight, int SurfacePitch, int X, int Y,
     __ESIMD_DNS::vector_type_t<Ty, N> vals) __ESIMD_INTRIN_END;
 

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -3085,7 +3085,7 @@ __ESIMD_API simd<T, N> load_2d_impl(const T *Ptr, unsigned SurfaceWidth,
   constexpr int DstElements = DstBlockElements * NBlocks;
 
   static_assert(N == ActualN || N == DstElements, "Incorrect element count");
-  simd_mask<ActualN> Mask = 1;
+  simd_mask<1> Mask = 1;
   constexpr lsc_data_size DS =
       finalize_data_size<RawT, lsc_data_size::default_size>();
   uintptr_t Addr = reinterpret_cast<uintptr_t>(Ptr);
@@ -3174,7 +3174,7 @@ __ESIMD_API void prefetch_2d_impl(const T *Ptr, unsigned SurfaceWidth,
       finalize_data_size<RawT, lsc_data_size::default_size>();
   uintptr_t Addr = reinterpret_cast<uintptr_t>(Ptr);
   constexpr lsc_data_order Transpose = lsc_data_order::nontranspose;
-  simd_mask<N> Mask = 1;
+  simd_mask<1> Mask = 1;
   __esimd_lsc_prefetch2d_stateless<RawT, L1H, L2H, DS, Transpose, NBlocks,
                                    BlockWidth, BlockHeight, false, N>(
       Mask.data(), Addr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y);
@@ -3226,7 +3226,7 @@ __ESIMD_API void store_2d_impl(T *Ptr, unsigned SurfaceWidth,
   constexpr int Pitch = getNextPowerOf2<BlockWidth>();
   constexpr int NElts = BlockHeight * Pitch;
   simd<RawT, NElts> Raw;
-  simd_mask<NElts> Mask = 1;
+  simd_mask<1> Mask = 1;
 
   if constexpr (NElts == N) {
     Raw = Vals;

--- a/sycl/test/esimd/lsc.cpp
+++ b/sycl/test/esimd/lsc.cpp
@@ -155,18 +155,18 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void foo(AccType &acc) {
   constexpr unsigned NumBlocks = 2;
   unsigned data_height, data_width, data_pitch, x, y;
 
-  // CHECK: call <32 x i32> @llvm.genx.lsc.load2d.stateless.v32i32.v32i1.i64(<32 x i1> {{[^)]+}}, i8 1, i8 1, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK: call <32 x i32> @llvm.genx.lsc.load2d.stateless.v32i32.v1i1.i64(<1 x i1> {{[^)]+}}, i8 1, i8 1, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   simd<int, Width * Height * NumBlocks> data7 =
       lsc_load_2d<int, Width, Height, NumBlocks, false, false,
                   cache_hint::uncached, cache_hint::uncached>(
           ptr, data_width, data_height, data_pitch, x, y);
 
   simd<int, Width * Height * 1> data8 = 7;
-  // CHECK: call void @llvm.genx.lsc.store2d.stateless.v16i1.i64.v16i32(<16 x i1> {{[^)]+}}, i8 1, i8 1, i8 3, i8 1, i8 1, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x i32> {{[^)]+}})
+  // CHECK: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16i32(<1 x i1> {{[^)]+}}, i8 1, i8 1, i8 3, i8 1, i8 1, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x i32> {{[^)]+}})
   lsc_store_2d<int, Width, Height, cache_hint::uncached, cache_hint::uncached>(
       ptr, data_width, data_height, data_pitch, x, y, data8);
 
-  // CHECK: call void @llvm.genx.lsc.prefetch2d.stateless.v32i1.i64(<32 x i1> {{[^)]+}}, i8 1, i8 2, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK: call void @llvm.genx.lsc.prefetch2d.stateless.v1i1.i64(<1 x i1> {{[^)]+}}, i8 1, i8 2, i8 3, i8 1, i8 2, i16 4, i16 4, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   lsc_prefetch_2d<int, Width, Height, NumBlocks, cache_hint::uncached,
                   cache_hint::cached>(ptr, data_width, data_height, data_pitch,
                                       x, y);

--- a/sycl/test/esimd/memory_properties.cpp
+++ b/sycl/test/esimd/memory_properties.cpp
@@ -2512,7 +2512,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   // 4) store_2d(): combinations of explicit and default template parameters
   // 5) same as (4) but without compile time properties
 
-  // CHECK-COUNT-3: call void @llvm.genx.lsc.prefetch2d.stateless.v16i1.i64(<16 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-COUNT-3: call void @llvm.genx.lsc.prefetch2d.stateless.v1i1.i64(<1 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   prefetch_2d<float, BlockWidth, BlockHeight, NBlocks>(
       ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y, props_cache_load);
   prefetch_2d<float, BlockWidth, BlockHeight>(
@@ -2520,7 +2520,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   prefetch_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight, SurfacePitch,
                                  X, Y, props_cache_load);
 
-  // CHECK-COUNT-5: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v16i1.i64(<16 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-COUNT-5: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v1i1.i64(<1 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   Vals =
       load_2d<float, BlockWidth, BlockHeight, NBlocks, Transposed, Transformed>(
           ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y,
@@ -2534,7 +2534,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   Vals = load_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight,
                                     SurfacePitch, X, Y, props_cache_load);
 
-  // CHECK-COUNT-5: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v16i1.i64(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
+  // CHECK-COUNT-5: call <16 x float> @llvm.genx.lsc.load2d.stateless.v16f32.v1i1.i64(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}})
   Vals =
       load_2d<float, BlockWidth, BlockHeight, NBlocks, Transposed, Transformed>(
           ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y);
@@ -2547,7 +2547,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
   Vals = load_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight,
                                     SurfacePitch, X, Y);
 
-  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v16i1.i64.v16f32(<16 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
+  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16f32(<1 x i1> {{[^)]+}}, i8 5, i8 1, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
   store_2d<float, BlockWidth, BlockHeight>(ptr, SurfaceWidth, SurfaceHeight,
                                            SurfacePitch, X, Y, Vals,
                                            props_cache_load);
@@ -2560,7 +2560,7 @@ SYCL_ESIMD_FUNCTION SYCL_EXTERNAL void test_2d(float *ptr) {
       ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X, Y,
       Vals_view.select<16, 1>(), props_cache_load);
 
-  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v16i1.i64.v16f32(<16 x i1> {{[^)]+}}, i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
+  // CHECK-COUNT-4: call void @llvm.genx.lsc.store2d.stateless.v1i1.i64.v16f32(<1 x i1> {{[^)]+}}, i8 0, i8 0, i8 3, i8 1, i8 1, i16 16, i16 1, i8 0, i64 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, i32 {{[^)]+}}, <16 x float> {{[^)]+}})
   store_2d<float, BlockWidth, BlockHeight>(ptr, SurfaceWidth, SurfaceHeight,
                                            SurfacePitch, X, Y, Vals);
   store_2d<float, BlockWidth>(ptr, SurfaceWidth, SurfaceHeight, SurfacePitch, X,


### PR DESCRIPTION
The actual mask is a scalar. ESIMD passed a vector mask, which worked because GPU driver ignored that until an unwanted assert there was added in December 2023.
Even though the assert was removed in GPU driver today(Apr30'2024), it will take long until it reaches our CI.

This fix resolves these test fails on PVC:
  SYCL :: ESIMD/lsc/lsc_load_2d_compare.cpp
  SYCL :: ESIMD/lsc/lsc_load_2d_u16.cpp
  SYCL :: ESIMD/lsc/lsc_load_2d_u32.cpp
  SYCL :: ESIMD/lsc/lsc_load_2d_u64.cpp
  SYCL :: ESIMD/lsc/lsc_load_2d_u8.cpp
  SYCL :: ESIMD/lsc/lsc_load_store_2d_compare.cpp
  SYCL :: ESIMD/lsc/lsc_prefetch_2d_u16.cpp
  SYCL :: ESIMD/lsc/lsc_prefetch_2d_u32.cpp
  SYCL :: ESIMD/lsc/lsc_prefetch_2d_u64.cpp
  SYCL :: ESIMD/lsc/lsc_prefetch_2d_u8.cpp
  SYCL :: ESIMD/lsc/lsc_store_2d_u32.cpp
  SYCL :: ESIMD/lsc/lsc_store_2d_u64.cpp
  SYCL :: ESIMD/lsc/lsc_store_2d_u8.cpp
  SYCL :: ESIMD/lsc/lsc_usm_2d.cpp
  SYCL :: ESIMD/unified_memory_api/load_2d.cpp
  SYCL :: ESIMD/unified_memory_api/prefetch_2d.cpp
  SYCL :: ESIMD/unified_memory_api/store_2d.cpp