### PR TITLE
Add AS for Globals to SPIR & SPIRV datalayouts

### DIFF
--- a/clang/lib/Basic/Targets/SPIR.h
+++ b/clang/lib/Basic/Targets/SPIR.h
@@ -267,7 +267,7 @@ public:
     PtrDiffType = IntPtrType = TargetInfo::SignedInt;
     resetDataLayout(
         "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-"
-        "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
+        "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1");
   }
 
   void getTargetDefines(const LangOptions &Opts,
@@ -286,7 +286,7 @@ public:
 
     resetDataLayout(
         "e-i64:64-v16:16-v24:32-v32:32-v48:64-"
-        "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64");
+        "v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1");
   }
 
   void getTargetDefines(const LangOptions &Opts,

--- a/clang/test/CodeGen/target-data.c
+++ b/clang/test/CodeGen/target-data.c
@@ -251,11 +251,11 @@
 
 // RUN: %clang_cc1 -triple spir-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIR
-// SPIR: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+// SPIR: target datalayout = "e-p:32:32-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
 
 // RUN: %clang_cc1 -triple spir64-unknown -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=SPIR64
-// SPIR64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+// SPIR64: target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
 
 // RUN: %clang_cc1 -triple bpfel -o - -emit-llvm %s | \
 // RUN: FileCheck %s -check-prefix=BPFEL

--- a/clang/test/CodeGenSYCL/device_global.cpp
+++ b/clang/test/CodeGenSYCL/device_global.cpp
@@ -135,8 +135,8 @@ void bar() {
 } // namespace
 
 // CHECK: @llvm.global_ctors = appending global [2 x { i32, ptr, ptr addrspace(4) }] [{ i32, ptr, ptr addrspace(4) } { i32 65535, ptr @__cxx_global_var_init{{.*}}, ptr addrspace(4) addrspacecast (ptr addrspace(1) @[[TEMPL_DEV_GLOB]] to ptr addrspace(4)) }, { i32, ptr, ptr addrspace(4) } { i32 65535, ptr @_GLOBAL__sub_I_device_global.cpp, ptr addrspace(4) null }]
-// CHECK: @llvm.used = appending global [1 x ptr addrspace(4)] [ptr addrspace(4) addrspacecast (ptr addrspace(1) @[[TEMPL_DEV_GLOB]] to ptr addrspace(4))], section "llvm.metadata"
-// CHECK: @llvm.compiler.used = appending global [2 x ptr addrspace(4)]
+// CHECK: @llvm.used = appending addrspace(1) global [1 x ptr addrspace(4)] [ptr addrspace(4) addrspacecast (ptr addrspace(1) @[[TEMPL_DEV_GLOB]] to ptr addrspace(4))], section "llvm.metadata"
+// CHECK: @llvm.compiler.used = appending addrspace(1) global [2 x ptr addrspace(4)]
 // CHECK-SAME: @_ZL1B
 // CHECK-SAME: @_ZN12_GLOBAL__N_19same_nameE
 

--- a/clang/test/CodeGenSYCL/intel-fpga-local.cpp
+++ b/clang/test/CodeGenSYCL/intel-fpga-local.cpp
@@ -29,12 +29,12 @@
 // CHECK-DEVICE:  [[ANN_max_replicates_4:@.str.[0-9]*]] = {{.*}}{max_replicates:4}
 
 // CHECK-BOTH: @llvm.global.annotations
-// CHECK-DEVICE-SAME: { ptr addrspacecast (ptr addrspace(1) @_ZZ15attrs_on_staticvE15static_numbanks to ptr)
+// CHECK-DEVICE-SAME: { ptr addrspace(1) @_ZZ15attrs_on_staticvE15static_numbanks
 // CHECK-DEVICE-SAME: [[ANN_numbanks_4]]{{.*}} i32 43
-// CHECK-DEVICE-SAME: { ptr addrspacecast (ptr addrspace(1) @_ZZ15attrs_on_staticvE15static_annotate to ptr)
+// CHECK-DEVICE-SAME: { ptr addrspace(1) @_ZZ15attrs_on_staticvE15static_annotate
 // CHECK-HOST-SAME: { ptr @_ZZ15attrs_on_staticvE15static_annotate
 // CHECK-BOTH-SAME: [[ANN_annotate]]{{.*}} i32 44
-// CHECK-DEVICE-SAME: { ptr addrspacecast (ptr addrspace(1) @_ZZ15attrs_on_staticvE16static_force_p2d to ptr)
+// CHECK-DEVICE-SAME: { ptr addrspace(1) @_ZZ15attrs_on_staticvE16static_force_p2d
 // CHECK-DEVICE-SAME: [[ANN_force_pow2_depth_0]]{{.*}} i32 45
 // CHECK-HOST-NOT: llvm.var.annotation
 // CHECK-HOST-NOT: llvm.ptr.annotation


### PR DESCRIPTION
llvm/llvm-project@1120d8e6f799
Added "-G1" to SPIR/SPRIV datalayout.

This is to update downatream code to sync with it.

Fix tests and using getAddrSpaceCast instead getBitCast.
