### PR TITLE
[CI] New workflow to ping issue assignee

### DIFF
--- a/.github/workflows/sycl-issues-ping-assignee.yml
+++ b/.github/workflows/sycl-issues-ping-assignee.yml
@@ -1,0 +1,64 @@
+name: Ping issue assignees
+# We have some specific pool of the issues we would like to handle. Sometimes
+# the issue from this pool has an assignee, but doesn't get any updates for a
+# long time. In this case it'd be useful to periodically ping the assignee.
+
+# Note: may be we could use "actions/stale@v*", but I'm not sure if it's
+# possible to not set the "stale" label at all. Even so, this action will not
+# ping the assignee of the "stale" issue more than onсe.
+
+# Note2: probably it'd be useful to have a small doc describing this "specific
+# pool" to refer to.
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+jobs:
+  run:
+    runs-on: ubuntu-20.04
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      REPO: ${{ github.repository }}
+    steps:
+    # List specific issues with an assignee but without recent updates.
+    # Note: for some reason gh returns 0 results if the "assignee:*" filter is
+    # added, so we have to manually filter the results.
+    - name: Get the specicifc list of issues
+      run: |
+          gh issue list --search '-label:"help wanted" -label:cuda \
+          -label:confirmed -label:hip -label:sycl-mlir -label:upstream is:open \
+          -label:genx -label:sycl-bindless-images -label:sycl-graph \
+          -label:native-cpu' --limit 200 --json assignees --json number \
+          --json updatedAt \
+          -R https://github.com/${{ env.REPO }}.git > issues.json
+
+    - name: Filter issues and ping
+      run: |
+          days_to_stale=60
+          current_time=$(date +%s)
+
+          cat issues.json | jq -c '.[]' | while read -r issue; do
+            assignees=$(echo "$issue" | jq '.assignees | length')
+            if [ "$assignees" -gt 0 ]; then
+              updated_at=$(echo "$issue" | jq -r '.updatedAt')
+              updated_at_seconds=$(date -d "$updated_at" +%s)
+              difference_days=$(( (current_time - updated_at_seconds) / 86400 ))
+              if [ "$difference_days" -gt $days_to_stale ]; then
+                issue_number=$(echo "$issue" | jq '.number')
+                assignee_logins=$(echo "$issue" | jq -r '.assignees[].login' | sed 's/^/@/' | paste -s -d ' ' -)
+                comment_body="Hi! There have been no updates for at least the last $days_to_stale days, though the issue has assignee(s).
+
+          $assignee_logins, could you please take one of the following actions:
+          - provide an update if you have any
+          - unassign yourself if you're not looking / going to look into this issue
+          - mark this issue with the 'confirmed' label if you have confirmed the problem/request and our team should work on it
+          - close the issue if it has been resolved
+          - take any other suitable action.
+
+          Thanks!"
+
+                gh issue comment $issue_number -R https://github.com/${{ env.REPO }}.git -b "$comment_body" >> $GITHUB_STEP_SUMMARY
+              fi
+            fi
+          done

--- a/.github/workflows/sycl-issues-ping-assignee.yml
+++ b/.github/workflows/sycl-issues-ping-assignee.yml
@@ -40,14 +40,16 @@ jobs:
 
           cat issues.json | jq -c '.[]' | while read -r issue; do
             assignees=$(echo "$issue" | jq '.assignees | length')
-            if [ "$assignees" -gt 0 ]; then
-              updated_at=$(echo "$issue" | jq -r '.updatedAt')
-              updated_at_seconds=$(date -d "$updated_at" +%s)
-              difference_days=$(( (current_time - updated_at_seconds) / 86400 ))
-              if [ "$difference_days" -gt $days_to_stale ]; then
-                issue_number=$(echo "$issue" | jq '.number')
-                assignee_logins=$(echo "$issue" | jq -r '.assignees[].login' | sed 's/^/@/' | paste -s -d ' ' -)
-                comment_body="Hi! There have been no updates for at least the last $days_to_stale days, though the issue has assignee(s).
+            [ "$assignees" -eq 0 ] && continue
+
+            updated_at=$(echo "$issue" | jq -r '.updatedAt')
+            updated_at_seconds=$(date -d "$updated_at" +%s)
+            difference_days=$(( (current_time - updated_at_seconds) / 86400 ))
+            [ "$difference_days" -lt $days_to_stale ] && continue
+
+            issue_number=$(echo "$issue" | jq '.number')
+            assignee_logins=$(echo "$issue" | jq -r '.assignees[].login' | sed 's/^/@/' | paste -s -d ' ' -)
+            comment_body="Hi! There have been no updates for at least the last $days_to_stale days, though the issue has assignee(s).
 
           $assignee_logins, could you please take one of the following actions:
           - provide an update if you have any
@@ -58,7 +60,5 @@ jobs:
 
           Thanks!"
 
-                gh issue comment $issue_number -R https://github.com/${{ env.REPO }}.git -b "$comment_body" >> $GITHUB_STEP_SUMMARY
-              fi
-            fi
+            gh issue comment $issue_number -R https://github.com/${{ env.REPO }}.git -b "$comment_body" >> $GITHUB_STEP_SUMMARY
           done


### PR DESCRIPTION
There is a set of "backlog" issues we'd like to handle. The new process is to confirm the issue and add the `confirmed` label, so the issue will be automatically copied to our system and then assigned to the appropriate team.

Sometimes the issue has an assignee but doesn't get any updates for a long time. We decided that in this case we'd like to occasionally ping the assignee to progress the work on this issue. There is also a big bunch of old issues with an assignee and no updates.