### PR TITLE
[SYCL][E2E] Fix deprecated warnings in `InorderQueue` e2e tests

### DIFF
--- a/sycl/test-e2e/InorderQueue/in_order_get_property.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_get_property.cpp
@@ -24,10 +24,11 @@ int main() {
     Queue1.get_property<property::queue::in_order>();
     assert(false && "Queue1 was created without any properties therefore get "
                     "property should fail.");
-  } catch (const invalid_object_error &e) {
+  } catch (const exception &e) {
     std::string ErrorMessage = e.what();
     assert(
-        (ErrorMessage.find("The property is not found") != std::string::npos) &&
+        (e.code() == errc::invalid &&
+         ErrorMessage.find("The property is not found") != std::string::npos) &&
         "Caught unexpected error!");
   }
 

--- a/sycl/test-e2e/InorderQueue/in_order_kernels.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_kernels.cpp
@@ -80,7 +80,7 @@ int main() {
     q.submit([&](handler &cgh) {
       cgh.parallel_for_work_group<class WkGrp>(
           range<1>{N / 2}, range<1>{2}, [=](group<1> myGroup) {
-            auto j = myGroup.get_id(0);
+            auto j = myGroup.get_group_id(0);
             myGroup.parallel_for_work_item(
                 [&](h_item<1> it) { A[(j * 2) + it.get_local_id(0)]++; });
           });
@@ -89,7 +89,7 @@ int main() {
     q.submit([&](handler &cgh) {
       cgh.parallel_for_work_group(
           range<1>{N / 2}, range<1>{2}, [=](group<1> myGroup) {
-            auto j = myGroup.get_id(0);
+            auto j = myGroup.get_group_id(0);
             myGroup.parallel_for_work_item(
                 [&](h_item<1> it) { A[(j * 2) + it.get_local_id(0)]++; });
           });

--- a/sycl/test-e2e/InorderQueue/in_order_usm_implicit.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_usm_implicit.cpp
@@ -41,7 +41,7 @@ int main() {
       dataB[i] = 0;
     }
 
-    Queue.mem_advise(dataA, numBytes, (pi_mem_advice)mem_advice);
+    Queue.mem_advise(dataA, numBytes, mem_advice);
 
     Queue.submit([&](handler &cgh) {
       auto myRange = range<1>(dataSize);


### PR DESCRIPTION
- `InorderQueue/in_order_get_property.cpp` -> Use non-deprecated `sycl::exception`, add check for errc to ensure we are still catching the correct exception
- `InorderQueue/in_order_kernels.cpp` -> Use group `get_group_id` function instead of deprecated `get_id`
- `InorderQueue/in_order_usm_implicit.cpp` -> Use queue `mem_advice` function that uses `int` instead of `pi_mem_advice`