### PR TITLE
[Driver][SYCL] Force an extension for AOT tool output files

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -9643,7 +9643,8 @@ const char *Driver::GetNamedOutputPath(Compilation &C, const JobAction &JA,
       bool IsHIPNoRDC = JA.getOffloadingDeviceKind() == Action::OFK_HIP &&
                         !C.getArgs().hasFlag(options::OPT_fgpu_rdc,
                                              options::OPT_fno_gpu_rdc, false);
-      bool UseOutExtension = IsHIPNoRDC || isa<OffloadPackagerJobAction>(JA);
+      bool UseOutExtension = IsHIPNoRDC || isa<OffloadPackagerJobAction>(JA) ||
+                             isa<BackendCompileJobAction>(JA);
       if (UseOutExtension) {
         Output = BaseName;
         llvm::sys::path::replace_extension(Output, "");

--- a/clang/test/Driver/sycl-offload-aot.cpp
+++ b/clang/test/Driver/sycl-offload-aot.cpp
@@ -298,3 +298,12 @@
 // RUN: %clang -fsycl -### -fsycl-targets=spir64_fpga -Xshardware -Xsycl-target-backend "-DBLAH" %s 2>&1 \
 // RUN:  | FileCheck -check-prefix=DUP-OPT %s
 // DUP-OPT-NOT: aoc{{.*}} "-DBLAH" {{.*}} "-DBLAH"
+
+/// Output files from ocloc should have an extension.
+// RUN:  %clangxx --target=x86_64-unknown-linux-gnu -fsycl \
+// RUN:           -fsycl-targets=intel_gpu_skl %s -### 2>&1 \
+// RUN:    | FileCheck -check-prefix=OCLOC_OUTPUT %s
+// RUN:  %clangxx --target=x86_64-unknown-linux-gnu -fsycl -save-temps \
+// RUN:           -fsycl-targets=intel_gpu_skl %s -### 2>&1 \
+// RUN:    | FileCheck -check-prefix=OCLOC_OUTPUT %s
+// OCLOC_OUTPUT: ocloc{{.*}} "-output" "{{.*}}.out"


### PR DESCRIPTION
When performing AOT and using -save-temps, make sure that the output files are created with an extension.  This is done for 'ocloc' behaviors as if an -output value does not have an extension, 'ocloc' will create a file with a default '.bin' extension causing issues with file consumption down the line.