### PR TITLE
[SYCL] Fix XPTI FW lib path for test-e2e on Win

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -521,10 +521,11 @@ if os.path.exists(xptifw_lib_dir) and os.path.exists(
     config.available_features.add("xptifw")
     config.substitutions.append(("%xptifw_dispatcher", xptifw_dispatcher))
     if cl_options:
+        xptifw_lib_name = os.path.normpath(os.path.join(xptifw_lib_dir, "xptifw.lib"))
         config.substitutions.append(
             (
                 "%xptifw_lib",
-                " {}/xptifw.lib /I{} ".format(xptifw_lib_dir, xptifw_includes),
+                " {} /I{} ".format(xptifw_lib_name, xptifw_includes),
             )
         )
     else:


### PR DESCRIPTION
This PR helps to avoid hardcoded path symbols and let OS dependent tools to work with paths.
Original version produces `path/....\lib\xptifw.lib` which causes skip of library linkage on windows.
`os.path.normpath` is the main change here that helps to handle path separators properly.
