### PR TITLE
[SYCL] Turn `indirectly-callable` property into `sycl_device` attribute

### DIFF
--- a/clang/include/clang/Basic/Attr.td
+++ b/clang/include/clang/Basic/Attr.td
@@ -1769,6 +1769,30 @@ class SYCLAddIRAttrMemberCodeHolder<code Code> {
 // Common class for SYCL add_ir_attributes_* attributes.
 def SYCLAddIRAttrCommonMembers : SYCLAddIRAttrMemberCodeHolder<[{
   static std::optional<std::string>
+  getValidAttributeNameAsString(const APValue &Value,
+                                 const ASTContext &Context,
+                                 QualType ValueQType) {
+    assert(!Value.isLValue());
+    if (ValueQType->isCharType()) {
+      char C = static_cast<char>(Value.getInt().getExtValue());
+      return std::string(&C, 1);
+    }
+    if (ValueQType->isArrayType() &&
+        (ValueQType->getArrayElementTypeNoTypeQual()->isCharType())) {
+      SmallString<10> StrBuffer;
+      for (unsigned I = 0; I < Value.getArrayInitializedElts(); ++I) {
+        const APValue &ArrayElem = Value.getArrayInitializedElt(I);
+        char C = static_cast<char>(ArrayElem.getInt().getExtValue());
+        if (C == 0)
+          break;
+        StrBuffer += C;
+      }
+      return std::string(StrBuffer);
+    }
+    return std::nullopt;
+  }
+
+  static std::optional<std::string>
   getValidAttributeNameAsString(const Expr *NameE, const ASTContext &Context) {
     if (const auto *NameLiteral = dyn_cast<StringLiteral>(NameE))
       return NameLiteral->getString().str();
@@ -1782,7 +1806,8 @@ def SYCLAddIRAttrCommonMembers : SYCLAddIRAttrMemberCodeHolder<[{
       NameLValue = NameCE->getAPValueResult();
 
     if (!NameLValue.isLValue())
-      return std::nullopt;
+      return getValidAttributeNameAsString(NameLValue, Context,
+                                            NameCE->getType());
 
     if (const auto *NameValExpr =
             NameLValue.getLValueBase().dyn_cast<const Expr *>())
@@ -1816,7 +1841,7 @@ def SYCLAddIRAttrCommonMembers : SYCLAddIRAttrMemberCodeHolder<[{
          ValueQType->getArrayElementTypeNoTypeQual()
                    ->isIntegralOrEnumerationType())) {
       SmallString<10> StrBuffer;
-      for (unsigned I = 0; I < Value.getArraySize(); ++I) {
+      for (unsigned I = 0; I < Value.getArrayInitializedElts(); ++I) {
         const APValue &ArrayElem = Value.getArrayInitializedElt(I);
         char C = static_cast<char>(ArrayElem.getInt().getExtValue());
         if (C == 0)

--- a/clang/lib/Sema/SemaDeclAttr.cpp
+++ b/clang/lib/Sema/SemaDeclAttr.cpp
@@ -8711,6 +8711,32 @@ void Sema::AddSYCLAddIRAttributesFunctionAttr(Decl *D,
                                   CI))
     return;
   D->addAttr(Attr);
+
+  // There are compile-time SYCL properties which we would like to turn into
+  // attributes to enable compiler diagnostics.
+  // At the moment the only such property is related to virtual functions and
+  // it is turned into sycl_device attribute. This is a tiny optimization to
+  // avoid deep dive into the attribute if we already know that a declaration
+  // is a device declaration. It may have to be removed later if/when we add
+  // handling of more compile-time properties here.
+  if (D->hasAttr<SYCLDeviceAttr>())
+    return;
+
+  // SYCL Headers use template magic to pass key=value pairs to the attribute
+  // and we should make sure that all template instantiations are done before
+  // accessing attribute arguments.
+  if (hasDependentExpr(Attr->args_begin(), Attr->args_size()))
+    return;
+
+  SmallVector<std::pair<std::string, std::string>, 4> Pairs =
+      Attr->getFilteredAttributeNameValuePairs(Context);
+
+  for (const auto &[Key, Value] : Pairs) {
+    if (Key == "indirectly-callable") {
+      D->addAttr(SYCLDeviceAttr::CreateImplicit(Context));
+      break;
+    }
+  }
 }
 
 static void handleSYCLAddIRAttributesFunctionAttr(Sema &S, Decl *D,

--- a/clang/test/AST/ast-attr-add-ir-attribute-extra-handling.cpp
+++ b/clang/test/AST/ast-attr-add-ir-attribute-extra-handling.cpp
@@ -1,0 +1,96 @@
+// RUN: %clang_cc1 -fsycl-is-device -std=gnu++11 -ast-dump %s | FileCheck %s
+
+// add_ir_attributes_function attribute used to represent compile-time SYCL
+// properties and some of those properties are intended to be turned into
+// attributes to enable various diagnostics.
+//
+// This test is intended to check one (and only, at least for now) of such
+// tranformations: property with "indirectly-callable" key should have the same
+// effect as applying sycl_device attribute and the test checks that we do add
+// that attribute implicitly.
+
+// CHECK-LABEL: ToBeTurnedIntoDeviceFunction 'void ()'
+// CHECK: SYCLAddIRAttributesFunctionAttr
+// CHECK: SYCLDeviceAttr {{.*}} Implicit
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void ToBeTurnedIntoDeviceFunction();
+
+// CHECK-LABEL: NotToBeTurnedIntoDeviceFunction 'void ()'
+// CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+// CHECK:     SYCLAddIRAttributesFunctionAttr
+// CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+[[__sycl_detail__::add_ir_attributes_function("not-indirectly-callable", "void")]]
+void NotToBeTurnedIntoDeviceFunction();
+
+template <int V>
+struct Metadata {
+  static constexpr const char *name = "not-indirectly-callable";
+  static constexpr const char *value = "void";
+};
+
+template <>
+struct Metadata<42> {
+  static constexpr const char *name = "indirectly-callable";
+  static constexpr const char *value = "void";
+};
+
+// CHECK-LABEL: ToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+// CHECK: SYCLAddIRAttributesFunctionAttr
+// CHECK: SYCLDeviceAttr {{.*}} Implicit
+[[__sycl_detail__::add_ir_attributes_function(Metadata<42>::name, Metadata<42>::value)]]
+void ToBeTurnedIntoDeviceFunctionAttrTemplateArgs();
+
+// CHECK-LABEL: NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+// CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+// CHECK:     SYCLAddIRAttributesFunctionAttr
+// CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+[[__sycl_detail__::add_ir_attributes_function(Metadata<1>::name, Metadata<1>::value)]]
+void NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs();
+
+// CHECK-LABEL: class Base definition
+class Base {
+  // CHECK-LABEL: ToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+  // CHECK: SYCLAddIRAttributesFunctionAttr
+  // CHECK: SYCLDeviceAttr {{.*}} Implicit
+  [[__sycl_detail__::add_ir_attributes_function(Metadata<42>::name, Metadata<42>::value)]]
+  virtual void ToBeTurnedIntoDeviceFunctionAttrTemplateArgs();
+
+  // CHECK-LABEL: NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+  // CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+  // CHECK:     SYCLAddIRAttributesFunctionAttr
+  // CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+  [[__sycl_detail__::add_ir_attributes_function(Metadata<1>::name, Metadata<1>::value)]]
+  virtual void NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs();
+};
+
+// CHECK-LABEL: class Derived definition
+class Derived : public Base {
+  // CHECK-LABEL: ToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+  // CHECK: SYCLAddIRAttributesFunctionAttr
+  // CHECK: SYCLDeviceAttr {{.*}} Implicit
+  [[__sycl_detail__::add_ir_attributes_function(Metadata<42>::name, Metadata<42>::value)]]
+  void ToBeTurnedIntoDeviceFunctionAttrTemplateArgs() override;
+
+  // CHECK-LABEL: NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+  // CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+  // CHECK:     SYCLAddIRAttributesFunctionAttr
+  // CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+  [[__sycl_detail__::add_ir_attributes_function(Metadata<1>::name, Metadata<1>::value)]]
+  void NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs() override;
+};
+
+// CHECK-LABEL: class SubDerived definition
+class SubDerived : public Derived {
+  // CHECK-LABEL: ToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+  // CHECK: SYCLAddIRAttributesFunctionAttr
+  // CHECK: SYCLDeviceAttr {{.*}} Implicit
+  [[__sycl_detail__::add_ir_attributes_function(Metadata<2>::name, Metadata<42>::name, Metadata<2>::value, Metadata<42>::value)]]
+  void ToBeTurnedIntoDeviceFunctionAttrTemplateArgs() override;
+
+  // CHECK-LABEL: NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs 'void ()'
+  // CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+  // CHECK:     SYCLAddIRAttributesFunctionAttr
+  // CHECK-NOT: SYCLDeviceAttr {{.*}} Implicit
+  [[__sycl_detail__::add_ir_attributes_function(Metadata<1>::name, Metadata<2>::name, Metadata<1>::value, Metadata<2>::value)]]
+  void NotToBeTurnedIntoDeviceFunctionAttrTemplateArgs() override;
+};

--- a/clang/test/SemaSYCL/implicit-sycl-device-attr.cpp
+++ b/clang/test/SemaSYCL/implicit-sycl-device-attr.cpp
@@ -1,0 +1,56 @@
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -triple spir64 \
+// RUN:  -aux-triple x86_64-unknown-linux-gnu -Wno-return-type -verify     \
+// RUN:  -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+
+// add_ir_attributes_function attribute used to represent compile-time SYCL
+// properties and some of those properties are intended to be turned into
+// attributes to enable various diagnostics.
+//
+// "indirectly-callable" property is supposed to be turned into sycl_device
+// attribute to make sure that functions market with that property are being
+// diagnosed for violating SYCL device code restrictions.
+//
+// This test ensures that this is indeed the case.
+
+namespace std {
+class type_info; // needed to make typeid compile without corresponding include
+} // namespace std
+
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void cannot_use_recursion() {
+  // expected-error@+2 {{SYCL kernel cannot call a recursive function}}
+  // expected-note@-2 {{function implemented using recursion declared here}}
+  cannot_use_recursion();
+}
+
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void cannot_allocate_storage() {
+  new int; // expected-error {{SYCL kernel cannot allocate storage}}
+}
+
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void cannot_use_rtti() {
+ (void)typeid(int); // expected-error {{SYCL kernel cannot use rtti}}
+}
+
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void cannot_use_zero_length_array() {
+  // expected-error@+1 {{zero-length arrays are not permitted in SYCL device code}}
+  int mosterArr[0];
+}
+
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void cannot_use_long_double() {
+  // expected-error@+1 {{'long double' is not supported on this target}}
+  long double terrorLD;
+}
+
+[[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "void")]]
+void cannot_use_exceptions() {
+  try { // expected-error {{SYCL kernel cannot use exceptions}}
+    ;
+  } catch (...) {
+    ;
+  }
+  throw 20; // expected-error {{SYCL kernel cannot use exceptions}}
+}


### PR DESCRIPTION
This PR is a part of virtual functions feature being designed in intel/llvm#10540. One aspects of the proposed language specification is to be able to mark functions as device functions using SYCL compile-time properties mechanism.

Compile-time properties are lowered into
`[[__sycl_detail__::add_ir_attribute_function()]]` attribute and this patch introduces extra processing for the attribute: property names passed to the attribute are analyzed so we can generate other attributes based on those strings.

The only example of such property/attribute pair is `indirectly-callable` string that indicates that a function with such property should be treated as if it had `sycl_device` attribute attached to it and we do exactly that implicitly now.

Note that there were changes required to the attribute parsing logic: because we now access its argument way earlier than we used to, that logic had to be improved to be more robust and pass existing `SemaSYCL/attr-add-ir-attributes.cpp` test.