### PR TITLE
[SYCL][COMPAT] Fixes missing required aspect-fp16

### DIFF
--- a/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
@@ -30,6 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
+// REQUIRES: aspect-fp16
 // RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
PR fixes a missing `REQUIRES: aspect-fp16` in the `vectorized_is_greater` tests