### PR TITLE
[SYCL][SCLA] Drop unneeded `addrspacecast` instruction

### DIFF
--- a/clang/lib/CodeGen/CGBuiltin.cpp
+++ b/clang/lib/CodeGen/CGBuiltin.cpp
@@ -23990,22 +23990,6 @@ RValue CodeGenFunction::EmitIntelSYCLAllocaBuiltin(
     return CI;
   }();
 
-  // Perform AS cast if needed.
-
-  constexpr int NoDecorated = 0;
-  llvm::APInt Decorated = TAL->get(DecorateAddressIndex).getAsIntegral();
-  // Both 'sycl::access::decorated::{yes and legacy}' lead to decorated (private
-  // AS) pointer type. Perform cast if 'sycl::access::decorated::no'.
-  if (Decorated == NoDecorated) {
-    IRBuilderBase::InsertPointGuard IPG(Builder);
-    Builder.SetInsertPoint(getPostAllocaInsertPoint());
-    unsigned DestAddrSpace =
-        getContext().getTargetAddressSpace(LangAS::Default);
-    llvm::PointerType *DestTy =
-        llvm::PointerType::get(Builder.getContext(), DestAddrSpace);
-    Allocation = Builder.CreateAddrSpaceCast(Allocation, DestTy);
-  }
-
   // If no slot is provided, simply return allocation.
   if (ReturnValue.isNull())
     return RValue::get(Allocation);

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -178,29 +178,16 @@ struct DecoratedType<ElementType, access::address_space::constant_space> {
 #endif
 };
 
