### PR TITLE
[SYCL] Remove rarely/un-used SYCL 1.2 exceptions

### DIFF
--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -301,20 +301,6 @@ public:
 };
 
 class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::memory_allocation instead.")
-    memory_allocation_error : public device_error {
-public:
-  memory_allocation_error()
-      : device_error(make_error_code(errc::memory_allocation)) {}
-
-  memory_allocation_error(const char *Msg, pi_int32 Err)
-      : memory_allocation_error(std::string(Msg), Err) {}
-
-  memory_allocation_error(const std::string &Msg, pi_int32 Err)
-      : device_error(make_error_code(errc::memory_allocation), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
     "use sycl::exception with sycl::errc::feature_not_supported instead.")
     feature_not_supported : public device_error {
 public:

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -328,19 +328,6 @@ public:
 };
 
 class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::profiling instead.") profiling_error
-    : public device_error {
-public:
-  profiling_error() : device_error(make_error_code(errc::profiling)) {}
-
-  profiling_error(const char *Msg, pi_int32 Err)
-      : profiling_error(std::string(Msg), Err) {}
-
-  profiling_error(const std::string &Msg, pi_int32 Err)
-      : device_error(make_error_code(errc::profiling), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
     "use sycl::exception with sycl::errc::feature_not_supported instead.")
     feature_not_supported : public device_error {
 public:

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -190,19 +190,6 @@ public:
 };
 
 class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::event instead.") event_error
-    : public runtime_error {
-public:
-  event_error() : runtime_error(make_error_code(errc::event)) {}
-
-  event_error(const char *Msg, pi_int32 Err)
-      : event_error(std::string(Msg), Err) {}
-
-  event_error(const std::string &Msg, pi_int32 Err)
-      : runtime_error(make_error_code(errc::event), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.")
     invalid_parameter_error : public runtime_error {
 public:

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -190,19 +190,6 @@ public:
 };
 
 class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::accessor instead.") accessor_error
-    : public runtime_error {
-public:
-  accessor_error() : runtime_error(make_error_code(errc::accessor)) {}
-
-  accessor_error(const char *Msg, pi_int32 Err)
-      : accessor_error(std::string(Msg), Err) {}
-
-  accessor_error(const std::string &Msg, pi_int32 Err)
-      : runtime_error(make_error_code(errc::accessor), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
     "use sycl::exception with sycl::errc::nd_range instead.") nd_range_error
     : public runtime_error {
 public:

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -276,19 +276,6 @@ public:
 
 class __SYCL2020_DEPRECATED(
     "use sycl::exception with a sycl::errc enum value instead.")
-    link_program_error : public device_error {
-public:
-  link_program_error() : device_error(make_error_code(errc::build)) {}
-
-  link_program_error(const char *Msg, pi_int32 Err)
-      : link_program_error(std::string(Msg), Err) {}
-
-  link_program_error(const std::string &Msg, pi_int32 Err)
-      : device_error(make_error_code(errc::build), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
-    "use sycl::exception with a sycl::errc enum value instead.")
     invalid_object_error : public device_error {
 public:
   invalid_object_error() : device_error(make_error_code(errc::invalid)) {}

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -176,19 +176,6 @@ protected:
   runtime_error(std::error_code Ec) : exception(Ec) {}
 };
 
-class __SYCL2020_DEPRECATED("use sycl::exception with sycl::errc::kernel or "
-                            "errc::kernel_argument instead.") kernel_error
-    : public runtime_error {
-public:
-  kernel_error() : runtime_error(make_error_code(errc::kernel)) {}
-
-  kernel_error(const char *Msg, pi_int32 Err)
-      : kernel_error(std::string(Msg), Err) {}
-
-  kernel_error(const std::string &Msg, pi_int32 Err)
-      : runtime_error(make_error_code(errc::kernel), Msg, Err) {}
-};
-
 class __SYCL2020_DEPRECATED(
     "use sycl::exception with sycl::errc::nd_range instead.") nd_range_error
     : public runtime_error {

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -315,19 +315,6 @@ public:
 };
 
 class __SYCL2020_DEPRECATED(
-    "use sycl::exception with sycl::errc::platform instead.") platform_error
-    : public device_error {
-public:
-  platform_error() : device_error(make_error_code(errc::platform)) {}
-
-  platform_error(const char *Msg, pi_int32 Err)
-      : platform_error(std::string(Msg), Err) {}
-
-  platform_error(const std::string &Msg, pi_int32 Err)
-      : device_error(make_error_code(errc::platform), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
     "use sycl::exception with sycl::errc::feature_not_supported instead.")
     feature_not_supported : public device_error {
 public:

--- a/sycl/include/sycl/usm/usm_allocator.hpp
+++ b/sycl/include/sycl/usm/usm_allocator.hpp
@@ -78,7 +78,7 @@ public:
         aligned_alloc(getAlignment(), NumberOfElements * sizeof(value_type),
                       MDevice, MContext, AllocKind, MPropList, CodeLoc));
     if (!Result) {
-      throw memory_allocation_error();
+      throw exception(make_error_code(errc::memory_allocation));
     }
     return Result;
   }

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -109,8 +109,6 @@ int main() {
   sycl::memory_allocation_error mae;
   // expected-warning@+1 {{'platform_error' is deprecated: use sycl::exception with sycl::errc::platform instead.}}
   sycl::platform_error ple;
-  // expected-warning@+1 {{'profiling_error' is deprecated: use sycl::exception with sycl::errc::profiling instead.}}
-  sycl::profiling_error pre;
   // expected-warning@+1 {{'feature_not_supported' is deprecated: use sycl::exception with sycl::errc::feature_not_supported instead.}}
   sycl::feature_not_supported fns;
   // expected-warning@+1{{'exception' is deprecated: The version of an exception constructor which takes no arguments is deprecated.}}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -107,8 +107,6 @@ int main() {
   sycl::invalid_object_error ioe;
   // expected-warning@+1 {{'memory_allocation_error' is deprecated: use sycl::exception with sycl::errc::memory_allocation instead.}}
   sycl::memory_allocation_error mae;
-  // expected-warning@+1 {{'platform_error' is deprecated: use sycl::exception with sycl::errc::platform instead.}}
-  sycl::platform_error ple;
   // expected-warning@+1 {{'feature_not_supported' is deprecated: use sycl::exception with sycl::errc::feature_not_supported instead.}}
   sycl::feature_not_supported fns;
   // expected-warning@+1{{'exception' is deprecated: The version of an exception constructor which takes no arguments is deprecated.}}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -87,8 +87,6 @@ int main() {
 
   // expected-warning@+1 {{'runtime_error' is deprecated: use sycl::exception with sycl::errc::runtime instead.}}
   sycl::runtime_error re;
-  // expected-warning@+1 {{'kernel_error' is deprecated: use sycl::exception with sycl::errc::kernel or errc::kernel_argument instead.}}
-  sycl::kernel_error ke;
   // expected-warning@+1 {{'nd_range_error' is deprecated: use sycl::exception with sycl::errc::nd_range instead.}}
   sycl::nd_range_error ne;
   // expected-warning@+1 {{'event_error' is deprecated: use sycl::exception with sycl::errc::event instead.}}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -89,8 +89,6 @@ int main() {
   sycl::runtime_error re;
   // expected-warning@+1 {{'kernel_error' is deprecated: use sycl::exception with sycl::errc::kernel or errc::kernel_argument instead.}}
   sycl::kernel_error ke;
-  // expected-warning@+1 {{'accessor_error' is deprecated: use sycl::exception with sycl::errc::accessor instead.}}
-  sycl::accessor_error ae;
   // expected-warning@+1 {{'nd_range_error' is deprecated: use sycl::exception with sycl::errc::nd_range instead.}}
   sycl::nd_range_error ne;
   // expected-warning@+1 {{'event_error' is deprecated: use sycl::exception with sycl::errc::event instead.}}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -89,8 +89,6 @@ int main() {
   sycl::runtime_error re;
   // expected-warning@+1 {{'nd_range_error' is deprecated: use sycl::exception with sycl::errc::nd_range instead.}}
   sycl::nd_range_error ne;
-  // expected-warning@+1 {{'event_error' is deprecated: use sycl::exception with sycl::errc::event instead.}}
-  sycl::event_error ee;
   // expected-warning@+1 {{'invalid_parameter_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
   sycl::invalid_parameter_error ipe;
   // expected-warning@+1 {{'device_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -101,8 +101,6 @@ int main() {
   sycl::device_error de;
   // expected-warning@+1 {{'compile_program_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
   sycl::compile_program_error cpe;
-  // expected-warning@+1 {{'link_program_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
-  sycl::link_program_error lpe;
   // expected-warning@+1 {{'invalid_object_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
   sycl::invalid_object_error ioe;
   // expected-warning@+1 {{'feature_not_supported' is deprecated: use sycl::exception with sycl::errc::feature_not_supported instead.}}

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -105,8 +105,6 @@ int main() {
   sycl::link_program_error lpe;
   // expected-warning@+1 {{'invalid_object_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
   sycl::invalid_object_error ioe;
-  // expected-warning@+1 {{'memory_allocation_error' is deprecated: use sycl::exception with sycl::errc::memory_allocation instead.}}
-  sycl::memory_allocation_error mae;
   // expected-warning@+1 {{'feature_not_supported' is deprecated: use sycl::exception with sycl::errc::feature_not_supported instead.}}
   sycl::feature_not_supported fns;
   // expected-warning@+1{{'exception' is deprecated: The version of an exception constructor which takes no arguments is deprecated.}}


### PR DESCRIPTION
Not part of SYCL 2020. Wider used exception subclasses will be removed in individual PRs to ease review.