### PR TITLE
[SYCL][E2E] Disable test-e2e/BFloat16/bfloat16_builtins.cpp on opencl:cpu

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -14,6 +14,9 @@
 
 // Currently the feature isn't supported on FPGA.
 // UNSUPPORTED: accelerator
+
+// https://github.com/intel/llvm/issues/13790
+// UNSUPPORTED: opencl && cpu
 #include "bfloat16_builtins.hpp"
 
 int main() {


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/13790.