### PR TITLE
[SYCL][Docs] Behavioral changes to in-order queue events extension

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
@@ -116,7 +116,13 @@ a|
 event ext_oneapi_get_last_event() const;
 ----
 | Returns an event representing the execution of the last command submitted to
-the queue.
+the queue. If a call to `ext_oneapi_set_external_event()` on the queue happened
+after all previously submitted commands to the queue, the event passed as the
+argument to that function will is returned.
+
+If the last event was set by a call to `ext_oneapi_set_external_event()`, the
+returned event is guaranteed to compare equal to the event argument of the 
+`ext_oneapi_set_external_event()` call.
 
 Calls to this member function throw a `sycl::exception` with `errc::invalid` if
 the queue does not have the `property::queue::in_order` property.
@@ -144,6 +150,9 @@ If `queue::wait()` or `queue::wait_and_throw()` is called prior to any command
 submission following a call to this member function, `externalEvent.wait()` is
 called and `externalEvent` will not be a dependency on the next command
 submitted to the queue.
+
+`externalEvent` is required to reach completed state after the event returned by
+`get_last_event()` reaches completed state.
 
 Calls to this member function throw a `sycl::exception` with `errc::invalid` if
 the queue does not have the `property::queue::in_order` property.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
@@ -118,7 +118,7 @@ event ext_oneapi_get_last_event() const;
 | Returns an event representing the execution of the last command submitted to
 the queue. If a call to `ext_oneapi_set_external_event()` on the queue happened
 after all previously submitted commands to the queue, the event passed as the
-argument to that function will is returned.
+argument to that function will be returned.
 
 If the last event was set by a call to `ext_oneapi_set_external_event()`, the
 returned event is guaranteed to compare equal to the event argument of the 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
@@ -151,8 +151,10 @@ submission following a call to this member function, `externalEvent.wait()` is
 called and `externalEvent` will not be a dependency on the next command
 submitted to the queue.
 
-`externalEvent` is required to reach completed state after the event returned by
-`get_last_event()` reaches completed state.
+The application is required to ensure that externalEvent does not reach the
+completed state before the completion of the most recent command that was
+submitted to the queue. If this requirement is violated, the behavior is
+undefined.
 
 Calls to this member function throw a `sycl::exception` with `errc::invalid` if
 the queue does not have the `property::queue::in_order` property.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_in_order_queue_events.asciidoc
@@ -117,12 +117,8 @@ event ext_oneapi_get_last_event() const;
 ----
 | Returns an event representing the execution of the last command submitted to
 the queue. If a call to `ext_oneapi_set_external_event()` on the queue happened
-after all previously submitted commands to the queue, the event passed as the
-argument to that function will be returned.
-
-If the last event was set by a call to `ext_oneapi_set_external_event()`, the
-returned event is guaranteed to compare equal to the event argument of the 
-`ext_oneapi_set_external_event()` call.
+after all previously submitted commands to the queue, this function returns a
+copy of the event that was passed to `ext_oneapi_set_external_event()`.
 
 Calls to this member function throw a `sycl::exception` with `errc::invalid` if
 the queue does not have the `property::queue::in_order` property.
@@ -151,7 +147,7 @@ submission following a call to this member function, `externalEvent.wait()` is
 called and `externalEvent` will not be a dependency on the next command
 submitted to the queue.
 
-The application is required to ensure that externalEvent does not reach the
+The application is required to ensure that `externalEvent` does not reach the
 completed state before the completion of the most recent command that was
 submitted to the queue. If this requirement is violated, the behavior is
 undefined.

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -260,6 +260,14 @@ event queue_impl::memcpyFromDeviceGlobal(
 }
 
 event queue_impl::getLastEvent() {
+  {
+    // The external event is required to finish last if set, so it is considered
+    // the last event if present.
+    std::lock_guard<std::mutex> Lock(MInOrderExternalEventMtx);
+    if (MInOrderExternalEvent)
+      return *MInOrderExternalEvent;
+  }
+
   std::lock_guard<std::mutex> Lock{MMutex};
   if (MDiscardEvents)
     return createDiscardedEvent();
@@ -485,6 +493,26 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
                           "recording to a command graph.");
   }
 
+  // If there is an external event set, we know we are using an in-order queue
+  // and the event is required to finish after the last event in the queue. As
+  // such, we can just wait for it and finish.
+  std::optional<event> ExternalEvent = popExternalEvent();
+  if (ExternalEvent) {
+    ExternalEvent->wait();
+
+    // Additionally, we can clean up the event lists that we would have
+    // otherwise cleared.
+    if (!MEventsWeak.empty() || !MEventsShared.empty()) {
+      std::lock_guard<std::mutex> Lock(MMutex);
+      MEventsWeak.clear();
+      MEventsShared.clear();
+    }
+    if (!MStreamsServiceEvents.empty()) {
+      std::lock_guard<std::mutex> Lock(MStreamsServiceEventsMutex);
+      MStreamsServiceEvents.clear();
+    }
+  }
+
   std::vector<std::weak_ptr<event_impl>> WeakEvents;
   std::vector<event> SharedEvents;
   {
@@ -526,11 +554,6 @@ void queue_impl::wait(const detail::code_location &CodeLoc) {
   }
   for (const EventImplPtr &Event : StreamsServiceEvents)
     Event->wait(Event);
-
-  // If there is an external event set, we need to wait on it.
-  std::optional<event> ExternalEvent = popExternalEvent();
-  if (ExternalEvent)
-    ExternalEvent->wait();
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   instrumentationEpilog(TelemetryEvent, Name, StreamID, IId);

--- a/sycl/test-e2e/InOrderEventsExt/get_last_event.cpp
+++ b/sycl/test-e2e/InOrderEventsExt/get_last_event.cpp
@@ -7,6 +7,8 @@
 //       only that the underlying native events are. Currently DPC++ implements
 //       this in a way that guarantees it, but this can change in the future.
 //       If it changes then so should this test.
+// OBS: The above note does not apply to equality of events returned after a
+//      call to ext_oneapi_set_external_event.
 
 #include <iostream>
 #include <sycl.hpp>
@@ -34,6 +36,14 @@ int main() {
   Failed += Check(Q, "host_task", [&]() {
     return Q.submit([&](sycl::handler &CGH) { CGH.host_task([]() {}); });
   });
+
+  // For external event, the equality of events is guaranteed by the extension.
+  sycl::event ExternalEvent = Q.single_task([]() {});
+  Failed += Check(Q, "ext_oneapi_set_external_event", [&]() {
+    Q.ext_oneapi_set_external_event(ExternalEvent);
+    return ExternalEvent;
+  });
+
   if (!Q.get_device().has(sycl::aspect::usm_shared_allocations))
     return Failed;
   constexpr size_t N = 64;


### PR DESCRIPTION
This commit makes the following changes to the
sycl_ext_oneapi_in_order_queue_events experimental extension:
 * The external event set using `queue::ext_oneapi_set_external_event()` is now required to finish after the latest command submitted to the corresponding queue.
 * The external event set using `queue::ext_oneapi_set_external_event()` will now be returned by `queue::ext_oneapi_get_last_event()` if no command has been submitted to the queue since the call.
 * Calling `queue::wait()` and similar on a queue with an external event set will now only wait on that event, as it is expected to finish only after other commands in the queue has finished (see previous point.)