### PR TITLE
[NFC][SYCL] Fix test to properly pick up device libraries

### DIFF
--- a/clang/test/Driver/sycl-offload-intelfpga.cpp
+++ b/clang/test/Driver/sycl-offload-intelfpga.cpp
@@ -271,9 +271,11 @@
 
 // When using -fintelfpga, we unbundle the device libraries instead of using
 // the LLVM-IR .bc files.
-// RUN: %clangxx -fintelfpga -ccc-print-phases %s 2>&1 \
+// RUN: %clangxx -fintelfpga -ccc-print-phases \
+// RUN:          --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix UNBUNDLE_DEVICELIB %s
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -ccc-print-phases %s 2>&1 \
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_fpga -ccc-print-phases \
+// RUN:          --sysroot=%S/Inputs/SYCL %s 2>&1 \
 // RUN:  | FileCheck -check-prefix UNBUNDLE_DEVICELIB %s
 // UNBUNDLE_DEVICELIB: [[#DEVLIB:]]: input, "{{.*}}libsycl-itt-user-wrappers{{.*}}", object
 // UNBUNDLE_DEVICELIB: [[#DEVLIB+1]]: clang-offload-unbundler, {[[#DEVLIB]]}, object


### PR DESCRIPTION
The sycl-offload-intelfpga.cpp test was recently modified to check that the proper device library objects are picked up.  The test was not using the local testing sysroot to pick up the files, causing problems when the actual libraries are not built with the compiler before the test is run.