### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-b456477

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-b906329",
-      "version": "b906329",
-      "updated_at": "2024-05-04T22:39:56Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1473544965/zip",
+      "github_tag": "igc-dev-b456477",
+      "version": "b456477",
+      "updated_at": "2024-05-09T02:54:52Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1486386355/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift