### PR TITLE
[SYCL][CUDA][libclc] Fix nextafter(-0.0,+0.0)

### DIFF
--- a/libclc/generic/libspirv/math/half_nextafter.inc
+++ b/libclc/generic/libspirv/math/half_nextafter.inc
@@ -25,7 +25,7 @@ _CLC_OVERLOAD _CLC_DEF half __spirv_ocl_nextafter(half x, half y) {
     return y;
   // Parity
   if (x == y)
-    return x;
+    return y;
 
   short *a = (short *)&x;
   short *b = (short *)&y;


### PR DESCRIPTION
Both C++17 and C99 specify that `nextafter(x,y)` returns `y` when `x==y`, so the SYCL/OpenCL implementations should follow the same rule. For any normal number returning either `x` or `y` has the same effect if they compare equal, except for negative zero and positive zero. Although they compare equal (as per IEEE-754), they are not bitwise identical. For consistency (as in the C++ and C standards) `nextafter(-0.0,+0.0)` should return `+0.0` and `nextafter(+0.0,-0.0)` should return `-0.0`.

Fix the libclc/generic implementation (included in PTX builtins) to follow these specifications.