### PR TITLE
[SYCL] Fix edge cases in ctanh and cexp

### DIFF
--- a/libdevice/fallback-complex-fp64.cpp
+++ b/libdevice/fallback-complex-fp64.cpp
@@ -153,8 +153,14 @@ double __complex__ __devicelib_cexp(double __complex__ z) {
     return z;
   }
   double __e = __spirv_ocl_exp(z_real);
-  return CMPLX((__e * __spirv_ocl_cos(z_imag)),
-               (__e * __spirv_ocl_sin(z_imag)));
+  double ret_real = __e * __spirv_ocl_cos(z_imag);
+  double ret_imag = __e * __spirv_ocl_sin(z_imag);
+
+  if (__spirv_IsNan(ret_real))
+    ret_real = 0.;
+  if (__spirv_IsNan(ret_imag))
+    ret_imag = 0.;
+  return CMPLX(ret_real, ret_imag);
 }
 
 DEVICE_EXTERN_C_INLINE
@@ -249,8 +255,9 @@ double __complex__ __devicelib_ctanh(double __complex__ z) {
   double z_imag = __devicelib_cimag(z);
   if (__spirv_IsInf(z_real)) {
     if (!__spirv_IsFinite(z_imag))
-      return CMPLX(1.0, 0.0);
-    return CMPLX(1.0, __spirv_ocl_copysign(0.0, __spirv_ocl_sin(2.0 * z_imag)));
+      return CMPLX(__spirv_ocl_copysign(1.0, z_real), 0.0);
+    return CMPLX(__spirv_ocl_copysign(1.0, z_real),
+                 __spirv_ocl_copysign(0.0, __spirv_ocl_sin(2.0 * z_imag)));
   }
   if (__spirv_IsNan(z_real) && z_imag == 0)
     return z;

--- a/libdevice/fallback-complex.cpp
+++ b/libdevice/fallback-complex.cpp
@@ -154,8 +154,14 @@ float __complex__ __devicelib_cexpf(float __complex__ z) {
     return z;
   }
   float __e = __spirv_ocl_exp(z_real);
-  return CMPLXF((__e * __spirv_ocl_cos(z_imag)),
-                (__e * __spirv_ocl_sin(z_imag)));
+  float ret_real = __e * __spirv_ocl_cos(z_imag);
+  float ret_imag = __e * __spirv_ocl_sin(z_imag);
+
+  if (__spirv_IsNan(ret_real))
+    ret_real = 0.f;
+  if (__spirv_IsNan(ret_imag))
+    ret_imag = 0.f;
+  return CMPLXF(ret_real, ret_imag);
 }
 
 DEVICE_EXTERN_C_INLINE
