### PR TITLE
Implement missing overloads for generic AS in generic target

### DIFF
--- a/libclc/generic/libspirv/atomic/atomic_add.cl
+++ b/libclc/generic/libspirv/atomic/atomic_add.cl
@@ -10,23 +10,39 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, FN_NAME)                                                                    \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                    \
   _CLC_DEF TYPE                                                                                                              \
-      _Z18__spirv_AtomicIAddPU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z18__spirv_AtomicIAddP##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                             \
           enum MemorySemanticsMask semantics, TYPE val) {                                                                    \
     return FN_NAME(p, val);                                                                                                  \
   }
 
-IMPL(int, i, global, AS1, __sync_fetch_and_add)
-IMPL(unsigned int, j, global, AS1, __sync_fetch_and_add)
-IMPL(int, i, local, AS3, __sync_fetch_and_add)
-IMPL(unsigned int, j, local, AS3, __sync_fetch_and_add)
+IMPL(int, i, global, U3AS1, 1, __sync_fetch_and_add)
+IMPL(unsigned int, j, global, U3AS1, 1, __sync_fetch_and_add)
+IMPL(int, i, local, U3AS3, 1, __sync_fetch_and_add)
+IMPL(unsigned int, j, local, U3AS3, 1, __sync_fetch_and_add)
 
 #ifdef cl_khr_int64_base_atomics
-IMPL(long, l, global, AS1, __sync_fetch_and_add_8)
-IMPL(unsigned long, m, global, AS1, __sync_fetch_and_add_8)
-IMPL(long, l, local, AS3, __sync_fetch_and_add_8)
-IMPL(unsigned long, m, local, AS3, __sync_fetch_and_add_8)
+IMPL(long, l, global, U3AS1, 1, __sync_fetch_and_add_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __sync_fetch_and_add_8)
+IMPL(long, l, local, U3AS3, 1, __sync_fetch_and_add_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_add_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
+
+IMPL_GENERIC(int, i, __sync_fetch_and_add)
+IMPL_GENERIC(unsigned int, j, __sync_fetch_and_add)
+
+#ifdef cl_khr_int64_base_atomics
+IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
+IMPL_GENERIC(unsigned long, m, __sync_fetch_and_add_8)
+#endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
+
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_and.cl
+++ b/libclc/generic/libspirv/atomic/atomic_and.cl
@@ -10,23 +10,39 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, FN_NAME)                                                                   \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                   \
   _CLC_DEF TYPE                                                                                                             \
-      _Z17__spirv_AtomicAndPU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z17__spirv_AtomicAndP##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                            \
           enum MemorySemanticsMask semantics, TYPE val) {                                                                   \
     return FN_NAME(p, val);                                                                                                 \
   }
 
-IMPL(int, i, global, AS1, __sync_fetch_and_and)
-IMPL(unsigned int, j, global, AS1, __sync_fetch_and_and)
-IMPL(int, i, local, AS3, __sync_fetch_and_and)
-IMPL(unsigned int, j, local, AS3, __sync_fetch_and_and)
+IMPL(int, i, global, U3AS1, 1, __sync_fetch_and_and)
+IMPL(unsigned int, j, global, U3AS1, 1, __sync_fetch_and_and)
+IMPL(int, i, local, U3AS3, 1, __sync_fetch_and_and)
+IMPL(unsigned int, j, local, U3AS3, 1, __sync_fetch_and_and)
 
 #ifdef cl_khr_int64_extended_atomics
-IMPL(long, l, global, AS1, __sync_fetch_and_and_8)
-IMPL(unsigned long, m, global, AS1, __sync_fetch_and_and_8)
-IMPL(long, l, local, AS3, __sync_fetch_and_and_8)
-IMPL(unsigned long, m, local, AS3, __sync_fetch_and_and_8)
+IMPL(long, l, global, U3AS1, 1, __sync_fetch_and_and_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __sync_fetch_and_and_8)
+IMPL(long, l, local, U3AS3, 1, __sync_fetch_and_and_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_and_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
+
+IMPL_GENERIC(int, i, __sync_fetch_and_and)
+IMPL_GENERIC(unsigned int, j, __sync_fetch_and_and)
+
+#ifdef cl_khr_int64_base_atomics
+IMPL_GENERIC(long, l, __sync_fetch_and_and_8)
+IMPL_GENERIC(unsigned long, m, __sync_fetch_and_and_8)
+#endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
+
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/generic/libspirv/atomic/atomic_cmpxchg.cl
@@ -24,6 +24,13 @@ _Z29__spirv_AtomicCompareExchangePU3AS1iN5__spv5Scope4FlagENS1_19MemorySemantics
   return __sync_val_compare_and_swap(p, cmp, val);
 }
 
