### PR TITLE
[SYCL] fix post-commit failures

### DIFF
--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -130,7 +130,6 @@ void test_build_and_run() {
                  "kernel bundle extension: "
               << q.get_device().get_info<sycl::info::device::name>()
               << std::endl;
-    assert(ok);
     return;
   }
 

--- a/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
@@ -80,6 +80,14 @@ int main() {
 
   sycl::queue q;
   sycl::context ctx = q.get_context();
+
+  bool ok =
+      q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl);
+  if (!ok) {
+    std::cout << "compiling from SYCL source not supported" << std::endl;
+    return 0;
+  }
+
   source_kb kbSrc = syclex::create_kernel_bundle_from_source(
       ctx, syclex::source_language::sycl, SYCLSource);
 


### PR DESCRIPTION
simply asserting that sycl kernel_compilation MUST be available is leading to post commit failures.  Better solution needs to be found. Restoring early exit in the interim.