### PR TITLE
[SYCL][E2E] Fix multiple test suite discovery

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -191,6 +191,7 @@ if lit_config.params.get("ur_l0_leaks_debug"):
 if lit_config.params.get("enable-perf-tests", False):
     config.available_features.add("enable-perf-tests")
 
+
 # Use this to make sure that any dynamic checks below are done in the build
 # directory and not where the sources are located. This is important for the
 # in-tree configuration (as opposite to the standalone one).

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -190,10 +190,12 @@ if lit_config.params.get("ur_l0_leaks_debug"):
 
 if lit_config.params.get("enable-perf-tests", False):
     config.available_features.add("enable-perf-tests")
-# Make sure that any dynamic checks below are done in the build directory and
-# not where the sources are located. This is important for the in-tree
-# configuration (as opposite to the standalone one).
-os.chdir(config.sycl_obj_root)
+
+# Use this to make sure that any dynamic checks below are done in the build
+# directory and not where the sources are located. This is important for the
+# in-tree configuration (as opposite to the standalone one).
+def open_check_file(file_name):
+    return open(os.path.join(config.sycl_obj_root, file_name), "w")
 
 # check if compiler supports CL command line options
 cl_options = False
@@ -204,7 +206,7 @@ if sp[0] == 0:
 
 # Check for Level Zero SDK
 check_l0_file = "l0_include.cpp"
-with open(check_l0_file, "w") as fp:
+with open_check_file(check_l0_file) as fp:
     print(
         textwrap.dedent(
             """
@@ -254,7 +256,7 @@ else:
 
 # Check for sycl-preview library
 check_preview_breaking_changes_file = "preview_breaking_changes_link.cpp"
-with open(check_preview_breaking_changes_file, "w") as fp:
+with open_check_file(check_preview_breaking_changes_file) as fp:
     print(
         textwrap.dedent(
             """
@@ -278,7 +280,7 @@ if sp[0] == 0:
 
 # Check for CUDA SDK
 check_cuda_file = "cuda_include.cpp"
-with open(check_cuda_file, "w") as fp:
+with open_check_file(check_cuda_file) as fp:
     print(
         textwrap.dedent(
             """
@@ -637,7 +639,7 @@ for aot_tool in aot_tools:
 # be ill-formed (compilation stops with non-zero exit code) if the feature
 # test macro for kernel fusion is not defined.
 check_fusion_file = "check_fusion.cpp"
-with open(check_fusion_file, "w") as ff:
+with open_check_file(check_fusion_file) as ff:
     ff.write("#include <sycl/sycl.hpp>\n")
     ff.write("#ifndef SYCL_EXT_CODEPLAY_KERNEL_FUSION\n")
     ff.write('#error "Feature test for fusion failed"\n')


### PR DESCRIPTION
Since #9078 (itself a fix for #8854), the SYCL E2E lit config would change the working directory and never set it back. This impeded LIT's ability to discover tests and test suites, when tasked with sourcing multiple.

For example:

    llvm-lit sycl/test/A sycl/test/B

LIT would discover test 'A' by appending its relative path to the CWD (e.g., `root/sycl/test/A`) and load up the SYCL E2E lit.cfg. This would change directory into the SYCL build directory. When discovering test 'B' it would append its relative path to the SYCL binary dir and fail to find it (e.g., `root/build/tools/sycl/test-e2e/sycl/test/B`).

This would also have the effect of loading the SYCL E2E LIT config a second time, even though it was already loaded.

With this change, we maintain the CWD but open the temp files using absolute paths. This allows us to run multiple tests from multiple different paths at the same time, even ones from different suites:

    llvm-lit sycl/test/A clang/test/B llvm/test/C

Running multiple individual SYCL tests on the same command line will also only load the SYCL config the once.