### PR TITLE
[SYCL][Graph] Disable flaky windows tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
@@ -7,6 +7,9 @@
 
 // REQUIRES: aspect-usm_host_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/basic_usm_host.cpp"

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
@@ -8,6 +8,9 @@
 // REQUIRES: aspect-usm_host_allocations
 // REQUIRES: aspect-usm_shared_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/basic_usm_mixed.cpp"

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
@@ -7,6 +7,9 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/basic_usm_shared.cpp"

--- a/sycl/test-e2e/Graph/Explicit/host_task2_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task2_multiple_roots.cpp
@@ -11,6 +11,9 @@
 // Windows
 // UNSUPPORTED: cuda && windows
 
+// Test is flaky on Windows for all targets, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/host_task2_multiple_roots.cpp"

--- a/sycl/test-e2e/Graph/Explicit/host_task_multiple_deps.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_multiple_deps.cpp
@@ -7,6 +7,9 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/host_task_multiple_deps.cpp"

--- a/sycl/test-e2e/Graph/Explicit/host_task_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_multiple_roots.cpp
@@ -11,6 +11,9 @@
 // Windows
 // UNSUPPORTED: cuda && windows
 
+// Test is flaky on Windows for all targets, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/host_task_multiple_roots.cpp"

--- a/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/queue_constructor_usm.cpp"

--- a/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 // This test attempts recording a set of kernels after they have already been
 // executed once before.

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #include "../graph_common.hpp"
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
@@ -7,6 +7,9 @@
 
 // REQUIRES: aspect-usm_host_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/basic_usm_host.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
@@ -8,6 +8,9 @@
 // REQUIRES: aspect-usm_host_allocations
 // REQUIRES: aspect-usm_shared_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/basic_usm_mixed.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
@@ -7,6 +7,9 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/basic_usm_shared.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/host_task2_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task2_multiple_roots.cpp
@@ -11,6 +11,9 @@
 // Windows
 // UNSUPPORTED: cuda && windows
 
+// Test is flaky on Windows for all targets, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/host_task2_multiple_roots.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_deps.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_deps.cpp
@@ -7,6 +7,9 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/host_task_multiple_deps.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_roots.cpp
@@ -11,6 +11,9 @@
 // Windows
 // UNSUPPORTED: cuda && windows
 
+// Test is flaky on Windows for all targets, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/host_task_multiple_roots.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
@@ -5,6 +5,9 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
+
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/queue_constructor_usm.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY
 


### PR DESCRIPTION
Several of the SYCL-Graph E2E tests occasionally fail in CI on Windows for unrelated PRs. We can replicate this locally with a lot of effort, but have not yet been able to diagnose the root cause of find a fix. Disable all the tests which have been documented as sporadically failing on Windows at any point.

See related GitHub Issues:

* https://github.com/intel/llvm/issues/13951
* https://github.com/intel/llvm/issues/12941
* https://github.com/intel/llvm/issues/11852