+_CLC_DEF int
+_Z29__spirv_AtomicCompareExchangePiN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_ii(
+    volatile int *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, int val, int cmp) {
+  return __sync_val_compare_and_swap(p, cmp, val);
+}
+
 _CLC_DEF uint
 _Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile local uint *p, enum Scope scope, enum MemorySemanticsMask eq,
@@ -34,6 +41,13 @@ _Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemantics
 _CLC_DEF uint
 _Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile global uint *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, uint val, uint cmp) {
+  return __sync_val_compare_and_swap(p, cmp, val);
+}
+
+_CLC_DEF uint
+_Z29__spirv_AtomicCompareExchangePjN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_jj(
+    volatile uint *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, uint val, uint cmp) {
   return __sync_val_compare_and_swap(p, cmp, val);
 }
@@ -53,6 +67,13 @@ _Z29__spirv_AtomicCompareExchangePU3AS1lN5__spv5Scope4FlagENS1_19MemorySemantics
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
+_CLC_DEF long
+_Z29__spirv_AtomicCompareExchangePlN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_ll(
+    volatile long *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, long val, long cmp) {
+  return __sync_val_compare_and_swap_8(p, cmp, val);
+}
+
 _CLC_DEF ulong
 _Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile local ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
@@ -63,6 +84,13 @@ _Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemantics
 _CLC_DEF ulong
 _Z29__spirv_AtomicCompareExchangePU3AS1mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile global ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, ulong val, ulong cmp) {
+  return __sync_val_compare_and_swap_8(p, cmp, val);
+}
+
+_CLC_DEF ulong
+_Z29__spirv_AtomicCompareExchangePmN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_mm(
+    volatile ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, ulong val, ulong cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }

--- a/libclc/generic/libspirv/atomic/atomic_cmpxchg.cl
+++ b/libclc/generic/libspirv/atomic/atomic_cmpxchg.cl
@@ -24,13 +24,6 @@ _Z29__spirv_AtomicCompareExchangePU3AS1iN5__spv5Scope4FlagENS1_19MemorySemantics
   return __sync_val_compare_and_swap(p, cmp, val);
 }
 
-_CLC_DEF int
-_Z29__spirv_AtomicCompareExchangePiN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_ii(
-    volatile int *p, enum Scope scope, enum MemorySemanticsMask eq,
-    enum MemorySemanticsMask neq, int val, int cmp) {
-  return __sync_val_compare_and_swap(p, cmp, val);
-}
-
 _CLC_DEF uint
 _Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile local uint *p, enum Scope scope, enum MemorySemanticsMask eq,
@@ -41,13 +34,6 @@ _Z29__spirv_AtomicCompareExchangePU3AS3jN5__spv5Scope4FlagENS1_19MemorySemantics
 _CLC_DEF uint
 _Z29__spirv_AtomicCompareExchangePU3AS1jN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_jj(
     volatile global uint *p, enum Scope scope, enum MemorySemanticsMask eq,
-    enum MemorySemanticsMask neq, uint val, uint cmp) {
-  return __sync_val_compare_and_swap(p, cmp, val);
-}
-
-_CLC_DEF uint
-_Z29__spirv_AtomicCompareExchangePjN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_jj(
-    volatile uint *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, uint val, uint cmp) {
   return __sync_val_compare_and_swap(p, cmp, val);
 }
