### PR TITLE
[SYCL][E2E] Fix CUDA include and lib paths.

### DIFF
--- a/sycl/test-e2e/Plugin/cuda_queue_priority.cpp
+++ b/sycl/test-e2e/Plugin/cuda_queue_priority.cpp
@@ -1,5 +1,4 @@
-// REQUIRES: gpu, cuda
-
+// REQUIRES: gpu, cuda, cuda_dev_kit
 // RUN: %{build} %cuda_options -o %t.out
 // RUN: %{run} %t.out
 //

--- a/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
+++ b/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
@@ -2,6 +2,7 @@
 
 // RUN: %{build} %cuda_options -o %t.out
 // RUN: %{run} %t.out
+// XFAIL: *
 
 #define SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL 1
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
+++ b/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
@@ -2,6 +2,8 @@
 
 // RUN: %{build} %cuda_options -o %t.out
 // RUN: %{run} %t.out
+
+// An issue has been reported in https://github.com/intel/llvm/issues/14116
 // XFAIL: *
 
 #define SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL 1

--- a/sycl/test-e2e/Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
+++ b/sycl/test-e2e/Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda && cuda_dev_kit
 // RUN: %{build} %cuda_options -lcudart -lcuda -x cuda -o %t.out
 // RUN: %{run} %t.out
+// XFAIL: *
 
 #include <cuda.h>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
+++ b/sycl/test-e2e/Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
@@ -1,6 +1,8 @@
 // REQUIRES: cuda && cuda_dev_kit
 // RUN: %{build} %cuda_options -lcudart -lcuda -x cuda -o %t.out
 // RUN: %{run} %t.out
+
+// An issue has been reported in https://github.com/intel/llvm/issues/14115
 // XFAIL: *
 
 #include <cuda.h>

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -465,6 +465,12 @@ if config.hip_platform not in supported_hip_platforms:
 
 if "cuda:gpu" in config.sycl_devices:
     llvm_config.with_system_environment("CUDA_PATH")
+    if platform.system() == "Windows":
+        config.cuda_libs_dir = '"' + os.path.join(os.environ['CUDA_PATH'], r"lib\x64") + '"'
+        config.cuda_include = '"' + os.path.join(os.environ['CUDA_PATH'], "include") + '"'
+    else:
+        config.cuda_libs_dir = os.path.join(os.environ['CUDA_PATH'], r"lib64")
+        config.cuda_include = os.path.join(os.environ['CUDA_PATH'], "include")
 
 # FIXME: This needs to be made per-device as well, possibly with a helper.
 if "hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -464,6 +464,35 @@ if config.hip_platform not in supported_hip_platforms:
     )
 
 if "cuda:gpu" in config.sycl_devices:
