### PR TITLE
[SYCL][TEST-E2E] Extend  `sycl-ls-gpu-default.cpp` test to cover Intel GPUs through OpenCL.

### DIFF
--- a/sycl/test-e2e/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls-gpu-default-any.cpp
@@ -4,9 +4,9 @@
 // RUN: env --unset=SYCL_DEVICE_FILTER  --unset=ONEAPI_DEVICE_SELECTOR sycl-ls --verbose >%t.default.out
 // RUN: FileCheck %s --check-prefixes=CHECK-GPU-BUILTIN,CHECK-GPU-CUSTOM --input-file %t.default.out
 
-// CHECK-GPU-BUILTIN: gpu_selector(){{.*}}gpu, {{.*}}{{Level-Zero|CUDA}}
+// CHECK-GPU-BUILTIN: gpu_selector(){{.*}}gpu, {{.*}}{{Level-Zero|CUDA|OpenCL}}
 // clang-format off
-// CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}gpu, {{.*}}{{Level-Zero|CUDA}}
+// CHECK-GPU-CUSTOM: custom_selector(gpu){{.*}}gpu, {{.*}}{{Level-Zero|CUDA|OpenCL}}
 // clang-format on
 
 //==--------------------- sycl-ls-gpu-default-any.cpp ----------------------==//


### PR DESCRIPTION
Extend the `sycl-ls-gpu-default.cpp` test to cover the support of Intel GPUs through OpenCL.
The patch fixes the failure when running the test on a system with Intel and CUDA gpus.