@@ -67,13 +53,6 @@ _Z29__spirv_AtomicCompareExchangePU3AS1lN5__spv5Scope4FlagENS1_19MemorySemantics
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
-_CLC_DEF long
-_Z29__spirv_AtomicCompareExchangePlN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_ll(
-    volatile long *p, enum Scope scope, enum MemorySemanticsMask eq,
-    enum MemorySemanticsMask neq, long val, long cmp) {
-  return __sync_val_compare_and_swap_8(p, cmp, val);
-}
-
 _CLC_DEF ulong
 _Z29__spirv_AtomicCompareExchangePU3AS3mN5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagES5_mm(
     volatile local ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
@@ -88,10 +67,40 @@ _Z29__spirv_AtomicCompareExchangePU3AS1mN5__spv5Scope4FlagENS1_19MemorySemantics
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
 
+#endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+_CLC_DEF int
+_Z29__spirv_AtomicCompareExchangePiN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_ii(
+    volatile int *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, int val, int cmp) {
+  return __sync_val_compare_and_swap(p, cmp, val);
+}
+
+_CLC_DEF uint
+_Z29__spirv_AtomicCompareExchangePjN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_jj(
+    volatile uint *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, uint val, uint cmp) {
+  return __sync_val_compare_and_swap(p, cmp, val);
+}
+
+#ifdef cl_khr_int64_base_atomics
+
+_CLC_DEF long
+_Z29__spirv_AtomicCompareExchangePlN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_ll(
+    volatile long *p, enum Scope scope, enum MemorySemanticsMask eq,
+    enum MemorySemanticsMask neq, long val, long cmp) {
+  return __sync_val_compare_and_swap_8(p, cmp, val);
+}
+
 _CLC_DEF ulong
 _Z29__spirv_AtomicCompareExchangePmN5__spv5Scope4FlagENS0_19MemorySemanticsMask4FlagES4_mm(
     volatile ulong *p, enum Scope scope, enum MemorySemanticsMask eq,
     enum MemorySemanticsMask neq, ulong val, ulong cmp) {
   return __sync_val_compare_and_swap_8(p, cmp, val);
 }
+
 #endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED

--- a/libclc/generic/libspirv/atomic/atomic_max.cl
+++ b/libclc/generic/libspirv/atomic/atomic_max.cl
@@ -10,18 +10,18 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, NAME, PREFIX, SUFFIX)                                             \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, NAME, PREFIX, SUFFIX)                                             \
   _CLC_DEF TYPE                                                                                                    \
-      _Z18##NAME##PU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z18##NAME##P##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                   \
           enum MemorySemanticsMask semantics, TYPE val) {                                                          \
     return PREFIX##__sync_fetch_and_##SUFFIX(p, val);                                                              \
   }
 
-IMPL(int, i, global, AS1, __spirv_AtomicSMax, , max)
-IMPL(unsigned int, j, global, AS1, __spirv_AtomicUMax, , umax)
-IMPL(int, i, local, AS3, __spirv_AtomicSMax, , max)
-IMPL(unsigned int, j, local, AS3, __spirv_AtomicUMax, , umax)
+IMPL(int, i, global, U3AS1, 1, __spirv_AtomicSMax, , max)
+IMPL(unsigned int, j, global, U3AS1, 1, __spirv_AtomicUMax, , umax)
+IMPL(int, i, local, U3AS3, 1, __spirv_AtomicSMax, , max)
+IMPL(unsigned int, j, local, U3AS3, 1, __spirv_AtomicUMax, , umax)
 
 #ifdef cl_khr_int64_extended_atomics
 unsigned long __clc__sync_fetch_and_max_local_8(volatile local long *, long);
@@ -29,9 +29,30 @@ unsigned long __clc__sync_fetch_and_max_global_8(volatile global long *, long);
 unsigned long __clc__sync_fetch_and_umax_local_8(volatile local unsigned long *, unsigned long);
 unsigned long __clc__sync_fetch_and_umax_global_8(volatile global unsigned long *, unsigned long);
 
