### PR TITLE
[SYCL] Use SYCL 2020 exception in `DispatchHostTask::operator()`

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -343,7 +343,7 @@ class DispatchHostTask {
       try {
         PluginWithEvents.first->call<PiApiKind::piEventsWait>(RawEvents.size(),
                                                               RawEvents.data());
-      } catch (const sycl::exception &E) {
+      } catch (const sycl::exception &) {
         CGHostTask &HostTask = static_cast<CGHostTask &>(MThisCmd->getCG());
         HostTask.MQueue->reportAsyncException(std::current_exception());
         return false;


### PR DESCRIPTION
Part of getting rid of the deprecated `exception::get_cl_code`.