### PR TITLE
[SYCL][E2E] Disable three hanging tests on Gen12 Win

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_vec.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_vec.cpp
@@ -10,6 +10,9 @@
 // TODO enable opaque pointers support on CPU.
 // UNSUPPORTED: cpu || accelerator
 
+// https://github.com/intel/llvm/issues/14397
+// UNSUPPORTED: windows && gpu-intel-gen12
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if preview-breaking-changes-supported %{  %{build} -fpreview-breaking-changes -o %t2.out   %}

--- a/sycl/test-e2e/Basic/stream/stream.cpp
+++ b/sycl/test-e2e/Basic/stream/stream.cpp
@@ -9,6 +9,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// https://github.com/intel/llvm/issues/14397
+// UNSUPPORTED: windows && gpu-intel-gen12
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/properties/all_properties.hpp>

--- a/sycl/test-e2e/Complex/sycl_complex_stream_test.cpp
+++ b/sycl/test-e2e/Complex/sycl_complex_stream_test.cpp
@@ -1,5 +1,8 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-finite-math-only%} %else %{-fno-finite-math-only%}
 
+// https://github.com/intel/llvm/issues/14397
+// UNSUPPORTED: windows && gpu-intel-gen12
+
 // RUN: %{build} -fsycl-device-code-split=per_kernel %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
https://github.com/intel/llvm/issues/14397

The hang causes all jobs after to fail because the install dir can't be deleted, we need to disable these ASAP.