### PR TITLE
[SYCL][libdevice] Don't force linkage to weak

### DIFF
--- a/libdevice/device.h
+++ b/libdevice/device.h
@@ -17,9 +17,9 @@
 
 #if defined(__SPIR__) || defined(__SPIRV__) || defined(__NVPTX__)
 #ifdef __SYCL_DEVICE_ONLY__
-#define DEVICE_EXTERNAL SYCL_EXTERNAL __attribute__((weak))
+#define DEVICE_EXTERNAL SYCL_EXTERNAL
 #else // __SYCL_DEVICE_ONLY__
-#define DEVICE_EXTERNAL __attribute__((weak))
+#define DEVICE_EXTERNAL
 #endif // __SYCL_DEVICE_ONLY__
 
 #define DEVICE_EXTERN_C DEVICE_EXTERNAL EXTERN_C


### PR DESCRIPTION
I'm working on thinLTO and weak symbols are not guaranteed to be the same everywhere, so the thinLTO infrastructure does not link them in so devices libraries don't work.

I don't know of any reason to explicitly mark them as weak and in reality these functions should follow ODR, so just remove the specification.