@@ -249,8 +255,8 @@ float __complex__ __devicelib_ctanhf(float __complex__ z) {
   float z_imag = __devicelib_cimagf(z);
   if (__spirv_IsInf(z_real)) {
     if (!__spirv_IsFinite(z_imag))
-      return CMPLXF(1.0f, 0.0f);
-    return CMPLXF(1.0f,
+      return CMPLXF(__spirv_ocl_copysign(1.0f, z_real), 0.0f);
+    return CMPLXF(__spirv_ocl_copysign(1.0f, z_real),
                   __spirv_ocl_copysign(0.0f, __spirv_ocl_sin(2.0f * z_imag)));
   }
   if (__spirv_IsNan(z_real) && z_imag == 0)

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -24,73 +24,78 @@ template <typename T> bool approx_equal_cmplx(complex<T> x, complex<T> y) {
          approx_equal_fp(x.imag(), y.imag());
 }
 
-static constexpr auto TestArraySize1 = 57;
+complex<double> ref1_results[] = {complex<double>(-1., 1.),
+                                  complex<double>(1., 3.),
+                                  complex<double>(-2., 10.),
+                                  complex<double>(-8., 31.),
+                                  complex<double>(1., 1.),
+                                  complex<double>(2., 1.),
+                                  complex<double>(2., 2.),
+                                  complex<double>(3., 4.),
+                                  complex<double>(2., 1.),
+                                  complex<double>(0., 1.),
+                                  complex<double>(2., 0.),
+                                  complex<double>(0., 0.),
+                                  complex<double>(0., 1.),
+                                  complex<double>(1., 1.),
+                                  complex<double>(2., 0.),
+                                  complex<double>(2., 3.),
+                                  complex<double>(1., 0.),
+                                  complex<double>(0., 1.),
+                                  complex<double>(-1., 0.),
+                                  complex<double>(0., M_E),
+                                  complex<double>(0., 0.),
+                                  complex<double>(0., M_PI_2),
+                                  complex<double>(0., M_PI),
+                                  complex<double>(1., M_PI_2),
+                                  complex<double>(0., 0.),
+                                  complex<double>(1., 0.),
+                                  complex<double>(1., 0.),
+                                  complex<double>(-1., 0.),
+                                  complex<double>(-INFINITY, 0.),
+                                  complex<double>(1., 0.),
+                                  complex<double>(10., 0.),
+                                  complex<double>(100., 0.),
+                                  complex<double>(200., 0.),
+                                  complex<double>(1., 2.),
+                                  complex<double>(INFINITY, 0.),
+                                  complex<double>(INFINITY, 0.),
+                                  complex<double>(0., 1.),
+                                  complex<double>(M_PI_2, 0.),
+                                  complex<double>(0., 0.),
+                                  complex<double>(1., 0.),
+                                  complex<double>(INFINITY, 0.),
+                                  complex<double>(0., 0.),
+                                  complex<double>(1., 0.),
+                                  complex<double>(0., 0.),
+                                  complex<double>(INFINITY, M_PI_2),
+                                  complex<double>(INFINITY, 0.),
+                                  complex<double>(0., M_PI_2),
+                                  complex<double>(INFINITY, M_PI_2),
+                                  complex<double>(INFINITY, 0.),
+                                  complex<double>(0., 0.),
+                                  complex<double>(0., M_PI_2),
+
+                                  complex<double>(1., -4.),
+                                  complex<double>(18., -7.),
+                                  complex<double>(1.557407724654902, 0.),
+                                  complex<double>(0, 0.761594155955765),
+                                  complex<double>(M_PI_2, 0.),
+                                  complex<double>(M_PI_2, 0.549306144334055),
+                                  complex<double>(-1., 0.),
+                                  complex<double>(-1., 0.),
+                                  complex<double>(-1., 0.),
+                                  complex<double>(INFINITY, 0.),
+                                  complex<double>(INFINITY, INFINITY),
+                                  complex<double>(INFINITY, -INFINITY)};
+
+double ref2_results[] = {0., 25., 169.,     INFINITY, 0.,
+                         5., 13., INFINITY, 0.,       M_PI_2};
+
+static constexpr auto TestArraySize1 = std::size(ref1_results);
 static constexpr auto TestArraySize2 = 10;
 
-std::array<complex<double>, TestArraySize1> ref1_results = {
-    complex<double>(-1., 1.),
-    complex<double>(1., 3.),
-    complex<double>(-2., 10.),
-    complex<double>(-8., 31.),
-    complex<double>(1., 1.),
-    complex<double>(2., 1.),
-    complex<double>(2., 2.),
-    complex<double>(3., 4.),
-    complex<double>(2., 1.),
-    complex<double>(0., 1.),
-    complex<double>(2., 0.),
-    complex<double>(0., 0.),
-    complex<double>(0., 1.),
-    complex<double>(1., 1.),
-    complex<double>(2., 0.),
-    complex<double>(2., 3.),
-    complex<double>(1., 0.),
-    complex<double>(0., 1.),
-    complex<double>(-1., 0.),
-    complex<double>(0., M_E),
-    complex<double>(0., 0.),
-    complex<double>(0., M_PI_2),
-    complex<double>(0., M_PI),
-    complex<double>(1., M_PI_2),
-    complex<double>(0., 0.),
-    complex<double>(1., 0.),
-    complex<double>(1., 0.),
-    complex<double>(-1., 0.),
-    complex<double>(-INFINITY, 0.),
-    complex<double>(1., 0.),
-    complex<double>(10., 0.),
-    complex<double>(100., 0.),
-    complex<double>(200., 0.),
-    complex<double>(1., 2.),
-    complex<double>(INFINITY, 0.),
-    complex<double>(INFINITY, 0.),
-    complex<double>(0., 1.),
-    complex<double>(M_PI_2, 0.),
-    complex<double>(0., 0.),
-    complex<double>(1., 0.),
-    complex<double>(INFINITY, 0.),
-    complex<double>(0., 0.),
-    complex<double>(1., 0.),
-    complex<double>(0., 0.),
-    complex<double>(INFINITY, M_PI_2),
-    complex<double>(INFINITY, 0.),
-    complex<double>(0., M_PI_2),
-    complex<double>(INFINITY, M_PI_2),
-    complex<double>(INFINITY, 0.),
-    complex<double>(0., 0.),
-    complex<double>(0., M_PI_2),
-
-    complex<double>(1., -4.),
-    complex<double>(18., -7.),
-    complex<double>(1.557407724654902, 0.),
-    complex<double>(0, 0.761594155955765),
-    complex<double>(M_PI_2, 0.),
-    complex<double>(M_PI_2, 0.549306144334055)};
-
-std::array<double, TestArraySize2> ref2_results = {
-    0., 25., 169., INFINITY, 0., 5., 13., INFINITY, 0., M_PI_2};
-
-void device_complex_test(s::queue &deviceQueue) {
+int device_complex_test(s::queue &deviceQueue) {
   s::range<1> numOfItems1{TestArraySize1};
   s::range<1> numOfItems2{TestArraySize2};
   std::array<complex<double>, TestArraySize1> result1;
@@ -172,6 +177,13 @@ void device_complex_test(s::queue &deviceQueue) {
         buf_out1_access[index++] = std::tan(complex<double>(0., 1.));
         buf_out1_access[index++] = std::asin(complex<double>(1., 0.));
         buf_out1_access[index++] = std::atan(complex<double>(0., 2.));
+        buf_out1_access[index++] = std::tanh(complex<double>(-INFINITY, NAN));
+        buf_out1_access[index++] =
+            std::tanh(complex<double>(-INFINITY, -INFINITY));
+        buf_out1_access[index++] = std::tanh(complex<double>(-INFINITY, -2.));
+        buf_out1_access[index++] = std::exp(complex<double>(1e6, 0.));
+        buf_out1_access[index++] = std::exp(complex<double>(1e6, 0.1));
+        buf_out1_access[index++] = std::exp(complex<double>(1e6, -0.1));
 
         index = 0;
         buf_out2_access[index++] = std::norm(complex<double>(0., 0.));
@@ -188,16 +200,30 @@ void device_complex_test(s::queue &deviceQueue) {
     });
   }
 
+  int n_fails = 0;
   for (size_t idx = 0; idx < TestArraySize1; ++idx) {
-    assert(approx_equal_cmplx(result1[idx], ref1_results[idx]));
+    if (!approx_equal_cmplx(result1[idx], ref1_results[idx])) {
+      ++n_fails;
+      std::cout << "test array 1 fail at index " << idx << "\n";
+      std::cout << "expected: " << ref1_results[idx] << "\n";
+      std::cout << "actual:   " << result1[idx] << "\n";
+    }
   }
   for (size_t idx = 0; idx < TestArraySize2; ++idx) {
-    assert(approx_equal_fp(result2[idx], ref2_results[idx]));
+    if (!approx_equal_fp(result2[idx], ref2_results[idx])) {
+      ++n_fails;
+      std::cout << "test array 2 fail at index " << idx << "\n";
+      std::cout << "expected: " << ref2_results[idx] << "\n";
+      std::cout << "actual:   " << result2[idx] << "\n";
+    }
   }
+  return n_fails;
 }
 
 int main() {
   s::queue deviceQueue;
-  device_complex_test(deviceQueue);
-  std::cout << "Pass" << std::endl;
+  auto n_fails = device_complex_test(deviceQueue);
+  if (n_fails == 0)
+    std::cout << "Pass" << std::endl;
+  return n_fails;
 }

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -24,37 +24,34 @@ template <typename T> bool approx_equal_cmplx(complex<T> x, complex<T> y) {
          approx_equal_fp(x.imag(), y.imag());
 }
 
-static constexpr auto TestArraySize1 = 41;
-static constexpr auto TestArraySize2 = 10;
-static constexpr auto TestArraySize3 = 16;
+complex<float> ref1_results[] = {
+    complex<float>(-1.f, 1.f),          complex<float>(1.f, 3.f),
+    complex<float>(-2.f, 10.f),         complex<float>(-8.f, 31.f),
+    complex<float>(1.f, 1.f),           complex<float>(2.f, 1.f),
+    complex<float>(2.f, 2.f),           complex<float>(3.f, 4.f),
+    complex<float>(2.f, 1.f),           complex<float>(0.f, 1.f),
+    complex<float>(2.f, 0.f),           complex<float>(0.f, 0.f),
+    complex<float>(1.f, 0.f),           complex<float>(0.f, 1.f),
+    complex<float>(-1.f, 0.f),          complex<float>(0.f, M_E),
+    complex<float>(0.f, 0.f),           complex<float>(0.f, M_PI_2),
+    complex<float>(0.f, M_PI),          complex<float>(1.f, M_PI_2),
+    complex<float>(0.f, 0.f),           complex<float>(1.f, 0.f),
+    complex<float>(1.f, 0.f),           complex<float>(-1.f, 0.f),
+    complex<float>(-INFINITY, 0.f),     complex<float>(1.f, 0.f),
+    complex<float>(10.f, 0.f),          complex<float>(100.f, 0.f),
+    complex<float>(200.f, 0.f),         complex<float>(1.f, 2.f),
+    complex<float>(INFINITY, 0.f),      complex<float>(INFINITY, 0.f),
+    complex<float>(0.f, 1.f),           complex<float>(0.f, 0.f),
+    complex<float>(1.f, 0.f),           complex<float>(INFINITY, 0.f),
+    complex<float>(0.f, 0.f),           complex<float>(0.f, M_PI_2),
+    complex<float>(1.f, -4.f),          complex<float>(18.f, -7.f),
+    complex<float>(M_PI_2, 0.549306f),  complex<float>(INFINITY, 0.f),
+    complex<float>(INFINITY, INFINITY), complex<float>(INFINITY, -INFINITY)};
 
-std::array<complex<float>, TestArraySize1> ref1_results = {
-    complex<float>(-1.f, 1.f),        complex<float>(1.f, 3.f),
-    complex<float>(-2.f, 10.f),       complex<float>(-8.f, 31.f),
-    complex<float>(1.f, 1.f),         complex<float>(2.f, 1.f),
-    complex<float>(2.f, 2.f),         complex<float>(3.f, 4.f),
-    complex<float>(2.f, 1.f),         complex<float>(0.f, 1.f),
-    complex<float>(2.f, 0.f),         complex<float>(0.f, 0.f),
-    complex<float>(1.f, 0.f),         complex<float>(0.f, 1.f),
-    complex<float>(-1.f, 0.f),        complex<float>(0.f, M_E),
-    complex<float>(0.f, 0.f),         complex<float>(0.f, M_PI_2),
-    complex<float>(0.f, M_PI),        complex<float>(1.f, M_PI_2),
-    complex<float>(0.f, 0.f),         complex<float>(1.f, 0.f),
-    complex<float>(1.f, 0.f),         complex<float>(-1.f, 0.f),
-    complex<float>(-INFINITY, 0.f),   complex<float>(1.f, 0.f),
-    complex<float>(10.f, 0.f),        complex<float>(100.f, 0.f),
-    complex<float>(200.f, 0.f),       complex<float>(1.f, 2.f),
-    complex<float>(INFINITY, 0.f),    complex<float>(INFINITY, 0.f),
-    complex<float>(0.f, 1.f),         complex<float>(0.f, 0.f),
-    complex<float>(1.f, 0.f),         complex<float>(INFINITY, 0.f),
-    complex<float>(0.f, 0.f),         complex<float>(0.f, M_PI_2),
-    complex<float>(1.f, -4.f),        complex<float>(18.f, -7.f),
-    complex<float>(M_PI_2, 0.549306f)};
+float ref2_results[] = {0.f, 25.f, 169.f,    INFINITY, 0.f,
+                        5.f, 13.f, INFINITY, 0.f,      M_PI_2};
 
-std::array<float, TestArraySize2> ref2_results = {
-    0.f, 25.f, 169.f, INFINITY, 0.f, 5.f, 13.f, INFINITY, 0.f, M_PI_2};
-
-std::array<complex<float>, TestArraySize3> ref3_results = {
+complex<float> ref3_results[] = {
     complex<float>(0.f, 1.f),         complex<float>(1.f, 1.f),
     complex<float>(2.f, 0.f),         complex<float>(2.f, 3.f),
     complex<float>(M_PI_2, 0.f),      complex<float>(0.f, 0.f),
@@ -63,9 +60,14 @@ std::array<complex<float>, TestArraySize3> ref3_results = {
     complex<float>(0.f, M_PI_2),      complex<float>(INFINITY, M_PI_2),
     complex<float>(INFINITY, 0.f),    complex<float>(1.557408f, 0.f),
     complex<float>(0.f, 0.761594f),   complex<float>(M_PI_2, 0.f),
+    complex<float>(-1.f, 0.f),        complex<float>(-1.f, 0.f),
+    complex<float>(-1.f, 0.f)};
 
-};
-void device_complex_test_1(s::queue &deviceQueue) {
+static constexpr auto TestArraySize1 = std::size(ref1_results);
+static constexpr auto TestArraySize2 = std::size(ref2_results);
+static constexpr auto TestArraySize3 = std::size(ref3_results);
+
+int device_complex_test_1(s::queue &deviceQueue) {
   s::range<1> numOfItems1{TestArraySize1};
   s::range<1> numOfItems2{TestArraySize2};
   std::array<complex<float>, TestArraySize1> result1;
@@ -131,6 +133,9 @@ void device_complex_test_1(s::queue &deviceQueue) {
         buf_out1_access[index++] = std::conj(complex<float>(1.f, 4.f));
         buf_out1_access[index++] = std::conj(complex<float>(18.f, 7.f));
         buf_out1_access[index++] = std::atan(complex<float>(0.f, 2.f));
+        buf_out1_access[index++] = std::exp(complex<float>(1e6f, 0.f));
+        buf_out1_access[index++] = std::exp(complex<float>(1e6f, 0.1f));
+        buf_out1_access[index++] = std::exp(complex<float>(1e6f, -0.1f));
 
         index = 0;
         buf_out2_access[index++] = std::norm(complex<float>(0.f, 0.f));
@@ -147,12 +152,24 @@ void device_complex_test_1(s::queue &deviceQueue) {
     });
   }
 
+  int n_fails = 0;
   for (size_t idx = 0; idx < TestArraySize1; ++idx) {
-    assert(approx_equal_cmplx(result1[idx], ref1_results[idx]));
+    if (!approx_equal_cmplx(result1[idx], ref1_results[idx])) {
+      ++n_fails;
+      std::cout << "test array 1 fail at index " << idx << "\n";
+      std::cout << "expected: " << ref1_results[idx] << "\n";
+      std::cout << "actual:   " << result1[idx] << "\n";
+    }
   }
   for (size_t idx = 0; idx < TestArraySize2; ++idx) {
-    assert(approx_equal_fp(result2[idx], ref2_results[idx]));
+    if (!approx_equal_fp(result2[idx], ref2_results[idx])) {
+      ++n_fails;
+      std::cout << "test array 2 fail at index " << idx << "\n";
+      std::cout << "expected: " << ref2_results[idx] << "\n";
+      std::cout << "actual:   " << result2[idx] << "\n";
+    }
   }
+  return n_fails;
 }
 
 // The MSVC implementation of some complex<float> math functions depends on
@@ -160,7 +177,7 @@ void device_complex_test_1(s::queue &deviceQueue) {
 // functions can only work on Windows with fp64 extension support from
 // underlying device.
 #ifndef _WIN32
-void device_complex_test_2(s::queue &deviceQueue) {
+int device_complex_test_2(s::queue &deviceQueue) {
   s::range<1> numOfItems1{TestArraySize3};
   std::array<complex<float>, TestArraySize3> result3;
   {
@@ -185,13 +202,24 @@ void device_complex_test_2(s::queue &deviceQueue) {
         buf_out1_access[index++] = std::tan(complex<float>(1.f, 0.f));
         buf_out1_access[index++] = std::tan(complex<float>(0.f, 1.f));
         buf_out1_access[index++] = std::asin(complex<float>(1.f, 0.f));
+        buf_out1_access[index++] = std::tanh(complex<float>(-INFINITY, NAN));
+        buf_out1_access[index++] =
+            std::tanh(complex<float>(-INFINITY, -INFINITY));
+        buf_out1_access[index++] = std::tanh(complex<float>(-INFINITY, -2.f));
       });
     });
   }
 
+  int n_fails = 0;
   for (size_t idx = 0; idx < TestArraySize3; ++idx) {
-    assert(approx_equal_cmplx(result3[idx], ref3_results[idx]));
+    if (!approx_equal_cmplx(result3[idx], ref3_results[idx])) {
+      ++n_fails;
+      std::cout << "test array 3 fail at index " << idx << "\n";
+      std::cout << "expected: " << ref3_results[idx] << "\n";
+      std::cout << "actual:   " << result3[idx] << "\n";
+    }
   }
+  return n_fails;
 }
 #endif
 int main() {
@@ -208,9 +236,12 @@ int main() {
   }
 #endif
 
-  device_complex_test_1(deviceQueue);
+  int n_fails = 0;
+  n_fails += device_complex_test_1(deviceQueue);
 #ifndef _WIN32
-  device_complex_test_2(deviceQueue);
+  n_fails += device_complex_test_2(deviceQueue);
 #endif
-  std::cout << "Pass" << std::endl;
+  if (n_fails == 0)
+    std::cout << "Pass" << std::endl;
+  return n_fails;
 }


### PR DESCRIPTION
Due to formatting, the test case diff is a bit hard to see. Here is an overview of the new tests cases added and their old behavior:

`ctanh(-inf + nan*i) == -1 + 0*i` (previously was `1 + 0*i`)
`ctanh(-inf + nan*i) == -1 + 0*i` (previously was `1 + 0*i`)
`ctanh(-inf + nan*i) == -1 + 0*i` (previously was `1 + 0*i`)
`cexp(1e6 + 0*i) == inf + 0*i` (previously was `inf + nan*i`)
`cexp(1e6 + 0.1*i) == inf + inf*i` (old behavior, just adding more coverage)
`cexp(1e6 + -0.*i) == inf + -inf*i` (old behavior, just adding more coverage)