### PR TITLE
[SYCL][COMPAT] Fixes SYCLCOMPAT_PROFILING_ENABLED codepath

### DIFF
--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -545,8 +545,14 @@ Use 64 bits as memory_bus_width default value."
     _queues.clear();
     // create new default queue
     // calls create_queue_impl since we already have a locked m_mutex
-    _saved_queue = _default_queue =
-        create_queue_impl(print_on_async_exceptions, in_order);
+
+    if (in_order) {
+      _saved_queue = _default_queue = create_queue_impl(
+          print_on_async_exceptions, sycl::property::queue::in_order());
+    } else {
+      _saved_queue = _default_queue =
+          create_queue_impl(print_on_async_exceptions);
+    }
   }
 
   void set_default_queue(const sycl::queue &q) {
@@ -573,7 +579,11 @@ Use 64 bits as memory_bus_width default value."
   queue_ptr create_queue(bool print_on_async_exceptions = false,
                          bool in_order = true) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    return create_queue_impl(print_on_async_exceptions, in_order);
+    if (in_order) {
+      return create_queue_impl(print_on_async_exceptions,
+                               sycl::property::queue::in_order());
+    }
+    return create_queue_impl(print_on_async_exceptions);
   }
   void destroy_queue(queue_ptr &queue) {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -645,15 +655,14 @@ Use 64 bits as memory_bus_width default value."
 private:
   /// Caller should only be done from functions where the resource \p m_mutex
   /// has been acquired.
+  template <typename... Properties>
   queue_ptr create_queue_impl(bool print_on_async_exceptions = false,
-                              bool in_order = true) {
-    sycl::property_list prop = {};
-    if (in_order) {
-      prop = {sycl::property::queue::in_order()};
-    }
+                              Properties... properties) {
+    sycl::property_list prop = sycl::property_list(
 #ifdef SYCLCOMPAT_PROFILING_ENABLED
-    prop.push_back(sycl::property::queue::enable_profiling());
+        sycl::property::queue::enable_profiling(),
 #endif
+        properties...);
     if (print_on_async_exceptions) {
       _queues.push_back(std::make_shared<sycl::queue>(
           _ctx, *this, detail::exception_handler, prop));

--- a/sycl/include/syclcompat/device.hpp
+++ b/sycl/include/syclcompat/device.hpp
@@ -546,13 +546,10 @@ Use 64 bits as memory_bus_width default value."
     // create new default queue
     // calls create_queue_impl since we already have a locked m_mutex
 
-    if (in_order) {
-      _saved_queue = _default_queue = create_queue_impl(
-          print_on_async_exceptions, sycl::property::queue::in_order());
-    } else {
-      _saved_queue = _default_queue =
-          create_queue_impl(print_on_async_exceptions);
-    }
+    _saved_queue = _default_queue =
+        in_order ? create_queue_impl(print_on_async_exceptions,
+                                     sycl::property::queue::in_order())
+                 : create_queue_impl(print_on_async_exceptions);
   }
 
   void set_default_queue(const sycl::queue &q) {
@@ -579,11 +576,9 @@ Use 64 bits as memory_bus_width default value."
   queue_ptr create_queue(bool print_on_async_exceptions = false,
                          bool in_order = true) {
     std::lock_guard<std::mutex> lock(m_mutex);
-    if (in_order) {
-      return create_queue_impl(print_on_async_exceptions,
-                               sycl::property::queue::in_order());
-    }
-    return create_queue_impl(print_on_async_exceptions);
+    return in_order ? create_queue_impl(print_on_async_exceptions,
+                                        sycl::property::queue::in_order())
+                    : create_queue_impl(print_on_async_exceptions);
   }
   void destroy_queue(queue_ptr &queue) {
     std::lock_guard<std::mutex> lock(m_mutex);
@@ -655,9 +650,9 @@ Use 64 bits as memory_bus_width default value."
 private:
   /// Caller should only be done from functions where the resource \p m_mutex
   /// has been acquired.
-  template <typename... Properties>
+  template <typename... PropertiesT>
   queue_ptr create_queue_impl(bool print_on_async_exceptions = false,
-                              Properties... properties) {
+                              PropertiesT... properties) {
     sycl::property_list prop = sycl::property_list(
 #ifdef SYCLCOMPAT_PROFILING_ENABLED
         sycl::property::queue::enable_profiling(),

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -392,6 +392,18 @@ void test_get_device_id() {
   assert(id == 0);
 }
 
+void test_event_profiling() {
+  sycl::queue q = syclcompat::get_default_queue();
+
+  if (!q.get_device().has(sycl::aspect::queue_profiling)) {
+    std::cout << "Device does not have aspect::queue_profiling, skipping."
+              << std::endl;
+    return;
+  }
+
+  assert(!q.has_property<sycl::property::queue::enable_profiling>());
+}
+
 int main() {
   test_at_least_one_device();
   test_matches_id();

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -392,18 +392,6 @@ void test_get_device_id() {
   assert(id == 0);
 }
 
-void test_event_profiling() {
-  sycl::queue q = syclcompat::get_default_queue();
-
-  if (!q.get_device().has(sycl::aspect::queue_profiling)) {
-    std::cout << "Device does not have aspect::queue_profiling, skipping."
-              << std::endl;
-    return;
-  }
-
-  assert(!q.has_property<sycl::property::queue::enable_profiling>());
-}
-
 int main() {
   test_at_least_one_device();
   test_matches_id();

--- a/sycl/test-e2e/syclcompat/device/device_profiling.cpp
+++ b/sycl/test-e2e/syclcompat/device/device_profiling.cpp
@@ -1,0 +1,50 @@
+/***************************************************************************
+ *
+ *  Copyright (C) Codeplay Software Ltd.
+ *
+ *  Part of the LLVM Project, under the Apache License v2.0 with LLVM
+ *  Exceptions. See https://llvm.org/LICENSE.txt for license information.
+ *  SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ *  SYCLcompat API
+ *
+ *  device_profiling.cpp
+ *
+ *  Description:
+ *    Tests for the profiling path
+ **************************************************************************/
+
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{run} %t.out
+
+#define SYCLCOMPAT_PROFILING_ENABLED 1
+
+#include <syclcompat/device.hpp>
+
+void test_event_profiling() {
+  sycl::queue q = syclcompat::get_default_queue();
+
+  if (!q.get_device().has(sycl::aspect::queue_profiling)) {
+    std::cout << "Device does not have aspect::queue_profiling, skipping."
+              << std::endl;
+    return;
+  }
+
+  assert(q.has_property<sycl::property::queue::enable_profiling>());
+
+  q = sycl::queue{q.get_device(), sycl::property::queue::enable_profiling()};
+  auto event = q.submit([&](sycl::handler &cgh) { cgh.single_task([=]() {}); });
+  event.get_profiling_info<sycl::info::event_profiling::command_end>();
+}
+
+int main() {
+  test_event_profiling();
+
+  return 0;
+}


### PR DESCRIPTION
The codepath which enabled profiling in syclcompat queues was neither working nor properly tested.

- Fixes `sycl::property::queue::enable_profiling` being added to queue properties if SYCLCOMPAT_PROFILING_ENABLED is defined
  - Tests added for both SYCLCOMPAT_PROFILING_ENABLED defined and undefined.
- Refactors `create_queue_impl` to accept a list of properties instead of a series of bools to enable properties.
  - Refactor does not affect public API. 