### PR TITLE
[SYCL][Test] Add test for ABI-neutrality of sycl classes

### DIFF
--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck --implicit-check-not "{{std::basic_string|std::list}}" %s
-// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck %s
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts-complete %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck --implicit-check-not "{{std::basic_string|std::list}}" %s
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts-complete %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck --implicit-check-not "{{std::basic_string|std::list}}" %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 

--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck %s
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck --implicit-check-not "{{std::basic_string|std::list}}" %s
 // RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
@@ -15,340 +15,323 @@
 // New exclusions are NOT ALLOWED to this file unless it is guaranteed that data
 // member is not crossing ABI boundary. All current exclusions are listed below.
 
+
+
 // CHECK: 0 | class sycl::detail::CG
 // CHECK-NEXT:          0 |   (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |   class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |   class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |     union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGAdviseUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGBarrier
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGCopy
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGCopy2DUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGCopyFromDeviceGlobal
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGCopyImage
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGCopyToDeviceGlobal
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGCopyUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGExecCommandBuffer
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGExecKernel
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       408 |   class std::basic_string<char> MKernelName
 // CHECK-NEXT:       408 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       424 |     union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGFill
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGFill2DUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGFillUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGHostTask
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGMemset2DUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGPrefetchUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGProfilingTag
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGReadWriteHostPipe
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       208 |   class std::basic_string<char> PipeName
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NEXT:       208 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       224 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGSemaphoreSignal
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGSemaphoreWait
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 // CHECK: 0 | class sycl::detail::CGUpdateHost
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       136 |     class std::basic_string<char> MFunctionName
 // CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       168 |     class std::basic_string<char> MFileName
 // CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
+// CHECK-NOT:  {{^0 \| class|std::basic_string|std::list}}
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
 
 #include <sycl/sycl.hpp>

--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -1,0 +1,333 @@
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | FileCheck %s
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | FileCheck %s
+// REQUIRES: linux
+// UNSUPPORTED: libcxx
+
+// The purpose of this test is to check that classes in sycl namespace which are
+// defined in SYCL headers don't have std::string and std::list data members to
+// avoid having dual-abi issues (see
+// https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html). I.e. if
+// application is built with the old ABI and such data member is crossing ABI
+// boundary then it will result in issues as SYCL RT is using new ABI by
+// default. All such data members can potentially cross ABI boundaries and
+// that's why we need to be sure that we use only abi-neutral data members.
+
+// New exclusions are NOT ALLOWED to this file unless it is guaranteed that data
+// member is not crossing ABI boundary. All current exclusions are listed below.
+
+// CHECK: 0 | class sycl::detail::CG
+// CHECK-NEXT:          0 |   (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |   class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |   class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |     union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGExecKernel
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       408 |   class std::basic_string<char> MKernelName
+// CHECK-NEXT:       408 |     struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       424 |     union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGCopy
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGFill
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGUpdateHost
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGCopyUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGFillUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGPrefetchUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGAdviseUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGBarrier
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGProfilingTag
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGCopy2DUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGFill2DUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGMemset2DUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGReadWriteHostPipe
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       208 |   class std::basic_string<char> PipeName
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       224 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGCopyToDeviceGlobal
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGCopyFromDeviceGlobal
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGCopyImage
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGSemaphoreWait
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGSemaphoreSignal
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGExecCommandBuffer
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+// CHECK: 0 | class sycl::detail::CGHostTask
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+#include <sycl/sycl.hpp>

--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -3,14 +3,14 @@
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 
-// The purpose of this test is to check that classes in sycl namespace which are
+// The purpose of this test is to check that classes in sycl namespace that are
 // defined in SYCL headers don't have std::string and std::list data members to
-// avoid having dual-abi issues (see
+// avoid having the dual ABI issue (see
 // https://gcc.gnu.org/onlinedocs/libstdc++/manual/using_dual_abi.html). I.e. if
 // application is built with the old ABI and such data member is crossing ABI
 // boundary then it will result in issues as SYCL RT is using new ABI by
 // default. All such data members can potentially cross ABI boundaries and
-// that's why we need to be sure that we use only abi-neutral data members.
+// that's why we need to be sure that we use only ABI-neutral data members.
 
 // New exclusions are NOT ALLOWED to this file unless it is guaranteed that data
 // member is not crossing ABI boundary. All current exclusions are listed below.

