### PR TITLE
[SYCL][Bindless] Fix OpaqueFD/Win32Handle's scope in piextImportExternalMemory/Semaphore

### DIFF
--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -5434,6 +5434,7 @@ piextImportExternalMemory(pi_context Context, pi_device Device,
   }
 
   ur_exp_file_descriptor_t OpaqueFD{};
+  ur_exp_win32_handle_t Win32Handle{};
   switch (MemDescriptor->handleType) {
   case pi_external_mem_handle_type::opaque_fd: {
     OpaqueFD.stype = UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR;
@@ -5443,7 +5444,6 @@ piextImportExternalMemory(pi_context Context, pi_device Device,
   }
   case pi_external_mem_handle_type::win32_nt_handle:
   case pi_external_mem_handle_type::win32_nt_dx12_resource: {
-    ur_exp_win32_handle_t Win32Handle{};
     Win32Handle.stype = UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE;
     Win32Handle.handle = MemDescriptor->handle.win32_handle;
     InteropMemDesc.pNext = &Win32Handle;
@@ -5560,9 +5560,10 @@ piextImportExternalSemaphore(pi_context Context, pi_device Device,
     return PI_ERROR_INVALID_VALUE;
   }
 
+  ur_exp_file_descriptor_t OpaqueFD{};
+  ur_exp_win32_handle_t Win32Handle{};
   switch (SemDescriptor->handleType) {
   case pi_external_semaphore_handle_type::opaque_fd: {
-    ur_exp_file_descriptor_t OpaqueFD{};
     OpaqueFD.stype = UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR;
     OpaqueFD.fd = SemDescriptor->handle.file_descriptor;
     InteropSemDesc.pNext = &OpaqueFD;
@@ -5570,7 +5571,6 @@ piextImportExternalSemaphore(pi_context Context, pi_device Device,
   }
   case pi_external_semaphore_handle_type::win32_nt_dx12_fence:
   case pi_external_semaphore_handle_type::win32_nt_handle: {
-    ur_exp_win32_handle_t Win32Handle{};
     Win32Handle.stype = UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE;
     Win32Handle.handle = SemDescriptor->handle.win32_handle;
     InteropSemDesc.pNext = &Win32Handle;

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -5420,28 +5420,36 @@ piextImportExternalMemory(pi_context Context, pi_device Device,
 
   ur_exp_external_mem_type_t UrExternalMemHandleType;
   switch (MemDescriptor->handleType) {
+#ifndef _WIN32
   case pi_external_mem_handle_type::opaque_fd:
     UrExternalMemHandleType = UR_EXP_EXTERNAL_MEM_TYPE_OPAQUE_FD;
     break;
+#else
   case pi_external_mem_handle_type::win32_nt_handle:
     UrExternalMemHandleType = UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT;
     break;
   case pi_external_mem_handle_type::win32_nt_dx12_resource:
     UrExternalMemHandleType = UR_EXP_EXTERNAL_MEM_TYPE_WIN32_NT_DX12_RESOURCE;
     break;
+#endif
   default:
     return PI_ERROR_INVALID_VALUE;
   }
 
+#ifndef _WIN32
   ur_exp_file_descriptor_t OpaqueFD{};
+#else
   ur_exp_win32_handle_t Win32Handle{};
+#endif
   switch (MemDescriptor->handleType) {
+#ifndef _WIN32
   case pi_external_mem_handle_type::opaque_fd: {
     OpaqueFD.stype = UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR;
     OpaqueFD.fd = MemDescriptor->handle.file_descriptor;
     InteropMemDesc.pNext = &OpaqueFD;
     break;
   }
+#else
   case pi_external_mem_handle_type::win32_nt_handle:
   case pi_external_mem_handle_type::win32_nt_dx12_resource: {
     Win32Handle.stype = UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE;
@@ -5449,6 +5457,7 @@ piextImportExternalMemory(pi_context Context, pi_device Device,
     InteropMemDesc.pNext = &Win32Handle;
     break;
   }
+#endif
   default:
     return PI_ERROR_INVALID_VALUE;
   }
@@ -5546,9 +5555,11 @@ piextImportExternalSemaphore(pi_context Context, pi_device Device,
 
   ur_exp_external_semaphore_type_t UrExternalSemHandleType;
   switch (SemDescriptor->handleType) {
+#ifndef _WIN32
   case pi_external_semaphore_handle_type::opaque_fd:
     UrExternalSemHandleType = UR_EXP_EXTERNAL_SEMAPHORE_TYPE_OPAQUE_FD;
     break;
+#else
   case pi_external_semaphore_handle_type::win32_nt_handle:
     UrExternalSemHandleType = UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT;
     break;
@@ -5556,19 +5567,25 @@ piextImportExternalSemaphore(pi_context Context, pi_device Device,
     UrExternalSemHandleType =
         UR_EXP_EXTERNAL_SEMAPHORE_TYPE_WIN32_NT_DX12_FENCE;
     break;
+#endif
   default:
     return PI_ERROR_INVALID_VALUE;
   }
 
+#ifndef _WIN32
   ur_exp_file_descriptor_t OpaqueFD{};
+#else
   ur_exp_win32_handle_t Win32Handle{};
+#endif
   switch (SemDescriptor->handleType) {
+#ifndef _WIN32
   case pi_external_semaphore_handle_type::opaque_fd: {
     OpaqueFD.stype = UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR;
     OpaqueFD.fd = SemDescriptor->handle.file_descriptor;
     InteropSemDesc.pNext = &OpaqueFD;
     break;
   }
+#else
   case pi_external_semaphore_handle_type::win32_nt_dx12_fence:
   case pi_external_semaphore_handle_type::win32_nt_handle: {
     Win32Handle.stype = UR_STRUCTURE_TYPE_EXP_WIN32_HANDLE;
@@ -5576,6 +5593,7 @@ piextImportExternalSemaphore(pi_context Context, pi_device Device,
     InteropSemDesc.pNext = &Win32Handle;
     break;
   }
+#endif
   default:
     return PI_ERROR_INVALID_VALUE;
   }

--- a/sycl/plugins/unified_runtime/pi2ur.hpp
+++ b/sycl/plugins/unified_runtime/pi2ur.hpp
@@ -5433,9 +5433,9 @@ piextImportExternalMemory(pi_context Context, pi_device Device,
     return PI_ERROR_INVALID_VALUE;
   }
 
+  ur_exp_file_descriptor_t OpaqueFD{};
   switch (MemDescriptor->handleType) {
   case pi_external_mem_handle_type::opaque_fd: {
-    ur_exp_file_descriptor_t OpaqueFD{};
     OpaqueFD.stype = UR_STRUCTURE_TYPE_EXP_FILE_DESCRIPTOR;
     OpaqueFD.fd = MemDescriptor->handle.file_descriptor;
     InteropMemDesc.pNext = &OpaqueFD;


### PR DESCRIPTION
OpaqueFD/Win32Handle is used in InteropMemDesc.pNext.
Their scope should be the same as of InteropMemDesc.