### PR TITLE
Bump idna from 3.7 in llvm/utils

### DIFF
--- a/llvm/utils/git/requirements.txt
+++ b/llvm/utils/git/requirements.txt
@@ -22,7 +22,7 @@ gitdb==4.0.9
     # via gitpython
 gitpython==3.1.41
     # via -r requirements.txt.in
-idna==3.4
+idna==3.7
     # via requests
 pycparser==2.21
     # via cffi


### PR DESCRIPTION
Bumps idna to v3.7 to resolve identified security vulnerability in 3rd party dependency.

Refer to [idna's releases notes](https://github.com/kjd/idna/releases)