### PR TITLE
Add a check to see if -fcf-protection=full is supported by the compiler

### DIFF
--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -218,9 +218,46 @@ set(imf_host_cxx_flags -c
   -D__LIBDEVICE_HOST_IMPL__
 )
 
+macro(mangle_name str output)
+  string(STRIP "${str}" strippedStr)
+  string(REGEX REPLACE "^/" "" strippedStr "${strippedStr}")
+  string(REGEX REPLACE "^-+" "" strippedStr "${strippedStr}")
+  string(REGEX REPLACE "-+$" "" strippedStr "${strippedStr}")
+  string(REPLACE "-" "_" strippedStr "${strippedStr}")
+  string(REPLACE "=" "_EQ_" strippedStr "${strippedStr}")
+  string(REPLACE "+" "X" strippedStr "${strippedStr}")
+  string(TOUPPER "${strippedStr}" ${output})
+endmacro()
+
+# Add a list of flags to 'imf_host_cxx_flags'.
+macro(add_imf_host_cxx_flags_compile_flags)
+  foreach(f ${ARGN})
+    list(APPEND imf_host_cxx_flags ${f})
+  endforeach()
+endmacro()
+
+# If 'condition' is true then add the specified list of flags to
+# 'imf_host_cxx_flags'
+macro(add_imf_host_cxx_flags_compile_flags_if condition)
+  if (${condition})
+    add_imf_host_cxx_flags_compile_flags(${ARGN})
+  endif()
+endmacro()
+
+# For each specified flag, add that flag to 'imf_host_cxx_flags' if the
+# flag is supported by the C++ compiler.
+macro(add_imf_host_cxx_flags_compile_flags_if_supported)
+  foreach(flag ${ARGN})
+      mangle_name("${flag}" flagname)
+      check_cxx_compiler_flag("${flag}" "CXX_SUPPORTS_${flagname}_FLAG")
+      add_imf_host_cxx_flags_compile_flags_if(CXX_SUPPORTS_${flagname}_FLAG ${flag})
+  endforeach()
+endmacro()
+
+
 if (NOT WIN32)
-  list(APPEND imf_host_cxx_flags -fPIC -fcf-protection=full)
-  list(APPEND imf_host_cxx_flags -fcf-protection=full)
+  list(APPEND imf_host_cxx_flags -fPIC)
+  add_imf_host_cxx_flags_compile_flags_if_supported("-fcf-protection=full")
 endif()
 
 add_custom_command(OUTPUT ${imf_fp32_fallback_src}


### PR DESCRIPTION
For compilation on non-Intel architectures, the flags `-fcf-protection=full` must be checked against the compiler flags supported for the architecture. This adds a similar check to that done in HandleLibcxxabiFlags.cmake to check whether the architecture supports it.
