### PR TITLE
[NFC] Add a variable use to silence 'set but not used' warning

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMDSlmReservation.cpp
@@ -360,6 +360,7 @@ public:
             continue;
           }
           if (CallInst *ScopeStartCI = IsScopeEnd(&I)) {
+            (void)ScopeStartCI;
             ScopeMet = true;
             // Scope end marker encountered - verify all enclosed scopes have
             // ended and truncate current scope path to the enclosing node.


### PR DESCRIPTION
ScopeStartCI is only used in an assert so a warning is given in release builds. Add a reference so -Werror builds can succeed.