### PR TITLE
[SYCL] Remove `*SUPPRESS*` macros and move some others to `source/`

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -165,75 +165,7 @@ private:
   /* ":" __SYCL_STRINGIFY(__LINE__) ": " */                                    \
                           "Native API returns: "
 
-#ifndef __SYCL_SUPPRESS_PI_ERROR_REPORT
-#include <sycl/detail/iostream_proxy.hpp>
-// TODO: rename all names with direct use of OCL/OPENCL to be backend agnostic.
-#define __SYCL_REPORT_PI_ERR_TO_STREAM(expr)                                   \
-  {                                                                            \
-    auto code = expr;                                                          \
-    if (code != PI_SUCCESS) {                                                  \
-      std::cerr << __SYCL_PI_ERROR_REPORT << sycl::detail::codeToString(code)  \
-                << std::endl;                                                  \
-    }                                                                          \
-  }
-#endif
-
-#ifndef SYCL_SUPPRESS_EXCEPTIONS
 #include <sycl/exception.hpp>
-// SYCL 1.2.1 exceptions
-#define __SYCL_REPORT_PI_ERR_TO_EXC(expr, exc, str)                            \
-  {                                                                            \
-    auto code = expr;                                                          \
-    if (code != PI_SUCCESS) {                                                  \
-      std::string err_str =                                                    \
-          str ? "\n" + std::string(str) + "\n" : std::string{};                \
-      throw exc(__SYCL_PI_ERROR_REPORT + sycl::detail::codeToString(code) +    \
-                    err_str,                                                   \
-                code);                                                         \
-    }                                                                          \
-  }
-#define __SYCL_REPORT_PI_ERR_TO_EXC_THROW(code, exc, str)                      \
-  __SYCL_REPORT_PI_ERR_TO_EXC(code, exc, str)
-#define __SYCL_REPORT_PI_ERR_TO_EXC_BASE(code)                                 \
-  __SYCL_REPORT_PI_ERR_TO_EXC(code, sycl::runtime_error, nullptr)
-#else
-#define __SYCL_REPORT_PI_ERR_TO_EXC_BASE(code)                                 \
-  __SYCL_REPORT_PI_ERR_TO_STREAM(code)
-#endif
-// SYCL 2020 exceptions
-#define __SYCL_REPORT_ERR_TO_EXC_VIA_ERRC(expr, errc)                          \
-  {                                                                            \
-    auto code = expr;                                                          \
-    if (code != PI_SUCCESS) {                                                  \
-      throw sycl::exception(sycl::make_error_code(errc),                       \
-                            __SYCL_PI_ERROR_REPORT +                           \
-                                sycl::detail::codeToString(code));             \
-    }                                                                          \
-  }
-#define __SYCL_REPORT_ERR_TO_EXC_THROW_VIA_ERRC(code, errc)                    \
-  __SYCL_REPORT_ERR_TO_EXC_VIA_ERRC(code, errc)
-
-#ifdef __SYCL_SUPPRESS_PI_ERROR_REPORT
-// SYCL 1.2.1 exceptions
-#define __SYCL_CHECK_OCL_CODE(X) (void)(X)
-#define __SYCL_CHECK_OCL_CODE_THROW(X, EXC, STR)                               \
-  {                                                                            \
-    (void)(X);                                                                 \
-    (void)(STR);                                                               \
-  }
-#define __SYCL_CHECK_OCL_CODE_NO_EXC(X) (void)(X)
-// SYCL 2020 exceptions
-#define __SYCL_CHECK_CODE_THROW_VIA_ERRC(X, ERRC) (void)(X)
-#else
-// SYCL 1.2.1 exceptions
-#define __SYCL_CHECK_OCL_CODE(X) __SYCL_REPORT_PI_ERR_TO_EXC_BASE(X)
-#define __SYCL_CHECK_OCL_CODE_THROW(X, EXC, STR)                               \
-  __SYCL_REPORT_PI_ERR_TO_EXC_THROW(X, EXC, STR)
-#define __SYCL_CHECK_OCL_CODE_NO_EXC(X) __SYCL_REPORT_PI_ERR_TO_STREAM(X)
-// SYCL 2020 exceptions
-#define __SYCL_CHECK_CODE_THROW_VIA_ERRC(X, ERRC)                              \
-  __SYCL_REPORT_ERR_TO_EXC_THROW_VIA_ERRC(X, ERRC)
-#endif
 
 // Helper for enabling empty-base optimizations on MSVC.
 // TODO: Remove this when MSVC has this optimization enabled by default.

