### PR TITLE
[SYCL] Properly format AST dump of TemplateArgument in tests.

### DIFF
--- a/clang/test/AST/ast-attr-add-ir-annotations-pack.cpp
+++ b/clang/test/AST/ast-attr-add-ir-annotations-pack.cpp
@@ -64,9 +64,9 @@ void InstantiateClassWithAnnotFieldTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
-  // CHECK-NEXT:       TemplateArgument integral 3
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
+  // CHECK-NEXT:       TemplateArgument integral '3'
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct ClassWithAnnotFieldTemplate1
   // CHECK-NEXT:     FieldDecl {{.*}} referenced ptr 'int *'
   // CHECK-NEXT:       SYCLAddIRAnnotationsMemberAttr
@@ -109,8 +109,8 @@ void InstantiateClassWithAnnotFieldTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct ClassWithAnnotFieldTemplate1
   // CHECK-NEXT:     FieldDecl {{.*}} referenced ptr 'int *'
   // CHECK-NEXT:     CXXConstructorDecl {{.*}} implicit used ClassWithAnnotFieldTemplate1 'void () noexcept'
@@ -158,9 +158,9 @@ void InstantiateClassWithAnnotFieldTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
-  // CHECK-NEXT:       TemplateArgument integral 3
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
+  // CHECK-NEXT:       TemplateArgument integral '3'
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct ClassWithAnnotFieldTemplate2
   // CHECK-NEXT:     FieldDecl {{.*}} referenced ptr 'int *'
   // CHECK-NEXT:       SYCLAddIRAnnotationsMemberAttr
@@ -206,8 +206,8 @@ void InstantiateClassWithAnnotFieldTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct ClassWithAnnotFieldTemplate2
   // CHECK-NEXT:     FieldDecl {{.*}} referenced ptr 'int *'
   // CHECK-NEXT:     CXXConstructorDecl {{.*}} implicit used ClassWithAnnotFieldTemplate2 'void () noexcept'

--- a/clang/test/AST/ast-attr-add-ir-attributes-misc.cpp
+++ b/clang/test/AST/ast-attr-add-ir-attributes-misc.cpp
@@ -173,7 +173,7 @@ class SubClass2 : BaseClass1 {};
 // CHECK-NEXT:       Destructor
 // CHECK-NEXT:   TemplateArgument type 'float'
 // CHECK-NEXT:     BuiltinType {{.*}} 'float'
-// CHECK-NEXT:   TemplateArgument integral 3
+// CHECK-NEXT:   TemplateArgument integral '3'
 // CHECK-NEXT:   SYCLAddIRAttributesGlobalVariableAttr
 // CHECK-NEXT:     ConstantExpr {{.*}} 'const char[6]' lvalue
 // CHECK-NEXT:       value: LValue
@@ -224,7 +224,7 @@ class SubClass2 : BaseClass1 {};
 // CHECK-NEXT:       Destructor
 // CHECK-NEXT:   TemplateArgument type 'bool'
 // CHECK-NEXT:     BuiltinType {{.*}} 'bool'
-// CHECK-NEXT:   TemplateArgument integral 2
+// CHECK-NEXT:   TemplateArgument integral '2'
 // CHECK-NEXT:   CXXRecordDecl {{.*}} implicit struct TemplateClass1
 // CHECK-NEXT:   CXXMethodDecl {{.*}} TemplateClassMethod 'void (int)'
 // CHECK-NEXT:     ParmVarDecl {{.*}} 'int'

