### PR TITLE
[SYCL] Remove `sycl::errc_for`

### DIFF
--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -59,10 +59,6 @@ namespace sycl {
 inline namespace _V1 {
 
 namespace detail {
-// TODO each backend can have its own custom errc enumeration
-// but the details for this are not fully specified yet
-enum class backend_errc : unsigned int {};
-
 // Convert from PI backend to SYCL backend enum
 backend convertBackend(pi_platform_backend PiBackend);
 } // namespace detail
@@ -74,8 +70,6 @@ public:
 
   template <class T>
   using return_type = typename detail::BackendReturn<Backend, T>::type;
-
-  using errc = detail::backend_errc;
 };
 
 template <backend Backend, typename SyclType>

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -10,7 +10,6 @@
 
 // 4.9.2 Exception Class Interface
 
-#include <sycl/backend_types.hpp>             // for backend
 #include <sycl/detail/cl.h>                   // for cl_int
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
@@ -48,8 +47,6 @@ enum class errc : unsigned int {
   kernel_not_supported = 13,
   backend_mismatch = 14,
 };
-
-template <backend B> using errc_for = typename backend_traits<B>::errc;
 
 /// Constructs an error code using e and sycl_category()
 __SYCL_EXPORT std::error_code make_error_code(sycl::errc E) noexcept;

--- a/sycl/test-e2e/Basic/exceptions-SYCL-2020.cpp
+++ b/sycl/test-e2e/Basic/exceptions-SYCL-2020.cpp
@@ -80,23 +80,6 @@ int main() {
   static_assert(!std::is_error_condition_enum<sycl::errc>::value,
                 "errc enum should not identify as error condition");
 
-  // Test errc_for and backends. Should compile without complaint.
-  constexpr int EC = 1;
-  sycl::backend_traits<sycl::backend::opencl>::errc someOpenCLErrCode{EC};
-  sycl::errc_for<sycl::backend::opencl> anotherOpenCLErrCode{EC};
-  assert(someOpenCLErrCode == anotherOpenCLErrCode);
-  sycl::backend_traits<sycl::backend::ext_oneapi_level_zero>::errc
-      someL0ErrCode{EC};
-  sycl::errc_for<sycl::backend::ext_oneapi_level_zero> anotherL0ErrCode{EC};
-  assert(someL0ErrCode == anotherL0ErrCode);
-  sycl::backend_traits<sycl::backend::ext_oneapi_cuda>::errc someCUDAErrCode{
-      EC};
-  sycl::errc_for<sycl::backend::ext_oneapi_cuda> anotherCUDAErrCode{EC};
-  assert(someCUDAErrCode == anotherCUDAErrCode);
-  sycl::backend_traits<sycl::backend::ext_oneapi_hip>::errc someHIPErrCode{EC};
-  sycl::errc_for<sycl::backend::ext_oneapi_hip> anotherHIPErrCode{EC};
-  assert(someHIPErrCode == anotherHIPErrCode);
-
   std::cout << "OK" << std::endl;
   return 0;
 }


### PR DESCRIPTION
It had been removed from the specification in
https://github.com/KhronosGroup/SYCL-Docs/pull/431. Originally introduced in https://github.com/intel/llvm/pull/4298 the implementation has never been completed, so, while technically a breaking change, no customer code can be really using it.