### PR TITLE
[SYCL] Fix unused variable errors on post-commit for forward_progress extension

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -859,13 +859,11 @@ bool device_impl::extOneapiCanCompile(
 // threads created at threadScope from a coordination scope given by
 // coordinationScope
 sycl::ext::oneapi::experimental::forward_progress_guarantee
-device_impl::getHostProgressGuarantee(
-    ext::oneapi::experimental::execution_scope threadScope,
-    ext::oneapi::experimental::execution_scope coordinationScope) {
-  std::ignore = threadScope;
-  std::ignore = coordinationScope;
-  return sycl::ext::oneapi::experimental::forward_progress_guarantee::
-      weakly_parallel;
+    device_impl::getHostProgressGuarantee(
+        ext::oneapi::experimental::execution_scope, // threadScope
+        ext::oneapi::experimental::execution_scope) // coordinationScope {
+    return sycl::ext::oneapi::experimental::forward_progress_guarantee::
+        weakly_parallel;
 }
 
 // Returns the strongest progress guarantee that can be provided by this device

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -875,9 +875,9 @@ sycl::ext::oneapi::experimental::forward_progress_guarantee
 device_impl::getProgressGuarantee(
     ext::oneapi::experimental::execution_scope threadScope,
     ext::oneapi::experimental::execution_scope coordinationScope) const {
-  //using forward_progress_guarantee =
-     // ext::oneapi::experimental::forward_progress_guarantee;
-  using execution_scope = ext::oneapi::experimental::execution_scope;
+  using forward_progress_guarantee =
+     ext::oneapi::experimental::forward_progress_guarantee;
+  //using execution_scope = ext::oneapi::experimental::execution_scope;
   //int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
   // between coordinationScope and threadScope and then return the weakest of these.

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -875,8 +875,25 @@ sycl::ext::oneapi::experimental::forward_progress_guarantee
 device_impl::getProgressGuarantee(
     ext::oneapi::experimental::execution_scope threadScope,
     ext::oneapi::experimental::execution_scope coordinationScope) const {
+  using forward_progress_guarantee =
+      ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
-  return  getImmediateProgressGuarantee(execution_scope::root_group);
+  const int executionScopeSize = 4;
+  (void)coordinationScope;
+  int threadScopeNum = static_cast<int>(threadScope);
+  // we get the immediate progress guarantee that is provided by each scope
+  // between root_group and threadScope and then return the weakest of these.
+  // Counterintuitively, this corresponds to taking the max of the enum values
+  // because of how the forward_progress_guarantee enum values are declared.
+  int guaranteeNum = static_cast<int>(
+      getImmediateProgressGuarantee(execution_scope::root_group));
+  for (int currentScope = executionScopeSize - 2; currentScope > threadScopeNum;
+       --currentScope) {
+    guaranteeNum = std::max(guaranteeNum,
+                            static_cast<int>(getImmediateProgressGuarantee(
+                                static_cast<execution_scope>(currentScope))));
+  }
+  return static_cast<forward_progress_guarantee>(guaranteeNum);
 }
 
 bool device_impl::supportsForwardProgress(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -878,16 +878,16 @@ device_impl::getProgressGuarantee(
   using forward_progress_guarantee =
       ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
+  const int executionScopeSize = 4;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
-  // between coordinationScope and threadScope and return the weakest of
-  // these. Counterintuitively, this corresponds to taking the max of the enum
-  // values because of how the forward_progress_guarantee enum values are
-  // declared.
-  int guaranteeNum =
-      static_cast<int>(getImmediateProgressGuarantee(coordinationScope));
-  for (int currentScope = static_cast<int>(coordinationScope) - 1;
-       currentScope > threadScopeNum; --currentScope) {
+  // between root_group and threadScope and then return the weakest of these.
+  // Counterintuitively, this corresponds to taking the max of the enum values
+  // because of how the forward_progress_guarantee enum values are declared.
+  int guaranteeNum = static_cast<int>(
+      getImmediateProgressGuarantee(execution_scope::root_group));
+  for (int currentScope = executionScopeSize - 2; currentScope > threadScopeNum;
+       --currentScope) {
     guaranteeNum = std::max(guaranteeNum,
                             static_cast<int>(getImmediateProgressGuarantee(
                                 static_cast<execution_scope>(currentScope))));

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -862,6 +862,8 @@ sycl::ext::oneapi::experimental::forward_progress_guarantee
 device_impl::getHostProgressGuarantee(
     ext::oneapi::experimental::execution_scope threadScope,
     ext::oneapi::experimental::execution_scope coordinationScope) {
+  std::ignore = threadScope;
+  std::ignore = coordinationScope;
   return sycl::ext::oneapi::experimental::forward_progress_guarantee::
       weakly_parallel;
 }
@@ -876,7 +878,6 @@ device_impl::getProgressGuarantee(
   using forward_progress_guarantee =
       ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
-  const int executionScopeSize = 4;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
   // between root_group and threadScope and then return the weakest of these.
@@ -884,7 +885,7 @@ device_impl::getProgressGuarantee(
   // because of how the forward_progress_guarantee enum values are declared.
   int guaranteeNum = static_cast<int>(
       getImmediateProgressGuarantee(execution_scope::root_group));
-  for (int currentScope = executionScopeSize - 2; currentScope > threadScopeNum;
+  for (int currentScope = coordinationScope; currentScope > threadScopeNum;
        --currentScope) {
     guaranteeNum = std::max(guaranteeNum,
                             static_cast<int>(getImmediateProgressGuarantee(
@@ -944,4 +945,5 @@ device_impl::getImmediateProgressGuarantee(
 
 } // namespace detail
 } // namespace _V1
+B B
 } // namespace sycl

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -875,24 +875,8 @@ sycl::ext::oneapi::experimental::forward_progress_guarantee
 device_impl::getProgressGuarantee(
     ext::oneapi::experimental::execution_scope threadScope,
     ext::oneapi::experimental::execution_scope coordinationScope) const {
-  using forward_progress_guarantee =
-     ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
-  //int threadScopeNum = static_cast<int>(threadScope);
-  // we get the immediate progress guarantee that is provided by each scope
-  // between coordinationScope and threadScope and then return the weakest of these.
-  // Counterintuitively, this corresponds to taking the max of the enum values
-  // because of how the forward_progress_guarantee enum values are declared.
-  int guaranteeNum = static_cast<int>(
-      getImmediateProgressGuarantee(execution_scope::root_group));
-  //int coordinationScopeNum = static_cast<int>(coordinationScope);
-  //for (int currentScope = coordinationScopeNum - 1; currentScope > threadScopeNum;
-   //    --currentScope) {
-    //guaranteeNum = std::max(guaranteeNum,
-      //                      static_cast<int>(getImmediateProgressGuarantee(
-      //                          static_cast<execution_scope>(currentScope))));
-  //}
-  return static_cast<forward_progress_guarantee>(guaranteeNum);
+  return  getImmediateProgressGuarantee(execution_scope::root_group));
 }
 
 bool device_impl::supportsForwardProgress(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -883,10 +883,10 @@ device_impl::getProgressGuarantee(
   // between root_group and threadScope and then return the weakest of these.
   // Counterintuitively, this corresponds to taking the max of the enum values
   // because of how the forward_progress_guarantee enum values are declared.
-  int guaranteeNum = static_cast<int>(
-      getImmediateProgressGuarantee(execution_scope::root_group));
-  for (int currentScope = coordinationScope; currentScope > threadScopeNum;
-       --currentScope) {
+  int guaranteeNum =
+      static_cast<int>(getImmediateProgressGuarantee(coordinationScope));
+  for (int currentScope = static_cast<int>(coordinationScope) - 1;
+       currentScope > threadScopeNum; --currentScope) {
     guaranteeNum = std::max(guaranteeNum,
                             static_cast<int>(getImmediateProgressGuarantee(
                                 static_cast<execution_scope>(currentScope))));

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -879,6 +879,7 @@ device_impl::getProgressGuarantee(
       ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
   const int executionScopeSize = 4;
+  (void)coordinationScope;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
   // between root_group and threadScope and then return the weakest of these.

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -859,11 +859,13 @@ bool device_impl::extOneapiCanCompile(
 // threads created at threadScope from a coordination scope given by
 // coordinationScope
 sycl::ext::oneapi::experimental::forward_progress_guarantee
-    device_impl::getHostProgressGuarantee(
-        ext::oneapi::experimental::execution_scope, // threadScope
-        ext::oneapi::experimental::execution_scope) // coordinationScope {
-    return sycl::ext::oneapi::experimental::forward_progress_guarantee::
-        weakly_parallel;
+device_impl::getHostProgressGuarantee(
+    ext::oneapi::experimental::execution_scope threadScope,
+    ext::oneapi::experimental::execution_scope coordinationScope) {
+  (void)threadScope;
+  (void)coordinationScope;
+  return sycl::ext::oneapi::experimental::forward_progress_guarantee::
+      weakly_parallel;
 }
 
 // Returns the strongest progress guarantee that can be provided by this device

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -880,7 +880,7 @@ device_impl::getProgressGuarantee(
   using execution_scope = ext::oneapi::experimental::execution_scope;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
-  // between coordinationScope and threadScope and then return the weakest of
+  // between coordinationScope and threadScope and return the weakest of
   // these. Counterintuitively, this corresponds to taking the max of the enum
   // values because of how the forward_progress_guarantee enum values are
   // declared.

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -876,7 +876,7 @@ device_impl::getProgressGuarantee(
     ext::oneapi::experimental::execution_scope threadScope,
     ext::oneapi::experimental::execution_scope coordinationScope) const {
   using execution_scope = ext::oneapi::experimental::execution_scope;
-  return  getImmediateProgressGuarantee(execution_scope::root_group));
+  return  getImmediateProgressGuarantee(execution_scope::root_group);
 }
 
 bool device_impl::supportsForwardProgress(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -880,7 +880,7 @@ device_impl::getProgressGuarantee(
   using execution_scope = ext::oneapi::experimental::execution_scope;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
-  // between root_group and threadScope and then return the weakest of these.
+  // between coordinationScope and threadScope and then return the weakest of these.
   // Counterintuitively, this corresponds to taking the max of the enum values
   // because of how the forward_progress_guarantee enum values are declared.
   int guaranteeNum =

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -880,9 +880,10 @@ device_impl::getProgressGuarantee(
   using execution_scope = ext::oneapi::experimental::execution_scope;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
-  // between coordinationScope and threadScope and then return the weakest of these.
-  // Counterintuitively, this corresponds to taking the max of the enum values
-  // because of how the forward_progress_guarantee enum values are declared.
+  // between coordinationScope and threadScope and then return the weakest of
+  // these. Counterintuitively, this corresponds to taking the max of the enum
+  // values because of how the forward_progress_guarantee enum values are
+  // declared.
   int guaranteeNum =
       static_cast<int>(getImmediateProgressGuarantee(coordinationScope));
   for (int currentScope = static_cast<int>(coordinationScope) - 1;

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -860,10 +860,8 @@ bool device_impl::extOneapiCanCompile(
 // coordinationScope
 sycl::ext::oneapi::experimental::forward_progress_guarantee
 device_impl::getHostProgressGuarantee(
-    ext::oneapi::experimental::execution_scope threadScope,
-    ext::oneapi::experimental::execution_scope coordinationScope) {
-  (void)threadScope;
-  (void)coordinationScope;
+    ext::oneapi::experimental::execution_scope,
+    ext::oneapi::experimental::execution_scope) {
   return sycl::ext::oneapi::experimental::forward_progress_guarantee::
       weakly_parallel;
 }

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -878,16 +878,14 @@ device_impl::getProgressGuarantee(
   using forward_progress_guarantee =
       ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
-  const int executionScopeSize = 4;
-  (void)coordinationScope;
   int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
-  // between root_group and threadScope and then return the weakest of these.
+  // between coordinationScope and threadScope and then return the weakest of these.
   // Counterintuitively, this corresponds to taking the max of the enum values
   // because of how the forward_progress_guarantee enum values are declared.
   int guaranteeNum = static_cast<int>(
-      getImmediateProgressGuarantee(execution_scope::root_group));
-  for (int currentScope = executionScopeSize - 2; currentScope > threadScopeNum;
+      getImmediateProgressGuarantee(coordinationScope));
+  for (int currentScope = static_cast<int>(coordinationScope) - 1; currentScope > threadScopeNum;
        --currentScope) {
     guaranteeNum = std::max(guaranteeNum,
                             static_cast<int>(getImmediateProgressGuarantee(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -884,7 +884,7 @@ device_impl::getProgressGuarantee(
   // Counterintuitively, this corresponds to taking the max of the enum values
   // because of how the forward_progress_guarantee enum values are declared.
   int guaranteeNum = static_cast<int>(
-      getImmediateProgressGuarantee(coordinationScope));
+      getImmediateProgressGuarantee(execution_scope::root_group));
   int coordinationScopeNum = static_cast<int>(coordinationScope);
   for (int currentScope = coordinationScopeNum - 1; currentScope > threadScopeNum;
        --currentScope) {

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -877,7 +877,7 @@ device_impl::getProgressGuarantee(
     ext::oneapi::experimental::execution_scope coordinationScope) const {
   using forward_progress_guarantee =
      ext::oneapi::experimental::forward_progress_guarantee;
-  //using execution_scope = ext::oneapi::experimental::execution_scope;
+  using execution_scope = ext::oneapi::experimental::execution_scope;
   //int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
   // between coordinationScope and threadScope and then return the weakest of these.

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -885,7 +885,8 @@ device_impl::getProgressGuarantee(
   // because of how the forward_progress_guarantee enum values are declared.
   int guaranteeNum = static_cast<int>(
       getImmediateProgressGuarantee(coordinationScope));
-  for (int currentScope = static_cast<int>(coordinationScope) - 1; currentScope > threadScopeNum;
+  int coordinationScopeNum = static_cast<int>(coordinationScope);
+  for (int currentScope = coordinationScopeNum - 1; currentScope > threadScopeNum;
        --currentScope) {
     guaranteeNum = std::max(guaranteeNum,
                             static_cast<int>(getImmediateProgressGuarantee(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -945,5 +945,4 @@ device_impl::getImmediateProgressGuarantee(
 
 } // namespace detail
 } // namespace _V1
-B B
 } // namespace sycl

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -875,23 +875,23 @@ sycl::ext::oneapi::experimental::forward_progress_guarantee
 device_impl::getProgressGuarantee(
     ext::oneapi::experimental::execution_scope threadScope,
     ext::oneapi::experimental::execution_scope coordinationScope) const {
-  using forward_progress_guarantee =
-      ext::oneapi::experimental::forward_progress_guarantee;
+  //using forward_progress_guarantee =
+     // ext::oneapi::experimental::forward_progress_guarantee;
   using execution_scope = ext::oneapi::experimental::execution_scope;
-  int threadScopeNum = static_cast<int>(threadScope);
+  //int threadScopeNum = static_cast<int>(threadScope);
   // we get the immediate progress guarantee that is provided by each scope
   // between coordinationScope and threadScope and then return the weakest of these.
   // Counterintuitively, this corresponds to taking the max of the enum values
   // because of how the forward_progress_guarantee enum values are declared.
   int guaranteeNum = static_cast<int>(
       getImmediateProgressGuarantee(execution_scope::root_group));
-  int coordinationScopeNum = static_cast<int>(coordinationScope);
-  for (int currentScope = coordinationScopeNum - 1; currentScope > threadScopeNum;
-       --currentScope) {
-    guaranteeNum = std::max(guaranteeNum,
-                            static_cast<int>(getImmediateProgressGuarantee(
-                                static_cast<execution_scope>(currentScope))));
-  }
+  //int coordinationScopeNum = static_cast<int>(coordinationScope);
+  //for (int currentScope = coordinationScopeNum - 1; currentScope > threadScopeNum;
+   //    --currentScope) {
+    //guaranteeNum = std::max(guaranteeNum,
+      //                      static_cast<int>(getImmediateProgressGuarantee(
+      //                          static_cast<execution_scope>(currentScope))));
+  //}
   return static_cast<forward_progress_guarantee>(guaranteeNum);
 }
 


### PR DESCRIPTION
The merge of https://github.com/intel/llvm/pull/13389 has caused post-commit failures due to three unused variable warnings. 
This PR fixes that. One of these warnings also revealed a bug in my original PR.