### PR TITLE
[SYCL][Graph] Delete tests for wrong node/edge order

### DIFF
--- a/sycl/unittests/Extensions/CommandGraph/Update.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Update.cpp
@@ -290,60 +290,6 @@ TEST_F(WholeGraphUpdateTest, MissingEdges) {
   EXPECT_THROW(GraphExec.update(UpdateGraph), sycl::exception);
 }
 
-TEST_F(WholeGraphUpdateTest, DISABLED_WrongOrderNodes) {
-  // Test that using an update graph with nodes added in a different order
-  // results in an error.
-
-  auto NodeA = Graph.add(EmptyKernel);
-  auto NodeB =
-      Graph.add(EmptyKernel, experimental::property::node::depends_on(NodeA));
-  auto NodeC =
-      Graph.add(EmptyKernel, experimental::property::node::depends_on(NodeA));
-  auto NodeD = Graph.add(
-      EmptyKernel, experimental::property::node::depends_on(NodeB, NodeC));
-
-  auto UpdateNodeA = UpdateGraph.add(EmptyKernel);
-  auto UpdateNodeC = UpdateGraph.add(
-      EmptyKernel, experimental::property::node::depends_on(UpdateNodeA));
-  auto UpdateNodeB = UpdateGraph.add(
-      EmptyKernel, experimental::property::node::depends_on(UpdateNodeA));
-  auto UpdateNodeD = UpdateGraph.add(
-      EmptyKernel,
-      experimental::property::node::depends_on(UpdateNodeB, UpdateNodeC));
-
-  auto GraphExec = Graph.finalize(experimental::property::graph::updatable{});
-  EXPECT_THROW(GraphExec.update(UpdateGraph), sycl::exception);
-}
-
-TEST_F(WholeGraphUpdateTest, DISABLED_WrongOrderEdges) {
-  // Test that using an update graph with edges added in a different order
-  // results in an error.
-
-  auto NodeA = Graph.add(EmptyKernel);
-  auto NodeB = Graph.add(EmptyKernel);
-  auto NodeC = Graph.add(EmptyKernel);
-  auto NodeD = Graph.add(EmptyKernel);
-
-  Graph.make_edge(NodeA, NodeB);
-  Graph.make_edge(NodeA, NodeC);
-  Graph.make_edge(NodeB, NodeD);
-  Graph.make_edge(NodeC, NodeD);
-
-  auto UpdateNodeA = UpdateGraph.add(EmptyKernel);
-  auto UpdateNodeB = UpdateGraph.add(EmptyKernel);
-  auto UpdateNodeC = UpdateGraph.add(EmptyKernel);
-  auto UpdateNodeD = UpdateGraph.add(EmptyKernel);
-
-  UpdateGraph.make_edge(UpdateNodeA, UpdateNodeB);
-  UpdateGraph.make_edge(UpdateNodeA, UpdateNodeC);
-  // Create the edge C->D before B->D, which is the reverse order of `Graph`.
-  UpdateGraph.make_edge(UpdateNodeC, UpdateNodeD);
-  UpdateGraph.make_edge(UpdateNodeB, UpdateNodeD);
-
-  auto GraphExec = Graph.finalize(experimental::property::graph::updatable{});
-  EXPECT_THROW(GraphExec.update(UpdateGraph), sycl::exception);
-}
-
 TEST_F(WholeGraphUpdateTest, UnsupportedNodeType) {
   // Test that using an update graph that contains unsupported node types
   // results in an error.


### PR DESCRIPTION
These tests were originally intended to be enabled after checks for node and edge ordering were added to the whole graph update implementation. However, after further investigation, the team concluded that such checks are not possible. As a consequence, these tests no longer make sense.