### PR TITLE
[SYCL][E2E] Fix another test in multi-device mode

### DIFF
--- a/sycl/test-e2e/syclcompat/math/math_byte_dot_product.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_byte_dot_product.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend --cuda-gpu-arch=sm_61 %}  %s -o %t.out
+// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_61 %}  %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
The compiler needs to be told which device the `--cuda-gpu-arch` parameter applies to.