### PR TITLE
[SYCL][E2E] Conditionally use `-fsycl-embed-ir` flags in `KernelFusion` e2e tests

### DIFF
--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/all_of.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/all_of.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -I . -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -I . -o %t.out
 // RUN: %{run} %t.out
 
 #include "../helpers.hpp"

--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/all_of.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/all_of.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -I . -o %t.out
+// RUN: %{build} %{embed-ir} -I . -o %t.out
 // RUN: %{run} %t.out
 
 #include "../helpers.hpp"

--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/exclusive_scan.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/exclusive_scan.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -I . -o %t.out
+// RUN: %{build} %{embed-ir} -I . -o %t.out
 // RUN: %{run} %t.out
 
 #include "../../helpers.hpp"

--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/exclusive_scan.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/exclusive_scan.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -I . -o %t.out
+// RUN: %{build}  %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -I . -o %t.out
 // RUN: %{run} %t.out
 
 #include "../../helpers.hpp"

--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/exclusive_scan.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/exclusive_scan.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build}  %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -I . -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -I . -o %t.out
 // RUN: %{run} %t.out
 
 #include "../../helpers.hpp"

--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/permute.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/permute.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion works with permute and remapping.

--- a/sycl/test-e2e/KernelFusion/GroupAlgorithm/permute.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupAlgorithm/permute.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion works with permute and remapping.

--- a/sycl/test-e2e/KernelFusion/GroupFunctions/group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupFunctions/group_barrier.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete_fusion preserves barriers by launching a kernel that requires a

--- a/sycl/test-e2e/KernelFusion/GroupFunctions/group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupFunctions/group_barrier.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete_fusion preserves barriers by launching a kernel that requires a

--- a/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion works with group_broadcast.

--- a/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion works with group_broadcast.

--- a/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast_remapping.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast_remapping.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion works with group_broadcast and remapping.

--- a/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast_remapping.cpp
+++ b/sycl/test-e2e/KernelFusion/GroupFunctions/group_broadcast_remapping.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion works with group_broadcast and remapping.

--- a/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_atomic_cross_wg.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_atomic_cross_wg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_atomic_cross_wg.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_atomic_cross_wg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_last_wg_detection.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_last_wg_detection.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // COM: When ran on HIP and CUDA, this algorithm launches 'memcpy' commands

--- a/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_last_wg_detection.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/group_reduce_and_last_wg_detection.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // COM: When ran on HIP and CUDA, this algorithm launches 'memcpy' commands

--- a/sycl/test-e2e/KernelFusion/Reduction/local_atomic_and_atomic_cross_wg.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/local_atomic_and_atomic_cross_wg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/local_atomic_and_atomic_cross_wg.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/local_atomic_and_atomic_cross_wg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/local_mem_tree_and_atomic_cross_wg.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/local_mem_tree_and_atomic_cross_wg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/local_mem_tree_and_atomic_cross_wg.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/local_mem_tree_and_atomic_cross_wg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/range_basic.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/range_basic.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/Reduction/range_basic.cpp
+++ b/sycl/test-e2e/KernelFusion/Reduction/range_basic.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 #include "./reduction.hpp"

--- a/sycl/test-e2e/KernelFusion/abort_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_fusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion being aborted: Different scenarios causing the JIT compiler

--- a/sycl/test-e2e/KernelFusion/abort_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_fusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion being aborted: Different scenarios causing the JIT compiler

--- a/sycl/test-e2e/KernelFusion/abort_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O2 %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} -O2 %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 SYCL_ENABLE_FUSION_CACHING=0 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test incomplete internalization: Different scenarios causing the JIT compiler

--- a/sycl/test-e2e/KernelFusion/abort_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O2 -fsycl-embed-ir -o %t.out
+// RUN: %{build} -O2 %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 SYCL_ENABLE_FUSION_CACHING=0 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test incomplete internalization: Different scenarios causing the JIT compiler

--- a/sycl/test-e2e/KernelFusion/abort_internalization_stored_ptr.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization_stored_ptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "Computation error" --implicit-check-not "Internalized" --check-prefix=CHECK %if hip %{ --check-prefix=CHECK-HIP %} %else %{ --check-prefix=CHECK-NON-HIP %}
 
 // Test pointers being stored are not internalized.

--- a/sycl/test-e2e/KernelFusion/abort_internalization_stored_ptr.cpp
+++ b/sycl/test-e2e/KernelFusion/abort_internalization_stored_ptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "Computation error" --implicit-check-not "Internalized" --check-prefix=CHECK %if hip %{ --check-prefix=CHECK-HIP %} %else %{ --check-prefix=CHECK-NON-HIP %}
 
 // Test pointers being stored are not internalized.

--- a/sycl/test-e2e/KernelFusion/barrier_local_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/barrier_local_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization and a combination of kernels

--- a/sycl/test-e2e/KernelFusion/barrier_local_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/barrier_local_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization and a combination of kernels

