### PR TITLE
[SYCL][E2E] Reenable in_order_profiling_queue for L0

### DIFF
--- a/sycl/test-e2e/ProfilingTag/in_order_profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/in_order_profiling_queue.cpp
@@ -21,9 +21,9 @@
 // https://github.com/intel/llvm/issues/14053
 // UNSUPPORTED: cuda
 
-// Fails on FPGA and level_zero too
+// FPGA emulator seems to return unexpected start time for the fallback barrier.
 // https://github.com/intel/llvm/issues/14315
-// UNSUPPORTED: accelerator || level_zero
+// UNSUPPORTED: accelerator
 
 #include "common.hpp"
 

--- a/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
+++ b/sycl/test-e2e/ProfilingTag/profiling_queue.cpp
@@ -17,6 +17,7 @@
 // UNSUPPORTED: hip
 
 // FPGA emulator seems to return unexpected start time for the fallback barrier.
+// https://github.com/intel/llvm/issues/14315
 // UNSUPPORTED: accelerator
 
 // Flaky on CUDA


### PR DESCRIPTION
Due to some confusion about the output from the in_order_profiling_queue test on L0, the test was disabled. However, the test can be safely reenabled for that target, while keeping it disabled for FPGA.

Additionally, the failure in profiling_queue is believed to be due to the same issue, so the JIRA has been added to it and the note in in_order_profiling_queue has been updated to reflect the known information about the failure.