### PR TITLE
[CI] Switch post-commit to use old working image.

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -32,7 +32,7 @@ jobs:
       build_artifact_suffix: sprod_shared
       build_configure_extra_args: --shared-libs --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
       # Docker image has last nightly pre-installed and added to the PATH
-      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
+      build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest-cc1dd89176dd35522d57022a57204b41ae2611a9"
       cc: clang
       cxx: clang++
       merge_ref: ''

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -32,7 +32,7 @@ jobs:
       build_artifact_suffix: sprod_shared
       build_configure_extra_args: --shared-libs --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
       # Docker image has last nightly pre-installed and added to the PATH
-      build_image: "ghcr.io/intel/llvm/ubuntu2204_build:latest-cc1dd89176dd35522d57022a57204b41ae2611a9"
+      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build-ecc812d9fd78b92974162f15b040c6c165cc944e"
       cc: clang
       cxx: clang++
       merge_ref: ''


### PR DESCRIPTION
This swaps the post-commit from using the nightly image back to an old working image, the same one used in

https://github.com/intel/llvm/pull/13618
https://github.com/intel/llvm/pull/13606

This is a temporary solution to fix post-commit whilst I continue to try to find a long term solution to build rocm that doesn't break anything.