### PR TITLE
[SYCL] Remove `device_error` exception and its subclasses

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_accessor_properties.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_accessor_properties.asciidoc
@@ -242,7 +242,7 @@ a|
 template<typename propertyT>
 propertyT get_property() const;
 ``` | Returns a copy of the property of type propertyT that T was constructed with. 
-Must throw an exception with the errc::invalid_object_error error code if T was not constructed with the propertyT property.
+Must throw an exception with the errc::invalid error code if T was not constructed with the propertyT property.
 Available only if propertyT is not a compile-time-constant property.
 a|
 ```c++

--- a/sycl/doc/extensions/supported/sycl_ext_oneapi_use_pinned_host_memory_property.asciidoc
+++ b/sycl/doc/extensions/supported/sycl_ext_oneapi_use_pinned_host_memory_property.asciidoc
@@ -18,7 +18,7 @@ This document describes an extension that introduces a +sycl::ext::oneapi::prope
 
 |Property |Description
 |`syc::ext::oneapi::property::buffer::use_pinned_host_memory`
-| The `use_pinned_host_memory` property adds the requirement that the SYCL runtime must allocate host pinned memory for the `sycl::buffer`. The property cannot be used with the `sycl::buffer` constructors that take hostData parameter, an invalid_object_error SYCL exception must be thrown in this case.
+| The `use_pinned_host_memory` property adds the requirement that the SYCL runtime must allocate host pinned memory for the `sycl::buffer`. The property cannot be used with the `sycl::buffer` constructors that take hostData parameter, a SYCL exception with errc::invalid error code must be thrown in this case.
 |===
 
 == Feature test macro

--- a/sycl/include/sycl/accessor.hpp
+++ b/sycl/include/sycl/accessor.hpp
@@ -1434,10 +1434,9 @@ public:
       addHostAccessorAndWait(AccessorBaseHost::impl.get());
     if (BufferRef.isOutOfBounds(AccessOffset, AccessRange,
                                 BufferRef.get_range()))
-      throw sycl::invalid_object_error(
-          "accessor with requested offset and range would exceed the bounds of "
-          "the buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "accessor with requested offset and range would "
+                            "exceed the bounds of the buffer");
 
     initHostAcc();
     detail::constructorNotification(detail::getSyclObjImpl(BufferRef).get(),
@@ -1478,10 +1477,9 @@ public:
       addHostAccessorAndWait(AccessorBaseHost::impl.get());
     if (BufferRef.isOutOfBounds(AccessOffset, AccessRange,
                                 BufferRef.get_range()))
-      throw sycl::invalid_object_error(
-          "accessor with requested offset and range would exceed the bounds of "
-          "the buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "accessor with requested offset and range would "
+                            "exceed the bounds of the buffer");
 
     initHostAcc();
     detail::constructorNotification(detail::getSyclObjImpl(BufferRef).get(),
@@ -1549,10 +1547,9 @@ public:
     preScreenAccessor(PropertyList);
     if (BufferRef.isOutOfBounds(AccessOffset, AccessRange,
                                 BufferRef.get_range()))
-      throw sycl::invalid_object_error(
-          "accessor with requested offset and range would exceed the bounds of "
-          "the buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "accessor with requested offset and range would "
+                            "exceed the bounds of the buffer");
 
     initHostAcc();
     detail::associateWithHandler(CommandGroupHandler, this, AccessTarget);
@@ -1593,10 +1590,9 @@ public:
     preScreenAccessor(PropertyList);
     if (BufferRef.isOutOfBounds(AccessOffset, AccessRange,
                                 BufferRef.get_range()))
-      throw sycl::invalid_object_error(
-          "accessor with requested offset and range would exceed the bounds of "
-          "the buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "accessor with requested offset and range would "
+                            "exceed the bounds of the buffer");
 
     initHostAcc();
     detail::associateWithHandler(CommandGroupHandler, this, AccessTarget);
@@ -1946,9 +1942,8 @@ private:
     // check that no_init property is compatible with access mode
     if (PropertyList.template has_property<property::no_init>() &&
         AccessMode == access::mode::read) {
-      throw sycl::invalid_object_error(
-          "accessor would cannot be both read_only and no_init",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+          "accessor cannot be both read_only and no_init");
     }
   }
 

--- a/sycl/include/sycl/buffer.hpp
+++ b/sycl/include/sycl/buffer.hpp
@@ -438,16 +438,14 @@ public:
         dimensions, sizeof(T), detail::rangeToArray(Range).data());
 
     if (b.is_sub_buffer())
-      throw sycl::invalid_object_error(
-          "Cannot create sub buffer from sub buffer.", PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+          "Cannot create sub buffer from sub buffer.");
     if (isOutOfBounds(baseIndex, subRange, b.Range))
