### PR TITLE
[SYCL][E2E] Move e2e test to proper directory

### DIFF
--- a/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
+++ b/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
@@ -1,8 +1,8 @@
 // REQUIRES: windows
 
-// RUN: %clang_cl -fsycl /MDd -c %s -o %t.obj
-// RUN: %clang_cl -fsycl %t.obj -o %t.out
-// RUN: %t.out
+// RUN: %clangxx --driver-mode=cl -fsycl /MDd -c %s -o %t.obj
+// RUN: %clangxx --driver-mode=cl -fsycl %t.obj -o %t.out
+// RUN: %{run} %t.out
 
 // The test aims to prevent regressions similar to the one which caused by
 // https://github.com/intel/llvm/pull/12793.


### PR DESCRIPTION
Test is e2e but was put to sycl/test/ directory. Move it to the e2e test directory.