### PR TITLE
[Driver][SYCL] Remove `-fsycl-link-huge-device-code`

### DIFF
--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -4041,12 +4041,6 @@ def flink_huge_device_code : Flag<["-"], "flink-huge-device-code">,
 def fno_link_huge_device_code : Flag<["-"], "fno-link-huge-device-code">,
   Group<Link_Group>, HelpText<"Do not generate or use a custom linker script"
   " for huge device code sections (default)">;
-def fsycl_link_huge_device_code : Flag<["-"], "fsycl-link-huge-device-code">,
-  Group<sycl_Group>, Alias<flink_huge_device_code>, HelpText<"Generate and use a custom linker script for huge"
-  " device code sections (deprecated)">, Flags<[Deprecated]>;
-def fno_sycl_link_huge_device_code : Flag<["-"], "fno-sycl-link-huge-device-code">,
-  Group<sycl_Group>, Alias<fno_link_huge_device_code>, HelpText<"Do not generate or use a custom linker script"
-  " for huge device code sections (default) (deprecated)">, Flags<[Deprecated]>;
 defm sycl_id_queries_fit_in_int: BoolFOption<"sycl-id-queries-fit-in-int",
   LangOpts<"SYCLValueFitInMaxInt">, DefaultTrue,
   PosFlag<SetTrue, [], [ClangOption], "Assume">, NegFlag<SetFalse, [], [ClangOption], "Do not assume">,

--- a/clang/test/Driver/flink-huge-device-code.cpp
+++ b/clang/test/Driver/flink-huge-device-code.cpp
@@ -1,10 +1,6 @@
 // UNSUPPORTED: system-windows
 // Test the addition of a custom linker script for huge device code.
 
-// The "fsycl-link-huge-device-code" spelling is deprecated.
-
-// RUN: %clangxx -### -fsycl -fsycl-link-huge-device-code %s 2>&1 | \
-// RUN:       FileCheck --check-prefix=CHECK-LINKER-SCRIPT %s
 // RUN: %clangxx -### -fsycl -flink-huge-device-code %s 2>&1 | \
 // RUN:       FileCheck --check-prefix=CHECK-LINKER-SCRIPT %s
 // RUN: %clangxx -### -fopenmp -fopenmp-targets=x86_64 -flink-huge-device-code %s 2>&1 | \
@@ -12,9 +8,6 @@
 // CHECK-LINKER-SCRIPT: "-T" "{{.*}}.ld"
 
 // Also check that a user-provided linker script may be used:
-// RUN: %clangxx -### -fsycl -fsycl-link-huge-device-code %s \
-// RUN:       -T custom-user-script.ld 2>&1 | \
-// RUN:       FileCheck --check-prefixes=CHECK-USER-SCRIPT %s
 // RUN: %clangxx -### -fsycl -flink-huge-device-code %s \
 // RUN:       -T custom-user-script.ld 2>&1 | \
 // RUN:       FileCheck --check-prefixes=CHECK-USER-SCRIPT %s

--- a/clang/test/Driver/sycl-deprecated.cpp
+++ b/clang/test/Driver/sycl-deprecated.cpp
@@ -1,8 +1,6 @@
 /// Test for any deprecated options
 // RUN: %clangxx -fsycl-explicit-simd %s -### 2>&1 | FileCheck %s -DOPTION=-fsycl-explicit-simd
 // RUN: %clangxx -fno-sycl-explicit-simd %s -### 2>&1 | FileCheck %s -DOPTION=-fno-sycl-explicit-simd
-// RUN: %clangxx -fsycl -fsycl-link-huge-device-code %s -### 2>&1 | FileCheck %s -DOPTION=-fsycl-link-huge-device-code
-// RUN: %clangxx -fsycl -fno-sycl-link-huge-device-code %s -### 2>&1 | FileCheck %s -DOPTION=-fno-sycl-link-huge-device-code
 // RUN: %clangxx -fsycl -fsycl-use-bitcode %s -### 2>&1 | FileCheck %s -DOPTION=-fsycl-use-bitcode
 // RUN: %clangxx -fsycl -fno-sycl-use-bitcode %s -### 2>&1 | FileCheck %s -DOPTION=-fno-sycl-use-bitcode
 // CHECK: option '[[OPTION]]' is deprecated and will be removed in a future release

--- a/sycl/doc/UsersManual.md
+++ b/sycl/doc/UsersManual.md
@@ -284,16 +284,6 @@ and not recommended to use in production environment.
     various events inside JIT generated kernels. These device libraries are
     linked in by default.
 
-**`-f[no-]sycl-link-huge-device-code`** [DEPRECATED]
-
-    Place device code later in the linked binary in order to avoid precluding
-    32-bit PC relative relocations between surrounding ELF sections when device
-    code is larger than 2GiB. This is disabled by default.
-
-    Deprecated in favor of `-f[no-]link-huge-device-code`.
-
-    NOTE: This option is currently only supported on Linux.
-
 **`-fsycl-force-target=<T>`**
 
     When used along with '-fsycl-targets', force the device object being


### PR DESCRIPTION
The `-fsycl-link-huge-device-code` option has been deprecated for over a
year in favor of `-flink-huge-device-code`. This change removes the
deprecated option.
