### PR TITLE
[SYCL] Remove `image.hpp` dependency from the `accessor.hpp`

### DIFF
--- a/sycl/include/sycl/properties/accessor_properties.hpp
+++ b/sycl/include/sycl/properties/accessor_properties.hpp
@@ -8,16 +8,15 @@
 
 #pragma once
 
-#include <sycl/access/access.hpp>                     // for mode, target
-#include <sycl/detail/common.hpp>                     // for __SYCL_EBO
-#include <sycl/detail/defines.hpp>                    // for __SYCL_TYPE
-#include <sycl/detail/defines_elementary.hpp>         // for __SYCL2020_DEP...
-#include <sycl/detail/property_helper.hpp>            // for DataLessPropKind
-#include <sycl/ext/oneapi/accessor_property_list.hpp> // for IsCompileTimeP...
-#include <sycl/image.hpp>                             // for image_accessor
-#include <sycl/properties/property_traits.hpp>        // for is_property_of
+#include <sycl/access/access.hpp>
+#include <sycl/detail/common.hpp>
+#include <sycl/detail/defines.hpp>
+#include <sycl/detail/defines_elementary.hpp>
+#include <sycl/detail/property_helper.hpp>
+#include <sycl/ext/oneapi/accessor_property_list.hpp>
+#include <sycl/properties/property_traits.hpp>
 
-#include <type_traits> // for true_type, fal...
+#include <type_traits>
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/source/detail/image_accessor_util.cpp
+++ b/sycl/source/detail/image_accessor_util.cpp
@@ -9,6 +9,7 @@
 #include <sycl/accessor.hpp>
 #include <sycl/accessor_image.hpp>
 #include <sycl/builtins.hpp>
+#include <sycl/image.hpp>
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -12,6 +12,7 @@
 #include <detail/platform_impl.hpp>
 #include <sycl/device.hpp>
 #include <sycl/device_selector.hpp>
+#include <sycl/image.hpp>
 #include <sycl/info/info_desc.hpp>
 #include <sycl/platform.hpp>
 

--- a/sycl/source/sampler.cpp
+++ b/sycl/source/sampler.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 #include <detail/sampler_impl.hpp>
+#include <sycl/image.hpp>
 #include <sycl/properties/all_properties.hpp>
 #include <sycl/property_list.hpp>
 #include <sycl/sampler.hpp>

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -115,8 +115,7 @@
 // CHECK-NEXT: detail/handler_proxy.hpp
 // CHECK-NEXT: pointers.hpp
 // CHECK-NEXT: properties/accessor_properties.hpp
-// CHECK-NEXT: image.hpp
-// CHECK-NEXT: detail/backend_traits.hpp
+// CHECK-NEXT: properties/buffer_properties.hpp
 // CHECK-NEXT: sampler.hpp
 // CHECK-NEXT: types.hpp
 // CHECK-NEXT: marray.hpp
@@ -124,5 +123,4 @@
 // CHECK-NEXT: detail/memcpy.hpp
 // CHECK-NEXT: detail/vector_convert.hpp
 // CHECK-NEXT: swizzles.def
-// CHECK-NEXT: properties/buffer_properties.hpp
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -116,8 +116,7 @@
 // CHECK-NEXT: detail/handler_proxy.hpp
 // CHECK-NEXT: pointers.hpp
 // CHECK-NEXT: properties/accessor_properties.hpp
-// CHECK-NEXT: image.hpp
-// CHECK-NEXT: detail/backend_traits.hpp
+// CHECK-NEXT: properties/buffer_properties.hpp
 // CHECK-NEXT: sampler.hpp
 // CHECK-NEXT: types.hpp
 // CHECK-NEXT: marray.hpp
@@ -125,7 +124,6 @@
 // CHECK-NEXT: detail/memcpy.hpp
 // CHECK-NEXT: detail/vector_convert.hpp
 // CHECK-NEXT: swizzles.def
-// CHECK-NEXT: properties/buffer_properties.hpp
 // CHECK-NEXT: queue.hpp
 // CHECK-NEXT: detail/assert_happened.hpp
 // CHECK-NEXT: detail/cg_types.hpp
@@ -140,6 +138,8 @@
 // CHECK-NEXT: device.hpp
 // CHECK-NEXT: kernel_bundle_enums.hpp
 // CHECK-NEXT: exception_list.hpp
+// CHECK-NEXT: image.hpp
+// CHECK-NEXT: detail/backend_traits.hpp
 // CHECK-NEXT: kernel_handler.hpp
 // CHECK-NEXT: nd_item.hpp
 // CHECK-NEXT: nd_range.hpp


### PR DESCRIPTION
To reduce amount of the code required by `sycl/detail/core.hpp` and make more granular includes possible.