### PR TITLE
[SYCL][NFC] Introduce more helpers to unittests

### DIFF
--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -14,59 +14,13 @@ class TestKernelCPUValidReqdWGSize3D;
 class TestKernelGPU;
 class TestKernelACC;
 
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <>
-struct KernelInfo<TestKernelCPU> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "TestKernelCPU"; }
-};
-
-template <>
-struct KernelInfo<TestKernelCPUInvalidReqdWGSize1D>
-    : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() {
-    return "TestKernelCPUInvalidReqdWGSize1D";
-  }
-};
-
-template <>
-struct KernelInfo<TestKernelCPUInvalidReqdWGSize2D>
-    : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() {
-    return "TestKernelCPUInvalidReqdWGSize2D";
-  }
-};
-
-template <>
-struct KernelInfo<TestKernelCPUInvalidReqdWGSize3D>
-    : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() {
-    return "TestKernelCPUInvalidReqdWGSize3D";
-  }
-};
-
-template <>
-struct KernelInfo<TestKernelCPUValidReqdWGSize3D>
-    : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() {
-    return "TestKernelCPUValidReqdWGSize3D";
-  }
-};
-
-template <>
-struct KernelInfo<TestKernelGPU> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "TestKernelGPU"; }
-};
-
-template <>
-struct KernelInfo<TestKernelACC> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "TestKernelACC"; }
-};
-
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
+MOCK_INTEGRATION_HEADER(TestKernelCPU)
+MOCK_INTEGRATION_HEADER(TestKernelCPUInvalidReqdWGSize1D)
+MOCK_INTEGRATION_HEADER(TestKernelCPUInvalidReqdWGSize2D)
+MOCK_INTEGRATION_HEADER(TestKernelCPUInvalidReqdWGSize3D)
+MOCK_INTEGRATION_HEADER(TestKernelCPUValidReqdWGSize3D)
+MOCK_INTEGRATION_HEADER(TestKernelGPU)
+MOCK_INTEGRATION_HEADER(TestKernelACC)
 
 static sycl::unittest::PiImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -20,27 +20,9 @@ class TestKernel;
 class TestKernelExeOnly;
 class TestKernelWithAspects;
 
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <>
-struct KernelInfo<TestKernel> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "TestKernel"; }
-};
-
-template <>
-struct KernelInfo<TestKernelExeOnly> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "TestKernelExeOnly"; }
-};
-
-template <>
-struct KernelInfo<TestKernelWithAspects> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "TestKernelWithAspects"; }
-};
-
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
+MOCK_INTEGRATION_HEADER(TestKernel)
+MOCK_INTEGRATION_HEADER(TestKernelExeOnly)
+MOCK_INTEGRATION_HEADER(TestKernelWithAspects)
 
 static sycl::unittest::PiImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -25,27 +25,12 @@ class KernelB;
 class KernelC;
 class KernelD;
 class KernelE;
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <> struct KernelInfo<KernelA> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "KernelA"; }
-};
-template <> struct KernelInfo<KernelB> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "KernelB"; }
-};
-template <> struct KernelInfo<KernelC> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "KernelC"; }
-};
-template <> struct KernelInfo<KernelD> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "KernelD"; }
-};
-template <> struct KernelInfo<KernelE> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "KernelE"; }
-};
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
+
+MOCK_INTEGRATION_HEADER(KernelA)
+MOCK_INTEGRATION_HEADER(KernelB)
+MOCK_INTEGRATION_HEADER(KernelC)
+MOCK_INTEGRATION_HEADER(KernelD)
+MOCK_INTEGRATION_HEADER(KernelE)
 
 namespace {
 

--- a/sycl/unittests/buffer/KernelArgMemObj.cpp
+++ b/sycl/unittests/buffer/KernelArgMemObj.cpp
@@ -33,27 +33,8 @@ struct KernelInfo<TestKernelWithMemObj> : public unittest::MockKernelInfoBase {
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernelWithMemObj"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-static sycl::unittest::PiImage Img = generateImage();
+static auto Img =
+    sycl::unittest::generateDefaultImage({"TestKernelWithMemObj"});
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 using namespace sycl;

--- a/sycl/unittests/helpers/MockKernelInfo.hpp
+++ b/sycl/unittests/helpers/MockKernelInfo.hpp
@@ -29,3 +29,18 @@ struct MockKernelInfoBase {
 } // namespace unittest
 } // namespace _V1
 } // namespace sycl