--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -1,5 +1,5 @@
-// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | FileCheck %s
-// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | FileCheck %s
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -fsycl-device-only -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck %s
+// RUN: %clangxx -std=c++17 -I %sycl_include -I %sycl_include/sycl -c -fno-color-diagnostics -Xclang -fdump-record-layouts %s -o %t.out | grep -Pzo "0 \| class sycl::.*\n([^\n].*\n)*" | sort -z | FileCheck %s
 // REQUIRES: linux
 // UNSUPPORTED: libcxx
 
@@ -26,6 +26,142 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       184 |     union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGAdviseUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGBarrier
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGCopy
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGCopy2DUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGCopyFromDeviceGlobal
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGCopyImage
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGCopyToDeviceGlobal
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGCopyUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGExecCommandBuffer
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
 // CHECK: 0 | class sycl::detail::CGExecKernel
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
@@ -45,20 +181,7 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       424 |     union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGCopy
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
+
 // CHECK: 0 | class sycl::detail::CGFill
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
@@ -73,118 +196,7 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGUpdateHost
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGCopyUSM
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGFillUSM
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGPrefetchUSM
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGAdviseUSM
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGBarrier
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGProfilingTag
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGCopy2DUSM
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
+
 // CHECK: 0 | class sycl::detail::CGFill2DUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
@@ -199,6 +211,37 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGFillUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGHostTask
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
 // CHECK: 0 | class sycl::detail::CGMemset2DUSM
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
@@ -213,6 +256,37 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGPrefetchUSM
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
+// CHECK: 0 | class sycl::detail::CGProfilingTag
+// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
+// CHECK-NEXT:         0 |     (CG vtable pointer)
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       136 |     class std::basic_string<char> MFunctionName
+// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       152 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       168 |     class std::basic_string<char> MFileName
+// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
+// CHECK-NOT:  {{^0}} | class
+// CHECK:       184 |       union std::basic_string<char>::(anonymous at
+// CHECK-NOT: {{std::basic_string|std::list}}
+
 // CHECK: 0 | class sycl::detail::CGReadWriteHostPipe
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
@@ -231,62 +305,7 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       224 |       union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGCopyToDeviceGlobal
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGCopyFromDeviceGlobal
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGCopyImage
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGSemaphoreWait
-// CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
-// CHECK-NEXT:         0 |     (CG vtable pointer)
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       136 |     class std::basic_string<char> MFunctionName
-// CHECK-NEXT:       136 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       152 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       168 |     class std::basic_string<char> MFileName
-// CHECK-NEXT:       168 |       struct std::basic_string<char>::_Alloc_hider _M_dataplus
-// CHECK-NOT:  {{^0}} | class
-// CHECK:       184 |       union std::basic_string<char>::(anonymous at
-// CHECK-NOT: {{std::basic_string|std::list}}
+
 // CHECK: 0 | class sycl::detail::CGSemaphoreSignal
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
@@ -301,7 +320,8 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGExecCommandBuffer
+
+// CHECK: 0 | class sycl::detail::CGSemaphoreWait
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
 // CHECK-NOT:  {{^0}} | class
@@ -315,7 +335,8 @@
 // CHECK-NOT:  {{^0}} | class
 // CHECK:       184 |       union std::basic_string<char>::(anonymous at
 // CHECK-NOT: {{std::basic_string|std::list}}
-// CHECK: 0 | class sycl::detail::CGHostTask
+
+// CHECK: 0 | class sycl::detail::CGUpdateHost
 // CHECK-NEXT:         0 |   class sycl::detail::CG (primary base)
 // CHECK-NEXT:         0 |     (CG vtable pointer)
 // CHECK-NOT:  {{^0}} | class


### PR DESCRIPTION
It is difficult to understand how to detect all possible data members which can cross ABI boundaries and cause problems because of dual ABI issue. For now using this approach which  covers most of the classes, more than currently covered by "sycl/test/abi/layout*" tests.
Current hits are in sycl::detail CG classes and subclasses (MFileName, MFunctinName, MKernelName and PipeName string data members). Even though I'm not sure if those cross ABI boundaries or not, I think we have to be conservative and fix those too.

Using -fdump-record-layouts-complete to get  dump for all complete record types, see description in  https://reviews.llvm.org/D104484 for details.