### PR TITLE
[NFC][SYCL] Change `enqueueImpKernel` to return `void`

### DIFF
--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -967,7 +967,7 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
               static_cast<sycl::detail::CGExecKernel *>(
                   NodeImpl->MCommandGroup.get());
           auto OutEvent = CreateNewEvent();
-          pi_int32 Res = sycl::detail::enqueueImpKernel(
+          sycl::detail::enqueueImpKernel(
               Queue, CG->MNDRDesc, CG->MArgs, CG->MKernelBundle,
               CG->MSyclKernel, CG->MKernelName, RawEvents, OutEvent,
               // TODO: Pass accessor mem allocations
@@ -975,11 +975,6 @@ exec_graph_impl::enqueue(const std::shared_ptr<sycl::detail::queue_impl> &Queue,
               // TODO: Extract from handler
               PI_EXT_KERNEL_EXEC_INFO_CACHE_DEFAULT, CG->MKernelIsCooperative,
               CG->MKernelUsesClusterLaunch);
-          if (Res != pi_result::PI_SUCCESS) {
-            throw sycl::exception(
-                sycl::make_error_code(sycl::errc::kernel),
-                "Error during emulated graph command group submission.");
-          }
           ScheduledEvents.push_back(NewEvent);
         } else if (!NodeImpl->isEmpty()) {
           // Empty nodes are node processed as other nodes, but only their

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2582,7 +2582,7 @@ pi_int32 enqueueImpCommandBufferKernel(
   return Res;
 }
 
-pi_int32 enqueueImpKernel(
+void enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,
@@ -2698,8 +2698,6 @@ pi_int32 enqueueImpKernel(
     detail::enqueue_kernel_launch::handleErrorOrWarning(Error, DeviceImpl,
                                                         Kernel, NDRDesc);
   }
-
-  return PI_SUCCESS;
 }
 
 pi_int32
@@ -3033,11 +3031,13 @@ pi_int32 ExecCGCommand::enqueueImpQueue() {
       }
     }
 
-    return enqueueImpKernel(
-        MQueue, NDRDesc, Args, ExecKernel->getKernelBundle(), SyclKernel,
-        KernelName, RawEvents, EventImpl, getMemAllocationFunc,
-        ExecKernel->MKernelCacheConfig, ExecKernel->MKernelIsCooperative,
-        ExecKernel->MKernelUsesClusterLaunch);
+    enqueueImpKernel(MQueue, NDRDesc, Args, ExecKernel->getKernelBundle(),
+                     SyclKernel, KernelName, RawEvents, EventImpl,
+                     getMemAllocationFunc, ExecKernel->MKernelCacheConfig,
+                     ExecKernel->MKernelIsCooperative,
+                     ExecKernel->MKernelUsesClusterLaunch);
+
+    return PI_SUCCESS;
   }
   case CG::CGTYPE::CopyUSM: {
     CGCopyUSM *Copy = (CGCopyUSM *)MCommandGroup.get();

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -624,7 +624,7 @@ enqueueReadWriteHostPipe(const QueueImplPtr &Queue, const std::string &PipeName,
                          std::vector<sycl::detail::pi::PiEvent> &RawEvents,
                          const detail::EventImplPtr &OutEventImpl, bool read);
 
-pi_int32 enqueueImpKernel(
+void enqueueImpKernel(
     const QueueImplPtr &Queue, NDRDescT &NDRDesc, std::vector<ArgDesc> &Args,
     const std::shared_ptr<detail::kernel_bundle_impl> &KernelBundleImplPtr,
     const std::shared_ptr<detail::kernel_impl> &MSyclKernel,


### PR DESCRIPTION
It only returns `PI_SUCCESS` through normal control flow, all the errors result in an exception thrown. In other words, there is no `return NOT_A_PI_SUCCESS` inside its body, so we can simply make it `void` and simplify its callers.