+
+// In most cases we don't need to redefine any other method besides getName(),
+// so here we only have the simplest helper. If any test needs to redefine more
+// methods, they can do that explicitly.
+#define MOCK_INTEGRATION_HEADER(KernelName)                                    \
+  namespace sycl {                                                             \
+  inline namespace _V1 {                                                       \
+  namespace detail {                                                           \
+  template <>                                                                  \
+  struct KernelInfo<KernelName> : public unittest::MockKernelInfoBase {        \
+    static constexpr const char *getName() { return #KernelName; }             \
+  };                                                                           \
+  } /* namespace detail */                                                     \
+  } /* namespace _V1 */                                                        \
+  } /* namespace sycl */

--- a/sycl/unittests/helpers/PiImage.hpp
+++ b/sycl/unittests/helpers/PiImage.hpp
@@ -536,6 +536,25 @@ addDeviceRequirementsProps(PiPropertySet &Props,
                std::move(Value));
 }
 
+inline PiImage
+generateDefaultImage(std::initializer_list<std::string> KernelNames) {
+  PiPropertySet PropSet;
+
+  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
+
+  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+
+  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+              "",                                     // Compile options
+              "",                                     // Link options
+              std::move(Bin),
+              std::move(Entries),
+              std::move(PropSet)};
+
+  return Img;
+}
+
 } // namespace unittest
 } // namespace _V1
 } // namespace sycl

--- a/sycl/unittests/helpers/TestKernel.hpp
+++ b/sycl/unittests/helpers/TestKernel.hpp
@@ -33,25 +33,6 @@ struct KernelInfo<TestKernel<KernelSize>>
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateDefaultImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-static sycl::unittest::PiImage Img = generateDefaultImage();
+static sycl::unittest::PiImage Img =
+    sycl::unittest::generateDefaultImage({"TestKernel"});
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -36,18 +36,13 @@ public:
   void operator()(sycl::item<1>){};
 };
 
