### PR TITLE
[TEST-E2E] Avoid conflicts of Windows headers with std::max.

### DIFF
--- a/sycl/test-e2e/syclcompat/kernel/Inputs/kernel_function.cpp
+++ b/sycl/test-e2e/syclcompat/kernel/Inputs/kernel_function.cpp
@@ -30,7 +30,9 @@
 //
 // ===---------------------------------------------------------------------===//
 #ifdef _WIN32
+#define NOMINMAX
 #include <windows.h>
+#undef NOMINMAX
 #else
 #include <dlfcn.h>
 #endif


### PR DESCRIPTION
Avoid conflicts of Windows headers with std::max using `#define NOMINMAX`
The patch fixes the build error seen in [kernel_win.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/syclcompat/kernel/kernel_win.cpp) 