### PR TITLE
[CI] Drop `permissions:` from AWS CUDA precommit task

### DIFF
--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -14,9 +14,6 @@ on:
     types:
       - completed
 
-permissions:
-  contents: read
-
 jobs:
   create-check:
     runs-on: [Linux, build]


### PR DESCRIPTION
It's been broken since https://github.com/intel/llvm/pull/13173.