### PR TITLE
[SYCL][Graph] Track disabled E2E Tests

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/Explicit/add_nodes_after_finalize.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_host.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: aspect-usm_host_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_mixed.cpp
@@ -9,6 +9,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/basic_usm_shared.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Host to device copy command not supported for OpenCL
+// Intended - Host to device copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_2d.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Host to device copy command not supported for OpenCL
+// Intended - Host to device copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_host2target_offset.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Host to device copy command not supported for OpenCL
+// Intended - Host to device copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Device to host copy command not supported for OpenCL
+// Intended - Device to host copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_2d.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Device to host copy command not supported for OpenCL
+// Intended - Device to host copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/buffer_copy_target2host_offset.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Device to host copy command not supported for OpenCL
+// Intended - Device to host copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/host_task2_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task2_multiple_roots.cpp
@@ -7,11 +7,12 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// Concurrent access to shared USM allocations is not supported by CUDA on
-// Windows
+// Intended - Concurrent access to shared USM allocations is not supported by
+// CUDA on Windows
 // UNSUPPORTED: cuda && windows
 
 // Test is flaky on Windows for all targets, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/host_task_last.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_last.cpp
@@ -3,7 +3,7 @@
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// Disabled due to https://github.com/intel/llvm/issues/14350
+// Disabled due to https://github.com/intel/llvm/issues/14473
 // Extra run to check for immediate-command-list in Level Zero
 // xRUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 

--- a/sycl/test-e2e/Graph/Explicit/host_task_multiple_deps.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_multiple_deps.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/host_task_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_multiple_roots.cpp
@@ -7,11 +7,12 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// Concurrent access to shared USM allocations is not supported by CUDA on
-// Windows
+// Intended Concurrent access to shared USM allocations is not supported by
+// CUDA on Windows
 // UNSUPPORTED: cuda && windows
 
 // Test is flaky on Windows for all targets, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/host_task_single.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_single.cpp
@@ -2,10 +2,12 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
 // Extra run to check for immediate-command-list in Level Zero
 // Immediate command-list testing is disabled on Windows due to a
 // non-deterministic leak of the Level Zero context, and is intended
 // to be re-enabled once this can be investigated and fixed.
+// https://github.com/intel/llvm/issues/14473
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_host_allocations

--- a/sycl/test-e2e/Graph/Explicit/memadvise.cpp
+++ b/sycl/test-e2e/Graph/Explicit/memadvise.cpp
@@ -3,7 +3,7 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// Mem advise command not supported for OpenCL
+// Intended - Mem advise command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 // Since Mem advise is only a memory hint that doesn't

--- a/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/Explicit/multiple_exec_graphs.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/prefetch.cpp
+++ b/sycl/test-e2e/Graph/Explicit/prefetch.cpp
@@ -3,7 +3,7 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// prefetch command not supported for OpenCL
+// Intended - prefetch command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 // Since Prefetch is only a memory hint that doesn't

--- a/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_constructor_usm.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/Explicit/queue_shortcuts.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_handler_api.cpp
@@ -6,7 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// The following limitation is not restricted to Sycl-Graph
+// Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/Explicit/spec_constants_kernel_bundle_api.cpp
@@ -6,7 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// The following limitation is not restricted to Sycl-Graph
+// Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/kernel-bundle-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/Explicit/sub_graph.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_copy.cpp
@@ -6,7 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 //
-// USM copy command not supported for OpenCL
+// Intended - USM copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// USM fill command not supported for OpenCL
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_host.cpp
@@ -7,7 +7,7 @@
 
 // REQUIRES: aspect-usm_host_allocations
 
-// USM fill command not supported for OpenCL
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_fill_shared.cpp
@@ -7,7 +7,7 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// USM fill command not supported for OpenCL
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/Explicit/usm_memset.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// USM memset command not supported for OpenCL
+// Intended - USM memset command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_EXPLICIT

