### PR TITLE
[SYCL] Move `codeToString` `common.hpp` -> `exception.hpp`

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -148,13 +148,6 @@ private:
   bool MLocalScope = true;
 };
 
-__SYCL_EXPORT const char *stringifyErrorCode(pi_int32 error);
-
-inline std::string codeToString(pi_int32 code) {
-  return std::string(std::to_string(code) + " (" + stringifyErrorCode(code) +
-                     ")");
-}
-
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -12,7 +12,6 @@
 
 #include <sycl/backend_types.hpp>             // for backend
 #include <sycl/detail/cl.h>                   // for cl_int
-#include <sycl/detail/common.hpp>             // for codeToString
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
 #include <sycl/detail/pi.h>                   // for pi_int32
@@ -58,6 +57,13 @@ __SYCL_EXPORT std::error_code make_error_code(sycl::errc E) noexcept;
 __SYCL_EXPORT const std::error_category &sycl_category() noexcept;
 
 namespace detail {
+__SYCL_EXPORT const char *stringifyErrorCode(pi_int32 error);
+
+inline std::string codeToString(pi_int32 code) {
+  return std::string(std::to_string(code) + " (" + stringifyErrorCode(code) +
+                     ")");
+}
+
 class __SYCL_EXPORT SYCLCategory : public std::error_category {
 public:
   const char *name() const noexcept override { return "sycl"; }

--- a/sycl/source/detail/common.cpp
+++ b/sycl/source/detail/common.cpp
@@ -53,22 +53,6 @@ tls_code_loc_t::~tls_code_loc_t() {
 
 const detail::code_location &tls_code_loc_t::query() { return GCodeLocTLS; }
 
-const char *stringifyErrorCode(pi_int32 error) {
-  switch (error) {
-#define _PI_ERRC(NAME, VAL)                                                    \
-  case NAME:                                                                   \
-    return #NAME;
-#define _PI_ERRC_WITH_MSG(NAME, VAL, MSG)                                      \
-  case NAME:                                                                   \
-    return MSG;
-#include <sycl/detail/pi_error.def>
-#undef _PI_ERRC
-#undef _PI_ERRC_WITH_MSG
-
-  default:
-    return "Unknown error code";
-  }
-}
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/exception.cpp
+++ b/sycl/source/exception.cpp
@@ -94,5 +94,24 @@ std::error_code make_error_code(sycl::errc Err) noexcept {
   return {static_cast<int>(Err), sycl_category()};
 }
 
+namespace detail {
+const char *stringifyErrorCode(pi_int32 error) {
+  switch (error) {
+#define _PI_ERRC(NAME, VAL)                                                    \
+  case NAME:                                                                   \
+    return #NAME;
+#define _PI_ERRC_WITH_MSG(NAME, VAL, MSG)                                      \
+  case NAME:                                                                   \
+    return MSG;
+#include <sycl/detail/pi_error.def>
+#undef _PI_ERRC
+#undef _PI_ERRC_WITH_MSG
+
+  default:
+    return "Unknown error code";
+  }
+}
+} // namespace detail
+
 } // namespace _V1
 } // namespace sycl

--- a/sycl/source/spirv_ops.cpp
+++ b/sycl/source/spirv_ops.cpp
@@ -8,6 +8,7 @@
 
 #include <CL/__spirv/spirv_ops.hpp>
 #include <detail/platform_util.hpp>
+#include <sycl/detail/iostream_proxy.hpp>
 #include <sycl/exception.hpp>
 
 #include <atomic>


### PR DESCRIPTION
That is its only use inside includes with others under `source/`. Breaks cyclical include dependency between those headers.