### PR TITLE
[SYCL] More cleanup to use SYCL 2020 `exception`

### DIFF
--- a/sycl/include/sycl/ext/oneapi/backend/hip.hpp
+++ b/sycl/include/sycl/ext/oneapi/backend/hip.hpp
@@ -17,10 +17,8 @@ inline namespace _V1 {
 template <>
 inline backend_return_t<backend::ext_oneapi_hip, device>
 get_native<backend::ext_oneapi_hip, device>(const device &Obj) {
-  // TODO swap with SYCL 2020 exception when in ABI-break window
   if (Obj.get_backend() != backend::ext_oneapi_hip) {
-    throw sycl::runtime_error(errc::backend_mismatch, "Backends mismatch",
-                              PI_ERROR_INVALID_OPERATION);
+    throw exception(errc::backend_mismatch, "Backends mismatch");
   }
   // HIP uses a 32-bit int instead of an opaque pointer like other backends,
   // so we need a specialization with static_cast instead of reinterpret_cast.

--- a/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/bf16_storage_builtins.hpp
@@ -49,8 +49,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fabs(T x) {
   return __clc_fabs(x);
 #else
   (void)x;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw exception(make_error_code(errc::runtime),
+                  "bf16 is not supported on host.");
 #endif
 }
 template <typename T>
@@ -60,8 +60,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmin(T x, T y) {
 #else
   (void)x;
   (void)y;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw exception(make_error_code(errc::runtime),
+                  "bf16 is not supported on host.");
 #endif
 }
 template <typename T>
@@ -71,8 +71,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fmax(T x, T y) {
 #else
   (void)x;
   (void)y;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw exception(make_error_code(errc::runtime),
+                  "bf16 is not supported on host.");
 #endif
 }
 template <typename T>
@@ -83,8 +83,8 @@ std::enable_if_t<detail::is_bf16_storage_type<T>::value, T> fma(T x, T y, T z) {
   (void)x;
   (void)y;
   (void)z;
-  throw runtime_error("bf16 is not supported on host device.",
-                      PI_ERROR_INVALID_DEVICE);
+  throw exception(make_error_code(errc::runtime),
+                  "bf16 is not supported on host.");
 #endif
 }
 

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -61,8 +61,8 @@ backend convertBackend(pi_platform_backend PiBackend) {
   case PI_EXT_PLATFORM_BACKEND_NATIVE_CPU:
     return backend::ext_oneapi_native_cpu;
   }
-  throw sycl::runtime_error{"convertBackend: Unsupported backend",
-                            PI_ERROR_INVALID_OPERATION};
+  throw exception(make_error_code(errc::runtime),
+                  "convertBackend: Unsupported backend");
 }
 
 platform make_platform(pi_native_handle NativeHandle, backend Backend) {

--- a/sycl/source/detail/config.hpp
+++ b/sycl/source/detail/config.hpp
@@ -381,7 +381,7 @@ private:
       std::string Msg =
           std::string{"Invalid value for bool configuration variable "} +
           getName() + std::string{": "} + ValStr;
-      throw runtime_error(Msg, PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime), Msg);
     }
     return ValStr[0] == '1';
   }
@@ -603,7 +603,7 @@ private:
       std::string Msg =
           std::string{"Invalid value for bool configuration variable "} +
           getName() + std::string{": "} + ValStr;
-      throw runtime_error(Msg, PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime), Msg);
     }
     return ValStr[0] == '1';
   }

--- a/sycl/source/detail/error_handling/error_handling.cpp
+++ b/sycl/source/detail/error_handling/error_handling.cpp
@@ -301,10 +301,8 @@ void handleInvalidWorkGroupSize(const device_impl &DeviceImpl, pi_kernel Kernel,
   // consistent with the required number of sub-groups for kernel in the
   // program source.
 
-  // Fallback
-  constexpr pi_result Error = PI_ERROR_INVALID_WORK_GROUP_SIZE;
-  throw runtime_error(
-      "PI backend failed. PI backend returns: " + codeToString(Error), Error);
+  throw exception(make_error_code(errc::nd_range),
+                  "internal error: expected HasLocalSize");
 }
 
 void handleInvalidWorkItemSize(const device_impl &DeviceImpl,
@@ -348,9 +346,7 @@ void handleInvalidValue(const device_impl &DeviceImpl,
   }
 
   // fallback
-  constexpr pi_result Error = PI_ERROR_INVALID_VALUE;
-  throw runtime_error(
-      "Native API failed. Native API returns: " + codeToString(Error), Error);
+  throw exception(make_error_code(errc::nd_range), "unknown internal error");
 }
 
 void handleErrorOrWarning(pi_result Error, const device_impl &DeviceImpl,
@@ -424,8 +420,8 @@ void handleErrorOrWarning(pi_result Error, const device_impl &DeviceImpl,
     // TODO: Handle other error codes
 
   default:
-    throw runtime_error(
-        "Native API failed. Native API returns: " + codeToString(Error), Error);
+    throw detail::set_pi_error(
+        exception(make_error_code(errc::runtime), "PI error"), Error);
   }
 }
 

