### PR TITLE
Fix tests after cbf6e93ce

### DIFF
--- a/clang/test/CodeGenSYCL/image_accessor.cpp
+++ b/clang/test/CodeGenSYCL/image_accessor.cpp
@@ -7,22 +7,22 @@
 // RUN: FileCheck < %t.ll --enable-var-scope %s --check-prefix=CHECK-3DWO
 //
 // CHECK-1DRO: define {{.*}}spir_kernel void @{{.*}}(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-1DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %{{[0-9]+}})
+// CHECK-1DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9_]+}}, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 0) %{{[0-9]+}})
 //
 // CHECK-2DRO: define {{.*}}spir_kernel void @{{.*}}(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-2DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %{{[0-9]+}})
+// CHECK-2DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9_]+}}, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 0) %{{[0-9]+}})
 //
 // CHECK-3DRO: define {{.*}}spir_kernel void @{{.*}}(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-3DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %{{[0-9]+}})
+// CHECK-3DRO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9_]+}}, target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 0) %{{[0-9]+}})
 //
 // CHECK-1DWO: define {{.*}}spir_kernel void @{{.*}}(target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-1DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) %{{[0-9]+}})
+// CHECK-1DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9_]+}}, target("spirv.Image", void, 0, 0, 0, 0, 0, 0, 1) %{{[0-9]+}})
 //
 // CHECK-2DWO: define {{.*}}spir_kernel void @{{.*}}(target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-2DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %{{[0-9]+}})
+// CHECK-2DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9_]+}}, target("spirv.Image", void, 1, 0, 0, 0, 0, 0, 1) %{{[0-9]+}})
 //
 // CHECK-3DWO: define {{.*}}spir_kernel void @{{.*}}(target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) [[IMAGE_ARG:%[a-zA-Z0-9_]+]])
-// CHECK-3DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z]+}}, target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) %{{[0-9]+}})
+// CHECK-3DWO: call spir_func void @{{.*}}__init{{.*}}(ptr addrspace(4) {{.*}} %{{[a-zA-Z0-9_]+}}, target("spirv.Image", void, 2, 0, 0, 0, 0, 0, 1) %{{[0-9]+}})
 //
 // TODO: Add tests for the image_array opencl datatype support.
 #include "Inputs/sycl.hpp"

--- a/clang/test/CodeGenSYCL/sampler.cpp
+++ b/clang/test/CodeGenSYCL/sampler.cpp
@@ -6,8 +6,9 @@
 // CHECK: [[ANONCAST:%[a-zA-Z0-9_.]+]] = addrspacecast ptr [[ANON]] to ptr addrspace(4)
 // CHECK: store target("spirv.Sampler") [[SAMPLER_ARG]], ptr addrspace(4) [[SAMPLER_ARG]].addr.ascast, align 8
 // CHECK-NEXT: [[GEP:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, ptr addrspace(4) [[ANONCAST]], i32 0, i32 0
+// CHECK-NEXT: [[GEP2:%[a-zA-z0-9]+]]  = getelementptr inbounds %class.anon, ptr addrspace(4) [[ANONCAST]], i32 0, i32 0
 // CHECK-NEXT: [[LOAD_SAMPLER_ARG:%[0-9]+]] = load target("spirv.Sampler"), ptr addrspace(4) [[SAMPLER_ARG]].addr.ascast, align 8
-// CHECK-NEXT: call spir_func void @{{[a-zA-Z0-9_]+}}(ptr addrspace(4) {{[^,]*}} [[GEP]], target("spirv.Sampler") [[LOAD_SAMPLER_ARG]])
+// CHECK-NEXT: call spir_func void @{{[a-zA-Z0-9_]+}}(ptr addrspace(4) {{[^,]*}} [[GEP2]], target("spirv.Sampler") [[LOAD_SAMPLER_ARG]])
 //
 
 // CHECK: define {{.*}}spir_kernel void @{{[a-zA-Z0-9_]+}}(target("spirv.Sampler") [[SAMPLER_ARG_WRAPPED:%[a-zA-Z0-9_]+]], i32 noundef [[ARG_A:%[a-zA-Z0-9_]+]])


### PR DESCRIPTION
Test needs update after cbf6e93ce 2024-05-28 [clang codegen] Delete unnecessary GEP cleanup code. (#90303).

Change made by  @premanandrao 