### PR TITLE
[NFCI][SYCL][ESIMD][E2E] Drop unnecessary `template` keyword

### DIFF
--- a/sycl/test-e2e/ESIMD/accessor_global.cpp
+++ b/sycl/test-e2e/ESIMD/accessor_global.cpp
@@ -52,7 +52,7 @@ bool test(queue Q, uint32_t LocalRange, uint32_t GlobalRange) {
                T *Ptr = TmpAcc.template get_multi_ptr<access::decorated::yes>()
                             .get();
                simd<T, VL> Values = block_load<T, VL>(Ptr + (GID + LID) * VL);
-               Values.template copy_to<sizeof(T)>(Out + (GID + LID) * VL);
+               Values.copy_to(Out + (GID + LID) * VL);
              }
            } // end for (int LID = 0; LID < LocalRange; LID++)
          } // end if (LID == 0)

--- a/sycl/test-e2e/ESIMD/private_memory/private_memory.cpp
+++ b/sycl/test-e2e/ESIMD/private_memory/private_memory.cpp
@@ -66,7 +66,7 @@ ESIMD_NOINLINE bool test(queue Q, int PrivateArrayLen) {
            for (int I = 0; I < ArrayLen; I++) {
              simd<int, 1> IV(static_cast<int>(Id) * PrivateArrayLen + I);
              simd<T, 1> TV = IV;
-             TV.template copy_to<sizeof(T)>(PrivateArray + I);
+             TV.copy_to(PrivateArray + I);
            }
 
            simd<T, PrivateArrayLenConst> BigVec(PrivateArray);

--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/copyto_copyfrom.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/copyto_copyfrom.hpp
@@ -205,7 +205,7 @@ bool testLocalAccSLM(queue Q, uint32_t Groups, PropertiesT Properties) {
              Vals = gather<T, N>(LocalAcc, ByteOffsets, PropertiesT{});
          } else {
            if (GlobalID % GroupSize)
-             Vals.template copy_from<decltype(LocalAcc), ChunkSize>(LocalAcc, LocalElemOffset);
+             Vals.copy_from(LocalAcc, LocalElemOffset);
            else
              Vals = gather<T, N>(LocalAcc, ByteOffsets);
          }


### PR DESCRIPTION
Partially changes implementation of the fix from
https://github.com/intel/llvm/commit/97e43dddcebfaa44214533888d072fa4cf3f24d5