### PR TITLE
[TEST-E2E][CUDA] Do not allow adding an event as a BlockedUser if it has the current event as a dependent.

### DIFF
--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -54,7 +54,7 @@ bool Scheduler::GraphProcessor::handleBlockingCmd(Command *Cmd,
   if (Cmd == RootCommand || Blocking)
     return true;
 
-  const auto hostDepEvents = RootCommand->getPreparedHostDepsEvents();
+  const auto &hostDepEvents = RootCommand->getPreparedHostDepsEvents();
   const auto eventIter = std::find_if(
       hostDepEvents.begin(), hostDepEvents.end(),
       [&](const auto Event) { return Event->getCommand() == Cmd; });

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -53,6 +53,14 @@ bool Scheduler::GraphProcessor::handleBlockingCmd(Command *Cmd,
                                                   BlockingT Blocking) {
   if (Cmd == RootCommand || Blocking)
     return true;
+
+  const auto hostDepEvents = RootCommand->getPreparedHostDepsEvents();
+  const auto eventIter = std::find_if(
+      hostDepEvents.begin(), hostDepEvents.end(),
+      [&](const auto Event) { return Event->getCommand() == Cmd; });
+  if (eventIter != std::end(hostDepEvents))
+    return true;
+
   {
     std::lock_guard<std::mutex> Guard(Cmd->MBlockedUsersMutex);
     if (Cmd->isBlocking()) {


### PR DESCRIPTION
Adding an event as a BlockedUser if it has the current event as a dependent could potentially result in failure as seen in related issue.
Using the patch, there is no regression on test-e2e. However, there are regression on unit tests. I will have the unit test fixed once I have a feedback from @intel/llvm-reviewers-runtime. 