--- a/clang/test/AST/ast-attr-add-ir-attributes-packs.cpp
+++ b/clang/test/AST/ast-attr-add-ir-attributes-packs.cpp
@@ -36,9 +36,9 @@ void InstantiateFunctionTemplates() {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'Is' 'int'
   // CHECK-NEXT:   FunctionDecl {{.*}} used FunctionTemplate1 'void ()'
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
-  // CHECK-NEXT:       TemplateArgument integral 3
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
+  // CHECK-NEXT:       TemplateArgument integral '3'
   // CHECK-NEXT:     CompoundStmt
   // CHECK-NEXT:     SYCLAddIRAttributesFunctionAttr
   // CHECK-NEXT:       ConstantExpr {{.*}} 'const char[6]' lvalue
@@ -67,8 +67,8 @@ void InstantiateFunctionTemplates() {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 'int' 3
   // CHECK-NEXT:   FunctionDecl {{.*}} used FunctionTemplate1 'void ()'
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
   // CHECK-NEXT:     CompoundStmt
   FunctionTemplate1<1, 2, 3>();
   FunctionTemplate1<1, 2>();
@@ -94,9 +94,9 @@ void InstantiateFunctionTemplates() {
   // CHECK-NEXT:         DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'Is' 'int'
   // CHECK-NEXT:   FunctionDecl {{.*}} used FunctionTemplate2 'void ()'
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
-  // CHECK-NEXT:       TemplateArgument integral 3
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
+  // CHECK-NEXT:       TemplateArgument integral '3'
   // CHECK-NEXT:     CompoundStmt
   // CHECK-NEXT:     SYCLAddIRAttributesFunctionAttr
   // CHECK-NEXT:       InitListExpr {{.*}} 'void'
@@ -128,8 +128,8 @@ void InstantiateFunctionTemplates() {
   // CHECK-NEXT:           IntegerLiteral {{.*}} 'int' 3
   // CHECK-NEXT:   FunctionDecl {{.*}} used FunctionTemplate2 'void ()'
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
   // CHECK-NEXT:     CompoundStmt
   FunctionTemplate2<1, 2, 3>();
   FunctionTemplate2<1, 2>();
@@ -584,9 +584,9 @@ template <const char *...Strs> struct [[__sycl_detail__::add_ir_attributes_globa
 // CHECK-NEXT:       MoveAssignment
 // CHECK-NEXT:       Destructor
 // CHECK-NEXT:     TemplateArgument pack
-// CHECK-NEXT:       TemplateArgument integral 1
-// CHECK-NEXT:       TemplateArgument integral 2
-// CHECK-NEXT:       TemplateArgument integral 3
+// CHECK-NEXT:       TemplateArgument integral '1'
+// CHECK-NEXT:       TemplateArgument integral '2'
+// CHECK-NEXT:       TemplateArgument integral '3'
 // CHECK-NEXT:     SYCLAddIRAttributesGlobalVariableAttr
 // CHECK-NEXT:       ConstantExpr {{.*}} 'const char[6]' lvalue
 // CHECK-NEXT:         value: LValue
@@ -628,8 +628,8 @@ template <const char *...Strs> struct [[__sycl_detail__::add_ir_attributes_globa
 // CHECK-NEXT:       MoveAssignment
 // CHECK-NEXT:       Destructor
 // CHECK-NEXT:     TemplateArgument pack
-// CHECK-NEXT:       TemplateArgument integral 1
-// CHECK-NEXT:       TemplateArgument integral 2
+// CHECK-NEXT:       TemplateArgument integral '1'
+// CHECK-NEXT:       TemplateArgument integral '2'
 // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct GlobalVarStructTemplate1
 // CHECK-NEXT:     CXXConstructorDecl {{.*}} implicit used constexpr GlobalVarStructTemplate1 'void () noexcept'
 // CHECK-NEXT:       CompoundStmt {{.*}}
@@ -675,9 +675,9 @@ GlobalVarStructTemplate1<1, 2> InstantiatedGV2;
 // CHECK-NEXT:       MoveAssignment
 // CHECK-NEXT:       Destructor
 // CHECK-NEXT:     TemplateArgument pack
-// CHECK-NEXT:       TemplateArgument integral 1
-// CHECK-NEXT:       TemplateArgument integral 2
-// CHECK-NEXT:       TemplateArgument integral 3
+// CHECK-NEXT:       TemplateArgument integral '1'
+// CHECK-NEXT:       TemplateArgument integral '2'
+// CHECK-NEXT:       TemplateArgument integral '3'
 // CHECK-NEXT:     SYCLAddIRAttributesGlobalVariableAttr
 // CHECK-NEXT:       InitListExpr {{.*}} 'void'
 // CHECK-NEXT:         StringLiteral {{.*}} 'const char[6]' lvalue "Attr1"
@@ -722,8 +722,8 @@ GlobalVarStructTemplate1<1, 2> InstantiatedGV2;
 // CHECK-NEXT:       MoveAssignment
 // CHECK-NEXT:       Destructor
 // CHECK-NEXT:     TemplateArgument pack
-// CHECK-NEXT:       TemplateArgument integral 1
-// CHECK-NEXT:       TemplateArgument integral 2
+// CHECK-NEXT:       TemplateArgument integral '1'
+// CHECK-NEXT:       TemplateArgument integral '2'
 // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct GlobalVarStructTemplate2
 // CHECK-NEXT:     CXXConstructorDecl {{.*}} implicit used constexpr GlobalVarStructTemplate2 'void () noexcept'
 // CHECK-NEXT:       CompoundStmt {{.*}}
@@ -1384,9 +1384,9 @@ void InstantiateSpecialClassStructTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
-  // CHECK-NEXT:       TemplateArgument integral 3
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
+  // CHECK-NEXT:       TemplateArgument integral '3'
   // CHECK-NEXT:     SYCLSpecialClassAttr
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct SpecialClassStructTemplate1
   // CHECK-NEXT:     CXXMethodDecl {{.*}} __init 'void (int)'
@@ -1431,8 +1431,8 @@ void InstantiateSpecialClassStructTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
   // CHECK-NEXT:     SYCLSpecialClassAttr
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct SpecialClassStructTemplate1
   // CHECK-NEXT:     CXXMethodDecl {{.*}} __init 'void (int)'
@@ -1485,9 +1485,9 @@ void InstantiateSpecialClassStructTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
-  // CHECK-NEXT:       TemplateArgument integral 3
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
+  // CHECK-NEXT:       TemplateArgument integral '3'
   // CHECK-NEXT:     SYCLSpecialClassAttr
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct SpecialClassStructTemplate2
   // CHECK-NEXT:     CXXMethodDecl {{.*}} __init 'void (int)'
@@ -1535,8 +1535,8 @@ void InstantiateSpecialClassStructTemplates() {
   // CHECK-NEXT:       MoveAssignment
   // CHECK-NEXT:       Destructor
   // CHECK-NEXT:     TemplateArgument pack
-  // CHECK-NEXT:       TemplateArgument integral 1
-  // CHECK-NEXT:       TemplateArgument integral 2
+  // CHECK-NEXT:       TemplateArgument integral '1'
+  // CHECK-NEXT:       TemplateArgument integral '2'
   // CHECK-NEXT:     SYCLSpecialClassAttr
   // CHECK-NEXT:     CXXRecordDecl {{.*}} implicit struct SpecialClassStructTemplate2
   // CHECK-NEXT:     CXXMethodDecl {{.*}} __init 'void (int)'

--- a/clang/test/SemaSYCL/device_has_ast.cpp
+++ b/clang/test/SemaSYCL/device_has_ast.cpp
@@ -29,7 +29,7 @@ queue q;
 [[sycl::device_has()]] void func3() {}
 
 // CHECK: FunctionDecl {{.*}} used func4 'void ()'
-// CHECK-NEXT: TemplateArgument integral 0
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::host'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLDeviceHasAttr
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}} 'sycl::aspect'
@@ -75,8 +75,8 @@ void func5() {}
 
 // CHECK: FunctionDecl {{.*}} func7 'void ()'
 // CHECK-NEXT: TemplateArgument pack
-// CHECK-NEXT: TemplateArgument integral 1
-// CHECK-NEXT: TemplateArgument integral 2
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::cpu'
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::gpu'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLDeviceHasAttr
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}} 'sycl::aspect'
@@ -90,7 +90,7 @@ void func5() {}
 
 // CHECK: FunctionDecl {{.*}} func7 'void ()'
 // CHECK-NEXT: TemplateArgument pack
-// CHECK-NEXT: TemplateArgument integral 1
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::cpu'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLDeviceHasAttr
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}} 'sycl::aspect'
@@ -111,9 +111,9 @@ template <sycl::aspect... Asp>
 // CHECK-NEXT: DeclRefExpr {{.*}} NonTypeTemplateParm {{.*}} 'AspPack' 'sycl::aspect'
 
 // CHECK-NEXT: FunctionDecl {{.*}} func8
-// CHECK-NEXT: TemplateArgument integral 0
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::host'
 // CHECK-NEXT: TemplateArgument pack
-// CHECK-NEXT: TemplateArgument integral 1
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::cpu'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLDeviceHasAttr
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}} 'sycl::aspect'

--- a/clang/test/SemaSYCL/initiation_interval_ast.cpp
+++ b/clang/test/SemaSYCL/initiation_interval_ast.cpp
@@ -20,7 +20,7 @@ sycl::queue deviceQueue;
 // CHECK-NEXT: SYCLIntelInitiationIntervalAttr {{.*}} initiation_interval
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func2 'void ()'
-// CHECK-NEXT: TemplateArgument integral 6
+// CHECK-NEXT: TemplateArgument integral '6'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelInitiationIntervalAttr {{.*}} initiation_interval
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset-ast.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset-ast.cpp
@@ -32,7 +32,7 @@ public:
 // CHECK-NEXT: SYCLIntelNoGlobalWorkOffsetAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func1 'void ()'
-// CHECK-NEXT: TemplateArgument integral 1
+// CHECK-NEXT: TemplateArgument integral '1'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelNoGlobalWorkOffsetAttr
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
@@ -19,7 +19,7 @@ queue q;
 // Test that checks template parameter support on member function of class template.
 // CHECK: ClassTemplateDecl {{.*}} {{.*}} KernelFunctor
 // CHECK: ClassTemplateSpecializationDecl {{.*}} {{.*}} class KernelFunctor definition
-// CHECK: TemplateArgument integral 2
+// CHECK: TemplateArgument integral '2'
 // CHECK: CXXRecordDecl {{.*}} {{.*}} implicit class KernelFunctor
 // CHECK: SYCLIntelMaxGlobalWorkDimAttr
 // CHECK-NEXT: ConstantExpr {{.*}} 'int'
@@ -40,7 +40,7 @@ int kernel() {
 
 // Test that checks template parameter support on function.
 // CHECK: FunctionDecl {{.*}} {{.*}} func1 'void ()'
-// CHECK: TemplateArgument integral 3
+// CHECK: TemplateArgument integral '3'
 // CHECK: SYCLIntelMaxGlobalWorkDimAttr
 // CHECK-NEXT: ConstantExpr {{.*}} 'int'
 // CHECK-NEXT: value: Int 3

--- a/clang/test/SemaSYCL/lb_sm_90_ast.cpp
+++ b/clang/test/SemaSYCL/lb_sm_90_ast.cpp
@@ -49,7 +49,7 @@ func1() {}
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 
 // CHECK: FunctionDecl {{.*}} func2 'void ()'
-// CHECK-NEXT: TemplateArgument integral 6
+// CHECK-NEXT: TemplateArgument integral '6'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelMaxWorkGroupSizeAttr {{.*}}
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/loop_fusion_ast.cpp
+++ b/clang/test/SemaSYCL/loop_fusion_ast.cpp
@@ -44,7 +44,7 @@ queue q;
 // CHECK-NEXT: SYCLIntelLoopFuseAttr {{.*}} loop_fuse
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func5 'void ()'
-// CHECK-NEXT: TemplateArgument integral 1
+// CHECK-NEXT: TemplateArgument integral '1'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelLoopFuseAttr {{.*}} loop_fuse
 // CHECK-NEXT: ConstantExpr{{.*}}'int'
@@ -61,7 +61,7 @@ template <int N>
 // CHECK-NEXT: SYCLIntelLoopFuseAttr {{.*}} loop_fuse_independent
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func6 'void ()'
-// CHECK-NEXT: TemplateArgument integral 5
+// CHECK-NEXT: TemplateArgument integral '5'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelLoopFuseAttr {{.*}} loop_fuse_independent
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/max-concurrency-ast.cpp
+++ b/clang/test/SemaSYCL/max-concurrency-ast.cpp
@@ -28,7 +28,7 @@ queue q;
 // CHECK-NEXT: SYCLIntelMaxConcurrencyAttr
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func3 'void ()'
-// CHECK-NEXT: TemplateArgument integral 5
+// CHECK-NEXT: TemplateArgument integral '5'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelMaxConcurrencyAttr
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
@@ -35,7 +35,7 @@ public:
 // CHECK-NEXT: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func 'void ()'
-// CHECK-NEXT: TemplateArgument integral 12
+// CHECK-NEXT: TemplateArgument integral '12'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: IntelReqdSubGroupSizeAttr {{.*}} reqd_sub_group_size
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/scheduler_target_fmax_mhz_ast.cpp
+++ b/clang/test/SemaSYCL/scheduler_target_fmax_mhz_ast.cpp
@@ -20,7 +20,7 @@ sycl::queue deviceQueue;
 // CHECK-NEXT: SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
 // CHECK-NEXT: DeclRefExpr {{.*}} 'int' NonTypeTemplateParm {{.*}} 'N' 'int'
 // CHECK: FunctionDecl {{.*}} func2 'void ()'
-// CHECK-NEXT: TemplateArgument integral 6
+// CHECK-NEXT: TemplateArgument integral '6'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLIntelSchedulerTargetFmaxMhzAttr {{.*}}
 // CHECK-NEXT: ConstantExpr{{.*}}'int'

--- a/clang/test/SemaSYCL/uses_aspects_ast.cpp
+++ b/clang/test/SemaSYCL/uses_aspects_ast.cpp
@@ -31,7 +31,7 @@ queue q;
 [[__sycl_detail__::__uses_aspects__()]] void func3() {}
 
 // CHECK: FunctionDecl {{.*}} used func4 'void ()'
-// CHECK-NEXT: TemplateArgument integral 0
+// CHECK-NEXT: TemplateArgument integral 'sycl::aspect::host'
 // CHECK-NEXT: CompoundStmt
 // CHECK-NEXT: SYCLUsesAspectsAttr
 // CHECK-NEXT: SubstNonTypeTemplateParmExpr {{.*}} 'sycl::aspect'


### PR DESCRIPTION
The format was changed in 1a2f33097 [clang] Improve ast-dumper text printing of TemplateArgument (#93431).
