### PR TITLE
Revert "[SYCL][E2E] Reenable 2D memory operation tests in L0 Windows"

### DIFF
--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_device.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Device>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_dhost.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_host.cpp
@@ -10,8 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: hip
+// Temporarily disabled until the failure is addressed.
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_device_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_device_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_device.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Device>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_dhost.cpp
@@ -9,6 +9,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_host.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_device.cpp
@@ -10,8 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: hip
+// Temporarily disabled until the failure is addressed.
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_dhost.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_host.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_device.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Device>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "copy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_device.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Device>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_dhost.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_host.cpp
@@ -10,8 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: hip
+// Temporarily disabled until the failure is addressed.
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_device_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Device, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_device.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Device>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_dhost.cpp
@@ -9,6 +9,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_host.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::DirectHost, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_device.cpp
@@ -10,8 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/10157.
-// UNSUPPORTED: hip
+// Temporarily disabled until the failure is addressed.
+// For HIP see https://github.com/intel/llvm/issues/10157.
+// UNSUPPORTED: (level_zero && windows) || hip
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_dhost.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_host.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Host, Alloc::Shared>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_device.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_device.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Device>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::DirectHost>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Host>(); }

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_shared.cpp
@@ -10,6 +10,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// Temporarily disabled until the failure is addressed.
+// UNSUPPORTED: (level_zero && windows)
+
 #include "memcpy2d_common.hpp"
 
 int main() { return test<Alloc::Shared, Alloc::Shared>(); }


### PR DESCRIPTION
Reverts intel/llvm#14158. Turns out https://github.com/intel/llvm/pull/14128 tried the same and failed some tests.