### PR TITLE
[SYCL][E2E] Use callable device selector in `FilterSelector/select_device_level_zero.cpp`

### DIFF
--- a/sycl/test-e2e/FilterSelector/select_device_level_zero.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_level_zero.cpp
@@ -22,30 +22,26 @@ int main() {
   }
 
   {
-    default_selector ds;
-    device d = ds.select_device();
+    device d(default_selector_v);
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("Level-Zero") != string::npos);
   }
   {
-    gpu_selector gs;
-    device d = gs.select_device();
+    device d(gpu_selector_v);
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("Level-Zero") != string::npos);
   }
   {
-    cpu_selector cs;
     try {
-      device d = cs.select_device();
+      device d(cpu_selector_v);
       cerr << "CPU device is found in error: " << d.is_cpu() << std::endl;
       return -1;
     } catch (...) {
     }
   }
   {
-    accelerator_selector as;
     try {
-      device d = as.select_device();
+      device d(accelerator_selector_v);
       cerr << "ACC device is found in error: " << d.is_accelerator()
            << std::endl;
     } catch (...) {


### PR DESCRIPTION
Fixing test that was missed in #14162 