### PR TITLE
[SYCL] Update CODEOWNERS for new offloading model E2E tests

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -166,6 +166,7 @@ sycl/test-e2e/DeviceCodeSplit/ @intel/dpcpp-tools-reviewers
 sycl/test-e2e/SeparateCompile/ @intel/dpcpp-tools-reviewers
 sycl/test-e2e/Printf/ @intel/dpcpp-tools-reviewers @intel/llvm-reviewers-runtime
 sycl/test-e2e/SpecConstants/ @intel/dpcpp-tools-reviewers
+sycl/test-e2e/NewOffloadDriver/ @intel/dpcpp-tools-reviewers
 
 # Sanitizer
 clang/lib/Driver/SanitizerArgs.cpp @intel/dpcpp-sanitizers-review


### PR DESCRIPTION
These are testing a feature owned by the tools team.