### PR TITLE
[SYCL] Fix assert unit test warning

### DIFF
--- a/sycl/unittests/helpers/PiImage.hpp
+++ b/sycl/unittests/helpers/PiImage.hpp
@@ -392,7 +392,7 @@ inline void setKernelUsesAssert(const std::vector<std::string> &Names,
                                 PiPropertySet &Set) {
   PiArray<PiProperty> Value;
   for (const std::string &N : Names)
-    Value.push_back({N, {4, 0}, PI_PROPERTY_TYPE_UINT32});
+    Value.push_back({N, {0, 0, 0, 0}, PI_PROPERTY_TYPE_UINT32});
   Set.insert(__SYCL_PI_PROPERTY_SET_SYCL_ASSERT_USED, std::move(Value));
 }
 


### PR DESCRIPTION
This value is the size of the data associated with the property, but for `PI_PROPERTY_TYPE_UINT32`, the data is always `nullptr` so this should be 0.

I suspect the initial patch meant to construct a vector of 4 values of 0, but that initializer list construct a vector of 2 values with 4 and 0 instead.

Should fix: https://github.com/intel/llvm/issues/13737