### PR TITLE
[SYCL][E2E] Disable unsupported tests and enable validated tests for Windows/CUDA

### DIFF
--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
@@ -1,6 +1,6 @@
-// RUN: %{build} -o %t.out -lcuda
+// RUN: %{build} -o %t.out %cuda_options
 // RUN: %{run} %t.out
-// REQUIRES: cuda
+// REQUIRES: cuda, cuda_dev_kit
 
 #include <cuda.h>
 

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: cuda
-// RUN: %{build} -o %t.out -lcuda
+// REQUIRES: cuda, cuda_dev_kit
+// RUN: %{build} -o %t.out %cuda_options
 // RUN: %{run} %t.out
 #include <cuda.h>
 

--- a/sycl/test-e2e/Printf/char.cpp
+++ b/sycl/test-e2e/Printf/char.cpp
@@ -5,7 +5,6 @@
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
 // UNSUPPORTED: hip_amd
-// XFAIL: cuda && windows
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/Printf/float.cpp
+++ b/sycl/test-e2e/Printf/float.cpp
@@ -5,7 +5,6 @@
 // [1]: https://en.cppreference.com/w/cpp/io/c/fprintf
 //
 // UNSUPPORTED: hip_amd
-// XFAIL: cuda && windows
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/Printf/long.cpp
+++ b/sycl/test-e2e/Printf/long.cpp
@@ -7,7 +7,6 @@
 // FIXME: Once the Windows OpenCL CPU/ACC support is fixed, merge this test's
 // contents into the common integer test.
 // UNSUPPORTED: (windows && (cpu || accelerator)) || hip_amd
-// XFAIL: cuda && windows
 //
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s

--- a/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: hip || (windows && (level_zero || cuda))
+// UNSUPPORTED: hip || (windows && level_zero)
 
 // RUN: %{build} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp
@@ -30,7 +30,7 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// UNSUPPORTED: hip || (windows && level_zero)
+// UNSUPPORTED: hip || (windows && (level_zero || cuda))
 
 // RUN: %{build} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_70 %} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/syclcompat/atomic/atomic_fixt.hpp
+++ b/sycl/test-e2e/syclcompat/atomic/atomic_fixt.hpp
@@ -131,8 +131,8 @@ public:
     if (skip_)
       return; // skip
     syclcompat::launch<Kernel>(grid_, threads_, atom_arr_device_);
-    HostFunc(atom_arr_host_);
     syclcompat::wait();
+    HostFunc(atom_arr_host_);
 
     verify();
   }
@@ -170,8 +170,8 @@ public:
       return;
     syclcompat::launch<Kernel>(this->grid_, this->threads_,
                                this->atom_arr_device_, atom_arr_shared_in_);
-    HostFunc(this->atom_arr_host_, atom_arr_shared_in_);
     syclcompat::wait();
+    HostFunc(this->atom_arr_host_, atom_arr_shared_in_);
 
     this->verify();
   }


### PR DESCRIPTION
- The test [atomic_class.cpp](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/syclcompat/atomic/atomic_class.cpp) modified to call host function after kernel function finishes. This is because CUDA on Windows does not support accessing host memory while a kernel is running, as discussed in [this forum post](https://forums.developer.nvidia.com/t/cudamallocmanaged-clarification-needed/67611) and [this bug report](https://developer.nvidia.com/bugs/4763389). 
- A number of previously XFAILed printf tests have been enabled for execution on Windows/CUDA. 

- Updated the relevant tests to include the necessary CUDA library and include paths for running tests on Windows.