### PR TITLE
[SYCL] Don't throw in `device_impl::has`

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -747,8 +747,8 @@ bool device_impl::has(aspect Aspect) const {
     return call_successful && support;
   }
   }
-  throw runtime_error("This device aspect has not been implemented yet.",
-                      PI_ERROR_INVALID_DEVICE);
+
+  return false; // This device aspect has not been implemented yet.
 }
 
 std::shared_ptr<device_impl> device_impl::getHostDeviceImpl() {

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -156,16 +156,9 @@ device::get_info_impl<info::device::aspects>() const {
 #undef __SYCL_ASPECT
   };
 
-  auto UnsupportedAspects = std::remove_if(
-      DeviceAspects.begin(), DeviceAspects.end(), [&](aspect Aspect) {
-        try {
-          return !impl->has(Aspect);
-        } catch (const runtime_error &ex) {
-          if (ex.get_cl_code() == PI_ERROR_INVALID_DEVICE)
-            return true;
-          throw;
-        }
-      });
+  auto UnsupportedAspects =
+      std::remove_if(DeviceAspects.begin(), DeviceAspects.end(),
+                     [&](aspect Aspect) { return !impl->has(Aspect); });
 
   DeviceAspects.erase(UnsupportedAspects, DeviceAspects.end());
 


### PR DESCRIPTION
1) It isn't right
2) We need this change to get rid of deprecated
   `sycl::exception::get_cl_code`