### PR TITLE
[SYCL] Fix exception thrown for composite_devices query

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -697,14 +697,14 @@ bool device_impl::has(aspect Aspect) const {
     if (getBackend() != backend::ext_oneapi_level_zero)
       return false;
 
-    typename sycl_to_pi<device>::type Result;
-    getPlugin()->call<PiApiKind::piDeviceGetInfo>(
-        getHandleRef(),
-        PiInfoCode<
-            ext::oneapi::experimental::info::device::composite_device>::value,
-        sizeof(Result), &Result, nullptr);
+    typename sycl_to_pi<device>::type Result = nullptr;
+    bool CallSuccessful = getPlugin()->call_nocheck<PiApiKind::piDeviceGetInfo>(
+                              getHandleRef(),
+                              PiInfoCode<ext::oneapi::experimental::info::
+                                             device::composite_device>::value,
+                              sizeof(Result), &Result, nullptr) == PI_SUCCESS;
 
-    return Result != nullptr;
+    return CallSuccessful && Result != nullptr;
   }
   case aspect::ext_oneapi_graph: {
     pi_bool SupportsCommandBufferUpdate = false;

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -1235,8 +1235,6 @@ template <>
 struct get_device_info_impl<
     sycl::device, ext::oneapi::experimental::info::device::composite_device> {
   static sycl::device get(const DeviceImplPtr &Dev) {
-    if (Dev->getBackend() != backend::ext_oneapi_level_zero)
-      return {};
     if (!Dev->has(sycl::aspect::ext_oneapi_is_component))
       throw sycl::exception(make_error_code(errc::invalid),
                             "Only devices with aspect::ext_oneapi_is_component "


### PR DESCRIPTION
The sycl_ext_oneapi_composite_device extension specifies that the composite_devices query should throw if a device returns false for device::has with ext_oneapi_is_composite. However, the current implementation simply returns an empty device list if the backend of the device is not L0. This commit fixes this discrepancy.