### PR TITLE
[SYCL][E2E] Remove deprecated multi_ptr use in `UserDefinedReductions` e2e tests

### DIFF
--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions.cpp
@@ -134,7 +134,7 @@ void test(queue q, InputContainer input, OutputContainer output,
                     it.get_group(), sycl::span(&scratch[0], temp_memory_size));
 
             const InputT *first =
-                in.template get_multi_ptr<access::decorated::no>();
+                in.template get_multi_ptr<access::decorated::no>().get();
             const InputT *last = first + N;
             // check reduce_over_group w/o init
             out[0] = sycl::ext::oneapi::experimental::reduce_over_group(

--- a/sycl/test-e2e/UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
+++ b/sycl/test-e2e/UserDefinedReductions/user_defined_reductions_wg_size_larger_than_data_size.cpp
@@ -46,9 +46,9 @@ void test(queue q, InputContainer input, OutputContainer output,
       cgh.parallel_for(
           nd_range<1>(workgroup_size, workgroup_size), [=](nd_item<1> it) {
             const InputT *segment_begin =
-                in.template get_multi_ptr<access::decorated::no>();
+                in.template get_multi_ptr<access::decorated::no>().get();
             const InputT *segment_end =
-                in.template get_multi_ptr<access::decorated::no>() +
+                in.template get_multi_ptr<access::decorated::no>().get() +
                 segment_size;
             auto handle =
                 sycl::ext::oneapi::experimental::group_with_scratchpad(


### PR DESCRIPTION
Use `multi_ptr` `get()` method, instead of implicitly converting to a pointer.