### PR TITLE
[syclcompat][E2E] Skip case in math_vectorized_isgreater_test if fp16 unsupported

### DIFF
--- a/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
@@ -131,6 +131,15 @@ void test_vec_gt_2() {
   syclcompat::device_ext &dev_ct1 = syclcompat::get_current_device();
   sycl::queue *q_ct1 = dev_ct1.default_queue();
 
+  // This test uses vector of sycl::half, which requires support for fp16 on
+  // the corresponding device.
+  if (!dev_ct1.has(sycl::aspect::fp16)) {
+    std::cout
+        << "Test case skipped as the device does not support aspect::fp16."
+        << std::endl;
+    return;
+  }
+
   const unsigned int num_data = 7;
   unsigned int mem_size = sizeof(unsigned int) * num_data;
 


### PR DESCRIPTION
The second test case in sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp uses vector of sycl::half, which requires devices to support aspect::fp16. This commit makes the test skip this case if the device does not support the aspect.