### PR TITLE
[SYCL] Screen tests on PVC-1T systems

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -1,7 +1,12 @@
 // REQUIRES: level_zero
 // REQUIRES: aspect-ext_intel_device_id
+// UNSUPPORTED: gpu-intel-pvc-1T
 
 // RUN: %{build} -o %t.out
+
+// TODO: at this time PVC 1T systems are not correctly supporting CSLICE
+// affinity partitioning So the test is marked as UNSUPPORTED until that is
+// fixed.
 
 // TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.  Once it is supported, we'll test on both.

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -1,6 +1,11 @@
 // REQUIRES: aspect-ext_intel_device_id
 // REQUIRES: level_zero
+// UNSUPPORTED: gpu-intel-pvc-1T
 // RUN: %{build} -o %t.out
+
+// TODO: at this time PVC 1T systems are not correctly supporting CSLICE
+// affinity partitioning So the test is marked as UNSUPPORTED until that is
+// fixed.
 
 // TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.  Once it is supported, we'll test on both.

--- a/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
@@ -1,6 +1,12 @@
 // REQUIRES:  gpu-intel-pvc, level_zero
 
+// UNSUPPORTED: gpu-intel-pvc-1T
+
 // RUN: %{build} %level_zero_options -o %t.out
+
+// TODO - at this time PVC 1T systems aren't correctly supporting affinity
+// subdomain partitioning so this test is marked as UNSUPPORTED on those
+// systems.
 
 // TODO - at this time ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.  Once it is supported, we'll test on both.

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -422,6 +422,8 @@ if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
     )
     sp = subprocess.check_output(cmd, text=True, shell=True)
     for line in sp.splitlines():
+        if "Max 1100" in line:
+            config.available_features.add("gpu-intel-pvc-1T")
         if "gfx90a" in line:
             config.available_features.add("gpu-amd-gfx90a")
         if not line.startswith("["):

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -422,7 +422,7 @@ if len(config.sycl_devices) == 1 and config.sycl_devices[0] == "all":
     )
     sp = subprocess.check_output(cmd, text=True, shell=True)
     for line in sp.splitlines():
-        if "Max 1100" in line:
+        if "Intel(R) Data Center GPU Max 1100" in line:
             config.available_features.add("gpu-intel-pvc-1T")
         if "gfx90a" in line:
             config.available_features.add("gpu-amd-gfx90a")


### PR DESCRIPTION
PVC 1T systems have some issues with partitioning.  Disabling these tests on those systems while awaiting driver fixes.