### PR TITLE
[SYCL][E2E] Fix deprecated warnings in `HostInteropTask` e2e tests

### DIFF
--- a/sycl/test-e2e/HostInteropTask/host-task-dependency2.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-dependency2.cpp
@@ -36,9 +36,9 @@ void test(queue &Q, size_t Count) {
     event E1 = Q.submit([&](handler &CGH) {
       std::cout << "Submit 1" << std::endl;
 
-      auto Acc0 = B0.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc1 = B1.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc2 = B2.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc0 = B0.get_host_access(CGH);
+      auto Acc1 = B1.get_host_access(CGH);
+      auto Acc2 = B2.get_host_access(CGH);
 
       auto Func = [=] {
         Acc0[0] = 1 * Idx;
@@ -53,8 +53,8 @@ void test(queue &Q, size_t Count) {
     event E2 = Q.submit([&](handler &CGH) {
       std::cout << "Submit 2" << std::endl;
 
-      auto Acc2 = B2.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc3 = B3.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc2 = B2.get_host_access(CGH);
+      auto Acc3 = B3.get_host_access(CGH);
 
       auto Func = [=] {
         Acc2[1] = 1 * Idx;
@@ -71,8 +71,8 @@ void test(queue &Q, size_t Count) {
 
       std::cout << "Submit 3" << std::endl;
 
-      auto Acc4 = B4.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc5 = B5.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc4 = B4.get_host_access(CGH);
+      auto Acc5 = B5.get_host_access(CGH);
 
       auto Func = [=] {
         Acc4[2] = 1 * Idx;

--- a/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-dependency3.cpp
@@ -44,7 +44,7 @@ void test(size_t Count) {
     Q.submit([&](handler &CGH) {
       std::cout << "Submit HT-1" << std::endl;
 
-      auto Acc0 = B0.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc0 = B0.get_host_access();
 
       CGH.host_task([=] {
         std::this_thread::sleep_for(SleepFor);
@@ -71,7 +71,7 @@ void test(size_t Count) {
     Q.submit([&](handler &CGH) {
       std::cout << "Submit HT-2" << std::endl;
 
-      auto Acc2 = B2.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc2 = B2.get_host_access();
 
       CGH.host_task([=] {
         std::this_thread::sleep_for(SleepFor);
@@ -84,9 +84,9 @@ void test(size_t Count) {
     event EHT3 = Q.submit([&](handler &CGH) {
       std::cout << "Submit HT-3" << std::endl;
 
-      auto Acc0 = B0.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc1 = B1.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc2 = B2.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc0 = B0.get_host_access();
+      auto Acc1 = B1.get_host_access();
+      auto Acc2 = B2.get_host_access();
 
       CGH.host_task([=] {
         std::this_thread::sleep_for(SleepFor);
@@ -104,7 +104,7 @@ void test(size_t Count) {
 
       CGH.depends_on(EHT3);
 
-      auto Acc5 = B5.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc5 = B5.get_host_access();
 
       CGH.host_task([=] { Acc5[5] = 1 * Idx; });
     });

--- a/sycl/test-e2e/HostInteropTask/host-task.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task.cpp
@@ -98,16 +98,16 @@ void test3(queue &Q) {
 
       std::cout << "Submit: " << Idx << std::endl;
 
-      auto Acc0 = B0.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc1 = B1.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc2 = B2.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc3 = B3.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc4 = B4.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc5 = B5.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc6 = B6.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc7 = B7.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc8 = B8.get_access<mode::read_write, target::host_buffer>(CGH);
-      auto Acc9 = B9.get_access<mode::read_write, target::host_buffer>(CGH);
+      auto Acc0 = B0.get_host_access();
+      auto Acc1 = B1.get_host_access();
+      auto Acc2 = B2.get_host_access();
+      auto Acc3 = B3.get_host_access();
+      auto Acc4 = B4.get_host_access();
+      auto Acc5 = B5.get_host_access();
+      auto Acc6 = B6.get_host_access();
+      auto Acc7 = B7.get_host_access();
+      auto Acc8 = B8.get_host_access();
+      auto Acc9 = B9.get_host_access();
 
       auto Func = [=] {
         uint64_t X = 0;


### PR DESCRIPTION
Replace use of buffer `get_access` calls in host with `get_host_access` for `HostInteropTask` e2e tests.