### PR TITLE
Revert "Fix Coverity dereference before null check issue (#13456)"

### DIFF
--- a/sycl/source/detail/graph_impl.hpp
+++ b/sycl/source/detail/graph_impl.hpp
@@ -940,7 +940,7 @@ public:
   void addEventForNode(std::shared_ptr<graph_impl> GraphImpl,
                        std::shared_ptr<sycl::detail::event_impl> EventImpl,
                        std::shared_ptr<node_impl> NodeImpl) {
-    if (EventImpl && !(EventImpl->getCommandGraph()))
+    if (!(EventImpl->getCommandGraph()))
       EventImpl->setCommandGraph(GraphImpl);
     MEventsMap[EventImpl] = NodeImpl;
   }


### PR DESCRIPTION
This reverts commit c02f915d42ac9bd1a3c4f2215d703b49b3a2173d since this Coverity issue is a false positive. `EventImpl` is always set when we pass it in the runtime, but the previous change suggests it might be null. The Coverity hit should be ignored instead.