### PR TITLE
[CI][HIP] Install libstdc++-12-dev without gcc12.

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -13,9 +13,7 @@ COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
 RUN apt install -yqq libnuma-dev wget gnupg2 && \
-  apt-get install -yqq gcc-12 g++-12 libstdc++-12-dev && \
-  update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-12 100 && \
-  update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-12 100
+  apt-get install -yqq libstdc++-12-dev
 
 RUN wget https://repo.radeon.com/amdgpu-install/6.1/ubuntu/jammy/amdgpu-install_6.1.60100-1_all.deb && \
   apt install -yqq ./amdgpu-install_6.1.60100-1_all.deb && \


### PR DESCRIPTION
This partially reverts the changes made in https://github.com/intel/llvm/pull/13619 to use libstdc++-12-dev without gcc12.
This also seems to work fine to build dpc++ within the docker. But should come without the CI failures that might have been induced by the gcc uplift:
- https://github.com/intel/llvm/issues/13736
- https://github.com/intel/llvm/issues/13735
If the above issues were not caused by the gcc version uplift, then this patch should also reveal that. 