### PR TITLE
[Driver][SYCL][NewOffload] Fix duplication of device targets

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1182,6 +1182,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     // of -fsycl*target options passed
     Arg *SYCLTargetsValues = SYCLTargets;
     if (SYCLTargetsValues) {
+      llvm::StringSet<> SYCLTriples;
       if (SYCLTargetsValues->getNumValues()) {
 
         // Multiple targets are currently not supported when using
@@ -1220,7 +1221,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             const ToolChain *HostTC =
                 C.getSingleOffloadToolChain<Action::OFK_Host>();
             llvm::Triple HostTriple = HostTC->getTriple();
-            UniqueSYCLTriplesVec.push_back(HostTriple);
+            SYCLTriples.insert(HostTriple.normalize());
             continue;
           }
 
@@ -1242,9 +1243,15 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           // the following iterations.
           FoundNormalizedTriples[NormalizedName] = Val;
           llvm::Triple DeviceTriple(MakeSYCLDeviceTriple(UserTargetName));
-          UniqueSYCLTriplesVec.push_back(DeviceTriple);
+          SYCLTriples.insert(DeviceTriple.normalize());
           if (!Arch.empty())
             DerivedArchs[DeviceTriple.getTriple()].insert(Arch);
+        }
+        if (!SYCLTriples.empty()) {
+          for (const auto &SYCLTriple : SYCLTriples) {
+            llvm::Triple Triple(SYCLTriple.getKey());
+            UniqueSYCLTriplesVec.push_back(Triple);
+          }
         }
         addSYCLDefaultTriple(C, UniqueSYCLTriplesVec);
       } else
@@ -5031,17 +5038,16 @@ class OffloadingActionBuilder final {
       }
 
       // By default, we produce an action for each device arch.