-IMPL(long, l, global, AS1, __spirv_AtomicSMax, __clc, max_global_8)
-IMPL(unsigned long, m, global, AS1, __spirv_AtomicUMax, __clc, umax_global_8)
-IMPL(long, l, local, AS3, __spirv_AtomicSMax, __clc, max_local_8)
-IMPL(unsigned long, m, local, AS3, __spirv_AtomicUMax, __clc, umax_local_8)
+IMPL(long, l, global, U3AS1, 1, __spirv_AtomicSMax, __clc, max_global_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __spirv_AtomicUMax, __clc, umax_global_8)
+IMPL(long, l, local, U3AS3, 1, __spirv_AtomicSMax, __clc, max_local_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __spirv_AtomicUMax, __clc, umax_local_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, NAME, PREFIX, SUFFIX) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, NAME, PREFIX, SUFFIX)
+
+IMPL_GENERIC(int, i, __spirv_AtomicSMax, , max)
+IMPL_GENERIC(unsigned int, j, __spirv_AtomicUMax, , umax)
+
+#ifdef cl_khr_int64_extended_atomics
+
+unsigned long __clc__sync_fetch_and_max_generic_8(volatile generic long *, long);
+unsigned long __clc__sync_fetch_and_umax_generic_8(volatile __generic unsigned long *, unsigned long);
+
+IMPL_GENERIC(long, l, __spirv_AtomicSMax, __clc, max_generic_8)
+IMPL_GENERIC(unsigned long, m,  __spirv_AtomicUMax, __clc, umax_generic_8)
+#endif
+
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_min.cl
+++ b/libclc/generic/libspirv/atomic/atomic_min.cl
@@ -10,18 +10,18 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, NAME, PREFIX, SUFFIX)                                             \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, NAME, PREFIX, SUFFIX)                                             \
   _CLC_DEF TYPE                                                                                                    \
-      _Z18##NAME##PU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z18##NAME##P##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                   \
           enum MemorySemanticsMask semantics, TYPE val) {                                                          \
     return PREFIX##__sync_fetch_and_##SUFFIX(p, val);                                                              \
   }
 
-IMPL(int, i, global, AS1, __spirv_AtomicSMin, , min)
-IMPL(unsigned int, j, global, AS1, __spirv_AtomicUMin, , umin)
-IMPL(int, i, local, AS3, __spirv_AtomicSMin, , min)
-IMPL(unsigned int, j, local, AS3, __spirv_AtomicUMin, , umin)
+IMPL(int, i, global, U3AS1, 1, __spirv_AtomicSMin, , min)
+IMPL(unsigned int, j, global, U3AS1, 1, __spirv_AtomicUMin, , umin)
+IMPL(int, i, local, U3AS3, 1, __spirv_AtomicSMin, , min)
+IMPL(unsigned int, j, local, U3AS3, 1, __spirv_AtomicUMin, , umin)
 
 #ifdef cl_khr_int64_extended_atomics
 unsigned long __clc__sync_fetch_and_min_local_8(volatile local long *, long);
@@ -29,9 +29,30 @@ unsigned long __clc__sync_fetch_and_min_global_8(volatile global long *, long);
 unsigned long __clc__sync_fetch_and_umin_local_8(volatile local unsigned long *, unsigned long);
 unsigned long __clc__sync_fetch_and_umin_global_8(volatile global unsigned long *, unsigned long);
 
-IMPL(long, l, global, AS1, __spirv_AtomicSMin, __clc, min_global_8)
-IMPL(unsigned long, m, global, AS1, __spirv_AtomicUMin, __clc, umin_global_8)
-IMPL(long, l, local, AS3, __spirv_AtomicSMin, __clc, min_local_8)
-IMPL(unsigned long, m, local, AS3, __spirv_AtomicUMin, __clc, umin_local_8)
+IMPL(long, l, global, U3AS1, 1, __spirv_AtomicSMin, __clc, min_global_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __spirv_AtomicUMin, __clc, umin_global_8)
+IMPL(long, l, local, U3AS3, 1, __spirv_AtomicSMin, __clc, min_local_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __spirv_AtomicUMin, __clc, umin_local_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, NAME, PREFIX, SUFFIX) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, NAME, PREFIX, SUFFIX)
+
+IMPL_GENERIC(int, i, __spirv_AtomicSMin, , min)
+IMPL_GENERIC(unsigned int, j, __spirv_AtomicUMin, , umin)
+
+#ifdef cl_khr_int64_extended_atomics
+
+unsigned long __clc__sync_fetch_and_min_generic_8(volatile generic long *, long);
+unsigned long __clc__sync_fetch_and_umin_generic_8(volatile __generic unsigned long *, unsigned long);
+
+IMPL_GENERIC(long, l, __spirv_AtomicSMin, __clc, min_generic_8)
+IMPL_GENERIC(unsigned long, m,  __spirv_AtomicUMin, __clc, umin_generic_8)
+#endif
+
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_or.cl
+++ b/libclc/generic/libspirv/atomic/atomic_or.cl
@@ -10,23 +10,39 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, FN_NAME)                                                                  \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                  \
   _CLC_DEF TYPE                                                                                                            \
