### PR TITLE
[SYCL][E2E] Reenable profiling tag tests on HIP

### DIFF
--- a/sycl/test-e2e/ProfilingTag/default_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/default_queue.cpp
@@ -4,10 +4,6 @@
 
 // Tests the get_profiling_tag extension function on an out-of-order queue.
 
-// HIP backend currently returns invalid values for submission time queries.
-// https://github.com/intel/llvm/issues/12904
-// UNSUPPORTED: hip
-
 // CUDA backend seems to fail sporadically for expected profiling tag time
 // query orderings.
 // https://github.com/intel/llvm/issues/14053

--- a/sycl/test-e2e/ProfilingTag/in_order_profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/in_order_profiling_queue.cpp
@@ -12,10 +12,6 @@
 // than the submission of the following work.
 // UNSUPPORTED: opencl && gpu
 
-// HIP backend currently returns invalid values for submission time queries.
-// https://github.com/intel/llvm/issues/12904
-// UNSUPPORTED: hip
-
 // CUDA backend seems to fail sporadically for expected profiling tag time
 // query orderings.
 // https://github.com/intel/llvm/issues/14053

--- a/sycl/test-e2e/ProfilingTag/in_order_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/in_order_queue.cpp
@@ -4,10 +4,6 @@
 
 // Tests the get_profiling_tag extension function on an in-order queue.
 
-// HIP backend currently returns invalid values for submission time queries.
-// https://github.com/intel/llvm/issues/12904
-// UNSUPPORTED: hip
-
 // CUDA backend seems to fail sporadically for expected profiling tag time
 // query orderings.
 // https://github.com/intel/llvm/issues/14053

--- a/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
@@ -12,10 +12,6 @@
 // than the submission of the following work.
 // UNSUPPORTED: opencl && gpu
 
-// HIP backend currently returns invalid values for submission time queries.
-// https://github.com/intel/llvm/issues/12904
-// UNSUPPORTED: hip
-
 // FPGA emulator seems to return unexpected start time for the fallback barrier.
 // UNSUPPORTED: accelerator
 


### PR DESCRIPTION
https://github.com/oneapi-src/unified-runtime/pull/1634 is believed to have fixed the issues for HIP in the profiling tag extension. This commit reenables the tests for HIP.

Closes https://github.com/intel/llvm/issues/12904.