### PR TITLE
[SYCLLowerIR][SemaSYCL] Support indirect hierarchical parallelism

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -752,6 +752,30 @@ static bool isDeclaredInSYCLNamespace(const Decl *D) {
   return ND && ND->getName() == "sycl";
 }
 
+static bool isSYCLPrivateMemoryVar(VarDecl *VD) {
+  return SemaSYCL::isSyclType(VD->getType(), SYCLTypeAttr::private_memory);
+}
+
+static void addScopeAttrToLocalVars(FunctionDecl &F) {
+  for (Decl *D : F.decls()) {
+    VarDecl *VD = dyn_cast<VarDecl>(D);
+
+    if (!VD || isa<ParmVarDecl>(VD) ||
+        VD->getStorageDuration() != StorageDuration::SD_Automatic)
+      continue;
+    // Local variables of private_memory type in the WG scope still have WI
+    // scope, all the rest - WG scope. Simple logic
+    // "if no scope than it is WG scope" won't work, because compiler may add
+    // locals not declared in user code (lambda object parameter, byval
+    // arguments) which will result in alloca w/o any attribute, so need WI
+    // scope too.
+    SYCLScopeAttr::Level L = isSYCLPrivateMemoryVar(VD)
+                                 ? SYCLScopeAttr::Level::WorkItem
+                                 : SYCLScopeAttr::Level::WorkGroup;
+    VD->addAttr(SYCLScopeAttr::CreateImplicit(F.getASTContext(), L));
+  }
+}
+
 // This type does the heavy lifting for the management of device functions,
 // recursive function detection, and attribute collection for a single
 // kernel/external function. It walks the callgraph to find all functions that
@@ -801,12 +825,23 @@ class SingleDeviceFunctionTracker {
     // Note: Here, we assume that this is called from within a
     // parallel_for_work_group; it is undefined to call it otherwise.
     // We deliberately do not diagnose a violation.
+    // The following changes have also been added:
+    // 1. The function inside which the parallel_for_work_item exists is
+    //    marked with WorkGroup scope attribute, if not present already.
+    // 2. The local variables inside the function are marked with appropriate
+    //    scope.
     if (CurrentDecl->getIdentifier() &&
         CurrentDecl->getIdentifier()->getName() == "parallel_for_work_item" &&
         isDeclaredInSYCLNamespace(CurrentDecl) &&
         !CurrentDecl->hasAttr<SYCLScopeAttr>()) {
       CurrentDecl->addAttr(SYCLScopeAttr::CreateImplicit(
           Parent.SemaSYCLRef.getASTContext(), SYCLScopeAttr::Level::WorkItem));
+      FunctionDecl *Caller = CallStack.back();
+      if (!Caller->hasAttr<SYCLScopeAttr>())
+        CallStack.back()->addAttr(
+            SYCLScopeAttr::CreateImplicit(Parent.SemaSYCLRef.getASTContext(),
+                                          SYCLScopeAttr::Level::WorkGroup));
+      addScopeAttrToLocalVars(*Caller);
     }
 
     // We previously thought we could skip this function if we'd seen it before,
@@ -998,30 +1033,6 @@ public:
 private:
   ASTContext &Ctx;
 };
-
-static bool isSYCLPrivateMemoryVar(VarDecl *VD) {
-  return SemaSYCL::isSyclType(VD->getType(), SYCLTypeAttr::private_memory);
-}
-
-static void addScopeAttrToLocalVars(CXXMethodDecl &F) {
-  for (Decl *D : F.decls()) {
-    VarDecl *VD = dyn_cast<VarDecl>(D);
-
-    if (!VD || isa<ParmVarDecl>(VD) ||
-        VD->getStorageDuration() != StorageDuration::SD_Automatic)
-      continue;
-    // Local variables of private_memory type in the WG scope still have WI
-    // scope, all the rest - WG scope. Simple logic
-    // "if no scope than it is WG scope" won't work, because compiler may add
-    // locals not declared in user code (lambda object parameter, byval
-    // arguments) which will result in alloca w/o any attribute, so need WI
-    // scope too.
-    SYCLScopeAttr::Level L = isSYCLPrivateMemoryVar(VD)
-                                 ? SYCLScopeAttr::Level::WorkItem
-                                 : SYCLScopeAttr::Level::WorkGroup;
-    VD->addAttr(SYCLScopeAttr::CreateImplicit(F.getASTContext(), L));
-  }
-}
 
 /// Return method by name
 static CXXMethodDecl *getMethodByName(const CXXRecordDecl *CRD,

--- a/clang/test/CodeGenSYCL/sycl-pf-work-item.cpp
+++ b/clang/test/CodeGenSYCL/sycl-pf-work-item.cpp
@@ -1,6 +1,7 @@
 // RUN: %clang_cc1 -fsycl-is-device -triple spir64-unknown-unknown -internal-isystem %S/Inputs -emit-llvm %s -o - | FileCheck %s
 // This test checks if the parallel_for_work_item called indirecly from
 // parallel_for_work_group gets the work_item_scope marker on it.
+// It also checks if the calling function gets the work_group_scope marker on it.
 #include <sycl.hpp>
 
 void foo(sycl::group<1> work_group) {
@@ -18,4 +19,5 @@ int main(int argc, char **argv) {
   return 0;
 }
 
+// CHECK: define {{.*}} void {{.*}}foo{{.*}} !work_group_scope
 // CHECK: define {{.*}} void @{{.*}}sycl{{.*}}group{{.*}}parallel_for_work_item{{.*}}(ptr addrspace(4) noundef align 1 dereferenceable_or_null(1) %this) {{.*}}!work_item_scope {{.*}}!parallel_for_work_item

--- a/sycl/test-e2e/HierPar/hier_par_indirect.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_indirect.cpp
@@ -1,0 +1,33 @@
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+//
+
+//==- hier_par_indirect.cpp --- hierarchical parallelism test for WG
+//scope---==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+// This test checks correctness of hierarchical kernel execution when the work
+// item code is not directly inside work group scope.
+
+#include <iostream>
+#include <sycl/sycl.hpp>
+
+void __attribute__((noinline)) foo(sycl::group<1> work_group) {
+  work_group.parallel_for_work_item([&](sycl::h_item<1> index) {});
+}
+
+int main(int argc, char **argv) {
+  sycl::queue q;
+  q.submit([&](sycl::handler &cgh) {
+     cgh.parallel_for_work_group(sycl::range<1>{1}, sycl::range<1>{1024},
+                                 ([=](sycl::group<1> wGroup) { foo(wGroup); }));
+   }).wait();
+  std::cout << "test passed" << std::endl;
+  return 0;
+}


### PR DESCRIPTION
This PR adds a missing feature in SYCL hierarchical parallelism support.
Specifically, this PR adds support for the case when there are functions between parallel_for_work_group and parallel_for_work_item in the call stack.
For example:
void foo(sycl::group<1> group, ...) {
    group.parallel_for_work_item(range<1>(), [&](h_item<1> i) { ... });
}
// ...
  cgh.parallel_for_work_group<class kernel>(
   range<1>(...), range<1>(...), [=](group<1> g) {
   foo(g, ...);
  });