### PR TITLE
[Driver][SYCL][FPGA] Use bundled device libraries for FPGA targets

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5905,7 +5905,10 @@ class OffloadingActionBuilder final {
             ++NumOfDeviceLibLinked;
             Arg *InputArg = MakeInputArg(Args, C.getDriver().getOpts(),
                                          Args.MakeArgString(LibName));
-            if (TC->getTriple().isNVPTX()) {
+            if (TC->getTriple().isNVPTX() ||
+                (TC->getTriple().isSPIR() &&
+                 TC->getTriple().getSubArch() ==
+                     llvm::Triple::SPIRSubArch_fpga)) {
               auto *SYCLDeviceLibsInputAction =
                   C.MakeAction<InputAction>(*InputArg, types::TY_Object);
               auto *SYCLDeviceLibsUnbundleAction =

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -275,12 +275,12 @@
 // RUN:  | FileCheck -check-prefix UNBUNDLE_DEVICELIB %s
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -ccc-print-phases %s 2>&1 \
 // RUN:  | FileCheck -check-prefix UNBUNDLE_DEVICELIB %s
-// UNBUNDLE_DEVICELIB: [[#DEVLIB:]]: input, "{{.*}}libsycl-itt-user-wrappers.o", object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB:]]: input, "{{.*}}libsycl-itt-user-wrappers{{.*}}", object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+1]]: clang-offload-unbundler, {[[#DEVLIB]]}, object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+2]]: offload, " (spir64_fpga-unknown-unknown)" {[[#DEVLIB+1]]}, object
-// UNBUNDLE_DEVICELIB: [[#DEVLIB+3]]: input, "{{.*}}libsycl-itt-compiler-wrappers.o", object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+3]]: input, "{{.*}}libsycl-itt-compiler-wrappers{{.*}}", object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+4]]: clang-offload-unbundler, {[[#DEVLIB+3]]}, object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+5]]: offload, " (spir64_fpga-unknown-unknown)" {[[#DEVLIB+4]]}, object
-// UNBUNDLE_DEVICELIB: [[#DEVLIB+6]]: input, "{{.*}}libsycl-itt-stubs.o", object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+6]]: input, "{{.*}}libsycl-itt-stubs{{.*}}", object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+7]]: clang-offload-unbundler, {[[#DEVLIB+6]]}, object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+8]]: offload, " (spir64_fpga-unknown-unknown)" {[[#DEVLIB+7]]}, object

--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -268,3 +268,19 @@
 // RUN:  | FileCheck -check-prefix=CHK-NO-HARDWARE %s
 // CHK-FPGA-FPMODEL: aoc{{.*}} "-dep-files={{.*}}" "-vpfp-relaxed"
 // CHK-NO-HARDWARE-NOT: "-vpfp-relaxed"
+
+// When using -fintelfpga, we unbundle the device libraries instead of using
+// the LLVM-IR .bc files.
+// RUN: %clangxx -fintelfpga -ccc-print-phases %s 2>&1 \
+// RUN:  | FileCheck -check-prefix UNBUNDLE_DEVICELIB %s
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -ccc-print-phases %s 2>&1 \
+// RUN:  | FileCheck -check-prefix UNBUNDLE_DEVICELIB %s
+// UNBUNDLE_DEVICELIB: [[#DEVLIB:]]: input, "{{.*}}libsycl-itt-user-wrappers.o", object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+1]]: clang-offload-unbundler, {[[#DEVLIB]]}, object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+2]]: offload, " (spir64_fpga-unknown-unknown)" {[[#DEVLIB+1]]}, object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+3]]: input, "{{.*}}libsycl-itt-compiler-wrappers.o", object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+4]]: clang-offload-unbundler, {[[#DEVLIB+3]]}, object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+5]]: offload, " (spir64_fpga-unknown-unknown)" {[[#DEVLIB+4]]}, object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+6]]: input, "{{.*}}libsycl-itt-stubs.o", object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+7]]: clang-offload-unbundler, {[[#DEVLIB+6]]}, object
+// UNBUNDLE_DEVICELIB: [[#DEVLIB+8]]: offload, " (spir64_fpga-unknown-unknown)" {[[#DEVLIB+7]]}, object


### PR DESCRIPTION
The change that introduced the ability to use device libraries as IR files does not play well with the FPGA target.  The IR generated with spir64_fpga is different, causing issues as the bitcode based device libraries are built with spir64.

Update the compilation flow specific to FPGA to use the bundled device libraries as opposed to the bitcode files.