### PR TITLE
[SYCL] Workaround for seg fault in `vec::convert<>` for OpenCL CPU at O0

### DIFF
--- a/sycl/include/sycl/vector_preview.hpp
+++ b/sycl/include/sycl/vector_preview.hpp
@@ -489,9 +489,9 @@ public:
           !std::is_same_v<convertT, bool>;
 
       if constexpr (canUseNativeVectorConvert) {
-        Result.m_Data = sycl::bit_cast<decltype(Result.m_Data)>(
-            detail::convertImpl<T, R, roundingMode, NumElements, OpenCLVecT,
-                                OpenCLVecR>(NativeVector));
+        auto val = detail::convertImpl<T, R, roundingMode, NumElements, OpenCLVecT,
+                                OpenCLVecR>(NativeVector);
+        Result.m_Data = sycl::bit_cast<decltype(Result.m_Data)>(val);
       } else
 #endif // __SYCL_DEVICE_ONLY__
       {


### PR DESCRIPTION
There seems to be a bug in CodeGen for OpenCL CPU which causes a seg-fault in `vec::convert<>`, when converting to `vec<long, 8>` at O0.
To unblock https://github.com/intel/llvm/pull/14317, this PR proposes a non-functional change as a workaround for the CodeGen bug.