### PR TITLE
[SYCL][E2E] Disable buffer_create.cpp for DG2 temporarily

### DIFF
--- a/sycl/test-e2e/Basic/buffer/buffer_create.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_create.cpp
@@ -3,6 +3,9 @@
 // RUN: env UR_L0_DEBUG=1 %{run} %t.out 2>&1 | FileCheck %s
 // UNSUPPORTED: ze_debug
 
+// Temporarily disabled for DG2 due to failures.
+// UNSUPPORTED: gpu-intel-dg2
+
 #include <iostream>
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
This commit disables the sycl/test-e2e/Basic/buffer/buffer_create.cpp for DG2 due to recent failures. An internal tracker has been created to investigate this.