### PR TITLE
[UR] Add interop testing for CUDA

### DIFF
--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
@@ -30,6 +30,13 @@ int main() {
   const auto &Devices =
       platform(gpu_selector_v).get_devices(info::device_type::gpu);
   std::cout << Devices.size() << " devices found" << std::endl;
+
+  if (Devices.size() == 1) {
+    // Since this is XFAIL for Devices.size() > 1 we need to return failure if
+    // test can't run
+    return 1;
+  }
+
   context C(Devices);
 
   int Index = 0;

--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
@@ -1,0 +1,58 @@
+// REQUIRES: cuda
+// XFAIL: cuda
+//
+// FIXME: this is broken with a multi device context
+//
+// RUN: %{build} -o %t.out -lcuda
+// RUN: %{run} %t.out
+//
+// Test for buffer use in a context with multiple devices (all found
+// root-devices)
+//
+// Make sure that memory migration works for buffers across devices in a context
+// when using host tasks.
+//
+
+#include <cuda.h>
+#include <iostream>
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+int main() {
+
+  int Data = 0;
+  int Result = 0;
+  buffer<int, 1> buf(&Data, range<1>(1));
+
+  const auto &Devices =
+      platform(gpu_selector_v).get_devices(info::device_type::gpu);
+  std::cout << Devices.size() << " devices found" << std::endl;
+  context C(Devices);
+
+  int Index = 0;
+  for (auto D : Devices) {
+    std::cout << "Using on device " << Index << ": "
+              << D.get_info<info::device::name>() << std::endl;
+
+    queue Q(C, D);
+    Q.submit([&](handler &cgh) {
+      accessor acc{buf, cgh, read_write};
+      cgh.host_task([=](interop_handle ih) {
+        auto ptr = ih.get_native_mem<backend::ext_oneapi_cuda>(acc);
+        int tmp = 0;
+        cuMemcpyDtoH(&tmp, ptr, sizeof(int));
+        tmp++;
+        cuMemcpyHtoD(ptr, &tmp, sizeof(int));
+      });
+    });
+    Q.wait();
+    ++Index;
+  }
+
+  auto host_acc = buf.get_host_access();
+  auto passed = (host_acc[0] == Index);
+  std::cout << "Checking result on host: " << (passed ? "passed" : "FAILED")
+            << std::endl;
+  std::cout << host_acc[0] << " ?= " << Index << std::endl;
+  return !passed;
+}

--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda-buffer-migrate.cpp
@@ -15,7 +15,10 @@
 
 #include <cuda.h>
 #include <iostream>
-#include <sycl/sycl.hpp>
+#include <sycl/backend.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/detail/host_task_impl.hpp>
+
 using namespace sycl;
 
 int main() {

--- a/sycl/test-e2e/HostInteropTask/interop-task-cuda.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-cuda.cpp
@@ -1,0 +1,134 @@
+// RUN: %{build} -o %t.out -lcuda
+// RUN: %{run} %t.out
+// REQUIRES: cuda
+
+#include <iostream>
+#include <sycl/backend.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/detail/host_task_impl.hpp>
+
+#include <cuda.h>
+
+using namespace sycl;
+using namespace sycl::access;
+
+static constexpr size_t BUFFER_SIZE = 1024;
+
+template <typename T> class Modifier;
+
+template <typename T> class Init;
+
+template <typename BufferT, typename ValueT>
+void checkBufferValues(BufferT Buffer, ValueT Value) {
+  auto Acc = Buffer.get_host_access();
+  for (size_t Idx = 0; Idx < Acc.get_count(); ++Idx) {
+    if (Acc[Idx] != Value) {
+      std::cerr << "buffer[" << Idx << "] = " << Acc[Idx]
+                << ", expected val = " << Value << '\n';
+      exit(1);
+    }
+  }
+}
+
+template <typename DataT>
+void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
+  Q.submit([&](handler &CGH) {
+    auto SrcA = Src.template get_access<mode::read>(CGH);
+    auto DstA = Dst.template get_access<mode::write>(CGH);
+
+    auto Func = [=](interop_handle IH) {
+      auto HipStream = IH.get_native_queue<backend::ext_oneapi_cuda>();
+      auto SrcMem = IH.get_native_mem<backend::ext_oneapi_cuda>(SrcA);
+      auto DstMem = IH.get_native_mem<backend::ext_oneapi_cuda>(DstA);
+
+      if (cuMemcpyAsync(DstMem, SrcMem, sizeof(DataT) * SrcA.get_count(),
+                        HipStream) != CUDA_SUCCESS) {
+        throw;
+      }
+
+      if (cuStreamSynchronize(HipStream) != CUDA_SUCCESS) {
+        throw;
+      }
+
+      if (Q.get_backend() != IH.get_backend())
+        throw;
+    };
+    CGH.host_task(Func);
+  });
+}
+
+template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
+  Q.submit([&](handler &CGH) {
+    auto Acc = B.template get_access<mode::read_write>(CGH);
+
+    auto Kernel = [=](item<1> Id) { Acc[Id] += 1; };
+
+    CGH.parallel_for<Modifier<DataT>>(Acc.get_count(), Kernel);
+  });
+}
+
+template <typename DataT, DataT B1Init, DataT B2Init>
+void init(buffer<DataT, 1> &B1, buffer<DataT, 1> &B2, queue &Q) {
+  Q.submit([&](handler &CGH) {
+    auto Acc1 = B1.template get_access<mode::write>(CGH);
+    auto Acc2 = B2.template get_access<mode::write>(CGH);
+
+    CGH.parallel_for<Init<DataT>>(BUFFER_SIZE, [=](item<1> Id) {
+      Acc1[Id] = B1Init;
+      Acc2[Id] = B2Init;
+    });
+  });
+}
+
+// Check that a single host-interop-task with a buffer will work.
+void test_ht_buffer(queue &Q) {
+  buffer<int, 1> Buffer{BUFFER_SIZE};
+
+  Q.submit([&](handler &CGH) {
+    auto Acc = Buffer.get_access<mode::write>(CGH);
+    auto Func = [=](interop_handle IH) { /*A no-op */ };
+    CGH.host_task(Func);
+  });
+}
+
+// A test that uses HIP interop to copy data from buffer A to buffer B, by
+// getting HIP ptrs and calling the cuMemcpyWithAsync. Then run a SYCL
+// kernel that modifies the data in place for B, e.g. increment one, then copy
+// back to buffer A. Run it on a loop, to ensure the dependencies and the
+// reference counting of the objects is not leaked.
+void test_ht_kernel_dependencies(queue &Q) {
+  static constexpr int COUNT = 4;
+  buffer<int, 1> Buffer1{BUFFER_SIZE};
+  buffer<int, 1> Buffer2{BUFFER_SIZE};
+
+  // Init the buffer with a'priori invalid data.
+  init<int, -1, -2>(Buffer1, Buffer2, Q);
+
+  // Repeat a couple of times.
+  for (size_t Idx = 0; Idx < COUNT; ++Idx) {
+    copy(Buffer1, Buffer2, Q);
+    modify(Buffer2, Q);
+    copy(Buffer2, Buffer1, Q);
+  }
+
+  checkBufferValues(Buffer1, COUNT - 1);
+  checkBufferValues(Buffer2, COUNT - 1);
+}
+
+void tests(queue &Q) {
+  test_ht_buffer(Q);
+  test_ht_kernel_dependencies(Q);
+}
+
+int main() {
+  queue Q([](sycl::exception_list ExceptionList) {
+    if (ExceptionList.size() != 1) {
+      std::cerr << "Should be one exception in exception list" << std::endl;
+      std::abort();
+    }
+    std::rethrow_exception(*ExceptionList.begin());
+  });
+  tests(Q);
+  std::cout << "Test PASSED" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
Add a basic interop test for CUDA, as well as an interop test that
ensures that memory migration will occur between devices in the same
context, when using host tasks. This is currently broken for CUDA but a fix
is TODO. This fix is nontrivial so will take some time.
