### PR TITLE
[SYCL][NATIVECPU] Support specialization constants on Native CPU

### DIFF
--- a/llvm/lib/SYCLLowerIR/SpecConstants.cpp
+++ b/llvm/lib/SYCLLowerIR/SpecConstants.cpp
@@ -9,9 +9,7 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/SYCLLowerIR/SpecConstants.h"
-#include "llvm/IR/DerivedTypes.h"
 #include "llvm/SYCLLowerIR/Support.h"
-#include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/StringMap.h"
@@ -939,7 +937,6 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
           unsigned Size = M.getDataLayout().getTypeStoreSize(SCTy);
           uint64_t Align = M.getDataLayout().getABITypeAlign(SCTy).value();
 
-
           // Ensure correct alignment
           if (CurrentOffset % Align != 0) {
             // Compute necessary padding to correctly align the constant.
@@ -954,14 +951,9 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
             updatePaddingInLastMDNode(Ctx, SCMetadata, Padding);
           }
 
-          if (sycl::utils::isSYCLNativeCPU(M) && isa<StructType>(DefaultValue->getType())) {
-            auto STy = cast<StructType>(DefaultValue->getType());
-            SCMetadata[SymID] = generateSpecConstantMetadata(
-                M, SymID, STy, NextID, /* is native spec constant */ false);
-          } else {
-            SCMetadata[SymID] = generateSpecConstantMetadata(
-                M, SymID, SCTy, NextID, /* is native spec constant */ false);
-          }
+          auto *DefValTy = DefaultValue->getType();
+          SCMetadata[SymID] = generateSpecConstantMetadata(
+              M, SymID, DefValTy, NextID, /* is native spec constant */ false);
 
           ++NextID.ID;
           NextOffset += Size;

--- a/llvm/lib/SYCLLowerIR/SpecConstants.cpp
+++ b/llvm/lib/SYCLLowerIR/SpecConstants.cpp
@@ -9,7 +9,9 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/SYCLLowerIR/SpecConstants.h"
+#include "llvm/IR/DerivedTypes.h"
 #include "llvm/SYCLLowerIR/Support.h"
+#include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
 
 #include "llvm/ADT/APInt.h"
 #include "llvm/ADT/StringMap.h"
@@ -937,6 +939,7 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
           unsigned Size = M.getDataLayout().getTypeStoreSize(SCTy);
           uint64_t Align = M.getDataLayout().getABITypeAlign(SCTy).value();
 
+
           // Ensure correct alignment
           if (CurrentOffset % Align != 0) {
             // Compute necessary padding to correctly align the constant.
@@ -951,8 +954,14 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
             updatePaddingInLastMDNode(Ctx, SCMetadata, Padding);
           }
 
-          SCMetadata[SymID] = generateSpecConstantMetadata(
-              M, SymID, SCTy, NextID, /* is native spec constant */ false);
+          if (sycl::utils::isSYCLNativeCPU(M) && isa<StructType>(DefaultValue->getType())) {
+            auto STy = cast<StructType>(DefaultValue->getType());
+            SCMetadata[SymID] = generateSpecConstantMetadata(
+                M, SymID, STy, NextID, /* is native spec constant */ false);
+          } else {
+            SCMetadata[SymID] = generateSpecConstantMetadata(
+                M, SymID, SCTy, NextID, /* is native spec constant */ false);
+          }
 
           ++NextID.ID;
           NextOffset += Size;

--- a/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
@@ -13,6 +13,7 @@ add_llvm_component_library(LLVMSYCLNativeCPUUtils
   Core
   Support
   Passes
+  SYCLLowerIR
   Target
   TargetParser
   TransformUtils

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -17,6 +17,7 @@
 #include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
 #include "llvm/Support/CommandLine.h"
 #include "llvm/SYCLLowerIR/SpecConstants.h"
+#include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
 
 #ifdef NATIVECPU_USE_OCK
 #include "compiler/utils/builtin_info.h"

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -14,10 +14,9 @@
 #include "llvm/SYCLLowerIR/ConvertToMuxBuiltinsSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/RenameKernelSYCLNativeCPU.h"
-#include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
-#include "llvm/Support/CommandLine.h"
 #include "llvm/SYCLLowerIR/SpecConstants.h"
 #include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
+#include "llvm/Support/CommandLine.h"
 
 #ifdef NATIVECPU_USE_OCK
 #include "compiler/utils/builtin_info.h"

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -16,6 +16,7 @@
 #include "llvm/SYCLLowerIR/RenameKernelSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
 #include "llvm/Support/CommandLine.h"
+#include "llvm/SYCLLowerIR/SpecConstants.h"
 
 #ifdef NATIVECPU_USE_OCK
 #include "compiler/utils/builtin_info.h"
@@ -60,6 +61,7 @@ static cl::opt<bool>
 void llvm::sycl::utils::addSYCLNativeCPUBackendPasses(
     llvm::ModulePassManager &MPM, ModuleAnalysisManager &MAM,
     OptimizationLevel OptLevel) {
+  MPM.addPass(SpecConstantsPass(SpecConstantsPass::HandlingMode::emulation));
   MPM.addPass(ConvertToMuxBuiltinsSYCLNativeCPUPass());
 #ifdef NATIVECPU_USE_OCK
   MPM.addPass(compiler::utils::TransferKernelMetadataPass());

--- a/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
@@ -473,6 +473,5 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
       ModuleChanged = true;
     }
   }
