### PR TITLE
[CI] Only test joint matrix for igc dev driver update

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           if [ "${{ contains(needs.detect_changes.outputs.filters, 'drivers') }}" == "true" ]; then
              echo 'arc_tests=""' >> "$GITHUB_OUTPUT"
+          elif [ "${{ contains(needs.detect_changes.outputs.filters, 'devigccfg') }}" == "true" ]; then
+            echo 'arc_tests="Matrix/"' >> "$GITHUB_OUTPUT"
           elif [ "${{ contains(needs.detect_changes.outputs.filters, 'esimd') }}" == "true" ]; then
             echo 'arc_tests="(ESIMD|InvokeSimd|Matrix)/"' >> "$GITHUB_OUTPUT"
           else


### PR DESCRIPTION
There are existing failures for non joint matrix tests.
eg: https://github.com/intel/llvm/actions/runs/8903576097/job/24452097484

We will only use igc dev driver for joint matrix for now, so we don't really need to run all e2e test,
only make sure joint matrix tests are clean is enough.