### PR TITLE
[SYCL][ESIMD][E2E] Re-enable LSC DG2 Windows test with correct flags

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u32.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_usm_store_u32.cpp
@@ -6,16 +6,15 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: gpu-intel-dg2
-// UNSUPPORTED: windows
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
 
-// TODO: Windows compiler causes this test to fail due to handling of floating
-// point arithmetics. Fixing requires using -Qfp-speculation=safe option to
-// disable some floating point optimizations to produce correct result. icx
-// compiler supports that option while clang-cl does not which causes test to
-// fail when running as part of a test suite. Therefore the test is disabled for
-// windows until equivalent option is found.
+// Windows compiler causes this test to fail due to handling of floating
+// point arithmetics. Fixing requires using
+// -ffp-exception-behavior=maytrap option to disable some floating point
+// optimizations to produce correct result.
+// DEFINE: %{fpflags} = %if cl_options %{/clang:-ffp-exception-behavior=maytrap%} %else %{-ffp-exception-behavior=maytrap%}
+
+// RUN: %{build} %{fpflags} -o %t.out
+// RUN: %{run} %t.out
 
 #include "Inputs/lsc_usm_store.hpp"
 


### PR DESCRIPTION
I verified manually this option fixes the issue that was being tracked internally.

Thanks to @aelovikov-intel for help finding the option that was required.