### PR TITLE
[SYCL][UT] Fix scheduler resources cleanup in PiMock dtor

### DIFF
--- a/sycl/unittests/helpers/PiMock.hpp
+++ b/sycl/unittests/helpers/PiMock.hpp
@@ -34,6 +34,7 @@
 #include <detail/global_handler.hpp>
 #include <detail/platform_impl.hpp>
 #include <detail/plugin.hpp>
+#include <detail/scheduler/scheduler.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/pi.hpp>
 #include <sycl/device.hpp>
@@ -237,7 +238,11 @@ public:
       return;
 
     MPiPluginMockPtr->PiFunctionTable = *OrigFuncTable;
-    detail::GlobalHandler::instance().prepareSchedulerToRelease(true);
+    // calling drainThreadPool and releaseResources explicitly due to win
+    // related WA in shutdown process
+    detail::GlobalHandler::instance().drainThreadPool();
+    detail::GlobalHandler::instance().getScheduler().releaseResources(
+        detail::BlockingT::BLOCKING);
     detail::GlobalHandler::instance().releaseDefaultContexts();
   }
 


### PR DESCRIPTION
Does scheduler cleanup explicitly. Windows path has some "cut" code in prepareSchedulerForRelease (due to shutdown features) that makes this function useless for UT PiMock cleanup.

fixes https://github.com/intel/llvm/issues/13457