### PR TITLE
[SYCL][Graph] Disable Windows test with L0 leak

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/host_task_single.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_single.cpp
@@ -3,7 +3,10 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
-// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Immediate command-list testing is disabled on Windows due to a
+// non-deterministic leak of the Level Zero context, and is intended
+// to be re-enabled once this can be investigated and fixed.
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_host_allocations
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_single.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_single.cpp
@@ -3,7 +3,10 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
-// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Immediate command-list testing is disabled on Windows due to a
+// non-deterministic leak of the Level Zero context, and is intended
+// to be re-enabled once this can be investigated and fixed.
+// RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_host_allocations
 


### PR DESCRIPTION
After PR https://github.com/intel/llvm/pull/13685 merged to re-enabling running graph E2E tests on Windows with immediate command lists, a non-deterministic leak has appeared in post-commit CI for a different PR https://github.com/intel/llvm/actions/runs/9097140304/job/25008463548

To keep CI green, don't run the test on Windows with immediate command lists until the leak can be investigated and fixed.

```quote
env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 env UR_L0_LEAKS_DEBUG=1 SYCL_ENABLE_DEFAULT_CONTEXTS=0 env ONEAPI_DEVICE_SELECTOR=level_zero:gpu  D:\github\actions-runner\_work\llvm\llvm\build-e2e\Graph\Explicit\Output\host_task_single.cpp.tmp.out 2>&1 | d:\github\actions-runner\_work\llvm\llvm\install\bin\filecheck.exe D:\github\actions-runner\_work\llvm\llvm\llvm\sycl\test-e2e\Graph\Explicit\host_task_single.cpp --implicit-check-not=LEAK
# note: command had no output on stdout or stderr
# error: command failed with exit status: 0xc0000409
# executed command: 'd:\github\actions-runner\_work\llvm\llvm\install\bin\filecheck.exe' 'D:\github\actions-runner\_work\llvm\llvm\llvm\sycl\test-e2e\Graph\Explicit\host_task_single.cpp' --implicit-check-not=LEAK
# .---command stderr------------
# | command line:1:22: error: IMPLICIT-CHECK-NOT: excluded string found in input
# | -implicit-check-not='LEAK'
# |                      ^
# | <stdin>:3:54: note: found here
# |  zeContextCreate = 1 \---> zeContextDestroy = 0 ---> LEAK = 1
# |                                                      ^~~~
# | 
# | Input file: <stdin>
# | Check file: D:\github\actions-runner\_work\llvm\llvm\llvm\sycl\test-e2e\Graph\Explicit\host_task_single.cpp
# | 
# | -dump-input=help explains the following input dump.
# | 
# | Input was:
# | <<<<<<
# |           1: Check balance of create/destroy calls 
# |           2: ---------------------------------------------------------- 
# |           3:  zeContextCreate = 1 \---> zeContextDestroy = 0 ---> LEAK = 1 
# | not:imp1                                                          !~~~      error: no match expected
# |           4:  zeCommandQueueCreate = 0 \---> zeCommandQueueDestroy = 0  
# |           5:  zeModuleCreate = 0 \---> zeModuleDestroy = 0  
# |           6:  zeKernelCreate = 0 \---> zeKernelDestroy = 0  
# |           7:  zeEventPoolCreate = 1 \---> zeEventPoolDestroy = 0 ---> LEAK = 1 
# |           8:  zeCommandListCreateImmediate = 2 |  
# |           .
# |           .
# |           .
# | >>>>>>
# `-----------------------------
# error: command failed with exit status: 1

```