### PR TITLE
[SYCL][E2E] Fix one of the compfails of TaskSequence tests

### DIFF
--- a/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
+++ b/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
@@ -93,6 +93,6 @@ int main() {
     q.wait();
   }
 
-  assert(abs(out[0] - golden) < 0.001);
+  assert(std::abs(out[0] - golden) < 0.001);
   return 0;
 }

--- a/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
+++ b/sycl/test-e2e/TaskSequence/concurrent-loops.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// FIXME: compfail, see https://github.com/intel/llvm/issues/14284, re-enable
+// when fixed:
+// UNSUPPORTED: linux, windows
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
@@ -59,7 +60,7 @@ class ConcurrentLoop;
 
 int main() {
 
-  double golden = exp(kA * kX) / exp(kB * kX);
+  double golden = std::exp(kA * kX) / std::exp(kB * kX);
 
   // initialize inputs
   std::vector<double> in = {kX, kA, kB};

--- a/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
+++ b/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
@@ -66,7 +66,7 @@ int main() {
 
   // verification
   for (int i = 0; i < kNumInputs; ++i) {
-    assert(abs(results[i] - golden[i]) < 0.001);
+    assert(std::abs(results[i] - golden[i]) < 0.001);
   }
 
   return 0;

--- a/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
+++ b/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// FIXME: compfail, see https://github.com/intel/llvm/issues/14284, re-enable
+// when fixed:
+// UNSUPPORTED: linux, windows
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
@@ -33,7 +34,7 @@ int main() {
   // test data
   for (int i = 0; i < kNumInputs; ++i) {
     values[i] = (static_cast<double>(-kNumInputs / 2.0 + i) / 1000);
-    golden[i] = 1 / (1 + exp(-values[i]));
+    golden[i] = 1 / (1 + std::exp(-values[i]));
   }
 
   {

--- a/sycl/test-e2e/TaskSequence/mult-and-add.cpp
+++ b/sycl/test-e2e/TaskSequence/mult-and-add.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// FIXME: compfail, see https://github.com/intel/llvm/issues/14284, re-enable
+// when fixed:
+// UNSUPPORTED: linux, windows
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out

--- a/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
+++ b/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// FIXME: compfail, see https://github.com/intel/llvm/issues/14284, re-enable
+// when fixed:
+// UNSUPPORTED: linux, windows
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out

--- a/sycl/test-e2e/TaskSequence/producer-consumer.cpp
+++ b/sycl/test-e2e/TaskSequence/producer-consumer.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// FIXME: compfail, see https://github.com/intel/llvm/issues/14284, re-enable
+// when fixed:
+// UNSUPPORTED: linux, windows
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out

--- a/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
+++ b/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
@@ -112,7 +112,9 @@ int main() {
     });
     q.wait();
   }
-  assert((abs(res_struct[0].val - vec_in_struct[0].val) < 0.001) && res_struct[0].isValid);
-  assert((abs(res_array[0][0] - vec_in_array[0][0]) < 0.001) && (abs(res_array[0][1] - vec_in_array[0][1]) < 0.001));
+  assert((std::abs(res_struct[0].val - vec_in_struct[0].val) < 0.001) &&
+         res_struct[0].isValid);
+  assert((std::abs(res_array[0][0] - vec_in_array[0][0]) < 0.001) &&
+         (std::abs(res_array[0][1] - vec_in_array[0][1]) < 0.001));
   return 0;
 }

--- a/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
+++ b/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
@@ -6,8 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// FIXME: failure in post-commit, re-enable when fixed:
-// UNSUPPORTED: linux
+// FIXME: compfail, see https://github.com/intel/llvm/issues/14284, re-enable
+// when fixed:
+// UNSUPPORTED: linux, windows
 
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
@@ -51,7 +52,7 @@ template <typename OutPipe> void argArray(DataArray data) {
 
 template <typename InPipe> DataStruct returnStruct() {
   float a = InPipe::read();
-  DataStruct res{sqrt(a), true};
+  DataStruct res{sycl::sqrt(a), true};
   return res;
 }
 
@@ -59,7 +60,7 @@ template <typename InPipe> DataArray returnArray() {
   DataArray res;
   for (int i = 0; i < 2; i++) {
     float a = InPipe::read();
-    res[i] = sqrt(a);
+    res[i] = sycl::sqrt(a);
   }
 
   return res;


### PR DESCRIPTION
This patch fixes errors like "call to 'XXX' is ambiguous" and also disables all TaskSequence tests on Windows because they fail in the same way as on Linux. Github issue was created against that and comment in tests was updated.