### PR TITLE
[SYCL][E2E] Disable NonUniformGroups/ballot_group_algorithms.cpp on CUDA

### DIFF
--- a/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
@@ -5,6 +5,10 @@
 // REQUIRES: sg-32
 // REQUIRES: aspect-ext_oneapi_ballot_group
 
+// Fails in Nightly testing on the self-hosted CUDA runner:
+// https://github.com/intel/llvm/issues/12995.
+// UNSUPPORTED: cuda
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/ballot_group.hpp>
 #include <sycl/group_algorithm.hpp>


### PR DESCRIPTION
Fails in Nightly testing on the self-hosted CUDA runner: https://github.com/intel/llvm/issues/12995.