### PR TITLE
[SYCL][E2E] Disable profiling_queue.hpp for FPGA

### DIFF
--- a/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
@@ -16,6 +16,9 @@
 // https://github.com/intel/llvm/issues/12904
 // UNSUPPORTED: hip
 
+// FPGA emulator seems to return unexpected start time for the fallback barrier.
+// UNSUPPORTED: accelerator
+
 #include "common.hpp"
 
 int main() {


### PR DESCRIPTION
Due to a problem in the reported timings of the fallback implementation on the FPGA emulator, the profiling_queue.hpp test fails. This disables the test for those devices.