-      _Z16__spirv_AtomicOrPU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z16__spirv_AtomicOrP##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                           \
           enum MemorySemanticsMask semantics, TYPE val) {                                                                  \
     return FN_NAME(p, val);                                                                                                \
   }
 
-IMPL(int, i, global, AS1, __sync_fetch_and_or)
-IMPL(unsigned int, j, global, AS1, __sync_fetch_and_or)
-IMPL(int, i, local, AS3, __sync_fetch_and_or)
-IMPL(unsigned int, j, local, AS3, __sync_fetch_and_or)
+IMPL(int, i, global, U3AS1, 1, __sync_fetch_and_or)
+IMPL(unsigned int, j, global, U3AS1, 1, __sync_fetch_and_or)
+IMPL(int, i, local, U3AS3, 1, __sync_fetch_and_or)
+IMPL(unsigned int, j, local, U3AS3, 1, __sync_fetch_and_or)
 
 #ifdef cl_khr_int64_extended_atomics
-IMPL(long, l, global, AS1, __sync_fetch_and_or_8)
-IMPL(unsigned long, m, global, AS1, __sync_fetch_and_or_8)
-IMPL(long, l, local, AS3, __sync_fetch_and_or_8)
-IMPL(unsigned long, m, local, AS3, __sync_fetch_and_or_8)
+IMPL(long, l, global, U3AS1, 1, __sync_fetch_and_or_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __sync_fetch_and_or_8)
+IMPL(long, l, local, U3AS3, 1, __sync_fetch_and_or_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_or_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
+
+IMPL_GENERIC(int, i, __sync_fetch_and_add)
+IMPL_GENERIC(unsigned int, j, __sync_fetch_and_or)
+
+#ifdef cl_khr_int64_base_atomics
+IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
+IMPL_GENERIC(unsigned long, m, __sync_fetch_and_or_8)
+#endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
+
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_or.cl
+++ b/libclc/generic/libspirv/atomic/atomic_or.cl
@@ -35,11 +35,11 @@ IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_or_8)
 #define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
   IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
 
-IMPL_GENERIC(int, i, __sync_fetch_and_add)
+IMPL_GENERIC(int, i, __sync_fetch_and_or)
 IMPL_GENERIC(unsigned int, j, __sync_fetch_and_or)
 
 #ifdef cl_khr_int64_base_atomics
-IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
+IMPL_GENERIC(long, l, __sync_fetch_and_or_8)
 IMPL_GENERIC(unsigned long, m, __sync_fetch_and_or_8)
 #endif
 

--- a/libclc/generic/libspirv/atomic/atomic_sub.cl
+++ b/libclc/generic/libspirv/atomic/atomic_sub.cl
@@ -39,7 +39,7 @@ IMPL_GENERIC(int, i, __sync_fetch_and_add)
 IMPL_GENERIC(unsigned int, j, __sync_fetch_and_sub)
 
 #ifdef cl_khr_int64_base_atomics
-IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
+IMPL_GENERIC(long, l, __sync_fetch_and_sub_8)
 IMPL_GENERIC(unsigned long, m, __sync_fetch_and_sub_8)
 #endif
 

--- a/libclc/generic/libspirv/atomic/atomic_sub.cl
+++ b/libclc/generic/libspirv/atomic/atomic_sub.cl
@@ -10,23 +10,38 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, FN_NAME)                                                                    \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                    \
   _CLC_DEF TYPE                                                                                                              \
-      _Z18__spirv_AtomicISubPU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z18__spirv_AtomicISubP##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                             \
           enum MemorySemanticsMask semantics, TYPE val) {                                                                    \
     return FN_NAME(p, val);                                                                                                  \
   }
 
