### PR TITLE
[SYCL][COMPAT] Migrate bug fixes & refactor of get_*version APIs

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -911,6 +911,13 @@ class device_ext : public sycl::device {
 } // syclcompat
 ```
 
+Free functions are provided for querying major and minor version directly from a `sycl::device`, equivalent to the methods of `device_ext` described above:
+
+```c++
+static int get_major_version(const sycl::device &dev);
+static int get_minor_version(const sycl::device &dev);
+```
+
 #### Multiple devices
 
 SYCLcompat allows you to manage multiple devices through

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -64,7 +64,7 @@ static void parse_version_string(const std::string &ver, int &major,
   // Version string has the following format:
   // a. OpenCL<space><major.minor><space><vendor-specific-information>
   // b. <major.minor>
-  // c. <AmdGcnArchName> e.g gfx1030 (unhandled)
+  // c. <AmdGcnArchName> e.g gfx1030
   std::string::size_type i = 0;
   while (i < ver.size()) {
     if (isdigit(ver[i]))

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -59,12 +59,12 @@
 namespace syclcompat {
 
 namespace detail {
-static void get_version(const sycl::device &dev, int &major, int &minor) {
+static void parse_version_string(const std::string &ver, int &major,
+                                 int &minor) {
   // Version string has the following format:
   // a. OpenCL<space><major.minor><space><vendor-specific-information>
   // b. <major.minor>
-  std::string ver;
-  ver = dev.get_info<sycl::info::device::version>();
+  // c. <AmdGcnArchName> e.g gfx1030 (unhandled)
   std::string::size_type i = 0;
   while (i < ver.size()) {
     if (isdigit(ver[i]))
@@ -85,6 +85,11 @@ static void get_version(const sycl::device &dev, int &major, int &minor) {
     minor = std::stoi(&(ver[i]));
   else
     minor = 0;
+}
+
+static void get_version(const sycl::device &dev, int &major, int &minor) {
+  std::string ver = dev.get_info<sycl::info::device::version>();
+  parse_version_string(ver, major, minor);
 }
 
 /// SYCL default exception handler

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -322,13 +322,9 @@ public:
   }
 
   bool is_native_host_atomic_supported() { return false; }
-  int get_major_version() const {
-    return syclcompat::get_major_version(*this);
-  }
+  int get_major_version() const { return syclcompat::get_major_version(*this); }
 
-  int get_minor_version() const {
-    return syclcompat::get_minor_version(*this);
-  }
+  int get_minor_version() const { return syclcompat::get_minor_version(*this); }
 
   int get_max_compute_units() const {
     return get_device_info().get_max_compute_units();

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -59,6 +59,33 @@
 namespace syclcompat {
 
 namespace detail {
+static void get_version(const sycl::device &dev, int &major, int &minor) {
+  // Version string has the following format:
+  // a. OpenCL<space><major.minor><space><vendor-specific-information>
+  // b. <major.minor>
+  std::string ver;
+  ver = dev.get_info<sycl::info::device::version>();
+  std::string::size_type i = 0;
+  while (i < ver.size()) {
+    if (isdigit(ver[i]))
+      break;
+    i++;
+  }
+  if (i < ver.size())
+    major = std::stoi(&(ver[i]));
+  else
+    major = 0;
+  while (i < ver.size()) {
+    if (ver[i] == '.')
+      break;
+    i++;
+  }
+  i++;
+  if (i < ver.size())
+    minor = std::stoi(&(ver[i]));
+  else
+    minor = 0;
+}
 
 /// SYCL default exception handler
 inline auto exception_handler = [](sycl::exception_list exceptions) {
@@ -261,6 +288,18 @@ private:
   std::array<unsigned char, 16> _uuid;
 };
 
+static int get_major_version(const sycl::device &dev) {
+  int major, minor;
+  detail::get_version(dev, major, minor);
+  return major;
+}
+
+static int get_minor_version(const sycl::device &dev) {
+  int major, minor;
+  detail::get_version(dev, major, minor);
+  return minor;
+}
+
 /// device extension
 class device_ext : public sycl::device {
 public:
@@ -284,11 +323,11 @@ public:
 
   bool is_native_host_atomic_supported() { return false; }
   int get_major_version() const {
-    return get_device_info().get_major_version();
+    return syclcompat::get_major_version(*this);
   }
 
   int get_minor_version() const {
-    return get_device_info().get_minor_version();
+    return syclcompat::get_minor_version(*this);
   }
 
   int get_max_compute_units() const {
@@ -569,32 +608,7 @@ private:
   }
 
   void get_version(int &major, int &minor) const {
-    // Version string has the following format:
-    // a. OpenCL<space><major.minor><space><vendor-specific-information>
-    // b. <major.minor>
-    // c. <AmdGcnArchName> e.g gfx1030
-    std::string ver;
-    ver = get_info<sycl::info::device::version>();
-    std::string::size_type i = 0;
-    while (i < ver.size()) {
-      if (isdigit(ver[i]))
-        break;
-      i++;
-    }
-    major = std::stoi(&(ver[i]));
-    while (i < ver.size()) {
-      if (ver[i] == '.')
-        break;
-      i++;
-    }
-    if (i < ver.size()) {
-      // a. and b.
-      i++;
-      minor = std::stoi(&(ver[i]));
-    } else {
-      // c.
-      minor = 0;
-    }
+    detail::get_version(*this, major, minor);
   }
   void add_event(sycl::event event) {
     std::lock_guard<std::mutex> lock(m_mutex);

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -107,6 +107,33 @@ void test_create_queue_arguments() {
   assert(!q_out_order.is_in_order());
 }
 
+void test_version_parsing_case(const std::string &ver_string,
+                               int expected_major, int expected_minor) {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  int major;
+  int minor;
+  syclcompat::detail::parse_version_string(ver_string, major, minor);
+  if (major != expected_major || minor != expected_minor) {
+    std::cout << "Failed comparing " << ver_string << " major " << major
+              << " expected_major " << expected_major << " minor " << minor
+              << " expected_minor " << expected_minor << std::endl;
+    assert(false);
+  }
+  assert(major == expected_major);
+  assert(minor == expected_minor);
+}
+
+void test_version_parsing() {
+  test_version_parsing_case("3.0", 3, 0);
+  test_version_parsing_case("3.0 NEO", 3, 0);
+  test_version_parsing_case("8.6", 8, 6);
+  test_version_parsing_case("8.0", 8, 0);
+  test_version_parsing_case("7.5", 7, 5);
+  test_version_parsing_case("1.3", 1, 3);
+  test_version_parsing_case("11.4", 11, 4);
+  test_version_parsing_case("0.1", 0, 1);
+}
+
 // We have *some* constraints on the major version that we can check
 void test_major_version(sycl::device &dev, int major) {
   auto backend = dev.get_backend();
@@ -264,6 +291,7 @@ int main() {
   test_saved_queue();
   test_reset();
   test_device_info_api();
+  test_version_parsing();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -111,10 +111,9 @@ void test_create_queue_arguments() {
 void test_major_version(sycl::device &dev, int major) {
   auto backend = dev.get_backend();
   if (backend == sycl::backend::opencl) {
-    assert(major == 3);
-  } else if (backend == sycl::backend::ext_oneapi_level_zero) {
-    assert(major == 1);
-  } else if (backend == sycl::backend::ext_oneapi_cuda) {
+    assert(major == 1 || major == 3);
+  } else if (backend == sycl::backend::ext_oneapi_level_zero ||
+             backend == sycl::backend::ext_oneapi_cuda) {
     assert(major < 99);
   }
 }

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -134,6 +134,15 @@ void test_device_ext_api() {
   auto Context = dev_.get_context();
 }
 
+void test_device_api() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+  DeviceExtFixt dev_ext;
+  auto &dev_ = dev_ext.get_dev_ext();
+
+  get_major_version(dev_);
+  get_minor_version(dev_);
+}
+
 void test_default_saved_queue() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   DeviceExtFixt dev_ext;
@@ -238,6 +247,7 @@ int main() {
   test_check_default_device();
   test_create_queue_arguments();
   test_device_ext_api();
+  test_device_api();
   test_default_saved_queue();
   test_saved_queue();
   test_reset();

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -126,12 +126,15 @@ void test_version_parsing_case(const std::string &ver_string,
 void test_version_parsing() {
   test_version_parsing_case("3.0", 3, 0);
   test_version_parsing_case("3.0 NEO", 3, 0);
+  test_version_parsing_case("OpenCL 3.0 NEO", 3, 0);
+  test_version_parsing_case("OpenCL 3.0 (Build 0)", 3, 0);
   test_version_parsing_case("8.6", 8, 6);
   test_version_parsing_case("8.0", 8, 0);
   test_version_parsing_case("7.5", 7, 5);
   test_version_parsing_case("1.3", 1, 3);
   test_version_parsing_case("11.4", 11, 4);
   test_version_parsing_case("0.1", 0, 1);
+  test_version_parsing_case("gfx1030", 1030, 0);
 }
 
 // We have *some* constraints on the major version that we can check

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -107,6 +107,18 @@ void test_create_queue_arguments() {
   assert(!q_out_order.is_in_order());
 }
 
+// We have *some* constraints on the major version that we can check
+void test_major_version(sycl::device &dev, int major) {
+  auto backend = dev.get_backend();
+  if (backend == sycl::backend::opencl) {
+    assert(major == 3);
+  } else if (backend == sycl::backend::ext_oneapi_level_zero) {
+    assert(major == 1);
+  } else if (backend == sycl::backend::ext_oneapi_cuda) {
+    assert(major < 99);
+  }
+}
+
 /*
   Device Extension Tests
 */
@@ -115,7 +127,8 @@ void test_device_ext_api() {
   DeviceExtFixt dev_ext;
   auto &dev_ = dev_ext.get_dev_ext();
   dev_.is_native_host_atomic_supported();
-  dev_.get_major_version();
+  auto major = dev_.get_major_version();
+  test_major_version(dev_, major);
   dev_.get_minor_version();
   dev_.get_max_compute_units();
   dev_.get_max_clock_frequency();
@@ -138,8 +151,8 @@ void test_device_api() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   DeviceExtFixt dev_ext;
   auto &dev_ = dev_ext.get_dev_ext();
-
-  get_major_version(dev_);
+  auto major = get_major_version(dev_);
+  test_major_version(dev_, major);
   get_minor_version(dev_);
 }
 


### PR DESCRIPTION
This PR migrates changes to `get_version`, `get_major_version` and `get_minor_version`, adds new free function equivalents which accept a `sycl::device` argument, and adds relevant tests and documentation.