-      throw sycl::invalid_object_error(
-          "Requested sub-buffer size exceeds the size of the parent buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+          "Requested sub-buffer size exceeds the size of the parent buffer");
     if (!isContiguousRegion(baseIndex, subRange, b.Range))
-      throw sycl::invalid_object_error(
-          "Requested sub-buffer region is not contiguous",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+          "Requested sub-buffer region is not contiguous");
   }
 
   buffer(const buffer &rhs,
@@ -539,9 +537,8 @@ public:
       id<dimensions> accessOffset = {},
       const detail::code_location CodeLoc = detail::code_location::current()) {
     if (isOutOfBounds(accessOffset, accessRange, this->Range))
-      throw sycl::invalid_object_error(
-          "Requested accessor would exceed the bounds of the buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+          "Requested accessor would exceed the bounds of the buffer");
 
     return accessor<T, dimensions, mode, target, access::placeholder::false_t,
                     ext::oneapi::accessor_property_list<>>(
@@ -562,9 +559,8 @@ public:
                                                        detail::code_location::
                                                            current()) {
     if (isOutOfBounds(accessOffset, accessRange, this->Range))
-      throw sycl::invalid_object_error(
-          "Requested accessor would exceed the bounds of the buffer",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+          "Requested accessor would exceed the bounds of the buffer");
 
     return accessor<T, dimensions, mode, access::target::host_buffer,
                     access::placeholder::false_t,
@@ -659,11 +655,11 @@ public:
              std::remove_const_t<ReinterpretT>>>
   reinterpret(range<ReinterpretDim> reinterpretRange) const {
     if (sizeof(ReinterpretT) * reinterpretRange.size() != byte_size())
-      throw sycl::invalid_object_error(
+      throw sycl::exception(
+          make_error_code(errc::invalid),
           "Total size in bytes represented by the type and range of the "
           "reinterpreted SYCL buffer does not equal the total size in bytes "
-          "represented by the type and range of this SYCL buffer",
-          PI_ERROR_INVALID_VALUE);
+          "represented by the type and range of this SYCL buffer");
 
     return buffer<ReinterpretT, ReinterpretDim,
                   typename std::allocator_traits<AllocatorT>::
@@ -692,10 +688,9 @@ public:
   reinterpret() const {
     long sz = byte_size();
     if (sz % sizeof(ReinterpretT) != 0)
-      throw sycl::invalid_object_error(
-          "Total byte size of buffer is not evenly divisible by the size of "
-          "the reinterpreted type",
-          PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "Total byte size of buffer is not evenly divisible "
+                            "by the size of the reinterpreted type");
 
     return buffer<ReinterpretT, ReinterpretDim, AllocatorT>(
         impl, range<1>{sz / sizeof(ReinterpretT)}, OffsetInBytes, IsSubBuffer);

--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -200,8 +200,8 @@ public:
 
   /// Gets the specified property of this context.
   ///
-  /// Throws invalid_object_error if this context does not have a property
-  /// of type propertyT.
+  /// Throws an exception with errc::invalid error code if this context does not
+  /// have a property of type propertyT.
   ///
   /// \return a copy of the property of type propertyT.
   template <typename propertyT> propertyT get_property() const;

--- a/sycl/include/sycl/detail/property_list_base.hpp
+++ b/sycl/include/sycl/detail/property_list_base.hpp
@@ -10,7 +10,7 @@
 
 #include <sycl/detail/pi.h>                // for PI_ERROR_INVALID_VALUE
 #include <sycl/detail/property_helper.hpp> // for DataLessPropKind, Propert...
-#include <sycl/exception.hpp>              // for invalid_object_error
+#include <sycl/exception.hpp>
 
 #include <algorithm>   // for iter_swap
 #include <bitset>      // for bitset
@@ -92,15 +92,15 @@ protected:
   get_property_helper() const {
     const int PropKind = static_cast<int>(PropT::getKind());
     if (PropKind >= PropWithDataKind::PropWithDataKindSize)
-      throw sycl::invalid_object_error("The property is not found",
-                                       PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "The property is not found");
 
     for (const std::shared_ptr<PropertyWithDataBase> &Prop : MPropsWithData)
       if (Prop->isSame(PropKind))
         return *static_cast<PropT *>(Prop.get());
 
-    throw sycl::invalid_object_error("The property is not found",
-                                     PI_ERROR_INVALID_VALUE);
+    throw sycl::exception(make_error_code(errc::invalid),
+                          "The property is not found");
   }
 
   void add_or_replace_accessor_properties_helper(

--- a/sycl/include/sycl/event.hpp
+++ b/sycl/include/sycl/event.hpp
@@ -122,8 +122,8 @@ public:
   /// call to this member function will block until the requested info is
   /// available. If the queue which submitted the command group this event is
   /// associated with was not constructed with the
-  /// property::queue::enable_profiling property, an invalid_object_error SYCL
-  /// exception is thrown.
+  /// property::queue::enable_profiling property, an a SYCL exception with
+  /// errc::invalid error code is thrown.
   ///
   /// \return depends on template parameter.
   template <typename Param>

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -203,51 +203,6 @@ public:
       : runtime_error(make_error_code(errc::kernel_argument), Msg, Err) {}
 };
 
-class __SYCL2020_DEPRECATED(
-    "use sycl::exception with a sycl::errc enum value instead.") device_error
-    : public exception {
-public:
-  device_error() : exception(make_error_code(errc::invalid)) {}
-
-  device_error(const char *Msg, pi_int32 Err)
-      : device_error(std::string(Msg), Err) {}
-
-  device_error(const std::string &Msg, pi_int32 Err)
-      : exception(make_error_code(errc::invalid), Msg, Err) {}
-
-protected:
-  device_error(std::error_code Ec) : exception(Ec) {}
-
-  device_error(std::error_code Ec, const std::string &Msg, const pi_int32 PIErr)
-      : exception(Ec, Msg, PIErr) {}
-};
-
-class __SYCL2020_DEPRECATED(
-    "use sycl::exception with a sycl::errc enum value instead.")
-    compile_program_error : public device_error {
-public:
-  compile_program_error() : device_error(make_error_code(errc::build)) {}
-
-  compile_program_error(const char *Msg, pi_int32 Err)
-      : compile_program_error(std::string(Msg), Err) {}
-
-  compile_program_error(const std::string &Msg, pi_int32 Err)
-      : device_error(make_error_code(errc::build), Msg, Err) {}
-};
-
-class __SYCL2020_DEPRECATED(
-    "use sycl::exception with a sycl::errc enum value instead.")
-    invalid_object_error : public device_error {
-public:
-  invalid_object_error() : device_error(make_error_code(errc::invalid)) {}
-
-  invalid_object_error(const char *Msg, pi_int32 Err)
-      : invalid_object_error(std::string(Msg), Err) {}
-
-  invalid_object_error(const std::string &Msg, pi_int32 Err)
-      : device_error(make_error_code(errc::invalid), Msg, Err) {}
-};
-
 } // namespace _V1
 } // namespace sycl
 

--- a/sycl/include/sycl/ext/oneapi/accessor_property_list.hpp
+++ b/sycl/include/sycl/ext/oneapi/accessor_property_list.hpp
@@ -13,7 +13,7 @@
 #include <sycl/detail/pi.h>                   // for PI_ERROR_INVALID_VALUE
 #include <sycl/detail/property_helper.hpp>    // for DataLessPropKind, Prop...
 #include <sycl/detail/property_list_base.hpp> // for PropertyListBase
-#include <sycl/exception.hpp>                 // for invalid_object_error
+#include <sycl/exception.hpp>
 #include <sycl/property_list.hpp>             // for property_list
 
 #include <bitset>      // for bitset
@@ -184,8 +184,8 @@ public:
                                 !is_compile_time_property<PropT>::value>>
   PropT get_property() const {
     if (!has_property<PropT>())
-      throw sycl::invalid_object_error("The property is not found",
-                                       PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "The property is not found");
 
     return get_property_helper<PropT>();
   }

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -2732,9 +2732,9 @@ public:
     static_assert(isValidModeForDestinationAccessor(AccessMode_Dst),
                   "Invalid destination accessor mode for the copy method.");
     if (Dst.get_size() < Src.get_size())
-      throw sycl::invalid_object_error(
-          "The destination accessor size is too small to copy the memory into.",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "The destination accessor size is too small to "
+                            "copy the memory into.");
 
     if (copyAccToAccHelper(Src, Dst))
       return;

--- a/sycl/include/sycl/interop_handle.hpp
+++ b/sycl/include/sycl/interop_handle.hpp
@@ -17,7 +17,7 @@
 #include <sycl/detail/impl_utils.hpp> // for getSyclObjImpl
 #include <sycl/detail/pi.h>           // for _pi_mem, pi_native_...
 #include <sycl/device.hpp>            // for device, device_impl
-#include <sycl/exception.hpp>         // for invalid_object_error
+#include <sycl/exception.hpp>
 #include <sycl/exception_list.hpp>    // for queue_impl
 #include <sycl/ext/oneapi/accessor_property_list.hpp> // for accessor_property_list
 #include <sycl/image.hpp>                             // for image
@@ -71,8 +71,8 @@ public:
                   "The method is available only for target::device accessors");
 #ifndef __SYCL_DEVICE_ONLY__
     if (Backend != get_backend())
-      throw invalid_object_error("Incorrect backend argument was passed",
-                                 PI_ERROR_INVALID_MEM_OBJECT);
+      throw exception(make_error_code(errc::invalid),
+                      "Incorrect backend argument was passed");
     const auto *AccBase = static_cast<const detail::AccessorBaseHost *>(&Acc);
     return getMemImpl<Backend, DataT, Dims>(
         detail::getSyclObjImpl(*AccBase).get());
@@ -97,8 +97,8 @@ public:
                                    IsPlh /*, PropertyListT */> &Acc) const {
 #ifndef __SYCL_DEVICE_ONLY__
     if (Backend != get_backend())
-      throw invalid_object_error("Incorrect backend argument was passed",
-                                 PI_ERROR_INVALID_MEM_OBJECT);
+      throw exception(make_error_code(errc::invalid),
+                      "Incorrect backend argument was passed");
     const auto *AccBase = static_cast<const detail::AccessorBaseHost *>(&Acc);
     return getMemImpl<Backend, Dims>(detail::getSyclObjImpl(*AccBase).get());
 #else
@@ -127,8 +127,8 @@ public:
     // with the error code 'errc::backend_mismatch' when those new exceptions
     // are ready to be used.
     if (Backend != get_backend())
-      throw invalid_object_error("Incorrect backend argument was passed",
-                                 PI_ERROR_INVALID_MEM_OBJECT);
+      throw exception(make_error_code(errc::invalid),
+                      "Incorrect backend argument was passed");
     int32_t NativeHandleDesc;
     return reinterpret_cast<backend_return_t<Backend, queue>>(
         getNativeQueue(NativeHandleDesc));
@@ -150,8 +150,8 @@ public:
     // with the error code 'errc::backend_mismatch' when those new exceptions
     // are ready to be used.
     if (Backend != get_backend())
-      throw invalid_object_error("Incorrect backend argument was passed",
-                                 PI_ERROR_INVALID_MEM_OBJECT);
+      throw exception(make_error_code(errc::invalid),
+                      "Incorrect backend argument was passed");
     // C-style cast required to allow various native types
     return (backend_return_t<Backend, device>)getNativeDevice();
 #else
@@ -172,8 +172,8 @@ public:
     // with the error code 'errc::backend_mismatch' when those new exceptions
     // are ready to be used.
     if (Backend != get_backend())
-      throw invalid_object_error("Incorrect backend argument was passed",
-                                 PI_ERROR_INVALID_MEM_OBJECT);
+      throw exception(make_error_code(errc::invalid),
+                      "Incorrect backend argument was passed");
     return reinterpret_cast<backend_return_t<Backend, context>>(
         getNativeContext());
 #else

--- a/sycl/include/sycl/property_list.hpp
+++ b/sycl/include/sycl/property_list.hpp
@@ -11,7 +11,7 @@
 #include <sycl/detail/pi.h>                    // for PI_ERROR_INVALID_VALUE
 #include <sycl/detail/property_helper.hpp>     // for DataLessPropKind, Pro...
 #include <sycl/detail/property_list_base.hpp>  // for PropertyListBase
-#include <sycl/exception.hpp>                  // for invalid_object_error
+#include <sycl/exception.hpp>
 #include <sycl/properties/property_traits.hpp> // for is_property
 
 #include <bitset>      // for bitset
@@ -46,8 +46,8 @@ public:
 
   template <typename PropT> PropT get_property() const {
     if (!has_property<PropT>())
-      throw sycl::invalid_object_error("The property is not found",
-                                       PI_ERROR_INVALID_VALUE);
+      throw sycl::exception(make_error_code(errc::invalid),
+                            "The property is not found");
 
     return get_property_helper<PropT>();
   }

--- a/sycl/include/sycl/queue.hpp
+++ b/sycl/include/sycl/queue.hpp
@@ -473,7 +473,7 @@ public:
 
   /// \return a copy of the property of type PropertyT that the queue was
   /// constructed with. If the queue was not constructed with the PropertyT
-  /// property, an invalid_object_error SYCL exception.
+  /// property, an SYCL exception with errc::invalid error code.
   template <typename PropertyT> PropertyT get_property() const;
 
   /// Fills the specified memory with the specified pattern.

--- a/sycl/include/sycl/sampler.hpp
+++ b/sycl/include/sycl/sampler.hpp
@@ -96,8 +96,8 @@ public:
 
   /// Gets the specified property of this sampler.
   ///
-  /// Throws invalid_object_error if this sampler does not have a property
-  /// of type propertyT.
+  /// Throws an exception with errc::invalid if this sampler does not have a
+  /// property of type propertyT.
   ///
   /// \return a copy of the property of type propertyT.
   template <typename propertyT> propertyT get_property() const;

--- a/sycl/include/sycl/usm/usm_pointer_info.hpp
+++ b/sycl/include/sycl/usm/usm_pointer_info.hpp
@@ -24,7 +24,8 @@ class context;
 __SYCL_EXPORT usm::alloc get_pointer_type(const void *ptr, const context &ctxt);
 
 /// Queries the device against which the pointer was allocated
-/// Throws an invalid_object_error if ptr is a host allocation.
+/// Throws an exception with errc::invalid error code if ptr is a host
+/// allocation.
 ///
 /// \param ptr is the USM pointer to query
 /// \param ctxt is the sycl context the ptr was allocated in

--- a/sycl/source/detail/buffer_impl.hpp
+++ b/sycl/source/detail/buffer_impl.hpp
@@ -48,9 +48,9 @@ public:
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
 
     if (Props.has_property<sycl::property::buffer::use_host_ptr>())
-      throw sycl::invalid_object_error(
-          "The use_host_ptr property requires host pointer to be provided",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "The use_host_ptr property requires host pointer to be provided");
   }
 
   buffer_impl(void *HostData, size_t SizeInBytes, size_t RequiredAlign,
@@ -60,9 +60,9 @@ public:
 
     if (Props.has_property<
             sycl::ext::oneapi::property::buffer::use_pinned_host_memory>())
-      throw sycl::invalid_object_error(
-          "The use_pinned_host_memory cannot be used with host pointer",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "The use_pinned_host_memory cannot be used with host pointer");
 
     BaseT::handleHostData(HostData, RequiredAlign);
   }
@@ -74,9 +74,9 @@ public:
 
     if (Props.has_property<
             sycl::ext::oneapi::property::buffer::use_pinned_host_memory>())
-      throw sycl::invalid_object_error(
-          "The use_pinned_host_memory cannot be used with host pointer",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "The use_pinned_host_memory cannot be used with host pointer");
 
     BaseT::handleHostData(HostData, RequiredAlign);
   }