--- a/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/Explicit/work_group_size_prop.cpp
@@ -6,14 +6,16 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// Temporarily disabled for CUDA and OpenCL
+// Temporarily disabled for CUDA and HIP
+// Note: failing negative test with HIP in the original test
+// XFAIL: cuda, hip
+
+// Intended OpenCL fail due to backend:
 // The OpenCL emulation layer does not return `CL_INVALID_WORK_GROUP_SIZE` as it
 // should. So the Sycl graph support cannot correctly catch the error and throw
-// the approriate exception for negative test. An issue has been reported
+// the appropriate exception for negative test. An issue has been reported
 // https://github.com/bashbaug/SimpleOpenCLSamples/issues/95
-// XFAIL: cuda, hip
 // UNSUPPORTED: opencl
-// Note: failing negative test with HIP in the original test
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/RecordReplay/add_nodes_after_finalize.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/add_nodes_after_finalize.cpp
@@ -7,6 +7,7 @@
 //
 //
 // Temporarily disabled until failure is addressed.
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/after_use.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 // This test attempts recording a set of kernels after they have already been

--- a/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/barrier_with_work.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #include "../graph_common.hpp"

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_host.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: aspect-usm_host_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_mixed.cpp
@@ -9,6 +9,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/basic_usm_shared.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Host to device copy command not supported for OpenCL
+// Intended - Host to device copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_2d.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Host to device copy command not supported for OpenCL
+// Intended - Host to device copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_host2target_offset.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Host to device copy command not supported for OpenCL
+// Intended - Host to device copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Device to host copy command not supported for OpenCL
+// Intended - Device to host copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_2d.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Device to host copy command not supported for OpenCL
+// Intended - Device to host copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/buffer_copy_target2host_offset.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// Device to host copy command not supported for OpenCL
+// Intended - Device to host copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/host_task2_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task2_multiple_roots.cpp
@@ -7,11 +7,12 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// Concurrent access to shared USM allocations is not supported by CUDA on
-// Windows
+// Intended - Concurrent access to shared USM allocations is not supported by
+// CUDA on Windows
 // UNSUPPORTED: cuda && windows
 
 // Test is flaky on Windows for all targets, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_deps.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_deps.cpp
@@ -8,6 +8,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_roots.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_multiple_roots.cpp
@@ -7,11 +7,12 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// Concurrent access to shared USM allocations is not supported by CUDA on
-// Windows
+// Concurrent access to shared USM allocations is not supported by
+// CUDA on Windows
 // UNSUPPORTED: cuda && windows
 
 // Test is flaky on Windows for all targets, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_single.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_single.cpp
@@ -2,10 +2,12 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+//
 // Extra run to check for immediate-command-list in Level Zero
 // Immediate command-list testing is disabled on Windows due to a
 // non-deterministic leak of the Level Zero context, and is intended
 // to be re-enabled once this can be investigated and fixed.
+// https://github.com/intel/llvm/issues/14473
 // RUN: %if level_zero && linux %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_host_allocations

--- a/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
@@ -3,7 +3,7 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// Mem advise command not supported for OpenCL
+// Intended - Mem advise command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 // Since Mem advise is only a memory hint that doesn't

--- a/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/multiple_exec_graphs.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
@@ -3,7 +3,7 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// prefetch command not supported for OpenCL
+// Inteded - prefetch command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 // Since Prefetch is only a memory hint that doesn't

--- a/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_constructor_usm.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/queue_shortcuts.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_handler_api.cpp
@@ -6,7 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// The following limitation is not restricted to Sycl-Graph
+// Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/handler-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/spec_constants_kernel_bundle_api.cpp
@@ -6,7 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// The following limitation is not restricted to Sycl-Graph
+// Intended - The following limitation is not restricted to Sycl-Graph
 // but comes from the orignal test : `SpecConstants/2020/kernel-bundle-api.cpp`
 // FIXME: ACC devices use emulation path, which is not yet supported
 // UNSUPPORTED: accelerator

