### PR TITLE
[SYCL] Force-emit more member functions into device code

### DIFF
--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12037,8 +12037,12 @@ bool ASTContext::DeclMustBeEmitted(const Decl *D) {
     if (LangOpts.SYCLIsDevice && isa<CXXMethodDecl>(D)) {
       if (auto *A = D->getAttr<SYCLDeviceIndirectlyCallableAttr>())
         return !A->isImplicit();
+      // Implicit 'sycl_device' attribute is treated as explicit one if method
+      // is also annotated with 'add_ir_attributes_function' attribute, because
+      // the latter can work as an alias for SYCL_EXTERNAL.
       if (auto *A = D->getAttr<SYCLDeviceAttr>())
-        return !A->isImplicit();
+        return !A->isImplicit() ||
+               D->hasAttr<SYCLAddIRAttributesFunctionAttr>();
     }
 
     GVALinkage Linkage = GetGVALinkageForFunction(FD);

--- a/clang/lib/AST/ASTContext.cpp
+++ b/clang/lib/AST/ASTContext.cpp
@@ -12035,14 +12035,10 @@ bool ASTContext::DeclMustBeEmitted(const Decl *D) {
     // or `indirectly_callable' attribute must be emitted regardless of number
     // of actual uses
     if (LangOpts.SYCLIsDevice && isa<CXXMethodDecl>(D)) {
-      if (auto *A = D->getAttr<SYCLDeviceIndirectlyCallableAttr>())
-        return !A->isImplicit();
-      // Implicit 'sycl_device' attribute is treated as explicit one if method
-      // is also annotated with 'add_ir_attributes_function' attribute, because
-      // the latter can work as an alias for SYCL_EXTERNAL.
-      if (auto *A = D->getAttr<SYCLDeviceAttr>())
-        return !A->isImplicit() ||
-               D->hasAttr<SYCLAddIRAttributesFunctionAttr>();
+      if (D->hasAttr<SYCLDeviceIndirectlyCallableAttr>())
+        return true;
+      if (D->hasAttr<SYCLDeviceAttr>())
+        return true;
     }
 
     GVALinkage Linkage = GetGVALinkageForFunction(FD);

--- a/clang/test/CodeGenSYCL/force-emit-device-virtual-funcs.cpp
+++ b/clang/test/CodeGenSYCL/force-emit-device-virtual-funcs.cpp
@@ -1,0 +1,47 @@
+// RUN: %clang_cc1 -internal-isystem %S/Inputs -triple spir64-unknown-unknown -fsycl-is-device \
+// RUN:     -fsycl-allow-virtual-functions -emit-llvm %s -o %t.ll
+// RUN: FileCheck %s --input-file=%t.ll --implicit-check-not _ZN7Derived3baz \
+// RUN:     --implicit-check-not _ZN4Base4baz --implicit-check-not _ZN4Base3foo
+//
+// Some SYCL properties may be turned into 'sycl_device' attribute implicitly
+// and we would like to ensure that functions like this (at the moment those
+// would be virtual member functions only) are forcefully emitted into device
+// code.
+
+class Base {
+  virtual void foo() {}
+
+  virtual void baz();
+
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "a")]]
+  virtual void bar();
+};
+
+void Base::bar() {}
+
+void Base::baz() {}
+
+class Derived : public Base {
+public:
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "b")]]
+  void foo() override;
+
+  [[__sycl_detail__::add_ir_attributes_function("indirectly-callable", "c")]]
+  void bar() override final;
+
+  [[__sycl_detail__::add_ir_attributes_function("not-indirectly-callable", "c")]]
+  void baz() override final;
+};
+
+void Derived::foo() {}
+
+void Derived::bar() {}
+
+void Derived::baz() {}
+
+// CHECK: define {{.*}}spir_func void @_ZN4Base3bar{{.*}} #[[#AttrA:]]
+// CHECK: define {{.*}}spir_func void @_ZN7Derived3foo{{.*}} #[[#AttrB:]]
+// CHECK: define {{.*}}spir_func void @_ZN7Derived3bar{{.*}} #[[#AttrC:]]
+// CHECK: attributes #[[#AttrA]] = {{.*}} "indirectly-callable"="a"
+// CHECK: attributes #[[#AttrB]] = {{.*}} "indirectly-callable"="b"
+// CHECK: attributes #[[#AttrC]] = {{.*}} "indirectly-callable"="c"


### PR DESCRIPTION
We only emit unused member functions if they have been explicitly annotated with `sycl_device` attribute (through `SYCL_EXTERNAL` macro).

SYCL extension for virtual functions introduces an alternative markup for specifying which function and that markup is SYCL compile-time properties that we turn into attributes implicitly under the hood.

Essentially, we now have a situation where an implicit `sycl_device` attribute on a member function should be treated as an explicit one, because it could be a result of SYCL compile-time property being applied to that method.