### PR TITLE
[SYCL][Graph] Bump L0 UR commit

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -109,14 +109,8 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_TAG 755a1e75e24ed55070a0f457d2d8a676521ad4f7)
 
   fetch_adapter_source(level_zero
-    ${UNIFIED_RUNTIME_REPO}
-    # commit 8e47ab5057458c5522ce5d86f7996b2882020220
-    # Merge: b816fe82 3d3aba65
-    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-    # Date:   Tue Jun 4 17:28:43 2024 +0100
-    #     Merge pull request #1694 from Bensuo/ewan/L0_update_query
-    #     Set minimum L0 device support to support UR kernel update
-    8e47ab5057458c5522ce5d86f7996b2882020220
+    "https://github.com/Bensuo/unified-runtime.git"
+    "ewan/var_lifetime"
   )
 
   fetch_adapter_source(opencl


### PR DESCRIPTION
Bump L0 commit to PR from https://github.com/oneapi-src/unified-runtime/pull/1721 to fix issues using SYCL-Graph update on L0 backend.