### PR TITLE
[Driver][SYCL] Allow for SYCL defaultlibs to be added with clang-cl

### DIFF
--- a/clang/lib/Driver/ToolChains/MSVC.cpp
+++ b/clang/lib/Driver/ToolChains/MSVC.cpp
@@ -135,14 +135,15 @@ void visualstudio::Linker::ConstructJob(Compilation &C, const JobAction &JA,
     CmdArgs.push_back("-defaultlib:oldnames");
   }
 
-  if ((!C.getDriver().IsCLMode() && Args.hasArg(options::OPT_fsycl) &&
+  if ((Args.hasArg(options::OPT_fsycl) &&
        !Args.hasArg(options::OPT_nolibsycl)) ||
       Args.hasArg(options::OPT_fsycl_host_compiler_EQ)) {
     CmdArgs.push_back(Args.MakeArgString(std::string("-libpath:") +
                                          TC.getDriver().Dir + "/../lib"));
     // When msvcrtd is added via --dependent-lib, we add the sycld
     // equivalent.  Do not add the -defaultlib as it conflicts.
-    if (!isDependentLibAdded(Args, "msvcrtd")) {
+    if (!isDependentLibAdded(Args, "msvcrtd") &&
+        !Args.hasArg(options::OPT__SLASH_MDd)) {
       if (Args.hasArg(options::OPT_fpreview_breaking_changes))
         CmdArgs.push_back("-defaultlib:sycl" SYCL_MAJOR_VERSION "-preview.lib");
       else

--- a/clang/test/Driver/sycl-device-lib-win.cpp
+++ b/clang/test/Driver/sycl-device-lib-win.cpp
@@ -189,3 +189,4 @@
 // RUN: %clang_cl -fsycl %s /winsysroot=%S/Inputs/SYCL -### 2>&1 \
 // RUN:   | FileCheck %s -check-prefix=SYCL_DEVICE_HOST_LIB
 // SYCL_DEVICE_HOST_LIB: {{.*}} "--dependent-lib=sycl-devicelib-host" {{.*}}
+// SYCL_DEVICE_HOST_LIB: link{{.*}} "-defaultlib:sycl-devicelib-host.lib"

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -484,9 +484,9 @@
 
 /// Check for default linking of syclN.lib with -fsycl usage
 // RUN: %clang -fsycl -target x86_64-unknown-windows-msvc %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL %s
-// RUN: %clang_cl -fsycl %s -o %t -### 2>&1 | FileCheck -check-prefix=CHECK-LINK-SYCL-CL %s
+// RUN: %clang_cl -fsycl %s -o %t -### 2>&1 \
+// RUN:  | FileCheck -check-prefixes=CHECK-LINK-SYCL-CL,CHECK-LINK-SYCL %s
 // CHECK-LINK-SYCL-CL: "--dependent-lib=sycl{{[0-9]*}}"
-// CHECK-LINK-SYCL-CL-NOT: "-defaultlib:sycl{{[0-9]*}}.lib"
 // CHECK-LINK-SYCL: "-defaultlib:sycl{{[0-9]*}}.lib"
 
 /// Check no SYCL runtime is linked with -nolibsycl


### PR DESCRIPTION
We were restricting the SYCL defaultlibs from being added to the link command line when using clang-cl, even when -fsycl is added on the command line.  Allow for these to be added to the link, as -fsycl implies the need for them.