### PR TITLE
[New offload][SYCL] Turn on --offload-new-driver for SYCL offloading JIT compilation

### DIFF
--- a/clang/include/clang/Driver/Driver.h
+++ b/clang/include/clang/Driver/Driver.h
@@ -591,6 +591,13 @@ public:
   /// specified subarch
   llvm::Triple MakeSYCLDeviceTriple(StringRef TargetArch = "spir64") const;
 
+  /// Utility function to parse all devices passed via -fsycl-targets.
+  /// Return 'true' if only SPIR/SPIRV JIT targets are specified.
+  /// Otherwise return 'false'.
+  bool
+  GetUseNewOffloadDriverForSYCLOffload(Compilation &C,
+                                       const llvm::opt::ArgList &Args) const;
+
   /// PrintActions - Print the list of actions.
   void PrintActions(const Compilation &C) const;
 

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1357,6 +1357,33 @@ static void appendOneArg(InputArgList &Args, const Arg *Opt,
   Args.append(Copy);
 }
 
+// Utility function to parse all devices passed via -fsycl-targets.
+// Return 'true' if only SPIR/SPIRV JIT targets are specified.
+// Otherwise return 'false'.
+bool Driver::GetUseNewOffloadDriverForSYCLOffload(Compilation &C,
+                                                  const ArgList &Args) const {
+  // Check only if enabled with -fsycl
+  if (!Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false))
+    return false;
+
+  if (Args.hasFlag(options::OPT_no_offload_new_driver,
+                   options::OPT_offload_new_driver, false))
+    return false;
+
+  if (Args.hasArg(options::OPT_fintelfpga))
+    return false;
+
+  if (const Arg *A = Args.getLastArg(options::OPT_fsycl_targets_EQ)) {
+    for (const char *Val : A->getValues()) {
+      llvm::Triple TT(C.getDriver().MakeSYCLDeviceTriple(Val));
+      if ((!TT.isSPIROrSPIRV()) || TT.isSPIRAOT())
+        // Non-JIT SPIR/SPIRV triple found
+        return false;
+    }
+  }
+  return true;
+}
+
 bool Driver::readConfigFile(StringRef FileName,
                             llvm::cl::ExpansionContext &ExpCtx) {
   // Try opening the given file.
@@ -1901,11 +1928,10 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   // Use new offloading path for OpenMP.  This is disabled as the SYCL
   // offloading path is not properly setup to use the updated device linking
   // scheme.
-  if ((C->isOffloadingHostKind(Action::OFK_OpenMP) &&
-       TranslatedArgs->hasFlag(options::OPT_fopenmp_new_driver,
-                               options::OPT_no_offload_new_driver, true)) ||
+  if (C->isOffloadingHostKind(Action::OFK_OpenMP) ||
       TranslatedArgs->hasFlag(options::OPT_offload_new_driver,
-                              options::OPT_no_offload_new_driver, false))
+                              options::OPT_no_offload_new_driver, false) ||
+      GetUseNewOffloadDriverForSYCLOffload(*C, *TranslatedArgs))
     setUseNewOffloadingDriver();
 
   // Determine FPGA emulation status.
@@ -7425,7 +7451,8 @@ void Driver::BuildActions(Compilation &C, DerivedArgList &Args,
   bool UseNewOffloadingDriver =
       C.isOffloadingHostKind(Action::OFK_OpenMP) ||
       Args.hasFlag(options::OPT_offload_new_driver,
-                   options::OPT_no_offload_new_driver, false);
+                   options::OPT_no_offload_new_driver, false) ||
+      GetUseNewOffloadDriverForSYCLOffload(C, Args);
 
   // Builder to be used to build offloading actions.
   std::unique_ptr<OffloadingActionBuilder> OffloadBuilder =

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -35,7 +35,7 @@
 // RUN:          --sysroot=%S/Inputs/SYCL -### %s 2>&1 \
 // RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS %s
 // WRAPPER_OPTIONS: clang-linker-wrapper{{.*}} "--triple=spir64"
-// WRAPPER_OPTIONS-SAME: "-sycl-device-libraries=libsycl-crt.new.o,libsycl-complex.new.o,libsycl-complex-fp64.new.o,libsycl-cmath.new.o,libsycl-cmath-fp64.new.o,libsycl-imf.new.o,libsycl-imf-fp64.new.o,libsycl-imf-bf16.new.o,libsycl-itt-user-wrappers.new.o,libsycl-itt-compiler-wrappers.new.o,libsycl-itt-stubs.new.o"
+// WRAPPER_OPTIONS-SAME: "-sycl-device-libraries=libsycl-crt.new.o,libsycl-complex.new.o,libsycl-complex-fp64.new.o,libsycl-cmath.new.o,libsycl-cmath-fp64.new.o,libsycl-imf.new.o,libsycl-imf-fp64.new.o,libsycl-imf-bf16.new.o,libsycl-fallback-cassert.new.o,libsycl-fallback-cstring.new.o,libsycl-fallback-complex.new.o,libsycl-fallback-complex-fp64.new.o,libsycl-fallback-cmath.new.o,libsycl-fallback-cmath-fp64.new.o,libsycl-fallback-imf.new.o,libsycl-fallback-imf-fp64.new.o,libsycl-fallback-imf-bf16.new.o,libsycl-itt-user-wrappers.new.o,libsycl-itt-compiler-wrappers.new.o,libsycl-itt-stubs.new.o"
 // WRAPPER_OPTIONS-SAME: "-sycl-device-library-location={{.*}}/lib"
 
 /// Verify phases used to generate SPIR-V instead of LLVM-IR

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1765,6 +1765,12 @@ Expected<SmallVector<StringRef>> linkAndWrapDeviceFiles(
     }
 
     if (HasSYCLOffloadKind) {
+      const llvm::Triple Triple(LinkerArgs.getLastArgValue(OPT_triple_EQ));
+      // Only JIT targets are supported for SYCL offloads
+      if (!Triple.isSPIROrSPIRV() || Triple.isSPIRAOT())
+        reportError(createStringError(
+            inconvertibleErrorCode(),
+            "Only SPIR/SPIRV JIT targets supported for SYCL offload"));
       // Link the remaining device files using the device linker for SYCL
       // offload.
       auto TmpOutputOrErr = sycl::linkDevice(InputFiles, LinkerArgs);


### PR DESCRIPTION
This is a draft PR for testing purposes. Please do not review. Thanks

We are planning to turn on --offload-new-driver option by default very soon. We have currently added support for JIT compilation flow for SYCL offloading. AOT compilation flow for Intel and third-party hardware will be added soon. FPGA support will be added at a later stage.

Thanks