### PR TITLE
[SYCL] Fix FloatVecToBF16Vec build

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -76,30 +76,6 @@ template <int N> void BF16VecToFloatVec(const bfloat16 src[N], float dst[N]) {
 #endif
 }
 
-template <int N> void FloatVecToBF16Vec(float src[N], bfloat16 dst[N]) {
-#if defined(__SYCL_DEVICE_ONLY__) && (defined(__SPIR__) || defined(__SPIRV__))
-  uint16_t *dst_i16 = sycl::bit_cast<uint16_t *>(dst);
-  if constexpr (N == 1)
-    __devicelib_ConvertFToBF16INTELVec1(src, dst_i16);
-  else if constexpr (N == 2)
-    __devicelib_ConvertFToBF16INTELVec2(src, dst_i16);
-  else if constexpr (N == 3)
-    __devicelib_ConvertFToBF16INTELVec3(src, dst_i16);
-  else if constexpr (N == 4)
-    __devicelib_ConvertFToBF16INTELVec4(src, dst_i16);
-  else if constexpr (N == 8)
-    __devicelib_ConvertFToBF16INTELVec8(src, dst_i16);
-  else if constexpr (N == 16)
-    __devicelib_ConvertFToBF16INTELVec16(src, dst_i16);
-#else
-  for (int i = 0; i < N; ++i) {
-    // No need to cast as bfloat16 has a assignment op overload that takes
-    // a float.
-    dst[i] = src[i];
-  }
-#endif
-}
-
 // sycl::vec support
 namespace bf16 {
 #ifndef __INTEL_PREVIEW_BREAKING_CHANGES
@@ -308,6 +284,30 @@ public:
 };
 
 namespace detail {
+
+template <int N> void FloatVecToBF16Vec(float src[N], bfloat16 dst[N]) {
+#if defined(__SYCL_DEVICE_ONLY__) && (defined(__SPIR__) || defined(__SPIRV__))
+  uint16_t *dst_i16 = sycl::bit_cast<uint16_t *>(dst);
+  if constexpr (N == 1)
+    __devicelib_ConvertFToBF16INTELVec1(src, dst_i16);
+  else if constexpr (N == 2)
+    __devicelib_ConvertFToBF16INTELVec2(src, dst_i16);
+  else if constexpr (N == 3)
+    __devicelib_ConvertFToBF16INTELVec3(src, dst_i16);
+  else if constexpr (N == 4)
+    __devicelib_ConvertFToBF16INTELVec4(src, dst_i16);
+  else if constexpr (N == 8)
+    __devicelib_ConvertFToBF16INTELVec8(src, dst_i16);
+  else if constexpr (N == 16)
+    __devicelib_ConvertFToBF16INTELVec16(src, dst_i16);
+#else
+  for (int i = 0; i < N; ++i) {
+    // No need to cast as bfloat16 has a assignment op overload that takes
+    // a float.
+    dst[i] = src[i];
+  }
+#endif
+}
 
 // Helper function for getting the internal representation of a bfloat16.
 inline Bfloat16StorageT bfloat16ToBits(const bfloat16 &Value) {


### PR DESCRIPTION
The function is using the `operator=` before it's defined which can cause some build failures:

```
build/include/sycl/ext/oneapi/bfloat16.hpp:98:19: error: no match for ‘operator=’ (operand types are ‘sycl::_V1::ext::oneapi::bfloat16’ and ‘float’)
   98 |     dst[i] = src[i];
      |                   ^
```

Moving it after the bfloat16 class definition fixes it.