### PR TITLE
[SYCL][Docs] Add kernel enqueue functions for kernel and properties

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
@@ -114,27 +114,6 @@ supports.
  feature-test macro always has this value.
 |===
 
-=== Kernel Property Trait
-
-Some kernel properties carry compile-time information to affect how the compiler
-handles the corresponding kernel object. However, some of the kernel enqueue
-functions take a `sycl::kernel` object and as such it may not be possible to
-infer which kernel function it refers to at compile-time. To help identify the
-properties that have compile-time effects on the kernel, the
-`has_compile_time_kernel_effect` trait.
-
-```c++
-namespace sycl::ext::oneapi::experimental {
-
-template<typename> struct has_compile_time_kernel_effect : std::false_type {};
-
-template<typename PropertyT>
-static constexpr bool has_compile_time_kernel_effect_v =
-    has_compile_time_kernel_effect<PropertyT>::value;
-
-} // namespace sycl::ext::oneapi::experimental
-```
-
 === Kernel Properties
 
 The kernel properties below correspond to kernel attributes defined in
@@ -202,15 +181,6 @@ template <> struct is_property_key<work_group_size_key> : std::true_type {};
 template <> struct is_property_key<work_group_size_hint_key> : std::true_type {};
 template <> struct is_property_key<sub_group_size_key> : std::true_type {};
 template <> struct is_property_key<device_has_key> : std::true_type {};
-
-template <size_t... Dims>
-struct has_compile_time_kernel_effect<work_group_size_key::value_t<Dims...>> : std::true_type {};
-template <size_t... Dims>
-struct has_compile_time_kernel_effect<work_group_size_hint_key::value_t<Dims...>> : std::true_type {};
-template <uint32_t Size>
-struct has_compile_time_kernel_effect<sub_group_size_key::value_t<Size>> : std::true_type {};
-template <sycl::aspect... Aspects>
-struct has_compile_time_kernel_effect<device_has_key::value_t<Aspects...>> : std::true_type {};
 
 } // namespace sycl::ext::oneapi::experimental
 ```
@@ -345,19 +315,19 @@ class handler {
                                PropertyList properties,
                                const WorkgroupFunctionType &kernelFunc);
 
-  // Available only if `!has_compile_time_kernel_effect<PropertyT>` for all
-  // properties `PropertyT` in `PropertyList`.
+  // Available only if all properties in `PropertList` only have launch-related
+  // effects.
   template <typename PropertyList>
   void single_task(PropertyList properties, const kernel& kernelObject);
 
-  // Available only if `!has_compile_time_kernel_effect<PropertyT>` for all
-  // properties `PropertyT` in `PropertyList`.
+  // Available only if all properties in `PropertList` only have launch-related
+  // effects.
   template <int Dimensions, typename PropertyList>
   void parallel_for(range<Dimensions> numWorkItems, PropertyList properties,
                     const kernel& kernelObject);
 
-  // Available only if `!has_compile_time_kernel_effect<PropertyT>` for all
-  // properties `PropertyT` in `PropertyList`.
+  // Available only if all properties in `PropertList` only have launch-related
+  // effects.
   template <int Dimensions, typename PropertyList>
   void parallel_for(nd_range<Dimensions> ndRange, PropertyList properties,
                     const kernel& kernelObject);

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
@@ -114,6 +114,27 @@ supports.
  feature-test macro always has this value.
 |===
 
+=== Kernel Property Trait
+
+Some kernel properties carry compile-time information to affect how the compiler
+handles the corresponding kernel object. However, some of the kernel enqueue
+functions take a `sycl::kernel` object and as such it may not be possible to
+infer which kernel function it refers to at compile-time. To help identify the
+properties that have compile-time effects on the kernel, the
+`has_compile_time_kernel_effect` trait.
+
+```c++
+namespace sycl::ext::oneapi::experimental {
+
+template<typename> struct has_compile_time_kernel_effect : std::false_type {};
+
+template<typename PropertyT>
+static constexpr bool has_compile_time_kernel_effect_v =
+    has_compile_time_kernel_effect<PropertyT>::value;
+
+} // namespace sycl::ext::oneapi::experimental
+```
+
 === Kernel Properties
 
 The kernel properties below correspond to kernel attributes defined in
@@ -121,10 +142,7 @@ Section 5.8.1 of the SYCL 2020 specification.  Note that deprecated attributes
 (such as `vec_type_hint`) are not included.
 
 ```c++
