### PR TITLE
[CI] Remove SYCL CTS build workaround

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -318,7 +318,6 @@ jobs:
         -DSYCL_CTS_ENABLE_OPENCL_INTEROP_TESTS=OFF \
         -DSYCL_CTS_MEASURE_BUILD_TIMES=ON \
         -DDPCPP_INSTALL_DIR="$(dirname $(which clang++))/.." \
-        -DCMAKE_CXX_FLAGS="-Wno-missing-template-arg-list-after-template-kw" \
         $CMAKE_EXTRA_ARGS
         # Ignore errors so that if one category build fails others still have a
         # chance to finish and be executed at the run stage. Note that


### PR DESCRIPTION
Fix was [merged](https://github.com/KhronosGroup/SYCL-CTS/pull/907) to CTS.

Manual nightly run with this change: https://github.com/intel/llvm/actions/runs/10045951175/job/27765157126

Closes: https://github.com/intel/llvm/issues/14478