### PR TITLE
[SYCL] Fix conflict with min/max macro from windows.h for -fpreview-breaking-changes

### DIFF
--- a/sycl/include/sycl/vector_preview.hpp
+++ b/sycl/include/sycl/vector_preview.hpp
@@ -590,7 +590,7 @@ private:
   // "The elements of an instance of the SYCL vec class template are stored
   // in memory sequentially and contiguously and are aligned to the size of
   // the element type in bytes multiplied by the number of elements."
-  static constexpr int alignment = std::min((size_t)64, sizeof(DataType));
+  static constexpr int alignment = (std::min)((size_t)64, sizeof(DataType));
   alignas(alignment) DataType m_Data;
 
   // friends

--- a/sycl/test/basic_tests/min_max_test.cpp
+++ b/sycl/test/basic_tests/min_max_test.cpp
@@ -1,5 +1,6 @@
 // REQUIRES: windows
 // RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify %s -I %sycl_include
+// RUN: %clangxx -fsycl -fpreview-breaking-changes -fsycl-device-only -fsyntax-only -Xclang -verify %s -I %sycl_include
 // expected-no-diagnostics
 
 #include "windows.h"


### PR DESCRIPTION
windows.h defines min/max macros which conflict with std::min  causing compilation failure. 
sycl/test/basic_tests/min_max_test.cpp is supposed to test that but it was not testing the case when -fpreview-breaking-changes is used.
Enable the test for -fpreview-breaking-changes and fix one case doing std::min -> (std::min) which is the common workaround for this issue.