### PR TITLE
[SYCL] Fix reporting duplicate composite devices

### DIFF
--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -124,7 +124,7 @@ std::vector<device> platform::ext_oneapi_get_composite_devices() const {
     auto Composite = Dev.get_info<
         sycl::ext::oneapi::experimental::info::device::composite_device>();
     if (std::find(Composites.begin(), Composites.end(), Composite) ==
-        Result.end())
+        Composites.end())
       Composites.push_back(Composite);
   }
   for (const auto &Composite : Composites) {

--- a/sycl/source/platform.cpp
+++ b/sycl/source/platform.cpp
@@ -123,7 +123,8 @@ std::vector<device> platform::ext_oneapi_get_composite_devices() const {
 
     auto Composite = Dev.get_info<
         sycl::ext::oneapi::experimental::info::device::composite_device>();
-    if (std::find(Result.begin(), Result.end(), Composite) == Result.end())
+    if (std::find(Composites.begin(), Composites.end(), Composite) ==
+        Result.end())
       Composites.push_back(Composite);
   }
   for (const auto &Composite : Composites) {


### PR DESCRIPTION
This patch intended to be an improvement for composite device implementation code coverage, but it turned out that it also helped to find a bug in the implementaiton.