### PR TITLE
[NFC][SYCL] Include `sycl/feature_test.hpp` in `sycl/detail/core.hpp`

### DIFF
--- a/sycl/include/sycl/detail/core.hpp
+++ b/sycl/include/sycl/detail/core.hpp
@@ -21,3 +21,8 @@
 #include <sycl/accessor.hpp>
 #include <sycl/buffer.hpp>
 #include <sycl/queue.hpp>
+
+// TODO: We assume that this is the property of a vendor's implementation and
+// can define feature macros even if the particular header file implementing it
+// (if such exists) isn't included.
+#include <sycl/feature_test.hpp>

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -30,7 +30,6 @@
 #include <sycl/event.hpp>
 #include <sycl/exception.hpp>
 #include <sycl/ext/oneapi/experimental/group_sort.hpp>
-#include <sycl/feature_test.hpp>
 #include <sycl/functional.hpp>
 #include <sycl/group.hpp>
 #include <sycl/group_algorithm.hpp>


### PR DESCRIPTION
Non-functional because it has been there transitively from `sycl/ext/oneapi/sub_group_mask.hpp`. Make that inclusion explicit so that it would remain there in future even if we will decouple that extension out of "core".