### PR TITLE
[SYCL][E2E] Merge `UNSUPPORTED` directives in `DeviceLib/string_test.cpp`

### DIFF
--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -1,15 +1,12 @@
 // UNSUPPORTED: hip
 // RUN: %{build} -fno-builtin -o %t.out
 // RUN: %{run} %t.out
-// TODO: Remove unsupported after fixing
-// https://github.com/intel/llvm/issues/12683
-// UNSUPPORTED: accelerator
 //
 // RUN: %{build} -fno-builtin -fsycl-device-lib-jit-link -o %t.out
 // RUN: %if !gpu %{ %{run} %t.out %}
 
 // FIXME: enable opaque pointers support on CPU.
-// UNSUPPORTED: cpu
+// UNSUPPORTED: cpu || accelerator
 
 #include <cassert>
 #include <cstdint>


### PR DESCRIPTION
Both `accelerator` and `cpu` are unsupported due to the same reason, there is no unique FPGA-related bug here. 
Closes #12683.