### PR TITLE
[CI] Make Windows LIT_OPTS match Linux

### DIFF
--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -84,7 +84,7 @@ jobs:
       shell: bash
       run: |
         # Run E2E tests.
-        export LIT_OPTS="-v --no-progress-bar --show-unsupported --max-time 3600 --time-tests ${{ inputs.extra_lit_opts }}"
+        export LIT_OPTS="-v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests ${{ inputs.extra_lit_opts }}"
         cmake --build build-e2e --target check-sycl-e2e
     - name: Cleanup
       shell: cmd


### PR DESCRIPTION
The `LIT_OPTS` were different compared to Linux so the output logs from CI runs is different. I noticed this when searching for passed tests in the Windows log and noticed it wasn't there.