### PR TITLE
[SYCL][DRIVER] Add option to forward options to llc

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4099,6 +4099,10 @@ def fsycl_host_compiler_options_EQ : Joined<["-"], "fsycl-host-compiler-options=
   Visibility<[ClangOption, CLOption, DXCOption]>, HelpText<"When performing the host compilation with "
   "-fsycl-host-compiler specified, use the given options during that compile. "
   "Options are expected to be a quoted list of space separated options.">;
+def fsycl_llc_options_EQ : Joined<["-"], "fsycl-llc-options=">,
+  Visibility<[ClangOption, CLOption, DXCOption]>, HelpText<"Options to pass to the llc invocation used "
+  "to compile the IR module from clang-offload-wrapper."
+  "Options are expected to be a quoted list of space separated options.">;
 def fsycl_range_rounding_EQ : Joined<["-"], "fsycl-range-rounding=">,
   Visibility<[ClangOption, CLOption, DXCOption, CC1Option]>,
   Values<"on,disable,force">,

--- a/clang/test/Driver/sycl-llc-opts.cpp
+++ b/clang/test/Driver/sycl-llc-opts.cpp
@@ -1,0 +1,4 @@
+// TODO: Remove the -fsycl-llc-options option once https://github.com/intel/llvm/issues/14139 is fixed.
+// RUN: %clang -fsycl -fsycl-llc-options="-foo -bar" -### 2>&1 %s | FileCheck %s
+// CHECK: clang-offload-wrapper
+// CHECK: llc{{.*}}-foo{{.*}}-bar


### PR DESCRIPTION
Temporary work around for https://github.com/intel/llvm/issues/14139, adds a command line option that can be used to set options for the `llc` invocation used to compile the module from `clang-offload-wrapper`.