### PR TITLE
[SYCL] Add AMDGPU_kernel calling convention to detected kernels

### DIFF
--- a/llvm/lib/SYCLLowerIR/ModuleSplitter.cpp
+++ b/llvm/lib/SYCLLowerIR/ModuleSplitter.cpp
@@ -113,7 +113,8 @@ bool isGenericBuiltin(StringRef FName) {
 }
 
 bool isKernel(const Function &F) {
-  return F.getCallingConv() == CallingConv::SPIR_KERNEL;
+  return F.getCallingConv() == CallingConv::SPIR_KERNEL ||
+         F.getCallingConv() == CallingConv::AMDGPU_KERNEL;
 }
 
 bool isEntryPoint(const Function &F, bool EmitOnlyKernelsAsEntryPoints) {

--- a/llvm/test/tools/sycl-post-link/device-code-split/amd-kernel-split.ll
+++ b/llvm/test/tools/sycl-post-link/device-code-split/amd-kernel-split.ll
@@ -1,0 +1,17 @@
+; -- Per-kernel split
+; RUN: sycl-post-link -split=kernel -emit-only-kernels-as-entry-points -S < %s -o %tC.table
+; RUN: FileCheck %s -input-file=%tC_0.ll --check-prefixes CHECK-A0
+; RUN: FileCheck %s -input-file=%tC_1.ll --check-prefixes CHECK-A1
+
+define dso_local amdgpu_kernel void @Kernel1() {
+  ret void
+}
+
+define dso_local amdgpu_kernel void @Kernel2() {
+  ret void
+}
+
+; CHECK-A0: define dso_local amdgpu_kernel void @Kernel2()
+; CHECK-A0-NOT: define dso_local amdgpu_kernel void @Kernel1()
+; CHECK-A1-NOT: define dso_local amdgpu_kernel void @Kernel2()
+; CHECK-A1: define dso_local amdgpu_kernel void @Kernel1()

--- a/sycl/test-e2e/KernelAndProgram/free_function_apis.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_apis.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 
 // The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: cuda
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 
 // The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: cuda
 
 // This test tests free function kernel code generation and execution.
 
@@ -212,7 +212,7 @@ SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((
   ptr2D[GId.get(0)][GId.get(1)] = LId.get(0) + LId.get(1) + start;
 }
 
-// Explicit instantiation with “int*”.
+// Explicit instantiation with "int*".
 template void ff_3(int *ptr, int start);
 
 bool test_3(queue Queue) {


### PR DESCRIPTION
`free_function_kernels.cpp` test had a bug where the kernels with demangled name for free functions will be deleted in the `sycl-post-link` step of compilation. And this happened as AMD kernels was not detected due to a missing condition. This was not detected before as the HIP device on CI doesn't have `usm_shared_allocations` aspect available so it was detected as unsupported but when I tried it locally with a device with `usm_shared_allocations` aspect available, the test was failing. 