### PR TITLE
[test-e2e][cuda] Fully qualify `sycl::sub_group` to avoid namespace ambiguity

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_apply_cuda.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_cuda.hpp
@@ -50,8 +50,10 @@ void matrix_verify_lambda(queue q,
 
             auto sg = spmd_item.get_sub_group();
 
-            joint_matrix<sycl::sub_group, T, use::a, M, K, layout::row_major> sub_a;
-            joint_matrix<sycl::sub_group, T, use::b, K, N, layout::row_major> sub_b;
+            joint_matrix<sycl::sub_group, T, use::a, M, K, layout::row_major>
+                sub_a;
+            joint_matrix<sycl::sub_group, T, use::b, K, N, layout::row_major>
+                sub_b;
             joint_matrix<sycl::sub_group, T2, use::accumulator, M, N> sub_c;
 
             joint_matrix_fill(sg, sub_a, 3);

--- a/sycl/test-e2e/Matrix/joint_matrix_apply_cuda.hpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_apply_cuda.hpp
@@ -50,9 +50,9 @@ void matrix_verify_lambda(queue q,
 
             auto sg = spmd_item.get_sub_group();
 
-            joint_matrix<sub_group, T, use::a, M, K, layout::row_major> sub_a;
-            joint_matrix<sub_group, T, use::b, K, N, layout::row_major> sub_b;
-            joint_matrix<sub_group, T2, use::accumulator, M, N> sub_c;
+            joint_matrix<sycl::sub_group, T, use::a, M, K, layout::row_major> sub_a;
+            joint_matrix<sycl::sub_group, T, use::b, K, N, layout::row_major> sub_b;
+            joint_matrix<sycl::sub_group, T2, use::accumulator, M, N> sub_c;
 
             joint_matrix_fill(sg, sub_a, 3);
             joint_matrix_fill(sg, sub_b, 1);


### PR DESCRIPTION
This change avoids the ambiguity between the deprecated `sycl::ext::oneapi::sub_group` and `sycl::sub_group` when both namespaces are used. This fixes a failure on windows for cuda.