### PR TITLE
[TEST-E2E] Address test build's missing triple on Windows. 

### DIFF
--- a/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
+++ b/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
-// RUN: %if windows %{  %clangxx -fsycl -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus'  -o %t2.out  %s  %}
+// RUN: %if windows %{  %{build} -fsycl-host-compiler=cl -fsycl-host-compiler-options='/std:c++17 /Zc:__cplusplus' -o %t2.out %}
 // RUN: %if windows %{  %{run} %t2.out  %}
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Address [test-e2e/Basic/bit_cast/bit_cast.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/Basic/bit_cast/bit_cast.cpp) build's missing triple on Windows.
