### PR TITLE
[SYCL] remove sycl 2017 incompatibility warning from tests

### DIFF
--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify \
 // RUN:  -aux-triple x86_64-unknown-linux-gnu -fsyntax-only       \
-// RUN:  -Wno-sycl-2017-compat  %s
+// RUN:   %s
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify \
 // RUN:  -aux-triple x86_64-pc-windows-msvc -fsyntax-only         \
-// RUN:  -Wno-sycl-2017-compat  %s
+// RUN:   %s
 //
 // Ensure SYCL type restrictions are applied to accessors as well.
 

--- a/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
+++ b/clang/test/SemaSYCL/accessor-type-diagnostics.cpp
@@ -1,9 +1,7 @@
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify \
-// RUN:  -aux-triple x86_64-unknown-linux-gnu -fsyntax-only       \
-// RUN:   %s
+// RUN:  -aux-triple x86_64-unknown-linux-gnu -fsyntax-only %s
 // RUN: %clang_cc1 -triple spir64 -fsycl-is-device -verify \
-// RUN:  -aux-triple x86_64-pc-windows-msvc -fsyntax-only         \
-// RUN:   %s
+// RUN:  -aux-triple x86_64-pc-windows-msvc -fsyntax-only %s
 //
 // Ensure SYCL type restrictions are applied to accessors as well.
 

--- a/clang/test/SemaSYCL/buffer_location.cpp
+++ b/clang/test/SemaSYCL/buffer_location.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 -fsycl-is-device -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
-// RUN: %clang_cc1 -fsycl-is-device -Wno-sycl-2017-compat -verify -pedantic -DTRIGGER_ERROR %s
+// RUN: %clang_cc1 -fsycl-is-device -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -pedantic -DTRIGGER_ERROR %s
 
 #include "Inputs/sycl.hpp"
 

--- a/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
+++ b/clang/test/SemaSYCL/deferred-diagnostics-aux-builtin.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -aux-triple x86_64-unknown-linux-gnu -Wno-sycl-2017-compat -verify -fsyntax-only  %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -triple spir64-unknown-unknown -aux-triple x86_64-unknown-linux-gnu -verify -fsyntax-only  %s
 
 #include "sycl.hpp"
 

--- a/clang/test/SemaSYCL/implicit-sycl-device-attr.cpp
+++ b/clang/test/SemaSYCL/implicit-sycl-device-attr.cpp
@@ -1,6 +1,6 @@
 // RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -triple spir64 \
 // RUN:  -aux-triple x86_64-unknown-linux-gnu -Wno-return-type -verify     \
-// RUN:  -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN:  -fsyntax-only -std=c++17 %s
 
 // add_ir_attributes_function attribute used to represent compile-time SYCL
 // properties and some of those properties are intended to be turned into

--- a/clang/test/SemaSYCL/inline-asm.cpp
+++ b/clang/test/SemaSYCL/inline-asm.cpp
@@ -1,6 +1,6 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s -DLINUX_ASM
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -triple x86_64-windows -fasm-blocks %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s -DLINUX_ASM -DSPIR_CHECK -triple spir64-unknown-unknown
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -triple x86_64-windows -fasm-blocks %s
 
 #ifndef SPIR_CHECK
 //expected-no-diagnostics

--- a/clang/test/SemaSYCL/intel-fpga-loop-ast.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-loop-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -ast-dump %s | FileCheck %s
 
 // Add AST tests for Loop attributes: [[intel::enable_loop_pipelining]],
 // [[intel::max_interleaving()]], [[intel::loop_coalesce]],

--- a/clang/test/SemaSYCL/intel-fpga-no-global-work-offset-ast.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-no-global-work-offset-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -ast-dump %s | FileCheck %s
 
 // Tests for AST of Intel FPGA no_global_work_offset function attribute.
 

