### PR TITLE
[SYCL] Remove last uses of `sycl::runtime_error`

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -319,7 +319,8 @@ public:
       } catch (const exception &Ex) {
         BuildResult->Error.Msg = Ex.what();
         BuildResult->Error.Code = detail::get_pi_error(Ex);
-        if (BuildResult->Error.Code == PI_ERROR_OUT_OF_RESOURCES ||
+        if (Ex.code() == errc::memory_allocation ||
+            BuildResult->Error.Code == PI_ERROR_OUT_OF_RESOURCES ||
             BuildResult->Error.Code == PI_ERROR_OUT_OF_HOST_MEMORY) {
           reset();
           BuildResult->updateAndNotify(BuildState::BS_Initial);

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -349,7 +349,8 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(
   AllocaCommandBase *AllocaCmdDst =
       getOrCreateAllocaForReq(Record, Req, Queue, ToEnqueue);
   if (!AllocaCmdDst)
-    throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+    throw exception(make_error_code(errc::memory_allocation),
+                    "Out of host memory");
 
   auto Context = queue_impl::getContext(Queue);
   std::set<Command *> Deps = findDepsForReq(Record, Req, Context);
@@ -379,8 +380,8 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(
     AllocaCmdSrc = (Record->MAllocaCommands.end() != It) ? *It : nullptr;
   }
   if (!AllocaCmdSrc)
-    throw runtime_error("Cannot find buffer allocation",
-                        PI_ERROR_INVALID_VALUE);
+    throw exception(make_error_code(errc::runtime),
+                    "Cannot find buffer allocation");
   // Get parent allocation of sub buffer to perform full copy of whole buffer
   if (IsSuitableSubReq(Req)) {
     if (AllocaCmdSrc->getType() == Command::CommandType::ALLOCA_SUB_BUF)
@@ -496,7 +497,8 @@ Scheduler::GraphBuilder::addCopyBack(Requirement *Req,
       SrcAllocaCmd->getQueue(), nullptr);
 
   if (!MemCpyCmdUniquePtr)
-    throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+    throw exception(make_error_code(errc::memory_allocation),
+                    "Out of host memory");
 
   MemCpyCommandHost *MemCpyCmd = MemCpyCmdUniquePtr.release();
 
@@ -870,7 +872,8 @@ EmptyCommand *Scheduler::GraphBuilder::addEmptyCmd(
   EmptyCommand *EmptyCmd = new EmptyCommand();
 
   if (!EmptyCmd)
-    throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+    throw exception(make_error_code(errc::memory_allocation),
+                    "Out of host memory");
 
   EmptyCmd->MIsBlockable = true;
   EmptyCmd->MEnqueueStatus = EnqueueResultT::SyclEnqueueBlocked;
@@ -945,7 +948,8 @@ Scheduler::GraphBuildResult Scheduler::GraphBuilder::addCG(
                                                 std::move(Dependencies));
 
   if (!NewCmd)
-    throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+    throw exception(make_error_code(errc::memory_allocation),
+                    "Out of host memory");
 
   // Only device kernel command groups can participate in fusion. Otherwise,
   // command groups take the regular route. If they create any requirement or
@@ -1342,7 +1346,8 @@ Command *Scheduler::GraphBuilder::connectDepEvent(
     ConnectCmd = new ExecCGCommand(std::move(ConnectCG), nullptr,
                                    /*EventNeeded=*/true);
   } catch (const std::bad_alloc &) {
-    throw runtime_error("Out of host memory", PI_ERROR_OUT_OF_HOST_MEMORY);
+    throw exception(make_error_code(errc::memory_allocation),
+                    "Out of host memory");
   }
 
   if (Dep.MDepRequirement) {


### PR DESCRIPTION
Exception subclasses have been removed in SYCL 2020.