### PR TITLE
[SYCL][E2E] Fix more Windows AOT tests

### DIFF
--- a/sycl/test-e2e/AOT/double.cpp
+++ b/sycl/test-e2e/AOT/double.cpp
@@ -3,11 +3,11 @@
 
 // REQUIRES: ocloc
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s
 
-// ocloc on windows does not have support for PVC, so this command will
+// ocloc on windows does not have support for PVC/CFL, so this command will
 // result in an error when on windows. (In general, there is no support
-// for pvc on windows.)
+// for pvc/cfl on windows.)
+// RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s %}
 // RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_pvc -o %t.pvc.out %s %}
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/AOT/reqd-sg-size.cpp
+++ b/sycl/test-e2e/AOT/reqd-sg-size.cpp
@@ -3,11 +3,11 @@
 
 // REQUIRES: ocloc
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
-// RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s
 
-// ocloc on windows does not have support for PVC, so this command will
+// ocloc on windows does not have support for PVC/CFL, so this command will
 // result in an error when on windows. (In general, there is no support
-// for pvc on windows.)
+// for pvc/cfl on windows.)
+// RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s %}
 // RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_pvc -o %t.pvc.out %s %}
 
 #include <cstdio>


### PR DESCRIPTION
Windows ocloc currently doesn't run in CI, and I'm trying to enable it. I hit failures here when trying to enable it. See run [here](https://github.com/intel/llvm/actions/runs/9960990637/job/27525889216?pr=14114).

```
...
# | Could not determine device target: cfl.
# | Error: Cannot get HW Info for device cfl.
...
```