### PR TITLE
[SYCL] Avoid using `sycl::exception::get_cl_code()` in tests

### DIFF
--- a/sycl/test-e2e/ESIMD/dp4a.cpp
+++ b/sycl/test-e2e/ESIMD/dp4a.cpp
@@ -69,7 +69,7 @@ int main(void) {
     e.wait();
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    return e.get_cl_code();
+    return e.code().value();
   }
 
   int err_cnt = 0;

--- a/sycl/test-e2e/ESIMD/fp_call_from_func.cpp
+++ b/sycl/test-e2e/ESIMD/fp_call_from_func.cpp
@@ -50,7 +50,7 @@ int main(int argc, char **argv) {
     });
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << std::endl;
-    return e.get_cl_code();
+    return e.code().value();
   }
 
   if (result != (in1 + in2)) {

--- a/sycl/test-e2e/ESIMD/fp_call_recursive.cpp
+++ b/sycl/test-e2e/ESIMD/fp_call_recursive.cpp
@@ -56,7 +56,7 @@ int main(int argc, char **argv) {
     });
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << std::endl;
-    return e.get_cl_code();
+    return e.code().value();
   }
 
   int etalon = in1;

--- a/sycl/test-e2e/ESIMD/noinline_call_recursive.cpp
+++ b/sycl/test-e2e/ESIMD/noinline_call_recursive.cpp
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
     });
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << std::endl;
-    return e.get_cl_code();
+    return e.code().value();
   }
 
   int etalon = in1;

--- a/sycl/test-e2e/ESIMD/regression/noinline_bypointers_vadd.cpp
+++ b/sycl/test-e2e/ESIMD/regression/noinline_bypointers_vadd.cpp
@@ -70,7 +70,7 @@ int main(void) {
     free(B, ctxt);
     free(C, ctxt);
 
-    return e.get_cl_code();
+    return e.code().value();
   }
 
   int err_cnt = 0;

--- a/sycl/test-e2e/KernelAndProgram/cache-build-result.cpp
+++ b/sycl/test-e2e/KernelAndProgram/cache-build-result.cpp
@@ -33,15 +33,15 @@ void test() {
       });
       assert(false && "There must be compilation error");
     } catch (const sycl::compile_program_error &e) {
-      fprintf(stderr, "Exception: %s, %d\n", e.what(), e.get_cl_code());
+      fprintf(stderr, "Exception: %s, %d\n", e.what(), e.code().value());
       if (Idx == 0) {
         Msg = e.what();
-        Result = e.get_cl_code();
+        Result = e.code().value();
       } else {
         // Exception constantly adds info on its error code in the message
         assert(Msg.find_first_of(e.what()) == 0 &&
                "PI_ERROR_BUILD_PROGRAM_FAILURE");
-        assert(Result == e.get_cl_code() && "Exception code differs");
+        assert(Result == e.code().value() && "Exception code differs");
       }
     } catch (...) {
       assert(false && "There must be sycl::compile_program_error");

--- a/sycl/test-e2e/Plugin/retain_events.cpp
+++ b/sycl/test-e2e/Plugin/retain_events.cpp
@@ -28,7 +28,7 @@ void async_sycl_error(sycl::exception_list el) {
     try {
       std::rethrow_exception(*l);
     } catch (const sycl::exception &e) {
-      fprintf(stderr, "what: %s code: %d\n", e.what(), e.get_cl_code());
+      fprintf(stderr, "what: %s code: %d\n", e.what(), e.code().value());
       std::exit(-1);
     }
   }
@@ -75,7 +75,7 @@ int main() {
     }
   } catch (sycl::exception &e) {
     fprintf(stderr, "...sycl failed to entertain with \"%s\" (%d) \n", e.what(),
-            e.get_cl_code());
+            e.code().value());
   }
   return 0;
 }

--- a/sycl/test/invoke_simd/invoke_simd.cpp
+++ b/sycl/test/invoke_simd/invoke_simd.cpp
@@ -134,7 +134,7 @@ int main(void) {
     e.wait();
   } catch (sycl::exception const &e) {
     std::cout << "SYCL exception caught: " << e.what() << '\n';
-    return e.get_cl_code();
+    return e.code().value();
   }
 
   int err_cnt = 0;


### PR DESCRIPTION
This interface has been removed in SYCL 2020.