### PR TITLE
[SYCL] Don't include `type_traits.hpp` explicitly from `buffer.hpp`

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -22,7 +22,6 @@
 #include <sycl/detail/property_helper.hpp>
 #include <sycl/detail/stl_type_traits.hpp>
 #include <sycl/detail/sycl_mem_obj_allocator.hpp>
-#include <sycl/detail/type_traits.hpp>
 #include <sycl/event.hpp>
 #include <sycl/exception.hpp>
 #include <sycl/ext/oneapi/accessor_property_list.hpp>
@@ -180,7 +179,7 @@ public:
   template <class Container>
   using EnableIfContiguous =
       std::void_t<std::enable_if_t<std::is_convertible_v<
-                      detail::remove_pointer_t<
+                      std::remove_pointer_t<
                           decltype(std::declval<Container>().data())> (*)[],
                       const T (*)[]>>,
                   decltype(std::declval<Container>().size())>;


### PR DESCRIPTION
Right now it's a no-op/NFC as it is still included transitively somewhere, but in my local prototype workspace this `remove_pointer_t` is latest use of it there. I think it's OK to upload this PR right now to decrease number of out-of-tree changes in my experimental branch.