### PR TITLE
[CI][HIP] Use apt to install rocm6.1.1

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -12,12 +12,22 @@ RUN apt-key adv --fetch-keys https://developer.download.nvidia.com/compute/cuda/
 COPY scripts/install_build_tools.sh /install.sh
 RUN /install.sh
 
-RUN apt install -yqq libnuma-dev wget gnupg2 && \
-  apt-get install -yqq libstdc++-12-dev
+# Install ROCM
 
-RUN wget https://repo.radeon.com/amdgpu-install/6.1/ubuntu/jammy/amdgpu-install_6.1.60100-1_all.deb && \
-  apt install -yqq ./amdgpu-install_6.1.60100-1_all.deb && \
-  amdgpu-install -y --usecase=rocmdev && \
+# Make the directory if it doesn't exist yet.
+# This location is recommended by the distribution maintainers.
+RUN mkdir --parents --mode=0755 /etc/apt/keyrings
+# Download the key, convert the signing-key to a full
+# keyring required by apt and store in the keyring directory
+RUN wget https://repo.radeon.com/rocm/rocm.gpg.key -O - | \
+gpg --dearmor | tee /etc/apt/keyrings/rocm.gpg > /dev/null && \
+# Add rocm repo
+echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/rocm.gpg] https://repo.radeon.com/rocm/apt/6.1.1 jammy main" \
+| tee --append /etc/apt/sources.list.d/rocm.list && \
+printf 'Package: *\nPin: release o=repo.radeon.com\nPin-Priority: 600' | tee /etc/apt/preferences.d/rocm-pin-600 && \
+apt update
+# Install the kernel driver
+RUN apt install -yqq rocm-dev && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Switch to using apt packages instead of amdgpu-install.
This uses c++-11-dev libraries so hopefully avoids the problems caused by https://github.com/intel/llvm/pull/13752