-// Equivalent to std::conditional
-template <bool B, class T, class F>
-struct conditional { using type = T; };
-
-template <class T, class F>
-struct conditional<false, T, F> { using type = F; };
-
-template <bool B, class T, class F>
-using conditional_t = typename conditional<B, T, F>::type;
-
 template <typename T, access::address_space AS,
           access::decorated DecorateAddress = access::decorated::legacy>
 class __SYCL_TYPE(multi_ptr) multi_ptr {
-  static constexpr bool is_decorated =
-      DecorateAddress == access::decorated::yes;
-
   using decorated_type = typename DecoratedType<T, AS>::type;
 
   static_assert(DecorateAddress != access::decorated::legacy);
   static_assert(AS != access::address_space::constant_space);
 
 public:
-  using pointer = conditional_t<is_decorated, decorated_type *, T *>;
+  using pointer = decorated_type *;
 
   multi_ptr(typename multi_ptr<T, AS, access::decorated::yes>::pointer Ptr)
     : m_Pointer((pointer)(Ptr)) {} // #MultiPtrConstructor

--- a/clang/test/CodeGenSYCL/builtin-alloca.cpp
+++ b/clang/test/CodeGenSYCL/builtin-alloca.cpp
@@ -18,8 +18,7 @@ struct myStruct {
 constexpr sycl::specialization_id<size_t> size(1);
 constexpr sycl::specialization_id<int> intSize(1);
 
-// For each call, we should generate a chain of: 'call @llvm.sycl.alloca.<ty>' + ('addrspacecast') + 'store'.
-// The 'addrspacecast' will only appear when the pointer is not decorated, i.e., `DecorateAddress == sycl::access::decorated::no`.
+// For each call, we should generate a chain of: 'call @llvm.sycl.alloca.<ty>' + 'store'.
 
 // CHECK-LABEL: define dso_local spir_func void @_Z4testRN4sycl3_V114kernel_handlerE(
 // CHECK-SAME: ptr addrspace(4) noundef align 1 dereferenceable(1) [[KH:%.*]])
@@ -35,11 +34,10 @@ constexpr sycl::specialization_id<int> intSize(1);
 // CHECK-NEXT:    [[PTR0_ASCAST:%.*]] = addrspacecast ptr [[PTR0]] to ptr addrspace(4)
 // CHECK-NEXT:    [[PTR1_ASCAST:%.*]] = addrspacecast ptr [[PTR1]] to ptr addrspace(4)
 // CHECK-NEXT:    [[PTR2_ASCAST:%.*]] = addrspacecast ptr [[PTR2]] to ptr addrspace(4)
-// CHECK-NEXT:    [[TMP5:%.*]] = addrspacecast ptr [[TMP4]] to ptr addrspace(4)
 // CHECK-NEXT:    store ptr addrspace(4) [[KH]], ptr addrspace(4) [[KH_ADDR_ASCAST]], align 8
 // CHECK-NEXT:    store ptr [[TMP0]], ptr addrspace(4) [[PTR0_ASCAST]], align 8
 // CHECK-NEXT:    store ptr [[TMP2]], ptr addrspace(4) [[PTR1_ASCAST]], align 8
-// CHECK-NEXT:    store ptr addrspace(4) [[TMP5]], ptr addrspace(4) [[PTR2_ASCAST]], align 8
+// CHECK-NEXT:    store ptr [[TMP4]], ptr addrspace(4) [[PTR2_ASCAST]], align 8
 // CHECK-NEXT:    ret void
 SYCL_EXTERNAL void test(sycl::kernel_handler &kh) {
   auto ptr0 = sycl::ext::oneapi::experimental::private_alloca<double, size, sycl::access::decorated::yes>(kh);
@@ -67,11 +65,10 @@ SYCL_EXTERNAL void test(sycl::kernel_handler &kh) {
 // CHECK-NEXT:    [[PTR0_ASCAST:%.*]] = addrspacecast ptr [[PTR0]] to ptr addrspace(4)
 // CHECK-NEXT:    [[PTR1_ASCAST:%.*]] = addrspacecast ptr [[PTR1]] to ptr addrspace(4)
 // CHECK-NEXT:    [[PTR2_ASCAST:%.*]] = addrspacecast ptr [[PTR2]] to ptr addrspace(4)
-// CHECK-NEXT:    [[TMP5:%.*]] = addrspacecast ptr [[TMP4]] to ptr addrspace(4)
 // CHECK-NEXT:    store ptr addrspace(4) [[KH]], ptr addrspace(4) [[KH_ADDR_ASCAST]], align 8
 // CHECK-NEXT:    store ptr [[TMP0]], ptr addrspace(4) [[PTR0_ASCAST]], align 8
 // CHECK-NEXT:    store ptr [[TMP2]], ptr addrspace(4) [[PTR1_ASCAST]], align 8
-// CHECK-NEXT:    store ptr addrspace(4) [[TMP5]], ptr addrspace(4) [[PTR2_ASCAST]], align 8
+// CHECK-NEXT:    store ptr [[TMP4]], ptr addrspace(4) [[PTR2_ASCAST]], align 8
 // CHECK-NEXT:    ret void
 SYCL_EXTERNAL void test_aligned(sycl::kernel_handler &kh) {
   auto ptr0 = sycl::ext::oneapi::experimental::aligned_private_alloca<double, alignof(double) * 2, size, sycl::access::decorated::yes>(kh);

--- a/clang/test/SemaSYCL/Inputs/sycl.hpp
+++ b/clang/test/SemaSYCL/Inputs/sycl.hpp
@@ -409,29 +409,16 @@ struct DecoratedType<ElementType, access::address_space::global_space> {
   using type = __attribute__((opencl_global)) ElementType;
 };
 
-// Equivalent to std::conditional
-template <bool B, class T, class F>
-struct conditional { using type = T; };
-
-template <class T, class F>
-struct conditional<false, T, F> { using type = F; };
-
-template <bool B, class T, class F>
-using conditional_t = typename conditional<B, T, F>::type;
-
 template <typename T, access::address_space AS,
           access::decorated DecorateAddress = access::decorated::legacy>
 class __SYCL_TYPE(multi_ptr) multi_ptr {
-  static constexpr bool is_decorated =
-      DecorateAddress == access::decorated::yes;
-
   using decorated_type = typename DecoratedType<T, AS>::type;
 
   static_assert(DecorateAddress != access::decorated::legacy);
   static_assert(AS != access::address_space::constant_space);
 
 public:
-    using pointer = conditional_t<is_decorated, decorated_type *, T *>;
+  using pointer = decorated_type *;
 
   multi_ptr(typename multi_ptr<T, AS, access::decorated::yes>::pointer Ptr)
     : m_Pointer((pointer)(Ptr)) {}

--- a/sycl/test/extensions/private_alloca.cpp
+++ b/sycl/test/extensions/private_alloca.cpp
@@ -7,13 +7,11 @@
 // Check SPIR-V code generation for 'sycl_ext_oneapi_private_alloca'. Each call
 // to the extension API is annotated as follows for future reference:
 //
-// <NAME>: storage_class=<sc>, element_type=<et>, alignment=<align>
+// <NAME>: element_type=<et>, alignment=<align>
 //
 // - <NAME>: Variable name in the test below. These will be the result of
 // bitcasting a variable to a different pointer type. We use this instead of the
 // variable due to FileCheck limitations.
-// - <sc>: 'generic' if <NAME> is casted to generic before being stored in the
-// multi_ptr or 'function' otherwise.
 // - <et>: element type. 'Bitcast X <NAME> Y' will originate value <NAME>, being
 // X a pointer to <et> and storage class function.
 // - <align>: alignment. <NAME> will appear in a 'Decorage <NAME> Aligment
@@ -44,17 +42,17 @@ SYCL_EXTERNAL void test(sycl::kernel_handler &kh) {
   keep(/*B0: storage_class=function, element_type=f32, alignment=4*/
        sycl::ext::oneapi::experimental::private_alloca<
            float, int8_id, sycl::access::decorated::yes>(kh),
-       /*B1: storage_class=generic, element_type=f64, alignment=8*/
+       /*B1: element_type=f64, alignment=8*/
        sycl::ext::oneapi::experimental::private_alloca<
            double, uint32_id, sycl::access::decorated::no>(kh),
-       /*B2: storage_class=function, element_type=i32, alignment=4*/
+       /*B2: element_type=i32, alignment=4*/
        sycl::ext::oneapi::experimental::private_alloca<
            int, int16_id, sycl::access::decorated::legacy>(kh),
-       /*B3: storage_class=generic, element_type=i64, alignment=16*/
+       /*B3: element_type=i64, alignment=16*/
        sycl::ext::oneapi::experimental::aligned_private_alloca<
            int64_t, alignof(int64_t) * 2, uint64_id,
            sycl::access::decorated::no>(kh),
-       /*B4: storage_class=function, element_type=composite, alignment=32*/
+       /*B4: element_type=composite, alignment=32*/
        sycl::ext::oneapi::experimental::aligned_private_alloca<
            composite, alignof(composite) * 8, int32_id,
            sycl::access::decorated::yes>(kh));
@@ -120,15 +118,13 @@ SYCL_EXTERNAL void test(sycl::kernel_handler &kh) {
 // CHECK-SPV-DAG: Store {{.*}} [[#B0]]
 // CHECK-SPV-DAG: Variable [[#ARRF64PTRTY]] [[#V1:]] [[#FUNCTIONSTORAGE]]
 // CHECK-SPV-DAG: Bitcast [[#F64PTRTY]] [[#B1:]] [[#V1]]
-// CHECK-SPV-DAG: PtrCastToGeneric {{.*}} [[#G1:]] [[#B1]]
-// CHECK-SPV-DAG: Store {{.*}} [[#G1]]
+// CHECK-SPV-DAG: Store {{.*}} [[#B1]]
 // CHECK-SPV-DAG: Variable [[#ARRI32PTRTY]] [[#V2:]] [[#FUNCTIONSTORAGE]]
 // CHECK-SPV-DAG: Bitcast [[#I32PTRTY]] [[#B2:]] [[#V2]]
 // CHECK-SPV-DAG: Store {{.*}} [[#B2]]
 // CHECK-SPV-DAG: Variable [[#ARRI64PTRTY]] [[#V3:]] [[#FUNCTIONSTORAGE]]
 // CHECK-SPV-DAG: Bitcast [[#I64PTRTY]] [[#B3:]] [[#V3]]
-// CHECK-SPV-DAG: PtrCastToGeneric {{.*}} [[#G3:]] [[#B3]]
-// CHECK-SPV-DAG: Store {{.*}} [[#G3]]
+// CHECK-SPV-DAG: Store {{.*}} [[#B3]]
 // CHECK-SPV-DAG: Variable [[#ARRCOMPPTRTY]] [[#V4:]] [[#FUNCTIONSTORAGE]]
 // CHECK-SPV-DAG: Bitcast [[#COMPPTRTY]] [[#B4:]] [[#V4]]
 // CHECK-SPV-DAG: Store {{.*}} [[#B4]]


### PR DESCRIPTION
As pointed out in
https://github.com/intel/llvm/pull/13514#discussion_r1595643260, `sycl::multi_ptr` pointer member is always decorated in DPC++. Drop unneeeded `addrspacecast` to the generic address space when `[aligned_]private_alloca` returns a `raw_private_ptr`.