### PR TITLE
[SYCL][Joint matrix] clarify the range of the prefetch templated arguments

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_matrix/sycl_ext_oneapi_matrix.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_matrix/sycl_ext_oneapi_matrix.asciidoc
@@ -467,6 +467,9 @@ q.parallel_for(nd_range<2>(G, L), [=](nd_item<2> it) {
   }
 });
 ```
+In the case of `ext_intel_packed` and `col_major` matrix memory
+layout, `Rows` and `Cols` represent the logical shape of the matrix
+before VNNI or transpose transformation.
 
 === Support for Machine Learning Types
 Some devices support special matrix element types that are commonly

--- a/sycl/doc/extensions/experimental/sycl_ext_matrix/sycl_ext_oneapi_matrix.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_matrix/sycl_ext_oneapi_matrix.asciidoc
@@ -467,9 +467,10 @@ q.parallel_for(nd_range<2>(G, L), [=](nd_item<2> it) {
   }
 });
 ```
-In the case of `ext_intel_packed` and `col_major` matrix memory
-layout, `Rows` and `Cols` represent the logical shape of the matrix
-before VNNI or transpose transformation.
+The `Rows` and `Cols` template parameters represent the logical shape
+of the matrix, which is not necessarily the way the matrix is layed
+out in memory. Thus, these template parameters have the same meaning
+in `joint_matrix_prefetch` as they do for `joint_matrix_load`.
 
 === Support for Machine Learning Types
 Some devices support special matrix element types that are commonly


### PR DESCRIPTION
This is a clarification to match all the matrix spec that `Rows` and `Cols` are in the range of the logical dimensions, independently from the memory layout.
For instance, in the `ext_intel_packed` (or VNNI) layout case, prefetch will look like:
`joint_matrix_prefetch<TK, TN>(sg, B + sg_starty / SG_SZ * TN * vnniFactor,
                                N * vnniFactor, layout::ext_intel_packed,
                                syclex::properties{syclex::prefetch_hint_L1});
`
instead of 
`joint_matrix_prefetch<TK / vnniFactor, TN * vnniFactor>(
      sg, B + sg_starty / SG_SZ * TN * vnniFactor, N * vnniFactor, layout::ext_intel_packed,
                                syclex::properties{syclex::prefetch_hint_L1});
`