-      auto TC = ToolChains.begin();
-      for (Action *&A : SYCLDeviceActions) {
-        if ((*TC)->getTriple().isNVPTX() && CurPhase >= phases::Backend) {
+      for (auto TargetActionInfo :
+           llvm::zip(SYCLDeviceActions, SYCLTargetInfoList)) {
+        auto &TargetInfo = std::get<1>(TargetActionInfo);
+        if (TargetInfo.TC->getTriple().isNVPTX() && CurPhase >= phases::Backend)
           // For CUDA, stop to emit LLVM IR so it can be linked later on.
-          ++TC;
           continue;
-        }
 
+        Action *&A = std::get<0>(TargetActionInfo);
         A = C.getDriver().ConstructPhaseAction(C, Args, CurPhase, A,
                                                AssociatedOffloadKind);
-        ++TC;
       }
 
       return ABRT_Success;

--- a/clang/test/Driver/sycl-fno-libspirv-warn.cpp
+++ b/clang/test/Driver/sycl-fno-libspirv-warn.cpp
@@ -1,7 +1,7 @@
 /// Test that appropriate warnings are output when -fno-sycl-libspirv is used.
 
 // RUN: not %clangxx -fsycl -fsycl-targets=nvptx64-nvidia-cuda,amdgcn-amd-amdhsa -fno-sycl-libspirv %s -### 2>&1 | FileCheck %s
-// CHECK: warning: '-fno-sycl-libspirv' should not be used with target 'nvptx64-nvidia-cuda'; libspirv is required for correct behavior [-Wno-libspirv-hip-cuda]
-// CHECK: warning: '-fno-sycl-libspirv' should not be used with target 'amdgcn-amd-amdhsa'; libspirv is required for correct behavior [-Wno-libspirv-hip-cuda]
+// CHECK-DAG: warning: '-fno-sycl-libspirv' should not be used with target 'nvptx64-nvidia-cuda'; libspirv is required for correct behavior [-Wno-libspirv-hip-cuda]
+// CHECK-DAG: warning: '-fno-sycl-libspirv' should not be used with target 'amdgcn-amd-amdhsa'; libspirv is required for correct behavior [-Wno-libspirv-hip-cuda]
 // RUN: %clangxx -fsycl -fsycl-targets=spir64-unknown-unknown -fno-sycl-libspirv %s -### 2>&1 | FileCheck --check-prefix=CHECK-SPIR64 %s
 // CHECK-SPIR64: ignoring '-fno-sycl-libspirv' option as it is not currently supported for target 'spir64-unknown-unknown' [-Woption-ignored]

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -117,8 +117,32 @@
 // RUN:          --offload-new-driver %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_PACKAGER_OPTS %s
 // CHK_PACKAGER_OPTS: clang-offload-packager{{.*}} "-o"
-// CHK_PACKAGER_OPTS-SAME: {{.*}}triple=spir64-unknown-unknown,arch=,kind=sycl,compile-opts={{.*}}-spir64-opt,link-opts=-spir64-link-opt
 // CHK_PACKAGER_OPTS-SAME: {{.*}}triple=spir64_gen-unknown-unknown,arch=pvc,kind=sycl,compile-opts={{.*}}-spir64_gen-opt,link-opts=-spir64_gen-link-opt
+// CHK_PACKAGER_OPTS-SAME: {{.*}}triple=spir64-unknown-unknown,arch=,kind=sycl,compile-opts={{.*}}-spir64-opt,link-opts=-spir64-link-opt
+
+/// Check phases with multiple intel_gpu settings
+// RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fsycl-targets=intel_gpu_dg1,intel_gpu_pvc \
+// RUN:          --offload-new-driver -ccc-print-phases %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=MULT_TARG_PHASES %s
+// MULT_TARG_PHASES: 0: input, "[[INPUT:.+\.c]]", c++, (host-sycl)
+// MULT_TARG_PHASES: 1: append-footer, {0}, c++, (host-sycl)
+// MULT_TARG_PHASES: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
+// MULT_TARG_PHASES: 3: compiler, {2}, ir, (host-sycl)
+// MULT_TARG_PHASES: 4: input, "[[INPUT]]", c++, (device-sycl, dg1)
+// MULT_TARG_PHASES: 5: preprocessor, {4}, c++-cpp-output, (device-sycl, dg1)
+// MULT_TARG_PHASES: 6: compiler, {5}, ir, (device-sycl, dg1)
+// MULT_TARG_PHASES: 7: backend, {6}, ir, (device-sycl, dg1)
+// MULT_TARG_PHASES: 8: offload, "device-sycl (spir64_gen-unknown-unknown:dg1)" {7}, ir
+// MULT_TARG_PHASES: 9: input, "[[INPUT]]", c++, (device-sycl, pvc)
+// MULT_TARG_PHASES: 10: preprocessor, {9}, c++-cpp-output, (device-sycl, pvc)
+// MULT_TARG_PHASES: 11: compiler, {10}, ir, (device-sycl, pvc)
+// MULT_TARG_PHASES: 12: backend, {11}, ir, (device-sycl, pvc)
+// MULT_TARG_PHASES: 13: offload, "device-sycl (spir64_gen-unknown-unknown:pvc)" {12}, ir
+// MULT_TARG_PHASES: 14: clang-offload-packager, {8, 13}, image, (device-sycl)
+// MULT_TARG_PHASES: 15: offload, "host-sycl (x86_64-unknown-linux-gnu)" {3}, "device-sycl (x86_64-unknown-linux-gnu)" {14}, ir
+// MULT_TARG_PHASES: 16: backend, {15}, assembler, (host-sycl)
+// MULT_TARG_PHASES: 17: assembler, {16}, object, (host-sycl)
 
 /// Test option passing behavior for clang-offload-wrapper options.
 // RUN: %clangxx --target=x86_64-unknown-linux-gnu -fsycl --offload-new-driver \


### PR DESCRIPTION
When passing along multiple targets in the form of -fsycl-targets=intel_gpu_dg1,intel_gpu_pvc, the number of the device compilations was n*n as opposed to just n.  Due to how we were handling duplicate entries for toolchain generation, the different names used even though they had the same target triple (spir64_gen) we being considered as unique, causing the multiple entries.

This is the second attempt to push this one in, updated the sycl-offload-new-driver.c test to reflect ordering issues encountered.