### PR TITLE
[SYCL][COMPAT] Add a "wait" in host pointer RAII

### DIFF
--- a/sycl/include/syclcompat/memory.hpp
+++ b/sycl/include/syclcompat/memory.hpp
@@ -349,6 +349,8 @@ public:
         cgh.depends_on(_deps);
         cgh.host_task([buf = _buf] { std::free(buf); });
       });
+      // Wait here to ensure that the queue and lambda are not dropped before the buffer is freed
+      _q.wait();
     }
   }
 };


### PR DESCRIPTION
Previously, the destructor of this class would drop the lambda before it was called, resulting in segfault race conditions. This change introduces a `wait` to ensure that the queue is entirely completed before it is dropped.

---

This was causing us segfaults in our modifications to Intel-LLVM, but I'm not able to reproduce it in "vanilla" Intel-LLVM. Regardless, I think not waiting here is still problematic.