### PR TITLE
[CI] Allow aux CUDA jobs to run on more machines

### DIFF
--- a/.github/workflows/sycl-linux-precommit-aws.yml
+++ b/.github/workflows/sycl-linux-precommit-aws.yml
@@ -19,7 +19,7 @@ permissions:
 
 jobs:
   create-check:
-    runs-on: [Linux, build]
+    runs-on: [Linux, aux-tasks]
     permissions:
       checks: write
       statuses: write
@@ -79,7 +79,7 @@ jobs:
   update-check:
     needs: [create-check, e2e-cuda]
     if: always()
-    runs-on: [Linux, build]
+    runs-on: [Linux, aux-tasks]
     permissions:
       checks: write
       statuses: write


### PR DESCRIPTION
We have limited build systems and these tasks can run on basically any Linux hardware.

Right now sometimes I have to wait over an hour for `update-check` to run even after that actual task that runs on the GPU succeeds. 