### PR TITLE
[SYCL][E2E] Change launch.cpp on dg2 to unsupported

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -20,7 +20,7 @@
  *     launch<F> and launch<F> with dinamyc local memory tests
  **************************************************************************/
 // https://github.com/intel/llvm/issues/14387
-// XFAIL: gpu-intel-dg2
+// UNSUPPORTED: gpu-intel-dg2
 // RUN: %clangxx -std=c++20 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
The sycl/test-e2e/syclcompat/launch/launch.cpp test was marked XFAIL but seems to be passing in post-commit. This commit changes in to UNSUPPORTED.