### PR TITLE
[SYCL] no exceptions leaking from destructors

### DIFF
--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -472,7 +472,13 @@ public:
 
   buffer &operator=(buffer &&rhs) = default;
 
-  ~buffer() { buffer_plain::handleRelease(); }
+  ~buffer() {
+    try {
+      buffer_plain::handleRelease();
+    } catch (std::exception &e) {
+      assert(false && "exception in ~buffer " && e.what());
+    }
+  }
 
   bool operator==(const buffer &rhs) const { return impl == rhs.impl; }
 

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -476,7 +476,7 @@ public:
     try {
       buffer_plain::handleRelease();
     } catch (std::exception &e) {
-      assert(false && "exception in ~buffer " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~buffer", e);
     }
   }
 

--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -368,6 +368,17 @@ static constexpr std::array<T, N> RepeatValue(const T &Arg) {
   return RepeatValueHelper(Arg, std::make_index_sequence<N>());
 }
 
+// to output exceptions caught in ~destructors
+#ifndef NDEBUG
+#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e)                              \
+  {                                                                            \
+    std::cerr << str << " " << e.what() << std::endl;                          \
+    assert(false);                                                             \
+  }
+#else
+#define __SYCL_REPORT_EXCEPTION_TO_STREAM(str, e)
+#endif
+
 } // namespace detail
 } // namespace _V1
 } // namespace sycl

--- a/sycl/include/sycl/image.hpp
+++ b/sycl/include/sycl/image.hpp
@@ -958,7 +958,7 @@ public:
       common_base::unsampledImageDestructorNotification(
           (void *)this->impl.get());
     } catch (std::exception &e) {
-      assert(false && "exception in ~unsampled_image " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~unsampled_image", e);
     }
   }
 
@@ -1103,7 +1103,7 @@ public:
     try {
       common_base::sampledImageDestructorNotification((void *)this->impl.get());
     } catch (std::exception &e) {
-      assert(false && "exception in ~sampled_image " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~sampled_image", e);
     }
   }
 