-IMPL(int, i, global, AS1, __sync_fetch_and_sub)
-IMPL(unsigned int, j, global, AS1, __sync_fetch_and_sub)
-IMPL(int, i, local, AS3, __sync_fetch_and_sub)
-IMPL(unsigned int, j, local, AS3, __sync_fetch_and_sub)
+IMPL(int, i, global, U3AS1, 1, __sync_fetch_and_sub)
+IMPL(unsigned int, j, global, U3AS1, 1, __sync_fetch_and_sub)
+IMPL(int, i, local, U3AS3, 1, __sync_fetch_and_sub)
+IMPL(unsigned int, j, local, U3AS3, 1, __sync_fetch_and_sub)
 
 #ifdef cl_khr_int64_base_atomics
-IMPL(long, l, global, AS1, __sync_fetch_and_sub_8)
-IMPL(unsigned long, m, global, AS1, __sync_fetch_and_sub_8)
-IMPL(long, l, local, AS3, __sync_fetch_and_sub_8)
-IMPL(unsigned long, m, local, AS3, __sync_fetch_and_sub_8)
+IMPL(long, l, global, U3AS1, 1, __sync_fetch_and_sub_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __sync_fetch_and_sub_8)
+IMPL(long, l, local, U3AS3, 1, __sync_fetch_and_sub_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_sub_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
+
+IMPL_GENERIC(int, i, __sync_fetch_and_add)
+IMPL_GENERIC(unsigned int, j, __sync_fetch_and_sub)
+
+#ifdef cl_khr_int64_base_atomics
+IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
+IMPL_GENERIC(unsigned long, m, __sync_fetch_and_sub_8)
+#endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_sub.cl
+++ b/libclc/generic/libspirv/atomic/atomic_sub.cl
@@ -35,7 +35,7 @@ IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_sub_8)
 #define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
   IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
 
-IMPL_GENERIC(int, i, __sync_fetch_and_add)
+IMPL_GENERIC(int, i, __sync_fetch_and_sub)
 IMPL_GENERIC(unsigned int, j, __sync_fetch_and_sub)
 
 #ifdef cl_khr_int64_base_atomics

--- a/libclc/generic/libspirv/atomic/atomic_xchg.cl
+++ b/libclc/generic/libspirv/atomic/atomic_xchg.cl
@@ -28,23 +28,39 @@ _Z22__spirv_AtomicExchangePU3AS3fN5__spv5Scope4FlagENS1_19MemorySemanticsMask4Fl
           (volatile local uint *)p, scope, semantics, as_uint(val)));
 }
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, FN_NAME)                                                                        \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                        \
   _CLC_DEF TYPE                                                                                                                  \
-      _Z22__spirv_AtomicExchangePU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z22__spirv_AtomicExchangeP##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                                 \
           enum MemorySemanticsMask semantics, TYPE val) {                                                                        \
     return FN_NAME(p, val);                                                                                                      \
   }
 
-IMPL(int, i, global, AS1, __sync_swap_4)
-IMPL(unsigned int, j, global, AS1, __sync_swap_4)
-IMPL(int, i, local, AS3, __sync_swap_4)
-IMPL(unsigned int, j, local, AS3, __sync_swap_4)
+IMPL(int, i, global, U3AS1, 1, __sync_swap_4)
+IMPL(unsigned int, j, global, U3AS1, 1, __sync_swap_4)
+IMPL(int, i, local, U3AS3, 1, __sync_swap_4)
+IMPL(unsigned int, j, local, U3AS3, 1, __sync_swap_4)
 
 #ifdef cl_khr_int64_base_atomics
