### PR TITLE
[DeviceSanitizer] Disable unsupported features for private mem check

### DIFF
--- a/clang/lib/Driver/SanitizerArgs.cpp
+++ b/clang/lib/Driver/SanitizerArgs.cpp
@@ -1163,6 +1163,10 @@ void SanitizerArgs::addArgs(const ToolChain &TC, const llvm::opt::ArgList &Args,
       CmdArgs.push_back("-asan-stack=0");
       CmdArgs.push_back("-mllvm");
       CmdArgs.push_back("-asan-globals=0");
+      CmdArgs.push_back("-mllvm");
+      CmdArgs.push_back("-asan-stack-dynamic-alloca=0");
+      CmdArgs.push_back("-mllvm");
+      CmdArgs.push_back("-asan-use-after-return=never");
 
       if (!RecoverableSanitizers.empty())
         CmdArgs.push_back(Args.MakeArgString("-fsanitize-recover=" +

--- a/clang/test/Driver/sycl-device-sanitizer.cpp
+++ b/clang/test/Driver/sycl-device-sanitizer.cpp
@@ -8,6 +8,8 @@
 // SYCL-ASAN-SAME: "-mllvm" "-asan-constructor-kind=none"
 // SYCL-ASAN-SAME: "-mllvm" "-asan-stack=0"
 // SYCL-ASAN-SAME: "-mllvm" "-asan-globals=0"
+// SYCL-ASAN-SAME: "-mllvm" "-asan-stack-dynamic-alloca=0"
+// SYCL-ASAN-SAME: "-mllvm" "-asan-use-after-return=never"
 // SYCL-ASAN-SAME: "-mllvm" "-asan-mapping-scale=4"
 
 // RUN: %clangxx -fsycl -Xarch_device -fsanitize=address -c %s -### 2>&1 \


### PR DESCRIPTION
We have enabled private mem check by default, but we don't have plan to support use-after-return and use-after-scope check now. So, disable related options by default now.