--- a/sycl/include/sycl/image.hpp
+++ b/sycl/include/sycl/image.hpp
@@ -954,7 +954,12 @@ public:
   unsampled_image &operator=(unsampled_image &&rhs) = default;
 
   ~unsampled_image() {
-    common_base::unsampledImageDestructorNotification((void *)this->impl.get());
+    try {
+      common_base::unsampledImageDestructorNotification(
+          (void *)this->impl.get());
+    } catch (std::exception &e) {
+      assert(false && "exception in ~unsampled_image " && e.what());
+    }
   }
 
   bool operator==(const unsampled_image &rhs) const {
@@ -1095,7 +1100,11 @@ public:
   sampled_image &operator=(sampled_image &&rhs) = default;
 
   ~sampled_image() {
-    common_base::sampledImageDestructorNotification((void *)this->impl.get());
+    try {
+      common_base::sampledImageDestructorNotification((void *)this->impl.get());
+    } catch (std::exception &e) {
+      assert(false && "exception in ~sampled_image " && e.what());
+    }
   }
 
   bool operator==(const sampled_image &rhs) const {

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -344,7 +344,7 @@ public:
       sycl::event::wait(_events);
       _queues.clear();
     } catch (std::exception &e) {
-      assert(false && "exception in ~device_ext " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~device_ext", e);
     }
   }
   device_ext(const sycl::device &base, bool print_on_async_exceptions = false,

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -339,9 +339,13 @@ class device_ext : public sycl::device {
 public:
   device_ext() : sycl::device(), _ctx(*this) {}
   ~device_ext() {
-    std::lock_guard<std::mutex> lock(m_mutex);
-    sycl::event::wait(_events);
-    _queues.clear();
+    try {
+      std::lock_guard<std::mutex> lock(m_mutex);
+      sycl::event::wait(_events);
+      _queues.clear();
+    } catch (std::exception &e) {
+      assert(false && "exception in ~device_ext " && e.what());
+    }
   }
   device_ext(const sycl::device &base, bool print_on_async_exceptions = false,
              bool in_order = true)

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -162,10 +162,10 @@ context_impl::~context_impl() {
     }
     if (!MHostContext) {
       // TODO catch an exception and put it to list of asynchronous exceptions
-      getPlugin()->call_nocheck<PiApiKind::piContextRelease>(MContext);
+      getPlugin()->call<PiApiKind::piContextRelease>(MContext);
     }
   } catch (std::exception &e) {
-    assert(false && "exception in ~context_impl " && e.what());
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~context_impl", e);
   }
 }
 

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -145,23 +145,27 @@ cl_context context_impl::get() const {
 bool context_impl::is_host() const { return MHostContext; }
 
 context_impl::~context_impl() {
-  // Free all events associated with the initialization of device globals.
-  for (auto &DeviceGlobalInitializer : MDeviceGlobalInitializers)
-    DeviceGlobalInitializer.second.ClearEvents(getPlugin());
-  // Free all device_global USM allocations associated with this context.
-  for (const void *DeviceGlobal : MAssociatedDeviceGlobals) {
-    DeviceGlobalMapEntry *DGEntry =
-        detail::ProgramManager::getInstance().getDeviceGlobalEntry(
-            DeviceGlobal);
-    DGEntry->removeAssociatedResources(this);
-  }
-  for (auto LibProg : MCachedLibPrograms) {
-    assert(LibProg.second && "Null program must not be kept in the cache");
-    getPlugin()->call<PiApiKind::piProgramRelease>(LibProg.second);
-  }
-  if (!MHostContext) {
-    // TODO catch an exception and put it to list of asynchronous exceptions
-    getPlugin()->call_nocheck<PiApiKind::piContextRelease>(MContext);
+  try {
+    // Free all events associated with the initialization of device globals.
+    for (auto &DeviceGlobalInitializer : MDeviceGlobalInitializers)
+      DeviceGlobalInitializer.second.ClearEvents(getPlugin());
+    // Free all device_global USM allocations associated with this context.
+    for (const void *DeviceGlobal : MAssociatedDeviceGlobals) {
+      DeviceGlobalMapEntry *DGEntry =
+          detail::ProgramManager::getInstance().getDeviceGlobalEntry(
+              DeviceGlobal);
+      DGEntry->removeAssociatedResources(this);
+    }
+    for (auto LibProg : MCachedLibPrograms) {
+      assert(LibProg.second && "Null program must not be kept in the cache");
+      getPlugin()->call<PiApiKind::piProgramRelease>(LibProg.second);
+    }
+    if (!MHostContext) {
+      // TODO catch an exception and put it to list of asynchronous exceptions
+      getPlugin()->call_nocheck<PiApiKind::piContextRelease>(MContext);
+    }
+  } catch (std::exception &e) {
+    assert(false && "exception in ~context_impl " && e.what());
   }
 }
 

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -300,15 +300,18 @@ public:
   }
 
   ~device_image_impl() {
-
-    if (MProgram) {
-      const PluginPtr &Plugin = getSyclObjImpl(MContext)->getPlugin();
-      Plugin->call<PiApiKind::piProgramRelease>(MProgram);
-    }
-    if (MSpecConstsBuffer) {
-      std::lock_guard<std::mutex> Lock{MSpecConstAccessMtx};
-      const PluginPtr &Plugin = getSyclObjImpl(MContext)->getPlugin();
-      memReleaseHelper(Plugin, MSpecConstsBuffer);
+    try {
+      if (MProgram) {
+        const PluginPtr &Plugin = getSyclObjImpl(MContext)->getPlugin();
+        Plugin->call<PiApiKind::piProgramRelease>(MProgram);
+      }
+      if (MSpecConstsBuffer) {
+        std::lock_guard<std::mutex> Lock{MSpecConstAccessMtx};
+        const PluginPtr &Plugin = getSyclObjImpl(MContext)->getPlugin();
+        memReleaseHelper(Plugin, MSpecConstsBuffer);
+      }
+    } catch (std::exception &e) {
+      assert(false && "exception in ~device_image_impl " && e.what());
     }
   }
 

--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -311,7 +311,7 @@ public:
         memReleaseHelper(Plugin, MSpecConstsBuffer);
       }
     } catch (std::exception &e) {
-      assert(false && "exception in ~device_image_impl " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~device_image_impl", e);
     }
   }
 

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -58,7 +58,7 @@ event_impl::~event_impl() {
     if (MEvent)
       getPlugin()->call<PiApiKind::piEventRelease>(MEvent);
   } catch (std::exception &e) {
-    assert(false && "exception in ~event_impl " && e.what());
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~event_impl", e);
   }
 }
 

