### PR TITLE
[SYCL][Fusion] Improve kernel fusion e2e tests

### DIFF
--- a/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/cancel_fusion.cpp
@@ -1,7 +1,11 @@
-// RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: %{build} -o %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test cancel fusion
+
+// As fusion is cancelled, this test launches two kernels.
+// CHECK-COUNT-2: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>

--- a/sycl/test-e2e/KernelFusion/complete_fusion.cpp
+++ b/sycl/test-e2e/KernelFusion/complete_fusion.cpp
@@ -1,7 +1,11 @@
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test complete fusion without any internalization
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>

--- a/sycl/test-e2e/KernelFusion/cooperative_kernel.cpp
+++ b/sycl/test-e2e/KernelFusion/cooperative_kernel.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test cooperative kernels are not fused

--- a/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
+++ b/sycl/test-e2e/KernelFusion/event_wait_cancel.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Test validity of events after cancel_fusion.

--- a/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
+++ b/sycl/test-e2e/KernelFusion/internal_explicit_dependency.cpp
@@ -1,9 +1,13 @@
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // Test complete fusion where one kernel in the fusion list specifies an
 // explicit dependency (via events) on another kernel in the fusion list.
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include "fusion_event_test_common.h"
 

--- a/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
+++ b/sycl/test-e2e/KernelFusion/jit_caching_multitarget.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: (gpu && (hip || cuda)), cpu
-// RUN: %{build} -fsycl-embed-ir -O2 -o %t.out
+// RUN: %{build} %{embed-ir} -O2 -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run-unfiltered-devices} %t.out 2>&1 | FileCheck %s --implicit-check-not "WRONG a VALUE" --implicit-check-not "WRONG b VALUE"
 
 // Test caching for JIT fused kernels when devices with different architectures

--- a/sycl/test-e2e/KernelFusion/math_function.cpp
+++ b/sycl/test-e2e/KernelFusion/math_function.cpp
@@ -1,7 +1,11 @@
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // Test fusion of a kernel using a math function.
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/KernelFusion/non-kernel-cg.cpp
+++ b/sycl/test-e2e/KernelFusion/non-kernel-cg.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test non-kernel device command groups are not fused

--- a/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
+++ b/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
@@ -8,7 +8,6 @@
 // CHECK-COUNT-1: piEnqueueKernelLaunch
 // CHECK-NOT: piEnqueueKernelLaunch
 
-
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>
 #include <sycl/properties/all_properties.hpp>

--- a/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
+++ b/sycl/test-e2e/KernelFusion/non_unit_local_size.cpp
@@ -1,8 +1,13 @@
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // Test complete fusion with local internalization specified on the
 // accessors, where each work-item processes multiple data-items.
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
+
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>

--- a/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_acc_mem_op.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_buffer_destruction.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_event_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_event_wait.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion cancellation on event::wait() happening before

--- a/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_accessor.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_host_task.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_host_task.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_destruction.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_queue_wait.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_second_queue.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Windows doesn't yet have full shutdown().

--- a/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_two_queues_requirement.cpp
@@ -1,5 +1,5 @@
 // For this test, complete_fusion must be supported.
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 
 // Test fusion cancellation for requirement between two active fusions.

--- a/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
+++ b/sycl/test-e2e/KernelFusion/sync_usm_mem_op.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %{embed-ir} -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=1 %{run} %t.out 2>&1 | FileCheck %s
 // Windows doesn't yet have full shutdown().
 // UNSUPPORTED: ze_debug && windows

--- a/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
+++ b/sycl/test-e2e/KernelFusion/usm_no_dependencies.cpp
@@ -1,8 +1,12 @@
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // Test complete fusion using USM pointers.
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>

--- a/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
+++ b/sycl/test-e2e/KernelFusion/work_group_barrier.cpp
@@ -1,8 +1,12 @@
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // Test complete fusion with a combination of kernels that require a work-group
 // barrier to be inserted by fusion.
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>

--- a/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
+++ b/sycl/test-e2e/KernelFusion/wrapped_usm.cpp
@@ -1,8 +1,12 @@
 // REQUIRES: aspect-usm_shared_allocations
 // RUN: %{build} %{embed-ir} -o %t.out
-// RUN: %{run} %t.out
+// RUN: env SYCL_PI_TRACE=2 %{run} %t.out | FileCheck %s
 
 // Test complete fusion using an wrapped USM pointer as kernel functor argument.
+
+// The two kernels are fused, so only a single, fused kernel is launched.
+// CHECK-COUNT-1: piEnqueueKernelLaunch
+// CHECK-NOT: piEnqueueKernelLaunch
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/codeplay/experimental/fusion_wrapper.hpp>


### PR DESCRIPTION
Improve the kernel fusion end-to-end tests:
* Remove the flag to embed IR on CUDA and AMD backend from the tests that abort execution before requiring access to IR.
* Check for the number of kernel launches to make sure fusion did not fail silently.