### PR TITLE
[LLVM] Add missing TargetParser link in FPBuiltinFnSelection

### DIFF
--- a/llvm/lib/Transforms/Scalar/CMakeLists.txt
+++ b/llvm/lib/Transforms/Scalar/CMakeLists.txt
@@ -98,4 +98,5 @@ add_llvm_component_library(LLVMScalarOpts
   InstCombine
   Support
   TransformUtils
+  TargetParser
   )


### PR DESCRIPTION
https://github.com/intel/llvm/pull/14339 moved the FPBuiltinFnSelection pass, but post-commit testing is failing due to the Transform/Scalar CMake not linking with TargetParser. This commit fixes this issue.