### PR TITLE
[WIP] Do not merge    kernel compiler via shared lib

### DIFF
--- a/sycl/source/detail/kernel_compiler/kernel_compiler_sycl.hpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_sycl.hpp
@@ -21,13 +21,15 @@ inline namespace _V1 {
 namespace ext::oneapi::experimental {
 namespace detail {
 
-using spirv_vec_t = std::vector<uint8_t>;
+// CP
+// using spirv_vec_t = std::vector<uint8_t>;
 using include_pairs_t = std::vector<std::pair<std::string, std::string>>;
 
-spirv_vec_t
-SYCL_to_SPIRV(const std::string &Source, include_pairs_t IncludePairs,
-              const std::vector<std::string> &UserArgs, std::string *LogPtr,
-              const std::vector<std::string> &RegisteredKernelNames);
+std::vector<sycl::kernel_id>
+SYCL_to_Kernel_IDs(const std::string &Source, include_pairs_t IncludePairs,
+                   const std::vector<std::string> &UserArgs,
+                   std::string *LogPtr,
+                   const std::vector<std::string> &RegisteredKernelNames);
 
 bool SYCL_Compilation_Available();
 

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -147,7 +147,8 @@ void test_build_and_run() {
   assert(beRes == ctx.get_backend());
 
   // Compilation of empty prop list, no devices.
-  exe_kb kbExe1 = syclex::build(kbSrc);
+  // CP - temporarily disabled while I re-approach the kernel_id diff issue.
+  //exe_kb kbExe1 = syclex::build(kbSrc);
 
   // Compilation with props and devices
   std::string log;


### PR DESCRIPTION
Quick pass at getting the kernel_compiler to use a shared library directly instead of the SPIR-V dump. 
Needs testing on Windows, possibly using a different interop handler, and more.