### PR TITLE
[SYCL] kernel_compiler include file paths collision fix

### DIFF
--- a/sycl/source/detail/kernel_compiler/kernel_compiler_sycl.cpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_sycl.cpp
@@ -138,6 +138,7 @@ void outputIncludeFiles(const std::filesystem::path &Dirpath,
   using pairStrings = std::pair<std::string, std::string>;
   for (pairStrings p : IncludePairs) {
     std::filesystem::path FilePath = Dirpath / p.first;
+    std::filesystem::create_directories(FilePath.parent_path());
     std::ofstream outfile(FilePath, std::ios::out | std::ios::trunc);
     if (outfile.is_open()) {
       outfile << p.second << std::endl;

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -107,8 +107,8 @@ void test_1(sycl::queue &Queue, sycl::kernel &Kernel, int seed) {
   Queue.wait();
 
   for (int i = 0; i < Range; i++) {
-    std::cout << usmPtr[i] << " ";
-    assert(usmPtr[i] = i + seed);
+    std::cout << usmPtr[i] << "=" << (i + seed) << " ";
+    assert(usmPtr[i] == i + seed);
   }
   std::cout << std::endl;
 
@@ -177,8 +177,8 @@ void test_build_and_run() {
   // clang-format on
 
   // Test the kernels.
-  test_1(q, k, 37 + 5); // AddEm will add 5 more.
-  test_1(q, k2, 39);
+  test_1(q, k, 37 + 5);  // ff_cp seeds 37. AddEm will add 5 more.
+  test_1(q, k2, 38 + 6); // ff_templated seeds 38. PlusEm adds 6 more.
 }
 
 void test_error() {


### PR DESCRIPTION
kernel_compiler include_file support shouldn't have files that might collide. Spec has been recently clarified as well  ( https://github.com/intel/llvm/pull/11985/commits/a6d875830cf489b6148e543ef2b515c428a4a38c )