### PR TITLE
[SYCL] Change expected unsupported error for device info query

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -1218,8 +1218,7 @@ struct get_device_info_impl<
 
     // If the feature is unsupported or if the result was empty, return an empty
     // list of devices.
-    if (Err == PI_ERROR_UNSUPPORTED_FEATURE ||
-        (Err == PI_SUCCESS && ResultSize == 0))
+    if (Err == PI_ERROR_INVALID_VALUE || (Err == PI_SUCCESS && ResultSize == 0))
       return {};
 
     // Otherwise, if there was an error from PI it is unexpected and we should

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -72,7 +72,7 @@ pi_result after_piDeviceGetInfo_unsupported(pi_device device,
   switch (param_name) {
   case PI_EXT_ONEAPI_DEVICE_INFO_COMPOSITE_DEVICE:
   case PI_EXT_ONEAPI_DEVICE_INFO_COMPONENT_DEVICES:
-    return PI_ERROR_UNSUPPORTED_FEATURE;
+    return PI_ERROR_INVALID_VALUE;
 
   default:
     return PI_SUCCESS;
@@ -84,7 +84,7 @@ pi_result after_piDeviceGetInfo_no_component_devices(
     void *param_value, size_t *param_value_size_ret) {
   switch (param_name) {
   case PI_EXT_ONEAPI_DEVICE_INFO_COMPOSITE_DEVICE:
-    return PI_ERROR_UNSUPPORTED_FEATURE;
+    return PI_ERROR_INVALID_VALUE;
   case PI_EXT_ONEAPI_DEVICE_INFO_COMPONENT_DEVICES:
     if (param_value_size_ret)
       *param_value_size_ret = 0;


### PR DESCRIPTION
As mentioned in https://github.com/oneapi-src/unified-runtime/pull/1678#discussion_r1620274932 the error code returned for unsupported info queries is `UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION`, which maps to `PI_ERROR_INVALID_VALUE`, so the component devices query should check this error code instead of `PI_ERROR_UNSUPPORTED_FEATURE`.