### PR TITLE
[SYCL][NATIVECPU] Implement urUSMGetMemAllocInfo and aligned alloc

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -155,8 +155,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   )
 
   fetch_adapter_source(native_cpu
-    ${UNIFIED_RUNTIME_REPO}
-    ${UNIFIED_RUNTIME_TAG}
+    "https://github.com/PietroGhg/unified-runtime.git"
+    pietro/usm_fixes
   )
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,13 +116,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 9deaabcbef168015df251c4ac0d47c2cba7bfbfb
-  # Merge: 84f5e705 ca2916e9
+  # commit a89657c2e36d7152820b9ecc088422a54ca1d844
+  # Merge: 2355a7d6 be7057c4
   # Author: Omar Ahmed <omar.ahmed@codeplay.com>
-  # Date:   Mon Aug 5 21:02:44 2024 +0100
-  #     Merge pull request #1929 from oneapi-src/revert-1880-l0-native-enqueue
-  #     Revert "[L0] L0 impl for enqueue native command"
-  set(UNIFIED_RUNTIME_TAG 9deaabcbef168015df251c4ac0d47c2cba7bfbfb)
+  # Date:   Wed Aug 7 12:01:33 2024 +0100
+  #     Merge pull request #1699 from PietroGhg/pietro/usm_fixes
+  #     [NATIVECPU] Implement urUSMGetMemAllocInfo and aligned alloc
+  set(UNIFIED_RUNTIME_TAG a89657c2e36d7152820b9ecc088422a54ca1d844)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need
@@ -155,8 +155,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   )
 
   fetch_adapter_source(native_cpu
-    "https://github.com/PietroGhg/unified-runtime.git"
-    pietro/usm_fixes
+    ${UNIFIED_RUNTIME_REPO}
+    ${UNIFIED_RUNTIME_TAG}
   )
 
   if(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_REPO)

--- a/sycl/test-e2e/USM/dmem_varied.cpp
+++ b/sycl/test-e2e/USM/dmem_varied.cpp
@@ -3,7 +3,7 @@
 
 // This test is expected to reliably work with USM allocator which is
 // currently enabled only on level zero.
-// REQUIRES: level_zero
+// REQUIRES: level_zero || native_cpu
 
 //==---------- dmem_varied.cpp - Test various sizes and alignments ---------==//
 //

--- a/sycl/test-e2e/USM/dmem_varied.cpp
+++ b/sycl/test-e2e/USM/dmem_varied.cpp
@@ -2,7 +2,7 @@
 // RUN: %{run} %t1.out
 
 // This test is expected to reliably work with USM allocator which is
-// currently enabled only on level zero.
+// currently enabled only on level zero and Native CPU.
 // REQUIRES: level_zero || native_cpu
 
 //==---------- dmem_varied.cpp - Test various sizes and alignments ---------==//


### PR DESCRIPTION
Testing PR for https://github.com/oneapi-src/unified-runtime/pull/1699.
`sycl/test-e2e/USM/dmem_varied.cpp` is passing on Native CPU with the corresponding UR changes.