### PR TITLE
[SYCL][COMPAT] Add default ctor to dim3 and update tests/docs

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -78,18 +78,24 @@ those to learn to use the library.
 
 SYCLcompat provides a `dim3` class akin to that of CUDA or HIP programming
 models. `dim3` encapsulates other languages iteration spaces that are
-represented with coordinate letters (x, y, z).
+represented with coordinate letters (x, y, z). In SYCL, the fastest-moving
+dimension is the one with the highest index, e.g. in a SYCL 2D range iteration
+space, there are two dimensions, 0 and 1, and 1 will be the one that "moves
+faster". For CUDA/HIP, the convention is reversed: `x` is the dimension which
+moves fastest. `syclcompat::dim3` follows this convention, so that
+`syclcompat::dim3(32, 4)` is equivalent to `sycl::range<2>(4, 32)`, and
+`syclcompat::dim3(32, 4, 2)` is equivalent to `sycl::range<3>(2, 4, 32)`.
 
 ```cpp
 namespace syclcompat {
 
 class dim3 {
 public:
-  const size_t x, y, z;
+  size_t x, y, z;
   dim3(const sycl::range<3> &r);
   dim3(const sycl::range<2> &r);
   dim3(const sycl::range<1> &r);
-  constexpr dim3(size_t x, size_t y = 1, size_t z = 1);
+  constexpr dim3(size_t x = 1, size_t y = 1, size_t z = 1);
 
   constexpr size_t size();
 
@@ -106,9 +112,7 @@ inline dim3 operator-(const dim3 &a, const dim3 &b);
 } // syclcompat
 ```
 
-In SYCL, the fastest-moving dimension is the one with the highest index, e.g. in
-a SYCL 2D range iteration space, there are two dimensions, 0 and 1, and 1 will
-be the one that "moves faster". The compatibility headers for SYCL offer a
+The compatibility headers for SYCL offer a
 number of convenience functions that help the mapping between xyz-based
 coordinates to SYCL iteration spaces in the different scopes available. In
 addition to the global range, the following helper functions are also provided:

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -112,10 +112,10 @@ inline dim3 operator-(const dim3 &a, const dim3 &b);
 } // syclcompat
 ```
 
-The compatibility headers for SYCL offer a
-number of convenience functions that help the mapping between xyz-based
-coordinates to SYCL iteration spaces in the different scopes available. In
-addition to the global range, the following helper functions are also provided:
+The compatibility headers for SYCL offer a number of convenience functions that
+help the mapping between xyz-based coordinates to SYCL iteration spaces in the
+different scopes available. In addition to the global range, the following
+helper functions are also provided:
 
 ``` c++
 namespace syclcompat {

--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -91,11 +91,11 @@ namespace syclcompat {
 
 class dim3 {
 public:
-  size_t x, y, z;
+  unsigned int x, y, z;
   dim3(const sycl::range<3> &r);
   dim3(const sycl::range<2> &r);
   dim3(const sycl::range<1> &r);
-  constexpr dim3(size_t x = 1, size_t y = 1, size_t z = 1);
+  constexpr dim3(unsigned int x = 1, unsigned int y = 1, unsigned int z = 1);
 
   constexpr size_t size();
 

--- a/sycl/include/syclcompat/dims.hpp
+++ b/sycl/include/syclcompat/dims.hpp
@@ -30,7 +30,7 @@ namespace syclcompat {
 
 class dim3 {
 public:
-  size_t x, y, z;
+  unsigned int x, y, z;
 
   dim3(const sycl::range<3> &r) : x(r[2]), y(r[1]), z(r[0]) {}
 
@@ -38,7 +38,7 @@ public:
 
   dim3(const sycl::range<1> &r) : x(r[0]), y(1), z(1) {}
 
-  constexpr dim3(size_t x = 1, size_t y = 1, size_t z = 1) : x(x), y(y), z(z) {}
+  constexpr dim3(unsigned int x = 1, unsigned int y = 1, unsigned int z = 1) : x(x), y(y), z(z) {}
 
   constexpr size_t size() const { return x * y * z; }
 

--- a/sycl/include/syclcompat/dims.hpp
+++ b/sycl/include/syclcompat/dims.hpp
@@ -38,7 +38,8 @@ public:
 
   dim3(const sycl::range<1> &r) : x(r[0]), y(1), z(1) {}
 
-  constexpr dim3(unsigned int x = 1, unsigned int y = 1, unsigned int z = 1) : x(x), y(y), z(z) {}
+  constexpr dim3(unsigned int x = 1, unsigned int y = 1, unsigned int z = 1)
+      : x(x), y(y), z(z) {}
 
   constexpr size_t size() const { return x * y * z; }
 

--- a/sycl/include/syclcompat/dims.hpp
+++ b/sycl/include/syclcompat/dims.hpp
@@ -30,7 +30,7 @@ namespace syclcompat {
 
 class dim3 {
 public:
-  const size_t x, y, z;
+  size_t x, y, z;
 
   dim3(const sycl::range<3> &r) : x(r[2]), y(r[1]), z(r[0]) {}
 
@@ -38,7 +38,7 @@ public:
 
   dim3(const sycl::range<1> &r) : x(r[0]), y(1), z(1) {}
 
-  constexpr dim3(size_t x, size_t y = 1, size_t z = 1) : x(x), y(y), z(z) {}
+  constexpr dim3(size_t x = 1, size_t y = 1, size_t z = 1) : x(x), y(y), z(z) {}
 
   constexpr size_t size() const { return x * y * z; }
 

--- a/sycl/test-e2e/syclcompat/dim.cpp
+++ b/sycl/test-e2e/syclcompat/dim.cpp
@@ -35,6 +35,33 @@ int main() {
     assert(d3.y == 1);
     assert(d3.z == 1);
   }
+  std::cout << "Testing Empty Construct" << std::endl;
+  {
+    syclcompat::dim3 d3;
+    assert(d3.x == 1);
+    assert(d3.y == 1);
+    assert(d3.z == 1);
+  }
+  std::cout << "Testing Empty Construct & Update" << std::endl;
+  {
+    syclcompat::dim3 d3;
+    d3.x = 1;
+    d3.y = 2;
+    d3.z = 3;
+
+    assert(d3.x == 1);
+    assert(d3.y == 2);
+    assert(d3.z == 3);
+  }
+  std::cout << "Testing Empty Construct & Update 2" << std::endl;
+  {
+    syclcompat::dim3 d3;
+    d3.x = 32;
+
+    assert(d3.x == 32);
+    assert(d3.y == 1);
+    assert(d3.z == 1);
+  }
   std::cout << "Testing Convert" << std::endl;
   {
     syclcompat::dim3 d3(512);


### PR DESCRIPTION
This PR adds a default constructor for `syclcompat::dim3`, and changes the type of members `x`,`y`,`z` from `const size_t` to `unsigned int`. The default constructor sets all 3 dimensions to `1`. This means patterns like this are now possible:

```cpp
syclcompat::dim3 myDim3;
myDim3.x = 32;
```

