### PR TITLE
[SYCL] Initial changes for the second version of sycl_ext_oneapi_group_sort extension

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
@@ -48,7 +48,7 @@ public:
   sycl::span<std::byte, Extent> get_memory() const { return scratch; }
 };
 
-// ---- sorters
+// Default sorter provided by the first version of the extension specification.
 template <typename Compare = std::less<>> class default_sorter {
   Compare comp;
   sycl::span<std::byte> scratch;
@@ -156,6 +156,7 @@ template <typename T> struct ConvertToComp<T, sorting_order::descending> {
 };
 } // namespace detail
 
+// Radix sorter provided by the first version of the extension specification.
 template <typename ValT, sorting_order OrderT = sorting_order::ascending,
           unsigned int BitsPerPass = 4>
 class radix_sorter {
@@ -232,6 +233,229 @@ public:
                       local_range.size() * (1 << bits) * sizeof(uint32_t));
   }
 };
+
+// Default sorters provided by the second version of the extension
+// specification.
+namespace default_sorters {
+
+template <typename CompareT = std::less<>> class joint_sorter {
+  CompareT comp;
+  sycl::span<std::byte> scratch;
+
+public:
+  template <size_t Extent>
+  joint_sorter(sycl::span<std::byte, Extent> scratch_,
+               CompareT comp_ = CompareT())
+      : comp(comp_), scratch(scratch_) {}
+
+  template <typename Group, typename Ptr>
+  void operator()([[maybe_unused]] Group g, [[maybe_unused]] Ptr first,
+                  [[maybe_unused]] Ptr last) {
+#ifdef __SYCL_DEVICE_ONLY__
+    // Adjust the scratch pointer based on alignment of the type T.
+    // Per extension specification if scratch size is less than the value
+    // returned by memory_required then behavior is undefined, so we don't check
+    // that the scratch size statisfies the requirement.
+    using T = typename sycl::detail::GetValueType<Ptr>::type;
+    T *scratch_begin = nullptr;
+    size_t n = last - first;
+    // We must have a barrier here before array placement new because it is
+    // possible that scratch memory is already in use, so we need to synchronize
+    // work items.
+    sycl::group_barrier(g);
+    if (g.leader()) {
+      void *scratch_ptr = scratch.data();
+      size_t space = scratch.size();
+      scratch_ptr = std::align(alignof(T), n * sizeof(T), scratch_ptr, space);
+      scratch_begin = ::new (scratch_ptr) T[n];
+    }
+    // Broadcast leader's pointer (the beginning of the scratch) to all work
+    // items in the group.
+    scratch_begin = sycl::group_broadcast(g, scratch_begin);
+    sycl::detail::merge_sort(g, first, n, comp, scratch_begin);
+#else
+    throw sycl::exception(
+        std::error_code(PI_ERROR_INVALID_DEVICE, sycl::sycl_category()),
+        "default_sorter constructor is not supported on host device.");
+#endif
+  }
+
+  template <typename T>
+  static constexpr size_t memory_required(sycl::memory_scope,
+                                          size_t range_size) {
+    return range_size * sizeof(T) + alignof(T);
+  }
+};
+
+template <typename T, typename CompareT = std::less<>,
+          std::size_t ElementsPerWorkItem = 1>
+class group_sorter {
+  CompareT comp;
+  sycl::span<std::byte> scratch;
+
+public:
+  template <std::size_t Extent>
+  group_sorter(sycl::span<std::byte, Extent> scratch_,
+               CompareT comp_ = CompareT{})
+      : comp(comp_), scratch(scratch_) {}
+
+  template <typename Group> T operator()([[maybe_unused]] Group g, T val) {
+#ifdef __SYCL_DEVICE_ONLY__
+    // Adjust the scratch pointer based on alignment of the type T.
+    // Per extension specification if scratch size is less than the value
+    // returned by memory_required then behavior is undefined, so we don't check
+    // that the scratch size statisfies the requirement.
+    T *scratch_begin = nullptr;
+    std::size_t local_id = g.get_local_linear_id();
+    auto range_size = g.get_local_range().size();
+    // We must have a barrier here before array placement new because it is
+    // possible that scratch memory is already in use, so we need to synchronize
+    // work items.
+    sycl::group_barrier(g);
+    if (g.leader()) {
+      void *scratch_ptr = scratch.data();
+      size_t space = scratch.size();
+      scratch_ptr =
+          std::align(alignof(T), /* output storage and temporary storage */ 2 *
+                                     range_size * sizeof(T),
+                     scratch_ptr, space);
+      scratch_begin = ::new (scratch_ptr) T[2 * range_size];
+    }
+    // Broadcast leader's pointer (the beginning of the scratch) to all work
+    // items in the group.
+    scratch_begin = sycl::group_broadcast(g, scratch_begin);
+    scratch_begin[local_id] = val;
+    sycl::detail::merge_sort(g, scratch_begin, range_size, comp,
+                             scratch_begin + range_size);
+    val = scratch_begin[local_id];
+#else
+    throw sycl::exception(
+        std::error_code(PI_ERROR_INVALID_DEVICE, sycl::sycl_category()),
+        "default_sorter operator() is not supported on host device.");
+#endif
+    return val;
+  }
+
+  static constexpr std::size_t memory_required(sycl::memory_scope scope,
+                                               size_t range_size) {
+    return 2 * joint_sorter<>::template memory_required<T>(
+                   scope, range_size * ElementsPerWorkItem);
+  }
+};
+
+} // namespace default_sorters
+
+// Radix sorters provided by the second version of the extension specification.
+namespace radix_sorters {
+
+template <typename ValT, sorting_order OrderT = sorting_order::ascending,
+          unsigned int BitsPerPass = 4>
+class joint_sorter {
+
+  sycl::span<std::byte> scratch;
+  uint32_t first_bit = 0;
+  uint32_t last_bit = 0;
+
+  static constexpr uint32_t bits = BitsPerPass;
+  using bitset_t = std::bitset<sizeof(ValT) * CHAR_BIT>;
+
+public:
+  template <std::size_t Extent>
+  joint_sorter(sycl::span<std::byte, Extent> scratch_,
+               const bitset_t mask = bitset_t{}.set())
+      : scratch(scratch_) {
+    static_assert((std::is_arithmetic<ValT>::value ||
+                   std::is_same<ValT, sycl::half>::value ||
+                   std::is_same<ValT, sycl::ext::oneapi::bfloat16>::value),
+                  "radix sort is not supported for the given type");
+
+    for (first_bit = 0; first_bit < mask.size() && !mask[first_bit];
+         ++first_bit)
+      ;
+    for (last_bit = first_bit; last_bit < mask.size() && mask[last_bit];
+         ++last_bit)
+      ;
+  }
+
+  template <typename GroupT, typename PtrT>
+  void operator()([[maybe_unused]] GroupT g, [[maybe_unused]] PtrT first,
+                  [[maybe_unused]] PtrT last) {
+#ifdef __SYCL_DEVICE_ONLY__
+    sycl::detail::privateDynamicSort</*is_key_value=*/false,
+                                     OrderT == sorting_order::ascending,
+                                     /*empty*/ 1, BitsPerPass>(
+        g, first, /*empty*/ first, last - first, scratch.data(), first_bit,
+        last_bit);
+#else
+    throw sycl::exception(
+        std::error_code(PI_ERROR_INVALID_DEVICE, sycl::sycl_category()),
+        "radix_sorter is not supported on host device.");
+#endif
+  }
+
+  static constexpr std::size_t
+  memory_required([[maybe_unused]] sycl::memory_scope scope,
+                  std::size_t range_size) {
+    return range_size * sizeof(ValT) +
+           (1 << bits) * range_size * sizeof(uint32_t) + alignof(uint32_t);
+  }
+};
+
+template <typename ValT, sorting_order OrderT = sorting_order::ascending,
+          size_t ElementsPerWorkItem = 1, unsigned int BitsPerPass = 4>
+class group_sorter {
+
+  sycl::span<std::byte> scratch;
+  uint32_t first_bit = 0;
+  uint32_t last_bit = 0;
+
+  static constexpr uint32_t bits = BitsPerPass;
+  using bitset_t = std::bitset<sizeof(ValT) * CHAR_BIT>;
+
+public:
+  template <std::size_t Extent>
+  group_sorter(sycl::span<std::byte, Extent> scratch_,
+               const bitset_t mask = bitset_t{}.set())
+      : scratch(scratch_) {
+    static_assert((std::is_arithmetic<ValT>::value ||
+                   std::is_same<ValT, sycl::half>::value ||
+                   std::is_same<ValT, sycl::ext::oneapi::bfloat16>::value),
+                  "radix sort is not usable");
+
+    for (first_bit = 0; first_bit < mask.size() && !mask[first_bit];
+         ++first_bit)
+      ;
+    for (last_bit = first_bit; last_bit < mask.size() && mask[last_bit];
+         ++last_bit)
+      ;
+  }
+
+  template <typename GroupT>
+  ValT operator()([[maybe_unused]] GroupT g, [[maybe_unused]] ValT val) {
+#ifdef __SYCL_DEVICE_ONLY__
+    ValT result[]{val};
+    sycl::detail::privateStaticSort</*is_key_value=*/false,
+                                    /*is_blocked=*/true,
+                                    OrderT == sorting_order::ascending,
+                                    /*items_per_work_item=*/1, bits>(
+        g, result, /*empty*/ result, scratch.data(), first_bit, last_bit);
+    return result[0];
+#else
+    throw sycl::exception(
+        std::error_code(PI_ERROR_INVALID_DEVICE, sycl::sycl_category()),
+        "radix_sorter is not supported on host device.");
+#endif
+  }
+
+  static constexpr size_t
+  memory_required([[maybe_unused]] sycl::memory_scope scope,
+                  size_t range_size) {
+    return (std::max)(range_size * sizeof(ValT),
+                      range_size * (1 << bits) * sizeof(uint32_t));
+  }
+};
+
+} // namespace radix_sorters
 
 } // namespace ext::oneapi::experimental
 } // namespace _V1

