### PR TITLE
[SYCL] Re-enable xfailed AddressSanitizer tests

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/common/config-red-zone-size.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/config-red-zone-size.cpp
@@ -5,9 +5,6 @@
 // RUN: env UR_LOG_SANITIZER=level:debug UR_LAYER_ASAN_OPTIONS=redzone:8 %{run} %t 2>&1 | FileCheck --check-prefixes CHECK-MIN %s
 // RUN: env UR_LOG_SANITIZER=level:debug UR_LAYER_ASAN_OPTIONS=max_redzone:4096 %{run} %t 2>&1 | FileCheck --check-prefixes CHECK-MAX %s
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14658
-// UNSUPPORTED: windows, linux
-
 #include <sycl/usm.hpp>
 
 int main() {

--- a/sycl/test-e2e/AddressSanitizer/common/kernel-debug.cpp
+++ b/sycl/test-e2e/AddressSanitizer/common/kernel-debug.cpp
@@ -3,9 +3,6 @@
 // RUN: env UR_LAYER_ASAN_OPTIONS=debug:1 %{run} %t 2>&1 | FileCheck --check-prefixes CHECK-DEBUG %s
 // RUN: env UR_LAYER_ASAN_OPTIONS=debug:0 %{run} %t 2>&1 | FileCheck %s
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14658
-// UNSUPPORTED: windows, linux
-
 #include <sycl/usm.hpp>
 
 /// This test is used to check enabling/disabling kernel debug message

--- a/sycl/test-e2e/AddressSanitizer/multiple-reports/multiple_kernels.cpp
+++ b/sycl/test-e2e/AddressSanitizer/multiple-reports/multiple_kernels.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} %device_asan_flags -Xarch_device -fsanitize-recover=address -O2 -g -o %t
 // RUN: env SYCL_PREFER_UR=1 %{run} %t 2>&1 | FileCheck %s
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14658
-// UNSUPPORTED: windows, linux
-
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/multiple-reports/one_kernel.cpp
+++ b/sycl/test-e2e/AddressSanitizer/multiple-reports/one_kernel.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} %device_asan_flags -Xarch_device -fsanitize-recover=address -O2 -g -o %t
 // RUN: env SYCL_PREFER_UR=1 %{run} %t 2>&1 | FileCheck %s
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14658
-// UNSUPPORTED: windows, linux
-
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 

--- a/sycl/test-e2e/AddressSanitizer/use-after-free/quarantine-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/use-after-free/quarantine-free.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} %device_asan_flags -O0 -g -o %t
 // RUN: %force_device_asan_rt UR_LAYER_ASAN_OPTIONS=quarantine_size_mb:5 UR_LOG_SANITIZER=level:info %{run} %t 2>&1 | FileCheck %s
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14658
-// UNSUPPORTED: windows, linux
-
 #include <sycl/usm.hpp>
 
 /// Quarantine Cache Test


### PR DESCRIPTION
Fixes #14825
Fixes #14658

these were disabled pending a UR fix which has now merged and upstreamed