--- a/sycl/source/detail/filter_selector_impl.cpp
+++ b/sycl/source/detail/filter_selector_impl.cpp
@@ -56,7 +56,7 @@ filter create_filter(const std::string &Input) {
   // There should only be up to 3 tokens.
   // BE:Device Type:Device Num
   if (Tokens.size() > 3)
-    throw sycl::runtime_error(Error, PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid), Error);
 
   for (const std::string &Token : Tokens) {
     if (Token == "cpu" && !Result.DeviceType) {
@@ -77,10 +77,10 @@ filter create_filter(const std::string &Input) {
       try {
         Result.DeviceNum = std::stoi(Token);
       } catch (std::logic_error &) {
-        throw sycl::runtime_error(Error, PI_ERROR_INVALID_VALUE);
+        throw exception(make_error_code(errc::invalid), Error);
       }
     } else {
-      throw sycl::runtime_error(Error, PI_ERROR_INVALID_VALUE);
+      throw exception(make_error_code(errc::invalid), Error);
     }
   }
 
@@ -141,9 +141,9 @@ int filter_selector_impl::operator()(const device &Dev) const {
 
   mNumDevicesSeen++;
   if ((mNumDevicesSeen == mNumTotalDevices) && !mMatchFound) {
-    throw sycl::runtime_error(
-        "Could not find a device that matches the specified filter(s)!",
-        PI_ERROR_DEVICE_NOT_FOUND);
+    throw exception(
+        make_error_code(errc::runtime),
+        "Could not find a device that matches the specified filter(s)!");
   }
 
   return Score;

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -152,9 +152,9 @@ public:
         break;
       case bundle_state::input:
       case bundle_state::ext_oneapi_source:
-        throw sycl::runtime_error("Internal error. The target state should not "
-                                  "be input or ext_oneapi_source",
-                                  PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Internal error. The target state should not be input "
+                        "or ext_oneapi_source");
         break;
       }
     }

--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -459,7 +459,9 @@ void *MemoryManager::allocateMemSubBuffer(ContextImplPtr TargetContext,
         Error);
 
   if (Error != PI_SUCCESS) {
-    Plugin->reportPiError(Error, "allocateMemSubBuffer()");
+    throw set_pi_error(exception(make_error_code(errc::runtime),
+                                 "allocateMemSubBuffer() failed"),
+                       Error);
   }
 
   return NewMem;
@@ -750,8 +752,8 @@ static void copyH2H(SYCLMemObjI *, char *SrcMem, QueueImplPtr,
   if ((DimSrc != 1 || DimDst != 1) &&
       (SrcOffset != id<3>{0, 0, 0} || DstOffset != id<3>{0, 0, 0} ||
        SrcSize != SrcAccessRange || DstSize != DstAccessRange)) {
-    throw runtime_error("Not supported configuration of memcpy requested",
-                        PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::feature_not_supported),
+                    "Not supported configuration of memcpy requested");
   }
 
   SrcMem += SrcOffset[0] * SrcElemSize;
@@ -842,8 +844,8 @@ void MemoryManager::fill(SYCLMemObjI *SYCLMemObj, void *Mem, QueueImplPtr Queue,
     }
     // The sycl::handler uses a parallel_for kernel in the case of unusable
     // Range or Offset, not CG:Fill. So we should not be here.
