### PR TITLE
[SYCL][Driver][thinLTO] Error for -foffload-lto and -fsycl-device-code-split=off

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -395,6 +395,8 @@ def warn_drv_opt_requires_opt
   : Warning<"'%0' should be used only in conjunction with '%1'">, InGroup<UnusedCommandLineArgument>;
 def err_drv_sycl_missing_amdgpu_arch : Error<
   "missing AMDGPU architecture for SYCL offloading; specify it with '-Xsycl-target-backend%select{|=%1}0 --offload-arch=<arch-name>'">;
+def err_drv_sycl_thinlto_split_off: Error<
+  "'%0' is not supported when '%1' is set with '-fsycl'">;
 def warn_drv_sycl_offload_target_duplicate : Warning<
   "SYCL offloading target '%0' is similar to target '%1' already specified; "
   "will be ignored">, InGroup<SyclTarget>;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5850,9 +5850,8 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
           Args.getLastArg(options::OPT_fsycl_device_code_split_EQ);
       bool IsDeviceCodeSplitDisabled =
           SYCLSplitMode && StringRef(SYCLSplitMode->getValue()) == "off";
-      bool IsSYCLLTOSupported = JA.isDeviceOffloading(Action::OFK_SYCL) &&
-                                IsUsingOffloadNewDriver &&
-                                !IsDeviceCodeSplitDisabled;
+      bool IsSYCLLTOSupported =
+          JA.isDeviceOffloading(Action::OFK_SYCL) && IsUsingOffloadNewDriver;
       if ((IsDeviceOffloadAction &&
            !JA.isDeviceOffloading(Action::OFK_OpenMP) && !Triple.isAMDGPU() &&
            !IsUsingOffloadNewDriver) ||
@@ -5869,6 +5868,13 @@ void Clang::ConstructJob(Compilation &C, const JobAction &JA,
                                options::OPT_foffload_lto_EQ)
                    ->getAsString(Args)
             << "-fno-gpu-rdc";
+      } else if (JA.isDeviceOffloading(Action::OFK_SYCL) &&
+                 IsDeviceCodeSplitDisabled && LTOMode == LTOK_Thin) {
+        D.Diag(diag::err_drv_sycl_thinlto_split_off)
+            << SYCLSplitMode->getAsString(Args)
+            << Args.getLastArg(options::OPT_foffload_lto,
+                               options::OPT_foffload_lto_EQ)
+                   ->getAsString(Args);
       } else {
         assert(LTOMode == LTOK_Full || LTOMode == LTOK_Thin);
         CmdArgs.push_back(Args.MakeArgString(

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -6,7 +6,7 @@
 
 // Verify we error when using the new offload driver but with device code split set to off.
 // RUN: not %clangxx -fsycl --offload-new-driver -foffload-lto=thin -fsycl-device-code-split=off %s -### 2>&1 | FileCheck -check-prefix=CHECK_SPLIT_ERROR %s
-// CHECK_SPLIT_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
+// CHECK_SPLIT_ERROR: '-fsycl-device-code-split=off' is not supported when '-foffload-lto=thin' is set with '-fsycl'
 
 // Verify there's no error and we see the expected cc1 flags with the new offload driver.
 // RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -4,6 +4,10 @@
 // RUN: not %clangxx -fsycl -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_ERROR %s
 // CHECK_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
 
+// Verify we error when using the new offload driver but with device code split set to off.
+// RUN: not %clangxx -fsycl --offload-new-driver -foffload-lto=thin -fsycl-device-code-split=off %s -### 2>&1 | FileCheck -check-prefix=CHECK_SPLIT_ERROR %s
+// CHECK_SPLIT_ERROR: unsupported option '-foffload-lto=thin' for target 'spir64-unknown-unknown'
+
 // Verify there's no error and we see the expected cc1 flags with the new offload driver.
 // RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
 // CHECK_SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"


### PR DESCRIPTION
This is really complicated to support so we decided to disallow it for now.

I also fixed the condition to be more of what we want.