### PR TITLE
[SYCL][E2e] Optionally allow unknown architectures in e2e

### DIFF
--- a/sycl/test-e2e/CMakeLists.txt
+++ b/sycl/test-e2e/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.20.0)
 
 message("Configuring SYCL End-to-End Tests")
 
+option(SYCL_E2E_LIT_ALLOW_UNKNOWN_ARCH
+  "Allow unknown architectures when configuring e2e tests" Off)
+
 if(CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR)
   project(sycl-e2e-test-suite CXX)
   set(SYCL_TEST_E2E_STANDALONE TRUE)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -753,11 +753,12 @@ for sycl_device in config.sycl_devices:
             "Architectures for {}: {}".format(sycl_device, ", ".join(architectures))
         )
         if len(architectures) != 1 or "unknown" in architectures:
-            lit_config.error(
-                "Cannot detect architecture for {}\nstdout:\n{}\nstderr:\n{}".format(
-                    sycl_device, sp.stdout, sp.stderr
+            if(not config.allow_unknown_arch):
+                lit_config.error(
+                    "Cannot detect architecture for {}\nstdout:\n{}\nstderr:\n{}".format(
+                        sycl_device, sp.stdout, sp.stderr
+                    )
                 )
-            )
             architectures = set()
 
     aspect_features = set("aspect-" + a for a in aspects)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -753,7 +753,7 @@ for sycl_device in config.sycl_devices:
             "Architectures for {}: {}".format(sycl_device, ", ".join(architectures))
         )
         if len(architectures) != 1 or "unknown" in architectures:
-            if(not config.allow_unknown_arch):
+            if not config.allow_unknown_arch:
                 lit_config.error(
                     "Cannot detect architecture for {}\nstdout:\n{}\nstderr:\n{}".format(
                         sycl_device, sp.stdout, sp.stderr

--- a/sycl/test-e2e/lit.site.cfg.py.in
+++ b/sycl/test-e2e/lit.site.cfg.py.in
@@ -43,6 +43,7 @@ config.vulkan_lib = "@Vulkan_LIBRARY@"
 config.vulkan_found = "@Vulkan_FOUND@"
 
 config.run_launcher = lit_config.params.get('run_launcher', "@SYCL_E2E_RUN_LAUNCHER@")
+config.allow_unknown_arch = "@SYCL_E2E_LIT_ALLOW_UNKNOWN_ARCH@"
 
 import lit.llvm
 lit.llvm.initialize(lit_config, config)


### PR DESCRIPTION
https://github.com/intel/llvm/pull/13976 adds support for using the `Architecture` output of `sycl-ls` when configuring `e2e` tests. This PR adds an opt-in option to allow configuring `e2e` tests when the architecture is `unknown`.