### PR TITLE
[SYCL][Graph][L0] Correctly report when device supports update

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -109,8 +109,14 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG 9f783837089c970a22cda08f768aa3dbed38f0d3)
 
   fetch_adapter_source(level_zero
-    "https://github.com/Bensuo/unified-runtime.git"
-    "ewan/L0_update_query"
+    ${UNIFIED_RUNTIME_REPO}
+    # commit 8e47ab5057458c5522ce5d86f7996b2882020220
+    # Merge: b816fe82 3d3aba65
+    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+    # Date:   Tue Jun 4 17:28:43 2024 +0100
+    #     Merge pull request #1694 from Bensuo/ewan/L0_update_query
+    #     Set minimum L0 device support to support UR kernel update
+    8e47ab5057458c5522ce5d86f7996b2882020220
   )
 
   fetch_adapter_source(opencl

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -109,8 +109,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG 9f783837089c970a22cda08f768aa3dbed38f0d3)
 
   fetch_adapter_source(level_zero
-    ${UNIFIED_RUNTIME_REPO}
-    ${UNIFIED_RUNTIME_TAG}
+    "https://github.com/Bensuo/unified-runtime.git"
+    "ewan/L0_update_query"
   )
 
   fetch_adapter_source(opencl


### PR DESCRIPTION
Bump UR L0 commit to https://github.com/oneapi-src/unified-runtime/pull/1694 so that the SYCL device aspect for supporting update in graphs is correctly reported for L0 devices. Currently, support can be incorrectly reported.