### PR TITLE
[SYCL] Add option to sycl-post-link to embed module properties/symbols as metadata

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10646,6 +10646,10 @@ static void getNonTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
   if (TCArgs.hasFlag(options::OPT_fno_sycl_esimd_force_stateless_mem,
                      options::OPT_fsycl_esimd_force_stateless_mem, false))
     addArgs(PostLinkArgs, TCArgs, {"-lower-esimd-force-stateless-mem=false"});
+  bool IsUsingLTO = TC.getDriver().isUsingLTO(/*IsDeviceOffloadAction=*/true);
+  auto LTOMode = TC.getDriver().getLTOMode(/*IsDeviceOffloadAction=*/true);
+  if (IsUsingLTO && LTOMode == LTOK_Thin)
+    addArgs(PostLinkArgs, TCArgs, {"-embed-aux-info-as-metadata"});
 }
 
 // Add any sycl-post-link options that rely on a specific Triple.
@@ -10717,10 +10721,6 @@ getTripleBasedSYCLPostLinkOpts(const ToolChain &TC, const JobAction &JA,
       (IsAOT || NewOffloadDriver))
     addArgs(PostLinkArgs, TCArgs,
             {"-generate-device-image-default-spec-consts"});
-  bool IsUsingLTO = TC.getDriver().isUsingLTO(/*IsDeviceOffloadAction=*/true);
-  auto LTOMode = TC.getDriver().getLTOMode(/*IsDeviceOffloadAction=*/true);
-  if (IsUsingLTO && LTOMode == LTOK_Thin)
-    addArgs(PostLinkArgs, TCArgs, {"-embed-aux-info-as-metadata"});
 }
 
 // sycl-post-link tool normally outputs a file table (see the tool sources for

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10717,6 +10717,10 @@ getTripleBasedSYCLPostLinkOpts(const ToolChain &TC, const JobAction &JA,
       (IsAOT || NewOffloadDriver))
     addArgs(PostLinkArgs, TCArgs,
             {"-generate-device-image-default-spec-consts"});
+  bool IsUsingLTO = TC.getDriver().isUsingLTO(/*IsDeviceOffloadAction=*/true);
+  auto LTOMode = TC.getDriver().getLTOMode(/*IsDeviceOffloadAction=*/true);
+  if (IsUsingLTO && LTOMode == LTOK_Thin)
+    addArgs(PostLinkArgs, TCArgs, {"-embed-aux-info-as-metadata"});
 }
 
 // sycl-post-link tool normally outputs a file table (see the tool sources for

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -7,3 +7,4 @@
 // Verify there's no error and we see the expected cc1 flags with the new offload driver.
 // RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
 // CHECK_SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"
+// CHECK_SUPPORTED: sycl-post-link{{.*}} -embed-aux-info-as-metadata

--- a/llvm/test/tools/sycl-post-link/embed_aux_info_as_metadata.ll
+++ b/llvm/test/tools/sycl-post-link/embed_aux_info_as_metadata.ll
@@ -1,0 +1,37 @@
+; This test verifies the -embed-aux-info-as-metadata option.
+; In particular, we should see the properties and symbols file are not added to the output table
+; and are instead embedded in the module as metadata.
+;
+; RUN: sycl-post-link -split=source -embed-aux-info-as-metadata -symbols -S < %s -o %t.table
+; RUN: FileCheck %s -input-file=%t.table -check-prefix=CHECK-TABLE
+; RUN: FileCheck %s -input-file=%t_0.ll -check-prefix=CHECK-BAR
+; RUN: FileCheck %s -input-file=%t_1.ll -check-prefix=CHECK-FOO
+
+; CHECK-TABLE: [Code]
+; CHECK-TABLE: {{.*}}_0.ll
+; CHECK-TABLE: {{.*}}_1.ll
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; CHECK-FOO: define dso_local spir_func noundef void @foo
+define dso_local spir_func noundef void @foo(i32 noundef %a, i32 noundef %b) local_unnamed_addr #0 {
+entry:
+ret void
+}
+
+define dso_local spir_func noundef void @bar(i32 noundef %a, i32 noundef %b) #1 {
+entry:
+ret void
+}
+attributes #0 = { mustprogress nofree norecurse nosync nounwind willreturn memory(none) "sycl-module-id"="test.cpp" "sycl-grf-size"="128" }
+attributes #1 = { convergent mustprogress noinline norecurse nounwind "sycl-module-id"="test.cpp" "sycl-grf-size"="256" }
+; CHECK-FOO: !sycl_properties = !{![[#FOO_PROP:]]}
+; CHECK-FOO: !sycl_symbol_table = !{![[#FOO_SYM:]]}
+; CHECK-FOO: ![[#FOO_PROP]] = !{!"[SYCL/devicelib req mask]\0ADeviceLibReqMask=1|0\0A[SYCL/device requirements]\0Aaspects=2|AAAAAAAAAAA\0A[SYCL/misc properties]\0Asycl-grf-size=1|128\0A"}
+; CHECK-FOO: ![[#FOO_SYM]] = !{!"foo\0A"}
+
+; CHECK-BAR: !sycl_properties = !{![[#BAR_PROP:]]}
+; CHECK-BAR: !sycl_symbol_table = !{![[#BAR_SYM:]]}
+; CHECK-BAR: ![[#BAR_PROP]] = !{!"[SYCL/devicelib req mask]\0ADeviceLibReqMask=1|0\0A[SYCL/device requirements]\0Aaspects=2|AAAAAAAAAAA\0A[SYCL/misc properties]\0Asycl-grf-size=1|256\0A"}
+; CHECK-BAR: ![[#BAR_SYM]] = !{!"bar\0A"}


### PR DESCRIPTION
With thinLTO, we decided to run `sycl-post-link` early. To do that, we need to be able to figure out the properties and symbol table for each split inside `clang-linker-wrapper`. Today these are computed inside `sycl-post-link` after splitting, and we need a way to get them inside `clang-linker-wrapper`. Right now `sycl-post-link` is written such that these are most easily computed on a module that has just been split. It should be possible to change that to only look at a BC file without requiring that it was just split, but it seemed simpler to just keep the current architecture. To do that, we embed the symbol table and module properties into the module when thinLTO is enabled. This information will later be read by `clang-linker-wrapper`, to be added in a future change. 

When this option is enabled, we don't create separate files for the properties and symbols and also do not add it to the output table.