--- a/sycl/source/detail/device_binary_image.hpp
+++ b/sycl/source/detail/device_binary_image.hpp
@@ -11,6 +11,8 @@
 #include <sycl/detail/os_util.hpp>
 #include <sycl/detail/pi.hpp>
 
+#include <sycl/detail/iostream_proxy.hpp>
+
 #include <atomic>
 #include <cstring>
 #include <memory>

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -21,6 +21,46 @@
 #include "xpti/xpti_trace_framework.h"
 #endif
 
+#include <sycl/detail/iostream_proxy.hpp>
+
+#define __SYCL_REPORT_PI_ERR_TO_STREAM(expr)                                   \
+  {                                                                            \
+    auto code = expr;                                                          \
+    if (code != PI_SUCCESS) {                                                  \
+      std::cerr << __SYCL_PI_ERROR_REPORT << sycl::detail::codeToString(code)  \
+                << std::endl;                                                  \
+    }                                                                          \
+  }
+
+#define __SYCL_REPORT_PI_ERR_TO_EXC(expr, exc, str)                            \
+  {                                                                            \
+    auto code = expr;                                                          \
+    if (code != PI_SUCCESS) {                                                  \
+      std::string err_str =                                                    \
+          str ? "\n" + std::string(str) + "\n" : std::string{};                \
+      throw exc(__SYCL_PI_ERROR_REPORT + sycl::detail::codeToString(code) +    \
+                    err_str,                                                   \
+                code);                                                         \
+    }                                                                          \
+  }
+
+#define __SYCL_REPORT_ERR_TO_EXC_VIA_ERRC(expr, errc)                          \
+  {                                                                            \
+    auto code = expr;                                                          \
+    if (code != PI_SUCCESS) {                                                  \
+      throw sycl::exception(sycl::make_error_code(errc),                       \
+                            __SYCL_PI_ERROR_REPORT +                           \
+                                sycl::detail::codeToString(code));             \
+    }                                                                          \
+  }
+
+#define __SYCL_CHECK_OCL_CODE_THROW(X, EXC, STR)                               \
+  __SYCL_REPORT_PI_ERR_TO_EXC(X, EXC, STR)
+#define __SYCL_CHECK_OCL_CODE_NO_EXC(X) __SYCL_REPORT_PI_ERR_TO_STREAM(X)
+
+#define __SYCL_CHECK_CODE_THROW_VIA_ERRC(X, ERRC)                              \
+  __SYCL_REPORT_ERR_TO_EXC_VIA_ERRC(X, ERRC)
+
 namespace sycl {
 inline namespace _V1 {
 namespace detail {

--- a/sycl/test/include_deps/sycl_buffer.hpp.cpp
+++ b/sycl/test/include_deps/sycl_buffer.hpp.cpp
@@ -35,7 +35,6 @@
 // CHECK-NEXT: CL/cl_platform.h
 // CHECK-NEXT: CL/cl_ext.h
 // CHECK-NEXT: detail/common.hpp
-// CHECK-NEXT: detail/iostream_proxy.hpp
 // CHECK-NEXT: range.hpp
 // CHECK-NEXT: info/info_desc.hpp
 // CHECK-NEXT: detail/type_traits.hpp
@@ -75,6 +74,7 @@
 // CHECK-NEXT: aliases.hpp
 // CHECK-NEXT: half_type.hpp
 // CHECK-NEXT: bit_cast.hpp
+// CHECK-NEXT: detail/iostream_proxy.hpp
 // CHECK-NEXT: detail/vector_traits.hpp
 // CHECK-NEXT: ext/oneapi/matrix/matrix-unified-utils.hpp
 // CHECK-NEXT: info/platform_traits.def


### PR DESCRIPTION
The ones being removed had no documentation nor known uses.