### PR TITLE
[SYCL][E2E] Exclude root_group.cpp XFAIL on opencl accelerator

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -1,5 +1,5 @@
 // Fails with opencl non-cpu, enable when fixed.
-// XFAIL: (opencl && !cpu)
+// XFAIL: (opencl && !cpu && !accelerator)
 // RUN: %{build} -I . -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
root_group.cpp can pass with OpenCL fpga emulator.