--- a/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
@@ -90,7 +90,7 @@ sort_over_group(experimental::group_with_scratchpad<Group, Extent> exec,
                 T value, Compare comp) {
   return sort_over_group(
       exec.get_group(), value,
-      experimental::default_sorter<Compare>(exec.get_memory(), comp));
+      default_sorters::group_sorter<T, Compare, 1>(exec.get_memory(), comp));
 }
 
 template <typename Group, typename T, size_t Extent>
@@ -98,7 +98,7 @@ std::enable_if_t<sycl::is_group_v<std::decay_t<Group>>, T>
 sort_over_group(experimental::group_with_scratchpad<Group, Extent> exec,
                 T value) {
   return sort_over_group(exec.get_group(), value,
-                         experimental::default_sorter<>(exec.get_memory()));
+                         default_sorters::group_sorter<T>(exec.get_memory()));
 }
 
 // ---- joint_sort
@@ -120,7 +120,7 @@ std::enable_if_t<!detail::is_sorter<Compare, Group, Iter>::value, void>
 joint_sort(experimental::group_with_scratchpad<Group, Extent> exec, Iter first,
            Iter last, Compare comp) {
   joint_sort(exec.get_group(), first, last,
-             experimental::default_sorter<Compare>(exec.get_memory(), comp));
+             default_sorters::joint_sorter<Compare>(exec.get_memory(), comp));
 }
 
 template <typename Group, typename Iter, size_t Extent>
