### PR TITLE
[SYCL][E2E] Enable ze_debug tests on Windows

### DIFF
--- a/sycl/test-e2e/Basic/group_async_copy.cpp
+++ b/sycl/test-e2e/Basic/group_async_copy.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -std=c++17 -o %t.run
 // RUN: %{run} %t.run
 
-// Windows doesn't yet have full shutdown(). Skipping TC MemLeak tests.
-// UNSUPPORTED: ze_debug && windows
-
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/types.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_bfloat16_integeral_convesions.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_bfloat16_integeral_convesions.cpp
@@ -6,9 +6,6 @@
 //
 // UNSUPPORTED: cuda || hip
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
@@ -8,9 +8,6 @@
 
 // UNSUPPORTED: cuda, hip
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "imf_utils.hpp"
 #include <cmath>
 #include <sycl/ext/intel/math.hpp>

--- a/sycl/test-e2e/DeviceLib/imf_fp32_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp32_test.cpp
@@ -6,9 +6,6 @@
 //
 // UNSUPPORTED: cuda || hip
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>
 namespace s = sycl;

--- a/sycl/test-e2e/DeviceLib/imf_half_type_cast.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_half_type_cast.cpp
@@ -9,9 +9,6 @@
 
 // UNSUPPORTED: cuda, hip
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "imf_utils.hpp"
 #include <sycl/ext/intel/math.hpp>
 

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
@@ -1,6 +1,4 @@
 //
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 // REQUIRES-INTEL-DRIVER: lin: 28454, win: 101.5333
 //
 // RUN: %{build} -o %t.1.out

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
@@ -1,6 +1,4 @@
 //
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 // REQUIRES-INTEL-DRIVER: lin: 28454, win: 101.5333
 //
 // RUN: %{build} -o %t.1.out

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -1,5 +1,3 @@
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 // REQUIRES: aspect-usm_shared_allocations
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-failure.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include <sycl/detail/core.hpp>
 #include <sycl/detail/host_task_impl.hpp>
 

--- a/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on an explicit memory operation on an accessor
 // happening before complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on buffer destruction happening before
 // complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on host accessor creation happening before
 // complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_host_task.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_task.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on host task submission happening before
 // complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on queue destruction happening before
 // complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on queue::wait() happening before
 // complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // Test fusion cancellation on submission of kernel with requirements to a
 // different queue happening before complete_fusion.
 

--- a/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} %{embed-ir} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 
 // Test fusion cancellation on an explicit memory operation on an USM pointer
 // happening before complete_fusion.

--- a/sycl/test-e2e/Reduction/reduction_big_data.cpp
+++ b/sycl/test-e2e/Reduction/reduction_big_data.cpp
@@ -5,9 +5,6 @@
 // XFAIL: hip_nvidia
 //
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // where the bigger data size and/or non-uniform work-group sizes may cause
 // errors.

--- a/sycl/test-e2e/Reduction/reduction_complex_nums.cpp
+++ b/sycl/test-e2e/Reduction/reduction_complex_nums.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include <algorithm>
 #include <complex>
 #include <numeric>

--- a/sycl/test-e2e/Reduction/reduction_ctor.cpp
+++ b/sycl/test-e2e/Reduction/reduction_ctor.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This performs basic checks such as reduction creation, identity methods,
 // and the combine() method of the aux class 'reducer'.
 // Note: This test relies on non-standard implementation details.

--- a/sycl/test-e2e/Reduction/reduction_nd_N_queue_shortcut.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_N_queue_shortcut.cpp
@@ -7,9 +7,6 @@
 // This test only checks that the method queue::parallel_for() accepting
 // reduction, can be properly translated into queue::submit + parallel_for().
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "reduction_utils.hpp"
 
 using namespace sycl;

--- a/sycl/test-e2e/Reduction/reduction_nd_N_vars.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_N_vars.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test checks handling of parallel_for() accepting nd_range and
 // two or more reductions.
 

--- a/sycl/test-e2e/Reduction/reduction_nd_conditional.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_conditional.cpp
@@ -6,9 +6,6 @@
 // Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reduction and conditional increment of the reduction variable.
 

--- a/sycl/test-e2e/Reduction/reduction_nd_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_dw.cpp
@@ -4,9 +4,6 @@
 // Group algorithms are not supported on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with a one element buffer and
 // initialize_to_identity property.

--- a/sycl/test-e2e/Reduction/reduction_nd_ext_half.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_ext_half.cpp
@@ -7,9 +7,6 @@
 // work group size not bigger than 1`.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // used with 'half' type.
 

--- a/sycl/test-e2e/Reduction/reduction_nd_lambda.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_lambda.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 
 // This test performs basic checks of parallel_for(nd_range, reduction, lambda)
 

--- a/sycl/test-e2e/Reduction/reduction_nd_queue_shortcut.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_queue_shortcut.cpp
@@ -4,9 +4,6 @@
 // Group algorithms are not supported on NVidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test only checks that the method queue::parallel_for() accepting
 // reduction, can be properly translated into queue::submit + parallel_for().
 

--- a/sycl/test-e2e/Reduction/reduction_nd_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_reducer_skip.cpp
@@ -4,9 +4,6 @@
 // Group algorithms are not supported on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with a one element buffer. Additionally, some
 // reducers will not be written to.

--- a/sycl/test-e2e/Reduction/reduction_nd_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_nd_rw.cpp
@@ -4,9 +4,6 @@
 // `Group algorithms are not supported on host device.` on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -DENABLE_64_BIT=false -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "reduction_utils.hpp"
 #include <iostream>
 

