### PR TITLE
[CI] Pass GPU lit options for nightly tests

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -44,6 +44,7 @@ jobs:
             target_devices: ext_oneapi_level_zero:gpu
             reset_gpu: true
             tests_selector: e2e
+            extra_lit_opts: --param gpu-intel-gen12=True
 
           - name: Intel OCL GPU
             runner: '["Linux", "gen12"]'
@@ -52,6 +53,7 @@ jobs:
             target_devices: opencl:gpu
             reset_gpu: true
             tests_selector: e2e
+            extra_lit_opts: --param gpu-intel-gen12=True
 
           - name: OCL CPU (AMD)
             runner: '["Linux", "amdgpu"]'
@@ -116,6 +118,7 @@ jobs:
       name: Intel GEN12 Graphics with Level Zero
       runner: '["Windows","gen12"]'
       sycl_toolchain_archive: ${{ needs.build-win.outputs.artifact_archive_name }}
+      extra_lit_opts: --param gpu-intel-gen12=True
 
   nightly_build_upload:
     name: Nightly Build Upload


### PR DESCRIPTION
Today we don't pass the gpu lit params so we see things running and failing in the nightly that are already disabled in pre/postcommit.

Example:
https://github.com/intel/llvm/actions/runs/9754298775/job/26921343546

```
FAIL: SYCL :: Regression/in_order_barrier_profiling.cpp (1746 of 2090)
******************** TEST 'SYCL :: Regression/in_order_barrier_profiling.cpp' FAILED ********************
Exit Code: -6

Command Output (stdout):
--
# RUN: at line 1
/__w/llvm/llvm/toolchain/bin//clang++   -fsycl -fsycl-targets=spir64  /__w/llvm/llvm/llvm/sycl/test-e2e/Regression/in_order_barrier_profiling.cpp -o /__w/llvm/llvm/build-e2e/Regression/Output/in_order_barrier_profiling.cpp.tmp.out
# executed command: /__w/llvm/llvm/toolchain/bin//clang++ -fsycl -fsycl-targets=spir64 /__w/llvm/llvm/llvm/sycl/test-e2e/Regression/in_order_barrier_profiling.cpp -o /__w/llvm/llvm/build-e2e/Regression/Output/in_order_barrier_profiling.cpp.tmp.out
# note: command had no output on stdout or stderr
# RUN: at line 2
env ONEAPI_DEVICE_SELECTOR=opencl:gpu  /__w/llvm/llvm/build-e2e/Regression/Output/in_order_barrier_profiling.cpp.tmp.out
# executed command: env ONEAPI_DEVICE_SELECTOR=opencl:gpu /__w/llvm/llvm/build-e2e/Regression/Output/in_order_barrier_profiling.cpp.tmp.out
# .---command stderr------------
# | in_order_barrier_profiling.cpp.tmp.out: /__w/llvm/llvm/llvm/sycl/test-e2e/Regression/in_order_barrier_profiling.cpp:42: int main(): Assertion `KernelEnd <= BarrierStart' failed.
# `-----------------------------
# error: command failed with exit status: -6

```

and the test already has:
```
// UNSUPPORTED: level_zero || (linux && opencl && gpu-intel-gen12)
```
