### PR TITLE
[SYCL][ESIMD] Add driver check for FMA tests on Windows

### DIFF
--- a/sycl/test-e2e/ESIMD/fma.cpp
+++ b/sycl/test-e2e/ESIMD/fma.cpp
@@ -5,6 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+// REQUIRES-INTEL-DRIVER: lin: 29138, win: 101.5499
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/ESIMD/fma_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/fma_pvc.cpp
@@ -6,6 +6,7 @@
 //
 //===-------------------------------------------------------===//
 // REQUIRES: gpu-intel-pvc
+// REQUIRES-INTEL-DRIVER: lin: 29138, win: 101.5499
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Windows driver is too old on some internal testing systems.