### PR TITLE
[SYCL][Graph][CUDA] Disable failing update test.

### DIFF
--- a/sycl/test-e2e/Graph/Update/Explicit/whole_update_double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Update/Explicit/whole_update_double_buffer.cpp
@@ -7,4 +7,6 @@
 
 #define GRAPH_E2E_EXPLICIT
 
+// UNSUPPORTED: cuda
+
 #include "../../Inputs/whole_update_double_buffer.cpp"

--- a/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_double_buffer.cpp
@@ -7,4 +7,6 @@
 
 #define GRAPH_E2E_RECORD_REPLAY
 
+// UNSUPPORTED: cuda
+
 #include "../../Inputs/whole_update_double_buffer.cpp"


### PR DESCRIPTION
https://github.com/intel/llvm/issues/13731

Disable whole graph update tests on CUDA, as they are flaky and failing on unrelated PRs, until such a time as the fail can be investigated and fixed.