### PR TITLE
[SYCL] Fix ONEAPI_DEVICE_SELECTOR handling of discard filters.

### DIFF
--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -201,6 +201,8 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
     std::vector<std::string_view> Pair =
         tokenize(Entry, ":", true /* ProhibitEmptyTokens */);
 
+    // Error handling. ONEAPI_DEVICE_SELECTOR terms should be in the
+    // format: <backend>:<devices>.
     if (Pair.empty()) {
       std::stringstream ss;
       ss << "Incomplete selector! Backend and device must be specified.";
@@ -210,8 +212,24 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
       ss << "Incomplete selector!  Try '" << Pair[0]
          << ":*' if all devices under the backend was original intention.";
       throw sycl::exception(sycl::make_error_code(errc::invalid), ss.str());
-    } else if (Pair.size() == 2) {
-      backend be = Parse_ODS_Backend(Pair[0], Entry); // Pair[0] is backend.
+    } else if (Pair.size() > 2) {
+      std::stringstream ss;
+      ss << "Error parsing selector string \"" << Entry
+         << "\"  Too many colons (:)";
+      throw sycl::exception(sycl::make_error_code(errc::invalid), ss.str());
+    }
+
+    // Parse ONEAPI_DEVICE_SELECTOR terms.
+    else if (Pair.size() == 2) {
+
+      // Remove `!` from input backend string if it is present.
+      std::string_view input_be = Pair[0];
+      if (Pair[0][0] == '!')
+        input_be = Pair[0].substr(1);
+
+      backend be = Parse_ODS_Backend(input_be, Entry);
+
+      // For each backend, we can have multiple targets, seperated by ','.
       std::vector<std::string_view> Targets = tokenize(Pair[1], ",");
       for (auto TargetStr : Targets) {
         ods_target DeviceTarget(be);
@@ -233,11 +251,6 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
         Parse_ODS_Device(DeviceTarget, TargetStr);
         Result.push_back(DeviceTarget);
       }
-    } else if (Pair.size() > 2) {
-      std::stringstream ss;
-      ss << "Error parsing selector string \"" << Entry
-         << "\"  Too many colons (:)";
-      throw sycl::exception(sycl::make_error_code(errc::invalid), ss.str());
     }
   }
 

--- a/sycl/source/detail/device_filter.cpp
+++ b/sycl/source/detail/device_filter.cpp
@@ -219,8 +219,8 @@ Parse_ONEAPI_DEVICE_SELECTOR(const std::string &envString) {
       throw sycl::exception(sycl::make_error_code(errc::invalid), ss.str());
     }
 
-    // Parse ONEAPI_DEVICE_SELECTOR terms.
-    else if (Pair.size() == 2) {
+    // Parse ONEAPI_DEVICE_SELECTOR terms for Pair.size() == 2.
+    else {
 
       // Remove `!` from input backend string if it is present.
       std::string_view input_be = Pair[0];

--- a/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
@@ -1,14 +1,14 @@
 // RUN: %{build} -o %t.out
 
 // Test discard filters in ONEAPI_DEVICE_SELECTOR.
-// RUN: env ONEAPI_DEVICE_SELECTOR="!*:gpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{gpu|GPU|Gpu}}{{.*}}]:[{{.*}}]"
-// RUN: env ONEAPI_DEVICE_SELECTOR="!*:cpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|cpu}}{{.*}}]:[{{.*}}]"
-// RUN: env ONEAPI_DEVICE_SELECTOR="!*:cpu,gpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|cpu|gpu|GPU|Gpu}}{{.*}}]:[{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:gpu" %{run-unfiltered-devices} %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{gpu|GPU|Gpu}}{{.*}}]:[{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:cpu" %{run-unfiltered-devices} %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|cpu}}{{.*}}]:[{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:cpu,gpu" %{run-unfiltered-devices} %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|cpu|gpu|GPU|Gpu}}{{.*}}]:[{{.*}}]"
 
-// RUN: env ONEAPI_DEVICE_SELECTOR="!opencl:*" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}]:[{{.*}}{{OpenCL|opencl|Opencl}}{{.*}}]"
-// RUN: env ONEAPI_DEVICE_SELECTOR="!level_zero:*" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}]:[{{.*}}{{Level-Zero}}{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!opencl:*" %{run-unfiltered-devices} %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}]:[{{.*}}{{OpenCL|opencl|Opencl}}{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!level_zero:*" %{run-unfiltered-devices} %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}]:[{{.*}}{{Level-Zero}}{{.*}}]"
 
-// RUN: env ONEAPI_DEVICE_SELECTOR="!level_zero:cpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|Cpu}}{{.*}}]:[{{.*}}{{Level-Zero}}{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!level_zero:cpu" %{run-unfiltered-devices} %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|Cpu}}{{.*}}]:[{{.*}}{{Level-Zero}}{{.*}}]"
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
@@ -1,0 +1,6 @@
+// REQUIRES: gpu
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
+
+// Test discard filters in ONEAPI_DEVICE_SELECTOR.
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:gpu" %t.out | FileCheck %s --allow-empty
+// CHECK-NOT: {{.*}}Device:{{.*}}{{gpu|GPU|Gpu}}{{.*}}

--- a/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
+++ b/sycl/test-e2e/OneapiDeviceSelector/discard_filters.cpp
@@ -1,6 +1,26 @@
-// REQUIRES: gpu
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/trivial.cpp -o %t.out
+// RUN: %{build} -o %t.out
 
 // Test discard filters in ONEAPI_DEVICE_SELECTOR.
-// RUN: env ONEAPI_DEVICE_SELECTOR="!*:gpu" %t.out | FileCheck %s --allow-empty
-// CHECK-NOT: {{.*}}Device:{{.*}}{{gpu|GPU|Gpu}}{{.*}}
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:gpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{gpu|GPU|Gpu}}{{.*}}]:[{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:cpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|cpu}}{{.*}}]:[{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!*:cpu,gpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|cpu|gpu|GPU|Gpu}}{{.*}}]:[{{.*}}]"
+
+// RUN: env ONEAPI_DEVICE_SELECTOR="!opencl:*" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}]:[{{.*}}{{OpenCL|opencl|Opencl}}{{.*}}]"
+// RUN: env ONEAPI_DEVICE_SELECTOR="!level_zero:*" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}]:[{{.*}}{{Level-Zero}}{{.*}}]"
+
+// RUN: env ONEAPI_DEVICE_SELECTOR="!level_zero:cpu" %t.out | FileCheck %s --allow-empty --implicit-check-not="[{{.*}}{{cpu|CPU|Cpu}}{{.*}}]:[{{.*}}{{Level-Zero}}{{.*}}]"
+
+#include <iostream>
+#include <sycl/detail/core.hpp>
+using namespace sycl;
+
+int main() {
+  for (auto &d : device::get_devices()) {
+    // Get device name and backend name.
+    std::string device_name = d.get_info<info::device::name>();
+    std::string be_name = d.get_platform().get_info<info::platform::name>();
+
+    std::cout << "[" << device_name << "]:[" << be_name << "]" << std::endl;
+  }
+  return 0;
+}


### PR DESCRIPTION
Currently, ONEAPI_DEVICE_SELECTOR incorrectly parses '!', used for discard filters.