### PR TITLE
[SYCL] Detach composite/component devices from L0

### DIFF
--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -179,12 +179,6 @@ public:
   /// it returns true if the device is either a member of the context or a
   /// descendant of a member.
   bool isDeviceValid(DeviceImplPtr Device) {
-    // OpenCL does not support using descendants of context members within that
-    // context yet.
-    // TODO remove once this limitation is lifted
-    if (!is_host() && Device->getBackend() == backend::opencl)
-      return hasDevice(Device);
-
     while (!hasDevice(Device)) {
       if (Device->isRootDevice()) {
         if (Device->has(aspect::ext_oneapi_is_component)) {
@@ -195,6 +189,12 @@ public:
           return hasDevice(detail::getSyclObjImpl(CompositeDevice));
         }
 
+        return false;
+      } else if (!is_host() && Device->getBackend() == backend::opencl) {
+        // OpenCL does not support using descendants of context members within
+        // that context yet. We make the exception in case it supports
+        // component/composite devices.
+        // TODO remove once this limitation is lifted
         return false;
       }
       Device = detail::getSyclObjImpl(

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -694,9 +694,6 @@ bool device_impl::has(aspect Aspect) const {
     return components.size() >= 2;
   }
   case aspect::ext_oneapi_is_component: {
-    if (getBackend() != backend::ext_oneapi_level_zero)
-      return false;
-
     typename sycl_to_pi<device>::type Result = nullptr;
     bool CallSuccessful = getPlugin()->call_nocheck<PiApiKind::piDeviceGetInfo>(
                               getHandleRef(),

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -1192,8 +1192,6 @@ struct get_device_info_impl<
     std::vector<sycl::device>,
     ext::oneapi::experimental::info::device::component_devices> {
   static std::vector<sycl::device> get(const DeviceImplPtr &Dev) {
-    if (Dev->getBackend() != backend::ext_oneapi_level_zero)
-      return {};
     size_t ResultSize = 0;
     // First call to get DevCount.
     pi_result Err = Dev->getPlugin()->call_nocheck<PiApiKind::piDeviceGetInfo>(

--- a/sycl/unittests/Extensions/CompositeDevice.cpp
+++ b/sycl/unittests/Extensions/CompositeDevice.cpp
@@ -111,7 +111,7 @@ pi_result after_piContextCreate(const pi_context_properties *,
 } // namespace
 
 TEST(CompositeDeviceTest, DescendentDeviceSupportInContext) {
-  sycl::unittest::PiMock Mock(sycl::backend::ext_oneapi_level_zero);
+  sycl::unittest::PiMock Mock;
   Mock.redefine<sycl::detail::PiApiKind::piDevicesGet>(redefine_piDevicesGet);
   Mock.redefineAfter<sycl::detail::PiApiKind::piDeviceGetInfo>(
       after_piDeviceGetInfo);
@@ -119,8 +119,6 @@ TEST(CompositeDeviceTest, DescendentDeviceSupportInContext) {
       after_piContextCreate);
 
   sycl::platform Plt = Mock.getPlatform();
-  ASSERT_EQ(Plt.get_backend(), sycl::backend::ext_oneapi_level_zero);
-
   sycl::device RootDevice = Plt.get_devices()[0];
   ASSERT_TRUE(RootDevice.has(sycl::aspect::ext_oneapi_is_component));
   sycl::context Ctx(RootDevice);
@@ -152,7 +150,7 @@ TEST(CompositeDeviceTest, DescendentDeviceSupportInContext) {
 }
 
 TEST(CompositeDeviceTest, DescendentDeviceSupportInQueue) {
-  sycl::unittest::PiMock Mock(sycl::backend::ext_oneapi_level_zero);
+  sycl::unittest::PiMock Mock;
   Mock.redefine<sycl::detail::PiApiKind::piDevicesGet>(redefine_piDevicesGet);
   Mock.redefineAfter<sycl::detail::PiApiKind::piDeviceGetInfo>(
       after_piDeviceGetInfo);
@@ -160,8 +158,6 @@ TEST(CompositeDeviceTest, DescendentDeviceSupportInQueue) {
       after_piContextCreate);
 
   sycl::platform Plt = Mock.getPlatform();
-  ASSERT_EQ(Plt.get_backend(), sycl::backend::ext_oneapi_level_zero);
-
   sycl::device ComponentDevice = Plt.get_devices()[0];
   ASSERT_TRUE(ComponentDevice.has(sycl::aspect::ext_oneapi_is_component));
 


### PR DESCRIPTION
The current implementation of component and composite devices makes multiple checks for the backend in order to bind the behavior of the extension to L0. However, this should instead be done by the backends, having them report missing support when possible, and allowing backends to potentially support the extension in the future without needing to change the SYCL runtime.