### PR TITLE
[SYCL][ESIMD][E2E] Fix PVC test compilation

### DIFF
--- a/sycl/test-e2e/ESIMD/named_barriers/exec_in_order.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/exec_in_order.cpp
@@ -9,8 +9,7 @@
 // REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -o %t1.out -DEXP
-// RUN: %{run} %t1.out
+
 //
 // Test checks support of named barrier in ESIMD kernel.
 // Threads are executed in ascending order of their local ID and each thread
@@ -19,11 +18,7 @@
 
 #include "../esimd_test_utils.hpp"
 
-#ifdef EXP
-#define NS __ESIMD_ENS
-#else
 #define NS __ESIMD_NS
-#endif
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/named_barriers/exec_in_order_branched.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/exec_in_order_branched.cpp
@@ -9,9 +9,7 @@
 // REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -o %t1.out -DEXP
-// RUN: %{run} %t1.out
-//
+
 // Test checks support of named barrier in ESIMD kernel.
 // Threads are executed in ascending order of their local ID and each thread
 // stores data to addresses that partially overlap with addresses used by
@@ -20,11 +18,7 @@
 
 #include "../esimd_test_utils.hpp"
 
-#ifdef EXP
-#define NS __ESIMD_ENS
-#else
 #define NS __ESIMD_NS
-#endif
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop.cpp
@@ -9,8 +9,6 @@
 // REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -o %t1.out -DEXP
-// RUN: %{run} %t1.out
 //
 // Test checks support of named barrier in a loop in ESIMD kernel.
 // SLM and surface size is 32 bytes, 16 bytes per iteration.
@@ -19,11 +17,7 @@
 
 #include "../esimd_test_utils.hpp"
 
-#ifdef EXP
-#define NS __ESIMD_ENS
-#else
 #define NS __ESIMD_NS
-#endif
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/loop_extended.cpp
@@ -9,8 +9,7 @@
 // REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -o %t1.out -DEXP
-// RUN: %{run} %t1.out
+
 //
 // Test checks support of named barrier in a loop in ESIMD kernel.
 // First iteration has 1 barrier and 1 producer, second - 2 barriers and 2
@@ -19,11 +18,7 @@
 
 #include "../esimd_test_utils.hpp"
 
-#ifdef EXP
-#define NS __ESIMD_ENS
-#else
 #define NS __ESIMD_NS
-#endif
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/named_barriers/multiple_wg.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/multiple_wg.cpp
@@ -9,8 +9,7 @@
 // REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -o %t1.out -DEXP
-// RUN: %{run} %t1.out
+
 //
 // Test checks support of named barrier in ESIMD kernel.
 // Basic case with 2 work-groups.
@@ -20,11 +19,7 @@
 
 #include "../esimd_test_utils.hpp"
 
-#ifdef EXP
-#define NS __ESIMD_ENS
-#else
 #define NS __ESIMD_NS
-#endif
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/ESIMD/named_barriers/single_wg.cpp
+++ b/sycl/test-e2e/ESIMD/named_barriers/single_wg.cpp
@@ -9,8 +9,7 @@
 // REQUIRES: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -o %t1.out -DEXP
-// RUN: %{run} %t1.out
+
 //
 // Test checks support of named barrier in ESIMD kernel.
 // Basic case with 1 work-group and 16 threads: 4 producer and 12 consumer.
@@ -20,11 +19,7 @@
 
 #include "../esimd_test_utils.hpp"
 
-#ifdef EXP
-#define NS __ESIMD_ENS
-#else
 #define NS __ESIMD_NS
