### PR TITLE
[SYCL] Fix barrier with wait list handling

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -338,6 +338,8 @@ class DispatchHostTask {
     for (auto &PluginWithEvents : RequiredEventsPerPlugin) {
       std::vector<sycl::detail::pi::PiEvent> RawEvents =
           MThisCmd->getPiEvents(PluginWithEvents.second);
+      if (RawEvents.size() == 0)
+        continue;
       try {
         PluginWithEvents.first->call<PiApiKind::piEventsWait>(RawEvents.size(),
                                                               RawEvents.data());

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -924,10 +924,16 @@ void handler::verifyUsedKernelBundleInternal(detail::string_view KernelName) {
 void handler::ext_oneapi_barrier(const std::vector<event> &WaitList) {
   throwIfActionIsCreated();
   MCGType = detail::CG::BarrierWaitlist;
-  MEventsWaitWithBarrier.resize(WaitList.size());
-  std::transform(
-      WaitList.begin(), WaitList.end(), MEventsWaitWithBarrier.begin(),
-      [](const event &Event) { return detail::getSyclObjImpl(Event); });
+  MEventsWaitWithBarrier.reserve(WaitList.size());
+  for (auto &Event : WaitList) {
+    auto EventImpl = detail::getSyclObjImpl(Event);
+    // We could not wait for host task events in backend.
+    // Adding them as dependency to enable proper scheduling.
+    if (EventImpl->is_host()) {
+      depends_on(EventImpl);
+    }
+    MEventsWaitWithBarrier.push_back(EventImpl);
+  }
 }
 
 using namespace sycl::detail;

--- a/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
+++ b/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
@@ -256,7 +256,9 @@ TEST_F(BarrierHandlingWithHostTask, HostTaskUnblockedWaitListBarrierKernel) {
   auto BarrierWaitList = BarrierEventImpl->getWaitList();
   // Events to wait by barrier are stored in a separated vector. Here we are
   // interested in implicit deps only.
-  ASSERT_EQ(BarrierWaitList.size(), 0u);
+  // Host task in barrier wait list could not be handled by backend so it is
+  // added by RT to dependency list to initiate deps tracking by scheduler.
+  ASSERT_EQ(BarrierWaitList.size(), 1u);
   EXPECT_EQ(BarrierEventImpl->isEnqueued(), true);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);


### PR DESCRIPTION
Fixes two things:
1) Prevent submitting empty wait list to piEVentsWait from host task execution handler. Backend treats empty wait list as not valid and reports error. If barrier with wait list is submitted with empty list or with host tasks as dependencies - it (barrier) is not submitted to backend and has null pi handle. Null pi handle means that it will be filtered out from wait list.
2) host tasks in wait list could not be handled by backend so we should add them as dependencies to enable dependencies handling by scheduler.