### PR TITLE
[SYCL][Fusion][Build] Add `sycl-fusion` dependency on `sycl-headers`

### DIFF
--- a/sycl-fusion/common/CMakeLists.txt
+++ b/sycl-fusion/common/CMakeLists.txt
@@ -20,6 +20,8 @@ target_include_directories(sycl-fusion-common
   ${CMAKE_CURRENT_SOURCE_DIR}/lib
 )
 
+add_dependencies(sycl-fusion-common sycl-headers)
+
 if (BUILD_SHARED_LIBS)
   if(NOT MSVC AND NOT APPLE)
     # Manage symbol visibility through the linker to make sure no LLVM symbols

--- a/sycl-fusion/jit-compiler/CMakeLists.txt
+++ b/sycl-fusion/jit-compiler/CMakeLists.txt
@@ -60,6 +60,8 @@ target_link_libraries(sycl-fusion
   ${CMAKE_THREAD_LIBS_INIT}
 )
 
+add_dependencies(sycl-fusion sycl-headers)
+
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
   target_compile_definitions(sycl-fusion PRIVATE FUSION_JIT_SUPPORT_PTX)
 endif()

--- a/sycl-fusion/passes/CMakeLists.txt
+++ b/sycl-fusion/passes/CMakeLists.txt
@@ -35,6 +35,8 @@ target_link_libraries(SYCLKernelFusion
   sycl-fusion-common
 )
 
+add_dependencies(SYCLKernelFusion sycl-headers)
+
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
   target_compile_definitions(SYCLKernelFusion PRIVATE FUSION_JIT_SUPPORT_PTX)
 endif()
@@ -86,6 +88,8 @@ target_link_libraries(SYCLKernelFusionPasses
   PRIVATE
   sycl-fusion-common
 )
+
+add_dependencies(SYCLKernelFusionPasses sycl-headers)
 
 if("NVPTX" IN_LIST LLVM_TARGETS_TO_BUILD)
   target_compile_definitions(SYCLKernelFusionPasses PRIVATE FUSION_JIT_SUPPORT_PTX)


### PR DESCRIPTION
Targets under `sycl-fusion` use `sycl::detail::string`, from the SYCL headers. Make sure these are available in `<build-dir>/include/` by adding dependency on the `sycl-headers` target.