### PR TITLE
[SYCL][ESIMD][E2E] Disable atomic_update test on Windows until new driver

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_usm_dg2_pvc_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_usm_dg2_pvc_cmpxchg.cpp
@@ -7,6 +7,7 @@
 //===---------------------------------------------------------------------===//
 
 // REQUIRES: gpu-intel-pvc || gpu-intel-dg2
+// REQUIRES-INTEL-DRIVER: win: 101.5660
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
A similar test was disabled in https://github.com/intel/llvm/commit/672b225e137b15de2465b62837ba32d17ab750a8, and this test was found to have the same issue.