### PR TITLE
[CI] Show IGC TAG in run tests

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -261,6 +261,7 @@ jobs:
     - run: which clang++ sycl-ls
     - run: sycl-ls --verbose
     - run: SYCL_PI_TRACE=-1 sycl-ls
+    - run: cat /usr/local/lib/igc/IGCTAG.txt
 
     - name: Deduce E2E CMake options
       if: inputs.tests_selector == 'e2e'

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -261,7 +261,10 @@ jobs:
     - run: which clang++ sycl-ls
     - run: sycl-ls --verbose
     - run: SYCL_PI_TRACE=-1 sycl-ls
-    - run: cat /usr/local/lib/igc/IGCTAG.txt
+    - run: |
+          if [ -f /usr/local/lib/igc/IGCTAG.txt ]; then
+            cat /usr/local/lib/igc/IGCTAG.txt
+          fi
 
     - name: Deduce E2E CMake options
       if: inputs.tests_selector == 'e2e'

--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -192,7 +192,8 @@ jobs:
         GITHUB_TOKEN: ${{ github.token }}
       run: |
         if [ "${{ inputs.use_dev_igc }}" = "true" ]; then
-            sudo apt-get install -yqq libllvm14;
+            # If libllvm14 is already installed (dev igc docker), still return true.
+            sudo apt-get install -yqq libllvm14 || true;
         fi
         sudo -E bash devops/scripts/install_drivers.sh llvm/devops/dependencies.json ${{ inputs.use_dev_igc == 'true' && 'llvm/devops/dependencies-igc-dev.json --use-dev-igc' || '' }} --all
     - name: Source OneAPI TBB vars.sh

--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-41e87ac",
-      "version": "41e87ac",
-      "updated_at": "2024-05-02T11:47:42Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1466894014/zip",
+      "github_tag": "igc-dev-b906329",
+      "version": "b906329",
+      "updated_at": "2024-05-04T22:39:56Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1473544965/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }

--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -132,6 +132,7 @@ InstallIGFX () {
     | wget -qi -
   dpkg -i *.deb && rm *.deb *.sum
   IS_IGC_DEV=$(CheckIGCdevTag $IGCTAG)
+  echo "$IGC_TAG" > /usr/local/lib/igc/IGCTAG.txt
   if [ "$IS_IGC_DEV" == "Yes" ]; then
     # Dev IGC deb package did not include libopencl-clang
     # opencl-clang repo does not provide release deb package either.
@@ -148,6 +149,7 @@ InstallIGFX () {
     cp -d libopencl-clang.so.14*  /usr/local/lib/
     echo "Clean up"
     rm *.deb libopencl-clang.so.14*
+    echo "$IGC_DEV_TAG" > /usr/local/lib/igc/IGCTAG.txt
   fi
 }
 


### PR DESCRIPTION
We need some way to show different igc we used in the test.
Save the tag info into install folder and show it in the run.
(Also fix a bug in install driver and update the igc dev driver)