### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-92c2e4b

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-1e81b14",
-      "version": "1e81b14",
-      "updated_at": "2024-06-15T03:46:04Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1604197860/zip",
+      "github_tag": "igc-dev-92c2e4b",
+      "version": "92c2e4b",
+      "updated_at": "2024-06-20T02:55:17Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1619069448/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift