### PR TITLE
[SYCL] Port changes in 414c1e5e6 to SemaSYCL.cpp.

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6621,15 +6621,16 @@ void SemaSYCL::handleKernelAttr(Decl *D, const ParsedAttr &AL) {
   const FunctionTemplateDecl *FT = FD->getDescribedFunctionTemplate();
   assert(FT && "Function template is expected");
 
-  // Function template must have at least two template parameters.
+  // Function template must have at least two template parameters so it
+  // can be used in OpenCL kernel generation.
   const TemplateParameterList *TL = FT->getTemplateParameters();
   if (TL->size() < 2) {
     Diag(FT->getLocation(), diag::warn_sycl_kernel_num_of_template_params);
     return;
   }
 
-  // Template parameters must be typenames.
-  for (unsigned I = 0; I < 2; ++I) {
+  // The first two template parameters must be typenames.
+  for (unsigned I = 0; I < 2 && I < TL->size(); ++I) {
     const NamedDecl *TParam = TL->getParam(I);
     if (isa<NonTypeTemplateParmDecl>(TParam)) {
       Diag(FT->getLocation(),
@@ -6638,8 +6639,8 @@ void SemaSYCL::handleKernelAttr(Decl *D, const ParsedAttr &AL) {
     }
   }
 
-  // Function must have at least one argument.
-  if (getFunctionOrMethodNumParams(D) != 1) {
+  // Function must have at least one parameter.
+  if (getFunctionOrMethodNumParams(D) < 1) {
     Diag(FT->getLocation(), diag::warn_sycl_kernel_num_of_function_params);
     return;
   }


### PR DESCRIPTION
6b755b0cf split SemaDeclAttr.cpp. But not all SYCL changes are properly
handled. This patch serves as a follow up and fixes most LIT failures.
