### PR TITLE
[SYCL] suppression of error dialogs in Win sycl-ls. 

### DIFF
--- a/sycl/tools/sycl-ls/sycl-ls.cpp
+++ b/sycl/tools/sycl-ls/sycl-ls.cpp
@@ -346,6 +346,7 @@ int main(int argc, char **argv) {
   if (DiscardFilters && FilterEnvVars.size()) {
     return unsetFilterEnvVarsAndFork();
   }
+  SetErrorMode(SEM_FAILCRITICALERRORS); // no need to restore in sycl-ls
 #endif
 
   try {


### PR DESCRIPTION
This is mostly relevant when sycl-ls might be run in the context of really old drivers/lzloader.  It is a workaround for some Win test systems.