### PR TITLE
[SYCL] Update diagnostic messages in tests to match community convention.

### DIFF
--- a/clang/test/Driver/pch-fsycl-error.cpp
+++ b/clang/test/Driver/pch-fsycl-error.cpp
@@ -6,14 +6,14 @@
 // Linux
 // RUN: not %clang -c -fsycl -x c++-header %t.h -###  %s 2> %t1.txt
 // RUN: FileCheck %s -input-file=%t1.txt
-// CHECK: Precompiled header generation is not supported with '-fsycl'
+// CHECK: precompiled header generation is not supported with '-fsycl'
 
 // Windows
 // RUN: not %clang_cl -c -fsycl -x c++-header %t.h -### -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-ERROR %s
-// CHECK-ERROR: Precompiled header generation is not supported with '-fsycl'
+// CHECK-ERROR: precompiled header generation is not supported with '-fsycl'
 
 // /Yc
 // RUN: not %clang_cl -fsycl /Ycpchfile.h /FIpchfile.h /c -### -- %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHECK-YC %s
-// CHECK-YC: Precompiled header generation is not supported with '-fsycl'
+// CHECK-YC: precompiled header generation is not supported with '-fsycl'

--- a/clang/test/Driver/sycl-add-default-spec-consts-image.cpp
+++ b/clang/test/Driver/sycl-add-default-spec-consts-image.cpp
@@ -4,7 +4,7 @@
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image 2>&1 %s | FileCheck %s -check-prefix=CHECK-NON-AOT
 // RUN: %clang_cl -### -fsycl -fsycl-add-default-spec-consts-image 2>&1 %s | FileCheck %s -check-prefix=CHECK-NON-AOT
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image -fsycl-targets=spir64 2>&1 %s | FileCheck %s -check-prefix=CHECK-NON-AOT
-// CHECK-NON-AOT: warning: -fsycl-add-default-spec-consts-image flag has an effect only in Ahead of Time Compilation mode (AOT).
+// CHECK-NON-AOT: warning: -fsycl-add-default-spec-consts-image flag has an effect only in Ahead of Time Compilation mode (AOT)
 
 // Check that non-AOT target doesn't add command line option into sycl-post-link invocation
 // CHECK-NON-AOT-NOT: {{.*}}sycl-post-link{{.*}} "-generate-device-image-default-spec-consts"
@@ -16,7 +16,7 @@
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image -fsycl-targets=intel_gpu_pvc 2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image -fsycl-targets=nvidia_gpu_sm_90 -nocudalib 2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
 // RUN: %clang -### -fsycl -fsycl-add-default-spec-consts-image -fsycl-targets=amd_gpu_gfx1034 -fno-sycl-libspirv -nogpulib  2>&1 %s | FileCheck %s -check-prefix=CHECK-AOT
-// CHECK-AOT-NOT: warning: -fsycl-add-default-spec-consts-image flag has an effect only in Ahead of Time Compilation mode (AOT).
+// CHECK-AOT-NOT: warning: -fsycl-add-default-spec-consts-image flag has an effect only in Ahead of Time Compilation mode (AOT)
 // CHECK-AOT: {{.*}}sycl-post-link{{.*}} "-generate-device-image-default-spec-consts"
 
 

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -13,7 +13,7 @@
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-CONFLICT %s
 // RUN:   not %clang_cl -### -fsycl-targets=spir64-unknown-unknown -fintelfpga  %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-SYCL-FPGA-CONFLICT %s
-// CHK-SYCL-FPGA-CONFLICT: error: The option -fsycl-targets= conflicts with -fintelfpga
+// CHK-SYCL-FPGA-CONFLICT: error: the option -fsycl-targets= conflicts with -fintelfpga
 
 /// Check that -aux-triple is passed with -fintelfpga
 // RUN:    %clang -### -fintelfpga %s 2>&1 \


### PR DESCRIPTION
This is required by 24a12a9c8 [clang] Diagnose problematic diagnostic messages (#93229).
