### PR TITLE
[SYCL][COMPAT] Removal of std++20 in e2e, refactor of RUN directives

### DIFF
--- a/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_arith.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cstddef>

--- a/sycl/test-e2e/syclcompat/atomic/atomic_bitwise.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_bitwise.cpp
@@ -35,7 +35,7 @@
 // to fail. The same applies to each test within this directory
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <type_traits>

--- a/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip || (windows && level_zero)
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %} %s -o %t.out
+// RUN: %{build} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_comp_exchange.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <type_traits>

--- a/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_memory_acq_rel.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %} %s -o %t.out
+// RUN: %{build} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %} -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_minmax.cpp
@@ -32,7 +32,7 @@
 
 // UNSUPPORTED: hip
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <type_traits>

--- a/sycl/test-e2e/syclcompat/common.hpp
+++ b/sycl/test-e2e/syclcompat/common.hpp
@@ -29,12 +29,15 @@ constexpr double ERROR_TOLERANCE = 1e-5;
 
 // Typed call helper
 // Iterates over all types and calls Functor f for each of them
+template <typename Functor, template <typename...> class Container,
+          typename... Ts>
+void for_each_type_call(Functor &&f, Container<Ts...> *) {
+  (f.template operator()<Ts>(), ...);
+}
+
 template <typename tuple, typename Functor>
 void instantiate_all_types(Functor &&f) {
-  auto for_each_type_call =
-      [&]<template <typename...> class Container, typename... Ts>(
-          Container<Ts...> *) { (f.template operator()<Ts>(), ...); };
-  for_each_type_call(static_cast<tuple *>(nullptr));
+  for_each_type_call(f, static_cast<tuple *>(nullptr));
 }
 
 #define INSTANTIATE_ALL_TYPES(tuple, f)                                        \

--- a/sycl/test-e2e/syclcompat/defs.cpp
+++ b/sycl/test-e2e/syclcompat/defs.cpp
@@ -20,7 +20,7 @@
  *     Syclcompat macros tests
  **************************************************************************/
 
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cassert>

--- a/sycl/test-e2e/syclcompat/device/device.cpp
+++ b/sycl/test-e2e/syclcompat/device/device.cpp
@@ -29,7 +29,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/device.hpp>

--- a/sycl/test-e2e/syclcompat/device/device_filter.cpp
+++ b/sycl/test-e2e/syclcompat/device/device_filter.cpp
@@ -20,7 +20,7 @@
  *    Device filtering tests
  **************************************************************************/
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/device.hpp>

--- a/sycl/test-e2e/syclcompat/device/device_profiling.cpp
+++ b/sycl/test-e2e/syclcompat/device/device_profiling.cpp
@@ -20,9 +20,9 @@
  *    Tests for the enable_profiling property paths
  **************************************************************************/
 
-// RUN: %clangxx -DSYCLCOMPAT_PROFILING_ENABLED=1 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t-profiling.out
+// RUN: %{build} -DSYCLCOMPAT_PROFILING_ENABLED=1 -o %t-profiling.out
 // RUN: %{run} %t-profiling.out
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t-no-profiling.out
+// RUN: %{build} -o %t-no-profiling.out
 // RUN: %{run} %t-no-profiling.out
 
 #include <syclcompat/device.hpp>

--- a/sycl/test-e2e/syclcompat/device/device_threaded.cpp
+++ b/sycl/test-e2e/syclcompat/device/device_threaded.cpp
@@ -31,7 +31,7 @@
 
 // REQUIRES: linux
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -lpthread %s -o %t.out
+// RUN: %{build} -lpthread -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/device.hpp>

--- a/sycl/test-e2e/syclcompat/dim.cpp
+++ b/sycl/test-e2e/syclcompat/dim.cpp
@@ -20,7 +20,7 @@
  *     dim3 tests
  **************************************************************************/
 
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cassert>

--- a/sycl/test-e2e/syclcompat/id_query/id_query.cpp
+++ b/sycl/test-e2e/syclcompat/id_query/id_query.cpp
@@ -20,7 +20,7 @@
  *    global_id query tests
  **************************************************************************/
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <algorithm>

--- a/sycl/test-e2e/syclcompat/launch/launch.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch.cpp
@@ -21,7 +21,7 @@
  **************************************************************************/
 // https://github.com/intel/llvm/issues/14387
 // UNSUPPORTED: gpu-intel-dg2
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-device-code-split=per_kernel -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
 #include <type_traits>

--- a/sycl/test-e2e/syclcompat/math/math_bfe.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_bfe.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <bitset>

--- a/sycl/test-e2e/syclcompat/math/math_bfi.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_bfi.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <bitset>

--- a/sycl/test-e2e/syclcompat/math/math_byte_dot_product.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_byte_dot_product.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_61 %}  %s -o %t.out
+// RUN: %{build} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_61 %} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_compare.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_compare.cpp
@@ -32,7 +32,7 @@
 
 // REQUIRES: aspect-fp16
 
-// RUN: %clangxx -std=c++17 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/half_type.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_complex.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_complex.cpp
@@ -30,7 +30,7 @@
 //===---------------------------------------------------------------===//
 
 // REQUIRES: aspect-fp64
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <complex>

--- a/sycl/test-e2e/syclcompat/math/math_complex_datatype.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_complex_datatype.cpp
@@ -29,7 +29,7 @@
 //
 //===---------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/syclcompat/math/math_extend.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cmath>

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_2.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_2.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cmath>