+MOCK_INTEGRATION_HEADER(CacheTestKernel)
+MOCK_INTEGRATION_HEADER(CacheTestKernel2)
+
 namespace sycl {
 const static specialization_id<int> SpecConst1{42};
 inline namespace _V1 {
 namespace detail {
-template <>
-struct KernelInfo<CacheTestKernel> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "CacheTestKernel"; }
-};
-template <>
-struct KernelInfo<CacheTestKernel2> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "CacheTestKernel2"; }
-};
 template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {
   return "SC1";
 }

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -23,43 +23,10 @@ using namespace sycl;
 
 class MultipleDevsCacheTestKernel;
 
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <>
-struct KernelInfo<MultipleDevsCacheTestKernel>
-    : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() {
-    return "MultipleDevsCacheTestKernel";
-  }
-};
+MOCK_INTEGRATION_HEADER(MultipleDevsCacheTestKernel)
 
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
-
-static sycl::unittest::PiImage generateDefaultImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries =
-      makeEmptyKernels({"MultipleDevsCacheTestKernel"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-static sycl::unittest::PiImage Img = generateDefaultImage();
+static sycl::unittest::PiImage Img =
+    sycl::unittest::generateDefaultImage({"MultipleDevsCacheTestKernel"});
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 static pi_result redefinedDevicesGetAfter(pi_platform platform,

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -24,45 +24,12 @@ using namespace sycl;
 class OutOfResourcesKernel1;
 class OutOfResourcesKernel2;
 
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <>
-struct KernelInfo<OutOfResourcesKernel1> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "OutOfResourcesKernel1"; }
-};
+MOCK_INTEGRATION_HEADER(OutOfResourcesKernel1)
+MOCK_INTEGRATION_HEADER(OutOfResourcesKernel2)
 
-template <>
-struct KernelInfo<OutOfResourcesKernel2> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "OutOfResourcesKernel2"; }
-};
-
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
-
-static sycl::unittest::PiImage makeImage(const char *kname) {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({kname});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
-
-static sycl::unittest::PiImage Img[2] = {makeImage("OutOfResourcesKernel1"),
-                                         makeImage("OutOfResourcesKernel2")};
+static sycl::unittest::PiImage Img[2] = {
+    sycl::unittest::generateDefaultImage({"OutOfResourcesKernel1"}),
+    sycl::unittest::generateDefaultImage({"OutOfResourcesKernel2"})};
 
 static sycl::unittest::PiImageArray<2> ImgArray{Img};
 

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -12,31 +12,13 @@
 #include <detail/device_binary_image.hpp>
 #include <detail/host_pipe_map_entry.hpp>
 #include <gtest/gtest.h>
+#include <helpers/MockKernelInfo.hpp>
 #include <helpers/PiImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/detail/host_pipe_map.hpp>
 
-template <size_t KernelSize = 1> class TestKernel;
-
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <size_t KernelSize> struct KernelInfo<TestKernel<KernelSize>> {
-  static constexpr unsigned getNumParams() { return 0; }
-  static const kernel_param_desc_t &getParamDesc(int) {
-    static kernel_param_desc_t Dummy;
-    return Dummy;
-  }
-  static constexpr const char *getName() { return "TestKernel"; }
-  static constexpr bool isESIMD() { return false; }
-  static constexpr bool callsThisItem() { return false; }
-  static constexpr bool callsAnyThisFreeFunction() { return false; }
-  static constexpr int64_t getKernelSize() { return KernelSize; }
-};
-
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
+class TestKernel;
+MOCK_INTEGRATION_HEADER(TestKernel)
 
 using namespace sycl;
 using default_pipe_properties =

--- a/sycl/unittests/queue/GetProfilingInfo.cpp
+++ b/sycl/unittests/queue/GetProfilingInfo.cpp
@@ -24,36 +24,7 @@
 
 class InfoTestKernel;
 
-namespace sycl {
-inline namespace _V1 {
-namespace detail {
-template <>
-struct KernelInfo<InfoTestKernel> : public unittest::MockKernelInfoBase {
-  static constexpr const char *getName() { return "InfoTestKernel"; }
-};
-
-} // namespace detail
-} // namespace _V1
-} // namespace sycl
-template <typename T> sycl::unittest::PiImage generateTestImage() {
-  using namespace sycl::unittest;
-
-  PiPropertySet PropSet;
-
-  std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"InfoTestKernel"});
-
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
-
-  return Img;
-}
+MOCK_INTEGRATION_HEADER(InfoTestKernel)
 
 static pi_result
 redefinedPiEventGetProfilingInfo(pi_event event, pi_profiling_info param_name,
@@ -86,7 +57,8 @@ TEST(GetProfilingInfo, normal_pass_without_exception) {
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
-  static sycl::unittest::PiImage DevImage = generateTestImage<InfoTestKernel>();
+  static auto DevImage =
+      sycl::unittest::generateDefaultImage({"InfoTestKernel"});
 
   static sycl::unittest::PiImageArray<1> DevImageArray = {&DevImage};
   auto KernelID = sycl::get_kernel_id<InfoTestKernel>();
@@ -123,7 +95,8 @@ TEST(GetProfilingInfo, command_exception_check) {
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
-  static sycl::unittest::PiImage DevImage = generateTestImage<InfoTestKernel>();
+  static auto DevImage =
+      sycl::unittest::generateDefaultImage({"InfoTestKernel"});
   static sycl::unittest::PiImageArray<1> DevImageArray = {&DevImage};
   auto KernelID = sycl::get_kernel_id<InfoTestKernel>();
   sycl::queue Queue{Ctx, Dev};
@@ -223,7 +196,8 @@ TEST(GetProfilingInfo, check_if_now_dead_queue_property_set) {
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
-  static sycl::unittest::PiImage DevImage = generateTestImage<InfoTestKernel>();
+  static auto DevImage =
+      sycl::unittest::generateDefaultImage({"InfoTestKernel"});
   static sycl::unittest::PiImageArray<1> DevImageArray = {&DevImage};
   auto KernelID = sycl::get_kernel_id<InfoTestKernel>();
   const int globalWIs{512};
@@ -262,7 +236,8 @@ TEST(GetProfilingInfo, check_if_now_dead_queue_property_not_set) {
       redefinedPiEventGetProfilingInfo);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
-  static sycl::unittest::PiImage DevImage = generateTestImage<InfoTestKernel>();
+  static auto DevImage =
+      sycl::unittest::generateDefaultImage({"InfoTestKernel"});
 
   static sycl::unittest::PiImageArray<1> DevImageArray = {&DevImage};
   auto KernelID = sycl::get_kernel_id<InfoTestKernel>();
@@ -407,7 +382,8 @@ TEST(GetProfilingInfo, fallback_profiling_PiGetDeviceAndHostTimer_unsupported) {
       redefinedDeviceGetInfoAcc);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
-  static sycl::unittest::PiImage DevImage = generateTestImage<InfoTestKernel>();
+  static auto DevImage =
+      sycl::unittest::generateDefaultImage({"InfoTestKernel"});
   static sycl::unittest::PiImageArray<1> DevImageArray = {&DevImage};
   auto KernelID = sycl::get_kernel_id<InfoTestKernel>();
   sycl::queue Queue{
@@ -445,7 +421,8 @@ TEST(GetProfilingInfo, fallback_profiling_mock_piEnqueueKernelLaunch) {
       redefinedDeviceGetInfoAcc);
   const sycl::device Dev = Plt.get_devices()[0];
   sycl::context Ctx{Dev};
-  static sycl::unittest::PiImage DevImage = generateTestImage<InfoTestKernel>();
+  static auto DevImage =
+      sycl::unittest::generateDefaultImage({"InfoTestKernel"});
   static sycl::unittest::PiImageArray<1> DevImageArray = {&DevImage};
   auto KernelID = sycl::get_kernel_id<InfoTestKernel>();
   sycl::queue Queue{


### PR DESCRIPTION
Introduced a macro to hide bolierplate of specializing `KernelInfo` structs.
Added a helper function to generate default image to avoid repeating the same code in every test.