### PR TITLE
[DeviceSanitizer] Don't instrument referenced-indirectly functions

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3360,14 +3360,16 @@ bool AddressSanitizer::instrumentFunction(Function &F,
   if (F.getLinkage() == GlobalValue::AvailableExternallyLinkage) return false;
   if (!ClDebugFunc.empty() && ClDebugFunc == F.getName()) return false;
   if (F.getName().starts_with("__asan_")) return false;
-  if (F.getName().contains("__sycl_service_kernel__"))
-    return false;
 
-  // Skip referenced-indirectly function as we may insert access to shared local
-  // memory (SLM) __AsanLaunchInfo in report function and access to SLM in
-  // referenced-indirectly function isn't supported in intel-graphics-compiler.
-  if (TargetTriple.isSPIR() && F.hasFnAttribute("referenced-indirectly"))
-    return false;
+  if (TargetTriple.isSPIR()) {
+    if (F.getName().contains("__sycl_service_kernel__"))
+      return false;
+    // Skip referenced-indirectly function as we insert access to shared local
+    // memory (SLM) __AsanLaunchInfo and access to SLM in referenced-indirectly
+    // function isn't supported yet in intel-graphics-compiler.
+    if (F.hasFnAttribute("referenced-indirectly"))
+      return false;
+  }
 
   bool FunctionModified = false;
 

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3363,6 +3363,12 @@ bool AddressSanitizer::instrumentFunction(Function &F,
   if (F.getName().contains("__sycl_service_kernel__"))
     return false;
 
+  // Skip referenced-indirectly function as we may insert access to shared local
+  // memory (SLM) __AsanLaunchInfo in report function and access to SLM in
+  // referenced-indirectly function isn't supported in intel-graphics-compiler.
+  if (TargetTriple.isSPIR() && F.hasFnAttribute("referenced-indirectly"))
+    return false;
+
   bool FunctionModified = false;
 
   // If needed, insert __asan_init before checking for SanitizeAddress attr.

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/skip_referenced_indirectly.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/skip_referenced_indirectly.ll
@@ -1,0 +1,23 @@
+; RUN: opt < %s -passes=asan -asan-instrumentation-with-call-threshold=0 | FileCheck %s
+
+; Check referenced-indirectly function isn't instrumented.
+
+target triple = "spir64-unknown-unknown"
+
+%structtype = type { [3 x ptr addrspace(4)] }
+%class.Base = type <{ ptr addrspace(4), i32, [4 x i8] }>
+@_ZTV8Derived1 = linkonce_odr addrspace(1) constant %structtype { [3 x ptr addrspace(4)] [ptr addrspace(4) null, ptr addrspace(4) null, ptr addrspace(4) addrspacecast (ptr @_ZN8Derived17displayEv to ptr addrspace(4))] }, align 8, !spirv.Decorations !0
+
+define linkonce_odr spir_func i32 @_ZN8Derived17displayEv(ptr addrspace(4) align 8 %this) sanitize_address "referenced-indirectly" {
+entry:
+; CHECK-NOT: call void @__asan_load
+
+  %base_data = getelementptr inbounds %class.Base, ptr addrspace(4) %this, i64 0, i32 1
+  %1 = load i32, ptr addrspace(4) %base_data, align 8
+  ret i32 %1
+}
+
+!0 = !{!1, !2, !3}
+!1 = !{i32 22}
+!2 = !{i32 41, !"_ZTV8Derived1", i32 2}
+!3 = !{i32 44, i32 8}


### PR DESCRIPTION
When we create SLM __AsanLaunchInfo and store newly added kernel arg __asan_launch into the SLM, the SLM is loaded in asan report function. If instructions in referenced-indirectly function are instrumented, the report function is called. However, access to SLM in referenced- indirectly function isn't supported in intel-graphics-compiler yet.