-namespace sycl {
-namespace ext {
-namespace oneapi {
-namespace experimental {
+namespace sycl::ext::oneapi::experimental {
 
 // Corresponds to reqd_work_group_size
 struct work_group_size_key {
@@ -185,10 +203,16 @@ template <> struct is_property_key<work_group_size_hint_key> : std::true_type {}
 template <> struct is_property_key<sub_group_size_key> : std::true_type {};
 template <> struct is_property_key<device_has_key> : std::true_type {};
 
-} // namespace experimental
-} // namespace oneapi
-} // namespace ext
-} // namespace sycl
+template <size_t... Dims>
+struct has_compile_time_kernel_effect<work_group_size_key::value_t<Dims...>> : std::true_type {};
+template <size_t... Dims>
+struct has_compile_time_kernel_effect<work_group_size_hint_key::value_t<Dims...>> : std::true_type {};
+template <uint32_t Size>
+struct has_compile_time_kernel_effect<sub_group_size_key::value_t<Size>> : std::true_type {};
+template <sycl::aspect... Aspects>
+struct has_compile_time_kernel_effect<device_has_key::value_t<Aspects...>> : std::true_type {};
+
+} // namespace sycl::ext::oneapi::experimental
 ```
 
 |===
@@ -320,6 +344,23 @@ class handler {
                                range<dimensions> workGroupSize,
                                PropertyList properties,
                                const WorkgroupFunctionType &kernelFunc);
+
+  // Available only if `!has_compile_time_kernel_effect<PropertyT>` for all
+  // properties `PropertyT` in `PropertyList`.
+  template <typename PropertyList>
+  void single_task(PropertyList properties, const kernel& kernelObject);
+
+  // Available only if `!has_compile_time_kernel_effect<PropertyT>` for all
+  // properties `PropertyT` in `PropertyList`.
+  template <int Dimensions, typename PropertyList>
+  void parallel_for(range<Dimensions> numWorkItems, PropertyList properties,
+                    const kernel& kernelObject);
+
+  // Available only if `!has_compile_time_kernel_effect<PropertyT>` for all
+  // properties `PropertyT` in `PropertyList`.
+  template <int Dimensions, typename PropertyList>
+  void parallel_for(nd_range<Dimensions> ndRange, PropertyList properties,
+                    const kernel& kernelObject);
 }
 }
 ```

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc
@@ -176,13 +176,6 @@ template <> struct is_property_key<intel::experimental::streaming_interface_key>
 template <> struct is_property_key<intel::experimental::register_map_interface_key> : std::true_type {};
 template <> struct is_property_key<intel::experimental::fpga_cluster_key> : std::true_type {};
 
-template <intel::experimental::streaming_interface_options_enum option>
-struct has_compile_time_kernel_effect<intel::experimental::streaming_interface_key::value_t<option>> : std::true_type {};
-template <intel::experimental::register_map_interface_options_enum option>
-struct has_compile_time_kernel_effect<intel::experimental::register_map_interface_key::value_t<option>> : std::true_type {};
-template<intel::experimental::fpga_cluster_options_enum option>
-struct has_compile_time_kernel_effect<intel::experimental::fpga_cluster_key::value_t<option>> : std::true_type {};
-
 } // intel::experimental
 } // namespace sycl::ext
 ```

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc
@@ -92,7 +92,8 @@ using the mechanism defined in sycl_ext_oneapi_kernel_properties.
 === Kernel Interface Properties
 
 ```c++
