### PR TITLE
[SYCL][Doc] Clarify "free_memory" query

### DIFF
--- a/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_device_info.md
@@ -391,6 +391,11 @@ Then the maximum memory bandwidth can be obtained using the standard get\_info()
 # Free Global Memory #
 
 A new device descriptor will be added which will provide the number of bytes of free global memory for the device.
+The amount of free global memory may be affected by other processes on the
+system that are also using this device.
+Beware that when other processes or threads are using this device when this call
+is made, the value it returns may be stale even before it is returned to the
+caller.
 
 This new device descriptor is only available for devices in the Level Zero platform, and the matching aspect is only true for those devices. The DPC++ default behavior is to expose GPU devices through the Level Zero platform. NOTE: one may need to set
 ZES_ENABLE_SYSMAN=1 to fully enable this extension.


### PR DESCRIPTION
Clarify the specification of the `ext::intel::info::device::free_memory` query.