### PR TITLE
[SYCL] Allow printf in check for variadic functions

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -378,11 +378,12 @@ bool SemaSYCL::isDeclAllowedInSYCLDeviceCode(const Decl *D) {
   if (const FunctionDecl *FD = dyn_cast<FunctionDecl>(D)) {
     const IdentifierInfo *II = FD->getIdentifier();
 
-    // Allow __builtin_assume_aligned and __builtin_printf to be called from
-    // within device code.
-    if (FD->getBuiltinID() &&
-        (FD->getBuiltinID() == Builtin::BI__builtin_assume_aligned ||
-         FD->getBuiltinID() == Builtin::BI__builtin_printf))
+    // Allow __builtin_assume_aligned, printf and __builtin_printf to be called
+    // from within device code.
+    const auto BuiltinID = FD->getBuiltinID();
+    if (BuiltinID && (BuiltinID == Builtin::BI__builtin_assume_aligned ||
+                      BuiltinID == Builtin::BIprintf ||
+                      BuiltinID == Builtin::BI__builtin_printf))
       return true;
 
     const DeclContext *DC = FD->getDeclContext();

--- a/sycl/test-e2e/Printf/different_printf_funcs.cpp
+++ b/sycl/test-e2e/Printf/different_printf_funcs.cpp
@@ -1,0 +1,63 @@
+// This test is written with an aim to make sure that `printf`,
+// `__builtin_printf` and `experimenta::printf` are handled correctly and
+// resolved to a call to `vprintf` (which is what CUDA expects), while
+// generating correct output.
+//
+// UNSUPPORTED: hip_amd
+//
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out | FileCheck %s
+//
+// RUN: %{build} -fsycl-device-only -S -emit-llvm -o - | FileCheck --check-prefix=CHECK-IR %s
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/builtins.hpp>
+
+#include "helper.hpp"
+
+using namespace sycl;
+
+// CHECK-IR: @.str = private unnamed_addr addrspace(1) constant [35 x i8] c"Printf - literal strings: s=%s %s\0A\00", align 1
+// CHECK-IR: @.str1 = private unnamed_addr addrspace(1) constant [6 x i8] c"Hello\00", align 1
+// CHECK-IR: @.str2 = private unnamed_addr addrspace(1) constant [7 x i8] c"World!\00", align 1
+// CHECK-IR: @.str3 = private unnamed_addr addrspace(1) constant [43 x i8] c"Builtin printf - literal strings: s=%s %s\0A\00", align 1
+// CHECK-IR: @.str4 = private unnamed_addr addrspace(1) constant [48 x i8] c"Experimental printf - literal strings: s=%s %s\0A\00", align 1
+
+ 
+// CHECK-IR: call i32 @vprintf(ptr addrspacecast (ptr addrspace(1) @.str to ptr)
+void do_printf_test() {
+  printf("Printf - literal strings: s=%s %s\n", "Hello",
+         "\x57\x6F\x72\x6C\x64\x21");
+}
+
+// CHECK-IR: call i32 @vprintf(ptr addrspacecast (ptr addrspace(1) @.str3 to ptr)
+void do_builtin_printf_test() {
+  __builtin_printf("Builtin printf - literal strings: s=%s %s\n", "Hello",
+                   "\x57\x6F\x72\x6C\x64\x21");
+}
+
+// CHECK-IR: call noundef i32 @vprintf(ptr addrspacecast (ptr addrspace(1) @.str4 to ptr)
+void do_experimental_printf_test() {
+  ext::oneapi::experimental::printf(
+      "Experimental printf - literal strings: s=%s %s\n", "Hello",
+      "\x57\x6F\x72\x6C\x64\x21");
+}
+class PrintfTester;
+
+int main() {
+  queue q;
+
+  q.submit([](handler &cgh) {
+    cgh.single_task<PrintfTester>([]() {
+      // CHECK: Printf - literal strings: s=Hello World!
+      do_printf_test();
+      // CHECK-NEXT: Builtin printf - literal strings: s=Hello World!
+      do_builtin_printf_test();
+      // CHECK-NEXT: Experimental printf - literal strings: s=Hello World!
+      do_experimental_printf_test();
+    });
+  });
+  q.wait();
+
+  return 0;
+}


### PR DESCRIPTION
The support for lowering of printf (calling CUDA's vprintf) and lowering of its arguments is already present.