### PR TITLE
[SYCL][Libdevice] Build for spirv64 on Windows

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -22,16 +22,8 @@ string(CONCAT sycl_targets_opt
   "spir64_x86_64-unknown-unknown,"
   "spir64_gen-unknown-unknown,"
   "spir64_fpga-unknown-unknown,"
-  "spir64-unknown-unknown")
-
-if (NOT WIN32)
-  # Don't build for spirv64 on Windows due to
-  # some type size difference issues.
-  # Build on Windows once internal tracker is fixed.
-  string(APPEND
-    sycl_targets_opt
-    ",spirv64-unknown-unknown")
-endif()
+  "spir64-unknown-unknown,"
+  "spirv64-unknown-unknown")
 
 set(compile_opts
   # suppress an error about SYCL_EXTERNAL being used for


### PR DESCRIPTION
The root cause for disabling it on Windows was fixed in https://github.com/intel/llvm/commit/d0744751abe535c1470ca8833d5dd3b3d1a72c6b.