### PR TITLE
[CI][CUDA] Uplift docker to use cuda 12.5 image.

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.1.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.5.0-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
This upgrades the docker to use the cuda 12.5 image.

I've ran the test-e2e locally using cuda 12.5 and all is well. cuda 12.5 also fixed an issue introduced by the cuda 12.4 driver: see https://github.com/intel/llvm/pull/13661#issuecomment-2140088722