### PR TITLE
[SYCL][E2E] Disable flaky profiling_queue.cpp test on CUDA

### DIFF
--- a/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
@@ -19,6 +19,10 @@
 // FPGA emulator seems to return unexpected start time for the fallback barrier.
 // UNSUPPORTED: accelerator
 
+// Flaky on CUDA
+// https://github.com/intel/llvm/issues/14053
+// UNSUPPORTED: cuda
+
 #include "common.hpp"
 
 int main() {


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/14053