### PR TITLE
[SYCL][E2E] Fix include of sycl/sycl.hpp in profiling tag tests

### DIFF
--- a/sycl/test-e2e/ProfilingTag/common.hpp
+++ b/sycl/test-e2e/ProfilingTag/common.hpp
@@ -1,6 +1,8 @@
 #pragma once
 
-#include <sycl/sycl.hpp>
+#include <sycl/builtins.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/profiling_tag.hpp>
 
 #define CHECK(Counter, Check)                                                  \
   if (!(Check)) {                                                              \


### PR DESCRIPTION
An include of sycl/sycl.hpp snuck in with https://github.com/intel/llvm/pull/12838. This commit fixes this.