### PR TITLE
[SYCL][E2E] Fix deprecated warnings in `Scheduler` e2e tests

### DIFF
--- a/sycl/test-e2e/Scheduler/DataMovement.cpp
+++ b/sycl/test-e2e/Scheduler/DataMovement.cpp
@@ -71,7 +71,7 @@ int main() {
 
   Queue1.wait_and_throw();
 
-  { auto HostAcc = Buf.get_access<sycl_access_mode::read>(); }
+  { sycl::host_accessor HostAcc(Buf, sycl::read_only); }
 
   Queue2.submit([&](sycl::handler &CGH) {
     auto BufAcc = Buf.get_access<sycl_access_mode::read_write>(CGH);
@@ -80,7 +80,7 @@ int main() {
 
   Queue2.wait_and_throw();
 
-  { auto HostAcc = Buf.get_access<sycl_access_mode::read>(); }
+  { sycl::host_accessor HostAcc(Buf, sycl::read_only); }
 
   return 0;
 }

--- a/sycl/test-e2e/Scheduler/InOrderQueueDeps.cpp
+++ b/sycl/test-e2e/Scheduler/InOrderQueueDeps.cpp
@@ -30,8 +30,7 @@ int main() {
   int val;
   sycl::buffer<int, 1> Buf{&val, sycl::range<1>(1)};
 
-  sycl::default_selector DeviceSelector;
-  sycl::device Dev = DeviceSelector.select_device();
+  sycl::device Dev(sycl::default_selector_v);
   sycl::context Ctx{Dev};
 
   sycl::queue InOrderQueueA{Ctx, Dev, sycl::property::queue::in_order()};

--- a/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
+++ b/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
@@ -33,7 +33,7 @@ int main() {
     // CHECK-NEXT: :
     // CHECK-NEXT: :
     // CHECK-NEXT: : 1
-    auto AccA = BufA.get_access<access::mode::read>();
+    host_accessor AccA(BufA, read_only);
     for (std::size_t I = 0; I < Size; ++I) {
       assert(AccA[I] == I);
     }
@@ -45,13 +45,13 @@ int main() {
     // CHECK-NEXT: :
     // CHECK-NEXT: :
     // CHECK-NEXT: : 3
-    auto AccA = BufA.get_access<access::mode::write>();
+    host_accessor AccA(BufA, write_only);
     for (std::size_t I = 0; I < Size; ++I)
       AccA[I] = 2 * I;
   }
 
   // CHECK-NOT: piEnqueueMemBufferMap
-  auto AccA = BufA.get_access<access::mode::read>();
+  host_accessor AccA(BufA, read_only);
   for (std::size_t I = 0; I < Size; ++I) {
     assert(AccA[I] == 2 * I);
   }

--- a/sycl/test-e2e/Scheduler/MultipleDevices.cpp
+++ b/sycl/test-e2e/Scheduler/MultipleDevices.cpp
@@ -93,36 +93,30 @@ int multidevice_test(queue MyQueue1, queue MyQueue2) {
 }
 
 int main() {
-  cpu_selector CPUSelector;
-  gpu_selector GPUSelector;
 
   int Result = -1;
   try {
-    queue MyQueue1(CPUSelector);
-    queue MyQueue2(CPUSelector);
+    queue MyQueue1(cpu_selector_v);
+    queue MyQueue2(cpu_selector_v);
     Result &= multidevice_test(MyQueue1, MyQueue2);
-  } catch (sycl::runtime_error &) {
+  } catch (sycl::exception &) {
     std::cout << "Skipping CPU and CPU" << std::endl;
   }
 
   try {
-    queue MyQueue1(CPUSelector);
-    queue MyQueue2(GPUSelector);
+    queue MyQueue1(cpu_selector_v);
+    queue MyQueue2(gpu_selector_v);
     Result &= multidevice_test(MyQueue1, MyQueue2);
-  } catch (sycl::runtime_error &) {
-    std::cout << "Skipping CPU and GPU" << std::endl;
-  } catch (sycl::compile_program_error &) {
+  } catch (sycl::exception &) {
     std::cout << "Skipping CPU and GPU" << std::endl;
   }
 
   try {
-    queue MyQueue1(GPUSelector);
-    queue MyQueue2(GPUSelector);
+    queue MyQueue1(gpu_selector_v);
+    queue MyQueue2(gpu_selector_v);
     Result &= multidevice_test(MyQueue1, MyQueue2);
-  } catch (sycl::runtime_error &) {
+  } catch (sycl::exception &) {
     std::cout << "Skipping GPU and GPU" << std::endl;
-  } catch (sycl::compile_program_error &) {
-    std::cout << "Skipping CPU and GPU" << std::endl;
   }
 
   return Result;


### PR DESCRIPTION
- Replace use of buffer `get_access` calls in host with `host_accessor` constructor
- Replace use of old device selector with new callable selector
- Replace use of old sycl exceptions