### PR TITLE
[Driver][SYCL][NewOffloadModel] Hook up options for the offload-wrapper

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11109,6 +11109,34 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
     for (const auto &A : TranslatorArgs)
       appendOption(OptString, A);
     CmdArgs.push_back(Args.MakeArgString("--llvm-spirv-options=" + OptString));
+
+    // Formulate and add any offload-wrapper specific options.
+    if (TargetTriple.getSubArch() == llvm::Triple::NoSubArch) {
+      const toolchains::SYCLToolChain &SYCLTC =
+          static_cast<const toolchains::SYCLToolChain &>(getToolChain());
+      // Only store compile/link opts in the image descriptor for the SPIR-V
+      // target.
+      const ArgList &Args =
+          C.getArgsForToolChain(nullptr, StringRef(), Action::OFK_SYCL);
+      const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
+      ArgStringList BuildArgs;
+      SmallString<128> OptString;
+      SYCLTC.AddImpliedTargetArgs(TargetTriple, Args, BuildArgs, JA, *HostTC);
+      SYCLTC.TranslateBackendTargetArgs(TargetTriple, Args, BuildArgs);
+      for (const auto &A : BuildArgs)
+        appendOption(OptString, A);
+      if (!OptString.empty())
+        CmdArgs.push_back(
+            Args.MakeArgString("--sycl-backend-compile-options=" + OptString));
+      BuildArgs.clear();
+      OptString.clear();
+      SYCLTC.TranslateLinkerTargetArgs(TargetTriple, Args, BuildArgs);
+      for (const auto &A : BuildArgs)
+        appendOption(OptString, A);
+      if (!OptString.empty())
+        CmdArgs.push_back(
+            Args.MakeArgString("--sycl-target-link-options=" + OptString));
+    }
   }
 
   // Construct the link job so we can wrap around it.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -11110,33 +11110,31 @@ void LinkerWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       appendOption(OptString, A);
     CmdArgs.push_back(Args.MakeArgString("--llvm-spirv-options=" + OptString));
 
-    // Formulate and add any offload-wrapper specific options.
-    if (TargetTriple.getSubArch() == llvm::Triple::NoSubArch) {
-      const toolchains::SYCLToolChain &SYCLTC =
-          static_cast<const toolchains::SYCLToolChain &>(getToolChain());
-      // Only store compile/link opts in the image descriptor for the SPIR-V
-      // target.
-      const ArgList &Args =
-          C.getArgsForToolChain(nullptr, StringRef(), Action::OFK_SYCL);
-      const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
-      ArgStringList BuildArgs;
-      SmallString<128> OptString;
-      SYCLTC.AddImpliedTargetArgs(TargetTriple, Args, BuildArgs, JA, *HostTC);
-      SYCLTC.TranslateBackendTargetArgs(TargetTriple, Args, BuildArgs);
-      for (const auto &A : BuildArgs)
-        appendOption(OptString, A);
-      if (!OptString.empty())
-        CmdArgs.push_back(
-            Args.MakeArgString("--sycl-backend-compile-options=" + OptString));
-      BuildArgs.clear();
-      OptString.clear();
-      SYCLTC.TranslateLinkerTargetArgs(TargetTriple, Args, BuildArgs);
-      for (const auto &A : BuildArgs)
-        appendOption(OptString, A);
-      if (!OptString.empty())
-        CmdArgs.push_back(
-            Args.MakeArgString("--sycl-target-link-options=" + OptString));
-    }
+    // Formulate and add any offload-wrapper and AOT specific options. These
+    // are additional options passed in via -Xsycl-target-linker and
+    // -Xsycl-target-backend.
+    const toolchains::SYCLToolChain &SYCLTC =
+        static_cast<const toolchains::SYCLToolChain &>(getToolChain());
+    // Only store compile/link opts in the image descriptor for the SPIR-V
+    // target.
+    const ArgList &Args =
+        C.getArgsForToolChain(nullptr, StringRef(), Action::OFK_SYCL);
+    ArgStringList BuildArgs;
+    OptString.clear();
+    SYCLTC.TranslateBackendTargetArgs(TargetTriple, Args, BuildArgs);
+    for (const auto &A : BuildArgs)
+      appendOption(OptString, A);
+    if (!OptString.empty())
+      CmdArgs.push_back(
+          Args.MakeArgString("--sycl-backend-compile-options=" + OptString));
+    BuildArgs.clear();
+    OptString.clear();
+    SYCLTC.TranslateLinkerTargetArgs(TargetTriple, Args, BuildArgs);
+    for (const auto &A : BuildArgs)
+      appendOption(OptString, A);
+    if (!OptString.empty())
+      CmdArgs.push_back(
+          Args.MakeArgString("--sycl-target-link-options=" + OptString));
   }
 
   // Construct the link job so we can wrap around it.

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -106,3 +106,16 @@
 // CHK_ARCH: clang{{.*}} "-triple" "[[TRIPLE]]"
 // CHK_ARCH-SAME: "-fsycl-is-device" {{.*}} "--offload-new-driver"{{.*}} "-o" "[[CC1DEVOUT:.+\.bc]]"
 // CHK_ARCH-NEXT: clang-offload-packager{{.*}} "--image=file=[[CC1DEVOUT]],triple=[[TRIPLE]],arch=[[ARCH]],kind=sycl"
+
+/// Test option passing behavior for clang-offload-wrapper options.
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN:          -Xsycl-target-backend -backend-opt -### %s 2>&1 \
+// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_BACKEND %s
+// WRAPPER_OPTIONS_BACKEND: clang-linker-wrapper{{.*}} "--triple=spir64"
+// WRAPPER_OPTIONS_BACKEND-SAME: "--sycl-backend-compile-options={{.*}}-backend-opt{{.*}}"
+
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN:          -Xsycl-target-linker -link-opt -### %s 2>&1 \
+// RUN:   | FileCheck -check-prefix WRAPPER_OPTIONS_LINK %s
+// WRAPPER_OPTIONS_LINK: clang-linker-wrapper{{.*}} "--triple=spir64"
+// WRAPPER_OPTIONS_LINK-SAME: "--sycl-target-link-options={{.*}}-link-opt{{.*}}"


### PR DESCRIPTION
Additional options can be passed along to the clang-offload-wrapper via -Xsycl-target-backend and -Xsycl-target-link.  Hook up the ability to pass the values from these options along to the clang-linker-wrapper.