### PR TITLE
[SYCL] Add support for key/value sorting APIs

### DIFF
--- a/sycl/include/sycl/detail/group_sort_impl.hpp
+++ b/sycl/include/sycl/detail/group_sort_impl.hpp
@@ -578,7 +578,7 @@ template <size_t items_per_work_item, uint32_t radix_bits, bool is_comp_asc,
           typename ValsT, typename GroupT>
 void performRadixIterStaticSize(GroupT group, const uint32_t radix_iter,
                                 const uint32_t last_iter, KeysT *keys,
-                                ValsT vals, const ScratchMemory &memory) {
+                                ValsT *vals, const ScratchMemory &memory) {
   const uint32_t radix_states = getStatesInBits(radix_bits);
   const size_t wgsize = group.get_local_linear_range();
   const size_t idx = group.get_local_linear_id();

--- a/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
@@ -343,6 +343,41 @@ public:
   }
 };
 
+template <typename T, typename U, typename CompareT = std::less<>,
+          std::size_t ElementsPerWorkItem = 1>
+class group_key_value_sorter {
+  CompareT comp;
+  sycl::span<std::byte> scratch;
+
+public:
+  template <std::size_t Extent>
+  group_key_value_sorter(sycl::span<std::byte, Extent> scratch_,
+                         CompareT comp_ = {})
+      : comp(comp_), scratch(scratch_) {}
+
+  template <typename Group>
+  std::tuple<T, U> operator()(Group g, T key, U value) {
+    static_assert(ElementsPerWorkItem == 1,
+                  "ElementsPerWorkItem must be equal 1");
+
+    using KeyValue = std::tuple<T, U>;
+    auto this_comp = this->comp;
+    auto comp_key_value = [this_comp](const KeyValue &lhs,
+                                      const KeyValue &rhs) {
+      return this_comp(std::get<0>(lhs), std::get<0>(rhs));
+    };
+    return group_sorter<KeyValue, decltype(comp_key_value),
+                        ElementsPerWorkItem>(scratch, comp_key_value)(
+        g, KeyValue(key, value));
+  }
+
+  static constexpr std::size_t memory_required(sycl::memory_scope scope,
+                                               std::size_t range_size) {
+    return group_sorter<std::tuple<T, U>, CompareT,
+                        ElementsPerWorkItem>::memory_required(scope,
+                                                              range_size);
+  }
+};
 } // namespace default_sorters
 
 // Radix sorters provided by the second version of the extension specification.
@@ -455,6 +490,56 @@ public:
   }
 };
 
+template <typename T, typename U,
+          sorting_order Order = sorting_order::ascending,
+          size_t ElementsPerWorkItem = 1, unsigned int BitsPerPass = 4>
+class group_key_value_sorter {
+  sycl::span<std::byte> scratch;
+  uint32_t first_bit;
+  uint32_t last_bit;
+
+  static constexpr uint32_t bits = BitsPerPass;
+  using bitset_t = std::bitset<sizeof(T) * CHAR_BIT>;
+
+public:
+  template <std::size_t Extent>
+  group_key_value_sorter(sycl::span<std::byte, Extent> scratch_,
+                         const bitset_t mask = bitset_t{}.set())
+      : scratch(scratch_) {
+    static_assert(
+        (std::is_arithmetic<T>::value || std::is_same<T, sycl::half>::value),
+        "radix sort is not usable");
+    for (first_bit = 0; first_bit < mask.size() && !mask[first_bit];
+         ++first_bit)
+      ;
+    for (last_bit = first_bit; last_bit < mask.size() && mask[last_bit];
+         ++last_bit)
+      ;
+  }
+
+  template <typename Group>
+  std::tuple<T, U> operator()([[maybe_unused]] Group g, T key, U val) {
+    static_assert(ElementsPerWorkItem == 1, "ElementsPerWorkItem must be 1");
+    T key_result[]{key};
+    U val_result[]{val};
+#ifdef __SYCL_DEVICE_ONLY__
+    sycl::detail::privateStaticSort<
+        /*is_key_value=*/true,
+        /*is_blocked=*/true, Order == sorting_order::ascending, 1, bits>(
+        g, key_result, val_result, scratch.data(), first_bit, last_bit);
+#endif
+    key = key_result[0];
+    val = val_result[0];
+    return {key, val};
+  }
+
+  static constexpr std::size_t memory_required(sycl::memory_scope scope,
+                                               std::size_t range_size) {
+    return (std::max)(range_size * ElementsPerWorkItem *
+                          (sizeof(T) + sizeof(U)),
+                      range_size * (1 << bits) * sizeof(uint32_t));
+  }
+};
 } // namespace radix_sorters
 
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
@@ -281,8 +281,7 @@ public:
   }
 
   template <typename T>
-  static constexpr size_t memory_required(sycl::memory_scope,
-                                          size_t range_size) {
+  static size_t memory_required(sycl::memory_scope, size_t range_size) {
     return range_size * sizeof(T) + alignof(T);
   }
 };
@@ -336,8 +335,8 @@ public:
     return val;
   }
 
-  static constexpr std::size_t memory_required(sycl::memory_scope scope,
-                                               size_t range_size) {
+  static std::size_t memory_required(sycl::memory_scope scope,
+                                     size_t range_size) {
     return 2 * joint_sorter<>::template memory_required<T>(
                    scope, range_size * ElementsPerWorkItem);
   }
@@ -370,8 +369,8 @@ public:
         g, KeyValue(key, value));
   }
 
