### PR TITLE
[SYCL][E2E] Only grep if compilation is supported in KernelCompiler/sycl_device_flags.cpp

### DIFF
--- a/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
@@ -12,14 +12,13 @@
 // IGC shader dump not available on Windows.
 
 // RUN: %{build} -o %t.out
-// RUN: env IGC_DumpToCustomDir=%T.dump IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out
-// RUN: find %T.dump/ -name "*_options.txt" -not -name "*_internal_options.txt" -type f -exec grep -e '-doubleGRF' {} +
-// RUN: find %T.dump/ -name "*_options.txt" -not -name "*_internal_options.txt" -type f -exec grep -e '-Xfinalizer "-printregusage"' {} +
+// RUN: env IGC_DumpToCustomDir=%T.dump IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out %T.dump/
 
 // clang-format off
 /*
     clang++ -fsycl -o sdf.bin sycl_device_flags.cpp
-    IGC_ShaderDumpEnable=1 IGC_DumpToCustomDir=./dump NEO_CACHE_PERSISTENT=0 ./sdf.bin 
+    IGC_ShaderDumpEnable=1 IGC_DumpToCustomDir=./dump NEO_CACHE_PERSISTENT=0 ./sdf.bin ./dump
+    
     grep -e '-doubleGRF' ./dump/OCL_asmaf99e2d4667ef6d3_options.txt
     grep -e '-Xfinalizer "-printregusage"' ./dump/OCL_asmaf99e2d4667ef6d3_options.txt
 
@@ -72,7 +71,32 @@ void test_1(sycl::queue &Queue, sycl::kernel &Kernel, int seed) {
   sycl::free(usmPtr, Queue);
 }
 
-int main() {
+int test_dump(std::string &dump_dir) {
+  // If this has been run with the shader dump environment variables set, then
+  // the output files we are looking for should be in ./dump
+
+  std::string command_one = "grep -q -e '-doubleGRF' " + dump_dir +
+                            "/OCL_asmaf99e2d4667ef6d3_options.txt";
+  std::string command_two = "grep -q -e '-Xfinalizer \"-printregusage\"' " +
+                            dump_dir + "/OCL_asmaf99e2d4667ef6d3_options.txt";
+  int result_one = std::system(command_one.c_str());
+  int result_two = std::system(command_two.c_str());
+
+  if (result_one == 0 && result_two == 0) {
+    return 0;
+  } else {
+    return -1;
+  }
+}
+
+int main(int argc, char *argv[]) {
+
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <dump_directory>" << std::endl;
+    return 1;
+  }
+  std::string dump_dir = argv[1];
+
   namespace syclex = sycl::ext::oneapi::experimental;
   using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
   using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
@@ -84,7 +108,7 @@ int main() {
       q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl);
   if (!ok) {
     std::cout << "compiling from SYCL source not supported" << std::endl;
-    return 0;
+    return 0; // if kernel compilation is not supported, do nothing.
   }
 
   source_kb kbSrc = syclex::create_kernel_bundle_from_source(
@@ -100,5 +124,5 @@ int main() {
 
   test_1(q, k, 30);
 
-  return 0;
+  return test_dump(dump_dir);
 }

--- a/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
+++ b/sycl/test-e2e/KernelCompiler/sycl_device_flags.cpp
@@ -12,10 +12,9 @@
 // IGC shader dump not available on Windows.
 
 // RUN: %{build} -o %t.out
-// RUN: env IGC_DumpToCustomDir=%t.dump IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out
-// RUN: grep -e '-doubleGRF' %t.dump/OCL_asmaf99e2d4667ef6d3_options.txt
-// RUN grep -e '-Xfinalizer "-printregusage"'
-// ./dump/OCL_asmaf99e2d4667ef6d3_options.txt
+// RUN: env IGC_DumpToCustomDir=%T.dump IGC_ShaderDumpEnable=1 NEO_CACHE_PERSISTENT=0 %{run} %t.out
+// RUN: find %T.dump/ -name "*_options.txt" -not -name "*_internal_options.txt" -type f -exec grep -e '-doubleGRF' {} +
+// RUN: find %T.dump/ -name "*_options.txt" -not -name "*_internal_options.txt" -type f -exec grep -e '-Xfinalizer "-printregusage"' {} +
 
 // clang-format off
 /*


### PR DESCRIPTION
After my last fix, another problem appeared (but only in post-commit). This is a blind fix for that.  Let me see if I can run that post-commit pass from GitHub Actions.

The premature exit if compilation is not available was leading to test failures once the test tried to call grep. I'm moving that check into the test app itself, rather than use a `// RUN: ` directive.

Ultimately, we may want something like `// REQUIRE: kernel_compiler::lang::sycl`  but this is not the time/place for that.