### PR TITLE
[E2E] Fix not enough input provided for private_alloca tests

### DIFF
--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/Inputs/private_alloca_test.hpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/Inputs/private_alloca_test.hpp
@@ -29,6 +29,7 @@ void test() {
   std::size_t N;
 
   std::cin >> N;
+  assert(!std::cin.fail());
 
   std::vector<std::size_t> v(N);
   {

--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_bool_size.cpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_bool_size.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -w -o %t.out
-// RUN: echo 1  | %{run} %t.out
+// RUN: echo 1 1  | %{run} %t.out
 
 // Test checking size of 'bool' type. This is not expected to be ever used, but,
 // as 'bool' is an integral type, it is a possible scenario.

--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_decorated.cpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_decorated.cpp
@@ -1,8 +1,8 @@
 // RUN: %{build} -o %t.out
-// RUN: echo 1  | %{run} %t.out
-// RUN: echo 10 | %{run} %t.out
-// RUN: echo 20 | %{run} %t.out
-// RUN: echo 30 | %{run} %t.out
+// RUN: echo 1 1  | %{run} %t.out
+// RUN: echo 10 10 | %{run} %t.out
+// RUN: echo 20 20 | %{run} %t.out
+// RUN: echo 30 30 | %{run} %t.out
 
 // Simple test filling a SYCL private alloca and copying it back to an output
 // accessor using a decorated multi_ptr.

--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_legacy.cpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_legacy.cpp
@@ -1,8 +1,8 @@
 // RUN: %{build} -w -o %t.out
-// RUN: echo 1  | %{run} %t.out
-// RUN: echo 10 | %{run} %t.out
-// RUN: echo 20 | %{run} %t.out
-// RUN: echo 30 | %{run} %t.out
+// RUN: echo 1 1  | %{run} %t.out
+// RUN: echo 10 10 | %{run} %t.out
+// RUN: echo 20 20 | %{run} %t.out
+// RUN: echo 30 30 | %{run} %t.out
 
 // Simple test filling a private alloca and copying it back to an output
 // accessor using a legacy multi_ptr.

--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_multiple.cpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_multiple.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -w -o %t.out
-// RUN: echo 10 20 30 | %{run} %t.out
+// RUN: echo 10 20 30 10 20 30 | %{run} %t.out
 
 // Chain of private_alloca test to check runtime support for compilation when
 // the default size is to be used.

--- a/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_raw.cpp
+++ b/sycl/test-e2e/PrivateAlloca/ValidUsage/private_alloca_raw.cpp
@@ -1,8 +1,8 @@
 // RUN: %{build} -o %t.out
-// RUN: echo 1  | %{run} %t.out
-// RUN: echo 10 | %{run} %t.out
-// RUN: echo 20 | %{run} %t.out
-// RUN: echo 30 | %{run} %t.out
+// RUN: echo 1 1  | %{run} %t.out
+// RUN: echo 10 10 | %{run} %t.out
+// RUN: echo 20 20 | %{run} %t.out
+// RUN: echo 30 30 | %{run} %t.out
 
 // Simple test filling a private alloca and copying it back to an output
 // accessor using a raw multi_ptr. This pointer checks struct allocation.


### PR DESCRIPTION
For private_alloca tests, every `test()` would require an input number. However, related tests do not provide enough input. This will lead to the undetermined result. This patch adds enough input number to the test, and add a assert to make sure all the read is successful.