### PR TITLE
[UR][L0] ensure a valid kernel handle for the device when reading max wg

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -104,14 +104,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG 1e1f577262747d67fcb5c513de4a11bec67ea5db)
 
   fetch_adapter_source(level_zero
-    ${UNIFIED_RUNTIME_REPO}
-    # commit b14af4bbd5cabc4e6c3c7ae738f5f6d886d9102b
-    # Merge: 1ff111c1 ece1e2cd
-    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Wed May 15 14:01:05 2024 +0100
-    #     Merge pull request #1592 from nrspruit/fix_event_use_after_delete
-    #     [L0] Fix timestamp event evict after delete
-    b14af4bbd5cabc4e6c3c7ae738f5f6d886d9102b
+    https://github.com/nrspruit/unified-runtime.git
+    f67122c0ed95ff45e680ee439bb47acfc9886326
   )
 
   fetch_adapter_source(opencl

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -104,8 +104,14 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG 1e1f577262747d67fcb5c513de4a11bec67ea5db)
 
   fetch_adapter_source(level_zero
-    https://github.com/nrspruit/unified-runtime.git
-    f67122c0ed95ff45e680ee439bb47acfc9886326
+    ${UNIFIED_RUNTIME_REPO}
+    # commit 65c39c8a0cc17ebb43686230f91e1c3560764494
+    # Merge: 09467b8d f67122c0
+    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+    # Date:   Thu May 16 11:11:37 2024 +0100
+    #     Merge pull request #1611 from nrspruit/fix_interop_wg_max_size
+    #     [L0] ensure a valid kernel handle for the device when reading max wg
+    65c39c8a0cc17ebb43686230f91e1c3560764494
   )
 
   fetch_adapter_source(opencl


### PR DESCRIPTION
pre-commit PR for https://github.com/oneapi-src/unified-runtime/pull/1611