### PR TITLE
[SYCL] Move `use_root_sync_key` property into its own header

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/root_group.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/root_group.hpp
@@ -8,8 +8,8 @@
 
 #pragma once
 
+#include <sycl/ext/oneapi/experimental/use_root_sync_prop.hpp>
 #include <sycl/ext/oneapi/free_function_queries.hpp>
-#include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/group.hpp>
 #include <sycl/memory_enums.hpp>
 #include <sycl/nd_item.hpp>
@@ -26,13 +26,6 @@ struct max_num_work_group_sync {
   using return_type = size_t;
 };
 } // namespace info::kernel_queue_specific
-
-struct use_root_sync_key
-    : detail::compile_time_property_key<detail::PropKind::UseRootSync> {
-  using value_t = property_value<use_root_sync_key>;
-};
-
-inline constexpr use_root_sync_key::value_t use_root_sync;
 
 template <int Dimensions> class root_group {
 public:

--- a/sycl/include/sycl/ext/oneapi/experimental/use_root_sync_prop.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/use_root_sync_prop.hpp
@@ -1,0 +1,29 @@
+//==--- use_root_sync_prop.hpp --- SYCL extension for root groups ----------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// Declaration of the property to be included in <sycl/handler.hpp> without
+// pulling in the entire root group extension header there.
+
+#pragma once
+
+#include <sycl/ext/oneapi/properties/properties.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+namespace ext::oneapi::experimental {
+
+struct use_root_sync_key
+    : detail::compile_time_property_key<detail::PropKind::UseRootSync> {
+  using value_t = property_value<use_root_sync_key>;
+};
+
+inline constexpr use_root_sync_key::value_t use_root_sync;
+
+} // namespace ext::oneapi::experimental
+} // namespace _V1
+} // namespace sycl

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -33,7 +33,7 @@
 #include <sycl/ext/oneapi/device_global/device_global.hpp>
 #include <sycl/ext/oneapi/device_global/properties.hpp>
 #include <sycl/ext/oneapi/experimental/graph.hpp>
-#include <sycl/ext/oneapi/experimental/root_group.hpp>
+#include <sycl/ext/oneapi/experimental/use_root_sync_prop.hpp>
 #include <sycl/ext/oneapi/kernel_properties/properties.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/group.hpp>

--- a/sycl/include/syclcompat/id_query.hpp
+++ b/sycl/include/syclcompat/id_query.hpp
@@ -22,6 +22,7 @@
 
 #pragma once
 
+#include <sycl/ext/oneapi/free_function_queries.hpp>
 #include <sycl/nd_item.hpp>
 
 namespace syclcompat {

--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -42,6 +42,7 @@
 #include <utility>
 
 #include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
 #include <sycl/ext/oneapi/group_local_memory.hpp>
 #include <sycl/group.hpp>
 #include <sycl/usm.hpp>

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -35,6 +35,7 @@
 #include <type_traits>
 
 #include <sycl/atomic_ref.hpp>
+#include <sycl/group_barrier.hpp>
 
 #include <syclcompat/math.hpp>
 #include <syclcompat/memory.hpp>

--- a/sycl/test-e2e/Assert/check_resource_leak.cpp
+++ b/sycl/test-e2e/Assert/check_resource_leak.cpp
@@ -11,6 +11,7 @@
 #include <sycl/detail/core.hpp>
 
 #include <sycl/builtins.hpp>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
 #include <sycl/ext/oneapi/sub_group_mask.hpp>
 
 // DeviceGlobalUSMMem::~DeviceGlobalUSMMem() has asserts to ensure some

--- a/sycl/test-e2e/Regression/range-rounding-this-id.cpp
+++ b/sycl/test-e2e/Regression/range-rounding-this-id.cpp
@@ -6,6 +6,8 @@
 // RUN: %{run} %t.out | FileCheck %s
 #include <sycl/detail/core.hpp>
 
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+
 constexpr int N = 3;
 
 using namespace sycl;

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -166,7 +166,6 @@
 // CHECK-NEXT: ext/intel/experimental/kernel_execution_properties.hpp
 // CHECK-NEXT: ext/oneapi/bindless_images_interop.hpp
 // CHECK-NEXT: ext/oneapi/bindless_images_mem_handle.hpp
-// CHECK-NEXT: ext/oneapi/experimental/root_group.hpp
-// CHECK-NEXT: ext/oneapi/free_function_queries.hpp
+// CHECK-NEXT: ext/oneapi/experimental/use_root_sync_prop.hpp
 // CHECK-NEXT: ext/oneapi/kernel_properties/properties.hpp
 // CHECK-EMPTY:


### PR DESCRIPTION
To avoid inclusion of the entire `root_group.hpp` in `handler.hpp`.