### PR TITLE
[SYCL][HIP] Remove unsupported from O0 tests on AMD

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -1,8 +1,6 @@
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows
-//
-// The CI GPU doesn't report support for shared USM
-// XFAIL: hip_amd
+// REQUIRES: aspect-usm_shared_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -1,8 +1,8 @@
-// Test hangs on AMD with https://github.com/intel/llvm/pull/8412
-// UNSUPPORTED: hip_amd
-
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows
+//
+// The CI GPU doesn't report support for shared USM
+// XFAIL: hip_amd
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
@@ -5,10 +5,6 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-
-// Test hangs on AMD with https://github.com/intel/llvm/pull/8412
-// UNSUPPORTED: hip_amd
-
 // RUN: %{build} -O0 -o %t.out
 
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Regression/unoptimized_stream.cpp
+++ b/sycl/test-e2e/Regression/unoptimized_stream.cpp
@@ -1,6 +1,3 @@
-// Test hangs on AMD with https://github.com/intel/llvm/pull/8412
-// UNSUPPORTED: hip_amd
-
 // RUN: %{build} -O0 -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
This was tracked down to a bug in ROCm that seems to be fixed with newer
versions, and the CI is now on ROCm 6+ so these should be fine.

ROCm ticket: https://github.com/ROCm/clr/pull/13

The reduce over group test works on W6800 and MI210, but it seems for
gfx1031 it reports not supporting shared USM, note that HIP for gfx1031
isn't officially supported by AMD.