### PR TITLE
[SYCL][ClangLinkerWrapper] Fix SYCL binary creation with spirv64 triple

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -967,10 +967,12 @@ wrapSYCLBinariesFromFile(std::vector<module_split::SplitModule> &SplitModules,
 
   SmallVector<llvm::offloading::SYCLImage> Images;
   // SYCL runtime currently works for spir64 target triple and not for
-  // spir64-unknown-unknown.
-  // TODO: Fix SYCL runtime to accept both triple
+  // spir64-unknown-unknown/spirv64-unknown-unknown/spirv64.
+  // TODO: Fix SYCL runtime to accept other triples
   llvm::Triple T(Target);
   StringRef A(T.getArchName());
+  if(A == "spirv64")
+    A = "spir64";
   for (auto &SI : SplitModules) {
     auto MBOrDesc = MemoryBuffer::getFile(SI.ModuleFilePath);
     if (!MBOrDesc)

--- a/sycl/test-e2e/NewOffloadDriver/buffer.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/buffer.cpp
@@ -12,6 +12,9 @@
 // RUN: %clangxx -fsycl --offload-new-driver %s -o %t.out
 // RUN: %{run} %t.out
 
+// RUN: %clangxx -fsycl -fsycl-targets=spirv64 --offload-new-driver %s -o %t1.out
+// RUN: %{run} %t1.out
+
 #include <sycl/detail/core.hpp>
 
 int main() {


### PR DESCRIPTION
I hit this working on thinLTO using the SPIR-V backend, but it's reproducible just with the triple.