### PR TITLE
Update UR tag

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -99,14 +99,14 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 1e9b1b493fe30e6236bf611ae6d82366c9376f6c
-  # Merge: a011f092 d8500a36
+  set(UNIFIED_RUNTIME_REPO "https://github.com/bensuo/unified-runtime.git")
+  # commit 33eb5ea82b46a794ce54027a0cc0c073e5f9112b
+  # Merge: a53f89db 58f68518
   # Author: Kenneth Benzie (Benie) <k.benzie@codeplay.com>
-  # Date:   Fri Jun 21 10:22:52 2024 +0100
-  #     Merge pull request #805 from aarongreig/aaron/kernelSetArgIndirectionFix
-  #     Correct level of indirection used in KernelSetArgPointer calls.
-  set(UNIFIED_RUNTIME_TAG 1e9b1b493fe30e6236bf611ae6d82366c9376f6c)
+  # Date:   Mon Jun 17 10:34:52 2024 +0100
+  #     Merge pull request #1678 from steffenlarsen/steffen/composite_devices_not_supported_and_empty
+  #     Fix return of component and composite device info queries
+  set(UNIFIED_RUNTIME_TAG ben/coverity-fix)
 
   fetch_adapter_source(level_zero
     ${UNIFIED_RUNTIME_REPO}


### PR DESCRIPTION
Update UR tag to include L0 coverity fix from https://github.com/oneapi-src/unified-runtime/pull/1763