### PR TITLE
[SYCL][E2E] Fix XPTI/basic_event_collection_linux.cpp

### DIFF
--- a/sycl/test-e2e/XPTI/basic_event_collection_linux.cpp
+++ b/sycl/test-e2e/XPTI/basic_event_collection_linux.cpp
@@ -35,7 +35,7 @@
 // CHECK-DAG:    from_source : false
 // CHECK-DAG:    kernel_name : typeinfo name for main::{lambda(sycl::_V1::handler&)#1}::operator()(sycl::_V1::handler&) const::{lambda()#1}
 // CHECK-DAG:    sycl_device : {{.*}}
-// CHECK-NEXT: Node create
+// CHECK:      Node create
 // CHECK-DAG:   queue_id : {{.*}}
 // CHECK-DAG:   kernel_name : virtual_node[{{.*}}]
 // CHECK-NEXT: Edge create
@@ -63,7 +63,7 @@
 // CHECK-DAG:    from_source : false
 // CHECK-DAG:    kernel_name : typeinfo name for main::{lambda(sycl::_V1::handler&)#1}::operator()(sycl::_V1::handler&) const::{lambda()#1}
 // CHECK-DAG:    sycl_device : {{.*}}
-// CHECK-NEXT: Task end
+// CHECK:      Task end
 // CHECK-DAG:    queue_id : {{.*}}
 // CHECK-DAG:    sym_line_no : {{.*}}
 // CHECK-DAG:    sym_source_file_name : {{.*}}
@@ -71,7 +71,7 @@
 // CHECK-DAG:    from_source : false
 // CHECK-DAG:    kernel_name : typeinfo name for main::{lambda(sycl::_V1::handler&)#1}::operator()(sycl::_V1::handler&) const::{lambda()#1}
 // CHECK-DAG:    sycl_device : {{.*}}
-// CHECK-NEXT: Wait begin
+// CHECK:      Wait begin
 // CHECK-DAG:    queue_id : {{.*}}
 // CHECK-NEXT: PI Call Begin : piEventsWait
 // CHECK-NEXT: Wait end
@@ -82,20 +82,20 @@
 // CHECK-DAG:    dest_memory_ptr : {{.*}}
 // CHECK-DAG:    src_memory_ptr : {{.*}}
 // CHECK-DAG:    sycl_device : {{.*}}
-// CHECK-NEXT: Task begin
+// CHECK:      Task begin
 // CHECK-DAG:    queue_id : {{.*}}
 // CHECK-DAG:    memory_size : {{.*}}
 // CHECK-DAG:    dest_memory_ptr : {{.*}}
 // CHECK-DAG:    src_memory_ptr : {{.*}}
 // CHECK-DAG:    sycl_device : {{.*}}
-// CHECK-NEXT: PI Call Begin : piextUSMEnqueueMemcpy
+// CHECK:      PI Call Begin : piextUSMEnqueueMemcpy
 // CHECK-NEXT: Task end
 // CHECK-DAG:    queue_id : {{.*}}
 // CHECK-DAG:    memory_size : {{.*}}
 // CHECK-DAG:    dest_memory_ptr : {{.*}}
 // CHECK-DAG:    src_memory_ptr : {{.*}}
 // CHECK-DAG:    sycl_device : {{.*}}
-// CHECK-NEXT: PI Call Begin : piEventRelease
+// CHECK:      PI Call Begin : piEventRelease
 // CHECK-NEXT: Wait begin
 // CHECK-DAG:    queue_id : {{.*}}
 // CHECK-DAG:    sycl_device_type : {{.*}}


### PR DESCRIPTION
If `CHECK-DAG`s don't cover all the sub-entries then the next entry cannot be `CHECK-NEXT` because the last `CHECK-DAG`ed sub-entry might not be the last emitted and it's possible there is an unchecked line inbetween it and the next entry.