+    if "CUDA_PATH" not in os.environ:
+        if platform.system() == "Windows":
+            cuda_root=r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
+            cuda_versions = []
+            if os.path.exists(cuda_root):
+                for entry in os.listdir(cuda_root):
+                    if os.path.isdir(os.path.join(cuda_root, entry)) and entry.startswith("v"):
+                        version = entry[1:]  # Remove the leading 'v'
+                        if re.match(r"^\d+\.\d+$", version):  # Match version pattern like 12.3
+                            cuda_versions.append(version)
+                latest_cuda_version = max(cuda_versions, key=lambda v: [int(i) for i in v.split('.')])
+                os.environ["CUDA_PATH"] = os.path.join(cuda_root, f'v{latest_cuda_version}')
+        else:
+            cuda_root="/usr/local"
+            cuda_versions = []
+            if os.path.exists(cuda_root):
+                for entry in os.listdir(cuda_root):
+                    if os.path.isdir(os.path.join(cuda_root, entry)) and entry.startswith("cuda-"):
+                        version = entry.split("-")[1]
+                        if re.match(r"^\d+\.\d+$", version):  # Match version pattern like 10.1
+                            cuda_versions.append(version)
+                latest_cuda_version = max(cuda_versions, key=lambda v: [int(i) for i in v.split('.')])
+                os.environ["CUDA_PATH"] = os.path.join(cuda_root, f'cuda-{latest_cuda_version}')
+
+    if "CUDA_PATH" not in os.environ:
+        lit_config.error(
+            "Cannot run tests for CUDA without valid CUDA_PATH." 
+        )
+
     llvm_config.with_system_environment("CUDA_PATH")
     if platform.system() == "Windows":
         config.cuda_libs_dir = (

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -466,11 +466,15 @@ if config.hip_platform not in supported_hip_platforms:
 if "cuda:gpu" in config.sycl_devices:
     llvm_config.with_system_environment("CUDA_PATH")
     if platform.system() == "Windows":
-        config.cuda_libs_dir = '"' + os.path.join(os.environ['CUDA_PATH'], r"lib\x64") + '"'
-        config.cuda_include = '"' + os.path.join(os.environ['CUDA_PATH'], "include") + '"'
+        config.cuda_libs_dir = (
+            '"' + os.path.join(os.environ["CUDA_PATH"], r"lib\x64") + '"'
+        )
+        config.cuda_include = (
+            '"' + os.path.join(os.environ["CUDA_PATH"], "include") + '"'
+        )
     else:
-        config.cuda_libs_dir = os.path.join(os.environ['CUDA_PATH'], r"lib64")
-        config.cuda_include = os.path.join(os.environ['CUDA_PATH'], "include")
+        config.cuda_libs_dir = os.path.join(os.environ["CUDA_PATH"], r"lib64")
+        config.cuda_include = os.path.join(os.environ["CUDA_PATH"], "include")
 
 # FIXME: This needs to be made per-device as well, possibly with a helper.
 if "hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -504,7 +504,7 @@ if "cuda:gpu" in config.sycl_devices:
                 cuda_root, f"cuda-{latest_cuda_version}"
             )
  
-     if "CUDA_PATH" not in os.environ:
+    if "CUDA_PATH" not in os.environ:
         lit_config.error("Cannot run tests for CUDA without valid CUDA_PATH.")
 
     llvm_config.with_system_environment("CUDA_PATH")

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -478,10 +478,12 @@ if "cuda:gpu" in config.sycl_devices:
                             r"^\d+\.\d+$", version
                         ):  # Match version pattern like 12.3
                             cuda_versions.append(version)
-            latest_cuda_version = max(
-                cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
-            )
-            os.environ["CUDA_PATH"] = os.path.join(cuda_root, f"v{latest_cuda_version}")
+                latest_cuda_version = max(
+                    cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
+                )
+                os.environ["CUDA_PATH"] = os.path.join(
+                    cuda_root, f"v{latest_cuda_version}"
+                )
         else:
             cuda_root = "/usr/local"
             cuda_versions = []
@@ -495,12 +497,12 @@ if "cuda:gpu" in config.sycl_devices:
                             r"^\d+\.\d+$", version
                         ):  # Match version pattern like 12.3
                             cuda_versions.append(version)
-            latest_cuda_version = max(
-                cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
-            )
-            os.environ["CUDA_PATH"] = os.path.join(
-                cuda_root, f"cuda-{latest_cuda_version}"
-            )
+                latest_cuda_version = max(
+                    cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
+                )
+                os.environ["CUDA_PATH"] = os.path.join(
+                    cuda_root, f"cuda-{latest_cuda_version}"
+                )
 
     if "CUDA_PATH" not in os.environ:
         lit_config.error("Cannot run tests for CUDA without valid CUDA_PATH.")

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -503,7 +503,7 @@ if "cuda:gpu" in config.sycl_devices:
             os.environ["CUDA_PATH"] = os.path.join(
                 cuda_root, f"cuda-{latest_cuda_version}"
             )
