### PR TITLE
[clang][NVPTX] Define macro indicating the PTX version

### DIFF
--- a/clang/lib/Basic/Targets/NVPTX.cpp
+++ b/clang/lib/Basic/Targets/NVPTX.cpp
@@ -175,6 +175,9 @@ void NVPTXTargetInfo::getTargetDefines(const LangOptions &Opts,
                                        MacroBuilder &Builder) const {
   Builder.defineMacro("__PTX__");
   Builder.defineMacro("__NVPTX__");
+  // PTXVersion is the value as parsed so 70 if +ptx70 is given.
+  // For symmetry with __CUDA_ARCH__, make it in the Major * 100 + Minor * 10.
+  Builder.defineMacro("__PTX_VERSION__", Twine(PTXVersion*10));
 
   // Skip setting architecture dependent macros if undefined.
   if (GPU == CudaArch::UNUSED && !HostTarget)

--- a/clang/test/Preprocessor/cuda-ptx-versioning.cu
+++ b/clang/test/Preprocessor/cuda-ptx-versioning.cu
@@ -1,0 +1,11 @@
+// RUN: %clang_cc1 %s -E -dM -o - -x cuda -fcuda-is-device -triple nvptx64 \
+// RUN: | FileCheck -match-full-lines %s --check-prefix=CHECK-CUDA32
+// CHECK-CUDA32: #define __PTX_VERSION__ 320
+
+// RUN: %clang_cc1 %s -E -dM -o - -x cuda -fcuda-is-device -triple nvptx64 -target-feature +ptx78 \
+// RUN:  -target-cpu sm_90 | FileCheck -match-full-lines %s --check-prefix=CHECK-CUDA78
+// CHECK-CUDA78: #define __PTX_VERSION__ 780
+
+// RUN: %clang_cc1 %s -E -dM -o - -x cuda -fcuda-is-device -triple nvptx64 -target-feature +ptx80 \
+// RUN:  -target-cpu sm_80 | FileCheck -match-full-lines %s --check-prefix=CHECK-CUDA80
+// CHECK-CUDA80: #define __PTX_VERSION__ 800


### PR DESCRIPTION
Define __PTX_VERSION__ macro to indicate the used PTX version.

Usually each new PTX version brings a new sm version and the associated instructions. However, some of these instructions can also be made avialable to older sm. This allows applications to check more accuratly for available instructions.