--- a/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_extend_v_4.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cmath>

--- a/sycl/test-e2e/syclcompat/math/math_funnelshift.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_funnelshift.cpp
@@ -20,7 +20,7 @@
  *    math funnel helpers tests
  **************************************************************************/
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/device.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_length_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_length_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <numeric>

--- a/sycl/test-e2e/syclcompat/math/math_ops.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_ops.cpp
@@ -20,7 +20,7 @@
  *    tests for non-vectorized math helper functions
  **************************************************************************/
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/dims.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_vectorized.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized.cpp
@@ -22,7 +22,7 @@
 
 // REQUIRES: aspect-fp16
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/math.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_max_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_max_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_min_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_min_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/memory/local_memory.cpp
+++ b/sycl/test-e2e/syclcompat/memory/local_memory.cpp
@@ -20,7 +20,7 @@
  *    launch<F> tests with static local memory
  **************************************************************************/
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <numeric>

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <malloc.h>

--- a/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memcpy_3d2.cpp
@@ -29,7 +29,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <malloc.h>

--- a/sycl/test-e2e/syclcompat/memory/memory_async.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_async.cpp
@@ -30,7 +30,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Tests for the sycl::events returned from syclcompat::*Async API calls

--- a/sycl/test-e2e/syclcompat/memory/memory_image.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_image.cpp
@@ -20,7 +20,7 @@
  *    3D memory copy tests for new image/memcpy_parameter API
  **************************************************************************/
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // FIXME(@intel/syclcompat-lib-reviewers): These are some limited tests for the

--- a/sycl/test-e2e/syclcompat/memory/memory_image_xfails.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_image_xfails.cpp
@@ -30,7 +30,7 @@
 //
 // ===---------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Tests for the sycl::events returned from syclcompat::*Async API calls

--- a/sycl/test-e2e/syclcompat/memory/memory_management_diff_queues.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_diff_queues.cpp
@@ -20,7 +20,7 @@
  *    memory operations tests for operations when changing the default queue
  **************************************************************************/
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_shared.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_shared.cpp
@@ -31,7 +31,7 @@
 // ===----------------------------------------------------------------------===//
 
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test1.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test2.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test2.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
+++ b/sycl/test-e2e/syclcompat/memory/memory_management_test3.cpp
@@ -29,7 +29,7 @@
 //
 //
 // ===----------------------------------------------------------------------===//
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/memory/usm_allocations.cpp
+++ b/sycl/test-e2e/syclcompat/memory/usm_allocations.cpp
@@ -20,7 +20,7 @@
  *    USM allocation tests
  **************************************************************************/
 
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cassert>

--- a/sycl/test-e2e/syclcompat/memory/usm_shared_allocations.cpp
+++ b/sycl/test-e2e/syclcompat/memory/usm_shared_allocations.cpp
@@ -21,7 +21,7 @@
  **************************************************************************/
 
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %clangxx -std=c++20 -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cassert>

--- a/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_cast_value_test.cpp
@@ -32,7 +32,7 @@
 
 // REQUIRES: aspect-fp64
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_find_first_set.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_find_first_set.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_helpers.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_helpers.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_logical_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_logical_group.cpp
@@ -31,7 +31,7 @@
 // ===----------------------------------------------------------------------===//
 
 // REQUIRES: sg-32
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cstdio>

--- a/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_all_over_group.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_match_any_over_group.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_matrix_mem_copy_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_matrix_mem_copy_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/syclcompat/util/util_nd_range_barrier_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_nd_range_barrier_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <cstring>

--- a/sycl/test-e2e/syclcompat/util/util_occupancy_calculation.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_occupancy_calculation.cpp
@@ -32,7 +32,7 @@
 // REQUIRES: gpu
 // REQUIRES: level_zero || opencl
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/util.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_perm_byte_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_perm_byte_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <stdio.h>

--- a/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_permute_sub_group_by_xor.cpp
@@ -31,7 +31,7 @@
 // ===----------------------------------------------------------------------===//
 
 // REQUIRES: sg-32
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_reverse_bits_test.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_reverse_bits_test.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_select_from_sub_group.cpp
@@ -31,7 +31,7 @@
 // ===----------------------------------------------------------------------===//
 
 // REQUIRES: sg-32
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_left.cpp
@@ -31,7 +31,7 @@
 // ===----------------------------------------------------------------------===//
 
 // REQUIRES: sg-32
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
+++ b/sycl/test-e2e/syclcompat/util/util_shift_sub_group_right.cpp
@@ -31,7 +31,7 @@
 // ===----------------------------------------------------------------------===//
 
 // REQUIRES: sg-32
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
@@ -140,7 +140,8 @@ void test_shift_sub_group_right() {
                           });
 
   dev_ct1.queues_wait_and_throw();
-q_ct1->memcpy(host_dev_data_u, dev_data_u, DATA_NUM * sizeof(unsigned int)).wait();
+  q_ct1->memcpy(host_dev_data_u, dev_data_u, DATA_NUM * sizeof(unsigned int))
+      .wait();
   verify_data<unsigned int>(host_dev_data_u, expect2, DATA_NUM);
 
   sycl::free(dev_data, *q_ct1);


### PR DESCRIPTION
This PR removes the use of std++20 in syclcompat e2e tests to avoid std++20 features being accidentally added in the headers.
It also changes %clang++ substitutions to use %build to reduce the length of RUN directives
