### PR TITLE
[SYCL][CUDA] XFAIL the root_group barrier test for Cuda until it is implemented correctly

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/root_group.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/root_group.cpp
@@ -1,5 +1,7 @@
 // Fails with opencl non-cpu, enable when fixed.
-// XFAIL: (opencl && !cpu && !accelerator)
+// Temporarily disabled for Cuda due to a known issue. Enable it again when the
+// root group barrier functionality is implemented correct in the NVPTX backend.
+// XFAIL: (opencl && !cpu && !accelerator) || cuda
 // RUN: %{build} -I . -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
The root group barrier support for Cuda is currently being worked on but we need this test to not fail in the CI for now in order to get other related functionality through. For example, see https://github.com/oneapi-src/unified-runtime/pull/1796.