### PR TITLE
[spirv] Restoring breaks incorrectly dropped

### DIFF
--- a/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
+++ b/llvm-spirv/lib/SPIRV/libSPIRV/SPIRVDecorate.cpp
@@ -126,6 +126,7 @@ void SPIRVDecorate::encode(spv_ostream &O) const {
     break;
   case internal::DecorationFuncParamDescINTEL:
     SPIRVDecorateFuncParamDescAttr::encodeLiterals(Encoder, Literals);
+    break;
   case internal::DecorationHostAccessINTEL:
     SPIRVDecorateHostAccessINTELLegacy::encodeLiterals(Encoder, Literals);
     break;
@@ -163,6 +164,7 @@ void SPIRVDecorate::decode(std::istream &I) {
     break;
   case internal::DecorationFuncParamDescINTEL:
     SPIRVDecorateFuncParamDescAttr::decodeLiterals(Decoder, Literals);
+    break;
   case internal::DecorationHostAccessINTEL:
     SPIRVDecorateHostAccessINTELLegacy::decodeLiterals(Decoder, Literals);
     break;


### PR DESCRIPTION
Breaks were lost in 5fd4877, restoring them. When the breaks are lost, literals are enconded/decoded twice, which is wrong. 

** This is done in this repo because this piece of code is not present in Khronos repo. **