### PR TITLE
[SYCL][E2E] Remove XFAIL from two passing tests

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
@@ -1,7 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// TODO: Remove XFAIL after fixing https://github.com/intel/llvm/issues/13397
-// XFAIL: cpu
 
 #include "helpers.hpp"
 

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_spirv.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_spirv.cpp
@@ -10,8 +10,6 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out %S/Kernels/kernels.spv %S/Kernels/kernels_fp16.spv %S/Kernels/kernels_fp64.spv
-// TODO: Remove XFAIL after fixing https://github.com/intel/llvm/issues/13397
-// XFAIL: cpu
 
 // Test case for the sycl_ext_oneapi_kernel_compiler_spirv extension. This test
 // loads pre-compiled kernels from a SPIR-V file and runs them.


### PR DESCRIPTION
These are passing in the nightly after the CPU RT uplift a few days ago

https://github.com/intel/llvm/actions/runs/9984827095/job/27595152217

```
 Unexpectedly Passed Tests (2):
  SYCL :: Basic/built-ins/marray_geometric.cpp
  SYCL :: KernelCompiler/kernel_compiler_spirv.cpp
```

Closes: https://github.com/intel/llvm/issues/13397