### PR TITLE
[SYCL] Use `sycl/detail/core.hpp` in `test-e2e/GroupAlgorithm/load_store/*`

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/group_load_store.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_load_store.hpp
@@ -11,6 +11,7 @@
 #pragma once
 
 #include <sycl/ext/oneapi/properties/properties.hpp>
+#include <sycl/group_barrier.hpp>
 #include <sycl/sycl_span.hpp>
 
 #include <cstring>

--- a/sycl/test-e2e/GroupAlgorithm/load_store/basic.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/basic.cpp
@@ -1,7 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
+
+#include <numeric>
 
 int main() {
   using namespace sycl;

--- a/sycl/test-e2e/GroupAlgorithm/load_store/conversions_load.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/conversions_load.cpp
@@ -1,7 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
+
+#include <numeric>
 
 struct S {
   S() : i(-1) {}

--- a/sycl/test-e2e/GroupAlgorithm/load_store/conversions_store.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/conversions_store.cpp
@@ -1,7 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 
 struct S {
   operator int() const { return i + 42; }

--- a/sycl/test-e2e/GroupAlgorithm/load_store/odd_sized_type.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/odd_sized_type.cpp
@@ -1,7 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
+
+#include <numeric>
 
 using namespace sycl;
 namespace sycl_exp = sycl::ext::oneapi::experimental;

--- a/sycl/test-e2e/GroupAlgorithm/load_store/odd_wg_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/odd_wg_size.cpp
@@ -1,7 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
+
+#include <numeric>
 
 using namespace sycl;
 namespace sycl_exp = sycl::ext::oneapi::experimental;

--- a/sycl/test-e2e/GroupAlgorithm/load_store/partial_sg.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/load_store/partial_sg.cpp
@@ -1,7 +1,10 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
+
+#include <numeric>
 
 using namespace sycl;
 namespace sycl_exp = sycl::ext::oneapi::experimental;


### PR DESCRIPTION
Continuation of changes started in https://github.com/intel/llvm/pull/12890.