-IMPL(long, l, global, AS1, __sync_swap_8)
-IMPL(unsigned long, m, global, AS1, __sync_swap_8)
-IMPL(long, l, local, AS3, __sync_swap_8)
-IMPL(unsigned long, m, local, AS3, __sync_swap_8)
+IMPL(long, l, global, U3AS1, 1, __sync_swap_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __sync_swap_8)
+IMPL(long, l, local, U3AS3, 1, __sync_swap_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __sync_swap_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
+
+IMPL_GENERIC(int, i, __sync_swap_4)
+IMPL_GENERIC(unsigned int, j, __sync_swap_4)
+
+#ifdef cl_khr_int64_base_atomics
+IMPL_GENERIC(long, l, __sync_swap_8)
+IMPL_GENERIC(unsigned long, m, __sync_swap_8)
+#endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
+
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_xor.cl
+++ b/libclc/generic/libspirv/atomic/atomic_xor.cl
@@ -10,23 +10,38 @@
 
 // TODO: Stop manually mangling this name. Need C++ namespaces to get the exact mangling.
 
-#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, FN_NAME)                                                                   \
+#define IMPL(TYPE, TYPE_MANGLED, AS, AS_MANGLED, SUB, FN_NAME)                                                                   \
   _CLC_DEF TYPE                                                                                                             \
-      _Z17__spirv_AtomicXorPU3##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS1_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
+      _Z17__spirv_AtomicXorP##AS_MANGLED##TYPE_MANGLED##N5__spv5Scope4FlagENS##SUB##_19MemorySemanticsMask4FlagE##TYPE_MANGLED( \
           volatile AS TYPE *p, enum Scope scope,                                                                            \
           enum MemorySemanticsMask semantics, TYPE val) {                                                                   \
     return FN_NAME(p, val);                                                                                                 \
   }
 
-IMPL(int, i, global, AS1, __sync_fetch_and_xor)
-IMPL(unsigned int, j, global, AS1, __sync_fetch_and_xor)
-IMPL(int, i, local, AS3, __sync_fetch_and_xor)
-IMPL(unsigned int, j, local, AS3, __sync_fetch_and_xor)
+IMPL(int, i, global, U3AS1, 1, __sync_fetch_and_xor)
+IMPL(unsigned int, j, global, U3AS1, 1, __sync_fetch_and_xor)
+IMPL(int, i, local, U3AS3, 1, __sync_fetch_and_xor)
+IMPL(unsigned int, j, local, U3AS3, 1, __sync_fetch_and_xor)
 
 #ifdef cl_khr_int64_extended_atomics
-IMPL(long, l, global, AS1, __sync_fetch_and_xor_8)
-IMPL(unsigned long, m, global, AS1, __sync_fetch_and_xor_8)
-IMPL(long, l, local, AS3, __sync_fetch_and_xor_8)
-IMPL(unsigned long, m, local, AS3, __sync_fetch_and_xor_8)
+IMPL(long, l, global, U3AS1, 1, __sync_fetch_and_xor_8)
+IMPL(unsigned long, m, global, U3AS1, 1, __sync_fetch_and_xor_8)
+IMPL(long, l, local, U3AS3, 1, __sync_fetch_and_xor_8)
+IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_xor_8)
 #endif
+
+#if _CLC_GENERIC_AS_SUPPORTED
+
+#define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
+  IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
+
+IMPL_GENERIC(int, i, __sync_fetch_and_add)
+IMPL_GENERIC(unsigned int, j, __sync_fetch_and_add)
+
+#ifdef cl_khr_int64_base_atomics
+IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
+IMPL_GENERIC(unsigned long, m, __sync_fetch_and_add_8)
+#endif
+
+#endif //_CLC_GENERIC_AS_SUPPORTED
 #undef IMPL

--- a/libclc/generic/libspirv/atomic/atomic_xor.cl
+++ b/libclc/generic/libspirv/atomic/atomic_xor.cl
@@ -35,12 +35,12 @@ IMPL(unsigned long, m, local, U3AS3, 1, __sync_fetch_and_xor_8)
 #define IMPL_GENERIC(TYPE, TYPE_MANGLED, FN_NAME) \
   IMPL(TYPE, TYPE_MANGLED, , , 0, FN_NAME)
 
-IMPL_GENERIC(int, i, __sync_fetch_and_add)
-IMPL_GENERIC(unsigned int, j, __sync_fetch_and_add)
+IMPL_GENERIC(int, i, __sync_fetch_and_xor)
+IMPL_GENERIC(unsigned int, j, __sync_fetch_and_xor)
 
 #ifdef cl_khr_int64_base_atomics
-IMPL_GENERIC(long, l, __sync_fetch_and_add_8)
-IMPL_GENERIC(unsigned long, m, __sync_fetch_and_add_8)
+IMPL_GENERIC(long, l, __sync_fetch_and_xor_8)
+IMPL_GENERIC(unsigned long, m, __sync_fetch_and_xor_8)
 #endif
 
 #endif //_CLC_GENERIC_AS_SUPPORTED

