### PR TITLE
[SYCL] Allow empty and unsupported case for component_devices

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -1209,11 +1209,22 @@ struct get_device_info_impl<
       return {};
     size_t ResultSize = 0;
     // First call to get DevCount.
-    Dev->getPlugin()->call<PiApiKind::piDeviceGetInfo>(
+    pi_result Err = Dev->getPlugin()->call_nocheck<PiApiKind::piDeviceGetInfo>(
         Dev->getHandleRef(),
         PiInfoCode<
             ext::oneapi::experimental::info::device::component_devices>::value,
         0, nullptr, &ResultSize);
+
+    // If the feature is unsupported or if the result was empty, return an empty
+    // list of devices.
+    if (Err == PI_ERROR_UNSUPPORTED_FEATURE ||
+        (Err == PI_SUCCESS && ResultSize == 0))
+      return {};
+
+    // Otherwise, if there was an error from PI it is unexpected and we should
+    // handle it accordingly.
+    Dev->getPlugin()->checkPiResult(Err);
+
     size_t DevCount = ResultSize / sizeof(pi_device);
     // Second call to get the list.
     std::vector<pi_device> Devs(DevCount);

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -79,6 +79,22 @@ pi_result after_piDeviceGetInfo_unsupported(pi_device device,
   }
 }
 
+pi_result after_piDeviceGetInfo_no_component_devices(
+    pi_device device, pi_device_info param_name, size_t param_value_size,
+    void *param_value, size_t *param_value_size_ret) {
+  switch (param_name) {
+  case PI_EXT_ONEAPI_DEVICE_INFO_COMPOSITE_DEVICE:
+    return PI_ERROR_UNSUPPORTED_FEATURE;
+  case PI_EXT_ONEAPI_DEVICE_INFO_COMPONENT_DEVICES:
+    if (param_value_size_ret)
+      *param_value_size_ret = 0;
+    return PI_SUCCESS;
+
+  default:
+    return PI_SUCCESS;
+  }
+}
+
 thread_local std::vector<pi_device> DevicesUsedInContextCreation;
 
 pi_result after_piContextCreate(const pi_context_properties *,
@@ -175,4 +191,20 @@ TEST(CompositeDeviceTest, UnsupportedNegative) {
   } catch (sycl::exception &E) {
     ASSERT_EQ(E.code(), sycl::make_error_code(sycl::errc::invalid));
   }
+}
+
+TEST(CompositeDeviceTest, NoComponentDevices) {
+  sycl::unittest::PiMock Mock;
+  Mock.redefine<sycl::detail::PiApiKind::piDevicesGet>(redefine_piDevicesGet);
+  Mock.redefineAfter<sycl::detail::PiApiKind::piDeviceGetInfo>(
+      after_piDeviceGetInfo_no_component_devices);
+
+  sycl::platform Plt = Mock.getPlatform();
+
+  sycl::device ComponentDevice = Plt.get_devices()[0];
+  ASSERT_FALSE(ComponentDevice.has(sycl::aspect::ext_oneapi_is_composite));
+
+  std::vector<sycl::device> ComponentDevices = ComponentDevice.get_info<
+      sycl::ext::oneapi::experimental::info::device::component_devices>();
+  ASSERT_TRUE(ComponentDevices.empty());
 }


### PR DESCRIPTION
This commit allows the backend to return an empty result or an unsupported-feature error when being queried about component devices.