### PR TITLE
[SYCL][COMPAT] Add inline in max and min functions

### DIFF
--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -423,38 +423,38 @@ cbrt(ValueT val) {
 // `std::int64_t` type arguments are acceptable.
 // sycl::half supported as well.
 template <typename ValueT, typename ValueU>
-std::enable_if_t<std::is_integral_v<ValueT> && std::is_integral_v<ValueU>,
+inline std::enable_if_t<std::is_integral_v<ValueT> && std::is_integral_v<ValueU>,
                  std::common_type_t<ValueT, ValueU>>
 min(ValueT a, ValueU b) {
   return sycl::min(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                    static_cast<std::common_type_t<ValueT, ValueU>>(b));
 }
 template <typename ValueT, typename ValueU>
-std::enable_if_t<std::is_floating_point_v<ValueT> &&
+inline std::enable_if_t<std::is_floating_point_v<ValueT> &&
                      std::is_floating_point_v<ValueU>,
                  std::common_type_t<ValueT, ValueU>>
 min(ValueT a, ValueU b) {
   return sycl::fmin(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                     static_cast<std::common_type_t<ValueT, ValueU>>(b));
 }
-sycl::half min(sycl::half a, sycl::half b) { return sycl::fmin(a, b); }
+inline sycl::half min(sycl::half a, sycl::half b) { return sycl::fmin(a, b); }
 
 template <typename ValueT, typename ValueU>
-std::enable_if_t<std::is_integral_v<ValueT> && std::is_integral_v<ValueU>,
+inline std::enable_if_t<std::is_integral_v<ValueT> && std::is_integral_v<ValueU>,
                  std::common_type_t<ValueT, ValueU>>
 max(ValueT a, ValueU b) {
   return sycl::max(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                    static_cast<std::common_type_t<ValueT, ValueU>>(b));
 }
 template <typename ValueT, typename ValueU>
-std::enable_if_t<std::is_floating_point_v<ValueT> &&
+inline std::enable_if_t<std::is_floating_point_v<ValueT> &&
                      std::is_floating_point_v<ValueU>,
                  std::common_type_t<ValueT, ValueU>>
 max(ValueT a, ValueU b) {
   return sycl::fmax(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                     static_cast<std::common_type_t<ValueT, ValueU>>(b));
 }
-sycl::half max(sycl::half a, sycl::half b) { return sycl::fmax(a, b); }
+inline sycl::half max(sycl::half a, sycl::half b) { return sycl::fmax(a, b); }
 
 /// Performs 2 elements comparison and returns the bigger one. If either of
 /// inputs is NaN, then return NaN.

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -432,8 +432,8 @@ min(ValueT a, ValueU b) {
 }
 template <typename ValueT, typename ValueU>
 inline std::enable_if_t<std::is_floating_point_v<ValueT> &&
-                     std::is_floating_point_v<ValueU>,
-                 std::common_type_t<ValueT, ValueU>>
+                            std::is_floating_point_v<ValueU>,
+                        std::common_type_t<ValueT, ValueU>>
 min(ValueT a, ValueU b) {
   return sycl::fmin(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                     static_cast<std::common_type_t<ValueT, ValueU>>(b));
@@ -450,8 +450,8 @@ max(ValueT a, ValueU b) {
 }
 template <typename ValueT, typename ValueU>
 inline std::enable_if_t<std::is_floating_point_v<ValueT> &&
-                     std::is_floating_point_v<ValueU>,
-                 std::common_type_t<ValueT, ValueU>>
+                            std::is_floating_point_v<ValueU>,
+                        std::common_type_t<ValueT, ValueU>>
 max(ValueT a, ValueU b) {
   return sycl::fmax(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                     static_cast<std::common_type_t<ValueT, ValueU>>(b));

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -423,8 +423,9 @@ cbrt(ValueT val) {
 // `std::int64_t` type arguments are acceptable.
 // sycl::half supported as well.
 template <typename ValueT, typename ValueU>
-inline std::enable_if_t<std::is_integral_v<ValueT> && std::is_integral_v<ValueU>,
-                 std::common_type_t<ValueT, ValueU>>
+inline std::enable_if_t<std::is_integral_v<ValueT> &&
+                            std::is_integral_v<ValueU>,
+                        std::common_type_t<ValueT, ValueU>>
 min(ValueT a, ValueU b) {
   return sycl::min(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                    static_cast<std::common_type_t<ValueT, ValueU>>(b));
@@ -440,8 +441,9 @@ min(ValueT a, ValueU b) {
 inline sycl::half min(sycl::half a, sycl::half b) { return sycl::fmin(a, b); }
 
 template <typename ValueT, typename ValueU>
-inline std::enable_if_t<std::is_integral_v<ValueT> && std::is_integral_v<ValueU>,
-                 std::common_type_t<ValueT, ValueU>>
+inline std::enable_if_t<std::is_integral_v<ValueT> &&
+                            std::is_integral_v<ValueU>,
+                        std::common_type_t<ValueT, ValueU>>
 max(ValueT a, ValueU b) {
   return sycl::max(static_cast<std::common_type_t<ValueT, ValueU>>(a),
                    static_cast<std::common_type_t<ValueT, ValueU>>(b));


### PR DESCRIPTION
This PR makes the `max` and `min` functions inline. It resolves a linker issue that occurs when a library that includes the SYCLCompat headers is linked to an executable that also includes the SYCLCompat headers. In which case the linker found multiple definitions of these functions. 