### PR TITLE
[SYCL][Bindless] Default ctr for image_descriptor

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_bindless_images.asciidoc
@@ -199,14 +199,16 @@ enum class image_type : /* unspecified */ {
 };
 
 struct image_descriptor {
-  size_t width;
-  size_t height;
-  size_t depth;
-  image_channel_type channel_type;
-  image_channel_order channel_order;
-  image_type type;
-  unsigned int num_levels;
-  unsigned int array_size;
+  size_t width{0};
+  size_t height{0};
+  size_t depth{0};
+  image_channel_order channel_order{image_channel_order::rgba};
+  image_channel_type channel_type{image_channel_type::fp32};
+  image_type type{image_type::standard};
+  unsigned int num_levels{1};
+  unsigned int array_size{1};
+
+  image_descriptor() = default;
 
   image_descriptor(sycl::range<1> dims, image_channel_order channel_order,
                    image_channel_type channel_type, 
@@ -2686,4 +2688,5 @@ These features still need to be handled:
                    `fetch_image` API.
 |5.8|2024-05-09| - Add missing cubemap `HintT` template parameter to 
                    `fetch_cubemap` and `sample_cubemap`.
+|5.9|2024-05-14| - Default constructor for `image_descriptor`.
 |======================

--- a/sycl/include/sycl/ext/oneapi/bindless_images_descriptor.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_descriptor.hpp
@@ -31,14 +31,14 @@ enum class image_type : unsigned int {
 
 /// A struct to describe the properties of an image.
 struct image_descriptor {
-  size_t width;
-  size_t height;
-  size_t depth;
-  image_channel_order channel_order;
-  image_channel_type channel_type;
-  image_type type;
-  unsigned int num_levels;
-  unsigned int array_size;
+  size_t width{0};
+  size_t height{0};
+  size_t depth{0};
+  image_channel_order channel_order{image_channel_order::rgba};
+  image_channel_type channel_type{image_channel_type::fp32};
+  image_type type{image_type::standard};
+  unsigned int num_levels{1};
+  unsigned int array_size{1};
 
   image_descriptor() = default;
 

--- a/sycl/include/sycl/ext/oneapi/bindless_images_mem_handle.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_mem_handle.hpp
@@ -13,8 +13,8 @@ inline namespace _V1 {
 namespace ext::oneapi::experimental {
 /// Opaque image memory handle type
 struct image_mem_handle {
-  using handle_type = void *;
-  handle_type raw_handle;
+  using raw_handle_type = void *;
+  raw_handle_type raw_handle;
 };
 } // namespace ext::oneapi::experimental
 } // namespace _V1

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -818,10 +818,20 @@ static bool runTest(sycl::range<NDims> dims, sycl::range<NDims> localSize,
   }
 
   try {
-
-    syclexp::image_descriptor desc(dims, COrder, CType);
+    // Check default constructor for image_descriptor
+    syclexp::image_descriptor desc;
+    desc = syclexp::image_descriptor(dims, COrder, CType);
 
     syclexp::image_mem imgMem(desc, q);
+
+    // Check that image_mem_handle can be constructed from raw_handle_type
+    syclexp::image_mem_handle img_mem_handle_copy{
+        static_cast<syclexp::image_mem_handle::raw_handle_type>(
+            imgMem.get_handle().raw_handle)};
+    if (img_mem_handle_copy.raw_handle != imgMem.get_handle().raw_handle) {
+      std::cerr << "Failed to copy raw_handle_type" << std::endl;
+      return false;
+    }
 
     auto img_input = syclexp::create_image(imgMem, samp, desc, q);
 


### PR DESCRIPTION
1. Add default constructor for `image_descriptor` on the spec side. The implementation already had it, but it was not initializing values, this has been fixed.
2. Rename `image_mem_handle::handle_type` to `image_mem_handle::raw_handle_type` to follow the Bindless Images spec.

Added basic tests for both.