### PR TITLE
[UR] Shorten FetchContent build paths

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -84,7 +84,7 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
     endif()
     message(STATUS
       "Will fetch Unified Runtime ${name} adapter from ${repo} at ${tag}")
-    set(fetch-name unified-runtime-${name})
+    set(fetch-name ur-${name})
     FetchContent_Declare(${fetch-name}
       GIT_REPOSITORY ${repo} GIT_TAG ${tag})
     # We don't want to add this repo to the build, only fetch its source.


### PR DESCRIPTION
Windows has an archaic 260 char path length limit by default. This patch replaces `unified-runtime` with `ur` prefix used for `FetchContent` in the `fetch_adapter_source()` helper function. This aims to mitigate creation of paths which exceed the 260 char default limit, especially when executed in a Jenkins runner.
