### PR TITLE
[SYCL][Fusion][NoSTL] Use `sycl::detail::string` in interface

### DIFF
--- a/sycl-fusion/common/include/DynArray.h
+++ b/sycl-fusion/common/include/DynArray.h
@@ -10,7 +10,6 @@
 #define SYCL_FUSION_COMMON_DYNARRAY_H
 
 #include <algorithm>
-#include <cstring>
 
 namespace jit_compiler {
 
@@ -91,24 +90,6 @@ private:
     Size = Other.Size;
     Other.Size = 0;
   }
-};
-
-///
-/// String-like class that owns its character storage.
-class DynString {
-public:
-  explicit DynString(const char *Str = "") : Chars{std::strlen(Str) + 1} {
-    std::copy(Str, Str + Chars.size(), Chars.begin());
-  }
-
-  const char *c_str() const { return Chars.begin(); }
-
-  friend bool operator==(const DynString &A, const char *B) {
-    return std::strcmp(A.c_str(), B) == 0;
-  }
-
-private:
-  DynArray<char> Chars;
 };
 
 } // namespace jit_compiler

--- a/sycl-fusion/common/include/Kernel.h
+++ b/sycl-fusion/common/include/Kernel.h
@@ -10,6 +10,7 @@
 #define SYCL_FUSION_COMMON_KERNEL_H
 
 #include "DynArray.h"
+#include "sycl/detail/string.hpp"
 
 #include <algorithm>
 #include <cassert>
@@ -327,7 +328,7 @@ private:
 /// Information about a kernel from DPC++.
 struct SYCLKernelInfo {
 
-  DynString Name;
+  sycl::detail::string Name;
 
   SYCLArgumentDescriptor Args;
 

--- a/sycl-fusion/jit-compiler/include/KernelFusion.h
+++ b/sycl-fusion/jit-compiler/include/KernelFusion.h
@@ -9,11 +9,11 @@
 #ifndef SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H
 #define SYCL_FUSION_JIT_COMPILER_KERNELFUSION_H
 
-#include "DynArray.h"
 #include "Kernel.h"
 #include "Options.h"
 #include "Parameter.h"
 #include "View.h"
+#include "sycl/detail/string.hpp"
 
 #include <cassert>
 
@@ -48,7 +48,7 @@ private:
 
   FusionResultType Type;
   SYCLKernelInfo KernelInfo;
-  DynString ErrorMessage;
+  sycl::detail::string ErrorMessage;
 };
 
 extern "C" {


### PR DESCRIPTION
Replace `jit_compiler::DynString` uses with `sycl::detail::string`.