--- a/clang/test/SemaSYCL/intel-fpga-nofusion.cpp
+++ b/clang/test/SemaSYCL/intel-fpga-nofusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -ast-dump -Wno-sycl-2017-compat -verify %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -ast-dump -verify %s | FileCheck %s
 // expected-no-diagnostics
 
 #include "sycl.hpp"

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -triple spir64 | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -ast-dump -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -triple spir64 | FileCheck %s
 
 // The test checks AST of [[intel::max_global_work_dim()]] attribute.
 

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -fsyntax-only -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -Wno-sycl-2017-compat -triple spir64 -verify
+// RUN: %clang_cc1 %s -fsyntax-only -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2020 -triple spir64 -verify
 
 // The test checks support and functionality of [[intel::max_global_work_dim()]] attribute.
 

--- a/clang/test/SemaSYCL/intel-max-global-work-dim-host.cpp
+++ b/clang/test/SemaSYCL/intel-max-global-work-dim-host.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-host -Wno-sycl-2017-compat -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 [[intel::max_global_work_dim(2)]] void func_do_not_ignore() {}

--- a/clang/test/SemaSYCL/intel-max-work-group-size-host.cpp
+++ b/clang/test/SemaSYCL/intel-max-work-group-size-host.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 [[intel::max_work_group_size(2, 2, 2)]] void func_do_not_ignore() {}

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-ast-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -ast-dump %s | FileCheck %s
 
 // Test for AST of reqd_work_group_size kernel attribute in SYCL 1.2.1.
 

--- a/clang/test/SemaSYCL/intel-reqd-work-group-size-host.cpp
+++ b/clang/test/SemaSYCL/intel-reqd-work-group-size-host.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-host -Wno-sycl-2017-compat -fsyntax-only -verify %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 [[sycl::reqd_work_group_size(4)]] void f4x1x1() {}

--- a/clang/test/SemaSYCL/intel-work-group-size-hint-ast-device.cpp
+++ b/clang/test/SemaSYCL/intel-work-group-size-hint-ast-device.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -ast-dump %s | FileCheck %s
 
 // Test for AST of work_group_size_hint kernel attribute in SYCL 1.2.1.
 

--- a/clang/test/SemaSYCL/invalid-kernel-arguments.cpp
+++ b/clang/test/SemaSYCL/invalid-kernel-arguments.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 
 // This test checks that compiler doesn't crash if type of kernel argument is
 // invalid.

--- a/clang/test/SemaSYCL/kernel-arg-opt-report.cpp
+++ b/clang/test/SemaSYCL/kernel-arg-opt-report.cpp
@@ -1,9 +1,9 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -fsycl-is-device \
-// RUN: -Wno-sycl-2017-compat -emit-llvm-bc %s -o %t-host.bc -opt-record-file %t-host.yaml
+// RUN: -emit-llvm-bc %s -o %t-host.bc -opt-record-file %t-host.yaml
 // RUN: FileCheck -check-prefix=SPIR --input-file %t-host.yaml %s
 
 // RUN: %clang_cc1 -triple nvptx64-unknown-unknown -fsycl-is-device \
-// RUN: -Wno-sycl-2017-compat -emit-llvm-bc %s -o %t-host.bc -opt-record-file %t-host.yaml
+// RUN: -emit-llvm-bc %s -o %t-host.bc -opt-record-file %t-host.yaml
 // RUN: FileCheck -check-prefix=NVPTX --input-file %t-host.yaml %s
 // The test generates remarks about the kernel argument, their location and type
 // in the resulting yaml file.

--- a/clang/test/SemaSYCL/kernel-function-type.cpp
+++ b/clang/test/SemaSYCL/kernel-function-type.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 // The kernel_single_task call is emitted as an OpenCL kernel function. The call

--- a/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
+++ b/clang/test/SemaSYCL/lambda_implicit_capture_this.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 //
 // This test checks that the compiler issues an error on attempt to capture
 // "this" pointer by lambdas passed to the device code (directly and indirectly)

--- a/clang/test/SemaSYCL/loop_fusion_ast.cpp
+++ b/clang/test/SemaSYCL/loop_fusion_ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -ast-dump %s | FileCheck %s
 
 // Tests for AST of Intel FPGA loop fusion function attributes
 #include "sycl.hpp"

