### PR TITLE
[CMake] Bump required CMake version to 3.20.0

### DIFF
--- a/llvm/lib/SYCLLowerIR/CMakeLists.txt
+++ b/llvm/lib/SYCLLowerIR/CMakeLists.txt
@@ -1,13 +1,3 @@
-if(${CMAKE_VERSION} VERSION_LESS 3.14)
-    macro(FetchContent_MakeAvailable NAME)
-        FetchContent_GetProperties(${NAME})
-        if(NOT ${NAME}_POPULATED)
-            FetchContent_Populate(${NAME})
-            add_subdirectory(${${NAME}_SOURCE_DIR} ${${NAME}_BINARY_DIR})
-        endif()
-    endmacro()
-endif()
-
 # Lowering of SYCL ESIMD kernels depends on vc-intrinsics
 # NOTE: could have been added earlier from llvm/projects
 if (NOT TARGET LLVMGenXIntrinsics)

--- a/opencl/CMakeLists.txt
+++ b/opencl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20.0)
 
 include(FetchContent)
 

--- a/opencl/opencl-aot/CMakeLists.txt
+++ b/opencl/opencl-aot/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(LLVM_LINK_COMPONENTS
         ${LLVM_TARGETS_TO_BUILD}

--- a/sycl-fusion/CMakeLists.txt
+++ b/sycl-fusion/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.20.0 FATAL_ERROR)
 
 # Define a variable holding the root directory of the JIT compiler project
 # for use in includes etc.

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.14)
+cmake_minimum_required(VERSION 3.20.0)
 
 project(sycl-solution)
 # Requirements

--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.15)
+cmake_minimum_required(VERSION 3.20.0)
 
 message("Configuring SYCL End-to-End Tests")
 

--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(XPTI_VERSION 0.4.1)
 project (xpti VERSION "${XPTI_VERSION}" LANGUAGES CXX)

--- a/xptifw/CMakeLists.txt
+++ b/xptifw/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.8)
+cmake_minimum_required(VERSION 3.20.0)
 
 set(XPTI_VERSION 0.6.0)
 


### PR DESCRIPTION
LLVM requires CMake 3.20 and up, which is specified in all the "built in" LLVM projects. This change bumps the DPCPP/SYCL specific projects to match that version.