### PR TITLE
[SYCL] Prohibit usage of `<sycl/sycl.hpp>` in E2E tests

### DIFF
--- a/sycl/test-e2e/DeviceLib/math_fp64_windows_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_fp64_windows_test.cpp
@@ -9,7 +9,7 @@
 #include "math_utils.hpp"
 #include <iostream>
 #include <math.h>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
 
 namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;

--- a/sycl/test-e2e/DeviceLib/math_windows_test.cpp
+++ b/sycl/test-e2e/DeviceLib/math_windows_test.cpp
@@ -8,7 +8,7 @@
 #include "math_utils.hpp"
 #include <iostream>
 #include <math.h>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
 
 namespace s = sycl;
 constexpr s::access::mode sycl_read = s::access::mode::read;

--- a/sycl/test-e2e/QueueFlushing/queue_flushing.cpp
+++ b/sycl/test-e2e/QueueFlushing/queue_flushing.cpp
@@ -2,7 +2,7 @@
 // RUN: %t.out
 
 #include <stdlib.h>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
 #include <vector>
 
 using namespace sycl;

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -291,10 +291,13 @@ llvm-lit --param dpcpp_compiler=path/to/clang++ --param dump_ir=True \
 While SYCL specification dictates that the only user-visible interface is
 `<sycl/sycl.hpp>` header file we found out that as the implementation and
 multiple extensions grew, the compile time was getting worse and worse,
-negatively affecting our CI turnaround time. We are just starting some efforts
-to create a much smaller set of basic feature needed for every SYCL end-to-end
-test/program so that this issue could be somewhat mitigated. This activity is in
-its early stage and NO production code should rely on it. It WILL be changed as
-we go with our experiments. For any code outside of this project only the
-`<sycl/sycl.hpp>` must be used until we feel confident to propose an extension
-that can provide an alternative.
+negatively affecting our CI turnaround time. As such, we decided to use
+finer-grained includes for the end-to-end tests used in this project (under
+`sycl/test-e2e/` folder).
+
+At this moment all the tests have been updated to include a limited set of
+headers only. However, the work of eliminating unnecessary dependencies between
+implementation header files is still in progress and the final set of these
+"fine-grained" includes that might be officially documented and suggested for
+customers to use isn't determined yet. Until then, code outside of this project
+must keep using `<sycl/sycl.hpp>` provided by the SYCL2020 specification.

--- a/sycl/test-e2e/README.md
+++ b/sycl/test-e2e/README.md
@@ -299,5 +299,5 @@ At this moment all the tests have been updated to include a limited set of
 headers only. However, the work of eliminating unnecessary dependencies between
 implementation header files is still in progress and the final set of these
 "fine-grained" includes that might be officially documented and suggested for
-customers to use isn't determined yet. Until then, code outside of this project
-must keep using `<sycl/sycl.hpp>` provided by the SYCL2020 specification.
+customers to use isn't determined yet. **Until then, code outside of this project
+must keep using `<sycl/sycl.hpp>` provided by the SYCL2020 specification.**

--- a/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
+++ b/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
@@ -10,7 +10,7 @@
 // the compile line. In that case, user application will crash during launching
 // with abort() message.
 
-#include <sycl/sycl.hpp>
+#include <sycl/queue.hpp>
 
 #include <iostream>
 

--- a/sycl/test-e2e/SubGroup/generic_reduce.cpp
+++ b/sycl/test-e2e/SubGroup/generic_reduce.cpp
@@ -9,7 +9,8 @@
 
 #include "helper.hpp"
 #include <complex>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/group_algorithm.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/no_sycl_hpp_in_e2e_tests.cpp
+++ b/sycl/test-e2e/no_sycl_hpp_in_e2e_tests.cpp
@@ -1,0 +1,14 @@
+// REQUIRES: linux
+//
+// RUN: grep -r -l 'sycl.hpp' %S | FileCheck  %s
+// RUN: grep -r -l 'sycl.hpp' %S | wc -l | FileCheck %s --check-prefix CHECK-NUM-MATCHES
+//
+// CHECK-DAG: README.md
+// CHECK-DAG: no_sycl_hpp_in_e2e_tests.cpp
+// CHECK-DAG: lit.cfg.py
+//
+// CHECK-NUM-MATCHES: 3
+//
+// This test verifies that `<sycl/sycl.hpp>` isn't used in E2E tests. Instead,
+// fine-grained includes should used, see
+// https://github.com/intel/llvm/tree/sycl/sycl/test-e2e#sycldetailcorehpp


### PR DESCRIPTION
Fine-grained includes should be used instead for the benefits of
compile-time. So far, the feature is still internal, customer code
should continue using standard header files only.

We can consider adding a Nightly workflow running E2E tests with extra
compilation flag `-include sycl/sycl.hpp` if people think that would be
important to have. I personally think that any potential discrepancies
between full `sycl.hpp` and individual includes can be caught in
compile-time and it should be enough to have tests in `sycl/test`.