### PR TITLE
[SYCL][E2E] Add a basic build expansion

### DIFF
--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl || level_zero, gpu, ocloc
 // UNSUPPORTED: gpu-intel-dg1 || windows
 //
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
+// RUN: %{basic-build} -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/context-with-multiple-devices.cpp
+++ b/sycl/test-e2e/Basic/context-with-multiple-devices.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: accelerator, opencl-aot
 
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t2.out
+// RUN: %{basic-build} -fintelfpga %s -o %t2.out
 // RUN: env CL_CONFIG_CPU_EMULATE_DEVICES=2 %t2.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_aocx.cpp
@@ -13,14 +13,14 @@
 // leftover archives, remove one if exists.
 
 // RUN: rm %t_image.a || true
-// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
+// RUN: %{basic-build} -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.a
 // Produce a host object
-// RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o
+// RUN: %{basic-build} -fintelfpga %S/Inputs/fpga_host.cpp -c -o %t.o
 
 // AOCX with source
-// RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp %t_image.a -o %t_aocx_src.out
+// RUN: %{basic-build} -fintelfpga %S/Inputs/fpga_host.cpp %t_image.a -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clangxx -fsycl -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
+// RUN: %{basic-build} -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
 //
 // RUN: %{run} %t_aocx_src.out
 // RUN: %{run} %t_aocx_obj.out

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -14,14 +14,14 @@
 // leftover archives, remove one if exists.
 
 // RUN: rm %t_image.a || true
-// RUN: %clangxx -fsycl -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
+// RUN: %{basic-build} -fintelfpga -fsycl-link=image %S/Inputs/fpga_device.cpp -o %t_image.lib
 // Produce a host object
-// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
+// RUN: %{basic-build} -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp -c -o %t.obj
 
 // AOCX with source
-// RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
+// RUN: %{basic-build} -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clangxx -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
+// RUN: %{basic-build} -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
 //
 // RUN: %{run} %t_aocx_src.out
 // RUN: %{run} %t_aocx_obj.out

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_dsp_control.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_dsp_control.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: accelerator, opencl-aot
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %{basic-build} -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_lsu.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_lsu.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: opencl-aot, accelerator
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %{basic-build} -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_pipe.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_latency_control_pipe.cpp
@@ -7,7 +7,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: opencl-aot, accelerator
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %{basic-build} -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_lsu.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_lsu.cpp
@@ -6,7 +6,7 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: accelerator, opencl-aot
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %{basic-build} -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <iostream>

--- a/sycl/test-e2e/Basic/fpga_tests/global_fpga_device_selector.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/global_fpga_device_selector.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl-aot, accelerator
 
-// RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
+// RUN: %{basic-build} -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/multisource.cpp
+++ b/sycl/test-e2e/Basic/multisource.cpp
@@ -9,14 +9,14 @@
 // Separate kernel sources and host code sources
 // RUN: %{build} -c -o %t.kernel.o -DINIT_KERNEL -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
+// RUN: %{basic-build} -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code
 // RUN: %{build} -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %{basic-build} -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/multisource_spv_obj.cpp
+++ b/sycl/test-e2e/Basic/multisource_spv_obj.cpp
@@ -11,21 +11,21 @@
 // Separate kernel sources and host code sources
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.kernel.o -DINIT_KERNEL -DCALC_KERNEL
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
+// RUN: %{basic-build} -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %{basic-build} -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code, mixed SPIR-V and LLVM-IR objects
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -fsycl-device-obj=llvmir -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %{basic-build} -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
 // RUN: %{run} %t.fat
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
+++ b/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
-// RUN: %clangxx -fsycl -fsycl-device-obj=spirv -c -o %t.o %s
-// RUN: %clangxx -fsycl -o %t.out %t.o
+// RUN: %{basic-build} -fsycl-device-obj=spirv -c -o %t.o %s
+// RUN: %{basic-build} -o %t.out %t.o
 // RUN: %{run} %t.out
 
 // This test verifies SPIR-V based fat objects.

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -176,6 +176,13 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 "%clangxx -fsycl -fsycl-targets=%{sycl_triple} %verbose_print %s",
             )
         )
+        # Barebone build expansion for tests that require more specific compilation
+        substitutions.append(
+            (
+                "%{basic-build}",
+                "%clangxx -fsycl %verbose_print",
+            )
+        )
         if platform.system() == "Windows":
             substitutions.append(
                 (


### PR DESCRIPTION
Adds `%{basic-build}` expansion for e2e tests that require more specific compilation.

A number of tests do not use the `%{build}` expansion because they need to be compiled in ways different to most tests. This patch adds a bare-bone version of that expansion, that can be used in these instances.

Using this will allow us in the future to add compile flags to all tests from a single location (for example, the `-Werror` flag).

Note: basic as in "bare-bone", not in reference to the test-e2e/Basic tests.