### PR TITLE
[CI] Improve issue templates by continue showing prompt after typing starts

### DIFF
--- a/.github/ISSUE_TEMPLATE/1-bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/1-bug-report.yml
@@ -14,7 +14,7 @@ body:
     attributes:
       label: To reproduce
       description: Please describe the steps to reproduce the behavior
-      placeholder: |
+      value: |
         1. Include a code snippet that is as short as possible
         2. Specify the command which should be used to compile the program
         3. Specify the command which should be used to launch the program
@@ -26,7 +26,7 @@ body:
     attributes:
       label: Environment
       description: Please complete the following information
-      placeholder: |
+      value: |
         - OS: [e.g Windows/Linux]
         - Target device and vendor: [e.g. Intel GPU]
         - DPC++ version: [e.g. commit hash or output of `clang++ --version`]

--- a/.github/ISSUE_TEMPLATE/2-bug-report-cuda.yml
+++ b/.github/ISSUE_TEMPLATE/2-bug-report-cuda.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: To reproduce
       description: Please describe the steps to reproduce the behavior
-      placeholder: |
+      value: |
         1. Include code snippet as short as possible
         2. Specify the command which should be used to compile the program
         3. Specify the command which should be used to launch the program
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Environment
       description: Please complete the following information
-      placeholder: |
+      value: |
         - OS: [e.g Windows/Linux]
         - Target device and vendor: [e.g. Nvidia GPU]
         - DPC++ version: [e.g. commit hash or output of `clang++ --version`]

--- a/.github/ISSUE_TEMPLATE/3-bug-report-hip.yml
+++ b/.github/ISSUE_TEMPLATE/3-bug-report-hip.yml
@@ -17,7 +17,7 @@ body:
     attributes:
       label: To reproduce
       description: Please describe the steps to reproduce the behavior
-      placeholder: |
+      value: |
         1. Include code snippet as short as possible
         2. Specify the command which should be used to compile the program
         3. Specify the command which should be used to launch the program
@@ -29,7 +29,7 @@ body:
     attributes:
       label: Environment
       description: Please complete the following information
-      placeholder: |
+      value: |
         - OS: [e.g Windows/Linux]
         - Target device and vendor: [e.g. AMD GPU]
         - DPC++ version: [e.g. commit hash or output of `clang++ --version`]


### PR DESCRIPTION
The patch changes the way of where prompts are shown:
- previously it was a placeholder, it means that when customer starts to type something in the textbox, the prompt disappears and customer discovers that they doesn't know what to write next, so they doesn't provide other essential info described in these prompts to us
- now the prompt is written as text in textboxs, so the list of required things is not disappeared, so customer needs to modify the content of that textbox