### PR TITLE
[SYCL][Doc] Update work-group-specific extension

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_static.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_static.asciidoc
@@ -1,4 +1,4 @@
-= sycl_ext_oneapi_work_group_specific
+= sycl_ext_oneapi_work_group_static
 
 :source-highlighter: coderay
 :coderay-linenums-mode: table
@@ -36,7 +36,7 @@ https://github.com/intel/llvm/issues
 
 == Dependencies
 
-This extension is written against the SYCL 2020 revision 7 specification.  All
+This extension is written against the SYCL 2020 revision 8 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 
@@ -58,17 +58,16 @@ not rely on APIs defined in this specification.*
 
 == Overview
 
-This extension defines a `sycl::ext::oneapi::experimental::work_group_specific`
-class template with behavior inspired by the {cpp} `thread_local` keyword
-and the CUDA `+__shared__+` keyword. The "specific" suffix is inspired by
-`tbb::enumerable_thread_specific`, and has been chosen to avoid potential
-confusion between the concepts of "local variables" and the "local address
-space".
+This extension adds a way to allocate device local memory, without passing a
+kernel argument.
+Device local memory is memory that is shared by all work-items in a work-group.
+The behavior is similar to the CUDA `+__shared__+` keyword, and the extension
+draws some inspiration from the {cpp} `thread_local` keyword.
 
-`work_group_specific` variables can be allocated at global or function scope,
+`work_group_static` variables can be allocated at global or function scope,
 lifting many of the restrictions in the existing
 link:../supported/sycl_ext_oneapi_local_memory.asciidoc[sycl_ext_oneapi_local_memory]
-extension. Note, however, that `work_group_specific` variables currently place
+extension. Note, however, that `work_group_static` variables currently place
 additional limits on the types that can be allocated, owing to differences in
 constructor behavior.
 
@@ -96,27 +95,27 @@ implementation supports.
 |===
 
 
-=== `work_group_specific` class template
+=== `work_group_static` class template
 
