### PR TITLE
[SYCL] all_props_are_keys_of fix

### DIFF
--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -305,8 +305,8 @@ struct all_props_are_keys_of<
     SyclT, ext::oneapi::experimental::properties<std::tuple<PropT, PropTs...>>>
     : std::bool_constant<
           ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value &&
-          all_props_are_keys_of<SyclT, ext::oneapi::experimental::properties<
-                                           std::tuple<PropTs...>>>::value> {};
+          all_props_are_keys_of<SyclT, ext::oneapi::experimental::detail::
+                                           properties_t<PropTs...>>::value> {};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -295,14 +295,14 @@ struct all_props_are_keys_of<SyclT,
 
 template <typename SyclT, typename PropT>
 struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::properties<std::tuple<PropT>>>
+    SyclT, ext::oneapi::experimental::detail::properties_t<PropT>>
     : std::bool_constant<
           ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value> {
 };
 
 template <typename SyclT, typename PropT, typename... PropTs>
 struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::properties<std::tuple<PropT, PropTs...>>>
+    SyclT, ext::oneapi::experimental::detail::properties_t<PropT, PropTs...>>
     : std::bool_constant<
           ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value &&
           all_props_are_keys_of<SyclT, ext::oneapi::experimental::detail::

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -283,10 +283,10 @@ struct ValueOrDefault<
   }
 };
 
-template <typename SyclT, typename PropertiesT> struct all_props_are_keys_of;
+// all_props_are_keys_of
 
 template <typename SyclT, typename PropertiesT>
-struct all_props_are_keys_of : std::true_type {};
+struct all_props_are_keys_of : std::false_type {};
 
 template <typename SyclT>
 struct all_props_are_keys_of<SyclT,
@@ -305,7 +305,8 @@ struct all_props_are_keys_of<
     SyclT, ext::oneapi::experimental::properties<std::tuple<PropT, PropTs...>>>
     : std::bool_constant<
           ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value &&
-          all_props_are_keys_of<SyclT, PropTs...>()> {};
+          all_props_are_keys_of<SyclT, ext::oneapi::experimental::properties<
+                                           std::tuple<PropTs...>>>::value> {};
 
 } // namespace detail
 } // namespace ext::oneapi::experimental

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -146,8 +146,7 @@ void test_build_and_run() {
   std::vector<sycl::device> devs = kbSrc.get_devices();
   exe_kb kbExe2 = syclex::build(
       kbSrc, devs,
-      syclex::properties{// syclex::build_options{flags},
-                         syclex::save_log{&log},
+      syclex::properties{syclex::build_options{flags}, syclex::save_log{&log},
                          syclex::registered_kernel_names{"ff_templated<int>"}});
   assert(log.find("warning: 'this_nd_item<1>' is deprecated") !=
          std::string::npos);

--- a/sycl/test/extensions/kernel_compiler_constraints.cpp
+++ b/sycl/test/extensions/kernel_compiler_constraints.cpp
@@ -82,7 +82,6 @@ int main() {
   syclex::build(kbSrc, syclex::properties{syclex::build_options{flags},
                                           syclex::save_log{&log}});
 
-  // expected-error@../include/sycl/ext/oneapi/properties/properties.hpp:* {{too many template arguments for class template 'all_props_are_keys_of'}}
   // expected-error@+1 {{no matching function for call to 'build'}}
   syclex::build(kbSrc, syclex::properties{
                            syclex::build_options{flags}, syclex::save_log{&log},


### PR DESCRIPTION
fixing minor sfinae problem in all_props_are_keys_of and updating tests accordingly.

at the moment the kernel_compiler is the only user of `all_props_are_keys_of` 