-  static constexpr std::size_t memory_required(sycl::memory_scope scope,
-                                               std::size_t range_size) {
+  static std::size_t memory_required(sycl::memory_scope scope,
+                                     std::size_t range_size) {
     return group_sorter<std::tuple<KeyTy, ValueTy>, CompareT,
                         ElementsPerWorkItem>::memory_required(scope,
                                                               range_size);

--- a/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_helpers_sorters.hpp
@@ -533,7 +533,7 @@ public:
     return {key, val};
   }
 
-  static constexpr std::size_t memory_required(sycl::memory_scope scope,
+  static constexpr std::size_t memory_required(sycl::memory_scope,
                                                std::size_t range_size) {
     return (std::max)(range_size * ElementsPerWorkItem *
                           (sizeof(T) + sizeof(U)),

--- a/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
@@ -154,11 +154,12 @@ joint_sort(experimental::group_with_scratchpad<Group, Extent> exec, Iter first,
              default_sorters::joint_sorter<>(exec.get_memory()));
 }
 
-template <typename Group, typename T, typename U, typename Sorter>
-std::enable_if_t<detail::is_key_value_sorter<Sorter, Group, T, U>::value,
-                 std::tuple<T, U>>
-sort_key_value_over_group([[maybe_unused]] Group g, [[maybe_unused]] T key,
-                          [[maybe_unused]] U value,
+template <typename Group, typename KeyTy, typename ValueTy, typename Sorter>
+std::enable_if_t<
+    detail::is_key_value_sorter<Sorter, Group, KeyTy, ValueTy>::value,
+    std::tuple<KeyTy, ValueTy>>
+sort_key_value_over_group([[maybe_unused]] Group g, [[maybe_unused]] KeyTy key,
+                          [[maybe_unused]] ValueTy value,
                           [[maybe_unused]] Sorter sorter) {
 #ifdef __SYCL_DEVICE_ONLY__
   return sorter(g, key, value);
@@ -169,26 +170,30 @@ sort_key_value_over_group([[maybe_unused]] Group g, [[maybe_unused]] T key,
 #endif
 }
 
-template <typename Group, typename T, typename U, typename Compare,
+template <typename Group, typename KeyTy, typename ValueTy, typename Compare,
           std::size_t Extent>
-std::enable_if_t<!detail::is_key_value_sorter<Compare, Group, T, U>::value,
-                 std::tuple<T, U>>
+std::enable_if_t<
+    !detail::is_key_value_sorter<Compare, Group, KeyTy, ValueTy>::value,
+    std::tuple<KeyTy, ValueTy>>
 sort_key_value_over_group(
-    experimental::group_with_scratchpad<Group, Extent> exec, T key, U value,
-    Compare comp) {
+    experimental::group_with_scratchpad<Group, Extent> exec, KeyTy key,
+    ValueTy value, Compare comp) {
   return sort_key_value_over_group(
       exec.get_group(), key, value,
-      default_sorters::group_key_value_sorter<T, U, Compare>(exec.get_memory(),
-                                                             comp));
+      default_sorters::group_key_value_sorter<KeyTy, ValueTy, Compare>(
+          exec.get_memory(), comp));
 }
 
-template <typename T, typename U, typename Group, std::size_t Extent>
-std::enable_if_t<sycl::is_group_v<std::decay_t<Group>>, std::tuple<T, U>>
+template <typename KeyTy, typename ValueTy, typename Group, std::size_t Extent>
+std::enable_if_t<sycl::is_group_v<std::decay_t<Group>>,
+                 std::tuple<KeyTy, ValueTy>>
 sort_key_value_over_group(
-    experimental::group_with_scratchpad<Group, Extent> exec, T key, U value) {
+    experimental::group_with_scratchpad<Group, Extent> exec, KeyTy key,
+    ValueTy value) {
   return sort_key_value_over_group(
       exec.get_group(), key, value,
-      default_sorters::group_key_value_sorter<T, U>(exec.get_memory()));
+      default_sorters::group_key_value_sorter<KeyTy, ValueTy>(
+          exec.get_memory()));
 }
 
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/group_sort.hpp
@@ -70,7 +70,7 @@ struct is_sorter : decltype(is_sorter_impl<Sorter, Group, ValOrPtr>::test(0)) {
 };
 
 template <typename Sorter, typename Group, typename Key, typename Value,
-          typename RetTy = void>
+          typename = void>
 struct is_key_value_sorter : std::false_type {};
 
 template <typename Sorter, typename Group, typename Key, typename Value>

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/common.hpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/common.hpp
@@ -1,0 +1,50 @@
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/group_sort.hpp>
+
+#pragma once
+
+namespace oneapi_exp = sycl::ext::oneapi::experimental;
+
+enum class UseGroupT { SubGroup = true, WorkGroup = false };
+
+// these classes are needed to pass non-type template parameters to KernelName
+template <int> class IntWrapper;
+template <UseGroupT> class UseGroupWrapper;
+
+class CustomType {
+public:
+  CustomType(size_t Val) : MVal(Val) {}
+  CustomType() : MVal(0) {}
+
+  bool operator<(const CustomType &RHS) const { return MVal < RHS.MVal; }
+  bool operator>(const CustomType &RHS) const { return MVal > RHS.MVal; }
+  bool operator==(const CustomType &RHS) const { return MVal == RHS.MVal; }
+
+private:
+  size_t MVal = 0;
+};
+
+template <class T> struct ConvertToSimpleType {
+  using Type = T;
+};
+
+// Dummy overloads for CustomType which is not supported by radix sorter
+template <> struct ConvertToSimpleType<CustomType> {
+  using Type = int;
+};
+
+template <class SorterT> struct ConvertToSortingOrder;
+
+template <class T> struct ConvertToSortingOrder<std::greater<T>> {
+  static const auto Type = oneapi_exp::sorting_order::descending;
+};
+
+template <class T> struct ConvertToSortingOrder<std::less<T>> {
+  static const auto Type = oneapi_exp::sorting_order::ascending;
+};
+
+constexpr size_t ReqSubGroupSize = 8;
+
+template <typename...> class KernelNameOverGroup;
+template <typename...> class KernelNameJoint;

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/group_and_joint_sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/group_and_joint_sort.cpp
@@ -29,6 +29,7 @@
 
 #include <sycl/detail/core.hpp>
 
+#include "common.hpp"
 #include <sycl/builtins.hpp>
 #include <sycl/ext/oneapi/experimental/group_sort.hpp>
 #include <sycl/group_algorithm.hpp>
@@ -38,31 +39,6 @@
 #include <numeric>
 #include <random>
 #include <vector>
-
-namespace oneapi_exp = sycl::ext::oneapi::experimental;
-
-template <typename...> class KernelNameOverGroup;
-template <typename...> class KernelNameJoint;
-template <typename...> class KernelNameKeyValueOverGroup;
-
-enum class UseGroupT { SubGroup = true, WorkGroup = false };
-
-// these classes are needed to pass non-type template parameters to KernelName
-template <int> class IntWrapper;
-template <UseGroupT> class UseGroupWrapper;
-
-class CustomType {
-public:
-  CustomType(size_t Val) : MVal(Val) {}
-  CustomType() : MVal(0) {}
-
-  bool operator<(const CustomType &RHS) const { return MVal < RHS.MVal; }
-  bool operator>(const CustomType &RHS) const { return MVal > RHS.MVal; }
-  bool operator==(const CustomType &RHS) const { return MVal == RHS.MVal; }
-
-private:
-  size_t MVal = 0;
-};
 
 #if VERSION == 1
 template <class CompT, class T> struct RadixSorterType;
@@ -87,28 +63,7 @@ template <> struct RadixSorterType<std::greater<CustomType>, CustomType> {
   using Type =
       oneapi_exp::radix_sorter<int, oneapi_exp::sorting_order::descending>;
 };
-#else
-template <class T> struct ConvertToSimpleType {
-  using Type = T;
-};
-
-// Dummy overloads for CustomType which is not supported by radix sorter
-template <> struct ConvertToSimpleType<CustomType> {
-  using Type = int;
-};
-
-template <class SorterT> struct ConvertToSortingOrder;
-
-template <class T> struct ConvertToSortingOrder<std::greater<T>> {
-  static const auto Type = oneapi_exp::sorting_order::descending;
-};
-
-template <class T> struct ConvertToSortingOrder<std::less<T>> {
-  static const auto Type = oneapi_exp::sorting_order::ascending;
-};
 #endif
-
-constexpr size_t ReqSubGroupSize = 8;
 
 template <UseGroupT UseGroup, int Dims, class T, class Compare>
 void RunJointSort(sycl::queue &Q, const std::vector<T> &DataToSort,
@@ -484,244 +439,11 @@ void RunSortOVerGroup(sycl::queue &Q, const std::vector<T> &DataToSort,
   }
 }
 
-#if VERSION == 2
-template <UseGroupT UseGroup, int Dims, class T, class U, class Compare>
-void RunSortKeyValueOverGroup(sycl::queue &Q, const std::vector<T> &DataToSort,
-                              const std::vector<U> &KeysToSort,
-                              const Compare &Comp) {
-
-  const size_t NumOfElements = DataToSort.size();
-  const size_t NumSubGroups = NumOfElements / ReqSubGroupSize + 1;
-
-  const sycl::nd_range<Dims> NDRange = [&]() {
-    if constexpr (Dims == 1)
-      return sycl::nd_range<1>{{NumOfElements}, {NumOfElements}};
-    else
-      return sycl::nd_range<2>{{1, NumOfElements}, {1, NumOfElements}};
-    static_assert(Dims < 3,
-                  "Only one and two dimensional kernels are supported");
-  }();
-
-  using RadixSorterT = oneapi_exp::radix_sorters::group_key_value_sorter<
-      typename ConvertToSimpleType<T>::Type, U,
-      ConvertToSortingOrder<Compare>::Type>;
-
-  std::size_t LocalMemorySizeDefault = 0;
-  std::size_t LocalMemorySizeRadix = 0;
-  if (UseGroup == UseGroupT::SubGroup) {
-    // Each sub-group needs a piece of memory for sorting
-    LocalMemorySizeDefault =
-        oneapi_exp::default_sorters::group_key_value_sorter<
-            T, U, Compare>::memory_required(sycl::memory_scope::sub_group,
-                                            ReqSubGroupSize);
-
-    LocalMemorySizeRadix = RadixSorterT::memory_required(
-        sycl::memory_scope::sub_group, ReqSubGroupSize);
-  } else {
-    // A single chunk of memory for each work-group
-    LocalMemorySizeDefault =
-        oneapi_exp::default_sorters::group_key_value_sorter<
-            T, U, Compare>::memory_required(sycl::memory_scope::work_group,
-                                            NumOfElements);
-
-    LocalMemorySizeRadix = RadixSorterT::memory_required(
-        sycl::memory_scope::work_group, NumOfElements);
-  }
-
-  std::vector<T> DataToSortCase0 = DataToSort;
-  std::vector<U> KeysToSortCase0 = KeysToSort;
-
-  std::vector<T> DataToSortCase1 = DataToSort;
-  std::vector<T> KeysToSortCase1 = KeysToSort;
-
-  std::vector<T> DataToSortCase2 = DataToSort;
-  std::vector<T> KeysToSortCase2 = KeysToSort;
-
-  std::vector<T> DataToSortCase3 = DataToSort;
-  std::vector<T> KeysToSortCase3 = KeysToSort;
-
-  // Sort data using 3 different versions of sort_over_group API
-  {
-    sycl::buffer<T> BufDataToSort0(DataToSortCase0.data(),
-                                   DataToSortCase0.size());
-    sycl::buffer<U> BufKeysToSort0(KeysToSortCase0.data(),
-                                   KeysToSortCase0.size());
-
-    sycl::buffer<T> BufDataToSort1(DataToSortCase1.data(),
-                                   DataToSortCase1.size());
-    sycl::buffer<T> BufKeysToSort1(KeysToSortCase1.data(),
-                                   KeysToSortCase1.size());
-
-    sycl::buffer<T> BufDataToSort2(DataToSortCase2.data(),
-                                   DataToSortCase2.size());
-    sycl::buffer<T> BufKeysToSort2(KeysToSortCase2.data(),
-                                   KeysToSortCase2.size());
-
-    sycl::buffer<T> BufDataToSort3(DataToSortCase3.data(),
-                                   DataToSortCase3.size());
-    sycl::buffer<T> BufKeysToSort3(KeysToSortCase3.data(),
-                                   KeysToSortCase3.size());
-
-    Q.submit([&](sycl::handler &CGH) {
-       auto AccDataToSort0 = sycl::accessor(BufDataToSort0, CGH);
-       auto AccKeysToSort0 = sycl::accessor(BufKeysToSort0, CGH);
-
-       auto AccDataToSort1 = sycl::accessor(BufDataToSort1, CGH);
-       auto AccKeysToSort1 = sycl::accessor(BufKeysToSort1, CGH);
-
-       auto AccDataToSort2 = sycl::accessor(BufDataToSort2, CGH);
-       auto AccKeysToSort2 = sycl::accessor(BufKeysToSort2, CGH);
-
-       auto AccDataToSort3 = sycl::accessor(BufDataToSort3, CGH);
-       auto AccKeysToSort3 = sycl::accessor(BufKeysToSort3, CGH);
-
-       // Allocate local memory for all sub-groups in a work-group
-       const size_t TotalLocalMemSizeDefault =
-           UseGroup == UseGroupT::SubGroup
-               ? LocalMemorySizeDefault * NumSubGroups
-               : LocalMemorySizeDefault;
-       sycl::local_accessor<std::byte, 1> ScratchDefault(
-           {TotalLocalMemSizeDefault}, CGH);
-
-       const size_t TotalLocalMemSizeRadix =
-           UseGroup == UseGroupT::SubGroup ? LocalMemorySizeRadix * NumSubGroups
-                                           : LocalMemorySizeRadix;
-
-       sycl::local_accessor<std::byte, 1> ScratchRadix({TotalLocalMemSizeRadix},
-                                                       CGH);
-
-       CGH.parallel_for<KernelNameKeyValueOverGroup<
-           IntWrapper<Dims>, UseGroupWrapper<UseGroup>, T, Compare>>(
-           NDRange, [=](sycl::nd_item<Dims> id) [[intel::reqd_sub_group_size(
-                        ReqSubGroupSize)]] {
-             const size_t GlobalLinearID = id.get_global_linear_id();
-
-             auto Group = [&]() {
-               if constexpr (UseGroup == UseGroupT::SubGroup)
-                 return id.get_sub_group();
-               else
-                 return id.get_group();
-             }();
-
-             // Each sub-group should use it's own part of the scratch pad
-             const size_t ScratchShiftDefault =
-                 UseGroup == UseGroupT::SubGroup
-                     ? id.get_sub_group().get_group_linear_id() *
-                           LocalMemorySizeDefault
-                     : 0;
-             std::byte *ScratchPtrDefault =
-                 &ScratchDefault[0] + ScratchShiftDefault;
-
-             if constexpr (std::is_same_v<Compare, std::less<T>>)
-               std::tie(AccKeysToSort0[GlobalLinearID],
-                        AccDataToSort0[GlobalLinearID]) =
-                   oneapi_exp::sort_key_value_over_group(
-                       oneapi_exp::group_with_scratchpad(
-                           Group, sycl::span{ScratchPtrDefault,
-                                             LocalMemorySizeDefault}),
-                       AccKeysToSort0[GlobalLinearID],
-                       AccDataToSort0[GlobalLinearID]); // (4)
-
-             std::tie(AccKeysToSort1[GlobalLinearID],
-                      AccDataToSort1[GlobalLinearID]) =
-                 oneapi_exp::sort_key_value_over_group(
-                     oneapi_exp::group_with_scratchpad(
-                         Group,
-                         sycl::span{ScratchPtrDefault, LocalMemorySizeDefault}),
-                     AccKeysToSort1[GlobalLinearID],
-                     AccDataToSort1[GlobalLinearID], Comp); // (5)
-
-             std::tie(AccKeysToSort2[GlobalLinearID],
-                      AccDataToSort2[GlobalLinearID]) =
-                 oneapi_exp::sort_key_value_over_group(
-                     Group, AccKeysToSort2[GlobalLinearID],
-                     AccDataToSort2[GlobalLinearID],
-                     oneapi_exp::default_sorters::group_key_value_sorter<
-                         T, U, Compare, /*ElementsPerWorkItem*/ 1>(sycl::span{
-                         ScratchPtrDefault, LocalMemorySizeDefault})); // (6)
-
-             // Each sub-group should use it's own part of the scratch pad
-             const size_t ScratchShiftRadix =
-                 UseGroup == UseGroupT::SubGroup
-                     ? id.get_sub_group().get_group_linear_id() *
-                           LocalMemorySizeRadix
-                     : 0;
-             std::byte *ScratchPtrRadix = &ScratchRadix[0] + ScratchShiftRadix;
-
-             // Radix doesn't support custom types
-             if constexpr (!std::is_same_v<CustomType, T>)
-               std::tie(AccKeysToSort3[GlobalLinearID],
-                        AccDataToSort3[GlobalLinearID]) =
-                   oneapi_exp::sort_key_value_over_group(
-                       Group, AccKeysToSort3[GlobalLinearID],
-                       AccDataToSort3[GlobalLinearID],
-                       RadixSorterT(
-                           sycl::span{ScratchPtrRadix,
-                                      LocalMemorySizeRadix})); // (6) radix
-           });
-     }).wait_and_throw();
-  }
-
-  // Verification
-  {
-    std::vector<std::pair<T, T>> KeyDataToSort;
-    KeyDataToSort.reserve(KeysToSort.size());
-    std::transform(KeysToSort.begin(), KeysToSort.end(), DataToSort.begin(),
-                   std::back_inserter(KeyDataToSort),
-                   [](T Key, T Value) { return std::make_pair(Key, Value); });
-    // Emulate independent sorting of each work-group/sub-group
-    const size_t ChunkSize = UseGroup == UseGroupT::SubGroup
-                                 ? ReqSubGroupSize
-                                 : NDRange.get_local_range().size();
-    auto It = KeyDataToSort.begin();
-    auto KeyValueComp = [&](const std::pair<T, T> &A,
-                            const std::pair<T, T> &B) -> bool {
-      return Comp(A.first, B.first);
-    };
-    for (; (It + ChunkSize) < KeyDataToSort.end(); It += ChunkSize)
-      std::stable_sort(It, It + ChunkSize, KeyValueComp);
-
-    // Sort remainder
-    std::stable_sort(It, KeyDataToSort.end(), KeyValueComp);
-
-    std::vector<T> KeysSorted, DataSorted;
-    KeysSorted.reserve(KeyDataToSort.size());
-    DataSorted.reserve(KeyDataToSort.size());
-    std::transform(
-        KeyDataToSort.begin(), KeyDataToSort.end(),
-        std::back_inserter(KeysSorted),
-        [](const std::pair<T, T> &KeyValue) { return KeyValue.first; });
-    std::transform(
-        KeyDataToSort.begin(), KeyDataToSort.end(),
-        std::back_inserter(DataSorted),
-        [](const std::pair<T, T> &KeyValue) { return KeyValue.second; });
-
-    if constexpr (std::is_same_v<Compare, std::less<T>>) {
-      assert(KeysToSortCase0 == KeysSorted);
-      assert(DataToSortCase0 == DataSorted);
-    }
-
-    assert(KeysToSortCase1 == KeysSorted);
-    assert(DataToSortCase1 == DataSorted);
-    assert(KeysToSortCase2 == KeysSorted);
-    assert(DataToSortCase2 == DataSorted);
-    if constexpr (!std::is_same_v<CustomType, T>) {
-      assert(KeysToSortCase3 == KeysSorted);
-      assert(DataToSortCase3 == DataSorted);
-    }
-  }
-}
-#endif
-
 template <class T> void RunOverType(sycl::queue &Q, size_t DataSize) {
   std::vector<T> DataReversed(DataSize);
-  std::vector<T> KeysReversed(DataSize);
-
   std::vector<T> DataRandom(DataSize);
-  std::vector<T> KeysRandom(DataSize);
 
   std::iota(DataReversed.rbegin(), DataReversed.rend(), (size_t)0);
-  KeysReversed = DataReversed;
 
   // Fill using random numbers
   {
@@ -729,23 +451,12 @@ template <class T> void RunOverType(sycl::queue &Q, size_t DataSize) {
     std::normal_distribution<float> distribution((10.0), (2.0));
     for (T &Elem : DataRandom)
       Elem = T(distribution(generator));
-
-    for (T &Elem : KeysRandom)
-      Elem = T(distribution(generator));
   }
 
   auto RunOnDataAndComp = [&](const std::vector<T> &Data,
-                              const std::vector<T> &Keys,
                               const auto &Comparator) {
     RunSortOVerGroup<UseGroupT::WorkGroup, 1>(Q, Data, Comparator);
     RunSortOVerGroup<UseGroupT::WorkGroup, 2>(Q, Data, Comparator);
-
-#if VERSION == 2
-    RunSortKeyValueOverGroup<UseGroupT::WorkGroup, 1>(Q, Data, Keys,
-                                                      Comparator);
-    RunSortKeyValueOverGroup<UseGroupT::WorkGroup, 2>(Q, Data, Keys,
-                                                      Comparator);
-#endif
 
     RunJointSort<UseGroupT::WorkGroup, 1>(Q, Data, Comparator);
     RunJointSort<UseGroupT::WorkGroup, 2>(Q, Data, Comparator);
@@ -759,19 +470,14 @@ template <class T> void RunOverType(sycl::queue &Q, size_t DataSize) {
     RunSortOVerGroup<UseGroupT::SubGroup, 1>(Q, Data, Comparator);
     RunSortOVerGroup<UseGroupT::SubGroup, 2>(Q, Data, Comparator);
 
-#if VERSION == 2
-    RunSortKeyValueOverGroup<UseGroupT::SubGroup, 1>(Q, Data, Keys, Comparator);
-    RunSortKeyValueOverGroup<UseGroupT::SubGroup, 2>(Q, Data, Keys, Comparator);
-#endif
-
     RunJointSort<UseGroupT::SubGroup, 1>(Q, Data, Comparator);
     RunJointSort<UseGroupT::SubGroup, 2>(Q, Data, Comparator);
   };
 
-  RunOnDataAndComp(DataReversed, KeysReversed, std::greater<T>{});
-  RunOnDataAndComp(DataReversed, KeysReversed, std::less<T>{});
-  RunOnDataAndComp(DataRandom, KeysRandom, std::less<T>{});
-  RunOnDataAndComp(DataRandom, KeysRandom, std::greater<T>{});
+  RunOnDataAndComp(DataReversed, std::greater<T>{});
+  RunOnDataAndComp(DataReversed, std::less<T>{});
+  RunOnDataAndComp(DataRandom, std::less<T>{});
+  RunOnDataAndComp(DataRandom, std::greater<T>{});
 }
 
 int main() {

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/key_value_sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/key_value_sort.cpp
@@ -1,0 +1,314 @@
+// REQUIRES: sg-8
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
+// RUN: %{run} %t.out
+
+// The test verifies key/value sorting from group_sort extension.
+#include "common.hpp"
+#include <sycl/ext/oneapi/experimental/group_sort.hpp>
+
+#include <algorithm>
+#include <iostream>
+#include <numeric>
+#include <random>
+#include <vector>
+
+template <typename...> class KernelNameOverGroup;
+
+template <UseGroupT UseGroup, int Dims, class KeyTy, class ValueTy,
+          class Compare>
+void RunSortKeyValueOverGroup(sycl::queue &Q,
+                              const std::vector<KeyTy> &KeysToSort,
+                              const std::vector<ValueTy> &DataToSort,
+                              const Compare &Comp) {
+
+  const size_t NumOfElements = DataToSort.size();
+  const size_t NumSubGroups = NumOfElements / ReqSubGroupSize + 1;
+
+  const sycl::nd_range<Dims> NDRange = [&]() {
+    if constexpr (Dims == 1)
+      return sycl::nd_range<1>{{NumOfElements}, {NumOfElements}};
+    else
+      return sycl::nd_range<2>{{1, NumOfElements}, {1, NumOfElements}};
+    static_assert(Dims < 3,
+                  "Only one and two dimensional kernels are supported");
+  }();
+
+  using RadixSorterT = oneapi_exp::radix_sorters::group_key_value_sorter<
+      typename ConvertToSimpleType<KeyTy>::Type, ValueTy,
+      ConvertToSortingOrder<Compare>::Type>;
+
+  std::size_t LocalMemorySizeDefault = 0;
+  std::size_t LocalMemorySizeRadix = 0;
+  if (UseGroup == UseGroupT::SubGroup) {
+    // Each sub-group needs a piece of memory for sorting
+    LocalMemorySizeDefault = oneapi_exp::default_sorters::
+        group_key_value_sorter<KeyTy, ValueTy, Compare>::memory_required(
+            sycl::memory_scope::sub_group, ReqSubGroupSize);
+
+    LocalMemorySizeRadix = RadixSorterT::memory_required(
+        sycl::memory_scope::sub_group, ReqSubGroupSize);
+  } else {
+    // A single chunk of memory for each work-group
+    LocalMemorySizeDefault = oneapi_exp::default_sorters::
+        group_key_value_sorter<KeyTy, ValueTy, Compare>::memory_required(
+            sycl::memory_scope::work_group, NumOfElements);
+
+    LocalMemorySizeRadix = RadixSorterT::memory_required(
+        sycl::memory_scope::work_group, NumOfElements);
+  }
+
+  std::vector<KeyTy> KeysToSortCase0 = KeysToSort;
+  std::vector<ValueTy> DataToSortCase0 = DataToSort;
+
+  std::vector<KeyTy> KeysToSortCase1 = KeysToSort;
+  std::vector<ValueTy> DataToSortCase1 = DataToSort;
+
+  std::vector<KeyTy> KeysToSortCase2 = KeysToSort;
+  std::vector<ValueTy> DataToSortCase2 = DataToSort;
+
+  std::vector<KeyTy> KeysToSortCase3 = KeysToSort;
+  std::vector<ValueTy> DataToSortCase3 = DataToSort;
+
+  // Sort data using 3 different versions of sort_over_group API
+  {
+    sycl::buffer<KeyTy> BufKeysToSort0(KeysToSortCase0.data(),
+                                       KeysToSortCase0.size());
+    sycl::buffer<ValueTy> BufDataToSort0(DataToSortCase0.data(),
+                                         DataToSortCase0.size());
+
+    sycl::buffer<KeyTy> BufKeysToSort1(KeysToSortCase1.data(),
+                                       KeysToSortCase1.size());
+    sycl::buffer<ValueTy> BufDataToSort1(DataToSortCase1.data(),
+                                         DataToSortCase1.size());
+
+    sycl::buffer<KeyTy> BufKeysToSort2(KeysToSortCase2.data(),
+                                       KeysToSortCase2.size());
+    sycl::buffer<ValueTy> BufDataToSort2(DataToSortCase2.data(),
+                                         DataToSortCase2.size());
+
+    sycl::buffer<KeyTy> BufKeysToSort3(KeysToSortCase3.data(),
+                                       KeysToSortCase3.size());
+    sycl::buffer<ValueTy> BufDataToSort3(DataToSortCase3.data(),
+                                         DataToSortCase3.size());
+
+    Q.submit([&](sycl::handler &CGH) {
+       auto AccKeysToSort0 = sycl::accessor(BufKeysToSort0, CGH);
+       auto AccDataToSort0 = sycl::accessor(BufDataToSort0, CGH);
+
+       auto AccKeysToSort1 = sycl::accessor(BufKeysToSort1, CGH);
+       auto AccDataToSort1 = sycl::accessor(BufDataToSort1, CGH);
+
+       auto AccKeysToSort2 = sycl::accessor(BufKeysToSort2, CGH);
+       auto AccDataToSort2 = sycl::accessor(BufDataToSort2, CGH);
+
+       auto AccKeysToSort3 = sycl::accessor(BufKeysToSort3, CGH);
+       auto AccDataToSort3 = sycl::accessor(BufDataToSort3, CGH);
+
+       // Allocate local memory for all sub-groups in a work-group
+       const size_t TotalLocalMemSizeDefault =
+           UseGroup == UseGroupT::SubGroup
+               ? LocalMemorySizeDefault * NumSubGroups
+               : LocalMemorySizeDefault;
+       sycl::local_accessor<std::byte, 1> ScratchDefault(
+           {TotalLocalMemSizeDefault}, CGH);
+
+       const size_t TotalLocalMemSizeRadix =
+           UseGroup == UseGroupT::SubGroup ? LocalMemorySizeRadix * NumSubGroups
+                                           : LocalMemorySizeRadix;
+
+       sycl::local_accessor<std::byte, 1> ScratchRadix({TotalLocalMemSizeRadix},
+                                                       CGH);
+
+       auto KeyValueSortKernel =
+           [=](sycl::nd_item<Dims> id) [[intel::reqd_sub_group_size(
+               ReqSubGroupSize)]] {
+             const size_t GlobalLinearID = id.get_global_linear_id();
+
+             auto Group = [&]() {
+               if constexpr (UseGroup == UseGroupT::SubGroup)
+                 return id.get_sub_group();
+               else
+                 return id.get_group();
+             }();
+
+             // Each sub-group should use it's own part of the scratch pad
+             const size_t ScratchShiftDefault =
+                 UseGroup == UseGroupT::SubGroup
+                     ? id.get_sub_group().get_group_linear_id() *
+                           LocalMemorySizeDefault
+                     : 0;
+             std::byte *ScratchPtrDefault =
+                 &ScratchDefault[0] + ScratchShiftDefault;
+
+             if constexpr (std::is_same_v<Compare, std::less<KeyTy>>)
+               std::tie(AccKeysToSort0[GlobalLinearID],
+                        AccDataToSort0[GlobalLinearID]) =
+                   oneapi_exp::sort_key_value_over_group(
+                       oneapi_exp::group_with_scratchpad(
+                           Group, sycl::span{ScratchPtrDefault,
+                                             LocalMemorySizeDefault}),
+                       AccKeysToSort0[GlobalLinearID],
+                       AccDataToSort0[GlobalLinearID]); // (4)
+
+             std::tie(AccKeysToSort1[GlobalLinearID],
+                      AccDataToSort1[GlobalLinearID]) =
+                 oneapi_exp::sort_key_value_over_group(
+                     oneapi_exp::group_with_scratchpad(
+                         Group,
+                         sycl::span{ScratchPtrDefault, LocalMemorySizeDefault}),
+                     AccKeysToSort1[GlobalLinearID],
+                     AccDataToSort1[GlobalLinearID], Comp); // (5)
+
+             std::tie(AccKeysToSort2[GlobalLinearID],
+                      AccDataToSort2[GlobalLinearID]) =
+                 oneapi_exp::sort_key_value_over_group(
+                     Group, AccKeysToSort2[GlobalLinearID],
+                     AccDataToSort2[GlobalLinearID],
+                     oneapi_exp::default_sorters::group_key_value_sorter<
+                         KeyTy, ValueTy, Compare, /*ElementsPerWorkItem*/ 1>(
+                         sycl::span{ScratchPtrDefault,
+                                    LocalMemorySizeDefault})); // (6)
+
+             // Each sub-group should use it's own part of the scratch pad
+             const size_t ScratchShiftRadix =
+                 UseGroup == UseGroupT::SubGroup
+                     ? id.get_sub_group().get_group_linear_id() *
+                           LocalMemorySizeRadix
+                     : 0;
+             std::byte *ScratchPtrRadix = &ScratchRadix[0] + ScratchShiftRadix;
+
+             // Radix doesn't support custom types
+             if constexpr (!std::is_same_v<CustomType, KeyTy>)
+               std::tie(AccKeysToSort3[GlobalLinearID],
+                        AccDataToSort3[GlobalLinearID]) =
+                   oneapi_exp::sort_key_value_over_group(
+                       Group, AccKeysToSort3[GlobalLinearID],
+                       AccDataToSort3[GlobalLinearID],
+                       RadixSorterT(
+                           sycl::span{ScratchPtrRadix,
+                                      LocalMemorySizeRadix})); // (6) radix
+           };
+
+       CGH.parallel_for<
+           KernelNameOverGroup<IntWrapper<Dims>, UseGroupWrapper<UseGroup>,
+                               KeyTy, ValueTy, Compare>>(NDRange,
+                                                         KeyValueSortKernel);
+     }).wait_and_throw();
+  }
+
+  // Verification
+  {
+    std::vector<std::pair<KeyTy, ValueTy>> KeyDataToSort;
+    KeyDataToSort.reserve(KeysToSort.size());
+    std::transform(
+        KeysToSort.begin(), KeysToSort.end(), DataToSort.begin(),
+        std::back_inserter(KeyDataToSort),
+        [](KeyTy Key, ValueTy Value) { return std::make_pair(Key, Value); });
+    // Emulate independent sorting of each work-group/sub-group
+    const size_t ChunkSize = UseGroup == UseGroupT::SubGroup
+                                 ? ReqSubGroupSize
+                                 : NDRange.get_local_range().size();
+    auto It = KeyDataToSort.begin();
+    auto KeyValueComp = [&](const std::pair<KeyTy, ValueTy> &A,
+                            const std::pair<KeyTy, ValueTy> &B) -> bool {
+      return Comp(A.first, B.first);
+    };
+    for (; (It + ChunkSize) < KeyDataToSort.end(); It += ChunkSize)
+      std::stable_sort(It, It + ChunkSize, KeyValueComp);
+
+    // Sort remainder
+    std::stable_sort(It, KeyDataToSort.end(), KeyValueComp);
+
+    std::vector<KeyTy> KeysSorted;
+    std::vector<ValueTy> DataSorted;
+    KeysSorted.reserve(KeyDataToSort.size());
+    DataSorted.reserve(KeyDataToSort.size());
+    std::transform(KeyDataToSort.begin(), KeyDataToSort.end(),
+                   std::back_inserter(KeysSorted),
+                   [](const std::pair<KeyTy, ValueTy> &KeyValue) {
+                     return KeyValue.first;
+                   });
+    std::transform(KeyDataToSort.begin(), KeyDataToSort.end(),
+                   std::back_inserter(DataSorted),
+                   [](const std::pair<KeyTy, ValueTy> &KeyValue) {
+                     return KeyValue.second;
+                   });
+
+    if constexpr (std::is_same_v<Compare, std::less<KeyTy>>) {
+      assert(KeysToSortCase0 == KeysSorted);
+      assert(DataToSortCase0 == DataSorted);
+    }
+
+    assert(KeysToSortCase1 == KeysSorted);
+    assert(DataToSortCase1 == DataSorted);
+    assert(KeysToSortCase2 == KeysSorted);
+    assert(DataToSortCase2 == DataSorted);
+    if constexpr (!std::is_same_v<CustomType, KeyTy>) {
+      assert(KeysToSortCase3 == KeysSorted);
+      assert(DataToSortCase3 == DataSorted);
+    }
+  }
+}
+
+template <class KeyTy, class ValueTy>
+void RunOverType(sycl::queue &Q, size_t DataSize) {
+  std::vector<KeyTy> KeysRandom(DataSize);
+  std::vector<ValueTy> DataRandom(DataSize);
+
+  // Fill using random numbers
+  {
+    std::default_random_engine generator;
+    std::normal_distribution<float> distribution((10.0), (2.0));
+    for (KeyTy &Elem : KeysRandom)
+      Elem = KeyTy(distribution(generator));
+
+    for (ValueTy &Elem : DataRandom)
+      Elem = ValueTy(distribution(generator));
+  }
+
+  auto RunOnDataAndComp = [&](const std::vector<KeyTy> &Keys,
+                              const std::vector<ValueTy> &Data,
+                              const auto &Comparator) {
+    RunSortKeyValueOverGroup<UseGroupT::WorkGroup, 1>(Q, Data, Keys,
+                                                      Comparator);
+    RunSortKeyValueOverGroup<UseGroupT::WorkGroup, 2>(Q, Data, Keys,
+                                                      Comparator);
+
+    if (Q.get_backend() == sycl::backend::ext_oneapi_cuda ||
+        Q.get_backend() == sycl::backend::ext_oneapi_hip) {
+      std::cout << "Note! Skipping sub group testing on CUDA BE" << std::endl;
+      return;
+    }
+
+    RunSortKeyValueOverGroup<UseGroupT::SubGroup, 1>(Q, Data, Keys, Comparator);
+    RunSortKeyValueOverGroup<UseGroupT::SubGroup, 2>(Q, Data, Keys, Comparator);
+  };
+
+  RunOnDataAndComp(KeysRandom, DataRandom, std::less<KeyTy>{});
+  RunOnDataAndComp(KeysRandom, DataRandom, std::greater<KeyTy>{});
+}
+
+int main() {
+  try {
+    sycl::queue Q;
+
+    std::vector<size_t> Sizes{18, 64};
+
+    for (size_t Size : Sizes) {
+      RunOverType<std::int32_t, char>(Q, Size);
+      RunOverType<char, std::int32_t>(Q, Size);
+      if (Q.get_device().has(sycl::aspect::fp16))
+        RunOverType<sycl::half, std::int32_t>(Q, Size);
+      if (Q.get_device().has(sycl::aspect::fp64))
+        RunOverType<double, char>(Q, Size);
+      RunOverType<CustomType, std::int32_t>(Q, Size);
+    }
+
+    std::cout << "Test passed." << std::endl;
+    return 0;
+  } catch (std::exception &E) {
+    std::cout << "Test failed" << std::endl;
+    std::cout << E.what() << std::endl;
+    return 1;
+  }
+}

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/key_value_sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/key_value_sort.cpp
@@ -131,7 +131,7 @@ void RunSortKeyValueOverGroup(sycl::queue &Q,
                  return id.get_group();
              }();
 
-             // Each sub-group should use it's own part of the scratch pad
+             // Each sub-group should use its own part of the scratch pad
              const size_t ScratchShiftDefault =
                  UseGroup == UseGroupT::SubGroup
                      ? id.get_sub_group().get_group_linear_id() *
@@ -169,7 +169,7 @@ void RunSortKeyValueOverGroup(sycl::queue &Q,
                          sycl::span{ScratchPtrDefault,
                                     LocalMemorySizeDefault})); // (6)
 
-             // Each sub-group should use it's own part of the scratch pad
+             // Each sub-group should use its own part of the scratch pad
              const size_t ScratchShiftRadix =
                  UseGroup == UseGroupT::SubGroup
                      ? id.get_sub_group().get_group_linear_id() *

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/sort.cpp
@@ -43,6 +43,7 @@ namespace oneapi_exp = sycl::ext::oneapi::experimental;
 
 template <typename...> class KernelNameOverGroup;
 template <typename...> class KernelNameJoint;
+template <typename...> class KernelNameKeyValueOverGroup;
 
 enum class UseGroupT { SubGroup = true, WorkGroup = false };
 
@@ -483,11 +484,244 @@ void RunSortOVerGroup(sycl::queue &Q, const std::vector<T> &DataToSort,
   }
 }
 
+#if VERSION == 2
+template <UseGroupT UseGroup, int Dims, class T, class U, class Compare>
+void RunSortKeyValueOverGroup(sycl::queue &Q, const std::vector<T> &DataToSort,
+                              const std::vector<U> &KeysToSort,
+                              const Compare &Comp) {
+
+  const size_t NumOfElements = DataToSort.size();
+  const size_t NumSubGroups = NumOfElements / ReqSubGroupSize + 1;
+
+  const sycl::nd_range<Dims> NDRange = [&]() {
+    if constexpr (Dims == 1)
+      return sycl::nd_range<1>{{NumOfElements}, {NumOfElements}};
+    else
+      return sycl::nd_range<2>{{1, NumOfElements}, {1, NumOfElements}};
+    static_assert(Dims < 3,
+                  "Only one and two dimensional kernels are supported");
+  }();
+
+  using RadixSorterT = oneapi_exp::radix_sorters::group_key_value_sorter<
+      typename ConvertToSimpleType<T>::Type, U,
+      ConvertToSortingOrder<Compare>::Type>;
+
+  std::size_t LocalMemorySizeDefault = 0;
+  std::size_t LocalMemorySizeRadix = 0;
+  if (UseGroup == UseGroupT::SubGroup) {
+    // Each sub-group needs a piece of memory for sorting
+    LocalMemorySizeDefault =
+        oneapi_exp::default_sorters::group_key_value_sorter<
+            T, U, Compare>::memory_required(sycl::memory_scope::sub_group,
+                                            ReqSubGroupSize);
+
+    LocalMemorySizeRadix = RadixSorterT::memory_required(
+        sycl::memory_scope::sub_group, ReqSubGroupSize);
+  } else {
+    // A single chunk of memory for each work-group
+    LocalMemorySizeDefault =
+        oneapi_exp::default_sorters::group_key_value_sorter<
+            T, U, Compare>::memory_required(sycl::memory_scope::work_group,
+                                            NumOfElements);
+
+    LocalMemorySizeRadix = RadixSorterT::memory_required(
+        sycl::memory_scope::work_group, NumOfElements);
+  }
+
+  std::vector<T> DataToSortCase0 = DataToSort;
+  std::vector<U> KeysToSortCase0 = KeysToSort;
+
+  std::vector<T> DataToSortCase1 = DataToSort;
+  std::vector<T> KeysToSortCase1 = KeysToSort;
+
+  std::vector<T> DataToSortCase2 = DataToSort;
+  std::vector<T> KeysToSortCase2 = KeysToSort;
+
+  std::vector<T> DataToSortCase3 = DataToSort;
+  std::vector<T> KeysToSortCase3 = KeysToSort;
+
+  // Sort data using 3 different versions of sort_over_group API
+  {
+    sycl::buffer<T> BufDataToSort0(DataToSortCase0.data(),
+                                   DataToSortCase0.size());
+    sycl::buffer<U> BufKeysToSort0(KeysToSortCase0.data(),
+                                   KeysToSortCase0.size());
+
+    sycl::buffer<T> BufDataToSort1(DataToSortCase1.data(),
+                                   DataToSortCase1.size());
+    sycl::buffer<T> BufKeysToSort1(KeysToSortCase1.data(),
+                                   KeysToSortCase1.size());
+
+    sycl::buffer<T> BufDataToSort2(DataToSortCase2.data(),
+                                   DataToSortCase2.size());
+    sycl::buffer<T> BufKeysToSort2(KeysToSortCase2.data(),
+                                   KeysToSortCase2.size());
+
+    sycl::buffer<T> BufDataToSort3(DataToSortCase3.data(),
+                                   DataToSortCase3.size());
+    sycl::buffer<T> BufKeysToSort3(KeysToSortCase3.data(),
+                                   KeysToSortCase3.size());
+
+    Q.submit([&](sycl::handler &CGH) {
+       auto AccDataToSort0 = sycl::accessor(BufDataToSort0, CGH);
+       auto AccKeysToSort0 = sycl::accessor(BufKeysToSort0, CGH);
+
+       auto AccDataToSort1 = sycl::accessor(BufDataToSort1, CGH);
+       auto AccKeysToSort1 = sycl::accessor(BufKeysToSort1, CGH);
+
+       auto AccDataToSort2 = sycl::accessor(BufDataToSort2, CGH);
+       auto AccKeysToSort2 = sycl::accessor(BufKeysToSort2, CGH);
+
+       auto AccDataToSort3 = sycl::accessor(BufDataToSort3, CGH);
+       auto AccKeysToSort3 = sycl::accessor(BufKeysToSort3, CGH);
+
+       // Allocate local memory for all sub-groups in a work-group
+       const size_t TotalLocalMemSizeDefault =
+           UseGroup == UseGroupT::SubGroup
+               ? LocalMemorySizeDefault * NumSubGroups
+               : LocalMemorySizeDefault;
+       sycl::local_accessor<std::byte, 1> ScratchDefault(
+           {TotalLocalMemSizeDefault}, CGH);
+
+       const size_t TotalLocalMemSizeRadix =
+           UseGroup == UseGroupT::SubGroup ? LocalMemorySizeRadix * NumSubGroups
+                                           : LocalMemorySizeRadix;
+
+       sycl::local_accessor<std::byte, 1> ScratchRadix({TotalLocalMemSizeRadix},
+                                                       CGH);
+
+       CGH.parallel_for<KernelNameKeyValueOverGroup<
+           IntWrapper<Dims>, UseGroupWrapper<UseGroup>, T, Compare>>(
+           NDRange, [=](sycl::nd_item<Dims> id) [[intel::reqd_sub_group_size(
+                        ReqSubGroupSize)]] {
+             const size_t GlobalLinearID = id.get_global_linear_id();
+
+             auto Group = [&]() {
+               if constexpr (UseGroup == UseGroupT::SubGroup)
+                 return id.get_sub_group();
+               else
+                 return id.get_group();
+             }();
+
+             // Each sub-group should use it's own part of the scratch pad
+             const size_t ScratchShiftDefault =
+                 UseGroup == UseGroupT::SubGroup
+                     ? id.get_sub_group().get_group_linear_id() *
+                           LocalMemorySizeDefault
+                     : 0;
+             std::byte *ScratchPtrDefault =
+                 &ScratchDefault[0] + ScratchShiftDefault;
+
+             if constexpr (std::is_same_v<Compare, std::less<T>>)
+               std::tie(AccKeysToSort0[GlobalLinearID],
+                        AccDataToSort0[GlobalLinearID]) =
+                   oneapi_exp::sort_key_value_over_group(
+                       oneapi_exp::group_with_scratchpad(
+                           Group, sycl::span{ScratchPtrDefault,
+                                             LocalMemorySizeDefault}),
+                       AccKeysToSort0[GlobalLinearID],
+                       AccDataToSort0[GlobalLinearID]); // (4)
+
+             std::tie(AccKeysToSort1[GlobalLinearID],
+                      AccDataToSort1[GlobalLinearID]) =
+                 oneapi_exp::sort_key_value_over_group(
+                     oneapi_exp::group_with_scratchpad(
+                         Group,
+                         sycl::span{ScratchPtrDefault, LocalMemorySizeDefault}),
+                     AccKeysToSort1[GlobalLinearID],
+                     AccDataToSort1[GlobalLinearID], Comp); // (5)
+
+             std::tie(AccKeysToSort2[GlobalLinearID],
+                      AccDataToSort2[GlobalLinearID]) =
+                 oneapi_exp::sort_key_value_over_group(
+                     Group, AccKeysToSort2[GlobalLinearID],
+                     AccDataToSort2[GlobalLinearID],
+                     oneapi_exp::default_sorters::group_key_value_sorter<
+                         T, U, Compare, /*ElementsPerWorkItem*/ 1>(sycl::span{
+                         ScratchPtrDefault, LocalMemorySizeDefault})); // (6)
+
+             // Each sub-group should use it's own part of the scratch pad
+             const size_t ScratchShiftRadix =
+                 UseGroup == UseGroupT::SubGroup
+                     ? id.get_sub_group().get_group_linear_id() *
+                           LocalMemorySizeRadix
+                     : 0;
+             std::byte *ScratchPtrRadix = &ScratchRadix[0] + ScratchShiftRadix;
+
+             // Radix doesn't support custom types
+             if constexpr (!std::is_same_v<CustomType, T>)
+               std::tie(AccKeysToSort3[GlobalLinearID],
+                        AccDataToSort3[GlobalLinearID]) =
+                   oneapi_exp::sort_key_value_over_group(
+                       Group, AccKeysToSort3[GlobalLinearID],
+                       AccDataToSort3[GlobalLinearID],
+                       RadixSorterT(
+                           sycl::span{ScratchPtrRadix,
+                                      LocalMemorySizeRadix})); // (6) radix
+           });
+     }).wait_and_throw();
+  }
+
+  // Verification
+  {
+    std::vector<std::pair<T, T>> KeyDataToSort;
+    KeyDataToSort.reserve(KeysToSort.size());
+    std::transform(KeysToSort.begin(), KeysToSort.end(), DataToSort.begin(),
+                   std::back_inserter(KeyDataToSort),
+                   [](T Key, T Value) { return std::make_pair(Key, Value); });
+    // Emulate independent sorting of each work-group/sub-group
+    const size_t ChunkSize = UseGroup == UseGroupT::SubGroup
+                                 ? ReqSubGroupSize
+                                 : NDRange.get_local_range().size();
+    auto It = KeyDataToSort.begin();
+    auto KeyValueComp = [&](const std::pair<T, T> &A,
+                            const std::pair<T, T> &B) -> bool {
+      return Comp(A.first, B.first);
+    };
+    for (; (It + ChunkSize) < KeyDataToSort.end(); It += ChunkSize)
+      std::stable_sort(It, It + ChunkSize, KeyValueComp);
+
+    // Sort remainder
+    std::stable_sort(It, KeyDataToSort.end(), KeyValueComp);
+
+    std::vector<T> KeysSorted, DataSorted;
+    KeysSorted.reserve(KeyDataToSort.size());
+    DataSorted.reserve(KeyDataToSort.size());
+    std::transform(
+        KeyDataToSort.begin(), KeyDataToSort.end(),
+        std::back_inserter(KeysSorted),
+        [](const std::pair<T, T> &KeyValue) { return KeyValue.first; });
+    std::transform(
+        KeyDataToSort.begin(), KeyDataToSort.end(),
+        std::back_inserter(DataSorted),
+        [](const std::pair<T, T> &KeyValue) { return KeyValue.second; });
+
+    if constexpr (std::is_same_v<Compare, std::less<T>>) {
+      assert(KeysToSortCase0 == KeysSorted);
+      assert(DataToSortCase0 == DataSorted);
+    }
+
+    assert(KeysToSortCase1 == KeysSorted);
+    assert(DataToSortCase1 == DataSorted);
+    assert(KeysToSortCase2 == KeysSorted);
+    assert(DataToSortCase2 == DataSorted);
+    if constexpr (!std::is_same_v<CustomType, T>) {
+      assert(KeysToSortCase3 == KeysSorted);
+      assert(DataToSortCase3 == DataSorted);
+    }
+  }
+}
+#endif
+
 template <class T> void RunOverType(sycl::queue &Q, size_t DataSize) {
   std::vector<T> DataReversed(DataSize);
+  std::vector<T> KeysReversed(DataSize);
+
   std::vector<T> DataRandom(DataSize);
+  std::vector<T> KeysRandom(DataSize);
 
   std::iota(DataReversed.rbegin(), DataReversed.rend(), (size_t)0);
+  KeysReversed = DataReversed;
 
   // Fill using random numbers
   {
@@ -495,12 +729,23 @@ template <class T> void RunOverType(sycl::queue &Q, size_t DataSize) {
     std::normal_distribution<float> distribution((10.0), (2.0));
     for (T &Elem : DataRandom)
       Elem = T(distribution(generator));
+
+    for (T &Elem : KeysRandom)
+      Elem = T(distribution(generator));
   }
 
   auto RunOnDataAndComp = [&](const std::vector<T> &Data,
+                              const std::vector<T> &Keys,
                               const auto &Comparator) {
     RunSortOVerGroup<UseGroupT::WorkGroup, 1>(Q, Data, Comparator);
     RunSortOVerGroup<UseGroupT::WorkGroup, 2>(Q, Data, Comparator);
+
+#if VERSION == 2
+    RunSortKeyValueOverGroup<UseGroupT::WorkGroup, 1>(Q, Data, Keys,
+                                                      Comparator);
+    RunSortKeyValueOverGroup<UseGroupT::WorkGroup, 2>(Q, Data, Keys,
+                                                      Comparator);
+#endif
 
     RunJointSort<UseGroupT::WorkGroup, 1>(Q, Data, Comparator);
     RunJointSort<UseGroupT::WorkGroup, 2>(Q, Data, Comparator);
@@ -514,14 +759,19 @@ template <class T> void RunOverType(sycl::queue &Q, size_t DataSize) {
     RunSortOVerGroup<UseGroupT::SubGroup, 1>(Q, Data, Comparator);
     RunSortOVerGroup<UseGroupT::SubGroup, 2>(Q, Data, Comparator);
 
+#if VERSION == 2
+    RunSortKeyValueOverGroup<UseGroupT::SubGroup, 1>(Q, Data, Keys, Comparator);
+    RunSortKeyValueOverGroup<UseGroupT::SubGroup, 2>(Q, Data, Keys, Comparator);
+#endif
+
     RunJointSort<UseGroupT::SubGroup, 1>(Q, Data, Comparator);
     RunJointSort<UseGroupT::SubGroup, 2>(Q, Data, Comparator);
   };
 
-  RunOnDataAndComp(DataReversed, std::greater<T>{});
-  RunOnDataAndComp(DataReversed, std::less<T>{});
-  RunOnDataAndComp(DataRandom, std::less<T>{});
-  RunOnDataAndComp(DataRandom, std::greater<T>{});
+  RunOnDataAndComp(DataReversed, KeysReversed, std::greater<T>{});
+  RunOnDataAndComp(DataReversed, KeysReversed, std::less<T>{});
+  RunOnDataAndComp(DataRandom, KeysRandom, std::less<T>{});
+  RunOnDataAndComp(DataRandom, KeysRandom, std::greater<T>{});
 }
 
 int main() {


### PR DESCRIPTION
Add group_key_value_sorter sorters and sort_key_value_over_group APIs based on https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_group_sort.asciidoc extension.

This PR was split out from larger PR: https://github.com/intel/llvm/pull/13713

Co-authored-by: "Andrei Fedorov [andrey.fedorov@intel.com](mailto:andrey.fedorov@intel.com)"
Co-authored-by: "Romanov Vlad [vlad.romanov@intel.com](mailto:vlad.romanov@intel.com)"