### PR TITLE
[SYCL][Fusion][NoSTL] Update `jit_compiler::View` constructor and drop deduction guide

### DIFF
--- a/sycl-fusion/common/include/View.h
+++ b/sycl-fusion/common/include/View.h
@@ -22,8 +22,7 @@ public:
 
   template <typename C, typename = std::enable_if_t<
                             std::is_same_v<T, typename C::value_type>>>
-  explicit constexpr View(const C &Cont)
-      : Ptr(std::data(Cont)), Size(std::size(Cont)) {}
+  constexpr View(const C &Cont) : Ptr(std::data(Cont)), Size(std::size(Cont)) {}
 
   constexpr const T *begin() const { return Ptr; }
   constexpr const T *end() const { return Ptr + Size; }
@@ -37,9 +36,6 @@ private:
   const T *const Ptr;
   const size_t Size;
 };
-
-// Deduction guide
-template <typename C> View(C) -> View<typename C::value_type>;
 
 } // namespace jit_compiler
 

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -911,10 +911,9 @@ jit_compiler::fuseKernels(QueueImplPtr Queue,
   AddToConfigHandle(
       ::jit_compiler::option::JITTargetInfo::set(std::move(TargetInfo)));
 
-  using ::jit_compiler::View;
   auto FusionResult = FuseKernelsHandle(
-      View{InputKernelInfo}, FusedKernelName.c_str(), View(ParamIdentities),
-      BarrierFlags, View(InternalizeParams), View(JITConstants));
+      InputKernelInfo, FusedKernelName.c_str(), ParamIdentities, BarrierFlags,
+      InternalizeParams, JITConstants);
 
   if (FusionResult.failed()) {
     if (DebugEnabled) {


### PR DESCRIPTION
Make `View` constructor more generic, e.g., accepting `std::array` and `std::initializer_list` as inputs. Also drop deduction guide. These changes try to address compilation error found in https://github.com/intel/llvm/actions/runs/9315099170/job/25640579916.

Making constructors implicit goes in line with `std::span` and `llvm::ArrayRef`.