### PR TITLE
[Driver][SYCL][NewOffload] Fix arch settings for nvptx and amd

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7870,7 +7870,6 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
     else if (Kind == Action::OFK_SYCL) {
       // For SYCL offloading, we need to check the triple for NVPTX or AMDGPU
       // and set the default arch accordingly
-      // mtoguchi
       if (TC->getTriple().isNVPTX())
         Archs.insert(CudaArchToString(CudaArch::SM_50));
       else if (TC->getTriple().isAMDGPU())

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7781,12 +7781,28 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
   for (auto *Arg : Args) {
     // Extract any '--[no-]offload-arch' arguments intended for this toolchain.
     std::unique_ptr<llvm::opt::Arg> ExtractedArg = nullptr;
-    if (Arg->getOption().matches(options::OPT_Xopenmp_target_EQ) &&
-        ToolChain::getOpenMPTriple(Arg->getValue(0)) == TC->getTriple()) {
-      Arg->claim();
-      unsigned Index = Args.getBaseArgs().MakeIndex(Arg->getValue(1));
-      ExtractedArg = getOpts().ParseOneArg(Args, Index);
-      Arg = ExtractedArg.get();
+    if (Kind == Action::OFK_SYCL) {
+      // For SYCL based offloading, we allow for -Xsycl-target-backend
+      // and -Xsycl-target-backend=<target> for specifying options.
+      if (Arg->getOption().matches(options::OPT_Xsycl_backend_EQ) &&
+          llvm::Triple(Arg->getValue(0)) == TC->getTriple()) {
+        Arg->claim();
+        unsigned Index = Args.getBaseArgs().MakeIndex(Arg->getValue(1));
+        ExtractedArg = getOpts().ParseOneArg(Args, Index);
+        Arg = ExtractedArg.get();
+      } else if (Arg->getOption().matches(options::OPT_Xsycl_backend)) {
+        unsigned Index = Args.getBaseArgs().MakeIndex(Arg->getValue(0));
+        ExtractedArg = getOpts().ParseOneArg(Args, Index);
+        Arg = ExtractedArg.get();
+      }
+    } else {
+      if (Arg->getOption().matches(options::OPT_Xopenmp_target_EQ) &&
+          ToolChain::getOpenMPTriple(Arg->getValue(0)) == TC->getTriple()) {
+        Arg->claim();
+        unsigned Index = Args.getBaseArgs().MakeIndex(Arg->getValue(1));
+        ExtractedArg = getOpts().ParseOneArg(Args, Index);
+        Arg = ExtractedArg.get();
+      }
     }
 
     // Add or remove the seen architectures in order of appearance. If an
@@ -7851,8 +7867,18 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
       Archs.insert(CudaArchToString(CudaArch::HIPDefault));
     else if (Kind == Action::OFK_OpenMP)
       Archs.insert(StringRef());
-    else if (Kind == Action::OFK_SYCL)
-      Archs.insert(StringRef());
+    else if (Kind == Action::OFK_SYCL) {
+      // For SYCL offloading, we need to check the triple for NVPTX or AMDGPU
+      // and set the default arch accordingly
+      // mtoguchi
+      if (TC->getTriple().isNVPTX())
+        Archs.insert(CudaArchToString(CudaArch::SM_50));
+      else if (TC->getTriple().isAMDGPU())
+        C.getDriver().Diag(clang::diag::err_drv_sycl_missing_amdgpu_arch)
+            << 1 << TC->getTriple().str();
+      else
+        Archs.insert(StringRef());
+    }
   } else {
     Args.ClaimAllArgs(options::OPT_offload_arch_EQ);
     Args.ClaimAllArgs(options::OPT_no_offload_arch_EQ);

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -7868,8 +7868,9 @@ Driver::getOffloadArchs(Compilation &C, const llvm::opt::DerivedArgList &Args,
     else if (Kind == Action::OFK_OpenMP)
       Archs.insert(StringRef());
     else if (Kind == Action::OFK_SYCL) {
-      // For SYCL offloading, we need to check the triple for NVPTX or AMDGPU
-      // and set the default arch accordingly
+      // For SYCL offloading, we need to check the triple for NVPTX or AMDGPU.
+      // The default arch is set for NVPTX if not provided.  For AMDGPU, emit
+      // an error as the user is responsible to set the arch.
       if (TC->getTriple().isNVPTX())
         Archs.insert(CudaArchToString(CudaArch::SM_50));
       else if (TC->getTriple().isAMDGPU())

--- a/clang/test/Driver/sycl-offload-new-driver.c
+++ b/clang/test/Driver/sycl-offload-new-driver.c
@@ -6,11 +6,11 @@
 // OFFLOAD-NEW-DRIVER: 1: append-footer, {0}, c++, (host-sycl)
 // OFFLOAD-NEW-DRIVER: 2: preprocessor, {1}, c++-cpp-output, (host-sycl)
 // OFFLOAD-NEW-DRIVER: 3: compiler, {2}, ir, (host-sycl)
-// OFFLOAD-NEW-DRIVER: 4: input, "[[INPUT]]", c++, (device-sycl)
-// OFFLOAD-NEW-DRIVER: 5: preprocessor, {4}, c++-cpp-output, (device-sycl)
-// OFFLOAD-NEW-DRIVER: 6: compiler, {5}, ir, (device-sycl)
-// OFFLOAD-NEW-DRIVER: 7: backend, {6}, ir, (device-sycl)
-// OFFLOAD-NEW-DRIVER: 8: offload, "device-sycl (nvptx64-nvidia-cuda)" {7}, ir
+// OFFLOAD-NEW-DRIVER: 4: input, "[[INPUT]]", c++, (device-sycl, sm_50)
+// OFFLOAD-NEW-DRIVER: 5: preprocessor, {4}, c++-cpp-output, (device-sycl, sm_50)
+// OFFLOAD-NEW-DRIVER: 6: compiler, {5}, ir, (device-sycl, sm_50)
+// OFFLOAD-NEW-DRIVER: 7: backend, {6}, ir, (device-sycl, sm_50)
+// OFFLOAD-NEW-DRIVER: 8: offload, "device-sycl (nvptx64-nvidia-cuda:sm_50)" {7}, ir
 // OFFLOAD-NEW-DRIVER: 9: input, "[[INPUT]]", c++, (device-sycl)
 // OFFLOAD-NEW-DRIVER: 10: preprocessor, {9}, c++-cpp-output, (device-sycl)
 // OFFLOAD-NEW-DRIVER: 11: compiler, {10}, ir, (device-sycl)
@@ -173,3 +173,16 @@
 // WRAPPER_OPTIONS_BACKEND_AOT: clang-linker-wrapper{{.*}}  "--host-triple=x86_64-unknown-linux-gnu"
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--gpu-tool-arg={{.*}}-backend-gpu-opt"
 // WRAPPER_OPTIONS_BACKEND_AOT-SAME: "--cpu-tool-arg={{.*}}-backend-cpu-opt"
+
+/// Verify arch settings for nvptx and amdgcn targets
+// RUN: %clangxx -fsycl -### -fsycl-targets=amdgcn-amd-gpu -fno-sycl-libspirv \
+// RUN:          -nocudalib --offload-new-driver \
+// RUN:          -Xsycl-target-backend=amdgcn-amd-gpu --offload-arch=gfx600 \
+// RUN:          %s 2>&1 \
+// RUN:   | FileCheck -check-prefix AMD_ARCH %s
+// AMD_ARCH: clang-offload-packager{{.*}} "--image=file={{.*}},triple=amdgcn-amd-gpu,arch=gfx600,kind=sycl,compile-opts=--offload-arch=gfx600"
+
+// RUN: %clangxx -fsycl -### -fsycl-targets=nvptx64-nvidia-cuda \
+// RUN:          -fno-sycl-libspirv -nocudalib --offload-new-driver %s 2>&1 \
+// RUN:   | FileCheck -check-prefix NVPTX_DEF_ARCH %s
+// NVPTX_DEF_ARCH: clang-offload-packager{{.*}} "--image=file={{.*}},triple=nvptx64-nvidia-cuda,arch=sm_50,kind=sycl"


### PR DESCRIPTION
When compiling for -fsycl-targets values of nvptx64-nvidia-cuda and amdgcn-amd-gpu, the default arch behaviors were not applied to the compilation.  Updates to do the following:
 - Add default of sm_50 for nvptx64 if not provided
 - Emit diagnostic if no arch provided for amd
 - Parse -Xsycl-backend-target for offload-arch values