### PR TITLE
[SYCL][ESIMD][E2E] Reenable bitreverse test

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/bitreverse.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bitreverse.cpp
@@ -7,8 +7,6 @@
 //===----------------------------------------------------------------------===//
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// TODO: Enable when driver issue fixed
-// UNSUPPORTED: gpu
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>


### PR DESCRIPTION
We updated the igc dev driver.