### PR TITLE
[SYCL][Matrix] Amend CODEOWNERS for check_device_code matrix tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -126,6 +126,7 @@ sycl/test-e2e/KernelFusion @intel/dpcpp-kernel-fusion-reviewers
 sycl/include/sycl/ext/oneapi/matrix/ @intel/sycl-matrix-reviewers
 sycl/test-e2e/Matrix @intel/sycl-matrix-reviewers
 sycl/test/matrix @intel/sycl-matrix-reviewers
+sycl/test/check_device_code/matrix @intel/sycl-matrix-reviewers
 
 # Native CPU
 llvm/**/*SYCLNativeCPU* @intel/dpcpp-nativecpu-pi-reviewers 


### PR DESCRIPTION
CODEOWNERS seems to be missing a line attributing `sycl/test/check_device_code/matrix` tests to intel/sycl-matrix-reviewers (As per [this discussion](https://github.com/intel/llvm/pull/14063#discussion_r1629880980)). This PR remedies this.

Although, I noticed the current CODEOWNERS section for the matrix reviewers uses paths; Let me know if I should use `sycl/**/matrix` instead.