### PR TITLE
[SYCL][CUDA] Enable support of msvc math functions for nvptx target.

### DIFF
--- a/libdevice/msvc_math.cpp
+++ b/libdevice/msvc_math.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-#if defined(__SPIR__) || defined(__SPIRV__)
+#if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__)
 
 #include "device.h"
 #include <math.h>
@@ -281,4 +281,4 @@ float _FSinh(float x, float y) { // compute y * sinh(x), |y| <= 1
     return neg ? -x : x;
   }
 }
-#endif
+#endif // __SPIR__ || __SPIRV__ || __NVPTX__


### PR DESCRIPTION
- Enable support of msvc math functions for NVPTX target.
- Adding the support fix the build errors seen in [cmath_test.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/DeviceLib/cmath_test.cpp) and [math_test.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/DeviceLib/math_test.cpp) tests.