### PR TITLE
[SYCL][NATIVECPU][DRIVER] Select remangled libclc variant for Native CPU

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -87,9 +87,9 @@ def do_configure(args):
         sycl_enabled_plugins.append("hip")
 
     if args.native_cpu:
-        #Todo: we should set whatever targets we support for native cpu
-        libclc_targets_to_build += ';x86_64-unknown-linux-gnu'
-        libclc_gen_remangled_variants = 'ON'
+        # Todo: we should set whatever targets we support for native cpu
+        libclc_targets_to_build += ";x86_64-unknown-linux-gnu"
+        libclc_gen_remangled_variants = "ON"
         sycl_enabled_plugins.append("native_cpu")
 
 

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -89,6 +89,7 @@ def do_configure(args):
     if args.native_cpu:
         #Todo: we should set whatever targets we support for native cpu
         libclc_targets_to_build += ';x86_64-unknown-linux-gnu'
+        libclc_gen_remangled_variants = 'ON'
         sycl_enabled_plugins.append("native_cpu")
 
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5855,7 +5855,10 @@ class OffloadingActionBuilder final {
         LibraryPaths.emplace_back(WithInstallPath.c_str());
 
         // Select libclc variant based on target triple
-        std::string LibSpirvTargetName = "libspirv-";
+       std::string LibSpirvTargetName =
+           (TC->getAuxTriple()->isOSWindows())
+               ? "remangled-l32-signed_char.libspirv-"
+               : "remangled-l64-signed_char.libspirv-";
         LibSpirvTargetName.append(TC->getTripleString() + ".bc");
 
         for (StringRef LibraryPath : LibraryPaths) {

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5854,7 +5854,9 @@ class OffloadingActionBuilder final {
         llvm::sys::path::append(WithInstallPath, Twine("../../../share/clc"));
         LibraryPaths.emplace_back(WithInstallPath.c_str());
 
-        // Select libclc variant based on target triple
+        // Select libclc variant based on target triple.
+        // On Windows long is 32 bits, so we have to select the right remangled
+        // libclc version.
        std::string LibSpirvTargetName =
            (TC->getAuxTriple()->isOSWindows())
                ? "remangled-l32-signed_char.libspirv-"

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -5857,10 +5857,10 @@ class OffloadingActionBuilder final {
         // Select libclc variant based on target triple.
         // On Windows long is 32 bits, so we have to select the right remangled
         // libclc version.
-       std::string LibSpirvTargetName =
-           (TC->getAuxTriple()->isOSWindows())
-               ? "remangled-l32-signed_char.libspirv-"
-               : "remangled-l64-signed_char.libspirv-";
+        std::string LibSpirvTargetName =
+            (TC->getAuxTriple()->isOSWindows())
+                ? "remangled-l32-signed_char.libspirv-"
+                : "remangled-l64-signed_char.libspirv-";
         LibSpirvTargetName.append(TC->getTripleString() + ".bc");
 
         for (StringRef LibraryPath : LibraryPaths) {

--- a/sycl/test/check_device_code/native_cpu/sycl-native-cpu-libclc.cpp
+++ b/sycl/test/check_device_code/native_cpu/sycl-native-cpu-libclc.cpp
@@ -2,4 +2,4 @@
 // REQUIRES: native_cpu
 // RUN: %clang -### -fsycl -fsycl-targets=native_cpu -target x86_64-unknown-linux-gnu %s 2> %t.ncpu.out
 // RUN: FileCheck %s --input-file %t.ncpu.out
-// CHECK: libspirv-x86_64-unknown-linux-gnu.bc
+// CHECK: {{(\\|/)}}remangled-l64-signed_char.libspirv-x86_64-unknown-linux-gnu.bc"

--- a/sycl/test/check_device_code/native_cpu/sycl-native-cpu-libclc.cpp
+++ b/sycl/test/check_device_code/native_cpu/sycl-native-cpu-libclc.cpp
@@ -3,3 +3,8 @@
 // RUN: %clang -### -fsycl -fsycl-targets=native_cpu -target x86_64-unknown-linux-gnu %s 2> %t.ncpu.out
 // RUN: FileCheck %s --input-file %t.ncpu.out
 // CHECK: {{(\\|/)}}remangled-l64-signed_char.libspirv-x86_64-unknown-linux-gnu.bc"
+
+// Check that l32 variant is selected for Windows
+// RUN: %clang -### -fsycl -fsycl-targets=native_cpu -target x86_64-windows %s 2> %t-win.ncpu.out
+// RUN: FileCheck %s --input-file %t-win.ncpu.out --check-prefix=CHECK-WIN
+// CHECK-WIN: {{(\\|/)}}remangled-l32-signed_char.libspirv-x86_64-unknown-windows-msvc.bc"


### PR DESCRIPTION
This PR makes it so we build the remangled variants for Native CPU libclc, and ensures that the driver selects it. 