-#endif
 
 using namespace sycl;
 using namespace sycl::ext::intel::esimd;

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_basic.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_basic.cpp
@@ -41,15 +41,15 @@ class Test {};
 
 ESIMD_INLINE void ESIMD_CALLEE_nbarrier(nd_item<1> *ndi) SYCL_ESIMD_FUNCTION {
   const uint8_t BARNUM = 32;
-  experimental_esimd::named_barrier_init<BARNUM>();
+  esimd::named_barrier_init<BARNUM>();
 
   uint8_t barrier_id = 1;
   uint8_t producer_consumer_mode = 0;
   uint32_t num_producers = 16;
   uint32_t num_consumers = 16;
-  __ESIMD_ENS::named_barrier_signal(barrier_id, producer_consumer_mode,
-                                    num_producers, num_consumers);
-  __ESIMD_ENS::named_barrier_wait(barrier_id);
+  __ESIMD_NS::named_barrier_signal(barrier_id, producer_consumer_mode,
+                                   num_producers, num_consumers);
+  __ESIMD_NS::named_barrier_wait(barrier_id);
 }
 
 [[intel::device_indirectly_callable]] SYCL_EXTERNAL void __regcall SIMD_CALLEE_nbarrier(

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_exec_in_order.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_exec_in_order.cpp
@@ -42,7 +42,7 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
                                         int *o) SYCL_ESIMD_FUNCTION {
   // Threads - 1 named barriers required
   // but id 0 reserved for unnamed
-  experimental_esimd::named_barrier_init<Threads>();
+  esimd::named_barrier_init<Threads>();
 
   int flag = 0; // producer-consumer mode
   int producers = 2;
@@ -72,8 +72,8 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
    */
   if (local_id > 0) {
     int barrier_id = local_id;
-    __ESIMD_ENS::named_barrier_signal(barrier_id, flag, producers, consumers);
-    __ESIMD_ENS::named_barrier_wait(barrier_id);
+    __ESIMD_NS::named_barrier_signal(barrier_id, flag, producers, consumers);
+    __ESIMD_NS::named_barrier_wait(barrier_id);
   }
 
   /* This is the payload store with overlapping offset. Since threads are
@@ -85,7 +85,7 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
   else
     experimental_esimd::lsc_block_store<int, VL>(o + off, val);
 
-  experimental_esimd::lsc_fence();
+  esimd::fence();
 
   /* local_id == 0 arrives here first and signals barrier 1
    * local_id == 1 arrives here next and signals barrier 2
@@ -94,8 +94,8 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
    */
   if (local_id < Threads - 1) {
     int barrier_id = local_id + 1;
-    __ESIMD_ENS::named_barrier_signal(barrier_id, flag, producers, consumers);
-    __ESIMD_ENS::named_barrier_wait(barrier_id);
+    __ESIMD_NS::named_barrier_signal(barrier_id, flag, producers, consumers);
+    __ESIMD_NS::named_barrier_wait(barrier_id);
   }
 
   esimd::barrier();

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_loop.cpp
@@ -50,7 +50,7 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
   // 2 named barriers, id 0 reserved for unnamed
   constexpr unsigned bnum = 3;
 
-  experimental_esimd::named_barrier_init<bnum>();
+  esimd::named_barrier_init<bnum>();
 
   // 2 producers on first iteration, 1 producer on second
   unsigned int indexes[2][2] = {{1, 2}, {3, 3}}; // local ids of producers
@@ -98,13 +98,13 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
       experimental_esimd::lsc_slm_block_store<int, VL>(slm_off, init);
     }
 
-    __ESIMD_ENS::named_barrier_signal(b, flag, producers, consumers);
+    __ESIMD_NS::named_barrier_signal(b, flag, producers, consumers);
 
     if (is_consumer)
-      __ESIMD_ENS::named_barrier_wait(b);
+      __ESIMD_NS::named_barrier_wait(b);
   }
 
-  experimental_esimd::lsc_fence();
+  esimd::fence();
 
   // Copying SLM content to buffer.
   if (local_id == 0) {

--- a/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/nbarrier_multiple_wg.cpp
@@ -42,7 +42,7 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
   // 1 named barrier, id 0 reserved for unnamed
   constexpr unsigned bnum = 2;
   constexpr unsigned bid = 1;
-  experimental_esimd::named_barrier_init<bnum>();
+  esimd::named_barrier_init<bnum>();
 
   constexpr unsigned producers = Threads / 2;
   constexpr unsigned consumers = Threads / 2;
@@ -73,11 +73,11 @@ ESIMD_INLINE void ESIMD_CALLEE_nbarrier(local_accessor<int, 1> local_acc,
     experimental_esimd::lsc_slm_block_store<int, VL>(slm_off, val);
   }
 
-  __ESIMD_ENS::named_barrier_signal(bid, flag, producers, consumers);
+  __ESIMD_NS::named_barrier_signal(bid, flag, producers, consumers);
 
   if (is_consumer) {
     // Consumers waiting here for signal from producer.
-    __ESIMD_ENS::named_barrier_wait(bid);
+    __ESIMD_NS::named_barrier_wait(bid);
     // Consumers simply copying producers data from SLM to global buffer.
     auto ret = experimental_esimd::lsc_slm_block_load<int, VL>(slm_off);
     experimental_esimd::lsc_block_store<int, VL>(o + global_off, ret);


### PR DESCRIPTION
Broken after https://github.com/intel/llvm/commit/b30e6f04766d6ce83c781151d43112ac6e3aa40f but since we don't test on PVC in CI it can only get caught manually.

Thanks to @AlexeySachkov for finding this.