### PR TITLE
[SYCL][CUDA] Fix support of `printf` for CUDA backend on Windows.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -383,11 +383,6 @@ bool SemaSYCL::isDeclAllowedInSYCLDeviceCode(const Decl *D) {
          FD->getBuiltinID() == Builtin::BI__builtin_printf))
       return true;
 
-    // Allow to use `::printf` only for CUDA.
-    if (getASTContext().getTargetInfo().getTriple().isNVPTX()) {
-      if (FD->getBuiltinID() == Builtin::BIprintf)
-        return true;
-    }
     const DeclContext *DC = FD->getDeclContext();
     if (II && II->isStr("__spirv_ocl_printf") &&
         !FD->isDefined() &&

--- a/clang/test/CodeGenSYCL/Inputs/sycl.hpp
+++ b/clang/test/CodeGenSYCL/Inputs/sycl.hpp
@@ -486,11 +486,15 @@ namespace experimental {
 #endif
 template <typename... Args>
 int printf(const __SYCL_CONSTANT_AS char *__format, Args... args) {
-#if defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
+#if defined(__SYCL_DEVICE_ONLY__)
+#if (defined(__SPIR__) || defined(__SPIRV__))
   return __spirv_ocl_printf(__format, args...);
 #else
+  return __builtin_printf(__format, args...);
+#endif // (defined(__SPIR__) || defined(__SPIRV__))
+#else
   return ::printf(__format, args...);
-#endif // defined(__SYCL_DEVICE_ONLY__) && defined(__SPIR__)
+#endif // defined(__SYCL_DEVICE_ONLY__) 
 }
 
 template <typename T, typename... Props>

--- a/sycl/include/sycl/ext/oneapi/experimental/builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/builtins.hpp
@@ -77,8 +77,12 @@ namespace ext::oneapi::experimental {
 //
 template <typename FormatT, typename... Args>
 int printf(const FormatT *__format, Args... args) {
-#if defined(__SYCL_DEVICE_ONLY__) && (defined(__SPIR__) || defined(__SPIRV__))
+#if defined(__SYCL_DEVICE_ONLY__)
+#if (defined(__SPIR__) || defined(__SPIRV__))
   return __spirv_ocl_printf(__format, args...);
+#else
+  return __builtin_printf(__format, args...);
+#endif
 #else
   return ::printf(__format, args...);
 #endif // defined(__SYCL_DEVICE_ONLY__) && (defined(__SPIR__) ||


### PR DESCRIPTION
- Addresses a build error seen when using `printf` for CUDA backend on Windows.
- The mentioned build error can be seen in [test-e2e/Basic/built-ins.cpp](https://github.com/mmoadeli/llvm/blob/sycl/sycl/test-e2e/Basic/built-ins.cpp)
- Remove dead code as `printf` in SYCL cuda /amd device code   calls `__builtin_printf`