### PR TITLE
[CI] Don't run E2E tests on self-hosted CUDA in Nightly

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -74,13 +74,6 @@ jobs:
             target_devices: opencl:cpu
             tests_selector: e2e
 
-          - name: Self-hosted CUDA
-            runner: '["Linux", "cuda"]'
-            image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
-            target_devices: ext_oneapi_cuda:gpu
-            tests_selector: e2e
-
           - name: SYCL-CTS on OCL CPU
             runner: '["Linux", "gen12"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest


### PR DESCRIPTION
The runner seems to be broken, don't run the tests until it's fixed.