@@ -89,9 +89,9 @@ public:
 
     if (Props.has_property<
             sycl::ext::oneapi::property::buffer::use_pinned_host_memory>())
-      throw sycl::invalid_object_error(
-          "The use_pinned_host_memory cannot be used with host pointer",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "The use_pinned_host_memory cannot be used with host pointer");
 
     BaseT::handleHostData(std::const_pointer_cast<void>(HostData),
                           RequiredAlign, IsConstPtr);
@@ -105,9 +105,9 @@ public:
       : BaseT(SizeInBytes, Props, std::move(Allocator)) {
     if (Props.has_property<
             sycl::ext::oneapi::property::buffer::use_pinned_host_memory>())
-      throw sycl::invalid_object_error(
-          "The use_pinned_host_memory cannot be used with host pointer",
-          PI_ERROR_INVALID_OPERATION);
+      throw sycl::exception(
+          make_error_code(errc::invalid),
+          "The use_pinned_host_memory cannot be used with host pointer");
 
     BaseT::handleHostData(CopyFromInput, RequiredAlign, IsConstPtr);
   }

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -512,7 +512,9 @@ std::optional<sycl::detail::pi::PiProgram> context_impl::getProgramForDevImgs(
   using BuildState = KernelProgramCache::BuildState;
   BuildState NewState = BuildRes->waitUntilTransition();
   if (NewState == BuildState::BS_Failed)
-    throw compile_program_error(BuildRes->Error.Msg, BuildRes->Error.Code);
+    throw detail::set_pi_error(
+        exception(make_error_code(errc::build), BuildRes->Error.Msg),
+        BuildRes->Error.Code);
 
   assert(NewState == BuildState::BS_Done);
   return BuildRes->Val;

--- a/sycl/source/detail/context_impl.hpp
+++ b/sycl/source/detail/context_impl.hpp
@@ -84,8 +84,8 @@ public:
 
   /// Gets the specified property of this context_impl.
   ///
-  /// Throws invalid_object_error if this context_impl does not have a property
-  /// of type propertyT.
+  /// Throws an exception with errc::invalid error code if this context_impl
+  /// does not have a property of type propertyT.
   ///
   /// \return a copy of the property of type propertyT.
   template <typename propertyT> propertyT get_property() const {

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -1050,9 +1050,8 @@ template <> struct get_device_info_impl<device, info::device::parent_device> {
         Dev->getHandleRef(), PiInfoCode<info::device::parent_device>::value,
         sizeof(result), &result, nullptr);
     if (result == nullptr)
-      throw invalid_object_error(
-          "No parent for device because it is not a subdevice",
-          PI_ERROR_INVALID_DEVICE);
+      throw exception(make_error_code(errc::invalid),
+                      "No parent for device because it is not a subdevice");
 
     const auto &Platform = Dev->getPlatformImpl();
     return createSyclObjFromImpl<device>(
@@ -1260,9 +1259,9 @@ typename Param::return_type get_device_info(const DeviceImplPtr &Dev) {
   if (std::is_same<Param,
                    sycl::_V1::ext::intel::info::device::free_memory>::value) {
     if (!Dev->has(aspect::ext_intel_free_memory))
-      throw invalid_object_error(
-          "The device does not have the ext_intel_free_memory aspect",
-          PI_ERROR_INVALID_DEVICE);
+      throw exception(
+          make_error_code(errc::invalid),
+          "The device does not have the ext_intel_free_memory aspect");
   }
   return get_device_info_impl<typename Param::return_type, Param>::get(Dev);
 }

--- a/sycl/source/detail/event_impl.hpp
+++ b/sycl/source/detail/event_impl.hpp
@@ -97,8 +97,8 @@ public:
   /// then the call to this member function will block until the requested
   /// info is available. If the queue which submitted the command group this
   /// event is associated with was not constructed with the
-  /// property::queue::enable_profiling property, an invalid_object_error SYCL
-  /// exception is thrown.
+  /// property::queue::enable_profiling property, a SYCL exception with
+  /// errc::invalid error code is thrown.
   ///
   /// \return depends on template parameter.
   template <typename Param> typename Param::return_type get_profiling_info();

--- a/sycl/source/detail/kernel_impl.hpp
+++ b/sycl/source/detail/kernel_impl.hpp
@@ -72,7 +72,7 @@ public:
   ///
   /// If this kernel encapsulates an instance of OpenCL kernel, a valid
   /// cl_kernel will be returned. If this kernel is a host kernel,
-  /// an invalid_object_error exception will be thrown.
+  /// an exception with errc::invalid error code will be thrown.
   ///
   /// \return a valid cl_kernel instance
   cl_kernel get() const {

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -233,7 +233,7 @@ public:
   /// Exception thrown by build procedure are rethrown.
   ///
   /// \tparam RetT type of entity to get
-  /// \tparam ExceptionT type of exception to throw on awaiting thread if the
+  /// \tparam Errc error code of exception to throw on awaiting thread if the
   ///         building thread fails build step.
   /// \tparam KeyT key (in cache) to fetch built entity with
   /// \tparam AcquireFT type of function which will acquire the locked version
@@ -247,7 +247,7 @@ public:
   ///
   /// \return a pointer to cached build result, return value must not be
   /// nullptr.
-  template <typename ExceptionT, typename GetCachedBuildFT, typename BuildFT>
+  template <errc Errc, typename GetCachedBuildFT, typename BuildFT>
   auto getOrBuild(GetCachedBuildFT &&GetCachedBuild, BuildFT &&Build) {
     using BuildState = KernelProgramCache::BuildState;
     constexpr size_t MaxAttempts = 2;
@@ -269,7 +269,9 @@ public:
         if (NewState == BuildState::BS_Failed ||
             AttemptCounter + 1 == MaxAttempts) {
           if (BuildResult->Error.isFilledIn())
-            throw ExceptionT(BuildResult->Error.Msg, BuildResult->Error.Code);
+            throw detail::set_pi_error(
+                exception(make_error_code(Errc), BuildResult->Error.Msg),
+                BuildResult->Error.Code);
           else
             throw exception();
         }

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -452,10 +452,11 @@ void *MemoryManager::allocateMemSubBuffer(ContextImplPtr TargetContext,
       pi::cast<sycl::detail::pi::PiMem>(ParentMemObj), PI_MEM_FLAGS_ACCESS_RW,
       PI_BUFFER_CREATE_TYPE_REGION, &Region, &NewMem);
   if (Error == PI_ERROR_MISALIGNED_SUB_BUFFER_OFFSET)
-    throw invalid_object_error(
-        "Specified offset of the sub-buffer being constructed is not a "
-        "multiple of the memory base address alignment",
-        PI_ERROR_INVALID_VALUE);
+    throw detail::set_pi_error(
+        exception(make_error_code(errc::invalid),
+                  "Specified offset of the sub-buffer being constructed is not "
+                  "a multiple of the memory base address alignment"),
+        Error);
 
   if (Error != PI_SUCCESS) {
     Plugin->reportPiError(Error, "allocateMemSubBuffer()");

--- a/sycl/source/detail/queue_impl.hpp
+++ b/sycl/source/detail/queue_impl.hpp
@@ -153,16 +153,16 @@ public:
     }
     if (!Context->isDeviceValid(Device)) {
       if (Context->getBackend() == backend::opencl)
-        throw sycl::invalid_object_error(
+        throw sycl::exception(
+            make_error_code(errc::invalid),
             "Queue cannot be constructed with the given context and device "
             "since the device is not a member of the context (descendants of "
-            "devices from the context are not supported on OpenCL yet).",
-            PI_ERROR_INVALID_DEVICE);
-      throw sycl::invalid_object_error(
+            "devices from the context are not supported on OpenCL yet).");
+      throw sycl::exception(
+          make_error_code(errc::invalid),
           "Queue cannot be constructed with the given context and device "
           "since the device is neither a member of the context nor a "
-          "descendant of its member.",
-          PI_ERROR_INVALID_DEVICE);
+          "descendant of its member.");
     }
 
     const QueueOrder QOrder =
@@ -630,7 +630,7 @@ public:
 
   /// \return a copy of the property of type PropertyT that the queue was
   /// constructed with. If the queue was not constructed with the PropertyT
-  /// property, an invalid_object_error SYCL exception.
+  /// property, a SYCL exception with errc::invalid error code will be thrown.
   template <typename propertyT> propertyT get_property() const {
     return MPropList.get_property<propertyT>();
   }

--- a/sycl/source/detail/sampler_impl.hpp
+++ b/sycl/source/detail/sampler_impl.hpp
@@ -50,8 +50,8 @@ public:
 
   /// Gets the specified property of this sampler_impl.
   ///
-  /// Throws invalid_object_error if this sampler_impl does not have a property
-  /// of type propertyT.
+  /// Throws an exception with errc::invalid error code if this sampler_impl
+  /// does not have a property of type propertyT.
   ///
   /// \return a copy of the property of type propertyT.
   template <typename propertyT> propertyT get_property() const {

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -134,9 +134,8 @@ device::get_info_impl<info::device::parent_device>() const {
   // have parents, but we don't want to return them. They must pretend to be
   // parentless root devices.
   if (impl->isRootDevice())
-    throw invalid_object_error(
-        "No parent for device because it is not a subdevice",
-        PI_ERROR_INVALID_DEVICE);
+    throw exception(make_error_code(errc::invalid),
+                    "No parent for device because it is not a subdevice");
   else
     return impl->template get_info<info::device::parent_device>();
 }

--- a/sycl/source/interop_handle.cpp
+++ b/sycl/source/interop_handle.cpp
@@ -28,8 +28,8 @@ pi_native_handle interop_handle::getNativeMem(detail::Requirement *Req) const {
                            [=](ReqToMem Elem) { return (Elem.first == Req); });
 
   if (Iter == std::end(MMemObjs)) {
-    throw invalid_object_error("Invalid memory object used inside interop",
-                               PI_ERROR_INVALID_MEM_OBJECT);
+    throw exception(make_error_code(errc::invalid),
+                    "Invalid memory object used inside interop");
   }
 
   auto Plugin = MQueue->getPlugin();

--- a/sycl/test-e2e/Basic/event_creation.cpp
+++ b/sycl/test-e2e/Basic/event_creation.cpp
@@ -17,7 +17,7 @@ int main() {
   try {
     std::cout << "Create default event" << std::endl;
     sycl::event e;
-  } catch (sycl::device_error e) {
+  } catch (const sycl::exception &e) {
     std::cout << "Failed to create device for event" << std::endl;
   }
 }

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_queue.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_queue.cpp
@@ -31,7 +31,7 @@ void GetCLQueue(event sycl_event, std::set<cl_command_queue> &cl_queues) {
     assert(CL_SUCCESS == error && "Failed to obtain queue from OpenCL event");
 
     cl_queues.insert(cl_queue);
-  } catch (invalid_object_error e) {
+  } catch (const exception &e) {
     std::cout << "Failed to get OpenCL queue from SYCL event: " << e.what()
               << std::endl;
   }

--- a/sycl/test-e2e/Config/env_vars.cpp
+++ b/sycl/test-e2e/Config/env_vars.cpp
@@ -33,8 +33,9 @@ int main() {
       // Exit immediately, otherwise the buffer destructor may actually try to
       // enqueue the command once again, and throw another exception.
       exit(0);
-    } catch (sycl::compile_program_error &e) {
-      exit(0);
+    } catch (sycl::exception &e) {
+      if (e.code() == errc::build)
+        exit(0);
     }
     assert(0 && "Expected exception was *not* thrown");
   } else {

--- a/sycl/test-e2e/DeprecatedFeatures/queue_old_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/queue_old_interop.cpp
@@ -36,7 +36,7 @@ int main() {
     queue q;
     print_queue_info(q);
 
-  } catch (device_error e) {
+  } catch (const exception &e) {
     std::cout << "Failed to create device for context" << std::endl;
   }
 

--- a/sycl/test-e2e/InlineAsm/include/asmhelper.h
+++ b/sycl/test-e2e/InlineAsm/include/asmhelper.h
@@ -131,10 +131,8 @@ bool launchInlineASMTest(F &f, const std::vector<int> &RequiredSGSizes = {},
   try {
     result = launchInlineASMTestImpl(f, RequiredSGSizes);
   } catch (sycl::exception &e) {
-    std::string what = e.what();
-    if (exception_expected &&
-        what.find("PI_ERROR_BUILD_PROGRAM_FAILURE") != std::string::npos) {
-      std::cout << "Caught expected exception: " << what << std::endl;
+    if (exception_expected && e.code() == sycl::errc::build) {
+      std::cout << "Caught expected exception." << std::endl;
     } else {
       std::cout << "Caught unexpected exception." << std::endl;
       throw e;

--- a/sycl/test-e2e/KernelAndProgram/build-log.cpp
+++ b/sycl/test-e2e/KernelAndProgram/build-log.cpp
@@ -21,8 +21,9 @@ void symbol_that_does_not_exist();
 void test() {
   sycl::queue Queue;
 
-  // Submitting this kernel should result in a compile_program_error exception
-  // with a message indicating "PI_ERROR_BUILD_PROGRAM_FAILURE".
+  // Submitting this kernel should result in an exception with error code
+  // `sycl::errc::build` and a message indicating
+  // "PI_ERROR_BUILD_PROGRAM_FAILURE".
   auto Kernel = []() {
 #ifdef __SYCL_DEVICE_ONLY__
 #ifdef GPU
@@ -45,7 +46,7 @@ void test() {
     std::cerr << Msg << std::endl;
     assert(e.code() == sycl::errc::build &&
            "Caught exception was not a compilation error");
-    assert(Msg.find("PI_ERROR_BUILD_PROGRAM_FAILURE") != std::string::npos);
+    assert(sycl::detail::get_pi_error(e) == PI_ERROR_BUILD_PROGRAM_FAILURE);
   } catch (...) {
     assert(false && "Caught exception was not a compilation error");
   }

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -91,12 +91,6 @@ int main() {
   sycl::nd_range_error ne;
   // expected-warning@+1 {{'invalid_parameter_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
   sycl::invalid_parameter_error ipe;
-  // expected-warning@+1 {{'device_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
-  sycl::device_error de;
-  // expected-warning@+1 {{'compile_program_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
-  sycl::compile_program_error cpe;
-  // expected-warning@+1 {{'invalid_object_error' is deprecated: use sycl::exception with a sycl::errc enum value instead.}}
-  sycl::invalid_object_error ioe;
   // expected-warning@+1{{'exception' is deprecated: The version of an exception constructor which takes no arguments is deprecated.}}
   sycl::exception ex;
 

--- a/sycl/unittests/queue/DeviceCheck.cpp
+++ b/sycl/unittests/queue/DeviceCheck.cpp
@@ -104,15 +104,16 @@ TEST(QueueDeviceCheck, CheckDeviceRestriction) {
     try {
       queue Q2{DefaultCtx, Subdevices[0]};
       EXPECT_NE(Q.get_backend(), backend::opencl);
-    } catch (sycl::invalid_object_error &e) {
+    } catch (sycl::exception &e) {
+      EXPECT_TRUE(e.code() == errc::invalid);
       EXPECT_EQ(Q.get_backend(), backend::opencl);
-      EXPECT_EQ(std::strcmp(
-                    e.what(),
-                    "Queue cannot be constructed with the given context and "
-                    "device since the device is not a member of the context "
-                    "(descendants of devices from the context are not "
-                    "supported on OpenCL yet). -33 (PI_ERROR_INVALID_DEVICE)"),
-                0);
+      EXPECT_EQ(
+          std::strcmp(e.what(),
+                      "Queue cannot be constructed with the given context and "
+                      "device since the device is not a member of the context "
+                      "(descendants of devices from the context are not "
+                      "supported on OpenCL yet)."),
+          0);
     }
   }
   // Device is neither of the two.
@@ -126,7 +127,8 @@ TEST(QueueDeviceCheck, CheckDeviceRestriction) {
     try {
       queue Q2{DefaultCtx, Device};
       EXPECT_TRUE(false);
-    } catch (sycl::invalid_object_error &e) {
+    } catch (sycl::exception &e) {
+      EXPECT_TRUE(e.code() == errc::invalid);
       EXPECT_NE(
           std::strstr(e.what(),
                       "Queue cannot be constructed with the given context and "


### PR DESCRIPTION
Remove both `compile_program_error` and `invalid_object_error` in a single PR because `getOrBuild` interface uses both and cannot be updated for one without another.