### PR TITLE
[Clang][SYCL][LIT] Fix lb_sm_90.cpp when nvptx target is not enabled

### DIFF
--- a/clang/test/SemaSYCL/lb_sm_90.cpp
+++ b/clang/test/SemaSYCL/lb_sm_90.cpp
@@ -1,3 +1,4 @@
+// REQUIRES: nvptx-registered-target
 // RUN: %clang_cc1 -internal-isystem %S/Inputs %s -triple nvptx64-nvidia-cuda -target-cpu sm_90 -fsycl-is-device -Wno-c++23-extensions -verify -S -o %t
 
 // Maximum work groups per multi-processor, mapped to maxclusterrank PTX


### PR DESCRIPTION
This fails for me constantly in `check-clang` locally because I don't build nvptx. I verified this is UNSUPPORTED when nvptx is not built and runs and passes when it is built.
