### PR TITLE
[RFC][UR][DeviceSanitizer] destruct loader before adapter

### DIFF
--- a/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
+++ b/sycl/plugins/unified_runtime/pi_unified_runtime.cpp
@@ -23,10 +23,10 @@ static void releaseAdapters(std::vector<ur_adapter_handle_t> &Vec) noexcept {
   static std::once_flag ReleaseFlag{};
   try {
     std::call_once(ReleaseFlag, [&]() {
+      urLoaderTearDown();
       for (auto Adapter : Vec) {
         urAdapterRelease(Adapter);
       }
-      urLoaderTearDown();
     });
   } catch (...) {
     // Ignore any potential exceptions on teardown. Worst case scenario


### PR DESCRIPTION
I know that there is an ongoing effect to remove the plugin system(https://github.com/intel/llvm/pull/14145), but I don't know how long would that take and I want this out for discussion first.

1. The adapter does not rely on loader(layers), but layers rely on adapters, so we should destruct the loader before adapters.
2. Adapter is constructed before layers, so it should be destructed later.

In Device sanitizer's layer, it calls API provided by adapter in its destructor, and that causes some problems. Like: for UR_L0_LEAKS_DEBUG=1 cases, after the `~SanitizerInterceptor()` would call `context.urDdiTable.VirtualMem.pfnFree()`, which in L0 adapter will try to record the API call in `ZeCallCount`, but that is deleted in L0 loader's destructor, causing a SEGV.