### PR TITLE
[SYCL][Graph] Missing Lit test aspect

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/host_task_single.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_single.cpp
@@ -4,7 +4,8 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// REQUIRES: aspect-usm_host_allocations
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_single.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_single.cpp
@@ -4,7 +4,8 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// REQUIRES: aspect-usm_host_allocations
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
`Inputs/host_task_single.cpp` has a call to `malloc_host` (https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/Graph/Inputs/host_task_single.cpp#L24) but the LIT requirement for USM host allocation support is missing.