- 
+
     if "CUDA_PATH" not in os.environ:
         lit_config.error("Cannot run tests for CUDA without valid CUDA_PATH.")
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -466,32 +466,46 @@ if config.hip_platform not in supported_hip_platforms:
 if "cuda:gpu" in config.sycl_devices:
     if "CUDA_PATH" not in os.environ:
         if platform.system() == "Windows":
-            cuda_root=r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
+            cuda_root = r"C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA"
             cuda_versions = []
             if os.path.exists(cuda_root):
                 for entry in os.listdir(cuda_root):
-                    if os.path.isdir(os.path.join(cuda_root, entry)) and entry.startswith("v"):
+                    if os.path.isdir(
+                        os.path.join(cuda_root, entry)
+                    ) and entry.startswith("v"):
                         version = entry[1:]  # Remove the leading 'v'
-                        if re.match(r"^\d+\.\d+$", version):  # Match version pattern like 12.3
-                            cuda_versions.append(version)
-                latest_cuda_version = max(cuda_versions, key=lambda v: [int(i) for i in v.split('.')])
-                os.environ["CUDA_PATH"] = os.path.join(cuda_root, f'v{latest_cuda_version}')
-        else:
-            cuda_root="/usr/local"
-            cuda_versions = []
-            if os.path.exists(cuda_root):
-                for entry in os.listdir(cuda_root):
-                    if os.path.isdir(os.path.join(cuda_root, entry)) and entry.startswith("cuda-"):
-                        version = entry.split("-")[1]
-                        if re.match(r"^\d+\.\d+$", version):  # Match version pattern like 10.1
-                            cuda_versions.append(version)
-                latest_cuda_version = max(cuda_versions, key=lambda v: [int(i) for i in v.split('.')])
-                os.environ["CUDA_PATH"] = os.path.join(cuda_root, f'cuda-{latest_cuda_version}')
-
-    if "CUDA_PATH" not in os.environ:
-        lit_config.error(
-            "Cannot run tests for CUDA without valid CUDA_PATH." 
-        )
+                        if re.match(
+                            r"^\d+\.\d+$", version
+                        ):  # Match version pattern like 12.3
+                                cuda_versions.append(version)
+            latest_cuda_version = max(
+                cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
+            )
+            os.environ["CUDA_PATH"] = os.path.join(
+                cuda_root, f"v{latest_cuda_version}"
+            )
+    else:
+        cuda_root = "/usr/local"
+        cuda_versions = []
+        if os.path.exists(cuda_root):
+            for entry in os.listdir(cuda_root):
+                if os.path.isdir(
+                    os.path.join(cuda_root, entry)
+                ) and entry.startswith("cuda-"):
+                    version = entry.split("-")[1]
+                    if re.match(
+                        r"^\d+\.\d+$", version
+                    ):  # Match version pattern like 12.3
+                        cuda_versions.append(version)
+            latest_cuda_version = max(
+                cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
+            )
+            os.environ["CUDA_PATH"] = os.path.join(
+                cuda_root, f"cuda-{latest_cuda_version}"
+            )
+ 
+     if "CUDA_PATH" not in os.environ:
+        lit_config.error("Cannot run tests for CUDA without valid CUDA_PATH.")
 
     llvm_config.with_system_environment("CUDA_PATH")
     if platform.system() == "Windows":

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -477,26 +477,24 @@ if "cuda:gpu" in config.sycl_devices:
                         if re.match(
                             r"^\d+\.\d+$", version
                         ):  # Match version pattern like 12.3
-                                cuda_versions.append(version)
+                            cuda_versions.append(version)
             latest_cuda_version = max(
                 cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
             )
