### PR TITLE
[SYCL][ESIMD][E2E] Disable assert.cpp on Gen12

### DIFF
--- a/sycl/test-e2e/ESIMD/assert.cpp
+++ b/sycl/test-e2e/ESIMD/assert.cpp
@@ -8,6 +8,10 @@
 // as expected to fail, whilst it is being investigated, see intel/llvm#11359
 // FIXME: remove that XFAIL
 // XFAIL: linux
+//
+// Hanging on gen12, remove when internal tracker fixed
+// UNSUPPORTED: gpu-intel-gen12
+//
 
 #include "esimd_test_utils.hpp"
 


### PR DESCRIPTION
When run in parallel with other tests, this is causing a GPU hang and having a significant effect on internal testing.