### PR TITLE
[SYCL] Add support for multiple missing math ops

### DIFF
--- a/libdevice/cmath_wrapper.cpp
+++ b/libdevice/cmath_wrapper.cpp
@@ -23,6 +23,23 @@ DEVICE_EXTERN_C_INLINE
 float fabsf(float x) { return __devicelib_fabsf(x); }
 
 DEVICE_EXTERN_C_INLINE
+float ceilf(float x) { return __devicelib_ceilf(x); }
+
+DEVICE_EXTERN_C_INLINE
+float copysignf(float x, float y) { return __devicelib_copysignf(x, y); }
+
+DEVICE_EXTERN_C_INLINE
+float cospif(float x) { return __devicelib_cospif(x); }
+
+extern "C" SYCL_EXTERNAL float __devicelib_fmaxf(float, float);
+DEVICE_EXTERN_C_INLINE
+float fmaxf(float x, float y) { return __devicelib_fmaxf(x, y); }
+
+extern "C" SYCL_EXTERNAL float __devicelib_fminf(float, float);
+DEVICE_EXTERN_C_INLINE
+float fminf(float x, float y) { return __devicelib_fminf(x, y); }
+
+DEVICE_EXTERN_C_INLINE
 div_t div(int x, int y) { return __devicelib_div(x, y); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -20,6 +20,23 @@ DEVICE_EXTERN_C_INLINE
 double fabs(double x) { return __devicelib_fabs(x); }
 
 DEVICE_EXTERN_C_INLINE
+double ceil(double x) { return __devicelib_ceil(x); }
+
+DEVICE_EXTERN_C_INLINE
+double copysign(double x, double y) { return __devicelib_copysign(x, y); }
+
+DEVICE_EXTERN_C_INLINE
+double cospi(double x) { return __devicelib_cospi(x); }
+
+extern "C" SYCL_EXTERNAL double __devicelib_fmax(double, double);
+DEVICE_EXTERN_C_INLINE
+double fmax(double x, double y) { return __devicelib_fmax(x, y); }
+
+extern "C" SYCL_EXTERNAL double __devicelib_fmin(double, double);
+DEVICE_EXTERN_C_INLINE
+double fmin(double x, double y) { return __devicelib_fmin(x, y); }
+
+DEVICE_EXTERN_C_INLINE
 double log(double x) { return __devicelib_log(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/device_math.h
+++ b/libdevice/device_math.h
@@ -47,6 +47,36 @@ DEVICE_EXTERN_C
 double __devicelib_fabs(double x);
 
 DEVICE_EXTERN_C
+float __devicelib_ceilf(float x);
+
+DEVICE_EXTERN_C
+double __devicelib_ceil(double x);
+
+DEVICE_EXTERN_C
+float __devicelib_copysignf(float x, float y);
+
+DEVICE_EXTERN_C
+double __devicelib_copysign(double x, double y);
+
+DEVICE_EXTERN_C
+float __devicelib_cospif(float x);
+
+DEVICE_EXTERN_C
+double __devicelib_cospi(double x);
+
+DEVICE_EXTERN_C
+float __devicelib_fmaxf(float x, float y);
+
+DEVICE_EXTERN_C
+double __devicelib_fmax(double x, double y);
+
+DEVICE_EXTERN_C
+float __devicelib_fminf(float x, float y);
+
+DEVICE_EXTERN_C
+double __devicelib_fmin(double x, double y);
+
+DEVICE_EXTERN_C
 div_t __devicelib_div(int x, int y);
 
 DEVICE_EXTERN_C

--- a/libdevice/fallback-cmath-fp64.cpp
+++ b/libdevice/fallback-cmath-fp64.cpp
@@ -19,6 +19,23 @@ DEVICE_EXTERN_C_INLINE
 double __devicelib_fabs(double x) { return x < 0 ? -x : x; }
 
 DEVICE_EXTERN_C_INLINE
+double __devicelib_ceil(double x) { return __spirv_ocl_ceil(x); }
+
+DEVICE_EXTERN_C_INLINE
+double __devicelib_copysign(double x, double y) {
+  return __spirv_ocl_copysign(x, y);
+}
+
+DEVICE_EXTERN_C_INLINE
+double __devicelib_cospi(double x) { return __spirv_ocl_cospi(x); }
+
+DEVICE_EXTERN_C_INLINE
+double __devicelib_fmax(double x, double y) { return __spirv_ocl_fmax(x, y); }
+
+DEVICE_EXTERN_C_INLINE
+double __devicelib_fmin(double x, double y) { return __spirv_ocl_fmin(x, y); }
+
+DEVICE_EXTERN_C_INLINE
 double __devicelib_log(double x) { return __spirv_ocl_log(x); }
 
 DEVICE_EXTERN_C_INLINE

--- a/libdevice/fallback-cmath.cpp
+++ b/libdevice/fallback-cmath.cpp
@@ -29,6 +29,23 @@ DEVICE_EXTERN_C_INLINE
 float __devicelib_fabsf(float x) { return x < 0 ? -x : x; }
 
 DEVICE_EXTERN_C_INLINE
+float __devicelib_ceilf(float x) { return __spirv_ocl_ceil(x); }
+
+DEVICE_EXTERN_C_INLINE
+float __devicelib_copysignf(float x, float y) {
+  return __spirv_ocl_copysign(x, y);
+}
+
+DEVICE_EXTERN_C_INLINE
+float __devicelib_cospif(float x) { return __spirv_ocl_cospi(x); }
+
+DEVICE_EXTERN_C_INLINE
+float __devicelib_fmaxf(float x, float y) { return __spirv_ocl_fmax(x, y); }
+
+DEVICE_EXTERN_C_INLINE
+float __devicelib_fminf(float x, float y) { return __spirv_ocl_fmin(x, y); }
+
+DEVICE_EXTERN_C_INLINE
 div_t __devicelib_div(int x, int y) { return {x / y, x % y}; }
 
 DEVICE_EXTERN_C_INLINE

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -14,17 +14,19 @@
 #include <cstdint>
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/usm.hpp>
 
 namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;
 constexpr s::access::mode sycl_write = s::access::mode::write;
 
-#define TEST_NUM 64
+#define TEST_NUM 69
 
-double ref[TEST_NUM] = {
-    1, 1, 0, 1, 1, 0, 0, 0, 0, 0, 1, 1, 0.5, 0, 2, 0,   0,   1,   0,   2, 0, 0,
-    0, 0, 0, 1, 0, 1, 2, 0, 1, 2, 5, 0, 0,   0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0,
-    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,   0, 0, 0,   0,   0,   0,   0};
+double ref[TEST_NUM] = {0,   -2,  1,   2,   1, 1, 1, 0, 1, 1, 0, 0, 0, 0,
+                        0,   1,   1,   0.5, 0, 2, 0, 0, 1, 0, 2, 0, 0, 0,
+                        0,   0,   1,   0,   1, 2, 0, 1, 2, 5, 0, 0, 0, 0,
+                        0.5, 0.5, NAN, NAN, 2, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+                        0,   0,   0,   0,   0, 0, 0, 0, 0, 0, 0, 0, 0};
 
 double refIptr = 1;
 
@@ -59,7 +61,12 @@ template <class T> void device_cmath_test(s::queue &deviceQueue) {
         T minus_infinity = -INFINITY;
         double subnormal;
         *((uint64_t *)&subnormal) = 0xFFFFFFFFFFFFFULL;
+        res_access[i++] = sycl::cospi(0.5);
+        res_access[i++] = std::copysign(2, -1);
+        res_access[i++] = std::fmin(2, 1);
+        res_access[i++] = std::fmax(2, 1);
         res_access[i++] = std::fabs(-1.0);
+        res_access[i++] = std::ceil(0.1);
         res_access[i++] = std::cos(0.0);
         res_access[i++] = std::sin(0.0);
         res_access[i++] = std::round(1.0);

--- a/sycl/test-e2e/DeviceLib/cmath_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_test.cpp
@@ -16,17 +16,19 @@
 #include <cstdint>
 #include <iostream>
 #include <sycl/detail/core.hpp>
+#include <sycl/usm.hpp>
 
 namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;
 constexpr s::access::mode sycl_write = s::access::mode::write;
 
-#define TEST_NUM 61
+#define TEST_NUM 66
 
-float ref[TEST_NUM] = {1, 0, 1,   1,   0,   0,   0, 0, 0, 1, 1, 0.5, 0, 0, 1, 0,
-                       2, 0, 0,   0,   0,   0,   1, 0, 1, 2, 0, 1,   2, 5, 0, 0,
-                       0, 0, 0.5, 0.5, NAN, NAN, 2, 0, 0, 0, 0, 0,   0, 0, 0, 0,
-                       0, 0, 0,   0,   0,   0,   0, 0, 0, 0, 0, 0,   0};
+float ref[TEST_NUM] = {0,   -2, 1,   2, 1, 1, 0, 1, 1, 0, 0, 0,   0,   0,
+                       1,   1,  0.5, 0, 0, 1, 0, 2, 0, 0, 0, 0,   0,   1,
+                       0,   1,  2,   0, 1, 2, 5, 0, 0, 0, 0, 0.5, 0.5, NAN,
+                       NAN, 2,  0,   0, 0, 0, 0, 0, 0, 0, 0, 0,   0,   0,
+                       0,   0,  0,   0, 0, 0, 0, 0, 0, 0};
 
 float refIptr = 1;
 
@@ -56,6 +58,11 @@ template <class T> void device_cmath_test_1(s::queue &deviceQueue) {
         float subnormal;
         *((uint32_t *)&subnormal) = 0x7FFFFF;
 
+        res_access[i++] = sycl::cospi(0.5f);
+        res_access[i++] = std::copysign(2.0f, -10.0f);
+        res_access[i++] = sycl::min(2.0f, 1.0f);
+        res_access[i++] = sycl::max(2.0f, 1.0f);
+        res_access[i++] = sycl::ceil(0.1f);
         res_access[i++] = std::cos(0.0f);
         res_access[i++] = std::sin(0.0f);
         res_access[i++] = std::round(1.0f);


### PR DESCRIPTION
    Add support for multiple missing math ops;
    - ceilf
    - copysignf
    - cospif
    - fmaxf
    - fminf