### PR TITLE
[SYCL] Remove unused parameter in InteropFreeFunc

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -324,7 +324,7 @@ struct EnqueueNativeCommandData {
   std::function<void(interop_handle)> func;
 };
 
-void InteropFreeFunc(pi_queue InteropQueue, void *InteropData) {
+void InteropFreeFunc(pi_queue, void *InteropData) {
   auto *Data = reinterpret_cast<EnqueueNativeCommandData *>(InteropData);
   return Data->func(Data->ih);
 }


### PR DESCRIPTION
This should address the post-commit failure introduced in https://github.com/intel/llvm/pull/14353