--- a/sycl/source/detail/event_impl.cpp
+++ b/sycl/source/detail/event_impl.cpp
@@ -54,8 +54,12 @@ bool event_impl::is_host() {
 }
 
 event_impl::~event_impl() {
-  if (MEvent)
-    getPlugin()->call<PiApiKind::piEventRelease>(MEvent);
+  try {
+    if (MEvent)
+      getPlugin()->call<PiApiKind::piEventRelease>(MEvent);
+  } catch (std::exception &e) {
+    assert(false && "exception in ~event_impl " && e.what());
+  }
 }
 
 void event_impl::waitInternal(bool *Success) {

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -53,7 +53,7 @@ public:
     if (MModifyCounter)
       MCounter++;
   }
-  ~ObjectUsageCounter() {
+  ~ObjectUsageCounter() noexcept(false) {
     if (!MModifyCounter)
       return;
 
@@ -233,7 +233,7 @@ void GlobalHandler::releaseDefaultContexts() {
 }
 
 struct EarlyShutdownHandler {
-  ~EarlyShutdownHandler() {
+  ~EarlyShutdownHandler() noexcept(false) {
 #ifdef _WIN32
     // on Windows we keep to the existing shutdown procedure
     GlobalHandler::instance().releaseDefaultContexts();

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -297,12 +297,12 @@ void exec_graph_impl::makePartitions() {
 }
 
 graph_impl::~graph_impl() {
-  try{
-  clearQueues();
-  for (auto &MemObj : MMemObjs) {
-    MemObj->markNoLongerBeingUsedInGraph();
-  }
-  }catch(std::exception &e){
+  try {
+    clearQueues();
+    for (auto &MemObj : MMemObjs) {
+      MemObj->markNoLongerBeingUsedInGraph();
+    }
+  } catch (std::exception &e) {
     __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~graph_impl", e);
   }
 }
@@ -786,37 +786,37 @@ exec_graph_impl::exec_graph_impl(sycl::context Context,
 }
 
 exec_graph_impl::~exec_graph_impl() {
-  try{
-  const sycl::detail::PluginPtr &Plugin =
-      sycl::detail::getSyclObjImpl(MContext)->getPlugin();
-  MSchedule.clear();
-  // We need to wait on all command buffer executions before we can release
-  // them.
-  for (auto &Event : MExecutionEvents) {
-    Event->wait(Event);
-  }
+  try {
+    const sycl::detail::PluginPtr &Plugin =
+        sycl::detail::getSyclObjImpl(MContext)->getPlugin();
+    MSchedule.clear();
+    // We need to wait on all command buffer executions before we can release
+    // them.
+    for (auto &Event : MExecutionEvents) {
+      Event->wait(Event);
+    }
 
-  for (const auto &Partition : MPartitions) {
-    Partition->MSchedule.clear();
-    for (const auto &Iter : Partition->MPiCommandBuffers) {
-      if (auto CmdBuf = Iter.second; CmdBuf) {
+    for (const auto &Partition : MPartitions) {
+      Partition->MSchedule.clear();
+      for (const auto &Iter : Partition->MPiCommandBuffers) {
+        if (auto CmdBuf = Iter.second; CmdBuf) {
+          pi_result Res = Plugin->call_nocheck<
+              sycl::detail::PiApiKind::piextCommandBufferRelease>(CmdBuf);
+          (void)Res;
+          assert(Res == pi_result::PI_SUCCESS);
+        }
+      }
+    }
+
+    for (auto &Iter : MCommandMap) {
+      if (auto Command = Iter.second; Command) {
         pi_result Res = Plugin->call_nocheck<
-            sycl::detail::PiApiKind::piextCommandBufferRelease>(CmdBuf);
+            sycl::detail::PiApiKind::piextCommandBufferReleaseCommand>(Command);
         (void)Res;
         assert(Res == pi_result::PI_SUCCESS);
       }
     }
-  }
-
-  for (auto &Iter : MCommandMap) {
-    if (auto Command = Iter.second; Command) {
-      pi_result Res = Plugin->call_nocheck<
-          sycl::detail::PiApiKind::piextCommandBufferReleaseCommand>(Command);
-      (void)Res;
-      assert(Res == pi_result::PI_SUCCESS);
-    }
-  }
-  }catch(std::exception &e){
+  } catch (std::exception &e) {
     __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~exec_graph_impl", e);
   }
 }

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -297,13 +297,13 @@ void exec_graph_impl::makePartitions() {
 }
 
 graph_impl::~graph_impl() {
-  try {
-    clearQueues();
-    for (auto &MemObj : MMemObjs) {
-      MemObj->markNoLongerBeingUsedInGraph();
-    }
-  } catch (std::exception &e) {
-    assert(false && "exception in ~graph_impl " && e.what());
+  try{
+  clearQueues();
+  for (auto &MemObj : MMemObjs) {
+    MemObj->markNoLongerBeingUsedInGraph();
+  }
+  }catch(std::exception &e){
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~graph_impl", e);
   }
 }
 
@@ -786,38 +786,38 @@ exec_graph_impl::exec_graph_impl(sycl::context Context,
 }
 
 exec_graph_impl::~exec_graph_impl() {
-  try {
-    const sycl::detail::PluginPtr &Plugin =
-        sycl::detail::getSyclObjImpl(MContext)->getPlugin();
-    MSchedule.clear();
-    // We need to wait on all command buffer executions before we can release
-    // them.
-    for (auto &Event : MExecutionEvents) {
-      Event->wait(Event);
-    }
+  try{
+  const sycl::detail::PluginPtr &Plugin =
+      sycl::detail::getSyclObjImpl(MContext)->getPlugin();
+  MSchedule.clear();
+  // We need to wait on all command buffer executions before we can release
+  // them.
+  for (auto &Event : MExecutionEvents) {
+    Event->wait(Event);
+  }
 
-    for (const auto &Partition : MPartitions) {
-      Partition->MSchedule.clear();
-      for (const auto &Iter : Partition->MPiCommandBuffers) {
-        if (auto CmdBuf = Iter.second; CmdBuf) {
-          pi_result Res = Plugin->call_nocheck<
-              sycl::detail::PiApiKind::piextCommandBufferRelease>(CmdBuf);
-          (void)Res;
-          assert(Res == pi_result::PI_SUCCESS);
-        }
-      }
-    }
-
-    for (auto &Iter : MCommandMap) {
-      if (auto Command = Iter.second; Command) {
+  for (const auto &Partition : MPartitions) {
+    Partition->MSchedule.clear();
+    for (const auto &Iter : Partition->MPiCommandBuffers) {
+      if (auto CmdBuf = Iter.second; CmdBuf) {
         pi_result Res = Plugin->call_nocheck<
-            sycl::detail::PiApiKind::piextCommandBufferReleaseCommand>(Command);
+            sycl::detail::PiApiKind::piextCommandBufferRelease>(CmdBuf);
         (void)Res;
         assert(Res == pi_result::PI_SUCCESS);
       }
     }
-  } catch (std::exception &e) {
-    assert(false && "exception in ~exec_graph_impl " && e.what());
+  }
+
+  for (auto &Iter : MCommandMap) {
+    if (auto Command = Iter.second; Command) {
+      pi_result Res = Plugin->call_nocheck<
+          sycl::detail::PiApiKind::piextCommandBufferReleaseCommand>(Command);
+      (void)Res;
+      assert(Res == pi_result::PI_SUCCESS);
+    }
+  }
+  }catch(std::exception &e){
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~exec_graph_impl", e);
   }
 }
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -81,7 +81,7 @@ kernel_impl::~kernel_impl() {
       getPlugin()->call<PiApiKind::piKernelRelease>(MKernel);
     }
   } catch (std::exception &e) {
-    assert(false && "exception in ~kernel_impl " && e.what());
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~kernel_impl", e);
   }
 }
 

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -75,9 +75,13 @@ kernel_impl::kernel_impl(ContextImplPtr Context, ProgramImplPtr ProgramImpl)
     : MContext(Context), MProgram(ProgramImpl->getHandleRef()) {}
 
 kernel_impl::~kernel_impl() {
-  // TODO catch an exception and put it to list of asynchronous exceptions
-  if (!is_host()) {
-    getPlugin()->call<PiApiKind::piKernelRelease>(MKernel);
+  try {
+    // TODO catch an exception and put it to list of asynchronous exceptions
+    if (!is_host()) {
+      getPlugin()->call<PiApiKind::piKernelRelease>(MKernel);
+    }
+  } catch (std::exception &e) {
+    assert(false && "exception in ~kernel_impl " && e.what());
   }
 }
 

--- a/sycl/source/detail/pi_utils.hpp
+++ b/sycl/source/detail/pi_utils.hpp
@@ -31,9 +31,14 @@ struct OwnedPiEvent {
       MPlugin->call<PiApiKind::piEventRetain>(*MEvent);
   }
   ~OwnedPiEvent() {
-    // Release the event if the ownership was not transferred.
-    if (MEvent.has_value())
-      MPlugin->call<PiApiKind::piEventRelease>(*MEvent);
+    try {
+      // Release the event if the ownership was not transferred.
+      if (MEvent.has_value())
+        MPlugin->call<PiApiKind::piEventRelease>(*MEvent);
+
+    } catch (std::exception &e) {
+      assert(false && "exception in ~OwnedPiEvent " && e.what());
+    }
   }
 
   OwnedPiEvent(OwnedPiEvent &&Other)

--- a/sycl/source/detail/pi_utils.hpp
+++ b/sycl/source/detail/pi_utils.hpp
@@ -37,7 +37,7 @@ struct OwnedPiEvent {
         MPlugin->call<PiApiKind::piEventRelease>(*MEvent);
 
     } catch (std::exception &e) {
-      assert(false && "exception in ~OwnedPiEvent " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~OwnedPiEvent", e);
     }
   }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -214,7 +214,7 @@ program_impl::~program_impl() {
       Plugin->call<PiApiKind::piProgramRelease>(MProgram);
     }
   } catch (std::exception &e) {
-    assert(false && "exception in ~program_impl " && e.what());
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~program_impl", e);
   }
 }
 

--- a/sycl/source/detail/program_impl.cpp
+++ b/sycl/source/detail/program_impl.cpp
@@ -207,10 +207,14 @@ program_impl::program_impl(ContextImplPtr Context,
 }
 
 program_impl::~program_impl() {
-  // TODO catch an exception and put it to list of asynchronous exceptions
-  if (!is_host() && MProgram != nullptr) {
-    const PluginPtr &Plugin = getPlugin();
-    Plugin->call<PiApiKind::piProgramRelease>(MProgram);
+  try {
+    // TODO catch an exception and put it to list of asynchronous exceptions
+    if (!is_host() && MProgram != nullptr) {
+      const PluginPtr &Plugin = getPlugin();
+      Plugin->call<PiApiKind::piProgramRelease>(MProgram);
+    }
+  } catch (std::exception &e) {
+    assert(false && "exception in ~program_impl " && e.what());
   }
 }
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -320,9 +320,10 @@ public:
   }
 
   ~queue_impl() {
-    // The trace event created in the constructor should be active through the
-    // lifetime of the queue object as member variables when ABI breakage is
-    // allowed. This example shows MTraceEvent as a member variable.
+    try {
+      // The trace event created in the constructor should be active through the
+      // lifetime of the queue object as member variables when ABI breakage is
+      // allowed. This example shows MTraceEvent as a member variable.
 #if XPTI_ENABLE_INSTRUMENTATION
     constexpr uint16_t NotificationTraceType =
         static_cast<uint16_t>(xpti::trace_point_type_t::queue_destroy);
@@ -339,6 +340,9 @@ public:
     if (!MHostQueue) {
       cleanup_fusion_cmd();
       getPlugin()->call<PiApiKind::piQueueRelease>(MQueues[0]);
+    }
+    } catch (std::exception &e) {
+      assert(false && "exception in ~queue_impl " && e.what());
     }
   }
 

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -325,22 +325,22 @@ public:
       // lifetime of the queue object as member variables when ABI breakage is
       // allowed. This example shows MTraceEvent as a member variable.
 #if XPTI_ENABLE_INSTRUMENTATION
-    constexpr uint16_t NotificationTraceType =
-        static_cast<uint16_t>(xpti::trace_point_type_t::queue_destroy);
-    if (xptiCheckTraceEnabled(MStreamID, NotificationTraceType)) {
-      // Used cached information in member variables
-      xptiNotifySubscribers(MStreamID, NotificationTraceType, nullptr,
-                            (xpti::trace_event_data_t *)MTraceEvent,
-                            MInstanceID,
-                            static_cast<const void *>("queue_destroy"));
-      xptiReleaseEvent((xpti::trace_event_data_t *)MTraceEvent);
-    }
+      constexpr uint16_t NotificationTraceType =
+          static_cast<uint16_t>(xpti::trace_point_type_t::queue_destroy);
+      if (xptiCheckTraceEnabled(MStreamID, NotificationTraceType)) {
+        // Used cached information in member variables
+        xptiNotifySubscribers(MStreamID, NotificationTraceType, nullptr,
+                              (xpti::trace_event_data_t *)MTraceEvent,
+                              MInstanceID,
+                              static_cast<const void *>("queue_destroy"));
+        xptiReleaseEvent((xpti::trace_event_data_t *)MTraceEvent);
+      }
 #endif
-    throw_asynchronous();
-    if (!MHostQueue) {
-      cleanup_fusion_cmd();
-      getPlugin()->call<PiApiKind::piQueueRelease>(MQueues[0]);
-    }
+      throw_asynchronous();
+      if (!MHostQueue) {
+        cleanup_fusion_cmd();
+        getPlugin()->call<PiApiKind::piQueueRelease>(MQueues[0]);
+      }
     } catch (std::exception &e) {
       __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~queue_impl", e);
     }

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -342,7 +342,7 @@ public:
       getPlugin()->call<PiApiKind::piQueueRelease>(MQueues[0]);
     }
     } catch (std::exception &e) {
-      assert(false && "exception in ~queue_impl " && e.what());
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~queue_impl", e);
     }
   }
 

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -49,7 +49,7 @@ sampler_impl::~sampler_impl() {
       Plugin->call<PiApiKind::piSamplerRelease>(Iter.second);
     }
   } catch (std::exception &e) {
-    assert(false && "exception in ~sampler_impl " && e.what());
+    __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~sample_impl", e);
   }
 }
 

--- a/sycl/source/detail/sampler_impl.cpp
+++ b/sycl/source/detail/sampler_impl.cpp
@@ -40,11 +40,16 @@ sampler_impl::sampler_impl(cl_sampler clSampler, const context &syclContext) {
 }
 
 sampler_impl::~sampler_impl() {
-  std::lock_guard<std::mutex> Lock(MMutex);
-  for (auto &Iter : MContextToSampler) {
-    // TODO catch an exception and add it to the list of asynchronous exceptions
-    const PluginPtr &Plugin = getSyclObjImpl(Iter.first)->getPlugin();
-    Plugin->call<PiApiKind::piSamplerRelease>(Iter.second);
+  try {
+    std::lock_guard<std::mutex> Lock(MMutex);
+    for (auto &Iter : MContextToSampler) {
+      // TODO catch an exception and add it to the list of asynchronous
+      // exceptions
+      const PluginPtr &Plugin = getSyclObjImpl(Iter.first)->getPlugin();
+      Plugin->call<PiApiKind::piSamplerRelease>(Iter.second);
+    }
+  } catch (std::exception &e) {
+    assert(false && "exception in ~sampler_impl " && e.what());
   }
 }
 

--- a/sycl/source/detail/thread_pool.hpp
+++ b/sycl/source/detail/thread_pool.hpp
@@ -74,7 +74,13 @@ public:
     start();
   }
 
-  ~ThreadPool() noexcept(false) { finishAndWait(); }
+  ~ThreadPool() {
+    try {
+      finishAndWait();
+    } catch (std::exception &e) {
+      __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~ThreadPool", e);
+    }
+  }
 
   void finishAndWait() {
     MStop.store(true);

--- a/sycl/source/detail/thread_pool.hpp
+++ b/sycl/source/detail/thread_pool.hpp
@@ -74,7 +74,7 @@ public:
     start();
   }
 
-  ~ThreadPool() { finishAndWait(); }
+  ~ThreadPool() noexcept(false) { finishAndWait(); }
 
   void finishAndWait() {
     MStop.store(true);

--- a/sycl/unittests/thread_safety/ThreadUtils.h
+++ b/sycl/unittests/thread_safety/ThreadUtils.h
@@ -48,7 +48,7 @@ public:
     enqueueHelper<N>(std::forward<Funcs>(funcs)...);
   }
 
-  ~ThreadPool() { wait(); }
+  ~ThreadPool() noexcept(false) { wait(); }
 
 private:
   template <int N, typename Func, typename... Funcs>

--- a/sycl/unittests/thread_safety/ThreadUtils.h
+++ b/sycl/unittests/thread_safety/ThreadUtils.h
@@ -48,7 +48,13 @@ public:
     enqueueHelper<N>(std::forward<Funcs>(funcs)...);
   }
 
-  ~ThreadPool() noexcept(false) { wait(); }
+  ~ThreadPool() {
+    try {
+      wait();
+    } catch (std::exception &e) {
+      std::cerr << "exception in ~ThreadPool" << e.what() << std::endl;
+    }
+  }
 
 private:
   template <int N, typename Func, typename... Funcs>


### PR DESCRIPTION
Destructors are implicitly noexcept, so we must ensure they don't actually throw exceptions. No change to API or ABI with this PR.
