### PR TITLE
[SYCL][Graph] Wait instead of flush dep events in update command

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3459,8 +3459,8 @@ UpdateCommandBufferCommand::UpdateCommandBufferCommand(
 pi_int32 UpdateCommandBufferCommand::enqueueImp() {
   waitForPreparedHostEvents();
   std::vector<EventImplPtr> EventImpls = MPreparedDepsEvents;
-  auto RawEvents = getPiEvents(EventImpls);
-  flushCrossQueueDeps(EventImpls, getWorkerQueue());
+  sycl::detail::pi::PiEvent &Event = MEvent->getHandleRef();
+  Command::waitForEvents(MQueue, EventImpls, Event);
 
   for (auto &Node : MNodes) {
     auto CG = static_cast<CGExecKernel *>(Node->MCommandGroup.get());

--- a/sycl/test-e2e/Graph/Update/Explicit/whole_update_double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Update/Explicit/whole_update_double_buffer.cpp
@@ -7,6 +7,4 @@
 
 #define GRAPH_E2E_EXPLICIT
 
-// UNSUPPORTED: cuda
-
 #include "../../Inputs/whole_update_double_buffer.cpp"

--- a/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_double_buffer.cpp
+++ b/sycl/test-e2e/Graph/Update/RecordReplay/whole_update_double_buffer.cpp
@@ -7,6 +7,4 @@
 
 #define GRAPH_E2E_RECORD_REPLAY
 
-// UNSUPPORTED: cuda
-
 #include "../../Inputs/whole_update_double_buffer.cpp"


### PR DESCRIPTION
- Could cause overlap of graph execution and initial h2d copy when updated with previously unused buffers
- Re-enable update double buffer tests on CUDA as this should fix failures observed in #13731