### PR TITLE
[SYCL][ClangLinkerWrapper] Unconditionally pass -properties to sycl-post-link

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -545,8 +545,9 @@ getTripleBasedSYCLPostLinkOpts(const ArgList &Args,
   else
     PostLinkArgs.push_back("-spec-const=emulation");
 
-  if (Triple.isSPIROrSPIRV() || SYCLNativeCPU)
-    PostLinkArgs.push_back("-properties");
+  // TODO: If we ever pass -ir-output-only based on the triple,
+  // make sure we don't pass -properties.
+  PostLinkArgs.push_back("-properties");
 
   // See if device code splitting is already requested. If not requested, then
   // set -split=auto for non-FPGA targets.


### PR DESCRIPTION
In the old offloading model we have an indirect target dependency because -properties is mutually exclusive with -ir-output-only, and the later option does depend on the triple.

However in the new offloading model we currently don’t ever pass -ir-output-only, so we should always be able to pass -properties, at least for now.