-            os.environ["CUDA_PATH"] = os.path.join(
-                cuda_root, f"v{latest_cuda_version}"
-            )
-    else:
-        cuda_root = "/usr/local"
-        cuda_versions = []
-        if os.path.exists(cuda_root):
-            for entry in os.listdir(cuda_root):
-                if os.path.isdir(
-                    os.path.join(cuda_root, entry)
-                ) and entry.startswith("cuda-"):
-                    version = entry.split("-")[1]
-                    if re.match(
-                        r"^\d+\.\d+$", version
-                    ):  # Match version pattern like 12.3
-                        cuda_versions.append(version)
+            os.environ["CUDA_PATH"] = os.path.join(cuda_root, f"v{latest_cuda_version}")
+        else:
+            cuda_root = "/usr/local"
+            cuda_versions = []
+            if os.path.exists(cuda_root):
+                for entry in os.listdir(cuda_root):
+                    if os.path.isdir(
+                        os.path.join(cuda_root, entry)
+                    ) and entry.startswith("cuda-"):
+                        version = entry.split("-")[1]
+                        if re.match(
+                            r"^\d+\.\d+$", version
+                        ):  # Match version pattern like 12.3
+                            cuda_versions.append(version)
             latest_cuda_version = max(
                 cuda_versions, key=lambda v: [int(i) for i in v.split(".")]
             )

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -21,7 +21,7 @@ config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.s
 config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRARY@" else "")
 config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"
 config.level_zero_include = "@LEVEL_ZERO_INCLUDE@"
-if platform.system() == "Windox":
+if platform.system() == "Windows":
     config.cuda_libs_dir = '"' + os.path.join(os.environ['CUDA_PATH'], r"lib\x64") + '"' 
     config.cuda_include = '"' + os.path.join(os.environ['CUDA_PATH'], "include") + '"'
 else:

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -21,8 +21,12 @@ config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.s
 config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRARY@" else "")
 config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"
 config.level_zero_include = "@LEVEL_ZERO_INCLUDE@"
-config.cuda_libs_dir = "@CUDA_LIBS_DIR@"
-config.cuda_include = "@CUDA_INCLUDE@"
+if platform.system() == "Windox":
+    config.cuda_libs_dir = '"' + os.path.join(os.environ['CUDA_PATH'], r"lib\x64") + '"' 
+    config.cuda_include = '"' + os.path.join(os.environ['CUDA_PATH'], "include") + '"'
+else:
+    config.cuda_libs_dir = os.path.join(os.environ['CUDA_PATH'], r"lib64") 
+    config.cuda_include = os.path.join(os.environ['CUDA_PATH'], "include")
 
 config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
 

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -21,12 +21,8 @@ config.sycl_libs_dir =  os.path.join(config.dpcpp_root_dir, ('bin' if platform.s
 config.opencl_libs_dir = (os.path.dirname("@OpenCL_LIBRARY@") if "@OpenCL_LIBRARY@" else "")
 config.level_zero_libs_dir = "@LEVEL_ZERO_LIBS_DIR@"
 config.level_zero_include = "@LEVEL_ZERO_INCLUDE@"
-if platform.system() == "Windows":
-    config.cuda_libs_dir = '"' + os.path.join(os.environ['CUDA_PATH'], r"lib\x64") + '"' 
-    config.cuda_include = '"' + os.path.join(os.environ['CUDA_PATH'], "include") + '"'
-else:
-    config.cuda_libs_dir = os.path.join(os.environ['CUDA_PATH'], r"lib64") 
-    config.cuda_include = os.path.join(os.environ['CUDA_PATH'], "include")
+config.cuda_libs_dir = "@CUDA_LIBS_DIR@"
+config.cuda_include = "@CUDA_INCLUDE@"
 
 config.opencl_include_dir = os.path.join(config.sycl_include, 'sycl')
 


### PR DESCRIPTION
`cuda_dev_kit` is not set properly in [test-e2e/lit.cfg.py](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/lit.cfg.py) due to invalid CUDA paths.
Fixing the paths showed errors in [14115](https://github.com/intel/llvm/issues/14115) and [14116](https://github.com/intel/llvm/issues/14116) which are XFAILed.
The patch fixes the failure of [cuda_queue_priority.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/Plugin/cuda_queue_priority.cpp) on Windows / CUDA. 