### PR TITLE
[SYCL] Add compile target to device image properties

### DIFF
--- a/llvm/test/tools/sycl-post-link/multiple-filtered-outputs.ll
+++ b/llvm/test/tools/sycl-post-link/multiple-filtered-outputs.ll
@@ -41,26 +41,45 @@
 ; CHECK-ALL-EMPTY:
 
 ; PVC does not support sg8 (=1) or sg64 (=2) 
-; CHECK-PVC:      _0.sym
-; CHECK-PVC-NEXT: _3.sym
-; CHECK-PVC-NEXT: _4.sym
-; CHECK-PVC-NEXT: _5.sym
+; CHECK-PVC:      _intel_gpu_pvc_0.prop|{{.*}}_0.sym
+; CHECK-PVC-NEXT: _intel_gpu_pvc_3.prop|{{.*}}_3.sym
+; CHECK-PVC-NEXT: _intel_gpu_pvc_4.prop|{{.*}}_4.sym
+; CHECK-PVC-NEXT: _intel_gpu_pvc_5.prop|{{.*}}_5.sym
 ; CHECK-PVC-EMPTY:
 
+; RUN: FileCheck %s -input-file=%t_intel_gpu_pvc_0.prop -check-prefix=CHECK-PVC-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_pvc_3.prop -check-prefix=CHECK-PVC-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_pvc_4.prop -check-prefix=CHECK-PVC-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_pvc_5.prop -check-prefix=CHECK-PVC-PROP
+; CHECK-PVC-PROP: compile_target=2|oBAAAAAAAAQauRXZs91ZwV3XwZ3Y
+
 ; TGLLP does not support fp64 (=0) or sg64 (=2)
-; CHECK-TGLLP:      _1.sym
-; CHECK-TGLLP-NEXT: _3.sym
-; CHECK-TGLLP-NEXT: _4.sym
-; CHECK-TGLLP-NEXT: _5.sym
+; CHECK-TGLLP:      _intel_gpu_tgllp_1.prop|{{.*}}_1.sym
+; CHECK-TGLLP-NEXT: _intel_gpu_tgllp_3.prop|{{.*}}_3.sym
+; CHECK-TGLLP-NEXT: _intel_gpu_tgllp_4.prop|{{.*}}_4.sym
+; CHECK-TGLLP-NEXT: _intel_gpu_tgllp_5.prop|{{.*}}_5.sym
 ; CHECK-TGLLP-EMPTY:
 
+; RUN: FileCheck %s -input-file=%t_intel_gpu_tgllp_1.prop -check-prefix=CHECK-TGLLP-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_tgllp_3.prop -check-prefix=CHECK-TGLLP-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_tgllp_4.prop -check-prefix=CHECK-TGLLP-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_tgllp_5.prop -check-prefix=CHECK-TGLLP-PROP
+; CHECK-TGLLP-PROP: compile_target=2|4BAAAAAAAAQauRXZs91ZwV3X0dGbsBH
+
 ; CFL does not support sg64 (=2)
-; CHECK-CFL:      _0.sym
-; CHECK-CFL-NEXT: _1.sym
-; CHECK-CFL-NEXT: _3.sym
-; CHECK-CFL-NEXT: _4.sym
-; CHECK-CFL-NEXT: _5.sym
+; CHECK-CFL:      _intel_gpu_cfl_0.prop|{{.*}}_0.sym
+; CHECK-CFL-NEXT: _intel_gpu_cfl_1.prop|{{.*}}_1.sym
+; CHECK-CFL-NEXT: _intel_gpu_cfl_3.prop|{{.*}}_3.sym
+; CHECK-CFL-NEXT: _intel_gpu_cfl_4.prop|{{.*}}_4.sym
+; CHECK-CFL-NEXT: _intel_gpu_cfl_5.prop|{{.*}}_5.sym
 ; CHECK-CFL-EMPTY:
+
+; RUN: FileCheck %s -input-file=%t_intel_gpu_cfl_0.prop -check-prefix=CHECK-CFL-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_cfl_1.prop -check-prefix=CHECK-CFL-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_cfl_3.prop -check-prefix=CHECK-CFL-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_cfl_4.prop -check-prefix=CHECK-CFL-PROP
+; RUN: FileCheck %s -input-file=%t_intel_gpu_cfl_5.prop -check-prefix=CHECK-CFL-PROP
+; CHECK-CFL-PROP: compile_target=2|oBAAAAAAAAQauRXZs91ZwV3XjZGb
 
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -311,7 +311,7 @@ std::string saveModuleProperties(module_split::ModuleDesc &MD,
                                          MD.isSpecConstantDefault());
 
   std::string NewSuff = Suff.str();
