### PR TITLE
[NFC][SYCL] Avoid hardcoding line no in clangd test

### DIFF
--- a/clang-tools-extra/clangd/test/sycl.test
+++ b/clang-tools-extra/clangd/test/sycl.test
@@ -24,12 +24,12 @@
 # CHECK-NEXT:      "declarationRange": {
 # CHECK-NEXT:        "range": {
 # CHECK-NEXT:          "end": {
-# CHECK-NEXT:            "character": 16,
-# CHECK-NEXT:            "line": 116
+# CHECK-NEXT:            "character": {{.*}},
+# CHECK-NEXT:            "line": {{.*}}
 # CHECK-NEXT:          },
 # CHECK-NEXT:          "start": {
-# CHECK-NEXT:            "character": 11,
-# CHECK-NEXT:            "line": 116
+# CHECK-NEXT:            "character": {{.*}},
+# CHECK-NEXT:            "line": {{.*}}
 # CHECK-NEXT:          }
 # CHECK-NEXT:        },
 # CHECK-NEXT:        "uri": "file://{{.*}}/include/sycl/queue.hpp"


### PR DESCRIPTION
We check line numbers in clangd sycl compilation test,
this is fragile, as everytime we have sycl header change,
we may have to update the test.

Use regex to match the line no instead to reduce the maintainece effort.
