### PR TITLE
[LLVM][SYCL][E2E] Disable xfail for passing tests

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/get_coord_int8_matB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/get_coord_int8_matB.cpp
@@ -10,8 +10,7 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-
-// XFAIL: *
+// XFAIL: cpu
 
 #include "../common.hpp"
 #include <iostream>

--- a/sycl/test-e2e/Matrix/get_coord_int8_matB.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matB.cpp
@@ -9,7 +9,7 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: *
+// XFAIL: cpu
 
 #include "common.hpp"
 #include <iostream>

--- a/sycl/test-e2e/Matrix/joint_matrix_annotated_ptr.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_annotated_ptr.cpp
@@ -10,9 +10,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Currently row major B fails when annotated_ptr is used
-// XFAIL: gpu
-
 #include "common.hpp"
 
 #define SG_SZ 16


### PR DESCRIPTION
Disabled xfail in following tests:

SYCL :: Matrix/SG32/get_coord_int8_matB.cpp
SYCL :: Matrix/get_coord_int8_matB.cpp
SYCL :: Matrix/joint_matrix_annotated_ptr.cpp