### PR TITLE
[Driver][SYCL] Restrict --coverage for SYCL device

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1223,7 +1223,7 @@ void SYCL::x86_64::BackendCompiler::ConstructJob(
 // Unsupported options for device compilation
 //  -fcf-protection, -fsanitize, -fprofile-generate, -fprofile-instr-generate
 //  -ftest-coverage, -fcoverage-mapping, -fcreate-profile, -fprofile-arcs
-//  -fcs-profile-generate -forder-file-instrumentation
+//  -fcs-profile-generate -forder-file-instrumentation, --coverage
 static std::vector<OptSpecifier> getUnsupportedOpts(void) {
   std::vector<OptSpecifier> UnsupportedOpts = {
       options::OPT_fsanitize_EQ,
@@ -1235,6 +1235,7 @@ static std::vector<OptSpecifier> getUnsupportedOpts(void) {
       options::OPT_fno_test_coverage,
       options::OPT_fcoverage_mapping,
       options::OPT_fno_coverage_mapping,
+      options::OPT_coverage,
       options::OPT_fprofile_instr_generate,
       options::OPT_fprofile_instr_generate_EQ,
       options::OPT_fprofile_arcs,

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -35,6 +35,10 @@
 // RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 // RUN: %clangxx -fsycl -forder-file-instrumentation -### %s 2>&1 \
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=-forder-file-instrumentation
+// RUN: %clangxx -fsycl --coverage -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=--coverage \
+// RUN:    -DOPT_CC1=-coverage-notes-file \
+// RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 // Check to make sure our '-fsanitize=address' exception isn't triggered by a
 // different option
 // RUN: %clangxx -fsycl -fprofile-instr-generate=address -### %s 2>&1 \

--- a/clang/test/Driver/sycl-unsupported.cpp
+++ b/clang/test/Driver/sycl-unsupported.cpp
@@ -39,6 +39,10 @@
 // RUN:  | FileCheck %s -DARCH=spir64 -DOPT=--coverage \
 // RUN:    -DOPT_CC1=-coverage-notes-file \
 // RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
+// RUN: %clang_cl -fsycl --coverage -### %s 2>&1 \
+// RUN:  | FileCheck %s -DARCH=spir64 -DOPT=--coverage \
+// RUN:    -DOPT_CC1=-coverage-notes-file \
+// RUN:    -check-prefixes=UNSUPPORTED_OPT_DIAG,UNSUPPORTED_OPT
 // Check to make sure our '-fsanitize=address' exception isn't triggered by a
 // different option
 // RUN: %clangxx -fsycl -fprofile-instr-generate=address -### %s 2>&1 \


### PR DESCRIPTION
When using -fsycl --coverage, we should not enable code coverage for device compilations as code coverage for device is not supported at this time.