### PR TITLE
Reenable check_resource_leak and sampler_ocl tests

### DIFF
--- a/sycl/test-e2e/Assert/check_resource_leak.cpp
+++ b/sycl/test-e2e/Assert/check_resource_leak.cpp
@@ -5,8 +5,7 @@
 // UNSUPPORTED: opencl && gpu
 
 // TODO: Fails at JIT compilation for some reason.
-// TODO: Reenable windows/linux, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: hip, windows, linux
+// UNSUPPORTED: hip
 #define SYCL_FALLBACK_ASSERT 1
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeprecatedFeatures/sampler_ocl.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/sampler_ocl.cpp
@@ -3,9 +3,6 @@
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib
 // RUN: %{run} %t.out
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14679
-// UNSUPPORTED: windows, linux
-
 //==--------------- sampler.cpp - SYCL sampler basic test ------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
sampler_ocl test is fixed with [UR PR](https://github.com/oneapi-src/unified-runtime/pull/1896). Fixes [14679](https://github.com/intel/llvm/issues/14679), [14806](https://github.com/intel/llvm/issues/14806)