### PR TITLE
[SYCL] Remove redundant code from L0 plugin's cmake file

### DIFF
--- a/sycl/plugins/level_zero/CMakeLists.txt
+++ b/sycl/plugins/level_zero/CMakeLists.txt
@@ -1,49 +1,5 @@
 # PI Level Zero plugin library
 
-if (NOT DEFINED LEVEL_ZERO_LIBRARY OR NOT DEFINED LEVEL_ZERO_INCLUDE_DIR)
-  message(STATUS "Download Level Zero loader and headers from github.com")
-
-  set(LEVEL_ZERO_LOADER_REPO "https://github.com/oneapi-src/level-zero.git")
-  set(LEVEL_ZERO_LOADER_TAG v1.16.1)
-
-  # Disable due to a bug https://github.com/oneapi-src/level-zero/issues/104
-  set(CMAKE_INCLUDE_CURRENT_DIR OFF)
-
-  message(STATUS "Will fetch Level Zero Loader from ${LEVEL_ZERO_LOADER_REPO}")
-  include(FetchContent)
-  FetchContent_Declare(level-zero-loader
-    GIT_REPOSITORY    ${LEVEL_ZERO_LOADER_REPO}
-    GIT_TAG           ${LEVEL_ZERO_LOADER_TAG}
-  )
-
-  # Workaround warnings/errors for Level Zero build
-  set(CMAKE_CXX_FLAGS_BAK "${CMAKE_CXX_FLAGS}")
-  if (WIN32)
-    # FIXME: Level Zero build fails with /DUNICODE
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /UUNICODE")
-    # USE_Z7 forces use of /Z7 instead of /Zi which is broken with sccache
-    set(USE_Z7 ON)
-  else()
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-but-set-variable")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-pedantic")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-stringop-truncation")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-parameter")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-c++98-compat-extra-semi")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unknown-warning-option")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-non-virtual-dtor")
-  endif()
-
-  FetchContent_MakeAvailable(level-zero-loader)
-  FetchContent_GetProperties(level-zero-loader)
-
-  # Restore original flags
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_BAK}")
-
-  set(LEVEL_ZERO_LIBRARY ze_loader)
-  set(LEVEL_ZERO_INCLUDE_DIR
-    ${level-zero-loader_SOURCE_DIR}/include CACHE PATH "Path to Level Zero Headers")
-endif()
-
 if (SYCL_ENABLE_XPTI_TRACING)
   set(XPTI_PROXY_SRC "${CMAKE_SOURCE_DIR}/../xpti/src/xpti_proxy.cpp")
   set(XPTI_INCLUDE "${CMAKE_SOURCE_DIR}/../xpti/include")
@@ -51,6 +7,8 @@ if (SYCL_ENABLE_XPTI_TRACING)
 endif()
 
 find_package(Python3 REQUIRED)
+
+get_target_property(LEVEL_ZERO_INCLUDE_DIR LevelZeroLoader-Headers INTERFACE_INCLUDE_DIRECTORIES)
 
 add_custom_target(ze-api DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/ze_api.def)
 add_custom_command(


### PR DESCRIPTION
Currently Level Zero plugin uses loader and headers fetched by the Level Zero adapter (LevelZeroLoader-Headers, LevelZeroLoader targets).  Currently downloaded loader code is not used, only headers are used for xpti.
So, get headers location from LevelZeroLoader-Headers target instead and remove unnecessary code.