### PR TITLE
[SYCL] Remove unnamed lambda check from headers

### DIFF
--- a/sycl/include/sycl/kernel.hpp
+++ b/sycl/include/sycl/kernel.hpp
@@ -48,21 +48,16 @@ class auto_name {};
 /// the \c Name.
 template <typename Name, typename Type> struct get_kernel_name_t {
   using name = Name;
-  static_assert(
-      !std::is_same_v<Name, auto_name>,
-      "No kernel name provided without -fsycl-unnamed-lambda enabled!");
 };
 
-#ifdef __SYCL_UNNAMED_LAMBDA__
 /// Specialization for the case when \c Name is undefined.
-/// This is only legal with our compiler with the unnamed lambda
-/// extension, so make sure the specialiation isn't available in that case: the
-/// lack of specialization allows us to trigger static_assert from the primary
-/// definition.
+/// This is only legal with our compiler with the unnamed lambda extension or if
+/// the kernel is a functor object. For the case where \c Type is a lambda
+/// function and unnamed lambdas are disabled, the compiler will issue a
+/// diagnostic.
 template <typename Type> struct get_kernel_name_t<detail::auto_name, Type> {
   using name = Type;
 };
-#endif // __SYCL_UNNAMED_LAMBDA__
 
 } // namespace detail
 

--- a/sycl/test/basic_tests/handler/unnamed-lambda-functor.cpp
+++ b/sycl/test/basic_tests/handler/unnamed-lambda-functor.cpp
@@ -1,0 +1,40 @@
+// RUN: %clangxx -fsycl -fsycl-device-only -std=c++17 -fno-sycl-unnamed-lambda -isystem %sycl_include/sycl -Xclang -verify -fsyntax-only %s -Xclang -verify-ignore-unexpected=note
+// expected-no-diagnostics
+
+// Tests that kernel functor objects are allowed through when unnamed lambdas
+// are disabled.
+
+#include <sycl/sycl.hpp>
+
+struct SingleTaskKernel {
+  void operator()() const {}
+};
+
+struct ParallelForKernel {
+  void operator()(sycl::item<1> it) const {}
+};
+
+struct ParallelForWorkGroupKernel {
+  void operator()(sycl::item<1> it) const {}
+};
+
+int main() {
+  sycl::queue q;
+
+  q.single_task(SingleTaskKernel{});
+
+  q.parallel_for(sycl::range<1>{1}, ParallelForKernel{});
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.single_task(SingleTaskKernel{});
+  });
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for(sycl::range<1>{1}, ParallelForKernel{});
+  });
+
+  q.submit([&](sycl::handler &cgh) {
+    cgh.parallel_for_work_group(sycl::range<1>{1},
+                                ParallelForWorkGroupKernel{});
+  });
+}

--- a/sycl/test/basic_tests/handler/unnamed-lambda-negative.cpp
+++ b/sycl/test/basic_tests/handler/unnamed-lambda-negative.cpp
@@ -1,27 +1,33 @@
 // RUN: %clangxx -fsycl -fsycl-device-only -std=c++17 -fno-sycl-unnamed-lambda -isystem %sycl_include/sycl -Xclang -verify -fsyntax-only %s -Xclang -verify-ignore-unexpected=note
+
+// NOTE: Due to rounded kernels, some parallel_for cases may issue two error
+//       diagnostics.
+
 #include <sycl/sycl.hpp>
 
 int main() {
   sycl::queue q;
 
-  // expected-error@sycl/kernel.hpp:* {{No kernel name provided without -fsycl-unnamed-lambda enabled!}}
+  // expected-error-re@sycl/handler.hpp:* {{unnamed type '{{.*}}' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
   // expected-note@+1 {{in instantiation of function template}}
   q.single_task([=](){});
 
-  // expected-error@sycl/kernel.hpp:* {{No kernel name provided without -fsycl-unnamed-lambda enabled!}}
+  // expected-error-re@sycl/handler.hpp:* {{unnamed type 'sycl::detail::RoundedRangeKernel<{{.*}}>' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
+  // expected-error-re@sycl/handler.hpp:* {{unnamed type '{{.*}}' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
   // expected-note@+1 {{in instantiation of function template}}
   q.parallel_for(sycl::range<1>{1}, [=](sycl::item<1>) {});
 
   q.submit([&](sycl::handler &cgh) {
-    // expected-error@sycl/kernel.hpp:* {{No kernel name provided without -fsycl-unnamed-lambda enabled!}}
+    // expected-error-re@sycl/handler.hpp:* {{unnamed type '{{.*}}' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
     // expected-note@+1 {{in instantiation of function template}}
     cgh.single_task([=](){});
 
-    // expected-error@sycl/kernel.hpp:* {{No kernel name provided without -fsycl-unnamed-lambda enabled!}}
+    // expected-error-re@sycl/handler.hpp:* {{unnamed type 'sycl::detail::RoundedRangeKernel<{{.*}}>' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
+    // expected-error-re@sycl/handler.hpp:* {{unnamed type '{{.*}}' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
     // expected-note@+1 {{in instantiation of function template}}
     cgh.parallel_for(sycl::range<1>{1}, [=](sycl::item<1>) {});
 
-    // expected-error@sycl/kernel.hpp:* {{No kernel name provided without -fsycl-unnamed-lambda enabled!}}
+    // expected-error-re@sycl/handler.hpp:* {{unnamed type '{{.*}}' is invalid; provide a kernel name, or use '-fsycl-unnamed-lambda' to enable unnamed kernel lambdas}}
     // expected-note@+1 {{in instantiation of function template}}
     cgh.parallel_for_work_group(sycl::range<1>{1}, [=](sycl::group<1>) {});
   });


### PR DESCRIPTION
Currently the SYCL headers checks for unnamed lambdas in the case where they have been disabled. However, this falsely flags functor objects which should not be covered by the unnamed lambda restriction. Luckily, the compiler already issues diagnostics for illegal unnamed lambdas, so this patch removes the check from the headers and instead relies on the frontend for issuing diagnostics for the illegal cases.