--- a/sycl/test-e2e/KernelFusion/buffer_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/buffer_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/buffer_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/buffer_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/cached_ndrange.cpp
+++ b/sycl/test-e2e/KernelFusion/cached_ndrange.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "COMPUTATION ERROR"
 // UNSUPPORTED: hip
 

--- a/sycl/test-e2e/KernelFusion/cached_ndrange.cpp
+++ b/sycl/test-e2e/KernelFusion/cached_ndrange.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "COMPUTATION ERROR"
 // UNSUPPORTED: hip
 

--- a/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test cancel fusion

--- a/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test cancel fusion

--- a/sycl/test-e2e/KernelFusion/complete_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/complete_fusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion without any internalization

--- a/sycl/test-e2e/KernelFusion/complete_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/complete_fusion.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion without any internalization

--- a/sycl/test-e2e/KernelFusion/cooperative_kernel.cpp
+++ b/sycl/test-e2e/KernelFusion/cooperative_kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test cooperative kernels are not fused

--- a/sycl/test-e2e/KernelFusion/cooperative_kernel.cpp
+++ b/sycl/test-e2e/KernelFusion/cooperative_kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test cooperative kernels are not fused

--- a/sycl/test-e2e/KernelFusion/diamond_shape.cpp
+++ b/sycl/test-e2e/KernelFusion/diamond_shape.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/diamond_shape.cpp
+++ b/sycl/test-e2e/KernelFusion/diamond_shape.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/diamond_shape_local.cpp
+++ b/sycl/test-e2e/KernelFusion/diamond_shape_local.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization specified on the

--- a/sycl/test-e2e/KernelFusion/diamond_shape_local.cpp
+++ b/sycl/test-e2e/KernelFusion/diamond_shape_local.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization specified on the

--- a/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test validity of events after cancel_fusion.

--- a/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test validity of events after cancel_fusion.

--- a/sycl/test-e2e/KernelFusion/event_wait_complete.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_complete.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test validity of events after complete_fusion.

--- a/sycl/test-e2e/KernelFusion/event_wait_complete.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_complete.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test validity of events after complete_fusion.

--- a/sycl/test-e2e/KernelFusion/existing_local_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/existing_local_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization and an local accessor that

--- a/sycl/test-e2e/KernelFusion/existing_local_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/existing_local_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization and an local accessor that

--- a/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
+++ b/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion where one kernel in the fusion list specifies an

--- a/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
+++ b/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion where one kernel in the fusion list specifies an

--- a/sycl/test-e2e/KernelFusion/internalize_array_wrapper.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_array_wrapper.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test internalization of a nested array type.

--- a/sycl/test-e2e/KernelFusion/internalize_array_wrapper.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_array_wrapper.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test internalization of a nested array type.

--- a/sycl/test-e2e/KernelFusion/internalize_array_wrapper_local.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_array_wrapper_local.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test local internalization of a nested array type.

--- a/sycl/test-e2e/KernelFusion/internalize_array_wrapper_local.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_array_wrapper_local.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test local internalization of a nested array type.

--- a/sycl/test-e2e/KernelFusion/internalize_deep.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_deep.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with internalization of a deep struct type.

--- a/sycl/test-e2e/KernelFusion/internalize_deep.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_deep.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with internalization of a deep struct type.

--- a/sycl/test-e2e/KernelFusion/internalize_multi_ptr.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_multi_ptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/internalize_multi_ptr.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_multi_ptr.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/internalize_non_unit_localsize.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_non_unit_localsize.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: fusion
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test private internalization with "LocalSize" == 3 on buffers that trigger

--- a/sycl/test-e2e/KernelFusion/internalize_non_unit_localsize.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_non_unit_localsize.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: fusion
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test private internalization with "LocalSize" == 3 on buffers that trigger

--- a/sycl/test-e2e/KernelFusion/internalize_vec.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vec.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with internalization of a struct type.

--- a/sycl/test-e2e/KernelFusion/internalize_vec.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vec.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with internalization of a struct type.

--- a/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
+++ b/sycl/test-e2e/KernelFusion/internalize_vfunc.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/jit_caching.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "COMPUTATION ERROR" --implicit-check-not "WRONG INTERNALIZATION"
 
 // Test caching for JIT fused kernels. Also test for debug messages being

--- a/sycl/test-e2e/KernelFusion/jit_caching.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not "COMPUTATION ERROR" --implicit-check-not "WRONG INTERNALIZATION"
 
 // Test caching for JIT fused kernels. Also test for debug messages being

--- a/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: (gpu && (hip || cuda)), cpu
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 
 // Test caching for JIT fused kernels when devices with different architectures

--- a/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: (gpu && (hip || cuda)), cpu
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} -fsycl-{embed-ir} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 
 // Test caching for JIT fused kernels when devices with different architectures

--- a/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: (gpu && (hip || cuda)), cpu
-// RUN: %{build} -fsycl-{embed-ir} -O2 -o %t.out
+// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 
 // Test caching for JIT fused kernels when devices with different architectures