--- a/clang/test/SemaSYCL/loop_unroll.cpp
+++ b/clang/test/SemaSYCL/loop_unroll.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify -pedantic %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify -pedantic %s
 
 template <int A>
 void bar() {

--- a/clang/test/SemaSYCL/markfunction-astconsumer.cpp
+++ b/clang/test/SemaSYCL/markfunction-astconsumer.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 void bar();
 
 template <typename T>

--- a/clang/test/SemaSYCL/max-concurrency-ast.cpp
+++ b/clang/test/SemaSYCL/max-concurrency-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -ast-dump %s | FileCheck %s
 
 // Tests for AST of Intel FPGA max concurrency function attribute.
 #include "sycl.hpp"

--- a/clang/test/SemaSYCL/no-vtables.cpp
+++ b/clang/test/SemaSYCL/no-vtables.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -verify -Wno-sycl-2017-compat -emit-llvm-only %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -verify -emit-llvm-only %s
 // expected-no-diagnostics
 // Should never fail, since the type is never used in kernel code.
 

--- a/clang/test/SemaSYCL/no-vtables2.cpp
+++ b/clang/test/SemaSYCL/no-vtables2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -Wno-return-type -verify -fsyntax-only %s
 
 struct Base {
   virtual void f() const {}

--- a/clang/test/SemaSYCL/num_simd_work_items.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -fsyntax-only -sycl-std=2020 -Wno-sycl-2017-compat -verify
+// RUN: %clang_cc1 %s -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -fsyntax-only -sycl-std=2020 -verify
 
 // The test checks support and functionality of [[intel::num_simd_work_items()]] attribute.
 

--- a/clang/test/SemaSYCL/num_simd_work_items_ast.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 %s -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -fsyntax-only -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump | FileCheck %s
+// RUN: %clang_cc1 %s -fsycl-is-device -internal-isystem %S/Inputs -triple spir64 -fsyntax-only -sycl-std=2017 -ast-dump | FileCheck %s
 
 // The test checks AST of [[intel::num_simd_work_items()]] attribute.
 

--- a/clang/test/SemaSYCL/num_simd_work_items_host.cpp
+++ b/clang/test/SemaSYCL/num_simd_work_items_host.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-host -fsyntax-only -verify %s
 // expected-no-diagnostics
 
 [[intel::num_simd_work_items(2)]] void func_do_not_ignore() {}

--- a/clang/test/SemaSYCL/pointer-to-vla.cpp
+++ b/clang/test/SemaSYCL/pointer-to-vla.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -fsyntax-only -verify %s
 //
 // This test checks if compiler reports compilation error on an attempt to pass
 // a pointer to VLA as kernel argument

--- a/clang/test/SemaSYCL/prohibit-thread-local.cpp
+++ b/clang/test/SemaSYCL/prohibit-thread-local.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -verify -fsyntax-only %s
 
 thread_local const int prohobit_ns_scope = 0;
 thread_local int prohobit_ns_scope2 = 0;

--- a/clang/test/SemaSYCL/reference-kernel-param.cpp
+++ b/clang/test/SemaSYCL/reference-kernel-param.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 // This test checks if compiler reports compilation error on an attempt to pass
 // a reference as SYCL kernel parameter.

--- a/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
+++ b/clang/test/SemaSYCL/reqd-sub-group-size-ast.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -Wno-sycl-2017-compat -ast-dump %s | FileCheck %s
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -sycl-std=2017 -ast-dump %s | FileCheck %s
 
 // The test checks AST of [[intel::reqd_sub_group_size()]] attribute.
 

--- a/clang/test/SemaSYCL/restrict-recursion.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion2.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion2.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion3.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion3.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-compat -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/restrict-recursion4.cpp
+++ b/clang/test/SemaSYCL/restrict-recursion4.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-sycl-2017-compat -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -Wno-return-type -Wno-error=sycl-strict -verify -fsyntax-only -std=c++17 %s
 
 // This recursive function is not called from sycl kernel,
 // so it should not be diagnosed.

--- a/clang/test/SemaSYCL/stall_enable_device.cpp
+++ b/clang/test/SemaSYCL/stall_enable_device.cpp
@@ -1,5 +1,5 @@
-// RUN: %clang_cc1 %s -fsyntax-only -internal-isystem %S/Inputs -fsycl-is-device -Wno-sycl-2017-compat -DTRIGGER_ERROR -verify
-// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -ast-dump -Wno-sycl-2017-compat %s | FileCheck %s
+// RUN: %clang_cc1 %s -fsyntax-only -internal-isystem %S/Inputs -fsycl-is-device -DTRIGGER_ERROR -verify
+// RUN: %clang_cc1 -fsycl-is-device -internal-isystem %S/Inputs -fsyntax-only -ast-dump %s | FileCheck %s
 
 // Test that checks [[intel::use_stall_enable_clusters]] attribute support on function.
 

--- a/clang/test/SemaSYCL/sycl-callstack.cpp
+++ b/clang/test/SemaSYCL/sycl-callstack.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only -std=c++17 %s
 
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel_single_task(const Func &kernelFunc) {

--- a/clang/test/SemaSYCL/sycl-cconv.cpp
+++ b/clang/test/SemaSYCL/sycl-cconv.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-windows -aux-triple x86_64-pc-windows-msvc -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-windows -aux-triple x86_64-pc-windows-msvc -fsyntax-only -verify %s
 
 // expected-no-warning@+1
 __inline __cdecl int printf(char const* const _Format, ...) { return 0; }

--- a/clang/test/SemaSYCL/sycl-device-const-static.cpp
+++ b/clang/test/SemaSYCL/sycl-device-const-static.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 struct Base {};
 struct S {

--- a/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-device-static-restrict.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 const int glob1 = 1;
 int glob2 = 2;
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-device-template-diag.cpp
+++ b/clang/test/SemaSYCL/sycl-device-template-diag.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s -internal-isystem %S/Inputs
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s -internal-isystem %S/Inputs
 
 // This test verifies that we generate deferred diagnostics when
 // such diagnostics are in a function template.

--- a/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
+++ b/clang/test/SemaSYCL/sycl-dllimport-dllexport.cpp
@@ -1,19 +1,19 @@
 // RUN: %clang_cc1 -triple spir64-unknown-unknown -fms-extensions \
 // RUN: -aux-triple x86_64-unknown-linux-gnu -fsycl-is-device \
-// RUN: -fsyntax-only -Wno-sycl-2017-compat -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
+// RUN: -fsyntax-only -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck %s
 // check random triple aux-triple with sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows -Wno-sycl-2017-compat -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows -fsyntax-only \
 // RUN: -fms-extensions -DWARNCHECK %s -o /dev/null 2>&1 | FileCheck --check-prefixes CHECKALL %s
 // check without -aux-triple but sycl-device
 
 // RUN: %clang_cc1 -triple spir64-unknown-windows \
 // RUN: -fsycl-is-device -aux-triple x86_64-pc-windows-msvc -fms-extensions \
-// RUN: -fsyntax-only -Wno-sycl-2017-compat -DWARNCHECK %s -o /dev/null 2>&1 | \
+// RUN: -fsyntax-only -DWARNCHECK %s -o /dev/null 2>&1 | \
 // RUN: FileCheck %s --check-prefixes CHECKALL
 // check -aux-tripe without sycl-device
 
-// RUN: %clang_cc1 -triple spir64-unknown-windows -Wno-sycl-2017-compat -fsyntax-only \
+// RUN: %clang_cc1 -triple spir64-unknown-windows -fsyntax-only \
 // RUN: -aux-triple x86_64-pc-windows-msvc -fsycl-is-device \
 // RUN: -fms-extensions -verify  %s
 // check error message when dllimport function gets called in sycl-kernel code

--- a/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
+++ b/clang/test/SemaSYCL/sycl-fptr-lambda.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -std=c++14 -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -std=c++14 -verify -fsyntax-only %s
 // expected-no-diagnostics
 
 template <typename name, typename Func>

--- a/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
+++ b/clang/test/SemaSYCL/sycl-pseudo-dtor.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -verify -fsyntax-only %s
 
 template <typename functor_t>
 struct functor_wrapper{

--- a/clang/test/SemaSYCL/sycl-restrict.cpp
+++ b/clang/test/SemaSYCL/sycl-restrict.cpp
@@ -1,14 +1,14 @@
 // RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -triple spir64 \
 // RUN:  -aux-triple x86_64-unknown-linux-gnu -Wno-return-type -verify     \
-// RUN:  -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN:  -fsyntax-only -std=c++17 %s
 // RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -triple spir64 \
 // RUN:  -aux-triple x86_64-unknown-linux-gnu -fno-sycl-allow-func-ptr     \
-// RUN:  -Wno-return-type -verify -Wno-sycl-2017-compat -fsyntax-only      \
+// RUN:  -Wno-return-type -verify -fsyntax-only      \
 // RUN:  -std=c++17 %s
 // RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -triple spir64 \
 // RUN:  -aux-triple x86_64-unknown-linux-gnu -DALLOW_FP=1                 \
 // RUN:  -fsycl-allow-func-ptr -Wno-return-type -verify                    \
-// RUN:  -Wno-sycl-2017-compat -fsyntax-only -std=c++17 %s
+// RUN:  -fsyntax-only -std=c++17 %s
 
 namespace std {
 class type_info;

--- a/clang/test/SemaSYCL/tls_error.cpp
+++ b/clang/test/SemaSYCL/tls_error.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64 -verify -fsyntax-only %s
 
 extern __thread void* __once_callable;  // expected-no-error
 extern __thread void (*__once_call)();  // expected-no-error

--- a/clang/test/SemaSYCL/unevaluated-function.cpp
+++ b/clang/test/SemaSYCL/unevaluated-function.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -verify -Wno-sycl-2017-compat -fsyntax-only %s
+// RUN: %clang_cc1 -fsycl-is-device -fcxx-exceptions -verify -fsyntax-only %s
 
 // Check that a function used in an unevaluated context is not subject
 // to delayed device diagnostics.

--- a/clang/test/SemaSYCL/unsupported_math.cpp
+++ b/clang/test/SemaSYCL/unsupported_math.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -fsyntax-only -verify %s
 template <typename name, typename Func>
 __attribute__((sycl_kernel)) void kernel(const Func &kernelFunc) {
   kernelFunc();

--- a/clang/test/SemaSYCL/variadic-func-call.cpp
+++ b/clang/test/SemaSYCL/variadic-func-call.cpp
@@ -1,4 +1,4 @@
-// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -fsyntax-only -Wno-sycl-2017-compat -verify %s
+// RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -fsyntax-only -verify %s
 
 void variadic(int, ...) {}
 namespace NS {


### PR DESCRIPTION
This PR removes the SYCL 2017 incompatibility warning as a preliminary step for continuation of PRs:
https://github.com/intel/llvm/pull/13411, https://github.com/intel/llvm/pull/13556 

Below is a list of the files remaining to be checked for -Wno-sycl-2017-compat flag impact:

  Clang :: Driver/clang-offload-bundler-bc-archive-support-linux.cpp
  Clang :: Driver/clang-offload-wrapper-input-bc.cpp
  Clang :: Driver/clang-offload-wrapper-input-multi-bc.cpp
  Clang :: Driver/sycl-linker-wrapper-image.cpp
  Clang :: SemaSYCL/check-notdirect-attribute-propagation.cpp
  Clang :: SemaSYCL/check-work-group-size-hint-device.cpp
  Clang :: SemaSYCL/intel-reqd-work-group-size-device.cpp
  Clang :: SemaSYCL/intel-restrict.cpp
  Clang :: SemaSYCL/lb_sm_90.cpp
  Clang :: SemaSYCL/reqd-sub-group-size.cpp
  Clang :: SemaSYCL/reqd-work-group-size-device.cpp
  Clang :: SemaSYCL/sycl-2017-future-compat.cpp
  Clang :: SemaSYCL/sycl-esimd.cpp