### PR TITLE
[SYCL][ESIMD][E2E] Fix bit shift vector test to not use c++20

### DIFF
--- a/sycl/test-e2e/ESIMD/regression/bit_shift_vector_compilation_test.cpp
+++ b/sycl/test-e2e/ESIMD/regression/bit_shift_vector_compilation_test.cpp
@@ -6,13 +6,12 @@
 //
 //===---------------------------------------===//
 
-// RUN: %{build} -fsycl-device-code-split=per_kernel -std=c++20 -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
 // This is a basic test to validate the vector bit shifting functions.
 
 #include "../esimd_test_utils.hpp"
-#include <bit>
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;


### PR DESCRIPTION
We don't actually need cpp20, this was left over from a previous iteration of the test.