### PR TITLE
[SYCL][NFCI] Remove unnecessary CG type argument in finalizeHandler

### DIFF
--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -778,8 +778,7 @@ protected:
 
   // template is needed for proper unit testing
   template <typename HandlerType = handler>
-  void finalizeHandler(HandlerType &Handler, const CG::CGTYPE &Type,
-                       event &EventRet) {
+  void finalizeHandler(HandlerType &Handler, event &EventRet) {
     if (MIsInorder) {
       // Accessing and changing of an event isn't atomic operation.
       // Hence, here is the lock for thread-safety.
@@ -807,6 +806,8 @@ protected:
       EventRet = Handler.finalize();
       EventToBuildDeps = getSyclObjImpl(EventRet);
     } else {
+      const CG::CGTYPE Type = Handler.getType();
+
       // The following code supports barrier synchronization if host task is
       // involved in the scenario. Native barriers cannot handle host task
       // dependency so in the case where some commands were not enqueued
@@ -886,11 +887,11 @@ protected:
         KernelUsesAssert = !(Handler.MKernel && Handler.MKernel->isInterop()) &&
                            ProgramManager::getInstance().kernelUsesAssert(
                                Handler.MKernelName.c_str());
-      finalizeHandler(Handler, Type, Event);
+      finalizeHandler(Handler, Event);
 
       (*PostProcess)(IsKernel, KernelUsesAssert, Event);
     } else
-      finalizeHandler(Handler, Type, Event);
+      finalizeHandler(Handler, Event);
 
     addEvent(Event);
     return Event;


### PR DESCRIPTION
The `finalizeHandler` function on queue_impl has a `CGType` argument, but the information in this argument could be queried directly from the handler instead. This commit removes the argument and makes the member function call `handler::getType()` instead.