-The `work_group_specific` class template acts as a view of an
-implementation-managed pointer to work-group-specific memory.
+The `work_group_static` class template acts as a view of an
+implementation-managed pointer to device local memory.
 
 [source,c++]
 ----
 namespace sycl::ext::oneapi::experimental {
 
 template <typename T>
-class work_group_specific {
+class work_group_static {
 public:
 
-  work_group_specific() = default;
-  work_group_specific(const work_group_specific&) = delete;
-  work_group_specific& operator=(const work_group_specific&) = delete;
+  work_group_static() = default;
+  work_group_static(const work_group_static&) = delete;
+  work_group_static& operator=(const work_group_static&) = delete;
 
   operator T&() const noexcept;
 
   // Available only if: std::is_array_v<T> == false
-  const work_group_specific& operator=(const T& value) const noexcept;
+  const work_group_static& operator=(const T& value) const noexcept;
 
   T* operator&() const noexcept;
 
@@ -128,23 +127,27 @@ private:
 } // namespace sycl::ext::oneapi::experimental
 ----
 
-`T` must be trivially constructible and trivially destructible.
+`T` must be one of the following:
 
-The storage for the object is allocated in work-group-specific memory before
+* A trivially constructible and trivially destructible type, or
+* An unbounded array of type `U`, where `U` is a trivially constructible and
+  trivially destructible type.
+
+The storage for the object is allocated in device local memory before
 calling the user's kernel lambda, and deallocated when all work-items
-in the group have completed execution of the kernel.
+in the work-group have completed execution of the kernel.
 
 SYCL implementations conforming to the full feature set treat
-`work_group_specific` similarly to the `thread_local` keyword, and when
-a `work_group_specific` object is declared at block scope it behaves
+`work_group_static` similarly to the `thread_local` keyword, and when
+a `work_group_static` object is declared at block scope it behaves
 as if the `static` keyword was specified implicitly. SYCL implementations
 conforming to the reduced feature set require the `static` keyword to be
 specified explicitly.
 
 [NOTE]
 ====
-If a `work_group_specific` object is declared at function scope, the
-work-group-specific memory associated with the object will be identical for all
+If a `work_group_static` object is declared at function scope, the
+device local memory associated with the object will be identical for all
 usages of that function within the kernel. In cases where a function is called
 multiple times, developers must take care to avoid race conditions (e.g., by
 calling `group_barrier` before and after using the memory).
@@ -152,30 +155,30 @@ calling `group_barrier` before and after using the memory).
 
 SYCL 2020 requires that all global variables accessed by a device function are
 `const` or `constexpr`. This extension lifts that restriction for
-`work_group_specific` variables.
+`work_group_static` variables.
 
 [NOTE]
 ====
-Since `work_group_specific` acts as a view, wrapping an underlying pointer, a
+Since `work_group_static` acts as a view, wrapping an underlying pointer, a
 developer may still choose to declare variables as `const`.
 ====
 
 When `T` is a class type or bounded array, the size of the allocation is known
 at compile-time, and a SYCL implementation may embed the size of the allocation
-directly within a kernel. Each instance of `work_group_specific<T>` is associated
-with a unique allocation in work-group-specific memory.
+directly within a kernel. Each instance of `work_group_static<T>` is associated
+with a unique allocation in device local memory.
 
 When `T` is an unbounded array, the size of the allocation is unknown at
 compile-time, and must be communicated to the SYCL implementation via the
-`work_group_specific_memory_size` property. Every instance of `work_group_specific`
+`work_group_static_memory_size` property. Every instance of `work_group_static`
 for which `T` is an unbounded array is associated with a single, shared,
-allocation in work-group-specific memory. For example, two instances declared
-as `work_group_specific<int[]>` and `work_group_specific<float[]>` will be
+allocation in device local memory. For example, two instances declared
+as `work_group_static<int[]>` and `work_group_static<float[]>` will be
 associated with the same shared allocation.
 
-If the total amount of work-group-specific memory requested (i.e., the sum of
+If the total amount of device local memory requested (i.e., the sum of
 all memory requested by `local_accessor`, `group_local_memory`,
-`group_local_memory_for_overwrite` and `work_group_specific`) exceeds a device's
+`group_local_memory_for_overwrite` and `work_group_static`) exceeds a device's
 local memory capacity (as reported by `local_mem_size`) then the implementation
 must throw a synchronous `exception` with the `errc::memory_allocation` error
 code from the kernel invocation command (e.g. `parallel_for`).
@@ -184,45 +187,45 @@ code from the kernel invocation command (e.g. `parallel_for`).
 ----
 operator T&() const noexcept;
 ----
-_Returns_: A reference to the object stored in the work-group-specific memory
-associated with this instance of `work_group_specific`.
+_Returns_: A reference to the object stored in the device local memory
+associated with this instance of `work_group_static`.
 
 [source,c++]
 ----
-const work_group_specific<T>& operator=(const T& value) const noexcept;
+const work_group_static<T>& operator=(const T& value) const noexcept;
 ----
 _Constraints_: Available only if `std::is_array_v<T>>` is false.
 
 _Effects_: Replaces the value referenced by `*ptr` with `value`.
 
-_Returns_: A reference to this instance of `work_group_specific`.
+_Returns_: A reference to this instance of `work_group_static`.
 
 [source,c++]
 ----
 T* operator&() const noexcept;
 ----
-_Returns_: A pointer to the work-group-specific memory associated with this
-instance of `work_group_specific` (i.e., `ptr`).
+_Returns_: A pointer to the device local memory associated with this
+instance of `work_group_static` (i.e., `ptr`).
 
 
 ==== Kernel properties
 
-The `work_group_specific_size` property must be passed to a kernel to determine
-the run-time size of the work-group-specific memory allocation associated with
-all `work_group_specific` variables of unbounded array type.
+The `work_group_static_size` property must be passed to a kernel to determine
+the run-time size of the device local memory allocation associated with
+all `work_group_static` variables of unbounded array type.
 
 [source,c++]
 ----
 namespace sycl::ext::oneapi::experimental {
 
-struct work_group_specific_size {
-  constexpr work_group_specific_size(size_t bytes) : value(bytes) {}
+struct work_group_static_size {
+  constexpr work_group_static_size(size_t bytes) : value(bytes) {}
   size_t value;
-}; // work_group_specific_size
+}; // work_group_static_size
 
-using work_group_specific_size_key = work_group_specific_size;
+using work_group_static_size_key = work_group_static_size;
 
-template <>struct is_property_key<work_group_specific_size_key> : std::true_type {};
+template <>struct is_property_key<work_group_static_size_key> : std::true_type {};
 
 } // namespace sycl::ext::oneapi::experimental
 ----
@@ -230,9 +233,9 @@ template <>struct is_property_key<work_group_specific_size_key> : std::true_type
 |===
 |Property|Description
 
-|`work_group_specific_size`
-|The `work_group_specific_size` property describes the amount of dynamic
-work-group-specific memory required by the kernel in bytes.
+|`work_group_static_size`
+|The `work_group_static_size` property describes the amount of dynamic
+device local memory required by the kernel in bytes.
 
 |===
 
@@ -245,18 +248,18 @@ work-group-specific memory required by the kernel in bytes.
 ----
 using namespace syclex = sycl::ext::oneapi::experimental;
 
-/* optional: static const */ syclex::work_group_specific<int> program_scope_scalar;
-/* optional: static const */ syclex::work_group_specific<int[16]> program_scope_array;
+/* optional: static const */ syclex::work_group_static<int> program_scope_scalar;
+/* optional: static const */ syclex::work_group_static<int[16]> program_scope_array;
 
 void foo() {
-  /* optional: static const */ syclex::work_group_specific<int> function_scope_scalar;
+  /* optional: static const */ syclex::work_group_static<int> function_scope_scalar;
   function_scope_scalar = 1; // assignment via overloaded = operator
   function_scope_scalar += 2; // += operator via implicit conversion to int&
   int* ptr = &function_scope_scalar; // conversion to pointer via overloaded & operator
 }
 
 void bar() {
-  /* optional: static const */ sylex::work_group_specific<int[64]> function_scope_array;
+  /* optional: static const */ sylex::work_group_static<int[64]> function_scope_array;
   function_scope_array[0] = 1; // [] operator via implicit conversion to int(&)[64]
   int* ptr = function_scope_array; // conversion to pointer via implicit conversion to int(&)[64]
 }
@@ -268,12 +271,12 @@ void bar() {
 ----
 using namespace syclex = sycl::ext::oneapi::experimental;
 
-/* optional: static const */ syclex::work_group_specific<int[]> dynamic_program_scope_array;
+/* optional: static const */ syclex::work_group_static<int[]> dynamic_program_scope_array;
 
 ...
 
 q.parallel_for(sycl::nd_range<1>{N, M},
-  syclex::properties{syclex::work_group_specific_size(M * sizeof(int))},
+  syclex::properties{syclex::work_group_static_size(M * sizeof(int))},
   [=](sycl::nd_item<1> it) {
   ...
 });
@@ -300,19 +303,28 @@ the existing `__sycl_allocateLocalMemory` intrinsic:
 Note, however, that implementing the correct semantics may require some
 adjustment to the handling of this intrinsic. A simple class as written above
 would create a separate allocation for every call to an inlined function.
-Creating work-group-specific allocations should be handled before inlining to
+Creating device local memory allocations should be handled before inlining to
 prevent this.
 
 For unbounded arrays, a separate specialization of the class will be required,
 and the implementation may need to generate some additional code to
-appropriately initialize the pointer(s) wrapped by `work_group_specific` objects.
+appropriately initialize the pointer(s) wrapped by `work_group_static` objects.
 Alternatively, it may be possible to initialize the pointer to the beginning
 of the device's local memory region (if that value is known). Either way, the
 implementation must account for the existence of one or more `local_accessor`
-objects (which themselves may allocate a dynamic amount of work-group-specific
+objects (which themselves may allocate a dynamic amount of device local
 memory).
 
 
 == Issues
 
-None.
+* We should clean up the wording regarding the scopes at which
+  `work_group_static` variables may be declared.
+  The current wording says they may be "allocated at global or function scope".
+  However, "function scope" is not a {cpp} term.
+  I assume we meant "block scope" here?
+  I assume we also meant "namespace scope" instead of "global scope"?
+  What about class scope or lambda scope?
+  Are we intentionally omitting those, or is that an oversight?
+  Are there any scopes where a `work_group_static` variable may not be declared?
+  If not, we should just say that they may be allocated at any scope.


### PR DESCRIPTION
Several changes to the specification for this proposed extension:

* Change the name to `work_group_static`.  This name is more consistent with our other extension named `work_group_memory`.

* Change the phrase "work-group-specific memory" to "device local memory".  This is the same phrase the core SYCL spec uses to describe this memory, and the word "specific" no longer makes sense now that we changed the name of the extension.

* Change the constraint for the `T` template parameter.  We cannot simply require `T` to be trivially constructible / destructible because this is not true for an unbounded array type.

* The restrictions about the legal scopes for a `work_group_static` variable seem confusing.  I'm not sure what we intended, so I just added an issue for now.