### PR TITLE
[SYCL][E2E] Add an env var to run on Windows

### DIFF
--- a/sycl/test-e2e/AbiNeutral/device-info.cpp
+++ b/sycl/test-e2e/AbiNeutral/device-info.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_ENABLE_DEFAULT_CONTEXTS=1 %{run} %t.out
 // RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -D_GLIBCXX_USE_CXX11_ABI=0 -o %t2.out %}
-// RUN: %if preview-breaking-changes-supported %{ %{run} %t2.out %}
+// RUN: %if preview-breaking-changes-supported %{ env SYCL_ENABLE_DEFAULT_CONTEXTS=1 %{run} %t2.out %}
 
 // This test case tests if compiling works with or without
 // _GLIBCXX_USE_CXX11_ABI=0.


### PR DESCRIPTION
SYCL_ENABLE_DEFAULT_CONTEXTS=1 is needed to run on Windows.