--- a/sycl/include/sycl/ext/intel/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/math.hpp
@@ -383,9 +383,9 @@ std::enable_if_t<detail::is_esimd_scalar<T>::value, T>(min)(T src0, T src1,
 #define __ESIMD_EMATH_SPIRV_COND                                               \
   std::is_same_v<T, float> || std::is_same_v<T, sycl::half>
 
-/// Inversion - calculates (1/x). Supports \c half and \c float.
+/// Inversion - calculates (1/x). Supports \c half, \c float and \c double.
 /// Precision: 1 ULP.
-__ESIMD_UNARY_INTRINSIC_DEF(__ESIMD_EMATH_SPIRV_COND, inv, recip)
+__ESIMD_UNARY_INTRINSIC_DEF(detail::is_generic_floating_point_v<T>, inv, recip)
 
 /// Logarithm base 2. Supports \c half and \c float.
 /// Precision depending on argument range:
@@ -435,13 +435,16 @@ __ESIMD_UNARY_INTRINSIC_DEF(__ESIMD_EMATH_SPIRV_COND, sin, sin)
 /// Absolute error: \c 0.0008 or less for the range [-32767*pi, 32767*pi].
 __ESIMD_UNARY_INTRINSIC_DEF(__ESIMD_EMATH_SPIRV_COND, cos, cos)
 
+/// Square root reciprocal - calculates <code>1/sqrt(x)</code>.
+/// Supports \c double.
+/// Precision: 4 ULP.
 template <class T, int N, class Sat = saturation_off_tag>
 __ESIMD_API std::enable_if_t<std::is_same_v<T, double>, simd<double, N>>
 rsqrt(simd<T, N> src, Sat sat = {}) {
   if constexpr (std::is_same_v<Sat, saturation_off_tag>)
-    return 1. / sqrt(src);
+    return inv(sqrt(src));
   else
-    return esimd::saturate<double>(1. / sqrt(src));
+    return esimd::saturate<double>(inv(sqrt(src)));
 }
 
 /** Scalar version.                                                       */
@@ -449,9 +452,9 @@ template <class T, class Sat = saturation_off_tag>
 __ESIMD_API std::enable_if_t<std::is_same_v<T, double>, double>
 rsqrt(T src, Sat sat = {}) {
   if constexpr (std::is_same_v<Sat, saturation_off_tag>)
-    return 1. / sqrt(src);
+    return inv(sqrt(src));
   else
-    return esimd::saturate<double>(1. / sqrt(src));
+    return esimd::saturate<double>(inv(sqrt(src)));
 }
 
 #undef __ESIMD_UNARY_INTRINSIC_DEF

--- a/sycl/test-e2e/ESIMD/ext_math.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math.cpp
@@ -463,6 +463,13 @@ template <class T, int N> bool testESIMDRSqrt(queue &Q) {
   Pass &= test<T, N, MathOp::rsqrt, ESIMDf>(Q, "rsqrt", InitWide<T>{});
   return Pass;
 }
+template <class T, int N> bool testESIMDInv(queue &Q) {
+  bool Pass = true;
+  std::cout << "--- TESTING ESIMD inv, T=" << typeid(T).name() << ", N = " << N
+            << "...\n";
+  Pass &= test<T, N, MathOp::inv, ESIMDf>(Q, "inv", InitWide<T>{});
+  return Pass;
+}
 
 template <class T, int N> bool testESIMDDivIEEE(queue &Q) {
   bool Pass = true;
@@ -506,6 +513,7 @@ int main(void) {
   if (Dev.has(sycl::aspect::fp64)) {
     Pass &= testESIMDSqrt<double, 32>(Q);
     Pass &= testESIMDRSqrt<double, 32>(Q);
+    Pass &= testESIMDInv<double, 32>(Q);
   }
 #ifdef TEST_IEEE_DIV_REM
   Pass &= testESIMDSqrtIEEE<float, 16>(Q);


### PR DESCRIPTION
Following up to https://github.com/intel/llvm/pull/13428, this PR implements the overloads for the generic AS that are missing in the `generic` libclc target.