@@ -128,7 +128,7 @@ std::enable_if_t<sycl::is_group_v<std::decay_t<Group>>, void>
 joint_sort(experimental::group_with_scratchpad<Group, Extent> exec, Iter first,
            Iter last) {
   joint_sort(exec.get_group(), first, last,
-             experimental::default_sorter<>(exec.get_memory()));
+             default_sorters::joint_sorter<>(exec.get_memory()));
 }
 
 } // namespace ext::oneapi::experimental

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: sg-8
-// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
-// RUN: %{run} %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -DVERSION=1 -o %t1.out
+// RUN: %{run} %t1.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -DVERSION=2 -o %t2.out
+// RUN: %{run} %t2.out
 // UNSUPPORTED: accelerator
 
 // The test verifies sort API extension.
@@ -61,6 +63,7 @@ private:
   size_t MVal = 0;
 };
 
+#if VERSION == 1
 template <class CompT, class T> struct RadixSorterType;
 
 template <class T> struct RadixSorterType<std::greater<T>, T> {
@@ -83,6 +86,26 @@ template <> struct RadixSorterType<std::greater<CustomType>, CustomType> {
   using Type =
       oneapi_exp::radix_sorter<int, oneapi_exp::sorting_order::descending>;
 };
+#else
+template <class T> struct ConvertToSimpleType {
+  using Type = T;
+};
+
+// Dummy overloads for CustomType which is not supported by radix sorter
+template <> struct ConvertToSimpleType<CustomType> {
+  using Type = int;
+};
+
+template <class SorterT> struct ConvertToSortingOrder;
+
+template <class T> struct ConvertToSortingOrder<std::greater<T>> {
+  static const auto Type = oneapi_exp::sorting_order::descending;
+};
+
+template <class T> struct ConvertToSortingOrder<std::less<T>> {
+  static const auto Type = oneapi_exp::sorting_order::ascending;
+};
+#endif
 
 constexpr size_t ReqSubGroupSize = 8;
 
@@ -97,22 +120,40 @@ void RunJointSort(sycl::queue &Q, const std::vector<T> &DataToSort,
 
   constexpr size_t NumSubGroups = WGSize / ReqSubGroupSize;
 
+#if VERSION == 1
   using RadixSorterT = typename RadixSorterType<Compare, T>::Type;
+#else
+  using RadixSorterT = oneapi_exp::radix_sorters::joint_sorter<
+      typename ConvertToSimpleType<T>::Type,
+      ConvertToSortingOrder<Compare>::Type>;
+#endif
 
   std::size_t LocalMemorySizeDefault = 0;
   std::size_t LocalMemorySizeRadix = 0;
   if (UseGroup == UseGroupT::SubGroup) {
     // Each sub-group needs a piece of memory for sorting
+#if VERSION == 1
     LocalMemorySizeDefault =
         oneapi_exp::default_sorter<Compare>::template memory_required<T>(
             sycl::memory_scope::sub_group, ReqSubGroupSize * ElemsPerWI);
+#else
+    LocalMemorySizeDefault = oneapi_exp::default_sorters::joint_sorter<
+        Compare>::template memory_required<T>(sycl::memory_scope::sub_group,
+                                              ReqSubGroupSize * ElemsPerWI);
+#endif
     LocalMemorySizeRadix = RadixSorterT::memory_required(
         sycl::memory_scope::sub_group, ReqSubGroupSize * ElemsPerWI);
   } else {
     // A single chunk of memory for each work-group
+#if VERSION == 1
     LocalMemorySizeDefault =
         oneapi_exp::default_sorter<Compare>::template memory_required<T>(
             sycl::memory_scope::work_group, WGSize * ElemsPerWI);
+#else
+    LocalMemorySizeDefault = oneapi_exp::default_sorters::joint_sorter<
+        Compare>::template memory_required<T>(sycl::memory_scope::work_group,
+                                              WGSize * ElemsPerWI);
+#endif
     LocalMemorySizeRadix = RadixSorterT::memory_required(
         sycl::memory_scope::sub_group, WGSize * ElemsPerWI);
   }
@@ -206,8 +247,13 @@ void RunJointSort(sycl::queue &Q, const std::vector<T> &DataToSort,
 
              oneapi_exp::joint_sort(
                  Group, &AccToSort2[StartIdx], &AccToSort2[EndIdx],
+#if VERSION == 1
                  oneapi_exp::default_sorter<Compare>(sycl::span{
                      &ScratchDefault[LocalPartID], LocalMemorySizeDefault}));
+#else
+                 oneapi_exp::default_sorters::joint_sorter<Compare>(sycl::span{
+                     &ScratchDefault[LocalPartID], LocalMemorySizeDefault}));
+#endif
 
              const size_t LocalPartIDRadix =
                  UseGroup == UseGroupT::SubGroup
@@ -266,26 +312,54 @@ void RunSortOVerGroup(sycl::queue &Q, const std::vector<T> &DataToSort,
                   "Only one and two dimensional kernels are supported");
   }();
 
+#if VERSION == 1
   using RadixSorterT = typename RadixSorterType<Compare, T>::Type;
+#else
+  using RadixSorterT = oneapi_exp::radix_sorters::group_sorter<
+      typename ConvertToSimpleType<T>::Type,
+      ConvertToSortingOrder<Compare>::Type>;
+#endif
 
   std::size_t LocalMemorySizeDefault = 0;
   std::size_t LocalMemorySizeRadix = 0;
   if (UseGroup == UseGroupT::SubGroup) {
     // Each sub-group needs a piece of memory for sorting
+#if VERSION == 1
     LocalMemorySizeDefault =
         oneapi_exp::default_sorter<Compare>::template memory_required<T>(
             sycl::memory_scope::sub_group, sycl::range<1>{ReqSubGroupSize});
+#else
+    LocalMemorySizeDefault = oneapi_exp::default_sorters::group_sorter<
+        T, Compare, 1>::memory_required(sycl::memory_scope::sub_group,
+                                        ReqSubGroupSize);
+#endif
 
+#if VERSION == 1
     LocalMemorySizeRadix = RadixSorterT::template memory_required(
         sycl::memory_scope::sub_group, sycl::range<1>{ReqSubGroupSize});
+#else
+    LocalMemorySizeRadix = RadixSorterT::memory_required(
+        sycl::memory_scope::sub_group, ReqSubGroupSize);
+#endif
   } else {
     // A single chunk of memory for each work-group
+#if VERSION == 1
     LocalMemorySizeDefault =
         oneapi_exp::default_sorter<Compare>::template memory_required<T>(
             sycl::memory_scope::work_group, sycl::range<1>{NumOfElements});
+#else
+    LocalMemorySizeDefault = oneapi_exp::default_sorters::group_sorter<
+        T, Compare, 1>::memory_required(sycl::memory_scope::work_group,
+                                        NumOfElements);
+#endif
 
+#if VERSION == 1
     LocalMemorySizeRadix = RadixSorterT::template memory_required(
         sycl::memory_scope::work_group, sycl::range<1>{NumOfElements});
+#else
+    LocalMemorySizeRadix = RadixSorterT::memory_required(
+        sycl::memory_scope::work_group, NumOfElements);
+#endif
   }
 
   std::vector<T> DataToSortCase0 = DataToSort;
@@ -358,8 +432,13 @@ void RunSortOVerGroup(sycl::queue &Q, const std::vector<T> &DataToSort,
 
              AccToSort2[GlobalLinearID] = oneapi_exp::sort_over_group(
                  Group, AccToSort2[GlobalLinearID],
+#if VERSION == 1
                  oneapi_exp::default_sorter<Compare>(
                      sycl::span{ScratchPtrDefault, LocalMemorySizeDefault}));
+#else
+                 oneapi_exp::default_sorters::group_sorter<T, Compare, 1>(
+                     sycl::span{ScratchPtrDefault, LocalMemorySizeDefault}));
+#endif
 
              // Each sub-group should use it's own part of the scratch pad
              const size_t ScratchShiftRadix =


### PR DESCRIPTION
Current implementation is aligned with the first version of the extension: https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_group_sort.asciidoc

This second version of the extension:
https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_group_sort.asciidoc changes the API by introducing separate sorter objects for sort_over_group and joint_sort APIs.

Save both versions of API until the second version is not fully implemented. When PRs supporting the second version will be fully merged and macro will be updated, then old APIs will be removed.

Currently PR doesn't include array input and key/value sorting support.
It's split from larger PR: https://github.com/intel/llvm/pull/13713

Co-authored-by: "Andrei Fedorov [andrey.fedorov@intel.com](mailto:andrey.fedorov@intel.com)"
Co-authored-by: "Romanov Vlad [vlad.romanov@intel.com](mailto:vlad.romanov@intel.com)"