### PR TITLE
[SYCL][E2E] Limit check_device_code/group_load.cpp to asserts build

### DIFF
--- a/sycl/test/check_device_code/group_load.cpp
+++ b/sycl/test/check_device_code/group_load.cpp
@@ -2,6 +2,9 @@
 // NOTE: and manually adjusted to follow the related explicit instantiation.
 // RUN: %clangxx -O3 -fsycl -fsycl-device-only -S -emit-llvm -fno-sycl-instrument-device-code  -o - %s | FileCheck %s
 
+// Generated checks have hard-coded basic block names, so need names in the IR.
+// REQUIRES: asserts
+
 // Windows/linux have some slight differences in IR generation (function
 // arguments passing and long/long long differences/mangling) that could
 // complicate test updates while not improving test coverage. Limiting to linux


### PR DESCRIPTION
That should address post-commit failures.