### PR TITLE
[SYCL][DeviceLib] Fix bug due to erroneous removal of library build option

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -50,6 +50,7 @@ if ("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
   string(APPEND sycl_targets_opt ",nvptx64-nvidia-cuda")
   list(APPEND compile_opts
     "-fno-sycl-libspirv"
+    "-fno-bundle-offload-arch"
     "-nocudalib"
     "--cuda-gpu-arch=sm_50")
 endif()


### PR DESCRIPTION
This bug was introduced in https://github.com/intel/llvm/pull/13579
Unfortunately CI testing decided not to run cuda testing for the guilty PR and the PR was merged. This PR resolves the issue.

Thanks