### PR TITLE
[SYCL][COMPAT] Fix memory_management_test3

### DIFF
--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -29,8 +29,6 @@
 //
 //
 // ===----------------------------------------------------------------------===//
-// https://github.com/intel/llvm/issues/14086
-// UNSUPPORTED: gpu-intel-gen12 && linux
 // RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -69,8 +69,7 @@ void test_free_memory_q() {
 void test_wait_and_free_memory() {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
-  sycl::queue q{{sycl::property::queue::in_order()}};
-  float *d_A = (float *)syclcompat::malloc(sizeof(float), q);
+  float *d_A = (float *)syclcompat::malloc(sizeof(float));
   syclcompat::wait_and_free((void *)d_A);
 
   syclcompat::wait_and_free(0);


### PR DESCRIPTION
This change is intended to fix a CI failure on the OpenCL backend for the `memory_management_test3`. This is because the memory is allocated on a different q to the one it is released on.