### PR TITLE
[CI] Allow detect changes and detect Arc tests to run on more Linux machines

### DIFF
--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -12,7 +12,7 @@ permissions: read-all
 jobs:
   need_check:
     name: Decide which tests could be affected by the changes
-    runs-on: Linux
+    runs-on: [Linux, aux-tasks]
     timeout-minutes: 3
     outputs:
       filters: ${{ steps.result.outputs.result }}

--- a/.github/workflows/sycl-detect-changes.yml
+++ b/.github/workflows/sycl-detect-changes.yml
@@ -12,9 +12,7 @@ permissions: read-all
 jobs:
   need_check:
     name: Decide which tests could be affected by the changes
-    # Github's ubuntu-* runners are slow to allocate. Use our CUDA runner since
-    # we don't use it for anything right now.
-    runs-on: [Linux, build]
+    runs-on: Linux
     timeout-minutes: 3
     outputs:
       filters: ${{ steps.result.outputs.result }}

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -51,7 +51,7 @@ jobs:
     name: Decide which Arc tests to run
     needs: [build, detect_changes]
     if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
-    runs-on: [Linux, build]
+    runs-on: Linux
     timeout-minutes: 3
     outputs:
       arc_tests: ${{ steps.arc_tests.outputs.arc_tests }}

--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -51,7 +51,7 @@ jobs:
     name: Decide which Arc tests to run
     needs: [build, detect_changes]
     if: ${{ always() && !cancelled() && needs.build.outputs.build_conclusion == 'success' }}
-    runs-on: Linux
+    runs-on: [Linux, aux-tasks]
     timeout-minutes: 3
     outputs:
       arc_tests: ${{ steps.arc_tests.outputs.arc_tests }}


### PR DESCRIPTION
Even the Windows detect changes job requires a Linux build machine today, and that can cause a bottleneck.

We may still get bottlenecked in the Linux tree because of the low number of Linux build systems, but there are more Windows build systems, so that tree might see a speedup.

We can hit a similar thing for the determine arc tests job, so update that too.

Also remove a comment that seems out of date.