--- a/sycl/test-e2e/KernelFusion/lit.local.cfg
+++ b/sycl/test-e2e/KernelFusion/lit.local.cfg
@@ -6,3 +6,7 @@ config.unsupported_features += ['accelerator']
 # TODO: enable on Windows once kernel fusion is supported on Windows.
 if platform.system() != "Linux":
    config.unsupported = True
+
+config.substitutions.append(
+    ("%{embed-ir}", "%if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %}")
+)

--- a/sycl/test-e2e/KernelFusion/local_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/local_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization specified on the

--- a/sycl/test-e2e/KernelFusion/local_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/local_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization specified on the

--- a/sycl/test-e2e/KernelFusion/math_function.cpp
+++ b/sycl/test-e2e/KernelFusion/math_function.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion of a kernel using a math function.

--- a/sycl/test-e2e/KernelFusion/math_function.cpp
+++ b/sycl/test-e2e/KernelFusion/math_function.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test fusion of a kernel using a math function.

--- a/sycl/test-e2e/KernelFusion/non-kernel-cg.cpp
+++ b/sycl/test-e2e/KernelFusion/non-kernel-cg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test non-kernel device command groups are not fused

--- a/sycl/test-e2e/KernelFusion/non-kernel-cg.cpp
+++ b/sycl/test-e2e/KernelFusion/non-kernel-cg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test non-kernel device command groups are not fused

--- a/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
+++ b/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization specified on the

--- a/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
+++ b/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with local internalization specified on the

--- a/sycl/test-e2e/KernelFusion/pointer_arg_function.cpp
+++ b/sycl/test-e2e/KernelFusion/pointer_arg_function.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 // This test currently fails because InferAddressSpace is not able to remove all
 // address-space casts, causing internalization to fail.

--- a/sycl/test-e2e/KernelFusion/private_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/private_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS=16:32:512 %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/private_internalization.cpp
+++ b/sycl/test-e2e/KernelFusion/private_internalization.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS=16:32:512 %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/queue-shortcut-functions.cpp
+++ b/sycl/test-e2e/KernelFusion/queue-shortcut-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 \
 // RUN:   | FileCheck %s --implicit-check-not=ERROR
 

--- a/sycl/test-e2e/KernelFusion/queue-shortcut-functions.cpp
+++ b/sycl/test-e2e/KernelFusion/queue-shortcut-functions.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 \
 // RUN:   | FileCheck %s --implicit-check-not=ERROR
 

--- a/sycl/test-e2e/KernelFusion/ranged_offset_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/ranged_offset_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization on accessors with different

--- a/sycl/test-e2e/KernelFusion/ranged_offset_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/ranged_offset_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization on accessors with different

--- a/sycl/test-e2e/KernelFusion/struct_with_array.cpp
+++ b/sycl/test-e2e/KernelFusion/struct_with_array.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization on a kernel functor with an

--- a/sycl/test-e2e/KernelFusion/struct_with_array.cpp
+++ b/sycl/test-e2e/KernelFusion/struct_with_array.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization on a kernel functor with an

--- a/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_event_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_event_wait.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion cancellation on event::wait() happening before

--- a/sycl/test-e2e/KernelFusion/sync_event_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_event_wait.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion cancellation on event::wait() happening before

--- a/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_host_task.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_task.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_host_task.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_task.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
@@ -1,5 +1,5 @@
 // For this test, complete_fusion must be supported.
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion cancellation for requirement between two active fusions.

--- a/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
@@ -1,5 +1,5 @@
 // For this test, complete_fusion must be supported.
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion cancellation for requirement between two active fusions.

--- a/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/KernelFusion/three_dimensional.cpp
+++ b/sycl/test-e2e/KernelFusion/three_dimensional.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/three_dimensional.cpp
+++ b/sycl/test-e2e/KernelFusion/three_dimensional.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/two_dimensional.cpp
+++ b/sycl/test-e2e/KernelFusion/two_dimensional.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS=16:32:64 %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/two_dimensional.cpp
+++ b/sycl/test-e2e/KernelFusion/two_dimensional.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: env SYCL_PARALLEL_FOR_RANGE_ROUNDING_PARAMS=16:32:64 %{run} %t.out
 
 // Test complete fusion with private internalization specified on the

--- a/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
+++ b/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion using USM pointers.

--- a/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
+++ b/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion using USM pointers.

--- a/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with a combination of kernels that require a work-group

--- a/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} %} -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with a combination of kernels that require a work-group

--- a/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion with a combination of kernels that require a work-group

--- a/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
+++ b/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
+// RUN: %{build} %{embed-ir} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion using an wrapped USM pointer as kernel functor argument.

--- a/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
+++ b/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -fsycl-embed-ir -o %t.out
+// RUN: %{build} %if any-device-is-hip || any-device-is-cuda %{ -fsycl-embed-ir %} -o %t.out
 // RUN: %{run} %t.out
 
 // Test complete fusion using an wrapped USM pointer as kernel functor argument.


### PR DESCRIPTION
`-fsycl-embed-ir` flag is only used when building the `KernelFusion` tests if there is a cuda or hip device. This removes the "argument unused during compilation" warning when running this test on other platforms.