### PR TITLE
[SYCL][NFC] Rename custom swap to avoid collision

### DIFF
--- a/sycl/include/sycl/detail/group_sort_impl.hpp
+++ b/sycl/include/sycl/detail/group_sort_impl.hpp
@@ -85,9 +85,13 @@ align_key_value_scratch(sycl::span<std::byte> scratch, Group g,
 }
 #endif
 
+template <typename T> void swap_tuples(T &first, T &second) {
+  std::swap(first, second);
+}
+
 // Swap tuples of references.
 template <template <typename...> class Tuple, typename... T>
-void swap(Tuple<T &...> &&first, Tuple<T &...> &&second) {
+void swap_tuples(Tuple<T &...> &&first, Tuple<T &...> &&second) {
   auto lhs = first;
   auto rhs = second;
   // Do std::swap for each element of the tuple.
@@ -240,7 +244,7 @@ void bubble_sort(Iter first, const size_t begin, const size_t end,
       // Handle intermediate items
       for (size_t idx = begin; idx < begin + (end - 1 - i); ++idx) {
         if (comp(first[idx + 1], first[idx])) {
-          detail::swap(first[idx], first[idx + 1]);
+          detail::swap_tuples(first[idx], first[idx + 1]);
         }
       }
     }

--- a/sycl/include/sycl/detail/key_value_iterator.hpp
+++ b/sycl/include/sycl/detail/key_value_iterator.hpp
@@ -85,10 +85,6 @@ private:
   std::tuple<T1 *, T2 *> KeyValue;
 };
 
-template <typename T> void swap(T &first, T &second) {
-  std::swap(first, second);
-}
-
 } // namespace detail
 } // namespace _V1
 } // namespace sycl


### PR DESCRIPTION
Current name (even though it is in sycl::detail namespace) somehow affects accessor_iterator causing the nightly cts failure: https://github.com/intel/llvm/issues/14517
So rename the function as an easy fix.