### PR TITLE
[SYCL][E2E] Fix two Windows ocloc tests

### DIFF
--- a/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/fp64-conv-emu.cpp
@@ -1,7 +1,7 @@
-// REQUIRES: ocloc, gpu
+// REQUIRES: ocloc, gpu, linux
 // UNSUPPORTED: cuda, hip
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen  -Xsycl-target-backend "-device pvc" -fsycl-fp64-conv-emu %if system-windows %{ -Od %} %else %{ -O0 %} %s -o %t_opt.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen  -Xsycl-target-backend "-device pvc" -fsycl-fp64-conv-emu -O0 %s -o %t_opt.out
 // TODO: Enable when GPU driver is updated.
 // RUNx: %{run} %t_opt.out
 

--- a/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
+++ b/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: gpu, opencl-aot, ocloc
+// REQUIRES: cpu, gpu, opencl-aot, ocloc
 // UNSUPPORTED: cuda, hip
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -I %S/Inputs/ %S/uneven_kernel_split.cpp -c -o %t.o

--- a/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
+++ b/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: cpu, gpu, opencl-aot, ocloc
+// REQUIRES: any-device-is-cpu, gpu, opencl-aot, ocloc
 // UNSUPPORTED: cuda, hip
 
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -I %S/Inputs/ %S/uneven_kernel_split.cpp -c -o %t.o


### PR DESCRIPTION
I recently found out ocloc tests weren't running in Windows CI because the ocloc tool wasn't installed on the runners.

When trying to fix it, I [hit](https://github.com/intel/llvm/actions/runs/9909706895/job/27379893885?pr=14114) two failures that would have always failed if we were testing (the other two are going to be fixed [here](https://github.com/intel/llvm/pull/14556)).

The first fix disables the test on Windows because it is using `pvc` which is not available on Windows.

The seconds add a requirement for the OCL CPU driver to be installed because the test is using `ocloc-aot`, as per the [ocloc-aot doc](https://github.com/intel/llvm/blob/56e88d591c52a978abdd5e4279853311cae4a55e/opencl/opencl-aot/README.md?plain=1#L11).

The CI testing in this PR is only confirming I didn't break the tests on non-win ocloc because I haven't enabled Windows ocloc testing yet, but I manually verified the fix.