### PR TITLE
[SYCL][Docs] Fix variadic properties ctor

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_arg.asciidoc
@@ -200,7 +200,7 @@ template <typename T, typename PropertyListT = empty_properties_t>
 class annotated_arg {
   public:
     annotated_arg() noexcept;
-    annotated_arg(const T& v_, const PropertyListT &P = properties{}) noexcept;
+    annotated_arg(const T& v_, const PropertyListT &P = PropertyListT{}) noexcept;
     template<typename... PropertyValueTs>
     annotated_arg(const T& v_, PropertyValueTs... props) noexcept;
 
@@ -277,7 +277,7 @@ Constructs an `annotated_arg` object which is default initialized.
 a|
 [source,c++]
 ----
-annotated_arg(const T& v_, const PropertyListT &P = properties{}) noexcept;
+annotated_arg(const T& v_, const PropertyListT &P = PropertyListT{}) noexcept;
 ----
 | Not available in device code.
 Constructs an `annotated_arg` object from the input object `v_`.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_annotated_ptr.asciidoc
@@ -287,7 +287,7 @@ class annotated_ptr {
     using reference = annotated_ref<T, PropertyListT>;
 
     annotated_ptr() noexcept;
-    explicit annotated_ptr(T *Ptr, const PropertyListT &P = properties{}) noexcept;
+    explicit annotated_ptr(T *Ptr, const PropertyListT &P = PropertyListT{}) noexcept;
     template<typename... PropertyValueTs>
     explicit annotated_ptr(T *Ptr, PropertyValueTs... props) noexcept;
 
@@ -359,7 +359,7 @@ underlying pointer is initialized to `nullptr`.
 a|
 [source,c++]
 ----
-explicit annotated_ptr(T *Ptr, const PropertyListT &P = properties{}) noexcept;
+explicit annotated_ptr(T *Ptr, const PropertyListT &P = PropertyListT{}) noexcept;
 ----
 |
 Constructs an `annotated_ptr` object. Does not allocate new storage. The

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_usm_malloc_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_usm_malloc_properties.asciidoc
@@ -281,7 +281,7 @@ malloc_device_annotated(
    size_t numBytes,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is allocated on `syclDevice`.
 The allocation size is specified in bytes.
@@ -316,7 +316,7 @@ malloc_device_annotated(
    size_t count,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@  Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is allocated on `syclDevice`.
 The allocation size is specified in number of elements of type
@@ -349,7 +349,7 @@ annotated_ptr<void, propertyListB>
 malloc_device_annotated(
    size_t numBytes,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device`
 and `context`.
@@ -364,7 +364,7 @@ annotated_ptr<T, propertyListB>
 malloc_device_annotated(
    size_t count,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device`
 and `context`.
@@ -379,7 +379,7 @@ aligned_alloc_device_annotated(
    size_t numBytes,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is allocated on
 `syclDevice`.
@@ -417,7 +417,7 @@ aligned_alloc_device_annotated(
    size_t count,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is allocated on
 `syclDevice`.
@@ -452,7 +452,7 @@ aligned_alloc_device_annotated(
    size_t alignment,
    size_t numBytes,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device`
 and `context`.
@@ -468,7 +468,7 @@ aligned_alloc_device_annotated(
    size_t alignment,
    size_t count,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device`
 and `context`.
@@ -497,7 +497,7 @@ annotated_ptr<void, propertyListB>
 malloc_host_annotated(
    size_t numBytes,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory. This allocation is specified in bytes.
 
@@ -526,7 +526,7 @@ annotated_ptr<T, propertyListB>
 malloc_host_annotated(
    size_t count,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory. This allocation is specified in number of elements of type `T`.
 
@@ -553,7 +553,7 @@ annotated_ptr<void, propertyListB>
 malloc_host_annotated(
    size_t numBytes,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`.
 
@@ -567,7 +567,7 @@ annotated_ptr<T, propertyListB>
 malloc_host_annotated(
    size_t count,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`.
 
@@ -580,7 +580,7 @@ aligned_alloc_host_annotated(
    size_t alignment,
    size_t numBytes,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory.
 This allocation is specified in bytes and aligned according to `alignment`.
@@ -611,7 +611,7 @@ aligned_alloc_host_annotated(
    size_t alignment,
    size_t count,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory.
 This allocation is specified in elements of type `T` and aligned according to `alignment`.
@@ -640,7 +640,7 @@ aligned_alloc_host_annotated(
    size_t alignment,
    size_t numBytes,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`.
 
@@ -655,7 +655,7 @@ aligned_alloc_host_annotated(
    size_t alignment,
    size_t count,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`.
 
@@ -683,7 +683,7 @@ malloc_shared_annotated(
    size_t numBytes,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is associated with `syclDevice`.
 This allocation is specified in bytes.
@@ -718,7 +718,7 @@ malloc_shared_annotated(
    size_t count,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is associated with `syclDevice`.
 This allocation is specified in number of elements of
@@ -751,7 +751,7 @@ annotated_ptr<void, propertyListB>
 malloc_shared_annotated(
    size_t numBytes,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device` and
 `context`.
@@ -766,7 +766,7 @@ annotated_ptr<T, propertyListB>
 malloc_shared_annotated(
    size_t count,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device` and
 `context`.
@@ -781,7 +781,7 @@ aligned_alloc_shared_annotated(
    size_t numBytes,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is associated with `syclDevice`.
 This allocation is specified in bytes and aligned according to `alignment`.
@@ -817,7 +817,7 @@ aligned_alloc_shared_annotated(
    size_t count,
    const device& syclDevice,
    const context& syclContext,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory, which is associated with `syclDevice`.
 This allocation is specified in number of elements of type `T` and aligned according to `alignment`. 
@@ -850,7 +850,7 @@ aligned_alloc_shared_annotated(
    size_t alignment,
    size_t numBytes,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device` and
 `context`.
@@ -866,7 +866,7 @@ aligned_alloc_shared_annotated(
    size_t alignment,
    size_t count,
    const queue& syclQueue,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `device` and
 `context`.
@@ -907,7 +907,7 @@ malloc_annotated(
    const device& syclDevice,
    const context& syclContext,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory of type `kind`.
 This allocation size is specified in bytes.
@@ -940,7 +940,7 @@ malloc_annotated(
    const device& syclDevice,
    const context& syclContext,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory of type `kind`.
 This allocation is specified in number of elements of type `T`.
@@ -971,7 +971,7 @@ malloc_annotated(
    size_t numBytes,
    const queue& syclQueue,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`
 and any necessary `device`.
@@ -987,7 +987,7 @@ malloc_annotated(
    size_t count,
    const queue& syclQueue,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`
 and any necessary `device`.
@@ -1003,7 +1003,7 @@ aligned_alloc_annotated(
    const device& syclDevice,
    const context& syclContext,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory of type `kind`.
 This allocation is specified in bytes and is aligned according to `alignment`.
@@ -1037,7 +1037,7 @@ aligned_alloc_annotated(
    const device& syclDevice,
    const context& syclContext,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Returns an `annotated_ptr` containing a raw pointer to the newly allocated memory of type `kind`.
 This allocation is specified in number of elements of type `T` and is aligned according to `alignment`.
@@ -1068,7 +1068,7 @@ aligned_alloc_annotated(
    size_t numBytes,
    const queue& syclQueue,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`
 and any necessary `device`.
@@ -1085,7 +1085,7 @@ aligned_alloc_annotated(
    size_t count,
    const queue& syclQueue,
    sycl::usm::alloc kind,
-   const propertyListA &propList = properties{})
+   const propertyListA &propList = propertyListA{})
 ----
 a@ Simplified form where `syclQueue` provides the `context`
 and any necessary `device`.

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -114,7 +114,7 @@ public:
   annotated_arg &operator=(annotated_arg &) = default;
 
   annotated_arg(T *_ptr,
-                const property_list_t &PropList = properties{}) noexcept
+                const property_list_t &PropList = property_list_t{}) noexcept
       : obj(_ptr) {
     (void)PropList;
   }
@@ -250,7 +250,7 @@ public:
   annotated_arg &operator=(annotated_arg &) = default;
 
   annotated_arg(const T &_obj,
-                const property_list_t &PropList = properties{}) noexcept
+                const property_list_t &PropList = property_list_t{}) noexcept
       : obj(_obj) {
     (void)PropList;
   }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -303,7 +303,7 @@ public:
   annotated_ptr &operator=(const annotated_ptr &) = default;
 
   explicit annotated_ptr(T *Ptr,
-                         const property_list_t & = properties{}) noexcept
+                         const property_list_t & = property_list_t{}) noexcept
       : m_Ptr(Ptr) {}
 
   // Constructs an annotated_ptr object from a raw pointer and variadic

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
@@ -44,7 +44,7 @@ std::enable_if_t<
 aligned_alloc_annotated(size_t alignment, size_t numBytes,
                         const device &syclDevice, const context &syclContext,
                         sycl::usm::alloc kind,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   detail::ValidAllocPropertyList<void, propertyListA>::value;
 
   // The input argument `propList` is useful when propertyListA contains valid
@@ -86,7 +86,7 @@ std::enable_if_t<
 aligned_alloc_annotated(size_t alignment, size_t count,
                         const device &syclDevice, const context &syclContext,
                         sycl::usm::alloc kind,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   detail::ValidAllocPropertyList<T, propertyListA>::value;
 
   // The input argument `propList` is useful when propertyListA contains valid
@@ -127,7 +127,7 @@ std::enable_if_t<
     annotated_ptr<void, propertyListB>>
 aligned_alloc_annotated(size_t alignment, size_t numBytes,
                         const queue &syclQueue, sycl::usm::alloc kind,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_annotated(alignment, numBytes, syclQueue.get_device(),
                                  syclQueue.get_context(), kind, propList);
 }
@@ -140,7 +140,7 @@ std::enable_if_t<
     annotated_ptr<T, propertyListB>>
 aligned_alloc_annotated(size_t alignment, size_t count, const queue &syclQueue,
                         sycl::usm::alloc kind,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_annotated<T>(alignment, count, syclQueue.get_device(),
                                     syclQueue.get_context(), kind, propList);
 }
@@ -153,7 +153,7 @@ std::enable_if_t<
     annotated_ptr<void, propertyListB>>
 malloc_annotated(size_t numBytes, const device &syclDevice,
                  const context &syclContext, sycl::usm::alloc kind,
-                 const propertyListA &propList = properties{}) {
+                 const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_annotated(0, numBytes, syclDevice, syclContext, kind,
                                  propList);
 }
@@ -166,7 +166,7 @@ std::enable_if_t<
     annotated_ptr<T, propertyListB>>
 malloc_annotated(size_t count, const device &syclDevice,
                  const context &syclContext, sycl::usm::alloc kind,
-                 const propertyListA &propList = properties{}) {
+                 const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_annotated<T>(0, count, syclDevice, syclContext, kind,
                                     propList);
 }
@@ -178,7 +178,7 @@ std::enable_if_t<
     detail::CheckTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
 malloc_annotated(size_t numBytes, const queue &syclQueue, sycl::usm::alloc kind,
-                 const propertyListA &propList = properties{}) {
+                 const propertyListA &propList = propertyListA{}) {
   return malloc_annotated(numBytes, syclQueue.get_device(),
                           syclQueue.get_context(), kind, propList);
 }
@@ -190,7 +190,7 @@ std::enable_if_t<
     detail::CheckTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
 malloc_annotated(size_t count, const queue &syclQueue, sycl::usm::alloc kind,
-                 const propertyListA &propList = properties{}) {
+                 const propertyListA &propList = propertyListA{}) {
   return malloc_annotated<T>(count, syclQueue.get_device(),
                              syclQueue.get_context(), kind, propList);
 }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_device.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_device.hpp
@@ -43,10 +43,10 @@ template <typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckDevicePtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
-aligned_alloc_device_annotated(size_t alignment, size_t numBytes,
-                               const device &syclDevice,
-                               const context &syclContext,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_device_annotated(
+    size_t alignment, size_t numBytes, const device &syclDevice,
+    const context &syclContext,
+    const propertyListA &propList = propertyListA{}) {
   auto tmp =
       aligned_alloc_annotated(alignment, numBytes, syclDevice, syclContext,
                               sycl::usm::alloc::device, propList);
@@ -59,10 +59,10 @@ template <typename T, typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckDevicePtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
-aligned_alloc_device_annotated(size_t alignment, size_t count,
-                               const device &syclDevice,
-                               const context &syclContext,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_device_annotated(
+    size_t alignment, size_t count, const device &syclDevice,
+    const context &syclContext,
+    const propertyListA &propList = propertyListA{}) {
   auto tmp =
       aligned_alloc_annotated<T>(alignment, count, syclDevice, syclContext,
                                  sycl::usm::alloc::device, propList);
@@ -75,9 +75,9 @@ template <typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckDevicePtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
-aligned_alloc_device_annotated(size_t alignment, size_t numBytes,
-                               const queue &syclQueue,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_device_annotated(
+    size_t alignment, size_t numBytes, const queue &syclQueue,
+    const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_device_annotated(alignment, numBytes,
                                         syclQueue.get_device(),
                                         syclQueue.get_context(), propList);
@@ -89,9 +89,9 @@ template <typename T, typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckDevicePtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
-aligned_alloc_device_annotated(size_t alignment, size_t count,
-                               const queue &syclQueue,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_device_annotated(
+    size_t alignment, size_t count, const queue &syclQueue,
+    const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_device_annotated<T>(alignment, count,
                                            syclQueue.get_device(),
                                            syclQueue.get_context(), propList);
@@ -112,7 +112,7 @@ std::enable_if_t<
     annotated_ptr<void, propertyListB>>
 malloc_device_annotated(size_t numBytes, const device &syclDevice,
                         const context &syclContext,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_device_annotated(0, numBytes, syclDevice, syclContext,
                                         propList);
 }
@@ -125,7 +125,7 @@ std::enable_if_t<
     annotated_ptr<T, propertyListB>>
 malloc_device_annotated(size_t count, const device &syclDevice,
                         const context &syclContext,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_device_annotated<T>(0, count, syclDevice, syclContext,
                                            propList);
 }
@@ -137,7 +137,7 @@ std::enable_if_t<
     CheckDevicePtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
 malloc_device_annotated(size_t numBytes, const queue &syclQueue,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return malloc_device_annotated(numBytes, syclQueue.get_device(),
                                  syclQueue.get_context(), propList);
 }
@@ -149,7 +149,7 @@ std::enable_if_t<
     CheckDevicePtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
 malloc_device_annotated(size_t count, const queue &syclQueue,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return malloc_device_annotated<T>(count, syclQueue.get_device(),
                                     syclQueue.get_context(), propList);
 }

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_host.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_host.hpp
@@ -46,7 +46,7 @@ std::enable_if_t<
     annotated_ptr<void, propertyListB>>
 aligned_alloc_host_annotated(size_t alignment, size_t numBytes,
                              const context &syclContext,
-                             const propertyListA &propList = properties{}) {
+                             const propertyListA &propList = propertyListA{}) {
   auto tmp = aligned_alloc_annotated(alignment, numBytes, {}, syclContext,
                                      sycl::usm::alloc::host, propList);
   return annotated_ptr<void, propertyListB>(tmp.get());
@@ -60,7 +60,7 @@ std::enable_if_t<
     annotated_ptr<T, propertyListB>>
 aligned_alloc_host_annotated(size_t alignment, size_t count,
                              const context &syclContext,
-                             const propertyListA &propList = properties{}) {
+                             const propertyListA &propList = propertyListA{}) {
   auto tmp = aligned_alloc_annotated<T>(alignment, count, {}, syclContext,
                                         sycl::usm::alloc::host, propList);
   return annotated_ptr<T, propertyListB>(tmp.get());
@@ -74,7 +74,7 @@ std::enable_if_t<
     annotated_ptr<void, propertyListB>>
 aligned_alloc_host_annotated(size_t alignment, size_t numBytes,
                              const queue &syclQueue,
-                             const propertyListA &propList = properties{}) {
+                             const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_host_annotated(alignment, numBytes,
                                       syclQueue.get_context(), propList);
 }
@@ -87,7 +87,7 @@ std::enable_if_t<
     annotated_ptr<T, propertyListB>>
 aligned_alloc_host_annotated(size_t alignment, size_t count,
                              const queue &syclQueue,
-                             const propertyListA &propList = properties{}) {
+                             const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_host_annotated<T>(alignment, count,
                                          syclQueue.get_context(), propList);
 }
@@ -106,7 +106,7 @@ std::enable_if_t<
     CheckHostPtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
 malloc_host_annotated(size_t numBytes, const context &syclContext,
-                      const propertyListA &propList = properties{}) {
+                      const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_host_annotated(0, numBytes, syclContext, propList);
 }
 
@@ -117,7 +117,7 @@ std::enable_if_t<
     CheckHostPtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
 malloc_host_annotated(size_t count, const context &syclContext,
-                      const propertyListA &propList = properties{}) {
+                      const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_host_annotated<T>(0, count, syclContext, propList);
 }
 
@@ -128,7 +128,7 @@ std::enable_if_t<
     CheckHostPtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
 malloc_host_annotated(size_t numBytes, const queue &syclQueue,
-                      const propertyListA &propList = properties{}) {
+                      const propertyListA &propList = propertyListA{}) {
   return malloc_host_annotated(numBytes, syclQueue.get_context(), propList);
 }
 
@@ -139,7 +139,7 @@ std::enable_if_t<
     CheckHostPtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
 malloc_host_annotated(size_t count, const queue &syclQueue,
-                      const propertyListA &propList = properties{}) {
+                      const propertyListA &propList = propertyListA{}) {
   return malloc_host_annotated<T>(count, syclQueue.get_context(), propList);
 }
 

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_shared.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_shared.hpp
@@ -43,10 +43,10 @@ template <typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckSharedPtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
-aligned_alloc_shared_annotated(size_t alignment, size_t numBytes,
-                               const device &syclDevice,
-                               const context &syclContext,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_shared_annotated(
+    size_t alignment, size_t numBytes, const device &syclDevice,
+    const context &syclContext,
+    const propertyListA &propList = propertyListA{}) {
   auto tmp =
       aligned_alloc_annotated(alignment, numBytes, syclDevice, syclContext,
                               sycl::usm::alloc::shared, propList);
@@ -59,10 +59,10 @@ template <typename T, typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckSharedPtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
-aligned_alloc_shared_annotated(size_t alignment, size_t count,
-                               const device &syclDevice,
-                               const context &syclContext,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_shared_annotated(
+    size_t alignment, size_t count, const device &syclDevice,
+    const context &syclContext,
+    const propertyListA &propList = propertyListA{}) {
   auto tmp =
       aligned_alloc_annotated<T>(alignment, count, syclDevice, syclContext,
                                  sycl::usm::alloc::shared, propList);
@@ -75,9 +75,9 @@ template <typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckSharedPtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
-aligned_alloc_shared_annotated(size_t alignment, size_t numBytes,
-                               const queue &syclQueue,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_shared_annotated(
+    size_t alignment, size_t numBytes, const queue &syclQueue,
+    const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_shared_annotated(alignment, numBytes,
                                         syclQueue.get_device(),
                                         syclQueue.get_context(), propList);
@@ -89,9 +89,9 @@ template <typename T, typename propertyListA = detail::empty_properties_t,
 std::enable_if_t<
     CheckSharedPtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
-aligned_alloc_shared_annotated(size_t alignment, size_t count,
-                               const queue &syclQueue,
-                               const propertyListA &propList = properties{}) {
+aligned_alloc_shared_annotated(
+    size_t alignment, size_t count, const queue &syclQueue,
+    const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_shared_annotated<T>(alignment, count,
                                            syclQueue.get_device(),
                                            syclQueue.get_context(), propList);
@@ -112,7 +112,7 @@ std::enable_if_t<
     annotated_ptr<void, propertyListB>>
 malloc_shared_annotated(size_t numBytes, const device &syclDevice,
                         const context &syclContext,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_shared_annotated(0, numBytes, syclDevice, syclContext,
                                         propList);
 }
@@ -125,7 +125,7 @@ std::enable_if_t<
     annotated_ptr<T, propertyListB>>
 malloc_shared_annotated(size_t count, const device &syclDevice,
                         const context &syclContext,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return aligned_alloc_shared_annotated<T>(0, count, syclDevice, syclContext,
                                            propList);
 }
@@ -137,7 +137,7 @@ std::enable_if_t<
     CheckSharedPtrTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
 malloc_shared_annotated(size_t numBytes, const queue &syclQueue,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return malloc_shared_annotated(numBytes, syclQueue.get_device(),
                                  syclQueue.get_context(), propList);
 }
@@ -149,7 +149,7 @@ std::enable_if_t<
     CheckSharedPtrTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
 malloc_shared_annotated(size_t count, const queue &syclQueue,
-                        const propertyListA &propList = properties{}) {
+                        const propertyListA &propList = propertyListA{}) {
   return malloc_shared_annotated<T>(count, syclQueue.get_device(),
                                     syclQueue.get_context(), propList);
 }

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -124,7 +124,7 @@ struct ExtractProperties<PropertyArgsT,
   static constexpr std::tuple<PropertyT, PropertiesTs...>
   Extract(const PropertyArgsT &PropertyValues) {
     // TODO: NumOccurrences and checks should be moved out of the function once
-    //       ISSUE has been fixed.
+    //       https://github.com/intel/llvm/issues/13677 has been fixed.
     constexpr size_t NumOccurrences =
         CountTypeInTuple<PropertyT, PropertyArgsT>::value;
     static_assert(

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -82,41 +82,71 @@ struct RuntimePropertyStorage<std::tuple<T, Ts...>>
                                              std::tuple<Ts...>>::type>,
                          RuntimePropertyStorage<std::tuple<Ts...>>> {};
 
+// Count occurrences of a type in a tuple.
+template <typename T, typename Tuple> struct CountTypeInTuple;
+template <typename T, typename... TupleTs>
+struct CountTypeInTuple<T, std::tuple<TupleTs...>>
+    : std::integral_constant<
+          size_t, (0 + ... + static_cast<size_t>(std::is_same_v<T, TupleTs>))> {
+};
+
+// Helper for counting the number of properties that are also in PropertyArgsT.
+template <typename PropertyArgsT, typename Props> struct CountContainedProps;
+template <typename PropertyArgsT>
+struct CountContainedProps<PropertyArgsT, std::tuple<>>
+    : std::integral_constant<size_t, 0> {};
+template <typename PropertyArgsT, typename PropertyT, typename... PropertyTs>
+struct CountContainedProps<PropertyArgsT,
+                           std::tuple<PropertyT, PropertyTs...>> {
+  static constexpr size_t NumOccurrences =
+      CountTypeInTuple<PropertyT, PropertyArgsT>::value;
+  static_assert(NumOccurrences <= 1,
+                "Duplicate occurrences of property in constructor arguments.");
+  static constexpr size_t value =
+      CountContainedProps<PropertyArgsT, std::tuple<PropertyTs...>>::value +
+      NumOccurrences;
+};
+
 // Helper class to extract a subset of elements from a tuple.
 // NOTES: This assumes no duplicate properties and that all properties in the
 //        struct template argument appear in the tuple passed to Extract.
-template <typename PropertiesT> struct ExtractProperties {};
-template <typename... PropertiesTs>
-struct ExtractProperties<std::tuple<PropertiesTs...>> {
-  template <typename... PropertyValueTs>
-  using ExtractedPropertiesT = std::tuple<>;
-
-  template <typename... PropertyValueTs>
-  static constexpr ExtractedPropertiesT<PropertyValueTs...>
-  Extract(std::tuple<PropertyValueTs...>) {
-    return {};
+template <typename PropertyArgsT, typename PropertiesT>
+struct ExtractProperties;
+template <typename PropertyArgsT>
+struct ExtractProperties<PropertyArgsT, std::tuple<>> {
+  static constexpr std::tuple<> Extract(const PropertyArgsT &) {
+    return std::tuple<>{};
   }
 };
-template <typename PropertyT, typename... PropertiesTs>
-struct ExtractProperties<std::tuple<PropertyT, PropertiesTs...>> {
-  template <typename... PropertyValueTs>
-  using NextExtractedPropertiesT =
-      typename ExtractProperties<std::tuple<PropertiesTs...>>::
-          template ExtractedPropertiesT<PropertyValueTs...>;
-  template <typename... PropertyValueTs>
-  using ExtractedPropertiesT =
-      typename PrependTuple<PropertyT,
-                            NextExtractedPropertiesT<PropertyValueTs...>>::type;
+template <typename PropertyArgsT, typename PropertyT, typename... PropertiesTs>
+struct ExtractProperties<PropertyArgsT,
+                         std::tuple<PropertyT, PropertiesTs...>> {
+  static constexpr std::tuple<PropertyT, PropertiesTs...>
+  Extract(const PropertyArgsT &PropertyValues) {
+    // TODO: NumOccurrences and checks should be moved out of the function once
+    //       ISSUE has been fixed.
+    constexpr size_t NumOccurrences =
+        CountTypeInTuple<PropertyT, PropertyArgsT>::value;
+    static_assert(
+        NumOccurrences <= 1,
+        "Duplicate occurrences of property in constructor arguments.");
+    static_assert(NumOccurrences == 1 ||
+                      std::is_default_constructible_v<PropertyT>,
+                  "Each property in the property list must either be given an "
+                  "argument in the constructor or be default-constructible.");
 
-  template <typename... PropertyValueTs>
-  static constexpr ExtractedPropertiesT<PropertyValueTs...>
-  Extract(std::tuple<PropertyValueTs...> PropertyValues) {
-    PropertyT ThisExtractedProperty = std::get<PropertyT>(PropertyValues);
-    NextExtractedPropertiesT<PropertyValueTs...> NextExtractedProperties =
-        ExtractProperties<std::tuple<PropertiesTs...>>::template Extract<
-            PropertyValueTs...>(PropertyValues);
-    return std::tuple_cat(std::tuple<PropertyT>{ThisExtractedProperty},
-                          NextExtractedProperties);
+    auto NextExtractedProperties =
+        ExtractProperties<PropertyArgsT, std::tuple<PropertiesTs...>>::Extract(
+            PropertyValues);
+
+    if constexpr (NumOccurrences == 1) {
+      return std::tuple_cat(
+          std::tuple<PropertyT>{std::get<PropertyT>(PropertyValues)},
+          NextExtractedProperties);
+    } else {
+      return std::tuple_cat(std::tuple<PropertyT>{PropertyT{}},
+                            NextExtractedProperties);
+    }
   }
 };
 
@@ -135,10 +165,24 @@ template <typename PropertiesT> class properties {
                 "Conflicting properties in property list.");
 
 public:
-  template <typename... PropertyValueTs>
+  template <typename... PropertyValueTs,
+            std::enable_if_t<detail::AllPropertyValues<
+                                 std::tuple<PropertyValueTs...>>::value,
+                             int> = 0>
   constexpr properties(PropertyValueTs... props)
-      : Storage(detail::ExtractProperties<StorageT>::Extract(
-            std::tuple<PropertyValueTs...>{props...})) {}
+      : Storage(detail::ExtractProperties<std::tuple<PropertyValueTs...>,
+                                          StorageT>::Extract({props...})) {
+    // Default-constructible properties do not need to be in the arguments.
+    // For properties with a storage, default-constructibility is checked in
+    // ExtractProperties, while those without are so by default. As such, all
+    // arguments must be a unique property type and must be in PropertiesT.
+    constexpr size_t NumContainedProps =
+        detail::CountContainedProps<std::tuple<PropertyValueTs...>,
+                                    PropertiesT>::value;
+    static_assert(NumContainedProps == sizeof...(PropertyValueTs),
+                  "One or more property argument is not a property in the "
+                  "property list.");
+  }
 
   template <typename PropertyT>
   static constexpr std::enable_if_t<detail::IsProperty<PropertyT>::value, bool>

--- a/sycl/test/extensions/properties/mock_compile_time_properties.hpp
+++ b/sycl/test/extensions/properties/mock_compile_time_properties.hpp
@@ -35,7 +35,7 @@ struct boo_key : detail::compile_time_property_key<fakePropKind(2)> {
 };
 
 struct foo : detail::run_time_property_key<fakePropKind(3)> {
-  constexpr foo(int v) : value(v) {}
+  constexpr foo(int v = 0) : value(v) {}
   int value;
 };
 

--- a/sycl/test/extensions/properties/properties_ctor_constexpr.cpp
+++ b/sycl/test/extensions/properties/properties_ctor_constexpr.cpp
@@ -52,6 +52,28 @@ int main() {
       sycl::ext::oneapi::experimental::foo(42),
       sycl::ext::oneapi::experimental::foz(3.14, false)};
 
+  // Constructing using a subset of properties in the type.
+  constexpr decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::foo(42),
+      sycl::ext::oneapi::experimental::foz(3.14, false)}) SubsetCtorProps1{
+      sycl::ext::oneapi::experimental::foo(42),
+      sycl::ext::oneapi::experimental::foz(3.14, false)};
+  constexpr decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::foo(42),
+      sycl::ext::oneapi::experimental::foz(3.14, false)}) SubsetCtorProps2{
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::foz(3.14, false)};
+  constexpr decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::foo(42),
+      sycl::ext::oneapi::experimental::foz(3.14, false)}) SubsetCtorProps3{
+      sycl::ext::oneapi::experimental::foz(3.14, false)};
+  constexpr decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::foo(42)}) SubsetCtorProps4{};
+
   // Runtime value property without constexpr ctors
   // expected-error@+2 {{constexpr variable cannot have non-literal type}}
   constexpr decltype(sycl::ext::oneapi::experimental::properties{

--- a/sycl/test/extensions/properties/properties_ctor_negative.cpp
+++ b/sycl/test/extensions/properties/properties_ctor_negative.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+// RUN: %clangxx -fsycl -fsycl-targets=%sycl_triple -fsyntax-only -ferror-limit=0 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
 
 #include <sycl/sycl.hpp>
 
@@ -30,5 +30,61 @@ int main() {
       sycl::ext::oneapi::experimental::boo<int>,
       sycl::ext::oneapi::experimental::bar,
       sycl::ext::oneapi::experimental::fir(3.14, false));
+  // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: One or more property argument is not a property in the property list.}}
+  sycl::ext::oneapi::experimental::empty_properties_t InvalidPropertyList7{
+      sycl::ext::oneapi::experimental::foo{0}};
+  /*
+  // TODO: Uncomment these lines once ISSUE has been fixed.
+  decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::foo{0}}) InvalidPropertyList8{
+      sycl::ext::oneapi::experimental::foo{0},
+      sycl::ext::oneapi::experimental::foo{1}};
+  decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::boo<int>}) InvalidPropertyList9{
+      sycl::ext::oneapi::experimental::boo<int>,
+      sycl::ext::oneapi::experimental::boo<int>};
+  decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::boo<int>,
+      sycl::ext::oneapi::experimental::foo{0}}) InvalidPropertyList10{
+      sycl::ext::oneapi::experimental::boo<int>,
+      sycl::ext::oneapi::experimental::foo{0},
+      sycl::ext::oneapi::experimental::foo{1}};
+  decltype(sycl::ext::oneapi::experimental::properties{
+      sycl::ext::oneapi::experimental::boo<int>}) InvalidPropertyList11{
+      sycl::ext::oneapi::experimental::foo{0},
+      sycl::ext::oneapi::experimental::boo<int>,
+      sycl::ext::oneapi::experimental::boo<int>};
+  */
+
+  // TODO: For the following cases, the second error could be removed by moving
+  //       the static assert out of the Extract function. However, this
+  //       currently causes the same Clang crash as above.
+  // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: Each property in the property list must either be given an argument in the constructor or be default-constructible.}}
+  // expected-error@sycl/ext/oneapi/properties/properties.hpp:* {{no matching constructor for initialization of 'sycl::ext::oneapi::experimental::fir'}}
+  decltype(sycl::ext::oneapi::experimental::properties(
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::fir(3.14, false))) InvalidPropertyList12{
+      sycl::ext::oneapi::experimental::bar};
+  // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: Each property in the property list must either be given an argument in the constructor or be default-constructible.}}
+  // expected-error@sycl/ext/oneapi/properties/properties.hpp:* {{no matching constructor for initialization of 'sycl::ext::oneapi::experimental::fir'}}
+  decltype(sycl::ext::oneapi::experimental::properties(
+      sycl::ext::oneapi::experimental::fir(3.14,
+                                           false))) InvalidPropertyList13{};
+  // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: Each property in the property list must either be given an argument in the constructor or be default-constructible.}}
+  // expected-error@sycl/ext/oneapi/properties/properties.hpp:* {{no matching constructor for initialization of 'sycl::ext::oneapi::experimental::fir'}}
+  // expected-error-re@sycl/ext/oneapi/properties/properties.hpp:* {{static assertion failed due to requirement {{.+}}: One or more property argument is not a property in the property list.}}
+  decltype(sycl::ext::oneapi::experimental::properties(
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::fir(3.14, false))) InvalidPropertyList14{
+      sycl::ext::oneapi::experimental::boo<int>,
+      sycl::ext::oneapi::experimental::bar};
+  // expected-error@+2 {{no matching constructor for initialization of }}
+  decltype(sycl::ext::oneapi::experimental::properties(
+      sycl::ext::oneapi::experimental::foo{1})) InvalidPropertyList15{1};
+  // expected-error@+3 {{no matching constructor for initialization of }}
+  decltype(sycl::ext::oneapi::experimental::properties(
+      sycl::ext::oneapi::experimental::bar,
+      sycl::ext::oneapi::experimental::foo{1})) InvalidPropertyList16{
+      sycl::ext::oneapi::experimental::bar, 1};
   return 0;
 }

--- a/sycl/test/extensions/properties/properties_ctor_negative.cpp
+++ b/sycl/test/extensions/properties/properties_ctor_negative.cpp
@@ -34,7 +34,8 @@ int main() {
   sycl::ext::oneapi::experimental::empty_properties_t InvalidPropertyList7{
       sycl::ext::oneapi::experimental::foo{0}};
   /*
-  // TODO: Uncomment these lines once ISSUE has been fixed.
+  // TODO: Uncomment these lines once https://github.com/intel/llvm/issues/13677
+  // has been fixed.
   decltype(sycl::ext::oneapi::experimental::properties{
       sycl::ext::oneapi::experimental::foo{0}}) InvalidPropertyList8{
       sycl::ext::oneapi::experimental::foo{0},


### PR DESCRIPTION
The [compile-time properties extension](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc) specifies that the variadic ctor has the following behavior:

>Available only when each argument in props is an object of a property
value. Construct a property list with zero or more property values. This constructor can accept both runtime and compile-time constant property values. Each property in the property list (as determined by PropertyValuesT) that is not default constructable must have an object provided in props.

However, the current implementation does not adhere to these requirements. This commit makes the following changes to adhere to the required behavior:

* The ctor is now SFINAE'd out when arguments are non-property types.
* Each argument must now have a corresponding property in the list.
* Default-constructible arguments can now be omitted from the arguments. This only applied to compile-time properties previously.

Additionally, this exposed bugs in a set of extensions relying on these properties, which has in turn also been fixed with this commit.