### PR TITLE
[GEN] Prefer CompositeExtract over VectorExtractDynamic

### DIFF
--- a/mlir/lib/Conversion/GENToSPIRV/GENToSPIRV.cpp
+++ b/mlir/lib/Conversion/GENToSPIRV/GENToSPIRV.cpp
@@ -63,10 +63,13 @@ public:
         op, builtin, builtinType, rewriter, spvBuiltinPrefix, spvBuiltinSuffix);
     Value idx = operands[0];
 
-    if (IntegerAttr idxAttr; matchPattern(idx, m_Constant(&idxAttr))) {
-      // Don't need to check the range here because that is verified already
-      rewriter.replaceOpWithNewOp<spirv::CompositeExtractOp>(
-          op, vector, idxAttr.getValue().getZExtValue());
+    if (llvm::APInt idxAttrValue;
+        matchPattern(idx, m_ConstantInt(&idxAttrValue))) {
+      auto idxValue = idxAttrValue.getZExtValue();
+      // The following assert should already be verified
+      assert(0 <= idxValue && idxValue < 3);
+      rewriter.replaceOpWithNewOp<spirv::CompositeExtractOp>(op, vector,
+                                                             idxValue);
     } else {
       rewriter.replaceOpWithNewOp<spirv::VectorExtractDynamicOp>(op, vector,
                                                                  idx);

--- a/mlir/test/Conversion/GENToSPIRV/gen-to-spirv.mlir
+++ b/mlir/test/Conversion/GENToSPIRV/gen-to-spirv.mlir
@@ -51,4 +51,45 @@ func.func @gen_nd_range(%dim: i32) {
   %3 = gen.num_work_groups %dim
   func.return
 }
+
+// CHECK-LABEL:   func.func @gen_nd_range_constant() {
+// CHECK:           %[[CST_0:.*]] = arith.constant 0 : i32
+func.func @gen_nd_range_constant() {
+  %cst_0 = arith.constant 0 : i32
+  %cst_1 = arith.constant 1 : i32
+  %cst_2 = arith.constant 2 : i32
+// CHECK-32:           %[[VAL_1:.*]] = spirv.mlir.addressof @__spirv_BuiltInLocalInvocationId : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_2:.*]] = spirv.Load "Input" %[[VAL_1]] : vector<3xi32>
+// CHECK-32:           %[[VAL_3:.*]] = spirv.CompositeExtract %[[VAL_2]][0 : i32] : vector<3xi32>
+
+// CHECK-64:           %[[VAL_1:.*]] = spirv.mlir.addressof @__spirv_BuiltInLocalInvocationId : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_2:.*]] = spirv.Load "Input" %[[VAL_1]] : vector<3xi64>
+// CHECK-64:           %[[VAL_3:.*]] = spirv.CompositeExtract %[[VAL_2]][0 : i32] : vector<3xi64>
+  %0 = gen.local_id %cst_0
+// CHECK-32:           %[[VAL_4:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupId : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_5:.*]] = spirv.Load "Input" %[[VAL_4]] : vector<3xi32>
+// CHECK-32:           %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_5]][1 : i32] : vector<3xi32>
+
+// CHECK-64:           %[[VAL_4:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupId : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_5:.*]] = spirv.Load "Input" %[[VAL_4]] : vector<3xi64>
+// CHECK-64:           %[[VAL_6:.*]] = spirv.CompositeExtract %[[VAL_5]][1 : i32] : vector<3xi64>
+  %1 = gen.work_group_id %cst_1
+// CHECK-32:           %[[VAL_7:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupSize : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_8:.*]] = spirv.Load "Input" %[[VAL_7]] : vector<3xi32>
+// CHECK-32:           %[[VAL_9:.*]] = spirv.CompositeExtract %[[VAL_8]][2 : i32] : vector<3xi32>
+
+// CHECK-64:           %[[VAL_7:.*]] = spirv.mlir.addressof @__spirv_BuiltInWorkgroupSize : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_8:.*]] = spirv.Load "Input" %[[VAL_7]] : vector<3xi64>
+// CHECK-64:           %[[VAL_9:.*]] = spirv.CompositeExtract %[[VAL_8]][2 : i32] : vector<3xi64>
+  %2 = gen.work_group_size %cst_2
+// CHECK-32:           %[[VAL_10:.*]] = spirv.mlir.addressof @__spirv_BuiltInNumWorkgroups : !spirv.ptr<vector<3xi32>, Input>
+// CHECK-32:           %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi32>
+// CHECK-32:           %[[VAL_12:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi32>
+
+// CHECK-64:           %[[VAL_10:.*]] = spirv.mlir.addressof @__spirv_BuiltInNumWorkgroups : !spirv.ptr<vector<3xi64>, Input>
+// CHECK-64:           %[[VAL_11:.*]] = spirv.Load "Input" %[[VAL_10]] : vector<3xi64>
+// CHECK-64:           %[[VAL_12:.*]] = spirv.CompositeExtract %[[VAL_11]][0 : i32] : vector<3xi64>
+  %3 = gen.num_work_groups %cst_0
+  func.return
+}
 }

--- a/mlir/test/Conversion/GENToSPIRV/gen-to-spirv.mlir
+++ b/mlir/test/Conversion/GENToSPIRV/gen-to-spirv.mlir
@@ -53,7 +53,6 @@ func.func @gen_nd_range(%dim: i32) {
 }
 
 // CHECK-LABEL:   func.func @gen_nd_range_constant() {
-// CHECK:           %[[CST_0:.*]] = arith.constant 0 : i32
 func.func @gen_nd_range_constant() {
   %cst_0 = arith.constant 0 : i32
   %cst_1 = arith.constant 1 : i32


### PR DESCRIPTION
When lowering ND-range operations from GEN to SPIR-V, with a constant dimension, use CompositeExtract instead of VectorExtractDynamic.