### PR TITLE
[SYCL] Re-enable `Basic/barrier_order.cpp`

### DIFF
--- a/sycl/test-e2e/Basic/barrier_order.cpp
+++ b/sycl/test-e2e/Basic/barrier_order.cpp
@@ -2,10 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Hangs on that platform (at least on gpu-intel-pvc),
-// https://github.com/intel/llvm/issues/7330.
-// UNSUPPORTED: opencl && gpu
-
 #include <iostream>
 #include <stdlib.h>
 


### PR DESCRIPTION
Closes https://github.com/intel/llvm/issues/7330.