### PR TITLE
[SYCL][Graph] Combined L0 Graph Update fixes

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -110,7 +110,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
 
   fetch_adapter_source(level_zero
     ${UNIFIED_RUNTIME_REPO}
-    ${UNIFIED_RUNTIME_TAG}
+    # commit 0f118d75f6bfe77eb8d933808f7a125e77ca7358
+    # Merge: ed4211cd 721d63c6
+    # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
+    # Date:   Mon Jun 10 10:38:10 2024 +0100
+    #     Merge pull request #1629 from Bensuo/ewan/L0_update_host_wait
+    #     Use fence rather than event for sync in L0 command-buffer update
+    "0f118d75f6bfe77eb8d933808f7a125e77ca7358"
   )
 
   fetch_adapter_source(opencl


### PR DESCRIPTION
Bumps the L0 adapter UR commit to include several merged fixes to the L0 adapter for implementing the SYCL-Graph update feature:

* [Use fence rather than event for sync in L0 command-buffer update](https://github.com/oneapi-src/unified-runtime/pull/1629)
* [Fix lifetime of pointer used in L0 update](https://github.com/oneapi-src/unified-runtime/pull/1721)
* [Fix L0 Event leak without return sync point](https://github.com/oneapi-src/unified-runtime/pull/1706)