-
   return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
@@ -473,5 +473,6 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
       ModuleChanged = true;
     }
   }
+
   return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -156,8 +156,8 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   )
 
   fetch_adapter_source(native_cpu
-    ${UNIFIED_RUNTIME_REPO}
-    ${UNIFIED_RUNTIME_TAG}
+    "https://github.com/PietroGhg/unified-runtime.git"
+    pietro/native_cpu_specconstants
   )
 
   if(SYCL_UR_OVERRIDE_FETCH_CONTENT_REPO)

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -117,13 +117,13 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit f31160dea6d142014f441bc4ca5e58e48827490e
-  # Merge: 2bbe9526 64068799
-  # Author: Piotr Balcer <piotr.balcer@intel.com>
-  # Date:   Thu Sep 12 14:19:48 2024 +0200
-  #     Merge pull request #2083 from kswiecicki/xpti-init-fix
-  #     Fix XPTI initialization bug
-  set(UNIFIED_RUNTIME_TAG f31160dea6d142014f441bc4ca5e58e48827490e)
+  # commit fa9ebe7bd3d9bd11dd5ea8a59eff12f5746411d3
+  # Merge: 92638b2a 9eb1c74f
+  # Author: Omar Ahmed <omar.ahmed@codeplay.com>
+  # Date:   Fri Sep 13 14:44:27 2024 +0100
+  #     Merge pull request #1821 from PietroGhg/pietro/native_cpu_specconstants
+  #     [NATIVECPU] Initial support for spec constants on Native CPU
+  set(UNIFIED_RUNTIME_TAG fa9ebe7bd3d9bd11dd5ea8a59eff12f5746411d3)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need
@@ -156,8 +156,8 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   )
 
   fetch_adapter_source(native_cpu
-    "https://github.com/PietroGhg/unified-runtime.git"
-    pietro/native_cpu_specconstants
+    ${UNIFIED_RUNTIME_REPO}
+    ${UNIFIED_RUNTIME_TAG}
   )
 
   if(SYCL_UR_OVERRIDE_FETCH_CONTENT_REPO)

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -329,6 +329,8 @@ bool is_compatible(const std::vector<kernel_id> &KernelIDs, const device &Dev) {
       return BE == sycl::backend::ext_oneapi_cuda;
     } else if (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_AMDGCN) == 0) {
       return BE == sycl::backend::ext_oneapi_hip;
+    } else if (strcmp(Target, __SYCL_PI_DEVICE_BINARY_TARGET_NATIVE_CPU) == 0) {
+      return BE == sycl::backend::ext_oneapi_native_cpu;
     }
 
     return false;

--- a/sycl/source/kernel_bundle.cpp
+++ b/sycl/source/kernel_bundle.cpp
@@ -329,7 +329,7 @@ bool is_compatible(const std::vector<kernel_id> &KernelIDs, const device &Dev) {
       return BE == sycl::backend::ext_oneapi_cuda;
     } else if (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_AMDGCN) == 0) {
       return BE == sycl::backend::ext_oneapi_hip;
-    } else if (strcmp(Target, __SYCL_PI_DEVICE_BINARY_TARGET_NATIVE_CPU) == 0) {
+    } else if (strcmp(Target, __SYCL_DEVICE_BINARY_TARGET_NATIVE_CPU) == 0) {
       return BE == sycl::backend::ext_oneapi_native_cpu;
     }
 

--- a/sycl/test-e2e/SpecConstants/2020/kernel-bundle-api.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/kernel-bundle-api.cpp
@@ -11,6 +11,7 @@
 // RUN: %{run} %t.out
 //
 // UNSUPPORTED: hip
+// UNSUPPORTED: native_cpu
 
 #include <cstdlib>
 #include <iostream>


### PR DESCRIPTION
Adds support to specialization constants by scheduling the `SpecConstantsPass` in the Native CPU pass pipeline. A small change is needed in that pass since, due to ABI, the return type of the spec const builtins can't be used to determine the type of the spec constant, so for Native CPU we use the default value instead.

UR PR: https://github.com/oneapi-src/unified-runtime/pull/1821