--- a/sycl/test-e2e/Reduction/reduction_range_1d_dw_64bit.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_dw_64bit.cpp
@@ -1,7 +1,4 @@
 // RUN: %{build} -DENABLE_64_BIT=true -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "reduction_range_1d_dw.cpp"

--- a/sycl/test-e2e/Reduction/reduction_range_1d_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_reducer_skip.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<1>, reduction, func)
 // with reductions initialized with a one element buffer. Additionally, some
 // reducers will not be written to.

--- a/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_1d_rw.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<1>, reduction, func)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<2>, reduction, func)
 // with reductions initialized with a one element buffer and
 // an initialize_to_identity property.

--- a/sycl/test-e2e/Reduction/reduction_range_2d_dw_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_dw_reducer_skip.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<2>, reduction, func)
 // with reductions initialized with a one element buffer. Additionally, some
 // reducers will not be written to.

--- a/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_2d_rw.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<2>, reduction, func)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_dw.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<3>, reduction, func)
 // with reductions initialized with a one element buffer and a
 // initialize_to_identity property.

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<3>, reduction, func)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_3d_rw_reducer_skip.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_3d_rw_reducer_skip.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_60 %}
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range<3>, reduction, func)
 // with reductions initialized with a one element buffer. Additionally, some
 // reducers will not be written to.

--- a/sycl/test-e2e/Reduction/reduction_range_N_vars.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_N_vars.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test checks handling of parallel_for() accepting range and
 // two or more reductions.
 

--- a/sycl/test-e2e/Reduction/reduction_range_item.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_item.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include <sycl/detail/core.hpp>
 
 #include <sycl/reduction.hpp>

--- a/sycl/test-e2e/Reduction/reduction_range_lambda.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_lambda.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(range, reduction, lambda)
 // with reductions initialized with a one element buffer.
 

--- a/sycl/test-e2e/Reduction/reduction_range_queue_shortcut.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_queue_shortcut.cpp
@@ -4,9 +4,6 @@
 // Group algorithms are not supported on NVidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test only checks that the shortcut method queue::parallel_for()
 // can accept 2 or more reduction variables.
 

--- a/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_range_usm_dw.cpp
@@ -5,9 +5,6 @@
 // supported on host device.` on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include "reduction_utils.hpp"
 
 // This test performs basic checks of parallel_for(range<1>, reduction, func)

--- a/sycl/test-e2e/Reduction/reduction_reducer_op_eq.cpp
+++ b/sycl/test-e2e/Reduction/reduction_reducer_op_eq.cpp
@@ -4,9 +4,6 @@
 // On nvidia a reduction appears to be unexpectedly executed via the host.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test checks that operators ++, +=, *=, |=, &=, ^= are supported
 // whent the corresponding std::plus<>, std::multiplies, etc are defined.
 

--- a/sycl/test-e2e/Reduction/reduction_span.cpp
+++ b/sycl/test-e2e/Reduction/reduction_span.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 // This test performs basic checks of reductions initialized with a sycl::span
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Reduction/reduction_span_pack.cpp
+++ b/sycl/test-e2e/Reduction/reduction_span_pack.cpp
@@ -4,8 +4,6 @@
 // `Group algorithms are not supported on host device.` on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
 // This test performs basic checks of reductions initialized with a pack
 // containing at least one sycl::span
 

--- a/sycl/test-e2e/Reduction/reduction_usm.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm.cpp
@@ -4,9 +4,6 @@
 // `Group algorithms are not supported on host device.` on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // FIXME: enable opaque pointers support
 // REQUIRES: TEMPORARY_DISABLED
 

--- a/sycl/test-e2e/Reduction/reduction_usm_dw.cpp
+++ b/sycl/test-e2e/Reduction/reduction_usm_dw.cpp
@@ -4,9 +4,6 @@
 // `Group algorithms are not supported on host device` on Nvidia.
 // XFAIL: hip_nvidia
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 // This test performs basic checks of parallel_for(nd_range, reduction, func)
 // with reductions initialized with USM var and
 // property::reduction::initialize_to_identity property.

--- a/sycl/test-e2e/Regression/kernel_bundle_ignore_sycl_external.cpp
+++ b/sycl/test-e2e/Regression/kernel_bundle_ignore_sycl_external.cpp
@@ -4,9 +4,6 @@
 // XFAIL: cuda
 // UNSUPPORTED: hip
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include <sycl/detail/core.hpp>
 
 class KernelName;

--- a/sycl/test-e2e/Regression/static-buffer-dtor.cpp
+++ b/sycl/test-e2e/Regression/static-buffer-dtor.cpp
@@ -15,9 +15,6 @@
 // Failing on HIP AMD
 // UNSUPPORTED: hip_amd
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include <sycl/detail/core.hpp>
 
 int main() {

--- a/sycl/test-e2e/Scheduler/HostAccDestruction.cpp
+++ b/sycl/test-e2e/Scheduler/HostAccDestruction.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -fsycl-dead-args-optimization -o %t.out
 // RUN: env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 //==---------------------- HostAccDestruction.cpp --------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/USM/free_during_kernel_execution.cpp
+++ b/sycl/test-e2e/USM/free_during_kernel_execution.cpp
@@ -9,9 +9,6 @@
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 
-// Windows doesn't yet have full shutdown().
-// UNSUPPORTED: ze_debug && windows
-
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 


### PR DESCRIPTION
Leak testing on Windows should work now, so we should be able to reenable the tests that were disabled due to the old issues.