### PR TITLE
[SYCL][Graph] Missing test dependency after data init

### DIFF
--- a/sycl/test-e2e/Graph/Update/whole_update_dynamic_param.cpp
+++ b/sycl/test-e2e/Graph/Update/whole_update_dynamic_param.cpp
@@ -31,6 +31,7 @@ int main() {
   Queue.copy(InputDataHost1.data(), InputDataDevice1, Size);
   Queue.copy(InputDataHost2.data(), InputDataDevice2, Size);
   Queue.copy(OutputDataHost1.data(), OutputDataDevice1, Size);
+  Queue.wait();
 
   exp_ext::command_graph GraphA{Queue.get_context(), Queue.get_device()};
 


### PR DESCRIPTION
In the `Graph/Update/whole_update_dynamic_param.cpp` test there is no dependency defined on the out-of-order queue between initalizing the data and running the graph which uses it.

On immediate command-list L0 backends in particular this manifests as a fail.

Fixed by adding a wait between data initialization and use.