### PR TITLE
[SYCL] Fix postcommit

### DIFF
--- a/llvm/test/CodeGen/SPIRV/transcoding/TransFNeg.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/TransFNeg.ll
@@ -1,5 +1,8 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
+; https://github.com/intel/llvm/issues/14372
+; UNSUPPORTED: windows
+
 ; CHECK-SPIRV: OpFNegate
 ; CHECK-SPIRV: OpFNegate
 ; CHECK-SPIRV: OpFNegate

--- a/sycl/source/detail/physical_mem_impl.hpp
+++ b/sycl/source/detail/physical_mem_impl.hpp
@@ -30,9 +30,6 @@ inline sycl::detail::pi::PiVirtualAccessFlags AccessModeToVirtualAccessFlags(
     return PI_VIRTUAL_ACCESS_FLAG_RW;
   case ext::oneapi::experimental::address_access_mode::none:
     return 0;
-  default:
-    throw sycl::exception(make_error_code(errc::invalid),
-                          "Invalid address_access_mode.");
   }
 }
 


### PR DESCRIPTION
Totally broken on all platforms right now.

```
/__w/llvm/llvm/src/sycl/source/detail/physical_mem_impl.hpp:33:3: error: default label in switch which covers all enumeration values [-Werror,-Wcovered-switch-default]
   33 |   default:
```

and

https://github.com/intel/llvm/issues/14372