-    throw runtime_error("Not supported configuration of fill requested",
-                        PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime),
+                    "Not supported configuration of fill requested");
   } else {
     if (OutEventImpl != nullptr)
       OutEventImpl->setHostEnqueueTime();
@@ -863,8 +865,8 @@ void *MemoryManager::map(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
                          std::vector<sycl::detail::pi::PiEvent> DepEvents,
                          sycl::detail::pi::PiEvent &OutEvent) {
   if (!Queue) {
-    throw runtime_error("Not supported configuration of map requested",
-                        PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime),
+                    "Not supported configuration of map requested");
   }
 
   pi_map_flags Flags = 0;
@@ -909,8 +911,8 @@ void MemoryManager::unmap(SYCLMemObjI *, void *Mem, QueueImplPtr Queue,
 
   // Execution on host is not supported here.
   if (!Queue) {
-    throw runtime_error("Not supported configuration of unmap requested",
-                        PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime),
+                    "Not supported configuration of unmap requested");
   }
   // All DepEvents are to the same Context.
   // Using the plugin of the Queue.
@@ -939,8 +941,8 @@ void MemoryManager::copy_usm(const void *SrcMem, QueueImplPtr SrcQueue,
   }
 
   if (!SrcMem || !DstMem)
-    throw runtime_error("NULL pointer argument in memory copy operation.",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "NULL pointer argument in memory copy operation.");
 
   const PluginPtr &Plugin = SrcQueue->getPlugin();
   if (OutEventImpl != nullptr)
@@ -968,8 +970,8 @@ void MemoryManager::fill_usm(void *Mem, QueueImplPtr Queue, size_t Length,
   }
 
   if (!Mem)
-    throw runtime_error("NULL pointer argument in memory fill operation.",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "NULL pointer argument in memory fill operation.");
   if (OutEventImpl != nullptr)
     OutEventImpl->setHostEnqueueTime();
   const PluginPtr &Plugin = Queue->getPlugin();
@@ -1551,8 +1553,8 @@ void MemoryManager::ext_oneapi_copy_usm_cmd_buffer(
     void *DstMem, std::vector<sycl::detail::pi::PiExtSyncPoint> Deps,
     sycl::detail::pi::PiExtSyncPoint *OutSyncPoint) {
   if (!SrcMem || !DstMem)
-    throw runtime_error("NULL pointer argument in memory copy operation.",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "NULL pointer argument in memory copy operation.");
 
   const PluginPtr &Plugin = Context->getPlugin();
   pi_result Result =
@@ -1576,8 +1578,8 @@ void MemoryManager::ext_oneapi_fill_usm_cmd_buffer(
     sycl::detail::pi::PiExtSyncPoint *OutSyncPoint) {
 
   if (!DstMem)
-    throw runtime_error("NULL pointer argument in memory fill operation.",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "NULL pointer argument in memory fill operation.");
 
   const PluginPtr &Plugin = Context->getPlugin();
 
@@ -1619,8 +1621,8 @@ void MemoryManager::ext_oneapi_fill_cmd_buffer(
   }
   // The sycl::handler uses a parallel_for kernel in the case of unusable
   // Range or Offset, not CG:Fill. So we should not be here.
-  throw runtime_error("Not supported configuration of fill requested",
-                      PI_ERROR_INVALID_OPERATION);
+  throw exception(make_error_code(errc::runtime),
+                  "Not supported configuration of fill requested");
 }
 
 void MemoryManager::ext_oneapi_prefetch_usm_cmd_buffer(

--- a/sycl/source/detail/pi.cpp
+++ b/sycl/source/detail/pi.cpp
@@ -504,8 +504,8 @@ template <backend BE> const PluginPtr &getPlugin() {
       return *Plugin;
     }
 
-  throw runtime_error("pi::getPlugin couldn't find plugin",
-                      PI_ERROR_INVALID_OPERATION);
+  throw exception(make_error_code(errc::runtime),
+                  "pi::getPlugin couldn't find plugin");
 }
 
 template __SYCL_EXPORT const PluginPtr &getPlugin<backend::opencl>();

--- a/sycl/source/detail/platform_util.cpp
+++ b/sycl/source/detail/platform_util.cpp
@@ -40,9 +40,8 @@ static void cpuid(uint32_t *CPUInfo, uint32_t Type, uint32_t SubType = 0) {
 #endif
 
 uint32_t PlatformUtil::getMaxClockFrequency() {
-  throw runtime_error(
-      "max_clock_frequency parameter is not supported for host device",
-      PI_ERROR_INVALID_DEVICE);
+  throw exception(make_error_code(errc::runtime),
+                  "max_clock_frequency parameter is not supported on host");
   return 0;
 }
 

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -189,16 +189,6 @@ public:
     __SYCL_CHECK_CODE_THROW_VIA_ERRC(pi_result, errc);
   }
 
-  void reportPiError(sycl::detail::pi::PiResult pi_result,
-                     const char *context) const {
-    if (pi_result != PI_SUCCESS) {
-      throw sycl::runtime_error(std::string(context) +
-                                    " API failed with error: " +
-                                    sycl::detail::codeToString(pi_result),
-                                pi_result);
-    }
-  }
-
   /// Calls the PiApi, traces the call, and returns the result.
   ///
   /// Usage:

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -92,7 +92,10 @@ createBinaryProgram(const ContextImplPtr Context, const device &Device,
       Metadata.size(), Metadata.data(), &BinaryStatus, &Program);
 
   if (BinaryStatus != CL_SUCCESS) {
-    throw runtime_error("Creating program with binary failed.", BinaryStatus);
+    throw detail::set_pi_error(
+        exception(make_error_code(errc::runtime),
+                  "Creating program with binary failed."),
+        BinaryStatus);
   }
 
   return Program;
@@ -179,12 +182,12 @@ ProgramManager::createPIProgram(const RTDeviceBinaryImage &Img,
 
   // perform minimal sanity checks on the device image and the descriptor
   if (RawImg.BinaryEnd < RawImg.BinaryStart) {
-    throw runtime_error("Malformed device program image descriptor",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::runtime),
+                    "Malformed device program image descriptor");
   }
   if (RawImg.BinaryEnd == RawImg.BinaryStart) {
-    throw runtime_error("Invalid device program image: size is zero",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::runtime),
+                    "Invalid device program image: size is zero");
   }
   size_t ImgSize = Img.getSize();
 
@@ -928,9 +931,9 @@ ProgramManager::ProgramManager() : m_AsanFoundInImage(false) {
     std::ifstream File(SpvFile, std::ios::binary);
 
     if (!File.is_open())
-      throw runtime_error(std::string("Can't open file specified via ") +
-                              UseSpvEnv + ": " + SpvFile,
-                          PI_ERROR_INVALID_VALUE);
+      throw exception(make_error_code(errc::runtime),
+                      std::string("Can't open file specified via ") +
+                          UseSpvEnv + ": " + SpvFile);
     File.seekg(0, std::ios::end);
     size_t Size = File.tellg();
     std::unique_ptr<char[]> Data(new char[Size]);
@@ -938,9 +941,9 @@ ProgramManager::ProgramManager() : m_AsanFoundInImage(false) {
     File.read(Data.get(), Size);
     File.close();
     if (!File.good())
-      throw runtime_error(std::string("read from ") + SpvFile +
-                              std::string(" failed"),
-                          PI_ERROR_INVALID_VALUE);
+      throw exception(make_error_code(errc::runtime),
+                      std::string("read from ") + SpvFile +
+                          std::string(" failed"));
     // No need for a mutex here since all access to these private fields is
     // blocked until the construction of the ProgramManager singleton is
     // finished.
@@ -1041,8 +1044,8 @@ ProgramManager::getDeviceImage(const std::string &KernelName,
     return *Img;
   }
 
-  throw runtime_error("No kernel named " + KernelName + " was found",
-                      PI_ERROR_INVALID_KERNEL_NAME);
+  throw exception(make_error_code(errc::runtime),
+                  "No kernel named " + KernelName + " was found");
 }
 
 RTDeviceBinaryImage &ProgramManager::getDeviceImage(
@@ -1449,7 +1452,7 @@ void ProgramManager::dumpImage(const RTDeviceBinaryImage &Img,
   std::ofstream F(Fname, std::ios::binary);
 
   if (!F.is_open()) {
-    throw runtime_error("Can not write " + Fname, PI_ERROR_UNKNOWN);
+    throw exception(make_error_code(errc::runtime), "Can not write " + Fname);
   }
   Img.dump(F);
   F.close();
@@ -1532,8 +1535,9 @@ static bool compatibleWithDevice(RTDeviceBinaryImage *BinImage,
           PIDeviceHandle, &DevBin,
           /*num bin images = */ (pi_uint32)1, &SuitableImageID);
   if (Error != PI_SUCCESS && Error != PI_ERROR_INVALID_BINARY)
-    throw runtime_error("Invalid binary image or device",
-                        PI_ERROR_INVALID_VALUE);
+    throw detail::set_pi_error(exception(make_error_code(errc::runtime),
+                                         "Invalid binary image or device"),
+                               Error);
 
   return (0 == SuitableImageID);
 }
@@ -1543,8 +1547,8 @@ kernel_id ProgramManager::getSYCLKernelID(const std::string &KernelName) {
 
   auto KernelID = m_KernelName2KernelIDs.find(KernelName);
   if (KernelID == m_KernelName2KernelIDs.end())
-    throw runtime_error("No kernel found with the specified name",
-                        PI_ERROR_INVALID_KERNEL_NAME);
+    throw exception(make_error_code(errc::runtime),
+                    "No kernel found with the specified name");
 
   return KernelID->second;
 }
@@ -1998,10 +2002,12 @@ ProgramManager::compile(const device_image_plain &DeviceImage,
   if (InputImpl->get_bin_image_ref()->getFormat() !=
           PI_DEVICE_BINARY_TYPE_SPIRV &&
       Devs.size() > 1)
-    sycl::runtime_error(
-        "Creating a program from AOT binary for multiple device is not "
-        "supported",
-        PI_ERROR_INVALID_OPERATION);
+    // FIXME: It was probably intended to be thrown, but a unittest starts
+    // failing if we do so, investigate independently of switching to SYCL 2020
+    // `exception`.
+    exception(make_error_code(errc::feature_not_supported),
+              "Creating a program from AOT binary for multiple device is "
+              "not supported");
 
   // Device is not used when creating program from SPIRV, so passing only one
   // device is OK.
@@ -2094,7 +2100,8 @@ ProgramManager::link(const device_image_plain &DeviceImage,
       const std::string ErrorMsg = getProgramBuildLog(LinkedProg, ContextImpl);
       throw sycl::exception(make_error_code(errc::build), ErrorMsg);
     }
-    Plugin->reportPiError(Error, "link()");
+    throw set_pi_error(exception(make_error_code(errc::build), "link() failed"),
+                       Error);
   }
 
   std::shared_ptr<std::vector<kernel_id>> KernelIDs{new std::vector<kernel_id>};
@@ -2193,10 +2200,12 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
     if (InputImpl->get_bin_image_ref()->getFormat() !=
             PI_DEVICE_BINARY_TYPE_SPIRV &&
         Devs.size() > 1)
-      sycl::runtime_error(
-          "Creating a program from AOT binary for multiple device is not "
-          "supported",
-          PI_ERROR_INVALID_OPERATION);
+      // FIXME: It was probably intended to be thrown, but a unittest starts
+      // failing if we do so, investigate independently of switching to SYCL
+      // 2020 `exception`.
+      exception(make_error_code(errc::feature_not_supported),
+                "Creating a program from AOT binary for multiple device "
+                "is not supported");
 
     // Device is not used when creating program from SPIRV, so passing only one
     // device is OK.

--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -222,8 +222,8 @@ event queue_impl::memcpy(const std::shared_ptr<detail::queue_impl> &Self,
 
   if ((!Src || !Dest) && Count != 0) {
     report(CodeLoc);
-    throw runtime_error("NULL pointer argument in memory copy operation.",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "NULL pointer argument in memory copy operation.");
   }
   return submitMemOpHelper(
       Self, DepEvents, CallerNeedsEvent,

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2908,8 +2908,8 @@ pi_int32 ExecCGCommand::enqueueImpCommandBuffer() {
   }
 
   default:
-    throw runtime_error("CG type not implemented for command buffers.",
-                        PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime),
+                    "CG type not implemented for command buffers.");
   }
 }
 

--- a/sycl/source/detail/scheduler/graph_processor.cpp
+++ b/sycl/source/detail/scheduler/graph_processor.cpp
@@ -36,7 +36,7 @@ void Scheduler::GraphProcessor::waitForEvent(const EventImplPtr &Event,
       enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd, BLOCKING);
   if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
     // TODO: Reschedule commands.
-    throw runtime_error("Enqueue process failed.", PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime), "Enqueue process failed.");
 
   assert(Cmd->getEvent() == Event);
 

--- a/sycl/source/detail/scheduler/scheduler.cpp
+++ b/sycl/source/detail/scheduler/scheduler.cpp
@@ -54,8 +54,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
     bool Enqueued =
         GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-      throw runtime_error("Enqueue process failed.",
-                          PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime),
+                      "Enqueue process failed.");
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Capture the dependencies
     DepCommands.insert(Cmd);
