### PR TITLE
[SYCL][COMPAT] Fix slow math_extend tests

### DIFF
--- a/sycl/test-e2e/syclcompat/math/math_extend.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend.cpp
@@ -44,9 +44,10 @@
 
 #define CHECK(S, REF)                                                          \
   {                                                                            \
+    ++test_id;                                                                 \
     auto ret = S;                                                              \
     if (ret != REF) {                                                          \
-      return {#S, REF};                                                        \
+      errc = test_id;                                                          \
     }                                                                          \
   }
 
@@ -56,7 +57,9 @@ const auto UINT32MAX = std::numeric_limits<uint32_t>::max();
 const auto UINT32MIN = std::numeric_limits<uint32_t>::min();
 const int b = 4, c = 5, d = 6;
 
-std::pair<const char *, int> vadd() {
+int vadd() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_add<int32_t>(3, 4), 7);
   CHECK(syclcompat::extend_add<uint32_t>(b, c), 9);
   CHECK(syclcompat::extend_add_sat<int32_t>(b, INT32MAX), INT32MAX);
@@ -65,10 +68,12 @@ std::pair<const char *, int> vadd() {
   CHECK(syclcompat::extend_add_sat<int32_t>(b, c, -20, sycl::minimum<>()), -20);
   CHECK(syclcompat::extend_add_sat<int32_t>(b, (-33), 9, sycl::maximum<>()), 9);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vsub() {
+int vsub() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_sub<int32_t>(3, 4), -1);
   CHECK(syclcompat::extend_sub<uint32_t>(c, b), 1);
   CHECK(syclcompat::extend_sub_sat<int32_t>(10, INT32MIN), INT32MAX);
@@ -78,10 +83,12 @@ std::pair<const char *, int> vsub() {
   CHECK(syclcompat::extend_sub_sat<int32_t>(b, (-33), 9, sycl::maximum<>()),
         37);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vabsdiff() {
+int vabsdiff() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_absdiff<int32_t>(3, 4), 1);
   CHECK(syclcompat::extend_absdiff<uint32_t>(c, b), 1);
   CHECK(syclcompat::extend_absdiff_sat<int32_t>(10, INT32MIN), INT32MAX);
@@ -92,10 +99,12 @@ std::pair<const char *, int> vabsdiff() {
   CHECK(syclcompat::extend_absdiff_sat<int32_t>(b, (-33), 9, sycl::maximum<>()),
         37);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmin() {
+int vmin() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_min<int32_t>(3, 4), 3);
   CHECK(syclcompat::extend_min<uint32_t>(c, b), 4);
   CHECK(syclcompat::extend_min_sat<int32_t>(UINT32MAX, 1), 1);
@@ -104,10 +113,12 @@ std::pair<const char *, int> vmin() {
   CHECK(syclcompat::extend_min_sat<int32_t>(b, c, -20, sycl::minimum<>()), -20);
   CHECK(syclcompat::extend_min_sat<int32_t>(b, (-33), 9, sycl::maximum<>()), 9);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmax() {
+int vmax() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_max<int32_t>(3, 4), 4);
   CHECK(syclcompat::extend_max<uint32_t>(c, b), 5);
   CHECK(syclcompat::extend_max_sat<int32_t>(UINT32MAX, 1), INT32MAX);
@@ -116,7 +127,7 @@ std::pair<const char *, int> vmax() {
   CHECK(syclcompat::extend_max_sat<int32_t>(b, c, -20, sycl::minimum<>()), -20);
   CHECK(syclcompat::extend_max_sat<int32_t>(b, (-33), 9, sycl::maximum<>()), 9);
 
-  return {nullptr, 0};
+  return errc;
 }
 
 template <typename Tp> struct scale {
@@ -127,7 +138,9 @@ template <typename Tp> struct noop {
   Tp operator()(Tp val, Tp /*scaler*/) { return val; }
 };
 
-std::pair<const char *, int> shl_clamp() {
+int shl_clamp() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_shl_clamp<int32_t>(3, 4), 48);
   CHECK(syclcompat::extend_shl_clamp<int32_t>(6, 33), 0);
   CHECK(syclcompat::extend_shl_clamp<int32_t>(3, 4, 4, scale<int32_t>()), 192);
@@ -139,10 +152,12 @@ std::pair<const char *, int> shl_clamp() {
   CHECK(syclcompat::extend_shl_sat_clamp<int8_t>(9, 5, -1, noop<int8_t>()),
         127);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> shl_wrap() {
+int shl_wrap() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_shl_wrap<int32_t>(3, 4), 48);
   CHECK(syclcompat::extend_shl_wrap<int32_t>(6, 32), 6);
   CHECK(syclcompat::extend_shl_wrap<int32_t>(6, 33), 12);
@@ -155,10 +170,12 @@ std::pair<const char *, int> shl_wrap() {
         -127);
   CHECK(syclcompat::extend_shl_sat_wrap<int8_t>(9, 5, -1, noop<int8_t>()), 127);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> shr_clamp() {
+int shr_clamp() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_shr_clamp<int32_t>(128, 5), 4);
   CHECK(syclcompat::extend_shr_clamp<int32_t>(INT32MAX, 33), 0);
   CHECK(syclcompat::extend_shr_clamp<int32_t>(128, 5, 4, scale<int32_t>()), 16);
@@ -170,10 +187,12 @@ std::pair<const char *, int> shr_clamp() {
   CHECK(syclcompat::extend_shr_sat_clamp<int8_t>(512, 1, -1, noop<int8_t>()),
         127);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> shr_wrap() {
+int shr_wrap() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_shr_wrap<int32_t>(128, 5), 4);
   CHECK(syclcompat::extend_shr_wrap<int32_t>(128, 32), 128);
   CHECK(syclcompat::extend_shr_wrap<int32_t>(128, 33), 64);
@@ -187,106 +206,43 @@ std::pair<const char *, int> shr_wrap() {
   CHECK(syclcompat::extend_shr_sat_wrap<int8_t>(512, 1, -1, noop<int8_t>()),
         127);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-void test(const sycl::stream &s, int *ec) {
-  {
-    auto res = vadd();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 1;
-      return;
-    }
-    s << "vadd check passed!\n";
+template <auto F> void test_fn(sycl::queue q, int *ec) {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.single_task([=]() {
+      auto res = F();
+      if(res != 0) *ec = res;
+    });
+  });
+  int ec_h{};
+  syclcompat::memcpy<int>(&ec_h, ec, 1, q);
+  q.wait_and_throw();
+
+  if (ec_h != 0) {
+    std::cout << "Test " << ec_h << " failed." << std::endl;
+    syclcompat::free(ec, q);
+    assert(false);
   }
-  {
-    auto res = vsub();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 2;
-      return;
-    }
-    s << "vsub check passed!\n";
-  }
-  {
-    auto res = vabsdiff();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 3;
-      return;
-    }
-    s << "vabsdiff check passed!\n";
-  }
-  {
-    auto res = vmin();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 4;
-      return;
-    }
-    s << "vmin check passed!\n";
-  }
-  {
-    auto res = vmax();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 5;
-      return;
-    }
-    s << "vmax check passed!\n";
-  }
-  {
-    auto res = shl_clamp();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 6;
-      return;
-    }
-    s << "shl_clamp check passed!\n";
-  }
-  {
-    auto res = shl_wrap();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 7;
-      return;
-    }
-    s << "shl_wrap check passed!\n";
-  }
-  {
-    auto res = shr_clamp();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 8;
-      return;
-    }
-    s << "shr_clamp check passed!\n";
-  }
-  {
-    auto res = shr_wrap();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 9;
-      return;
-    }
-    s << "shr_wrap check passed!\n";
-  }
-  *ec = 0;
 }
 
 int main() {
   sycl::queue q = syclcompat::get_default_queue();
-  int *ec = syclcompat::malloc<int>(1);
-  syclcompat::fill<int>(ec, 0, 1);
-  q.submit([&](sycl::handler &cgh) {
-    sycl::stream out(1024, 256, cgh);
-    cgh.parallel_for(1, [=](sycl::item<1> it) { test(out, ec); });
-  });
-  q.wait_and_throw();
+  int *ec = syclcompat::malloc<int>(1, q);
+  syclcompat::fill<int>(ec, 0, 1, q);
 
-  int ec_h;
-  syclcompat::memcpy<int>(&ec_h, ec, 1);
+  test_fn<vadd>(q, ec);
+  test_fn<vsub>(q, ec);
+  test_fn<vabsdiff>(q, ec);
+  test_fn<vmin>(q, ec);
+  test_fn<vmax>(q, ec);
+  test_fn<shl_clamp>(q, ec);
+  test_fn<shl_wrap>(q, ec);
+  test_fn<shr_clamp>(q, ec);
+  test_fn<shr_wrap>(q, ec);
 
-  return ec_h;
+  syclcompat::free(ec, q);
 }

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_2.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_2.cpp
@@ -48,6 +48,7 @@
       errc = test_id;                                                          \
     }                                                                          \
   }