--- a/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/sub_graph.cpp
@@ -6,6 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // Test is flaky on Windows, disable until it can be fixed
+// https://github.com/intel/llvm/issues/11852
 // UNSUPPORTED: windows
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// USM copy command not supported for OpenCL
+// Intended - USM copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_copy_in_order.cpp
@@ -6,7 +6,7 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 //
-// USM copy command not supported for OpenCL
+// Intended - USM copy command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 // Tests memcpy operation using device USM and an in-order queue.

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
-// USM fill command not supported for OpenCL
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill_host.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill_host.cpp
@@ -7,7 +7,7 @@
 
 // REQUIRES: aspect-usm_host_allocations
 
-// USM fill command not supported for OpenCL
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/usm_fill_shared.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_fill_shared.cpp
@@ -7,7 +7,7 @@
 
 // REQUIRES: aspect-usm_shared_allocations
 
-// USM fill command not supported for OpenCL
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_memset.cpp
@@ -5,7 +5,7 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// USM memset command not supported for OpenCL
+// Intended - USM memset command not supported for OpenCL
 // UNSUPPORTED: opencl
 
 #define GRAPH_E2E_RECORD_REPLAY

--- a/sycl/test-e2e/Graph/RecordReplay/usm_memset_shortcut.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/usm_memset_shortcut.cpp
@@ -2,7 +2,8 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{ %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
-// USM fill command not supported for OpenCL
+//
+// Intended - USM fill command not supported for OpenCL
 // UNSUPPORTED: opencl
 //
 // Tests adding a USM memset queue shortcut operation as a graph node.

--- a/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/work_group_size_prop.cpp
@@ -6,14 +6,16 @@
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 //
 
-// Temporarily disabled for CUDA and OpenCL
+// Temporarily disabled for CUDA and HIP
+// XFAIL: cuda, hip
+// Note: failing negative test with HIP in the original test
+//
+// Intended - OpenCL fail due to backend
 // The OpenCL emulation layer does not return `CL_INVALID_WORK_GROUP_SIZE` as it
 // should. So the Sycl graph support cannot correctly catch the error and throw
 // the approriate exception for negative test. An issue has been reported
 // https://github.com/bashbaug/SimpleOpenCLSamples/issues/95
-// XFAIL: cuda, hip
 // UNSUPPORTED: opencl
-// Note: failing negative test with HIP in the original test
 
 #define GRAPH_E2E_RECORD_REPLAY
 

--- a/sycl/test-e2e/Graph/UnsupportedDevice/device_query.cpp
+++ b/sycl/test-e2e/Graph/UnsupportedDevice/device_query.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// OpenCL support depends on extensions
+// Intended - OpenCL support depends on extensions
 // UNSUPPORTED: opencl
 
 // Tests the using device query for graphs support, and that the return value

--- a/sycl/test-e2e/Graph/lit.local.cfg
+++ b/sycl/test-e2e/Graph/lit.local.cfg
@@ -1,1 +1,2 @@
+# Disabled on Arc due to https://github.com/intel/llvm/issues/14474
 config.unsupported_features += ['gpu-intel-dg2']


### PR DESCRIPTION
Improve tracking of disabled E2E tests by providing a link to GitHub issue where the bug is tracked, or explicitly mentioning that a skip is intended, i.e. Due to a known limitation external to the SYCL RT.

See the [OpenCL section](https://github.com/intel/llvm/blob/sycl/sycl/doc/design/CommandGraph.md#limitations) of the SYCL-Graph design doc as to why a large number of tests are intended skips on the OpenCL backend.

Unsupported SYCL-Graph tests currently fall into 3 categories:
* [Flaky Windows tests](https://github.com/intel/llvm/issues/11852)
* [Arc fails](https://github.com/intel/llvm/issues/14474)
* [host-task leaks when using with L0 immediate command-lists](https://github.com/intel/llvm/issues/14473)