@@ -67,8 +67,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
     bool Enqueued =
         GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-      throw runtime_error("Enqueue process failed.",
-                          PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime),
+                      "Enqueue process failed.");
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     DepCommands.insert(Cmd);
 #endif
@@ -80,8 +80,8 @@ void Scheduler::waitForRecordToFinish(MemObjRecord *Record,
     bool Enqueued = GraphProcessor::enqueueCommand(ReleaseCmd, GraphReadLock,
                                                    Res, ToCleanUp, ReleaseCmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-      throw runtime_error("Enqueue process failed.",
-                          PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime),
+                      "Enqueue process failed.");
 #ifdef XPTI_ENABLE_INSTRUMENTATION
     // Report these dependencies to the Command so these dependencies can be
     // reported as edges
@@ -171,8 +171,8 @@ void Scheduler::enqueueCommandForCG(EventImplPtr NewEvent,
                                                 Blocking);
       try {
         if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-          throw runtime_error("Auxiliary enqueue process failed.",
-                              PI_ERROR_INVALID_OPERATION);
+          throw exception(make_error_code(errc::runtime),
+                          "Auxiliary enqueue process failed.");
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak
@@ -188,8 +188,8 @@ void Scheduler::enqueueCommandForCG(EventImplPtr NewEvent,
         bool Enqueued = GraphProcessor::enqueueCommand(
             NewCmd, Lock, Res, ToCleanUp, NewCmd, Blocking);
         if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-          throw runtime_error("Enqueue process failed.",
-                              PI_ERROR_INVALID_OPERATION);
+          throw exception(make_error_code(errc::runtime),
+                          "Enqueue process failed.");
       } catch (...) {
         // enqueueCommand() func and if statement above may throw an exception,
         // so destroy required resources to avoid memory leak
@@ -222,15 +222,15 @@ EventImplPtr Scheduler::addCopyBack(Requirement *Req) {
     for (Command *Cmd : AuxiliaryCmds) {
       Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-        throw runtime_error("Enqueue process failed.",
-                            PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
     }
 
     Enqueued =
         GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-      throw runtime_error("Enqueue process failed.",
-                          PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime),
+                      "Enqueue process failed.");
   } catch (...) {
     auto WorkerQueue = NewCmd->getEvent()->getWorkerQueue();
     assert(WorkerQueue && "WorkerQueue for CopyBack command must be not null");
@@ -309,16 +309,16 @@ EventImplPtr Scheduler::addHostAccessor(Requirement *Req) {
     for (Command *Cmd : AuxiliaryCmds) {
       Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-        throw runtime_error("Enqueue process failed.",
-                            PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
     }
 
     if (Command *NewCmd = static_cast<Command *>(NewCmdEvent->getCommand())) {
       Enqueued =
           GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-        throw runtime_error("Enqueue process failed.",
-                            PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
     }
   }
 
@@ -352,8 +352,8 @@ void Scheduler::enqueueLeavesOfReqUnlocked(const Requirement *const Req,
       bool Enqueued = GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res,
                                                      ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-        throw runtime_error("Enqueue process failed.",
-                            PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
     }
   };
 
@@ -372,8 +372,8 @@ void Scheduler::enqueueUnblockedCommands(
     bool Enqueued =
         GraphProcessor::enqueueCommand(Cmd, GraphReadLock, Res, ToCleanUp, Cmd);
     if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-      throw runtime_error("Enqueue process failed.",
-                          PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::runtime),
+                      "Enqueue process failed.");
   }
 }
 
@@ -674,16 +674,16 @@ EventImplPtr Scheduler::addCommandGraphUpdate(
     for (Command *Cmd : AuxiliaryCmds) {
       Enqueued = GraphProcessor::enqueueCommand(Cmd, Lock, Res, ToCleanUp, Cmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-        throw runtime_error("Enqueue process failed.",
-                            PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
     }
 
     if (Command *NewCmd = static_cast<Command *>(NewCmdEvent->getCommand())) {
       Enqueued =
           GraphProcessor::enqueueCommand(NewCmd, Lock, Res, ToCleanUp, NewCmd);
       if (!Enqueued && EnqueueResultT::SyclEnqueueFailed == Res.MResult)
-        throw runtime_error("Enqueue process failed.",
-                            PI_ERROR_INVALID_OPERATION);
+        throw exception(make_error_code(errc::runtime),
+                        "Enqueue process failed.");
     }
   }
 

--- a/sycl/source/detail/spec_constant_impl.cpp
+++ b/sycl/source/detail/spec_constant_impl.cpp
@@ -22,8 +22,8 @@ namespace detail {
 
 void spec_constant_impl::set(size_t Size, const void *Val) {
   if (0 == Size)
-    throw sycl::runtime_error("invalid spec constant size",
-                              PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "invalid spec constant size");
   auto *BytePtr = reinterpret_cast<const char *>(Val);
   this->Bytes.assign(BytePtr, BytePtr + Size);
 }

--- a/sycl/source/detail/sycl_mem_obj_t.hpp
+++ b/sycl/source/detail/sycl_mem_obj_t.hpp
@@ -249,10 +249,9 @@ public:
     MHostPtrReadOnly = IsConstPtr;
     setAlign(RequiredAlign);
     if (useHostPtr())
-      throw runtime_error(
-          "Buffer constructor from a pair of iterator values does not support "
-          "use_host_ptr property.",
-          PI_ERROR_INVALID_OPERATION);
+      throw exception(make_error_code(errc::invalid),
+                      "Buffer constructor from a pair of iterator values does "
+                      "not support use_host_ptr property.");
 
     setAlign(RequiredAlign);
     MShadowCopy = allocateHostMem();
@@ -277,7 +276,7 @@ public:
     (void)InitFromUserData;
     (void)HostPtr;
     (void)InteropEvent;
-    throw runtime_error("Not implemented", PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime), "Not implemented");
   }
 
   MemObjType getType() const override { return MemObjType::Undefined; }

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -554,7 +554,9 @@ alloc get_pointer_type(const void *Ptr, const context &Ctxt) {
     return alloc::unknown;
   // otherwise PI_SUCCESS is expected
   if (Err != PI_SUCCESS) {
-    Plugin->reportPiError(Err, "get_pointer_type()");
+    throw detail::set_pi_error(
+        exception(make_error_code(errc::runtime), "get_pointer_type() failed"),
+        Err);
   }
 
   alloc ResultAlloc;
@@ -583,8 +585,8 @@ alloc get_pointer_type(const void *Ptr, const context &Ctxt) {
 device get_pointer_device(const void *Ptr, const context &Ctxt) {
   // Check if ptr is a valid USM pointer
   if (get_pointer_type(Ptr, Ctxt) == alloc::unknown)
-    throw runtime_error("Ptr not a valid USM allocation!",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "Ptr not a valid USM allocation!");
 
   std::shared_ptr<detail::context_impl> CtxImpl = detail::getSyclObjImpl(Ctxt);
 
@@ -592,8 +594,8 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
   if (get_pointer_type(Ptr, Ctxt) == alloc::host) {
     auto Devs = CtxImpl->getDevices();
     if (Devs.size() == 0)
-      throw runtime_error("No devices in passed context!",
-                          PI_ERROR_INVALID_VALUE);
+      throw exception(make_error_code(errc::invalid),
+                      "No devices in passed context!");
 
     // Just return the first device in the context
     return Devs[0];
@@ -614,8 +616,8 @@ device get_pointer_device(const void *Ptr, const context &Ctxt) {
       PltImpl->getDeviceImpl(DeviceId);
   if (DevImpl)
     return detail::createSyclObjFromImpl<device>(DevImpl);
-  throw runtime_error("Cannot find device associated with USM allocation!",
-                      PI_ERROR_INVALID_OPERATION);
+  throw exception(make_error_code(errc::runtime),
+                  "Cannot find device associated with USM allocation!");
 }
 
 // Device copy enhancement APIs, prepare_for and release_from USM.

--- a/sycl/source/device_selector.cpp
+++ b/sycl/source/device_selector.cpp
@@ -128,7 +128,7 @@ device select_device(DSelectorInvocableType DeviceSelectorInvocable,
     Message += Acc;
   }
   Message += Suffix;
-  throw sycl::runtime_error(Message, PI_ERROR_DEVICE_NOT_FOUND);
+  throw exception(make_error_code(errc::runtime), Message);
 }
 
 // select_device(selector)

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -504,9 +504,8 @@ event handler::finalize() {
   }
 
   if (!CommandGroup)
-    throw sycl::runtime_error(
-        "Internal Error. Command group cannot be constructed.",
-        PI_ERROR_INVALID_OPERATION);
+    throw exception(make_error_code(errc::runtime),
+                    "Internal Error. Command group cannot be constructed.");
 
   // If there is a graph associated with the handler we are in the explicit
   // graph mode, so we store the CG instead of submitting it to the scheduler,
@@ -796,7 +795,8 @@ void handler::processArg(void *Ptr, const detail::kernel_param_kind_t &Kind,
     break;
   }
   case kernel_param_kind_t::kind_invalid:
-    throw runtime_error("Invalid kernel param kind", PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::invalid),
+                    "Invalid kernel param kind");
     break;
   }
 }

--- a/sycl/test-e2e/Config/env_vars.cpp
+++ b/sycl/test-e2e/Config/env_vars.cpp
@@ -23,25 +23,17 @@ int main() {
   int data = 5;
   buffer<int, 1> buf(&data, range<1>(1));
   queue myQueue;
-  if (getenv("SHOULD_CRASH")) {
-    try {
-      myQueue.submit([&](handler &cgh) {
-        auto B = buf.get_access<access::mode::read_write>(cgh);
-        cgh.single_task<class kernel_name1>([=]() { B[0] = 0; });
-      });
-    } catch (sycl::runtime_error &e) {
-      // Exit immediately, otherwise the buffer destructor may actually try to
-      // enqueue the command once again, and throw another exception.
-      exit(0);
-    } catch (sycl::exception &e) {
-      if (e.code() == errc::build)
-        exit(0);
-    }
-    assert(0 && "Expected exception was *not* thrown");
-  } else {
+  bool shouldCrash = getenv("SHOULD_CRASH");
+  try {
     myQueue.submit([&](handler &cgh) {
       auto B = buf.get_access<access::mode::read_write>(cgh);
-      cgh.single_task<class kernel_name2>([=]() { B[0] = 0; });
+      cgh.single_task<class kernel_name1>([=]() { B[0] = 0; });
     });
+    assert(!shouldCrash);
+  } catch (sycl::exception &e) {
+    assert(shouldCrash);
+    assert(e.code() == errc::build);
   }
+
+  return 0;
 }

--- a/sycl/test-e2e/FilterSelector/select.cpp
+++ b/sycl/test-e2e/FilterSelector/select.cpp
@@ -116,7 +116,7 @@ int main() {
     // pick something crazy
     device d10(filter_selector("bob:gpu"));
   } catch (const sycl::exception &e) {
-    assert(e.code() == sycl::errc::runtime);
+    assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
     assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
            "filter_selector(\"bob:gpu\") unexpectedly selected a device");
@@ -126,7 +126,7 @@ int main() {
     // pick something crazy
     device d11(filter_selector("opencl:bob"));
   } catch (const sycl::exception &e) {
-    assert(e.code() == sycl::errc::runtime);
+    assert(e.code() == sycl::errc::invalid);
     const char *ErrorMesg = "Invalid filter string!";
     assert(std::string{e.what()}.find(ErrorMesg) == 0 &&
            "filter_selector(\"opencl:bob\") unexpectedly selected a device");

--- a/sycl/test-e2e/Tracing/code_location_queue_submit.cpp
+++ b/sycl/test-e2e/Tracing/code_location_queue_submit.cpp
@@ -24,7 +24,7 @@ int main() {
     // CHECK-DAG:        sycl_device_name : {{.*}}
     // CHECK-DAG:        sycl_context : {{.*}}
     // CHECK: [SYCL] Runtime reports:
-    // CHECK-NEXT: what:  NULL pointer argument in memory copy operation. -30 (PI_ERROR_INVALID_VALUE)
+    // CHECK-NEXT: what:  NULL pointer argument in memory copy operation.
     // CHECK-NEXT: where:{{.*}}code_location_queue_submit.cpp:[[# @LINE + 2 ]] main
     try {
       Q.submit(

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -261,9 +261,7 @@ TEST(KernelID, GetKernelIDInvalidKernelName) {
     FAIL() << "Expected an exception";
   } catch (sycl::exception const &e) {
     EXPECT_TRUE(e.code() == sycl::errc::runtime);
-    EXPECT_EQ(std::string("No kernel found with the specified name -46 "
-                          "(PI_ERROR_INVALID_KERNEL_NAME)"),
-              e.what());
+    EXPECT_EQ(std::string("No kernel found with the specified name"), e.what());
   } catch (...) {
     FAIL() << "Expected sycl::exception";
   }


### PR DESCRIPTION
... instead of deprecated SYCL 1.2 subclasses that we're going to remove during this ABI breaking window. In many cases there is no clear choice of using `errc::runtime` vs `errc::invalid` or something else. I tried to use my best judgement. Reviewers, feel free to start inline discussions in comments if you disagree with my choice(s).