### PR TITLE
[SYCL][Bindless] Enable non-Vulkan tests on Windows

### DIFF
--- a/sycl/test-e2e/bindless_images/bindless_helpers.hpp
+++ b/sycl/test-e2e/bindless_images/bindless_helpers.hpp
@@ -53,6 +53,8 @@ static void fill_rand(std::vector<sycl::vec<DType, NChannels>> &v,
       return std::uniform_real_distribution<float>(0.0, 100.0);
     } else if constexpr (std::is_floating_point_v<DType>) {
       return std::uniform_real_distribution<DType>(0.0, 100.0);
+    } else if constexpr (sizeof(DType) == 1) {
+      return std::uniform_int_distribution<unsigned short>(0, 100);
     } else {
       return std::uniform_int_distribution<DType>(0, 100);
     }
@@ -61,7 +63,7 @@ static void fill_rand(std::vector<sycl::vec<DType, NChannels>> &v,
     sycl::vec<DType, NChannels> temp;
 
     for (int j = 0; j < NChannels; j++) {
-      temp[j] = distribution(generator);
+      temp[j] = static_cast<DType>(distribution(generator));
     }
 
     v[i] = temp;

--- a/sycl/test-e2e/bindless_images/cubemap/cubemap_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/cubemap/cubemap_sampled.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: linux,cuda,aspect-ext_oneapi_cubemap
+// REQUIRES: cuda,aspect-ext_oneapi_cubemap
 // REQUIRES: aspect-ext_oneapi_cubemap_seamless_filtering
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/cubemap/cubemap_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/cubemap/cubemap_unsampled.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: linux,cuda,aspect-ext_oneapi_cubemap
+// REQUIRES: cuda,aspect-ext_oneapi_cubemap
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %t.out

--- a/sycl/test-e2e/bindless_images/device_to_device_copy.cpp
+++ b/sycl/test-e2e/bindless_images/device_to_device_copy.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/image_get_info.cpp
+++ b/sycl/test-e2e/bindless_images/image_get_info.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_1D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
@@ -160,13 +159,13 @@ int main() {
 
   failed += runTest<int, sycl::image_channel_type::signed_int32>();
 
-  failed += runTest<uint, sycl::image_channel_type::unsigned_int32>();
+  failed += runTest<unsigned int, sycl::image_channel_type::unsigned_int32>();
 
   failed += runTest<float, sycl::image_channel_type::fp32>();
 
   failed += runTest<short, sycl::image_channel_type::signed_int16>();
 
-  failed += runTest<ushort, sycl::image_channel_type::unsigned_int16>();
+  failed += runTest<unsigned short, sycl::image_channel_type::unsigned_int16>();
 
   failed += runTest<char, sycl::image_channel_type::signed_int8>();
 

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_2D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
@@ -167,13 +166,13 @@ int main() {
 
   failed += runTest<int, sycl::image_channel_type::signed_int32>();
 
-  failed += runTest<uint, sycl::image_channel_type::unsigned_int32>();
+  failed += runTest<unsigned int, sycl::image_channel_type::unsigned_int32>();
 
   failed += runTest<float, sycl::image_channel_type::fp32>();
 
   failed += runTest<short, sycl::image_channel_type::signed_int16>();
 
-  failed += runTest<ushort, sycl::image_channel_type::unsigned_int16>();
+  failed += runTest<unsigned short, sycl::image_channel_type::unsigned_int16>();
 
   failed += runTest<char, sycl::image_channel_type::signed_int8>();
 

--- a/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
+++ b/sycl/test-e2e/bindless_images/mipmap/mipmap_read_3D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
@@ -159,13 +158,13 @@ int main() {
 
   failed += runTest<int, sycl::image_channel_type::signed_int32>();
 
-  failed += runTest<uint, sycl::image_channel_type::unsigned_int32>();
+  failed += runTest<unsigned int, sycl::image_channel_type::unsigned_int32>();
 
   failed += runTest<float, sycl::image_channel_type::fp32>();
 
   failed += runTest<short, sycl::image_channel_type::signed_int16>();
 
-  failed += runTest<ushort, sycl::image_channel_type::unsigned_int16>();
+  failed += runTest<unsigned short, sycl::image_channel_type::unsigned_int16>();
 
   failed += runTest<char, sycl::image_channel_type::signed_int8>();
 

--- a/sycl/test-e2e/bindless_images/read_1D.cpp
+++ b/sycl/test-e2e/bindless_images/read_1D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_2D.cpp
+++ b/sycl/test-e2e/bindless_images/read_2D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_2D_dynamic.cpp
+++ b/sycl/test-e2e/bindless_images/read_2D_dynamic.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_3D.cpp
+++ b/sycl/test-e2e/bindless_images/read_3D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_norm_types.cpp
+++ b/sycl/test-e2e/bindless_images/read_norm_types.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/read_sampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_sampled.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_1D.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_1D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_1D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_1D_subregion.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_2D.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_2D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_2D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_2D_subregion.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_3D.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_3D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_3D_subregion.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_3D_subregion.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/read_write_unsampled.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D_USM.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_1D_USM.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 // REQUIRES: aspect-ext_oneapi_bindless_sampled_image_fetch_1d_usm
 

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 // REQUIRES: aspect-ext_oneapi_bindless_sampled_image_fetch_2d
 

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D_USM.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_2D_USM.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 // REQUIRES: aspect-ext_oneapi_bindless_sampled_image_fetch_2d_usm
 

--- a/sycl/test-e2e/bindless_images/sampled_fetch/fetch_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampled_fetch/fetch_3D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 // REQUIRES: aspect-ext_oneapi_bindless_sampled_image_fetch_3d
 

--- a/sycl/test-e2e/bindless_images/sampling_1D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_1D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/sampling_2D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/sampling_2D_USM_shared.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_USM_shared.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 // REQUIRES: aspect-ext_oneapi_bindless_images_shared_usm
 

--- a/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_2D_half.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 // REQUIRES: aspect-fp16
 

--- a/sycl/test-e2e/bindless_images/sampling_3D.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_3D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out

--- a/sycl/test-e2e/bindless_images/sampling_unique_addr_modes.cpp
+++ b/sycl/test-e2e/bindless_images/sampling_unique_addr_modes.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/mipmap_read_user_type_2D.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
+++ b/sycl/test-e2e/bindless_images/user_types/read_write_user_type.cpp
@@ -1,4 +1,3 @@
-// REQUIRES: linux
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out


### PR DESCRIPTION
Bindless Images should now properly work on Windows, with the exception of Vulkan interop, which requires extra work. Required a few fixes to non-conformant C++ code.