### PR TITLE
[SYCL][Graph] Disable flaky Windows test

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
@@ -4,7 +4,9 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-//
+
+// Test is flaky on Windows, disable until it can be fixed
+// UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT
 


### PR DESCRIPTION
`test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp` has been reported as failing on an unrelated PR on Windows - https://github.com/intel/llvm/issues/11852#issuecomment-2151687966

Disable this test in line with how other flaky graphs tests have been disabled on Windows in https://github.com/intel/llvm/pull/13966

The `RecordReplay` equivalent of this Explicit test is already disabled on Windows.