### PR TITLE
Disable RecordReplay/host_task_last

### DIFF
--- a/sycl/test-e2e/Graph/RecordReplay/host_task_last.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_last.cpp
@@ -2,8 +2,10 @@
 // RUN: %{run} %t.out
 // Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Disabled due to https://github.com/intel/llvm/issues/14473
 // Extra run to check for immediate-command-list in Level Zero
-// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// xRUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_shared_allocations
 


### PR DESCRIPTION
The RecordReplay/host_task_last.cpp test failed in https://github.com/intel/llvm/pull/14498 which appears to be the same as was previously reported in https://github.com/intel/llvm/issues/14473. This commit disables the test.