### PR TITLE
[AMDGPU][SYCL] Make unsafe atomic fadd opt in

### DIFF
--- a/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_add.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_add.cl
@@ -29,8 +29,13 @@ AMDGPU_ATOMIC(_Z18__spirv_AtomicIAdd, unsigned long, m, __hip_atomic_fetch_add)
     return __hip_atomic_fetch_add(p, val, memory_order, atomic_scope);                                     \
   }
 
-AMDGPU_ATOMIC_FP32_ADD_IMPL(global, U3AS1, 1, AMDGPU_ARCH_BETWEEN(9010, 10000),
-                            __builtin_amdgcn_global_atomic_fadd_f32)
+// Global AS atomics can be unsafe for malloc shared atomics, so should be opt
+// in
+AMDGPU_ATOMIC_FP32_ADD_IMPL(
+    global, U3AS1, 1,
+    __oclc_amdgpu_reflect("AMDGPU_OCLC_UNSAFE_FP_ATOMICS") &&
+        AMDGPU_ARCH_BETWEEN(9010, 10000),
+    __builtin_amdgcn_global_atomic_fadd_f32)
 AMDGPU_ATOMIC_FP32_ADD_IMPL(local, U3AS3, 1, AMDGPU_ARCH_GEQ(8000),
                             __builtin_amdgcn_ds_atomic_fadd_f32)
 AMDGPU_ATOMIC_FP32_ADD_IMPL(, , 0, AMDGPU_ARCH_BETWEEN(9400, 10000),
@@ -69,9 +74,13 @@ AMDGPU_ATOMIC_FP32_ADD_IMPL(, , 0, AMDGPU_ARCH_BETWEEN(9400, 10000),
   }
 
 #ifdef cl_khr_int64_base_atomics
-AMDGPU_ATOMIC_FP64_ADD_IMPL(global, U3AS1, 1, 5,
-                            AMDGPU_ARCH_BETWEEN(9010, 10000),
-                            __builtin_amdgcn_global_atomic_fadd_f64)
+// Global AS atomics can be unsafe for malloc shared atomics, so should be opt
+// in
+AMDGPU_ATOMIC_FP64_ADD_IMPL(
+    global, U3AS1, 1, 5,
+    __oclc_amdgpu_reflect("AMDGPU_OCLC_UNSAFE_FP_ATOMICS") &&
+        AMDGPU_ARCH_BETWEEN(9010, 10000),
+    __builtin_amdgcn_global_atomic_fadd_f64)
 AMDGPU_ATOMIC_FP64_ADD_IMPL(local, U3AS3, 1, 5,
                             AMDGPU_ARCH_BETWEEN(9010, 10000),
                             __builtin_amdgcn_ds_atomic_fadd_f64)

--- a/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_add.cl
+++ b/libclc/amdgcn-amdhsa/libspirv/atomic/atomic_add.cl
@@ -33,8 +33,8 @@ AMDGPU_ATOMIC(_Z18__spirv_AtomicIAdd, unsigned long, m, __hip_atomic_fetch_add)
 // in
 AMDGPU_ATOMIC_FP32_ADD_IMPL(
     global, U3AS1, 1,
-    __oclc_amdgpu_reflect("AMDGPU_OCLC_UNSAFE_FP_ATOMICS") &&
-        AMDGPU_ARCH_BETWEEN(9010, 10000),
+    AMDGPU_ARCH_BETWEEN(9010, 10000) &&
+        __oclc_amdgpu_reflect("AMDGPU_OCLC_UNSAFE_FP_ATOMICS"),
     __builtin_amdgcn_global_atomic_fadd_f32)
 AMDGPU_ATOMIC_FP32_ADD_IMPL(local, U3AS3, 1, AMDGPU_ARCH_GEQ(8000),
                             __builtin_amdgcn_ds_atomic_fadd_f32)
@@ -78,8 +78,8 @@ AMDGPU_ATOMIC_FP32_ADD_IMPL(, , 0, AMDGPU_ARCH_BETWEEN(9400, 10000),
 // in
 AMDGPU_ATOMIC_FP64_ADD_IMPL(
     global, U3AS1, 1, 5,
-    __oclc_amdgpu_reflect("AMDGPU_OCLC_UNSAFE_FP_ATOMICS") &&
-        AMDGPU_ARCH_BETWEEN(9010, 10000),
+    AMDGPU_ARCH_BETWEEN(9010, 10000) &&
+        __oclc_amdgpu_reflect("AMDGPU_OCLC_UNSAFE_FP_ATOMICS"),
     __builtin_amdgcn_global_atomic_fadd_f64)
 AMDGPU_ATOMIC_FP64_ADD_IMPL(local, U3AS3, 1, 5,
                             AMDGPU_ARCH_BETWEEN(9010, 10000),

--- a/llvm/lib/Target/AMDGPU/AMDGPUOclcReflect.cpp
+++ b/llvm/lib/Target/AMDGPU/AMDGPUOclcReflect.cpp
@@ -15,6 +15,9 @@
 // 1. Choose a safe or unsafe version of atomic_xor at compile time, which can
 //    be chosen at compile time by setting the flag
 //    --amdgpu-oclc-unsafe-int-atomics=true.
+// 2. Choose a safe or unsafe version of atomic_fadd at compile time, which can
+//    be chosen at compile time by setting the flag
+//    --amdgpu-oclc-unsafe-fp-atomics=true.
 //
 // This pass is similar to the NVPTX pass NVVMReflect.
 //
@@ -39,6 +42,9 @@ static cl::opt<bool>
 static cl::opt<bool> AMDGPUUnsafeIntAtomicsEnable(
     "amdgpu-oclc-unsafe-int-atomics", cl::init(false), cl::Hidden,
     cl::desc("Should unsafe int atomics be chosen. Disabled by default."));
+static cl::opt<bool> AMDGPUUnsafeFPAtomicsEnable(
+    "amdgpu-oclc-unsafe-fp-atomics", cl::init(false), cl::Hidden,
+    cl::desc("Should unsafe fp atomics be chosen. Disabled by default."));
 
 PreservedAnalyses AMDGPUOclcReflectPass::run(Function &F,
                                              FunctionAnalysisManager &AM) {
@@ -78,6 +84,9 @@ PreservedAnalyses AMDGPUOclcReflectPass::run(Function &F,
 
     if (ReflectArg == "AMDGPU_OCLC_UNSAFE_INT_ATOMICS") {
       int ReflectVal = AMDGPUUnsafeIntAtomicsEnable ? 1 : 0;
+      Call->replaceAllUsesWith(ConstantInt::get(Call->getType(), ReflectVal));
+    } else if (ReflectArg == "AMDGPU_OCLC_UNSAFE_FP_ATOMICS") {
+      int ReflectVal = AMDGPUUnsafeFPAtomicsEnable ? 1 : 0;
       Call->replaceAllUsesWith(ConstantInt::get(Call->getType(), ReflectVal));
     } else {
       report_fatal_error("Invalid arg passed to __oclc_amdgpu_reflect");

--- a/sycl/test/check_device_code/hip/atomic/amdgpu_unsafe_atomics.cpp
+++ b/sycl/test/check_device_code/hip/atomic/amdgpu_unsafe_atomics.cpp
@@ -1,24 +1,49 @@
 // REQUIRES: hip
 // RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx906 %s -S -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-SAFE
 // RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx906 %s -mllvm --amdgpu-oclc-unsafe-int-atomics=true -S -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-UNSAFE
+// RUN: %clangxx -fsycl -fsycl-targets=amd_gpu_gfx90a %s -mllvm --amdgpu-oclc-unsafe-fp-atomics=true  -mllvm --amdgpu-oclc-unsafe-int-atomics=true -S -emit-llvm -o - | FileCheck %s --check-prefixes=CHECK,CHECK-UNSAFE-FP
 
 #include <sycl/sycl.hpp>
 
+class intKernel;
+class fpKernel;
+
 int main() {
-  sycl::queue{}.single_task([=] {
-    int a;
+  int *i;
+  float *f;
+  double *d;
+  sycl::queue{}.single_task<intKernel>([=] {
     sycl::atomic_ref<int, sycl::memory_order_relaxed, sycl::memory_scope_device>
-        atomicInt(a);
+        atomicInt(*i);
     atomicInt.fetch_xor(1);
     atomicInt.fetch_and(1);
     atomicInt.fetch_or(1);
-    // CHECK: __CLANG_OFFLOAD_BUNDLE____START__ sycl-amdgcn-amd-amdhsa-
+    // CHECK: amdgpu_kernel void{{.*}}intKernel
     // CHECK-SAFE: cmpxchg volatile
     // CHECK-SAFE-NOT: atomicrmw
     // CHECK-UNSAFE: atomicrmw volatile xor
     // CHECK-UNSAFE: atomicrmw volatile and
     // CHECK-UNSAFE: atomicrmw volatile or
     // CHECK-UNSAFE-NOT: cmpxchg
+  });
+  sycl::queue{}.single_task<fpKernel>([=] {
+    sycl::atomic_ref<float, sycl::memory_order_relaxed,
+                     sycl::memory_scope_device,
+                     sycl::access::address_space::global_space>(*f)
+        .fetch_add(1.0f);
+    // CHECK: amdgpu_kernel void{{.*}}fpKernel
+    // CHECK-SAFE: atomicrmw volatile fadd
+    // CHECK-SAFE-NOT: llvm.amdgcn.global.atomic.fadd.f32
+    // CHECK-UNSAFE-FP: llvm.amdgcn.global.atomic.fadd.f32
+    // CHECK-UNSAFE-FP-NOT: atomicrmw volatile fadd
+    sycl::atomic_ref<double, sycl::memory_order_relaxed,
+                     sycl::memory_scope_device,
+                     sycl::access::address_space::global_space>(*d)
+        .fetch_add(1.0);
+    // CHECK-SAFE: cmpxchg
+    // CHECK-SAFE-NOT: llvm.amdgcn.global.atomic.fadd.f64
+    // CHECK-UNSAFE-FP: llvm.amdgcn.global.atomic.fadd.f64
+    // CHECK-UNSAFE-FP-NOT: cmpxchg
     // CHECK: __CLANG_OFFLOAD_BUNDLE____END__ sycl-amdgcn-amd-amdhsa-
   });
 }


### PR DESCRIPTION
Atomic fadd can fail for malloc_shared allocations if the PCIe bus doesn't support PCIe atomics. This makes the default CAS atomics, so that atomics are guaranteed to work. Fast, unsafe atomics can be used if the flag -mllvm --amdgpu-oclc-unsafe-fp-atomics=true is used.

Testing is updated to test this new option.

Ping @konradkusiak97 