### PR TITLE
[CI] Use cuda 12.1 docker image again.

### DIFF
--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -1,4 +1,4 @@
-FROM nvidia/cuda:12.5.0-devel-ubuntu22.04
+FROM nvidia/cuda:12.1.0-devel-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
Updating the docker to 12.5 led to the below described problems. Since the testing output of 12.1 matches 12.5, and we don't actually use any cuda features later than 12.1 (which are minor updates) in the compiler, this PR reverts back to the 12.1 image.
We can update the docker later only when we really need to (probably when cuda 13 is released). For the purposes of intel/llvm CI 12.1 is sufficient.
This fixes the "latest" docker image, allowing other updates to the docker image to be made in the future.

CUDA docker issues:

Depending on the host setup of the runners, there are various issues on recent nvidia docker images related to interactions with the host, whereby nvidia devices are not visible.

- https://github.com/NVIDIA/nvidia-container-toolkit/issues/48
- https://github.com/NVIDIA/nvidia-docker/issues/1671
- https://github.com/NVIDIA/nvidia-container-toolkit/issues/154