### PR TITLE
Revert "[SYCL] Always pass -ftranslate-legacy-memory-intrinsics to IGC for ESIMD images (#13662)"

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -332,13 +332,12 @@ static void appendCompileOptionsFromImage(std::string &CompileOpts,
       CompileOpts += std::string(TemporaryStr);
   }
   bool isEsimdImage = getUint32PropAsBool(Img, "isEsimdImage");
-  // The -vc-codegen and -ftranslate-legacy-memory-intrinsics options are
-  // always preserved for ESIMD kernels, regardless of the contents
-  // of the SYCL_PROGRAM_COMPILE_OPTIONS environment variable.
+  // The -vc-codegen option is always preserved for ESIMD kernels, regardless
+  // of the contents SYCL_PROGRAM_COMPILE_OPTIONS environment variable.
   if (isEsimdImage) {
     if (!CompileOpts.empty())
       CompileOpts += " ";
-    CompileOpts += "-vc-codegen -ftranslate-legacy-memory-intrinsics";
+    CompileOpts += "-vc-codegen";
     // Allow warning and performance hints from vc/finalizer if the RT warning
     // level is at least 1.
     if (detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() == 0)

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -118,13 +118,10 @@ TEST(KernelBuildOptions, KernelBundleBasic) {
                                                          {KernelID});
   auto ExecBundle = sycl::build(KernelBundle);
   EXPECT_EQ(BuildOpts,
-            "-compile-img -vc-codegen -ftranslate-legacy-memory-intrinsics "
-            "-disable-finalizer-msg -link-img");
+            "-compile-img -vc-codegen -disable-finalizer-msg -link-img");
 
   auto ObjBundle = sycl::compile(KernelBundle, KernelBundle.get_devices());
-  EXPECT_EQ(BuildOpts,
-            "-compile-img -vc-codegen -ftranslate-legacy-memory-intrinsics "
-            "-disable-finalizer-msg");
+  EXPECT_EQ(BuildOpts, "-compile-img -vc-codegen -disable-finalizer-msg");
 
   auto LinkBundle = sycl::link(ObjBundle, ObjBundle.get_devices());
   EXPECT_EQ(BuildOpts, "-link-img");


### PR DESCRIPTION
This reverts commit 4d5c25c5b57a4bb595caffc77a62fb1192e9110c.

This breaks Arc postcommit.