### PR TITLE
[SYCL][ESIMD][E2E] Add Windows driver check for atomic update test

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_dg2_pvc_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_dg2_pvc_cmpxchg.cpp
@@ -7,6 +7,7 @@
 //===---------------------------------------------------------------------===//
 
 // REQUIRES: gpu-intel-pvc || gpu-intel-dg2
+// REQUIRES-INTEL-DRIVER: win: 101.5660
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
Test is failing and causing a GPU reset on Windows with earlier driver versions.