### PR TITLE
[NFCI] Remove/inline [rarely|never] used `exception` ctor overloads

### DIFF
--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -127,31 +127,20 @@ private:
 
 protected:
   // base constructors used by SYCL 1.2.1 exception subclasses
-  exception(std::error_code Ec, const char *Msg, const pi_int32 PIErr,
-            std::shared_ptr<context> Context = nullptr)
-      : exception(Ec, std::string(Msg), PIErr, Context) {}
+  exception(std::error_code Ec, const char *Msg, const pi_int32 PIErr)
+      : exception(Ec, std::string(Msg), PIErr) {}
 
-  exception(std::error_code Ec, const std::string &Msg, const pi_int32 PIErr,
-            std::shared_ptr<context> Context = nullptr)
-      : exception(Ec, Context, Msg + " " + detail::codeToString(PIErr)) {
+  exception(std::error_code Ec, const std::string &Msg, const pi_int32 PIErr)
+      : exception(Ec, nullptr, Msg + " " + detail::codeToString(PIErr)) {
     MPIErr = PIErr;
   }
 
-  exception(const std::string &Msg)
-#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
-      : MMsg(std::make_shared<detail::string>(Msg)), MContext(nullptr){}
-#else
-      : MMsg(std::make_shared<std::string>(Msg)), MContext(nullptr) {
-  }
-#endif
-
-        // base constructor for all SYCL 2020 constructors
-        // exception(context *ctxPtr, std::error_code Ec, const std::string
-        // &what_arg);
-        exception(std::error_code Ec, std::shared_ptr<context> SharedPtrCtx,
-                  const std::string &what_arg)
-      : exception(Ec, SharedPtrCtx, what_arg.c_str()) {
-  }
+  // base constructor for all SYCL 2020 constructors
+  // exception(context *ctxPtr, std::error_code Ec, const std::string
+  // &what_arg);
+  exception(std::error_code Ec, std::shared_ptr<context> SharedPtrCtx,
+            const std::string &what_arg)
+      : exception(Ec, SharedPtrCtx, what_arg.c_str()) {}
   exception(std::error_code Ec, std::shared_ptr<context> SharedPtrCtx,
             const char *WhatArg);
 };

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -136,8 +136,7 @@ protected:
   }
 
   // base constructor for all SYCL 2020 constructors
-  // exception(context *ctxPtr, std::error_code Ec, const std::string
-  // &what_arg);
+  // exception(context *, std::error_code, const std::string);
   exception(std::error_code Ec, std::shared_ptr<context> SharedPtrCtx,
             const std::string &what_arg)
       : exception(Ec, SharedPtrCtx, what_arg.c_str()) {}

--- a/sycl/include/sycl/ext/intel/experimental/online_compiler.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/online_compiler.hpp
@@ -67,7 +67,8 @@ private:
 class online_compile_error : public sycl::exception {
 public:
   online_compile_error() = default;
-  online_compile_error(const std::string &Msg) : sycl::exception(Msg) {}
+  online_compile_error(const std::string &Msg)
+      : sycl::exception(make_error_code(errc::invalid), Msg) {}
 };
 
 /// Designates a source language for the online compiler.

--- a/sycl/test/abi/sycl_symbols_windows.dump
+++ b/sycl/test/abi/sycl_symbols_windows.dump
@@ -529,9 +529,8 @@
 ??0event@_V1@sycl@@QEAA@AEBV012@@Z
 ??0event@_V1@sycl@@QEAA@PEAU_cl_event@@AEBVcontext@12@@Z
 ??0event@_V1@sycl@@QEAA@XZ
-??0exception@_V1@sycl@@IEAA@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@std@@@Z
-??0exception@_V1@sycl@@IEAA@Verror_code@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@4@HV?$shared_ptr@Vcontext@_V1@sycl@@@4@@Z
-??0exception@_V1@sycl@@IEAA@Verror_code@std@@PEBDHV?$shared_ptr@Vcontext@_V1@sycl@@@4@@Z
+??0exception@_V1@sycl@@IEAA@Verror_code@std@@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@4@H@Z
+??0exception@_V1@sycl@@IEAA@Verror_code@std@@PEBDH@Z
 ??0exception@_V1@sycl@@IEAA@Verror_code@std@@V?$shared_ptr@Vcontext@_V1@sycl@@@4@AEBV?$basic_string@DU?$char_traits@D@std@@V?$allocator@D@2@@4@@Z
 ??0exception@_V1@sycl@@IEAA@Verror_code@std@@V?$shared_ptr@Vcontext@_V1@sycl@@@4@PEBD@Z
 ??0exception@_V1@sycl@@QEAA@AEBV012@@Z


### PR DESCRIPTION
SYCL 1.2 exception classes don't use `context` argument so it can be removed. `online_compile_error` was the single user of an overload, so I've removed it and change the ctor used by it.