### PR TITLE
[SYCL] Allow specifying -foffload-lto with the new offload driver and build libdevice with thinLTO

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5843,10 +5843,15 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-llvm-uselists");
 
     if (IsUsingLTO) {
+      bool IsUsingNewOffloadDriver =
+          Args.hasFlag(options::OPT_offload_new_driver,
+                       options::OPT_no_offload_new_driver, false);
+      bool IsSYCLLTOSupported = JA.isDeviceOffloading(Action::OFK_SYCL) &&
+                                Triple.isSPIROrSPIRV() &&
+                                IsUsingNewOffloadDriver;
       if (IsDeviceOffloadAction && !JA.isDeviceOffloading(Action::OFK_OpenMP) &&
-          !Args.hasFlag(options::OPT_offload_new_driver,
-                        options::OPT_no_offload_new_driver, false) &&
-          !Triple.isAMDGPU()) {
+          !IsUsingNewOffloadDriver && !Triple.isAMDGPU() &&
+          !IsSYCLLTOSupported) {
         D.Diag(diag::err_drv_unsupported_opt_for_target)
             << Args.getLastArg(options::OPT_foffload_lto,
                                options::OPT_foffload_lto_EQ)

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5843,14 +5843,14 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
       CmdArgs.push_back("-emit-llvm-uselists");
 
     if (IsUsingLTO) {
-      bool IsUsingNewOffloadDriver =
+      bool IsUsingOffloadNewDriver =
           Args.hasFlag(options::OPT_offload_new_driver,
                        options::OPT_no_offload_new_driver, false);
       bool IsSYCLLTOSupported = JA.isDeviceOffloading(Action::OFK_SYCL) &&
                                 Triple.isSPIROrSPIRV() &&
-                                IsUsingNewOffloadDriver;
+                                IsUsingOffloadNewDriver;
       if (IsDeviceOffloadAction && !JA.isDeviceOffloading(Action::OFK_OpenMP) &&
-          !IsUsingNewOffloadDriver && !Triple.isAMDGPU() &&
+          !IsUsingOffloadNewDriver && !Triple.isAMDGPU() &&
           !IsSYCLLTOSupported) {
         D.Diag(diag::err_drv_unsupported_opt_for_target)
             << Args.getLastArg(options::OPT_foffload_lto,

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -5,4 +5,4 @@
 
 // CHECK_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
 
-// CHECK_SUPPORTED: clang-19{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"
+// CHECK_SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -1,8 +1,7 @@
 // Verify the usage of -foffload-lto with SYCL.
-// RUN: touch %t.cpp
-// RUN: not %clangxx -fsycl -foffload-lto=thin %t.cpp -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
+// RUN: not %clangxx -fsycl -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
 //
-// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %t.cpp -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
+// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
 
 // CHECK_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
 

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -1,8 +1,9 @@
 // Verify the usage of -foffload-lto with SYCL.
-// RUN: not %clangxx -fsycl -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
-//
-// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
 
+// Verify we error when using the old offload driver.
+// RUN: not %clangxx -fsycl -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
 // CHECK_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
 
+// Verify there's no error and we see the expected cc1 flags with the new offload driver.
+// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
 // CHECK_SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -1,0 +1,9 @@
+// Verify the usage of -foffload-lto with SYCL.
+// RUN: touch %t.cpp
+// RUN: not %clangxx -fsycl -foffload-lto=thin %t.cpp -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
+//
+// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %t.cpp -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
+
+// CHECK_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
+
+// CHECK_SUPPORTED: clang-19{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -91,7 +91,7 @@ function(add_devicelib_obj obj_filename)
 
   set(devicelib-obj-file-new-offload ${obj_new_offload_binary_dir}/${obj_filename}.${new-offload-lib-suffix})
   add_custom_command(OUTPUT ${devicelib-obj-file-new-offload}
-                     COMMAND ${clang} -fsycl -c --offload-new-driver
+                     COMMAND ${clang} -fsycl -c --offload-new-driver -foffload-lto=thin
                              ${compile_opts} ${sycl_targets_opt} ${OBJ_EXTRA_ARGS}
                              ${CMAKE_CURRENT_SOURCE_DIR}/${OBJ_SRC}
                              -o ${devicelib-obj-file-new-offload}
@@ -270,7 +270,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf.${new-offload-lib-suffix}
-                   COMMAND ${clang} -fsycl -c --offload-new-driver
+                   COMMAND ${clang} -fsycl -c --offload-new-driver -foffload-lto=thin
                            ${compile_opts} ${sycl_targets_opt}
                            ${imf_fp32_fallback_src} -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
                            -o ${obj_binary_dir}/libsycl-fallback-imf.${new-offload-lib-suffix}
@@ -286,7 +286,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-fp32-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-fp32-host.${new-offload-lib-suffix}
-                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver
+                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver -foffload-lto=thin
                            -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
                            ${imf_fp32_fallback_src}
                            -o ${obj_binary_dir}/fallback-imf-fp32-host.${new-offload-lib-suffix}
@@ -321,7 +321,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf-fp64.${lib-suff
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf-fp64.${new-offload-lib-suffix}
                    COMMAND ${clang} -fsycl -c -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
-                           --offload-new-driver
+                           --offload-new-driver -foffload-lto=thin
                            ${compile_opts} ${sycl_targets_opt}
                            ${imf_fp64_fallback_src}
                            -o ${obj_binary_dir}/libsycl-fallback-imf-fp64.${new-offload-lib-suffix}
@@ -337,7 +337,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-fp64-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-fp64-host.${new-offload-lib-suffix}
-                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver
+                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver -foffload-lto=thin
                            -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
                            ${imf_fp64_fallback_src}
                            -o ${obj_binary_dir}/fallback-imf-fp64-host.${new-offload-lib-suffix}
@@ -372,7 +372,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf-bf16.${lib-suff
 
 add_custom_command(OUTPUT ${obj_binary_dir}/libsycl-fallback-imf-bf16.${new-offload-lib-suffix}
                    COMMAND ${clang} -fsycl -c -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
-                           --offload-new-driver
+                           --offload-new-driver -foffload-lto=thin
                            ${compile_opts} ${sycl_targets_opt}
                            ${imf_bf16_fallback_src}
                            -o ${obj_binary_dir}/libsycl-fallback-imf-bf16.${new-offload-lib-suffix}
@@ -388,7 +388,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-bf16-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/fallback-imf-bf16-host.${new-offload-lib-suffix}
-                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver
+                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver -foffload-lto=thin
                            -I ${CMAKE_CURRENT_SOURCE_DIR}/imf
                            ${imf_bf16_fallback_src}
                            -o ${obj_binary_dir}/fallback-imf-bf16-host.${new-offload-lib-suffix}
@@ -437,7 +437,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/imf-fp32-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/imf-fp32-host.${new-offload-lib-suffix}
-                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver
+                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver -foffload-lto=thin
                            ${CMAKE_CURRENT_SOURCE_DIR}/imf_wrapper.cpp
                            -o ${obj_binary_dir}/imf-fp32-host.${new-offload-lib-suffix}
                    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/imf_wrapper.cpp
@@ -453,7 +453,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/imf-fp64-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/imf-fp64-host.${new-offload-lib-suffix}
-                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver
+                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver -foffload-lto=thin
                            ${CMAKE_CURRENT_SOURCE_DIR}/imf_wrapper_fp64.cpp
                            -o ${obj_binary_dir}/imf-fp64-host.${new-offload-lib-suffix}
                    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/imf_wrapper_fp64.cpp
@@ -469,7 +469,7 @@ add_custom_command(OUTPUT ${obj_binary_dir}/imf-bf16-host.${lib-suffix}
                    VERBATIM)
 
 add_custom_command(OUTPUT ${obj_binary_dir}/imf-bf16-host.${new-offload-lib-suffix}
-                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver
+                   COMMAND ${clang} ${imf_host_cxx_flags} --offload-new-driver -foffload-lto=thin
                            ${CMAKE_CURRENT_SOURCE_DIR}/imf_wrapper_bf16.cpp
                            -o ${obj_binary_dir}/imf-bf16-host.${new-offload-lib-suffix}
                    MAIN_DEPENDENCY ${CMAKE_CURRENT_SOURCE_DIR}/imf_wrapper_bf16.cpp


### PR DESCRIPTION
This is the first change in my work on thinLTO for SYCL. 