### PR TITLE
[NFC] Remove uses of deprecated StringRef::equals

### DIFF
--- a/clang/lib/CodeGen/CGCall.cpp
+++ b/clang/lib/CodeGen/CGCall.cpp
@@ -1881,9 +1881,9 @@ static llvm::fp::FPAccuracy convertFPAccuracy(StringRef FPAccuracyStr) {
 }
 
 static int32_t convertFPAccuracyToAspect(StringRef FPAccuracyStr) {
-  assert(FPAccuracyStr.equals("high") || FPAccuracyStr.equals("medium") ||
-         FPAccuracyStr.equals("low") || FPAccuracyStr.equals("sycl") ||
-         FPAccuracyStr.equals("cuda"));
+  assert(FPAccuracyStr == "high" || FPAccuracyStr == "medium" ||
+         FPAccuracyStr == "low" || FPAccuracyStr == "sycl" ||
+         FPAccuracyStr == "cuda");
   return llvm::StringSwitch<int32_t>(FPAccuracyStr)
       .Case("high", SYCLInternalAspect::fp_intrinsic_accuracy_high)
       .Case("medium", SYCLInternalAspect::fp_intrinsic_accuracy_medium)

--- a/clang/lib/Frontend/CompilerInvocation.cpp
+++ b/clang/lib/Frontend/CompilerInvocation.cpp
@@ -3858,7 +3858,7 @@ void CompilerInvocation::ParseFpAccuracyArgs(LangOptions &Opts, ArgList &Args,
             checkFPAccuracyIsValid(ValElement[0], Diags);
             // No need to fill the map if the FPaccuracy is 'default'.
             // The default builtin will be generated.
-            if (!ValElement[0].equals("default")) {
+            if (ValElement[0] != "default") {
               // if FPAccuracyFuncMap of this function has been previously set
               // update its value; the last fp-accuracy option in the command
               // line wins.

--- a/llvm/include/llvm/SYCLLowerIR/CompileTimePropertiesPass.h
+++ b/llvm/include/llvm/SYCLLowerIR/CompileTimePropertiesPass.h
@@ -57,7 +57,7 @@ namespace detail {
 ///
 /// @returns \c false if the value of \c Value equals to "false", \c true
 /// otherwise.
-inline bool toBool(StringRef Value) { return !Value.equals("false"); }
+inline bool toBool(StringRef Value) { return Value != "false"; }
 
 } // namespace detail
 


### PR DESCRIPTION
Uses have already been removed upstream and downstream, so remove the remaining ones here.