### PR TITLE
[SYCL][E2E] Fix sycl/sycl.hpp use in sub_byte_bitreverse.hpp

### DIFF
--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -45,7 +45,8 @@
 #include "common.hpp"
 #include <iostream>
 #include <string.h>
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/usm.hpp>
 
 using namespace sycl;
 


### PR DESCRIPTION
https://github.com/intel/llvm/pull/13875 made sycl/sycl.hpp include in E2E tests prohibited. However,
LLVMIntrinsicLowering/sub_byte_bitreverse.cpp snuck in without this check. This commit fixes the includes in that test.