### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-1866cdc

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-6fe460a",
-      "version": "6fe460a",
-      "updated_at": "2024-06-24T01:03:13Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1629761341/zip",
+      "github_tag": "igc-dev-1866cdc",
+      "version": "1866cdc",
+      "updated_at": "2024-07-15T03:01:39Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1700190910/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift