### PR TITLE
[SYCL][E2E] Fix warnings in `AtomicRef` e2e tests

### DIFF
--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
+// RUN: %{build} -O3 -o %t.out %if cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
 // RUN: %{run} %t.out
 
 // NOTE: Tests fetch_add for acquire and release memory ordering.

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O3 -o %t.out %if cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
+// RUN: %{build} -O3 -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
 // RUN: %{run} %t.out
 
 // NOTE: Tests fetch_add for acquire and release memory ordering.

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_acq_rel.cpp
@@ -25,7 +25,7 @@ template <memory_order order> void test_acquire_global() {
            error_buf.template get_access<access::mode::read_write>(cgh);
        auto val = val_buf.template get_access<access::mode::read_write>(cgh);
        cgh.parallel_for(range<1>(N_items), [=](item<1> it) {
-         volatile int *val_p = val.get_pointer();
+         volatile int *val_p = val.get_multi_ptr<access::decorated::no>().get();
          auto atm0 =
              atomic_ref<int, memory_order::relaxed, memory_scope::device,
                         access::address_space::global_space>(val[0]);
@@ -74,7 +74,8 @@ template <memory_order order> void test_acquire_local() {
              val[0] = 0;
              val[1] = 0;
              it.barrier(access::fence_space::local_space);
-             volatile int *val_p = val.get_pointer();
+             volatile int *val_p =
+                 val.get_multi_ptr<access::decorated::no>().get();
              auto atm0 =
                  atomic_ref<int, memory_order::relaxed, memory_scope::device,
                             access::address_space::local_space>(val[0]);
@@ -116,7 +117,7 @@ template <memory_order order> void test_release_global() {
            error_buf.template get_access<access::mode::read_write>(cgh);
        auto val = val_buf.template get_access<access::mode::read_write>(cgh);
        cgh.parallel_for(range<1>(N_items), [=](item<1> it) {
-         volatile int *val_p = val.get_pointer();
+         volatile int *val_p = val.get_multi_ptr<access::decorated::no>().get();
          auto atm0 =
              atomic_ref<int, memory_order::relaxed, memory_scope::device,
                         access::address_space::global_space>(val[0]);
@@ -165,7 +166,8 @@ template <memory_order order> void test_release_local() {
              val[0] = 0;
              val[1] = 0;
              it.barrier(access::fence_space::local_space);
-             volatile int *val_p = val.get_pointer();
+             volatile int *val_p =
+                 val.get_multi_ptr<access::decorated::no>().get();
              auto atm0 =
                  atomic_ref<int, memory_order::relaxed, memory_scope::device,
                             access::address_space::local_space>(val[0]);

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O3 -o %t.out -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70
+// RUN: %{build} -O3 -o %t.out %if cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
 // RUN: %{run} %t.out
 
 #include "atomic_memory_order.h"

--- a/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
+++ b/sycl/test-e2e/AtomicRef/atomic_memory_order_seq_cst.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O3 -o %t.out %if cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
+// RUN: %{build} -O3 -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %}
 // RUN: %{run} %t.out
 
 #include "atomic_memory_order.h"


### PR DESCRIPTION
- Remove deprecated use of `get_pointer` in `atomic_memory_order_acq_rel.cpp`

- Compile `atomic_memory_order_acq_rel.cpp` and `atomic_memory_order_seq_cst.cpp` with cuda backend flags, only if there is a cuda device