### PR TITLE
[SYCL][Graph] Update L0 aspect test

### DIFF
--- a/sycl/test-e2e/Graph/UnsupportedDevice/device_query.cpp
+++ b/sycl/test-e2e/Graph/UnsupportedDevice/device_query.cpp
@@ -18,9 +18,9 @@ int main() {
   auto Backend = Device.get_backend();
 
   if ((Backend == backend::ext_oneapi_level_zero)) {
-    assert(!SupportsGraphs);
+    // Full graph support is dependent on the Level Zero device & driver,
+    // and cannot be asserted without diving into these details.
     assert(SupportsLimitedGraphs);
-
   } else if ((Backend == backend::ext_oneapi_cuda) ||
              (Backend == backend::ext_oneapi_hip)) {
     assert(SupportsGraphs);


### PR DESCRIPTION
The `Graph/UnsupportedDevice/device_query.cpp` test asserts that L0 devices will never have full graph support. This is not the case, depending on the L0 device and driver version full graphs support is possible.

Update the test to remove asserting on this, as diving into these details is out of the scope of the test. This was previously decided when discussion how to check the OpenCL backend for similar possible variances in aspect support.