### PR TITLE
[OpenCL] Set WG dimension metadata for all reqd_work_group_size attrs

### DIFF
--- a/clang/lib/CodeGen/CodeGenFunction.cpp
+++ b/clang/lib/CodeGen/CodeGenFunction.cpp
@@ -683,11 +683,11 @@ void CodeGenFunction::EmitKernelMetadata(const FunctionDecl *FD,
         llvm::ConstantAsMetadata::get(Builder.getInt32(A->getXDim())),
         llvm::ConstantAsMetadata::get(Builder.getInt32(A->getYDim())),
         llvm::ConstantAsMetadata::get(Builder.getInt32(A->getZDim()))};
-    Fn->setMetadata("reqd_work_group_size",
-                    llvm::MDNode::get(Context, AttrMDArgs));
     Fn->setMetadata("work_group_num_dim",
                     llvm::MDNode::get(Context, llvm::ConstantAsMetadata::get(
                                                    Builder.getInt32(3))));
+    Fn->setMetadata("reqd_work_group_size",
+                    llvm::MDNode::get(Context, AttrMDArgs));
   }
 
   if (const SYCLReqdWorkGroupSizeAttr *A =
@@ -711,11 +711,11 @@ void CodeGenFunction::EmitKernelMetadata(const FunctionDecl *FD,
     for (unsigned i = NumDims; i < 3; i++)
       AttrMDArgs.push_back(llvm::ConstantAsMetadata::get(Builder.getInt32(1)));
 
-    Fn->setMetadata("reqd_work_group_size",
-                    llvm::MDNode::get(Context, AttrMDArgs));
     Fn->setMetadata("work_group_num_dim",
                     llvm::MDNode::get(Context, llvm::ConstantAsMetadata::get(
                                                    Builder.getInt32(NumDims))));
+    Fn->setMetadata("reqd_work_group_size",
+                    llvm::MDNode::get(Context, AttrMDArgs));
   }
 
   bool IsKernelOrDevice =

--- a/clang/test/CodeGenOpenCL/kernel-attributes.cl
+++ b/clang/test/CodeGenOpenCL/kernel-attributes.cl
@@ -3,7 +3,7 @@
 typedef unsigned int uint4 __attribute__((ext_vector_type(4)));
 
 kernel  __attribute__((vec_type_hint(int))) __attribute__((reqd_work_group_size(1,2,4))) void kernel1(int a) {}
-// CHECK: define {{(dso_local )?}}spir_kernel void @kernel1(i32 {{[^%]*}}%a) {{[^{]+}} !vec_type_hint ![[MD1:[0-9]+]] !reqd_work_group_size ![[MD2:[0-9]+]] !work_group_num_dim ![[MD6:[0-9]+]]
+// CHECK: define {{(dso_local )?}}spir_kernel void @kernel1(i32 {{[^%]*}}%a) {{[^{]+}} !vec_type_hint ![[MD1:[0-9]+]]  !work_group_num_dim ![[MD6:[0-9]+]] !reqd_work_group_size ![[MD2:[0-9]+]]
 
 kernel __attribute__((vec_type_hint(uint4))) __attribute__((work_group_size_hint(8,16,32))) void kernel2(int a) {}
 // CHECK: define {{(dso_local )?}}spir_kernel void @kernel2(i32 {{[^%]*}}%a) {{[^{]+}} !vec_type_hint ![[MD3:[0-9]+]] !work_group_size_hint ![[MD4:[0-9]+]]
@@ -12,8 +12,8 @@ kernel __attribute__((intel_reqd_sub_group_size(8))) void kernel3(int a) {}
 // CHECK: define {{(dso_local )?}}spir_kernel void @kernel3(i32 {{[^%]*}}%a) {{[^{]+}} !intel_reqd_sub_group_size ![[MD5:[0-9]+]]
 
 // CHECK: [[MD1]] = !{i32 undef, i32 1}
-// CHECK: [[MD2]] = !{i32 1, i32 2, i32 4}
 // CHECK: [[MD6]] = !{i32 3}
+// CHECK: [[MD2]] = !{i32 1, i32 2, i32 4}
 // CHECK: [[MD3]] = !{<4 x i32> undef, i32 0}
 // CHECK: [[MD4]] = !{i32 8, i32 16, i32 32}
 // CHECK: [[MD5]] = !{i32 8}

--- a/clang/test/CodeGenOpenCL/kernel-attributes.cl
+++ b/clang/test/CodeGenOpenCL/kernel-attributes.cl
@@ -3,7 +3,7 @@
 typedef unsigned int uint4 __attribute__((ext_vector_type(4)));
 
 kernel  __attribute__((vec_type_hint(int))) __attribute__((reqd_work_group_size(1,2,4))) void kernel1(int a) {}
-// CHECK: define {{(dso_local )?}}spir_kernel void @kernel1(i32 {{[^%]*}}%a) {{[^{]+}} !vec_type_hint ![[MD1:[0-9]+]] !reqd_work_group_size ![[MD2:[0-9]+]]
+// CHECK: define {{(dso_local )?}}spir_kernel void @kernel1(i32 {{[^%]*}}%a) {{[^{]+}} !vec_type_hint ![[MD1:[0-9]+]] !reqd_work_group_size ![[MD2:[0-9]+]] !work_group_num_dim ![[MD6:[0-9]+]]
 
 kernel __attribute__((vec_type_hint(uint4))) __attribute__((work_group_size_hint(8,16,32))) void kernel2(int a) {}
 // CHECK: define {{(dso_local )?}}spir_kernel void @kernel2(i32 {{[^%]*}}%a) {{[^{]+}} !vec_type_hint ![[MD3:[0-9]+]] !work_group_size_hint ![[MD4:[0-9]+]]
@@ -13,6 +13,7 @@ kernel __attribute__((intel_reqd_sub_group_size(8))) void kernel3(int a) {}
 
 // CHECK: [[MD1]] = !{i32 undef, i32 1}
 // CHECK: [[MD2]] = !{i32 1, i32 2, i32 4}
+// CHECK: [[MD6]] = !{i32 3}
 // CHECK: [[MD3]] = !{<4 x i32> undef, i32 0}
 // CHECK: [[MD4]] = !{i32 8, i32 16, i32 32}
 // CHECK: [[MD5]] = !{i32 8}


### PR DESCRIPTION
This makes the OpenCL and SYCL function attributes lower consistently to the same LLVM IR. This could be useful, e.g., in a middle-end or backend pass processing the `!reqd_work_group_size` metadata that has no knowledge of the front-end attributes. It might not even be able to distinguish between OpenCL and SYCL kernels since they usually share the same calling conventions, metadata, etc. The choices the pass would have to make to work around the possible presence or absence of the !work_group_num_dim metadata and the assumptions either would imply would be greatly simplified with a uniform metadata format.

This also cleans up the SYCL side of the attribute handling somewhat.