### PR TITLE
[DeviceSanitizer] Disable handling no return calls

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3467,6 +3467,8 @@ bool AddressSanitizer::instrumentFunction(Function &F,
         NumInsnsPerBB++;
       } else {
         if (auto *CB = dyn_cast<CallBase>(&Inst)) {
+          // On device side, the only non return cases should be *.trap or
+          // assert, and none of these cases need to be handles.
           if (!TargetTriple.isSPIROrSPIRV()) {
             // A call inside BB.
             TempsToInstrument.clear();

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3467,10 +3467,12 @@ bool AddressSanitizer::instrumentFunction(Function &F,
         NumInsnsPerBB++;
       } else {
         if (auto *CB = dyn_cast<CallBase>(&Inst)) {
-          // A call inside BB.
-          TempsToInstrument.clear();
-          if (CB->doesNotReturn())
-            NoReturnCalls.push_back(CB);
+          if (!TargetTriple.isSPIROrSPIRV()) {
+            // A call inside BB.
+            TempsToInstrument.clear();
+            if (CB->doesNotReturn())
+              NoReturnCalls.push_back(CB);
+          }
         }
         if (CallInst *CI = dyn_cast<CallInst>(&Inst)) {
           if (TargetTriple.isSPIROrSPIRV() && CI->getCalledFunction() &&

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/no_return.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/no_return.ll
@@ -1,0 +1,19 @@
+; RUN: opt < %s -passes=asan -asan-instrumentation-with-call-threshold=0 -asan-stack=0 -asan-globals=0 -asan-constructor-kind=none -S | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
+target triple = "spir64-unknown-unknown"
+
+; Function Attrs: mustprogress nounwind sanitize_address uwtable
+define spir_func void @no_return(ptr addrspace(4) noundef align 8 dereferenceable_or_null(12) %this) unnamed_addr #0 {
+  ; CHECK-LABEL:  @no_return
+  ; CHECK-NOT: call void @__asan_handle_no_return
+  tail call void @llvm.trap() #1
+  unreachable
+}
+
+; Function Attrs: cold noreturn nounwind memory(inaccessiblemem: write)
+declare void @llvm.trap() #2
+
+attributes #0 = { mustprogress nounwind sanitize_address uwtable }
+attributes #1 = { noreturn nounwind }
+attributes #2 = { cold noreturn nounwind memory(inaccessiblemem: write) }


### PR DESCRIPTION
'__asan_handle_no_return' is used to unpoison stack before non return calls.
And we didn't poison stack in device code, so we don't need to handle such
case.