### PR TITLE
[Driver][SYCL][NewOffloadModel] Incorporate -device settings for GPU

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1249,7 +1249,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             // right most entry.
             for (int i = TargetArgs.size() - 2; i >= 0; --i) {
               if (StringRef(TargetArgs[i]) == "-device") {
-                Arch = TargetArgs[i+1];
+                Arch = TargetArgs[i + 1];
                 break;
               }
             }

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1225,9 +1225,42 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             continue;
           }
 
-          if (!isValidSYCLTriple(MakeSYCLDeviceTriple(UserTargetName))) {
+          llvm::Triple DeviceTriple(MakeSYCLDeviceTriple(UserTargetName));
+          if (!isValidSYCLTriple(DeviceTriple)) {
             Diag(clang::diag::err_drv_invalid_sycl_target) << Val;
             continue;
+          }
+
+          // For any -fsycl-targets=spir64_gen additions, we will scan the
+          // additional -X* options for potential -device settings.  These
+          // need to be added as a known Arch to the packager.
+          if (DeviceTriple.isSPIRAOT() && Arch.empty() &&
+              DeviceTriple.getSubArch() == llvm::Triple::SPIRSubArch_gen) {
+            const ToolChain *HostTC =
+                C.getSingleOffloadToolChain<Action::OFK_Host>();
+            auto DeviceTC = std::make_unique<toolchains::SYCLToolChain>(
+                  *this, DeviceTriple, *HostTC, C.getInputArgs());
+            assert(DeviceTC && "Device toolchain not defined.");
+            ArgStringList TargetArgs;
+            DeviceTC->TranslateBackendTargetArgs(DeviceTC->getTriple(),
+                C.getInputArgs(), TargetArgs);
+            // Capture the argument for '-device'
+            bool DeviceSeen = false;
+            StringRef DeviceArg;
+            for (StringRef ArgString : TargetArgs) {
+              // Look for -device <string> and use that as the known arch to
+              // be associated with the current spir64_gen entry.  Continue
+              // scanning until we hit the last one.
+              if (DeviceSeen) {
+                DeviceArg = ArgString;
+                DeviceSeen = false;
+                continue;
+              }
+              if (ArgString == "-device")
+                DeviceSeen = true;
+            }
+            if (!DeviceArg.empty())
+              Arch = DeviceArg;
           }
 
           // Make sure we don't have a duplicate triple.
@@ -1242,7 +1275,6 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
           // Store the current triple so that we can check for duplicates in
           // the following iterations.
           FoundNormalizedTriples[NormalizedName] = Val;
-          llvm::Triple DeviceTriple(MakeSYCLDeviceTriple(UserTargetName));
           SYCLTriples.insert(DeviceTriple.normalize());
           if (!Arch.empty())
             DerivedArchs[DeviceTriple.getTriple()].insert(Arch);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1244,23 +1244,15 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             ArgStringList TargetArgs;
             DeviceTC->TranslateBackendTargetArgs(DeviceTC->getTriple(),
                                                  C.getInputArgs(), TargetArgs);
-            // Capture the argument for '-device'
-            bool DeviceSeen = false;
-            StringRef DeviceArg;
-            for (StringRef ArgString : TargetArgs) {
-              // Look for -device <string> and use that as the known arch to
-              // be associated with the current spir64_gen entry.  Continue
-              // scanning until we hit the last one.
-              if (DeviceSeen) {
-                DeviceArg = ArgString;
-                DeviceSeen = false;
-                continue;
+            // Look for -device <string> and use that as the known arch to
+            // be associated with the current spir64_gen entry.  Grab the
+            // right most entry.
+            for (int i = TargetArgs.size() - 2; i >= 0; --i) {
+              if (StringRef(TargetArgs[i]) == "-device") {
+                Arch = TargetArgs[i+1];
+                break;
               }
-              if (ArgString == "-device")
-                DeviceSeen = true;
             }
-            if (!DeviceArg.empty())
-              Arch = DeviceArg;
           }
 
           // Make sure we don't have a duplicate triple.

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -1239,11 +1239,11 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
             const ToolChain *HostTC =
                 C.getSingleOffloadToolChain<Action::OFK_Host>();
             auto DeviceTC = std::make_unique<toolchains::SYCLToolChain>(
-                  *this, DeviceTriple, *HostTC, C.getInputArgs());
+                *this, DeviceTriple, *HostTC, C.getInputArgs());
             assert(DeviceTC && "Device toolchain not defined.");
             ArgStringList TargetArgs;
             DeviceTC->TranslateBackendTargetArgs(DeviceTC->getTriple(),
-                C.getInputArgs(), TargetArgs);
+                                                 C.getInputArgs(), TargetArgs);
             // Capture the argument for '-device'
             bool DeviceSeen = false;
             StringRef DeviceArg;

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -96,6 +96,12 @@
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=spir64_gen-unknown-unknown -DARCH=pvc %s
 // RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen \
+// RUN:          "-device pvc" -Xsycl-target-backend=spir64_gen "-device dg1" \
+// RUN:          --offload-new-driver %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK_ARCH \
+// RUN:              -DTRIPLE=spir64_gen-unknown-unknown -DARCH=dg1 %s
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
 // RUN:          -fno-sycl-libspirv -fsycl-targets=amd_gpu_gfx900 \
 // RUN:          -nogpulib --offload-new-driver %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -91,6 +91,11 @@
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \
 // RUN:              -DTRIPLE=spir64_gen-unknown-unknown -DARCH=pvc %s
 // RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:          -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen \
+// RUN:          "-device pvc" --offload-new-driver %s 2>&1 \
+// RUN:  | FileCheck -check-prefix=CHK_ARCH \
+// RUN:              -DTRIPLE=spir64_gen-unknown-unknown -DARCH=pvc %s
+// RUN: %clangxx -### --target=x86_64-unknown-linux-gnu -fsycl \
 // RUN:          -fno-sycl-libspirv -fsycl-targets=amd_gpu_gfx900 \
 // RUN:          -nogpulib --offload-new-driver %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=CHK_ARCH \


### PR DESCRIPTION
One of the models that is used for specifying the device architecture for spir64_gen is to use the -Xsycl-target-backend "-device arg" syntax on the command line.

Hook up the ability to scan the target backend values to embed the proper information in the packaged binary when using the new offload model.