### PR TITLE
[SYCL][COMPAT] Add funnelshift APIs and corresponding tests

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1457,6 +1457,15 @@ static void invoke_kernel_function(kernel_function &function,
 
 ### Math Functions
 
+The `funnelshift_*` APIs take two unsigned integer arguments (`low` and `high`),
+concatenate them, bit-shift the 64-bit result by `shift` bits and return either
+the most or least significant 32-bits. The `_l*` variants shift left and return
+the most significant 32 bits, while the `_r*` variants shift right and return
+the least significant 32 bits. The `_l`/`_r` APIs differ from the `_lc`/`_rc`
+APIs in how they clamp the `shift` argument: `funnelshift_l` and `funnelshift_r`
+shift the result by `shift & 31` bits, whereas `funnelshift_lc` and
+`funnelshift_rc` shift the result by `min(shift, 32)` bits.
+
 `syclcompat::fast_length` provides a wrapper to SYCL's
 `fast_length(sycl::vec<float,N>)` that accepts arguments for a C++ array and a
 length. `syclcompat::length` provides a templated version that wraps over
@@ -1480,6 +1489,18 @@ The functions `cmul`,`cdiv`,`cabs`, `cmul_add`, and `conj` define complex math o
 which accept `sycl::vec<T,2>` arguments representing complex values.
 
 ```cpp
+inline unsigned int funnelshift_l(unsigned int low, unsigned int high,
+                                  unsigned int shift); 
+
+inline unsigned int funnelshift_lc(unsigned int low, unsigned int high,
+                                   unsigned int shift); 
+
+inline unsigned int funnelshift_r(unsigned int low, unsigned int high,
+                                  unsigned int shift);
+
+inline unsigned int funnelshift_rc(unsigned int low, unsigned int high,
+                                   unsigned int shift);
+
 inline float fast_length(const float *a, int len);
 
 template <typename ValueT>

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1457,12 +1457,14 @@ static void invoke_kernel_function(kernel_function &function,
 
 ### Math Functions
 
-The `funnelshift_*` APIs take two unsigned integer arguments (`low` and `high`),
-concatenate them, bit-shift the 64-bit result by `shift` bits and return either
-the most or least significant 32-bits. The `_l*` variants shift left and return
-the most significant 32 bits, while the `_r*` variants shift right and return
-the least significant 32 bits. The `_l`/`_r` APIs differ from the `_lc`/`_rc`
-APIs in how they clamp the `shift` argument: `funnelshift_l` and `funnelshift_r`
+The `funnelshift_*` APIs perform a concatenate-shift operation on two 32-bit
+values, and return a 32-bit result. The two unsigned integer arguments (`low`
+and `high`) are concatenated to a 64-bit value which is then shifted left or
+right by `shift` bits. The functions then return either the least- or
+most-significant 32 bits. The `_l*` variants shift *left* and return the *most*
+significant 32 bits, while the `_r*` variants shift *right* and return the
+*least* significant 32 bits. The `_l`/`_r` APIs differ from the `_lc`/`_rc` APIs
+in how they clamp the `shift` argument: `funnelshift_l` and `funnelshift_r`
 shift the result by `shift & 31` bits, whereas `funnelshift_lc` and
 `funnelshift_rc` shift the result by `min(shift, 32)` bits.
 

--- a/sycl/include/syclcompat/math.hpp
+++ b/sycl/include/syclcompat/math.hpp
@@ -128,6 +128,30 @@ inline bool isnan(const sycl::ext::oneapi::bfloat16 a) {
 
 } // namespace detail
 
+/// Emulated function for __funnelshift_l
+inline unsigned int funnelshift_l(unsigned int low, unsigned int high,
+                                  unsigned int shift) {
+  return (sycl::upsample(high, low) << (shift & 31U)) >> 32;
+}
+
+/// Emulated function for __funnelshift_lc
+inline unsigned int funnelshift_lc(unsigned int low, unsigned int high,
+                                   unsigned int shift) {
+  return (sycl::upsample(high, low) << sycl::min(shift, 32U)) >> 32;
+}
+
+/// Emulated function for __funnelshift_r
+inline unsigned int funnelshift_r(unsigned int low, unsigned int high,
+                                  unsigned int shift) {
+  return (sycl::upsample(high, low) >> (shift & 31U)) & 0xFFFFFFFF;
+}
+
+/// Emulated function for __funnelshift_rc
+inline unsigned int funnelshift_rc(unsigned int low, unsigned int high,
+                                   unsigned int shift) {
+  return (sycl::upsample(high, low) >> sycl::min(shift, 32U)) & 0xFFFFFFFF;
+}
+
 /// Compute fast_length for variable-length array
 /// \param [in] a The array
 /// \param [in] len Length of the array

--- a/sycl/test-e2e/syclcompat/math/math_funnelshift.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_funnelshift.cpp
@@ -27,13 +27,13 @@
 #include <syclcompat/math.hpp>
 #include <syclcompat/memory.hpp>
 
-void testFunnelShiftKernel(int * const TestResults) {
+void testFunnelShiftKernel(int *const TestResults) {
   TestResults[0] = (syclcompat::funnelshift_l(0xAA000000, 0xBB, 8) == 0xBBAA);
-  TestResults[1] = (syclcompat::funnelshift_lc(0xAA000000, 0xBB, 16) == 0xBBAA00);
+  TestResults[1] =
+      (syclcompat::funnelshift_lc(0xAA000000, 0xBB, 16) == 0xBBAA00);
   TestResults[2] = (syclcompat::funnelshift_r(0xAA00, 0xBB, 8) == 0xBB0000AA);
   TestResults[3] = (syclcompat::funnelshift_rc(0xAA0000, 0xBB, 16) == 0xBB00AA);
 }
-
 
 int main() {
   constexpr int nTests = 4;
@@ -44,9 +44,9 @@ int main() {
   syclcompat::fill<int>(testResults, 0, nTests, q);
 
   q.submit([&](sycl::handler &cgh) {
-    sycl::stream out(1024, 256, cgh);
-    cgh.parallel_for(1, [=](sycl::item<1> it) { testFunnelShiftKernel(testResults); });
-  }).wait_and_throw();
+     cgh.parallel_for(
+         1, [=](sycl::item<1> it) { testFunnelShiftKernel(testResults); });
+   }).wait_and_throw();
 
   syclcompat::memcpy<int>(testResultsHost, testResults, nTests, q);
 

--- a/sycl/test-e2e/syclcompat/math/math_funnelshift.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_funnelshift.cpp
@@ -1,0 +1,63 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  math_funnelshift.cpp
+ *
+ *  Description:
+ *    math funnel helpers tests
+ **************************************************************************/
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#include <syclcompat/device.hpp>
+#include <syclcompat/math.hpp>
+#include <syclcompat/memory.hpp>
+
+void testFunnelShiftKernel(int * const TestResults) {
+  TestResults[0] = (syclcompat::funnelshift_l(0xAA000000, 0xBB, 8) == 0xBBAA);
+  TestResults[1] = (syclcompat::funnelshift_lc(0xAA000000, 0xBB, 16) == 0xBBAA00);
+  TestResults[2] = (syclcompat::funnelshift_r(0xAA00, 0xBB, 8) == 0xBB0000AA);
+  TestResults[3] = (syclcompat::funnelshift_rc(0xAA0000, 0xBB, 16) == 0xBB00AA);
+}
+
+
+int main() {
+  constexpr int nTests = 4;
+
+  sycl::queue q = syclcompat::get_default_queue();
+  int *testResults = syclcompat::malloc<int>(nTests, q);
+  int *testResultsHost = syclcompat::malloc_host<int>(nTests, q);
+  syclcompat::fill<int>(testResults, 0, nTests, q);
+
+  q.submit([&](sycl::handler &cgh) {
+    sycl::stream out(1024, 256, cgh);
+    cgh.parallel_for(1, [=](sycl::item<1> it) { testFunnelShiftKernel(testResults); });
+  }).wait_and_throw();
+
+  syclcompat::memcpy<int>(testResultsHost, testResults, nTests, q);
+
+  for (int i = 0; i < nTests; i++) {
+    if (testResultsHost[i] == 0) {
+      std::cerr << "funnelshift test " << i << " failed" << std::endl;
+      return 1;
+    }
+  }
+  syclcompat::free(testResults, q);
+  syclcompat::free(testResultsHost, q);
+
+  return 0;
+}


### PR DESCRIPTION
Adds `funnelshift_*` math functions to SYCLcompat, and corresponding tests.