### PR TITLE
[DeviceSanitizer][test] Update test to satisfy both libstdc++ and libc++

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/common/demangle-kernel-name.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/demangle-kernel-name.cpp
@@ -1,7 +1,6 @@
 // REQUIRES: linux, cpu
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t &> %t.txt 
-// RUN: FileCheck --check-prefix=LIBSTDCXX --input-file %t.txt %s || FileCheck --check-prefix=LIBCXX --input-file %t.txt %s
+// RUN: env SYCL_PREFER_UR=1 %{run} not %t &> %t.txt ; FileCheck --input-file %t.txt %s
 #include <sycl/detail/core.hpp>
 
 #include <sycl/usm.hpp>
@@ -17,8 +16,7 @@ int main() {
         [=](sycl::nd_item<1> item) { ++array[item.get_global_id(0)]; });
   });
   Q.wait();
-  // LIBSTDCXX: kernel <typeinfo name for main::{lambda(sycl::_V1::handler&)#1}::operator()(sycl::_V1::handler&) const::MyKernel>
-  // LIBCXX: kernel <typeinfo name for main::'lambda'(sycl::_V1::handler&)::operator()(sycl::_V1::handler&) const::MyKernel>
+  // CHECK: kernel <typeinfo name for main::{{.*\(sycl::_V1::handler&\).*}}::operator()(sycl::_V1::handler&) const::MyKernel>
 
   sycl::free(array, Q);
   return 0;

--- a/sycl/test-e2e/AddressSanitizer/common/demangle-kernel-name.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/demangle-kernel-name.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: linux, cpu
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
-// RUN: env SYCL_PREFER_UR=1 %{run} not %t &> %t.txt ; FileCheck --input-file %t.txt %s
+// RUN: env SYCL_PREFER_UR=1 %{run} not %t &> %t.txt 
+// RUN: FileCheck --check-prefix=LIBSTDCXX --input-file %t.txt %s || FileCheck --check-prefix=LIBCXX --input-file %t.txt %s
 #include <sycl/detail/core.hpp>
 
 #include <sycl/usm.hpp>
@@ -16,7 +17,8 @@ int main() {
         [=](sycl::nd_item<1> item) { ++array[item.get_global_id(0)]; });
   });
   Q.wait();
-  // CHECK: kernel <typeinfo name for main::{lambda(sycl::_V1::handler&)#1}::operator()(sycl::_V1::handler&) const::MyKernel>
+  // LIBSTDCXX: kernel <typeinfo name for main::{lambda(sycl::_V1::handler&)#1}::operator()(sycl::_V1::handler&) const::MyKernel>
+  // LIBCXX: kernel <typeinfo name for main::'lambda'(sycl::_V1::handler&)::operator()(sycl::_V1::handler&) const::MyKernel>
 
   sycl::free(array, Q);
   return 0;


### PR DESCRIPTION
The implementation of kernel name detangling is standard lib dependent, and both libstdc++ and libc++ are likely to be used, so we should make the test pass both with libstdc++ and libc++.