### PR TITLE
[SYCL][JM tests] small correction to OOB test, remove xfail from prefetch test

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_prefetch.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_prefetch.cpp
@@ -7,6 +7,7 @@
 //===----------------------------------------------------------------------===//
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943
 // REQUIRES: aspect-ext_intel_matrix
+// UNSUPPORTED: gpu-intel-dg2
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_out_bounds_impl.hpp
@@ -63,7 +63,7 @@ void matrix_multiply(T1 *C, T2 *A, T2 *B, queue q) {
            joint_matrix<sub_group, float, use::accumulator, TM, TN> sub_c;
            // bounds-checked load where width and height are added
            ext::intel::experimental::matrix::joint_matrix_fill_checked(
-               sg, sub_c, 1, N, M, N, sg_startx * TM, sg_starty / sg_size * TN);
+               sg, sub_c, 1, M, N, sg_startx * TM, sg_starty / sg_size * TN);
            for (int k = 0; k < K; k += TK) {
              // bounds-checked load where width and height are added
              ext::intel::experimental::matrix::joint_matrix_load_checked(
@@ -72,7 +72,7 @@ void matrix_multiply(T1 *C, T2 *A, T2 *B, queue q) {
              // bounds-checked load where width and height are added
              ext::intel::experimental::matrix::joint_matrix_load_checked(
                  sg, sub_b, pB, N * vnniFactor, K / vnniFactor, N * vnniFactor,
-                 k, sg_starty / sg_size * TN * vnniFactor);
+                 k / vnniFactor, sg_starty / sg_size * TN * vnniFactor);
              joint_matrix_mad(sg, sub_c, sub_a, sub_b, sub_c);
            }
            // bounds-checked store where width and height are added

--- a/sycl/test-e2e/Matrix/joint_matrix_prefetch.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_prefetch.cpp
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: aspect-ext_intel_matrix
+
+// UNSUPPORTED: gpu-intel-dg2
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-
-// XFAIL: gpu
 
 #include "common.hpp"
 


### PR DESCRIPTION
 - OOB test: correct VNNI coordinate, remove stride argument from fill to match spec
 - Prefetch test: remove xfail, add unsupported on DG2