### PR TITLE
[SYCL][E2E] Disable flaky in_order_barrier_profiling.cpp test

### DIFF
--- a/sycl/test-e2e/Regression/in_order_barrier_profiling.cpp
+++ b/sycl/test-e2e/Regression/in_order_barrier_profiling.cpp
@@ -10,7 +10,8 @@
 //===----------------------------------------------------------------------===//
 // Level Zero adapter has a similar in-order queue barrier optimization that
 // leads to incorrect profiling values.
-// UNSUPPORTED: level_zero
+// https://github.com/intel/llvm/issues/14186
+// UNSUPPORTED: level_zero || (linux && opencl && gpu-intel-gen12)
 #include <sycl/detail/core.hpp>
 
 #include <sycl/properties/all_properties.hpp>


### PR DESCRIPTION
Failing on unrelated changes, see https://github.com/intel/llvm/issues/14186