-  if (Target != "") {
+  if (!Target.empty()) {
     PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS, "compile_target",
                 Target);
     NewSuff += "_";
@@ -663,7 +663,7 @@ bool isTargetCompatibleWithModule(const std::string &Target,
   // (e.g. -o out.table compared to -o intel_gpu_pvc,out-pvc.table)
   // Target will be empty and we will not want to perform any filtering, so
   // we return true here.
-  if (Target == "")
+  if (Target.empty())
     return true;
 
   // TODO: If a target not found in the device config file is passed,

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -104,7 +104,7 @@ cl::opt<std::string> OutputDir{
     cl::value_desc("dirname"), cl::cat(PostLinkCat)};
 
 struct TargetFilenamePair {
-  std::optional<std::string> Target;
+  std::string Target;
   std::string Filename;
 };
 
@@ -305,13 +305,21 @@ std::string saveModuleIR(Module &M, int I, StringRef Suff) {
 
 std::string saveModuleProperties(module_split::ModuleDesc &MD,
                                  const GlobalBinImageProps &GlobProps, int I,
-                                 StringRef Suff) {
-  const auto &PropSet = computeModuleProperties(
-      MD.getModule(), MD.entries(), GlobProps, MD.Props.SpecConstsMet,
-      MD.isSpecConstantDefault());
+                                 StringRef Suff, StringRef Target = "") {
+  auto PropSet = computeModuleProperties(MD.getModule(), MD.entries(),
+                                         GlobProps, MD.Props.SpecConstsMet,
+                                         MD.isSpecConstantDefault());
+
+  std::string NewSuff = Suff.str();
+  if (Target != "") {
+    PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS, "compile_target",
+                Target);
+    NewSuff += "_";
+    NewSuff += Target;
+  }
 
   std::error_code EC;
-  std::string SCFile = makeResultFileName(".prop", I, Suff);
+  std::string SCFile = makeResultFileName(".prop", I, NewSuff);
   raw_fd_ostream SCOut(SCFile, EC);
   checkError(EC, "error opening file '" + SCFile + "'");
   PropSet.write(SCOut);
@@ -394,37 +402,6 @@ bool lowerEsimdConstructs(module_split::ModuleDesc &MD) {
 // Compute the filename suffix for the module
 StringRef getModuleSuffix(const module_split::ModuleDesc &MD) {
   return MD.isESIMD() ? "_esimd" : "";
-}
-
-// @param MD Module descriptor to save
-// @param IRFilename filename of already available IR component. If not empty,
-//   IR component saving is skipped, and this file name is recorded as such in
-//   the result.
-// @return a triple of files where IR, Property and Symbols components of the
-//   Module descriptor are written respectively.
-IrPropSymFilenameTriple saveModule(module_split::ModuleDesc &MD, int I,
-                                   StringRef IRFilename = "") {
-  IrPropSymFilenameTriple Res;
-  StringRef Suffix = getModuleSuffix(MD);
-
-  if (!IRFilename.empty()) {
-    // don't save IR, just record the filename
-    Res.Ir = IRFilename.str();
-  } else {
-    MD.cleanup();
-    Res.Ir = saveModuleIR(MD.getModule(), I, Suffix);
-  }
-  GlobalBinImageProps Props = {EmitKernelParamInfo, EmitProgramMetadata,
-                               EmitExportedSymbols, EmitImportedSymbols,
-                               DeviceGlobals};
-  if (DoPropGen)
-    Res.Prop = saveModuleProperties(MD, Props, I, Suffix);
-
-  if (DoSymGen) {
-    // save the names of the entry points - the symbol table
-    Res.Sym = saveModuleSymbolTable(MD, I, Suffix);
-  }
-  return Res;
 }
 
 module_split::ModuleDesc link(module_split::ModuleDesc &&MD1,
@@ -680,13 +657,13 @@ handleESIMD(module_split::ModuleDesc &&MDesc, bool &Modified,
 // information comes from the device config file (DeviceConfigFile.td).
 // For example, the intel_gpu_tgllp target does not support fp64 - therefore,
 // a module using fp64 would *not* be compatible with intel_gpu_tgllp.
-bool isTargetCompatibleWithModule(const std::optional<std::string> &Target,
+bool isTargetCompatibleWithModule(const std::string &Target,
                                   module_split::ModuleDesc &IrMD) {
   // When the user does not specify a target,
   // (e.g. -o out.table compared to -o intel_gpu_pvc,out-pvc.table)
-  // Target will have no value and we will not want to perform any filtering, so
+  // Target will be empty and we will not want to perform any filtering, so
   // we return true here.
-  if (!Target.has_value())
+  if (Target == "")
     return true;
 
   // TODO: If a target not found in the device config file is passed,
@@ -694,11 +671,11 @@ bool isTargetCompatibleWithModule(const std::optional<std::string> &Target,
   // since not all the information for all the targets is filled out
   // right now, we return true, having the affect that unrecognized
   // targets have no filtering applied to them.
-  if (!is_contained(DeviceConfigFile::TargetTable, *Target))
+  if (!is_contained(DeviceConfigFile::TargetTable, Target))
     return true;
 
   const DeviceConfigFile::TargetInfo &TargetInfo =
-      DeviceConfigFile::TargetTable[*Target];
+      DeviceConfigFile::TargetTable[Target];
   const SYCLDeviceRequirements &ModuleReqs =
       IrMD.getOrComputeDeviceRequirements();
 
@@ -719,6 +696,42 @@ bool isTargetCompatibleWithModule(const std::optional<std::string> &Target,
     return false;
 
   return true;
+}
+
+// @param OutTables List of tables (one for each target) to output results
+// @param MD Module descriptor to save
+// @param IRFilename filename of already available IR component. If not empty,
+//   IR component saving is skipped, and this file name is recorded as such in
+//   the result.
+void saveModule(std::vector<std::unique_ptr<util::SimpleTable>> &OutTables,
+                module_split::ModuleDesc &MD, int I, StringRef IRFilename) {
+  IrPropSymFilenameTriple BaseTriple;
+  StringRef Suffix = getModuleSuffix(MD);
+  if (!IRFilename.empty()) {
+    // don't save IR, just record the filename
+    BaseTriple.Ir = IRFilename.str();
+  } else {
+    MD.cleanup();
+    BaseTriple.Ir = saveModuleIR(MD.getModule(), I, Suffix);
+  }
+  if (DoSymGen) {
+    // save the names of the entry points - the symbol table
+    BaseTriple.Sym = saveModuleSymbolTable(MD, I, Suffix);
+  }
+
+  for (const auto &[Table, OutputFile] : zip_equal(OutTables, OutputFiles)) {
+    if (!isTargetCompatibleWithModule(OutputFile.Target, MD))
+      continue;
+    auto CopyTriple = BaseTriple;
+    if (DoPropGen) {
+      GlobalBinImageProps Props = {EmitKernelParamInfo, EmitProgramMetadata,
+                                   EmitExportedSymbols, EmitImportedSymbols,
+                                   DeviceGlobals};
+      CopyTriple.Prop =
+          saveModuleProperties(MD, Props, I, Suffix, OutputFile.Target);
+    }
+    addTableRow(*Table, CopyTriple);
+  }
 }
 
 std::vector<std::unique_ptr<util::SimpleTable>>
@@ -856,10 +869,7 @@ processInputModule(std::unique_ptr<Module> M) {
                 "have been made\n";
     }
     for (module_split::ModuleDesc &IrMD : MMs) {
-      IrPropSymFilenameTriple T = saveModule(IrMD, ID, OutIRFileName);
-      for (const auto &[Table, OutputFile] : zip_equal(Tables, OutputFiles))
-        if (isTargetCompatibleWithModule(OutputFile.Target, IrMD))
-          addTableRow(*Table, T);
+      saveModule(Tables, IrMD, ID, OutIRFileName);
     }
 
     ++ID;
@@ -867,10 +877,7 @@ processInputModule(std::unique_ptr<Module> M) {
     if (!MMsWithDefaultSpecConsts.empty()) {
       for (size_t i = 0; i != MMsWithDefaultSpecConsts.size(); ++i) {
         module_split::ModuleDesc &IrMD = MMsWithDefaultSpecConsts[i];
-        IrPropSymFilenameTriple T = saveModule(IrMD, ID, OutIRFileName);
-        for (const auto &[Table, OutputFile] : zip_equal(Tables, OutputFiles))
-          if (isTargetCompatibleWithModule(OutputFile.Target, IrMD))
-            addTableRow(*Table, T);
+        saveModule(Tables, IrMD, ID, OutIRFileName);
       }
 
       ++ID;


### PR DESCRIPTION
Previously, when compiling with any `intel_gpu_*` target, the device image only had the generic `spir64_gen` as its value for the [`DeviceTargetSpec`](https://github.com/intel/llvm/blob/450683b6fa1d1be1b9391905f43073b7a9555aa1/sycl/include/sycl/detail/pi.h#L1143) in its device image, so there was no way to differentiate device images compiled for a specific GPU in the runtime. Now, a new property is added to the image specifying the specific `intel_gpu_*` value it is compiled for.