### PR TITLE
[SYCL Joint Matrix][E2E] Add 1d vector load/store tests for big combinations

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bfloat16_packedB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bfloat16_packedB.cpp
@@ -10,6 +10,7 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if gpu %{ env IGC_JointMatrixLoadStoreOpt=2 %{run} %t.out %}
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/Matrix/joint_matrix_rowmajorA_rowmajorB.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_rowmajorA_rowmajorB.cpp
@@ -11,6 +11,7 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+// RUN: %if gpu %{ env IGC_JointMatrixLoadStoreOpt=2 %{run} %t.out %}
 
 // This tests support of row major layout for matrix B which does automatic VNNI
 // transform. This is currently only available on AMX and XMX of PVC

--- a/sycl/test-e2e/Matrix/joint_matrix_rowmajorA_rowmajorB_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_rowmajorA_rowmajorB_impl.hpp
@@ -123,6 +123,8 @@ int main() {
                             int32_t>();
 
       if (combination.nsize == 16) { // architecture::intel_gpu_pvc
+        res += gemm_row_major<16, 16, 16, class bf16_16x16x16, bfloat16,
+                              bfloat16, float>();
         res += gemm_row_major<1, 64, 16, class bf16_1x64x16, bfloat16, bfloat16,
                               float>();
         res += gemm_row_major<32, 64, 16, class bf16_32x64x16, bfloat16,


### PR DESCRIPTION
This change is partially addressing requirement to enable 1d block load testing (IGC_JointMatrixLoadStoreOpt=2) for only big combinations 32x64x16, 1x64x16, 16x16x16.
This environment variable was added to as minimum tests as possible, while keeping the coverage of big combinations to maximum.
This environment variable was not added to Matrix/element_wise_ops.cpp yet, because, IGC compiler needs to be fixed to pass this test with IGC_JointMatrixLoadStoreOpt=2