### PR TITLE
[SYCL][Docs][NFC] Update the copyright year format

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_intel_fp_control.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_intel_fp_control.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_intel_grf_size.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_intel_grf_size.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -24,7 +24,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_auto_local_range.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_auto_local_range.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_composite_device.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_composite_device.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_copy_optimize.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_copy_optimize.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_cuda_async_barrier.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_cuda_async_barrier.asciidoc
@@ -19,7 +19,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_cuda_tex_cache_read.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_cuda_tex_cache_read.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2024-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2024 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
@@ -24,7 +24,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler_opencl.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler_spirv.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler_spirv.asciidoc
@@ -22,7 +22,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2021-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2021 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_native_math.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_native_math.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_non_uniform_groups.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_root_group.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_uniform.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_uniform.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2021 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_user_defined_reductions.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_user_defined_reductions.asciidoc
@@ -19,7 +19,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_cache_controls.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_cache_controls.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_datapath.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_datapath.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation. All rights reserved.
+Copyright (C) 2023 Intel Corporation. All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc. OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc
@@ -24,7 +24,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_mem.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_mem.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation. All rights reserved.
+Copyright (C) 2023 Intel Corporation. All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc. OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_runtime_buffer_location.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_runtime_buffer_location.asciidoc
@@ -19,7 +19,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_address_cast.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_append_and_shift.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_append_and_shift.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_atomic16.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_atomic16.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_barrier.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_barrier.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_if.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_device_if.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2021 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_enqueue_functions.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_enqueue_functions.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_forward_progress.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_forward_progress.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_launch_queries.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_launch_queries.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_named_sub_group_sizes.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_named_sub_group_sizes.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2019-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2019 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_prefetch.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_prefetch.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_prod.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_prod.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_profiling_tag.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_raw_kernel_arg.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_raw_kernel_arg.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_specific.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_specific.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_intel_cslice.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_cslice.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_intel_fpga_device_selector.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_fpga_device_selector.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_intel_legacy_image.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_legacy_image.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_intel_queue_immediate_command_list.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_queue_immediate_command_list.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2023-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2023 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_intel_queue_index.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_queue_index.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_bfloat16.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_bfloat16.asciidoc
@@ -23,7 +23,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_free_function_queries.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_free_function_queries.asciidoc
@@ -22,7 +22,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2020-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2020 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_local_memory.asciidoc
@@ -19,7 +19,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2021 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_memcpy2d.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_memcpy2d.asciidoc
@@ -18,7 +18,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_peer_access.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_peer_access.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_queue_empty.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_queue_empty.asciidoc
@@ -19,7 +19,7 @@
 
 == Notice
 
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_queue_priority.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_queue_priority.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group_mask.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_sub_group_mask.asciidoc
@@ -21,7 +21,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2021-2023 Intel Corporation.  All rights reserved.
+Copyright (C) 2021 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_usm_device_read_only.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_weak_object.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2022-2022 Intel Corporation.  All rights reserved.
+Copyright (C) 2022 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by

--- a/sycl/doc/extensions/template.asciidoc
+++ b/sycl/doc/extensions/template.asciidoc
@@ -20,7 +20,7 @@
 == Notice
 
 [%hardbreaks]
-Copyright (C) 2024-2024 Intel Corporation.  All rights reserved.
+Copyright (C) 2024 Intel Corporation.  All rights reserved.
 
 Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are trademarks
 of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc. used by


### PR DESCRIPTION
Use the First Publication Date only to avoid maintaining the *Latest Publication Date*.
We have switched to use "First Publication Date only" in internal branches,  updating in `sycl` branch to avoid unnecessary conflict.