### PR TITLE
[SYCL][ASan] Mark PVC & DG2 as unsupported in E2E tests

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/lit.local.cfg
+++ b/sycl/test-e2e/AddressSanitizer/lit.local.cfg
@@ -11,4 +11,4 @@ config.substitutions.append(
 config.unsupported_features += ['cuda', 'hip']
 
 # FIXME: Skip gen devices, waiting for gfx driver uplifting
-config.unsupported_features += ['gpu-intel-gen9', 'gpu-intel-gen11', 'gpu-intel-gen12']
+config.unsupported_features += ['gpu-intel-gen9', 'gpu-intel-gen11', 'gpu-intel-gen12', 'gpu-intel-dg2', 'gpu-intel-pvc']


### PR DESCRIPTION
Following the merge of https://github.com/intel/llvm/pull/13450 there were reports of failures on PVC & DG2:

* https://github.com/intel/llvm/pull/14720#issuecomment-2248649742
* https://github.com/intel/llvm/pull/13450#issuecomment-2249736888

This patch the suggestion in https://github.com/intel/llvm/pull/14720#issuecomment-2249798071 to disable AddressSanitizer testing on PVC & DG2 devices.
