### PR TITLE
[SYCL][Driver] Allow for -save-temps to work with -fsycl-host-compiler

### DIFF
--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -8461,7 +8461,8 @@ class ToolSelector final {
   // a third party host compilation step for SYCL offloading.  We don't know
   // what the third party compiler is capable of, so only allow for object
   // creation when performing -save-temps.
-  bool SYCLHostCompiler = BaseAction->isHostOffloading(Action::OFK_SYCL) &&
+  bool SYCLHostCompiler =
+      BaseAction->isHostOffloading(Action::OFK_SYCL) &&
       C.getArgs().hasArg(options::OPT_fsycl_host_compiler_EQ);
 
   /// Return true if an assemble action can be collapsed.

--- a/clang/test/Driver/sycl-host-compiler-old-model.cpp
+++ b/clang/test/Driver/sycl-host-compiler-old-model.cpp
@@ -76,3 +76,17 @@
 // CHECK-ZC-CPLUSPLUS: "/Zc:__cplusplus"
 // CHECK-ZC-CPLUSPLUS-MINUS: "/Zc:__cplusplus-"
 // CHECK-NO-ZC-CPLUSPLUS-NOT: "/Zc:__cplusplus"
+
+/// -fsycl-host-compiler -save-temps behavior
+// RUN: %clangxx -### -fsycl-host-compiler=g++ -fsycl --no-offload-new-driver \
+// RUN:          -save-temps -c %s 2>&1 \
+// RUN:   | FileCheck -check-prefix=CHECK_SAVE_TEMPS %s
+// CHECK_SAVE_TEMPS-NOT error: unsupported output type when using external host compiler
+// CHECK_SAVE_TEMPS: clang{{.*}} "-fsycl-is-device"
+// CHECK_SAVE_TEMPS-SAME: "-E" {{.*}} "-o" "[[PREPROC_OUT:.+sycl-spir64-unknown-unknown.ii]]"
+// CHECK_SAVE_TEMPS-NEXT: clang{{.*}} "-fsycl-is-device"
+// CHECK_SAVE_TEMPS-SAME: "-emit-llvm-bc" {{.*}} "-o" "[[DEVICE_BC:.+sycl-spir64-unknown-unknown.bc]]"{{.*}} "[[PREPROC_OUT]]"
+// CHECK_SAVE_TEMPS-NEXT: append-file{{.*}} "--output=[[APPEND_CPP:.+\.cpp]]
+// CHECK_SAVE_TEMPS-NEXT: g++{{.*}} "[[APPEND_CPP]]" "-c"
+// CHECK_SAVE_TEMPS-SAME: "-o" "[[HOST_OBJ:.+\.o]]"
+// CHECK_SAVE_TEMPS-NEXT: clang-offload-bundler{{.*}} "-input=[[DEVICE_BC]]" "-input=[[HOST_OBJ]]"


### PR DESCRIPTION
When using -save-temps, the driver will break down each compilation step to multiple steps (preprocess, ir, asm, obj) for a good gathering of all of the files needed for compilation.  When performing offload compilations, this behavior is valid with the exception of using a third party compiler with -fsycl-host-compiler.  The reason it does not work is due to the fact that the third party compiler may or may not support these separate step creations, so we error out letting the user know.

Update the behavior of the driver to collapse all of these compilation steps into one so only the object creation step is performed when doing the third party compilation.