+
 int vadd2() {
   int errc{};
   int test_id{};

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_2.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_2.cpp
@@ -34,8 +34,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <limits>
-#include <stdio.h>
 #include <sycl/detail/core.hpp>
 
 #include <syclcompat/device.hpp>
@@ -44,13 +42,15 @@
 
 #define CHECK(S, REF)                                                          \
   {                                                                            \
+    ++test_id;                                                                 \
     auto ret = S;                                                              \
     if (ret != REF) {                                                          \
-      return {#S, REF};                                                        \
+      errc = test_id;                                                          \
     }                                                                          \
   }
-
-std::pair<const char *, int> vadd2() {
+int vadd2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vadd2<int32_t>(0x0001FFFF, 0x00010005, 0),
         0x00020004);
   CHECK(syclcompat::extend_vadd2<int32_t>(0x7FFF7FFF, 0x00010001, 0),
@@ -65,11 +65,12 @@ std::pair<const char *, int> vadd2() {
   CHECK(syclcompat::extend_vadd2_sat<uint32_t>((uint32_t)0xFFFEFFFF,
                                                (uint32_t)0x00030003, 0),
         0xFFFFFFFF);
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vsub2() {
-
+int vsub2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vsub2<int32_t>(0x0001FFFF, 0xFFFF0001, 0),
         0x0002FFFE);
   // Testing API & Saturated API with mixed types
@@ -113,11 +114,12 @@ std::pair<const char *, int> vsub2() {
                                                (int32_t)0x0002FFFF, 0),
         0x00000002);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vadd2_add() {
-
+int vadd2_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vadd2_add<int32_t>(0x00010002, 0x00030004, 1),
         0x0000000B);
   CHECK(syclcompat::extend_vadd2_add<int32_t>(0x0001FFFF, 0x0002FFFE, -1),
@@ -133,11 +135,12 @@ std::pair<const char *, int> vadd2_add() {
   CHECK(syclcompat::extend_vadd2_add<uint32_t>(0x0001FFFF, 0x0002FFFF, 1),
         0x00000002);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vsub2_add() {
-
+int vsub2_add() {
+  int errc{};
+  int test_id{};
   // Testing API with mixed types
   CHECK(syclcompat::extend_vsub2_add<int32_t>((int32_t)0x0001FFFF,
                                               (int32_t)0xFFFF0001, 1),
@@ -160,11 +163,12 @@ std::pair<const char *, int> vsub2_add() {
   CHECK(syclcompat::extend_vsub2_add<uint32_t>(0x00010001, 0x0002FFFF, 3),
         0x00000004);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vabsdiff2() {
-
+int vabsdiff2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vabsdiff2<int32_t>((int32_t)0xFFFF0001,
                                               (int32_t)0x0003FFFF, 0),
         0x00040002);
@@ -184,11 +188,12 @@ std::pair<const char *, int> vabsdiff2() {
                                                    (int32_t)0xFFFE0003, 0),
         0xFFFF0002);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vabsdiff2_add() {
-
+int vabsdiff2_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vabsdiff2_add<int32_t>((int32_t)0xFFFF0001,
                                                   (int32_t)0x0003FFFF, -2),
         0x00000004);
@@ -196,11 +201,12 @@ std::pair<const char *, int> vabsdiff2_add() {
   CHECK(syclcompat::extend_vabsdiff2_add<uint32_t>(0x000A000C, 0x000B000A, 1),
         0x00000004);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmin2() {
-
+int vmin2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vmin2<int32_t>((int32_t)0xFFFF0002, 0x00010001, 0),
         (int32_t)0xFFFF0001);
   CHECK(syclcompat::extend_vmin2_sat<int32_t>(0x0002FFF1, 0x0001FFF2, 0),
@@ -211,11 +217,12 @@ std::pair<const char *, int> vmin2() {
   CHECK(syclcompat::extend_vmin2_sat<uint32_t>(0x0002FFF1, 0x0001FFF2, 0),
         0x00010000);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmax2() {
-
+int vmax2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vmax2<int32_t>((int32_t)0xFFFF0002, 0x00010001, 0),
         0x00010002);
   CHECK(syclcompat::extend_vmax2_sat<int32_t>(0x80008000, 0x00018001, 0),
@@ -226,11 +233,12 @@ std::pair<const char *, int> vmax2() {
   CHECK(syclcompat::extend_vmax2_sat<uint32_t>(0x0002FFF1, 0x0001FFF2, 0),
         0x00020000);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmin2_vmax2_add() {
-
+int vmin2_vmax2_add() {
+  int errc{};
+  int test_id{};
   CHECK(
       syclcompat::extend_vmin2_add<int32_t>((int32_t)0xFFFF0002, 0x00010001, 2),
       0x00000002);
@@ -243,11 +251,12 @@ std::pair<const char *, int> vmin2_vmax2_add() {
   CHECK(syclcompat::extend_vmax2_add<uint32_t>(0x000A000D, 0x000B000C, 2),
         0x0000001A);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vavrg2() {
-
+int vavrg2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vavrg2<int32_t>((int32_t)0xFFFFFFF6, 0x0005FFFA, 0),
         0x0002FFF8);
   CHECK(syclcompat::extend_vavrg2_sat<int32_t>((int32_t)0xFFFFFFF6, 0x0005FFFA,
@@ -259,11 +268,12 @@ std::pair<const char *, int> vavrg2() {
   CHECK(syclcompat::extend_vavrg2_sat<uint32_t>(0x00010006, 0x00030001, 0),
         0x00020004);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vavrg2_add() {
-
+int vavrg2_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vavrg2_add<int32_t>((int32_t)0xFFFFFFF6, 0x0005FFFA,
                                                -2),
         0xFFFFFFF8);
@@ -271,11 +281,12 @@ std::pair<const char *, int> vavrg2_add() {
   CHECK(syclcompat::extend_vavrg2_add<uint32_t>(0x00010006, 0x00030002, 2),
         0x00000008);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vcompare2() {
-
+int vcompare2() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vcompare2(0x0002FFFF, 0x0001FFFF, std::greater<>()),
         (unsigned)0x00010000);
   CHECK(syclcompat::extend_vcompare2((uint32_t)0x0002FFFF, (int32_t)0x0001FFFF,
@@ -299,11 +310,12 @@ std::pair<const char *, int> vcompare2() {
                                      std::not_equal_to<>()),
         (unsigned)0x00010000);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vcompare2_add() {
-
+int vcompare2_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vcompare2_add(0x0002FFFF, 0x0001FFFF, 1,
                                          std::greater<>()),
         (unsigned)0x00000002);
@@ -323,142 +335,48 @@ std::pair<const char *, int> vcompare2_add() {
                                          std::not_equal_to<>()),
         (unsigned)0x00000100);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-void test(const sycl::stream &s, int *ec) {
-  {
-    auto res = vadd2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 1;
-      return;
-    }
-    s << "vadd2 check passed!\n";
+
+template <auto F> void test_fn(sycl::queue q, int *ec) {
+  std::cout << __PRETTY_FUNCTION__ << std::endl;
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.single_task([=]() {
+      auto res = F();
+      if(res != 0) *ec = res;
+    });
+  });
+  int ec_h{};
+  syclcompat::memcpy<int>(&ec_h, ec, 1, q);
+  q.wait_and_throw();
+
+  if (ec_h != 0) {
+    std::cout << "Test " << ec_h << " failed." << std::endl;
+    syclcompat::free(ec, q);
+    assert(false);
   }
-  {
-    auto res = vsub2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 2;
-      return;
-    }
-    s << "vsub2 check passed!\n";
-  }
-  {
-    auto res = vadd2_add();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 3;
-      return;
-    }
-    s << "vadd2_add check passed!\n";
-  }
-  {
-    auto res = vsub2_add();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 4;
-      return;
-    }
-    s << "vsub2_add check passed!\n";
-  }
-  {
-    auto res = vabsdiff2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 5;
-      return;
-    }
-    s << "vabsdiff2 check passed!\n";
-  }
-  {
-    auto res = vmin2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 6;
-      return;
-    }
-    s << "vmin2 check passed!\n";
-  }
-  {
-    auto res = vmax2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 7;
-      return;
-    }
-    s << "vmax2 check passed!\n";
-  }
-  {
-    auto res = vmin2_vmax2_add();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 8;
-      return;
-    }
-    s << "vmin2_add/vmax2_add check passed!\n";
-  }
-  {
-    auto res = vavrg2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 9;
-      return;
-    }
-    s << "vavrg2 check passed!\n";
-  }
-  {
-    auto res = vavrg2_add();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 10;
-      return;
-    }
-    s << "vavrg2_add check passed!\n";
-  }
-  {
-    auto res = vabsdiff2_add();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 11;
-      return;
-    }
-    s << "vabsdiff2_add check passed!\n";
-  }
-  {
-    auto res = vcompare2();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 12;
-      return;
-    }
-    s << "vcompare2 check passed!\n";
-  }
-  {
-    auto res = vcompare2_add();
-    if (res.first) {
-      s << res.first << " = " << res.second << " check failed!\n";
-      *ec = 13;
-      return;
-    }
-    s << "vcompare2_add check passed!\n";
-  }
-  *ec = 0;
 }
 
 int main() {
   sycl::queue q = syclcompat::get_default_queue();
-  int *ec = syclcompat::malloc<int>(1);
-  syclcompat::fill<int>(ec, 0, 1);
-  q.submit([&](sycl::handler &cgh) {
-    sycl::stream out(1024, 256, cgh);
-    cgh.parallel_for(1, [=](sycl::item<1> it) { test(out, ec); });
-  });
-  q.wait_and_throw();
+  int *ec = syclcompat::malloc<int>(1, q);
+  syclcompat::fill<int>(ec, 0, 1, q);
 
-  int ec_h;
-  syclcompat::memcpy<int>(&ec_h, ec, 1);
+  test_fn<vadd2>(q, ec);
+  test_fn<vsub2>(q, ec);
+  test_fn<vadd2_add>(q, ec);
+  test_fn<vsub2_add>(q, ec);
+  test_fn<vabsdiff2>(q, ec);
+  test_fn<vabsdiff2_add>(q, ec);
+  test_fn<vmin2>(q, ec);
+  test_fn<vmax2>(q, ec);
+  test_fn<vmin2_vmax2_add>(q, ec);
+  test_fn<vavrg2>(q, ec);
+  test_fn<vavrg2_add>(q, ec);
+  test_fn<vcompare2>(q, ec);
+  test_fn<vcompare2_add>(q, ec);
 
-  return ec_h;
+  syclcompat::free(ec, q);
 }

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
@@ -34,8 +34,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <limits>
-#include <stdio.h>
 #include <sycl/detail/core.hpp>
 
 #include <syclcompat/device.hpp>
@@ -44,13 +42,16 @@
 
 #define CHECK(S, REF)                                                          \
   {                                                                            \
+    ++test_id;                                                                 \
     auto ret = S;                                                              \
     if (ret != REF) {                                                          \
-      return {#S, REF};                                                        \
+      errc = test_id;                                                          \
     }                                                                          \
   }
 
-std::pair<const char *, int> vadd4() {
+int vadd4() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vadd4<int32_t>(0x0102FFFE, 0x01FF02FF, 0),
         0x020101FD);
   CHECK(syclcompat::extend_vadd4<int32_t>((int32_t)0x7E81FEFF,
@@ -87,11 +88,12 @@ std::pair<const char *, int> vadd4() {
                                                (uint32_t)0x00FE0001, 0),
         0x00FF00FF);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vadd4_add() {
-
+int vadd4_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vadd4_add<int32_t>(0x0102FFFE, 0x01FF02FF, 1),
         0x00000002);
   CHECK(syclcompat::extend_vadd4_add<int32_t>((int32_t)0x7E81FEFF,
@@ -113,11 +115,12 @@ std::pair<const char *, int> vadd4_add() {
                                                (uint32_t)0x00FE0001, 1),
         0x0000000200);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vsub4() {
-
+int vsub4() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vsub4<int32_t>((int32_t)0x0102FFFF,
                                           (int32_t)0x020101FE, 0),
         0xFF01FE01);
@@ -134,11 +137,12 @@ std::pair<const char *, int> vsub4() {
   CHECK(syclcompat::extend_vsub4_sat<uint32_t>(0x01020304, 0x02040608, 0),
         0x00000000);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vsub4_add() {
-
+int vsub4_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vsub4_add<int32_t>((int32_t)0x0102FFFF,
                                               (int32_t)0x020101FE, -1),
         0xFFFFFFFE);
@@ -155,11 +159,12 @@ std::pair<const char *, int> vsub4_add() {
                                                (uint32_t)0x02040608, 1),
         0xFFFFFFF7);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vabsdiff4() {
-
+int vabsdiff4() {
+  int errc{};
+  int test_id{};
   CHECK(
       syclcompat::extend_vabsdiff4<int32_t>((int32_t)0xFF01FF02, 0x01FF02FF, 0),
       0x02020303);
@@ -179,11 +184,12 @@ std::pair<const char *, int> vabsdiff4() {
                                                    (int32_t)0xF0FE0003, 0),
         0xFFFF0002);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vabsdiff4_add() {
-
+int vabsdiff4_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vabsdiff4_add<int32_t>((int32_t)0xFF01FF02,
                                                   0x01FF02FF, 1),
         0x0000000B);
@@ -197,11 +203,12 @@ std::pair<const char *, int> vabsdiff4_add() {
                                                    (int32_t)0xF0FE0003, 1),
         0x00000212);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmin4() {
-
+int vmin4() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vmin4<int32_t>((int32_t)0xFFFF0102,
                                           (int32_t)0xFE010201, 0),
         0xFEFF0101);
@@ -215,11 +222,12 @@ std::pair<const char *, int> vmin4() {
   CHECK(syclcompat::extend_vmin4_sat<uint32_t>(0x020201FF, 0x0201FFFE, 0),
         0x02010000);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmax4() {
-
+int vmax4() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vmax4<int32_t>((int32_t)0xFFFF0102,
                                           (int32_t)0xFE010201, 0),
         0xFF010202);
@@ -231,11 +239,12 @@ std::pair<const char *, int> vmax4() {
   CHECK(syclcompat::extend_vmax4_sat<uint32_t>(0x020201FF, 0x0201FFFE, 0),
         0x02020100);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vmin4_vmax4_add() {
-
+int vmin4_vmax4_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vmin4_add<int32_t>((int32_t)0xFFFF0102,
                                               (int32_t)0xFE010201, -1),
         0xFFFFFFFE);
@@ -249,11 +258,12 @@ std::pair<const char *, int> vmin4_vmax4_add() {
   CHECK(syclcompat::extend_vmax4_add<uint32_t>(0x010A020D, 0x000B020C, -1),
         0x0000001A);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vavrg4() {
-
+int vavrg4() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vavrg4<int32_t>((int32_t)0xFF01FF01, 0x0505FF00, 0),
         0x0203FF01);
   CHECK(syclcompat::extend_vavrg4_sat<int32_t>((int32_t)0xFF01FF01, 0x0505FF00,
@@ -266,11 +276,12 @@ std::pair<const char *, int> vavrg4() {
                                                 0),
         (int32_t)0x00030104);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vavrg4_add() {
-
+int vavrg4_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vavrg4_add<int32_t>((int32_t)0xFF01FF01, 0x0505FF00,
                                                1),
         0x00000006);
@@ -286,11 +297,12 @@ std::pair<const char *, int> vavrg4_add() {
                                                 -1),
         (int32_t)0x00000005);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vcompare4() {
-
+int vcompare4() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vcompare4(0x0102FEFF, 0x01FFFFFE, std::greater<>()),
         (unsigned)0x00010001);
   CHECK(syclcompat::extend_vcompare4((uint32_t)0x0102FEFF, (int32_t)0x01FFFFFE,
@@ -314,11 +326,12 @@ std::pair<const char *, int> vcompare4() {
                                      std::not_equal_to<>()),
         (unsigned)0x00010100);
 
-  return {nullptr, 0};
+  return errc;
 }
 
-std::pair<const char *, int> vcompare4_add() {
-
+int vcompare4_add() {
+  int errc{};
+  int test_id{};
   CHECK(syclcompat::extend_vcompare4_add(0x0102FEFF, 0x01FFFFFE, 1,
                                          std::greater<>()),
         (unsigned)0x00000003);
@@ -338,28 +351,27 @@ std::pair<const char *, int> vcompare4_add() {
                                          std::not_equal_to<>()),
         (unsigned)0x00010001);
 
-  return {nullptr, 0};
+  return errc;
 }
 
 template <auto F> void test_fn(sycl::queue q, int *ec, int id) {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   q.submit([&](sycl::handler &cgh) {
-    sycl::stream out(1024, 256, cgh);
-    cgh.parallel_for(1, [=](sycl::item<1> it) {
+    cgh.parallel_for(1, [=](sycl::item<1>) {
       auto res = F();
-      if (res.first) {
-        out << res.first << " = " << res.second << " check failed!\n";
-        *ec = id;
-        return;
-      }
+      if(res != 0) *ec = res;
     });
   });
   q.wait_and_throw();
 
   int ec_h;
   syclcompat::memcpy<int>(&ec_h, ec, 1);
-  assert(ec_h == 0);
+  if (ec_h != 0) {
+    std::cout << "Test " << ec_h << " failed." << std::endl;
+    syclcompat::free(ec, q);
+    assert(false);
+  }
 }
 
 

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
@@ -354,7 +354,7 @@ int vcompare4_add() {
   return errc;
 }
 
-template <auto F> void test_fn(sycl::queue q, int *ec, int id) {
+template <auto F> void test_fn(sycl::queue q, int *ec) {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   q.submit([&](sycl::handler &cgh) {
@@ -365,8 +365,8 @@ template <auto F> void test_fn(sycl::queue q, int *ec, int id) {
   });
   q.wait_and_throw();
 
-  int ec_h;
-  syclcompat::memcpy<int>(&ec_h, ec, 1);
+  int ec_h{};
+  syclcompat::memcpy<int>(&ec_h, ec, 1, q);
   if (ec_h != 0) {
     std::cout << "Test " << ec_h << " failed." << std::endl;
     syclcompat::free(ec, q);
@@ -378,21 +378,21 @@ template <auto F> void test_fn(sycl::queue q, int *ec, int id) {
 int main() {
   sycl::queue q = syclcompat::get_default_queue();
   int *ec = syclcompat::malloc<int>(1, q);
-  syclcompat::fill<int>(ec, 0, 1);
+  syclcompat::fill<int>(ec, 0, 1, q);
 
-  test_fn<vadd4>(q, ec, 1);
-  test_fn<vsub4>(q, ec, 2);
-  test_fn<vadd4_add>(q, ec, 3);
-  test_fn<vsub4_add>(q, ec, 4);
-  test_fn<vabsdiff4>(q, ec, 5);
-  test_fn<vabsdiff4_add>(q, ec, 6);
-  test_fn<vmin4>(q, ec, 7);
-  test_fn<vmax4>(q, ec, 8);
-  test_fn<vmin4_vmax4_add>(q, ec, 9);
-  test_fn<vavrg4>(q, ec, 10);
-  test_fn<vavrg4_add>(q, ec, 11);
-  test_fn<vcompare4>(q, ec, 12);
-  test_fn<vcompare4_add>(q, ec, 13);
+  test_fn<vadd4>(q, ec);
+  test_fn<vsub4>(q, ec);
+  test_fn<vadd4_add>(q, ec);
+  test_fn<vsub4_add>(q, ec);
+  test_fn<vabsdiff4>(q, ec);
+  test_fn<vabsdiff4_add>(q, ec);
+  test_fn<vmin4>(q, ec);
+  test_fn<vmax4>(q, ec);
+  test_fn<vmin4_vmax4_add>(q, ec);
+  test_fn<vavrg4>(q, ec);
+  test_fn<vavrg4_add>(q, ec);
+  test_fn<vcompare4>(q, ec);
+  test_fn<vcompare4_add>(q, ec);
 
   syclcompat::free(ec, q);
 }

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
@@ -358,7 +358,7 @@ template <auto F> void test_fn(sycl::queue q, int *ec, int id) {
   std::cout << __PRETTY_FUNCTION__ << std::endl;
 
   q.submit([&](sycl::handler &cgh) {
-    cgh.parallel_for(1, [=](sycl::item<1>) {
+    cgh.single_task([=]() {
       auto res = F();
       if(res != 0) *ec = res;
     });


### PR DESCRIPTION
The `math_extend*cpp` tests were very slow despite not doing a huge amount of work. This PR accelerates these tests with the following changes:
 - Split into several different kernels
 - Replace `parallel_for` with `single_task`
 - Avoid branching return statements
 - Avoid storing function names as `char` arrays in kernel
 - Avoid `sycl::stream` for output

Locally, the `math_extend_v_4.cpp` tests are about 5x faster. The other 2 are around 2x faster.