### PR TITLE
[Driver][SYCL][NewOffloadModel] Improve arch association for device

### DIFF
--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -83,3 +83,26 @@
 // RUN:          -shared %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHECK_SHARED %s
 // CHECK_SHARED: clang-linker-wrapper{{.*}} "-shared"
+
+// Verify 'arch' offload-packager values for known targets
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fsycl-targets=spir64 --offload-new-driver %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK_ARCH \
+// RUN:              -DTRIPLE=spir64-unknown-unknown -DARCH= %s
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fsycl-targets=intel_gpu_pvc --offload-new-driver %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK_ARCH \
+// RUN:              -DTRIPLE=spir64_gen-unknown-unknown -DARCH=pvc %s
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fno-sycl-libspirv -fsycl-targets=amd_gpu_gfx900 \
+// RUN:          -nogpulib --offload-new-driver %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK_ARCH \
+// RUN:              -DTRIPLE=amdgcn-amd-amdhsa -DARCH=gfx900 %s
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fno-sycl-libspirv -fsycl-targets=nvidia_gpu_sm_50 \
+// RUN:          -nogpulib --offload-new-driver %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK_ARCH \
+// RUN:              -DTRIPLE=nvptx64-nvidia-cuda -DARCH=sm_50 %s
+// CHK_ARCH: clang{{.*}} "-triple" "[[TRIPLE]]"
+// CHK_ARCH-SAME: "-fsycl-is-device" {{.*}} "--offload-new-driver"{{.*}} "-o" "[[CC1DEVOUT:.+\.bc]]"
+// CHK_ARCH-NEXT: clang-offload-packager{{.*}} "--image=file=[[CC1DEVOUT]],triple=[[TRIPLE]],arch=[[ARCH]],kind=sycl"


### PR DESCRIPTION
When using the new offloading model, the values being passed to -fsycl-targets were not fully being realized when attempting to target specific architectures.  Uses of -fsycl-targets=intel_gpu_* were not properly setting the arch values that are used down the line (namely the packaging step).

Improve this situation by populating the assocated architecture mappings with what is seen when parsing the -fsycl-targets option.  This applies to all intel_gpu, nvidia_gpu and amd_gpu targets.