-namespace sycl::ext::intel::experimental {
+namespace sycl::ext {
+namespace intel::experimental {
 
 enum class streaming_interface_options_enum {
   accept_downstream_stall,
@@ -167,11 +168,23 @@ inline constexpr fpga_cluster_key::value_t<
 inline constexpr fpga_cluster_key::value_t<
   fpga_cluster_options_enum::stall_free_clusters> stall_free_clusters;
 
-template <> struct is_property_key<streaming_interface_key> : std::true_type {};
-template <> struct is_property_key<register_map_interface_key> : std::true_type {};
-template <> struct is_property_key<fpga_cluster_key> : std::true_type {};
+} // intel::experimental
 
-} // namespace sycl::ext::intel::experimental
+namespace oneapi::experimental {
+
+template <> struct is_property_key<intel::experimental::streaming_interface_key> : std::true_type {};
+template <> struct is_property_key<intel::experimental::register_map_interface_key> : std::true_type {};
+template <> struct is_property_key<intel::experimental::fpga_cluster_key> : std::true_type {};
+
+template <intel::experimental::streaming_interface_options_enum option>
+struct has_compile_time_kernel_effect<intel::experimental::streaming_interface_key::value_t<option>> : std::true_type {};
+template <intel::experimental::register_map_interface_options_enum option>
+struct has_compile_time_kernel_effect<intel::experimental::register_map_interface_key::value_t<option>> : std::true_type {};
+template<intel::experimental::fpga_cluster_options_enum option>
+struct has_compile_time_kernel_effect<intel::experimental::fpga_cluster_key::value_t<option>> : std::true_type {};
+
+} // intel::experimental
+} // namespace sycl::ext
 ```
 
 |===

--- a/sycl/include/sycl/detail/kernel_properties.hpp
+++ b/sycl/include/sycl/detail/kernel_properties.hpp
@@ -45,6 +45,7 @@ struct PropertyMetaInfo<sycl::detail::register_alloc_mode_key::value_t<Mode>> {
   static constexpr const char *name = "sycl-register-alloc-mode";
   static constexpr sycl::detail::register_alloc_mode_enum value = Mode;
 };
+
 } // namespace detail
 } // namespace ext::oneapi::experimental
 } // namespace _V1

--- a/sycl/include/sycl/ext/intel/experimental/fpga_kernel_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_kernel_properties.hpp
@@ -103,16 +103,16 @@ struct is_property_key_of<
     intel::experimental::fpga_kernel_attribute<T, PropertyListT>>
     : std::true_type {};
 
+namespace detail {
 template <intel::experimental::streaming_interface_options_enum option>
-struct has_compile_time_kernel_effect<
+struct HasCompileTimeEffect<
     intel::experimental::streaming_interface_key::value_t<option>>
     : std::true_type {};
 template <intel::experimental::register_map_interface_options_enum option>
-struct has_compile_time_kernel_effect<
+struct HasCompileTimeEffect<
     intel::experimental::register_map_interface_key::value_t<option>>
     : std::true_type {};
 
-namespace detail {
 template <intel::experimental::streaming_interface_options_enum Stall_Free>
 struct PropertyMetaInfo<
     intel::experimental::streaming_interface_key::value_t<Stall_Free>> {

--- a/sycl/include/sycl/ext/intel/experimental/fpga_kernel_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_kernel_properties.hpp
@@ -103,6 +103,15 @@ struct is_property_key_of<
     intel::experimental::fpga_kernel_attribute<T, PropertyListT>>
     : std::true_type {};
 
+template <intel::experimental::streaming_interface_options_enum option>
+struct has_compile_time_kernel_effect<
+    intel::experimental::streaming_interface_key::value_t<option>>
+    : std::true_type {};
+template <intel::experimental::register_map_interface_options_enum option>
+struct has_compile_time_kernel_effect<
+    intel::experimental::register_map_interface_key::value_t<option>>
+    : std::true_type {};
+
 namespace detail {
 template <intel::experimental::streaming_interface_options_enum Stall_Free>
 struct PropertyMetaInfo<

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -238,20 +238,20 @@ template <> struct is_property_key<work_group_progress_key> : std::true_type {};
 template <> struct is_property_key<sub_group_progress_key> : std::true_type {};
 template <> struct is_property_key<work_item_progress_key> : std::true_type {};
 
+namespace detail {
+
 template <size_t... Dims>
-struct has_compile_time_kernel_effect<work_group_size_key::value_t<Dims...>>
+struct HasCompileTimeEffect<work_group_size_key::value_t<Dims...>>
     : std::true_type {};
 template <size_t... Dims>
-struct has_compile_time_kernel_effect<
+struct HasCompileTimeEffect<
     work_group_size_hint_key::value_t<Dims...>> : std::true_type {};
 template <uint32_t Size>
-struct has_compile_time_kernel_effect<sub_group_size_key::value_t<Size>>
+struct HasCompileTimeEffect<sub_group_size_key::value_t<Size>>
     : std::true_type {};
 template <sycl::aspect... Aspects>
-struct has_compile_time_kernel_effect<device_has_key::value_t<Aspects...>>
+struct HasCompileTimeEffect<device_has_key::value_t<Aspects...>>
     : std::true_type {};
-
-namespace detail {
 
 template <size_t Dim0, size_t... Dims>
 struct PropertyMetaInfo<work_group_size_key::value_t<Dim0, Dims...>> {

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -238,6 +238,19 @@ template <> struct is_property_key<work_group_progress_key> : std::true_type {};
 template <> struct is_property_key<sub_group_progress_key> : std::true_type {};
 template <> struct is_property_key<work_item_progress_key> : std::true_type {};
 
+template <size_t... Dims>
+struct has_compile_time_kernel_effect<work_group_size_key::value_t<Dims...>>
+    : std::true_type {};
+template <size_t... Dims>
+struct has_compile_time_kernel_effect<
+    work_group_size_hint_key::value_t<Dims...>> : std::true_type {};
+template <uint32_t Size>
+struct has_compile_time_kernel_effect<sub_group_size_key::value_t<Size>>
+    : std::true_type {};
+template <sycl::aspect... Aspects>
+struct has_compile_time_kernel_effect<device_has_key::value_t<Aspects...>>
+    : std::true_type {};
+
 namespace detail {
 
 template <size_t Dim0, size_t... Dims>

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -244,8 +244,8 @@ template <size_t... Dims>
 struct HasCompileTimeEffect<work_group_size_key::value_t<Dims...>>
     : std::true_type {};
 template <size_t... Dims>
-struct HasCompileTimeEffect<
-    work_group_size_hint_key::value_t<Dims...>> : std::true_type {};
+struct HasCompileTimeEffect<work_group_size_hint_key::value_t<Dims...>>
+    : std::true_type {};
 template <uint32_t Size>
 struct HasCompileTimeEffect<sub_group_size_key::value_t<Size>>
     : std::true_type {};

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -274,6 +274,11 @@ struct is_property_key
 };
 template <typename, typename> struct is_property_key_of : std::false_type {};
 
+template <typename> struct has_compile_time_kernel_effect : std::false_type {};
+template <typename PropertyT>
+static constexpr bool has_compile_time_kernel_effect_v =
+    has_compile_time_kernel_effect<PropertyT>::value;
+
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -266,6 +266,8 @@ template <typename PropertyT> struct PropertyMetaInfo {
   static constexpr std::nullptr_t value = nullptr;
 };
 
+template <typename> struct HasCompileTimeEffect : std::false_type {};
+
 } // namespace detail
 
 template <typename T>
@@ -273,11 +275,6 @@ struct is_property_key
     : std::bool_constant<std::is_base_of_v<detail::property_key_base_tag, T>> {
 };
 template <typename, typename> struct is_property_key_of : std::false_type {};
-
-template <typename> struct has_compile_time_kernel_effect : std::false_type {};
-template <typename PropertyT>
-static constexpr bool has_compile_time_kernel_effect_v =
-    has_compile_time_kernel_effect<PropertyT>::value;
 
 } // namespace experimental
 } // namespace oneapi

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -273,7 +273,7 @@ template <typename... Ts>
 struct NoPropertyHasCompileTimeKernelEffect<
     ext::oneapi::experimental::detail::properties_t<Ts...>> {
   static constexpr bool value =
-      !(ext::oneapi::experimental::has_compile_time_kernel_effect_v<Ts> ||
+      !(ext::oneapi::experimental::detail::HasCompileTimeEffect<Ts>::value ||
         ... || false);
 };
 

--- a/sycl/test/extensions/properties/kernel_properties_negative.cpp
+++ b/sycl/test/extensions/properties/kernel_properties_negative.cpp
@@ -1,0 +1,99 @@
+// RUN: %clangxx -ferror-limit=0 %fsycl-host-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+
+// Negative tests for kernel properties.
+
+#include <sycl/sycl.hpp>
+
+namespace oneapi = sycl::ext::oneapi::experimental;
+
+extern sycl::kernel TestKernel;
+
+int main() {
+  sycl::queue Q{};
+
+  oneapi::properties props1{oneapi::sub_group_size<8>};
+  oneapi::properties props2{
+      oneapi::sub_group_size<8>,
+      oneapi::work_group_progress<oneapi::forward_progress_guarantee::parallel,
+                                  oneapi::execution_scope::root_group>};
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.single_task(props1, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.single_task(props2, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::range<1>{1}, props1, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::range<1>{1}, props2, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::range<2>{1, 1}, props1, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::range<2>{1, 1}, props2, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::range<3>{1, 1, 1}, props1, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::range<3>{1, 1, 1}, props2, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::nd_range<1>{sycl::range<1>{1}, sycl::range<1>{1}},
+                     props1, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(sycl::nd_range<1>{sycl::range<1>{1}, sycl::range<1>{1}},
+                     props2, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(
+        sycl::nd_range<2>{sycl::range<2>{1, 1}, sycl::range<2>{1, 1}}, props1,
+        TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(
+        sycl::nd_range<2>{sycl::range<2>{1, 1}, sycl::range<2>{1, 1}}, props2,
+        TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(
+        sycl::nd_range<3>{sycl::range<3>{1, 1, 1}, sycl::range<3>{1, 1, 1}},
+        props1, TestKernel);
+  });
+
+  Q.submit([&](sycl::handler &CGH) {
+    // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} This kernel enqueue function does not allow properties with compile-time kernel effects.}}
+    CGH.parallel_for(
+        sycl::nd_range<3>{sycl::range<3>{1, 1, 1}, sycl::range<3>{1, 1, 1}},
+        props2, TestKernel);
+  });
+}

--- a/sycl/test/extensions/properties/properties_kernel.cpp
+++ b/sycl/test/extensions/properties/properties_kernel.cpp
@@ -42,6 +42,15 @@ int main() {
   static_assert(is_property_key<sub_group_size_key>::value);
   static_assert(is_property_key<device_has_key>::value);
 
+  static_assert(
+      has_compile_time_kernel_effect<work_group_size_key::value_t<1>>::value);
+  static_assert(has_compile_time_kernel_effect<
+                work_group_size_hint_key::value_t<1>>::value);
+  static_assert(
+      has_compile_time_kernel_effect<sub_group_size_key::value_t<28>>::value);
+  static_assert(has_compile_time_kernel_effect<
+                device_has_key::value_t<aspect::fp64>>::value);
+
   static_assert(is_property_value<decltype(work_group_size<1>)>::value);
   static_assert(is_property_value<decltype(work_group_size<2, 2>)>::value);
   static_assert(is_property_value<decltype(work_group_size<3, 3, 3>)>::value);

--- a/sycl/test/extensions/properties/properties_kernel.cpp
+++ b/sycl/test/extensions/properties/properties_kernel.cpp
@@ -42,13 +42,13 @@ int main() {
   static_assert(is_property_key<sub_group_size_key>::value);
   static_assert(is_property_key<device_has_key>::value);
 
-  static_assert(
-      has_compile_time_kernel_effect<work_group_size_key::value_t<1>>::value);
-  static_assert(has_compile_time_kernel_effect<
+  static_assert(sycl::ext::oneapi::experimental::detail::HasCompileTimeEffect<
+                work_group_size_key::value_t<1>>::value);
+  static_assert(sycl::ext::oneapi::experimental::detail::HasCompileTimeEffect<
                 work_group_size_hint_key::value_t<1>>::value);
-  static_assert(
-      has_compile_time_kernel_effect<sub_group_size_key::value_t<28>>::value);
-  static_assert(has_compile_time_kernel_effect<
+  static_assert(sycl::ext::oneapi::experimental::detail::HasCompileTimeEffect<
+                sub_group_size_key::value_t<28>>::value);
+  static_assert(sycl::ext::oneapi::experimental::detail::HasCompileTimeEffect<
                 device_has_key::value_t<aspect::fp64>>::value);
 
   static_assert(is_property_value<decltype(work_group_size<1>)>::value);

--- a/sycl/test/extensions/properties/properties_kernel_fpga.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_fpga.cpp
@@ -16,13 +16,13 @@ int main() {
   static_assert(oneapi::experimental::is_property_key<
                 intel::experimental::pipelined_key>::value);
 
-  // Check that oneapi::experimental::has_compile_time_kernel_effect is
+  // Check that oneapi::experimental::detail::HasCompileTimeEffect is
   // correctly specialized
-  static_assert(oneapi::experimental::has_compile_time_kernel_effect<
+  static_assert(oneapi::experimental::detail::HasCompileTimeEffect<
                 intel::experimental::register_map_interface_key::value_t<
                     intel::experimental::register_map_interface_options_enum::
                         wait_for_done_write>>::value);
-  static_assert(oneapi::experimental::has_compile_time_kernel_effect<
+  static_assert(oneapi::experimental::detail::HasCompileTimeEffect<
                 intel::experimental::register_map_interface_key::value_t<
                     intel::experimental::register_map_interface_options_enum::
                         wait_for_done_write>>::value);

--- a/sycl/test/extensions/properties/properties_kernel_fpga.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_fpga.cpp
@@ -16,6 +16,17 @@ int main() {
   static_assert(oneapi::experimental::is_property_key<
                 intel::experimental::pipelined_key>::value);
 
+  // Check that oneapi::experimental::has_compile_time_kernel_effect is
+  // correctly specialized
+  static_assert(oneapi::experimental::has_compile_time_kernel_effect<
+                intel::experimental::register_map_interface_key::value_t<
+                    intel::experimental::register_map_interface_options_enum::
+                        wait_for_done_write>>::value);
+  static_assert(oneapi::experimental::has_compile_time_kernel_effect<
+                intel::experimental::register_map_interface_key::value_t<
+                    intel::experimental::register_map_interface_options_enum::
+                        wait_for_done_write>>::value);
+
   // Check that oneapi::experimental::is_property_value is correctly specialized
   static_assert(oneapi::experimental::is_property_value<
                 decltype(intel::experimental::streaming_interface<

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -13,6 +13,7 @@ add_sycl_unittest(ExtensionsTests OBJECT
   EnqueueFunctionsEvents.cpp
   DiscardEvent.cpp
   ProfilingTag.cpp
+  KernelProperties.cpp
 )
 
 add_subdirectory(CommandGraph)

--- a/sycl/unittests/Extensions/KernelProperties.cpp
+++ b/sycl/unittests/Extensions/KernelProperties.cpp
@@ -1,0 +1,140 @@
+//==----------------------- KernelProperties.cpp ---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include <helpers/PiMock.hpp>
+#include <helpers/TestKernel.hpp>
+
+#include <gtest/gtest.h>
+
+#include <sycl/detail/core.hpp>
+#include <sycl/kernel_bundle.hpp>
+
+namespace oneapiext = sycl::ext::oneapi::experimental;
+
+namespace {
+
+inline pi_result after_piKernelGetInfo(pi_kernel kernel,
+                                       pi_kernel_info param_name,
+                                       size_t param_value_size,
+                                       void *param_value,
+                                       size_t *param_value_size_ret) {
+  constexpr char MockKernel[] = "TestKernel";
+  if (param_name == PI_KERNEL_INFO_FUNCTION_NAME) {
+    if (param_value) {
+      assert(param_value_size == sizeof(MockKernel));
+      std::memcpy(param_value, MockKernel, sizeof(MockKernel));
+    }
+    if (param_value_size_ret)
+      *param_value_size_ret = sizeof(MockKernel);
+  }
+  return PI_SUCCESS;
+}
+
+class KernelPropertiesTests : public ::testing::Test {
+public:
+  KernelPropertiesTests()
+      : Mock{}, Q{sycl::context(Mock.getPlatform()), sycl::default_selector_v} {
+  }
+
+  inline sycl::kernel GetTestKernel() {
+    auto KB = sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+        Q.get_context());
+    return KB.get_kernel<TestKernel<>>();
+  }
+
+  template <typename FuncT> void RunForwardProgressTest(const FuncT &F) {
+    sycl::kernel K = GetTestKernel();
+
+    try {
+      F(K);
+      FAIL() << "Exception was expected.";
+    } catch (sycl::exception &E) {
+      // Intention of this test is to ensure that properties without kernel
+      // effects are applied correctly through the interface. For forward
+      // progress we can do this by expecting that the kernel reports that it is
+      // using an unsupported forward progress.
+      ASSERT_EQ(E.code(),
+                sycl::make_error_code(sycl::errc::feature_not_supported));
+    }
+  }
+
+protected:
+  void SetUp() override {
+    Mock.redefineAfter<sycl::detail::PiApiKind::piKernelGetInfo>(
+        after_piKernelGetInfo);
+  }
+
+  sycl::unittest::PiMock Mock;
+  sycl::queue Q;
+};
+
+oneapiext::properties ForwardProgressProp{oneapiext::work_group_progress<
+    oneapiext::forward_progress_guarantee::parallel,
+    oneapiext::execution_scope::root_group>};
+
+TEST_F(KernelPropertiesTests, SingleTaskKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit(
+        [&](sycl::handler &CGH) { CGH.single_task(ForwardProgressProp, K); });
+  });
+}
+
+TEST_F(KernelPropertiesTests, ParallelForRange1DKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.parallel_for(sycl::range<1>{1}, ForwardProgressProp, K);
+    });
+  });
+}
+
+TEST_F(KernelPropertiesTests, ParallelForRange2DKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.parallel_for(sycl::range<2>{1, 1}, ForwardProgressProp, K);
+    });
+  });
+}
+
+TEST_F(KernelPropertiesTests, ParallelForRange3DKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.parallel_for(sycl::range<3>{1, 1, 1}, ForwardProgressProp, K);
+    });
+  });
+}
+
+TEST_F(KernelPropertiesTests, ParallelForNDRange1DKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.parallel_for(sycl::nd_range<1>{sycl::range<1>{1}, sycl::range<1>{1}},
+                       ForwardProgressProp, K);
+    });
+  });
+}
+
+TEST_F(KernelPropertiesTests, ParallelForNDRange2DKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.parallel_for(
+          sycl::nd_range<2>{sycl::range<2>{1, 1}, sycl::range<2>{1, 1}},
+          ForwardProgressProp, K);
+    });
+  });
+}
+
+TEST_F(KernelPropertiesTests, ParallelForNDRange3DKernelObjForwardProgress) {
+  RunForwardProgressTest([&](sycl::kernel &K) {
+    Q.submit([&](sycl::handler &CGH) {
+      CGH.parallel_for(
+          sycl::nd_range<3>{sycl::range<3>{1, 1, 1}, sycl::range<3>{1, 1, 1}},
+          ForwardProgressProp, K);
+    });
+  });
+}
+
+} // namespace


### PR DESCRIPTION
The current version of the [sycl_ext_oneapi_kernel_properties](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc) extension does not have overloads for `single_task` and `parallel_for` that takes a `sycl::kernel` argument. This was likely omitted as all the properties added by the extension had direct effects on how the compiler would handle the kernel code, which cannot be done when the kernel argument is a `sycl::kernel` object. However, as more kernel property extension are written, some of them affect how the runtime handles the launch of kernels and could as such be applied to such kernel enqueue functions.

This commit adds member function overloads to `sycl::handler` for `single_task` and `parallel_for` that takes a `sycl::kernel` argument in the [sycl_ext_oneapi_kernel_properties](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc) extension. Likewise, these new overloads are added to the implementation of `sycl::handler`.