### PR TITLE
[SYCL][NATIVECPU] Update OCK tag

### DIFF
--- a/sycl/plugins/native_cpu/CMakeLists.txt
+++ b/sycl/plugins/native_cpu/CMakeLists.txt
@@ -31,13 +31,13 @@ option(NATIVECPU_OCK_USE_FETCHCONTENT "Use FetchContent to acquire oneAPI Constr
 if(NATIVECPU_USE_OCK)
   if(NATIVECPU_OCK_USE_FETCHCONTENT)
     set(OCK_GIT_INTERNAL_REPO "https://github.com/codeplaysoftware/oneapi-construction-kit.git")
-    # commit bd7eadaf7ffc7d74c88dd309119e858b7ffae0cf
-    # Merge: e4f71dc16 792461086
+    # commit 0e913951b61b709ce5c5c136f7557dd88d6e200c
+    # Merge: 0cf91055 85624e50
     # Author: Colin Davidson <colin.davidson@codeplay.com>
-    # Date:   Tue May 7 09:40:38 2024 +0100
-    #     Merge pull request #448 from coldav/colin/support_compiler_passes_only
-    #     Add top level directory which can be used to just build compiler passes
-    set(OCK_GIT_INTERNAL_TAG bd7eadaf7ffc7d74c88dd309119e858b7ffae0cf)
+    # Date:   Mon Jul 1 15:39:36 2024 +0100
+    #     Merge pull request #485 from coldav/colin/fix_memmove_bug_finegrained
+    #     Fix risc-v memmove creating memcpy instrinsic
+    set(OCK_GIT_INTERNAL_TAG 0e913951b61b709ce5c5c136f7557dd88d6e200c)
 
     # Overwrite OCK_GIT_INTERNAL_REPO/OCK_GIT_INTERNAL_TAG if the corresponding options are set
     if(OCK_GIT_REPO)


### PR DESCRIPTION
Updates the git tag used to fetch the oneAPI Construction Kit.