### PR TITLE
[SYCL] Remove redundant template keywords.

### DIFF
--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1277,7 +1277,7 @@ struct NDRangeReduction<reduction::strategy::local_atomic_and_atomic_cross_wg> {
           for (size_t E = 0; E < NElements; ++E) {
             *getReducerAccess(Reducer).getElement(E) = GroupSum[E];
           }
-          Reducer.template atomic_combine(&Out[0]);
+          Reducer.atomic_combine(&Out[0]);
         }
       });
     });

--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -2091,7 +2091,7 @@ public:
   template <access::address_space Space, access::decorated DecorateAddress>
   void load(size_t offset, multi_ptr<DataT, Space, DecorateAddress> ptr) {
     vec_t Tmp;
-    Tmp.template load(offset, ptr);
+    Tmp.load(offset, ptr);
     *this = Tmp;
   }
 

--- a/sycl/include/sycl/vector_preview.hpp
+++ b/sycl/include/sycl/vector_preview.hpp
@@ -2089,7 +2089,7 @@ public:
   template <access::address_space Space, access::decorated DecorateAddress>
   void load(size_t offset, multi_ptr<DataT, Space, DecorateAddress> ptr) {
     vec_t Tmp;
-    Tmp.template load(offset, ptr);
+    Tmp.load(offset, ptr);
     *this = Tmp;
   }
 

--- a/sycl/test/esimd/simd.cpp
+++ b/sycl/test/esimd/simd.cpp
@@ -358,7 +358,7 @@ template <class T1, class T2> bool test_simd_iselect() SYCL_ESIMD_FUNCTION {
   simd<T2, 8> a(0, 2);
   auto data = v.iselect(a);
   data += 16;
-  v.template iupdate(a, data, simd_mask<8>(1));
+  v.iupdate(a, data, simd_mask<8>(1));
   auto ref = v.template select<8, 2>(0);
   return ref[0] == 16 && ref[14] == 32;
 }


### PR DESCRIPTION
This is required by f46d1463b [clang] require template arg list after template kw (#80801).
