### PR TITLE
[SYCL][Joint Matrix] Test combinations are queried Part 3 (#13991)

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -290,7 +290,8 @@ public:
       } catch (const exception &Ex) {
         BuildResult->Error.Msg = Ex.what();
         BuildResult->Error.Code = Ex.get_cl_code();
-        if (BuildResult->Error.Code == PI_ERROR_OUT_OF_RESOURCES) {
+        if (BuildResult->Error.Code == PI_ERROR_OUT_OF_RESOURCES ||
+            BuildResult->Error.Code == PI_ERROR_OUT_OF_HOST_MEMORY) {
           reset();
           BuildResult->updateAndNotify(BuildState::BS_Initial);
           continue;

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -68,6 +68,7 @@ static sycl::unittest::PiImageArray<2> ImgArray{Img};
 
 static int nProgramCreate = 0;
 static volatile bool outOfResourcesToggle = false;
+static volatile bool outOfHostMemoryToggle = false;
 
 static pi_result redefinedProgramCreate(pi_context context, const void *il,
                                         size_t length,
@@ -76,6 +77,17 @@ static pi_result redefinedProgramCreate(pi_context context, const void *il,
   if (outOfResourcesToggle) {
     outOfResourcesToggle = false;
     return PI_ERROR_OUT_OF_RESOURCES;
+  }
+  return PI_SUCCESS;
+}
+
+static pi_result redefinedProgramCreateOutOfHostMemory(pi_context context, const void *il,
+                                        size_t length,
+                                        pi_program *res_program) {
+  ++nProgramCreate;
+  if (outOfHostMemoryToggle) {
+    outOfHostMemoryToggle = false;
+    return PI_ERROR_OUT_OF_HOST_MEMORY;
   }
   return PI_SUCCESS;
 }
@@ -121,6 +133,69 @@ TEST(OutOfResourcesTest, piProgramCreate) {
   // the cache will clear out, and will try again.
   q.single_task<class OutOfResourcesKernel1>([] {});
   EXPECT_FALSE(outOfResourcesToggle);
+  EXPECT_EQ(nProgramCreate, runningTotal += 2);
+  {
+    detail::KernelProgramCache::ProgramCache &Cache =
+        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+    EXPECT_EQ(Cache.size(), 1U) << "Expected 1 program in the cache";
+  }
+
+  // Finally, OutOfResourcesKernel1 will be in the cache, but
+  // OutOfResourceKenel2 will not, so one more piProgramCreate.
+  // Toggle is not set, so this should succeed.
+  q.single_task<class OutOfResourcesKernel1>([] {});
+  q.single_task<class OutOfResourcesKernel2>([] {});
+  EXPECT_EQ(nProgramCreate, runningTotal += 1);
+  {
+    detail::KernelProgramCache::ProgramCache &Cache =
+        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+    EXPECT_EQ(Cache.size(), 2U) << "Expected 2 program in the cache";
+  }
+}
+
+TEST(OutOfHostMemoryTest, piProgramCreate) {
+  // Reset to zero after the previous test.
+  nProgramCreate = 0;
+  sycl::unittest::PiMock Mock;
+  Mock.redefineBefore<detail::PiApiKind::piProgramCreate>(
+      redefinedProgramCreateOutOfHostMemory);
+
+  sycl::platform Plt{Mock.getPlatform()};
+  sycl::context Ctx{Plt};
+  auto CtxImpl = detail::getSyclObjImpl(Ctx);
+  queue q(Ctx, default_selector_v);
+
+  int runningTotal = 0;
+  // Cache is empty, so one piProgramCreate call.
+  q.single_task<class OutOfResourcesKernel1>([] {});
+  EXPECT_EQ(nProgramCreate, runningTotal += 1);
+
+  // Now, we make the next piProgramCreate call fail with
+  // PI_ERROR_OUT_OF_HOST_MEMORY. The caching mechanism should catch this,
+  // clear the cache, and retry the piProgramCreate.
+  outOfHostMemoryToggle = true;
+  q.single_task<class OutOfResourcesKernel2>([] {});
+  EXPECT_FALSE(outOfHostMemoryToggle);
+  EXPECT_EQ(nProgramCreate, runningTotal += 2);
+  {
+    detail::KernelProgramCache::ProgramCache &Cache =
+        CtxImpl->getKernelProgramCache().acquireCachedPrograms().get();
+    EXPECT_EQ(Cache.size(), 1U) << "Expected 1 program in the cache";
+  }
+
+  // The next piProgramCreate call will fail with
+  // PI_ERROR_OUT_OF_HOST_MEMORY. But OutOfResourcesKernel2 is in
+  // the cache, so we expect no new piProgramCreate calls.
+  outOfHostMemoryToggle = true;
+  q.single_task<class OutOfResourcesKernel2>([] {});
+  EXPECT_TRUE(outOfHostMemoryToggle);
+  EXPECT_EQ(nProgramCreate, runningTotal);
+
+  // OutOfResourcesKernel1 is not in the cache, so we have to
+  // build it. From what we set before, this call will fail,
+  // the cache will clear out, and will try again.
+  q.single_task<class OutOfResourcesKernel1>([] {});
+  EXPECT_FALSE(outOfHostMemoryToggle);
   EXPECT_EQ(nProgramCreate, runningTotal += 2);
   {
     detail::KernelProgramCache::ProgramCache &Cache =


### PR DESCRIPTION
Supported matrix dimensions are queried from the device, and inform the
tests which tile sizes one can use.

This is a subset of all tests that are planned to be modified.

Test manually tested on PVC and SPR

---------

Co-authored-by: Yury Plyakhin <yury.plyakhin@intel.com>