### PR TITLE
[SYCL][ESIMD][ABI Break] Remove predec atomic op

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -908,9 +908,6 @@ static std::string getESIMDIntrinSuffix(id::FunctionEncoding *FE,
     case 0x14:
       Suff = ".fsub";
       break;
-    case 0xff:
-      Suff = ".predec";
-      break;
     default:
       llvm_unreachable("unknown atomic OP");
     };

--- a/sycl/include/sycl/ext/intel/esimd/common.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/common.hpp
@@ -198,9 +198,6 @@ enum class atomic_op : uint8_t {
   fsub = 0x14,
   load = 0x15,
   store = 0x16,
-  /// Decrement: <code>*addr = *addr - 1</code>. The only operation which
-  /// returns new value of the destination rather than old.
-  predec = 0xff,
 };
 
 #undef __ESIMD_USM_DWORD_TO_LSC_MSG
@@ -211,7 +208,6 @@ namespace detail {
 template <__ESIMD_NS::atomic_op Op> constexpr bool has_lsc_equivalent() {
   switch (Op) {
   case __ESIMD_NS::atomic_op::xchg:
-  case __ESIMD_NS::atomic_op::predec:
     return false;
   default:
     return true;
@@ -315,7 +311,6 @@ template <__ESIMD_NS::atomic_op Op> constexpr int get_num_args() {
   case __ESIMD_NS::atomic_op::load:
     return 0;
   case __ESIMD_NS::atomic_op::xchg:
-  case __ESIMD_NS::atomic_op::predec:
   case __ESIMD_NS::atomic_op::store:
   case __ESIMD_NS::atomic_op::add:
   case __ESIMD_NS::atomic_op::sub:

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -5606,7 +5606,6 @@ constexpr void check_atomic() {
 
   if constexpr (Op == __ESIMD_NS::atomic_op::xchg ||
                 Op == __ESIMD_NS::atomic_op::cmpxchg ||
-                Op == __ESIMD_NS::atomic_op::predec ||
                 Op == __ESIMD_NS::atomic_op::inc ||
                 Op == __ESIMD_NS::atomic_op::dec) {
 

--- a/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/atomic_smoke.cpp
@@ -120,8 +120,6 @@ const char *to_string(DWORDAtomicOp op) {
     return "load";
   case DWORDAtomicOp::store:
     return "store";
-  case DWORDAtomicOp::predec:
-    return "predec";
   }
   return "<unknown>";
 }

--- a/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/local_accessor_atomic_smoke.cpp
@@ -87,8 +87,6 @@ const char *to_string(DWORDAtomicOp op) {
     return "load";
   case DWORDAtomicOp::store:
     return "store";
-  case DWORDAtomicOp::predec:
-    return "predec";
   }
   return "<unknown>";
 }

--- a/sycl/test-e2e/ESIMD/lsc/lsc_slm_atomic_smoke.cpp
+++ b/sycl/test-e2e/ESIMD/lsc/lsc_slm_atomic_smoke.cpp
@@ -37,8 +37,6 @@ template <class, int, template <class, int> class> class TestID;
 
 const char *to_string(LSCAtomicOp op) {
   switch (op) {
-  case LSCAtomicOp::predec:
-    return "lsc::predec";
   case LSCAtomicOp::add:
     return "lsc::add";
   case LSCAtomicOp::sub:

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update.hpp
@@ -82,8 +82,6 @@ const char *to_string(atomic_op op) {
     return "load";
   case atomic_op::store:
     return "store";
-  case atomic_op::predec:
-    return "predec";
   }
   return "<unknown>";
 }

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update_slm.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/atomic_update_slm.hpp
@@ -65,8 +65,6 @@ const char *to_string(atomic_op op) {
     return "load";
   case atomic_op::store:
     return "store";
-  case atomic_op::predec:
-    return "predec";
   }
   return "<unknown>";
 }


### PR DESCRIPTION
It never worked, VC doesn't support it, and nobody has ever reported it broken so there's no use in emulating it.