### PR TITLE
[SYCL][COMPAT] Add device_count and testing

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -918,6 +918,12 @@ static inline void list_devices();
 // Util function to select a device by its id
 static inline unsigned int select_device(unsigned int id);
 
+// Util function to get the device id from a device
+static inline unsigned int get_device_id(const sycl::device &dev);
+
+// Util function to get the number of available devices
+static inline unsigned int device_count();
+
 } // syclcompat
 ```
 

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -938,4 +938,7 @@ static inline unsigned int get_device_id(const sycl::device &dev) {
   return detail::dev_mgr::instance().get_device_id(dev);
 }
 
+static inline unsigned int device_count() {
+  return detail::dev_mgr::instance().device_count();
+}
 } // namespace syclcompat

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -274,6 +274,7 @@ void test_device_info_api() {
   assert(Info.get_global_mem_cache_size() == 1000);
 }
 
+<<<<<<< HEAD
 void test_image_max_attrs() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   syclcompat::device_info info;
@@ -377,6 +378,21 @@ void test_list_devices() {
   assert(countingBuf.get_line_count() == dtf.get_n_devices());
 }
 
+void test_device_count() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  unsigned int count = syclcompat::device_count();
+  assert(count > 0);
+}
+
+void test_get_device_id() {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  sycl::device dev = syclcompat::get_device(0);
+  unsigned int id = syclcompat::get_device_id(dev);
+  assert(id == 0);
+}
+
 int main() {
   test_at_least_one_device();
   test_matches_id();
@@ -396,6 +412,8 @@ int main() {
   test_image_max_attrs();
   test_max_nd_range();
   test_list_devices();
+  test_device_count();
+  test_get_device_id();
 
   return 0;
 }

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -274,7 +274,6 @@ void test_device_info_api() {
   assert(Info.get_global_mem_cache_size() == 1000);
 }
 
-<<<<<<< HEAD
 void test_image_max_attrs() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
   syclcompat::device_info info;

--- a/sycl/test-e2e/syclcompat/device/device_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/device/device_fixt.hpp
@@ -32,7 +32,7 @@ protected:
 
 public:
   DeviceTestsFixt()
-      : n_devices{syclcompat::detail::dev_mgr::instance().device_count()},
+      : n_devices{syclcompat::device_count()},
         def_q_{syclcompat::get_default_queue()} {}
 
   unsigned int get_n_devices() { return n_devices; }


### PR DESCRIPTION
This PR adds the syclcompat free function `device_count`.
It provides testing for this new function and for `get_device_id()`