### PR TITLE
[SYCL][NFC] Avoid warnings in SYCLSpecConstMaterializer and program_manager

### DIFF
--- a/sycl-fusion/passes/kernel-fusion/SYCLSpecConstMaterializer.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLSpecConstMaterializer.cpp
@@ -214,6 +214,7 @@ void SYCLSpecConstMaterializer::populateUses(Argument *A) {
 }
 
 void SYCLSpecConstMaterializer::reportAndReset() {
+#ifndef NDEBUG
   if (LoadsToTypes.empty()) {
     LLVM_DEBUG(dbgs() << "Did not find any loads from spec const buffer.\n");
   } else {
@@ -229,6 +230,7 @@ void SYCLSpecConstMaterializer::reportAndReset() {
     }
   }
   LLVM_DEBUG(dbgs() << "\n\n");
+#endif
 
   // Reset the state.
   TypesAndOffsets.clear();

--- a/sycl-fusion/passes/kernel-fusion/SYCLSpecConstMaterializer.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLSpecConstMaterializer.cpp
@@ -214,23 +214,23 @@ void SYCLSpecConstMaterializer::populateUses(Argument *A) {
 }
 
 void SYCLSpecConstMaterializer::reportAndReset() {
-#ifndef NDEBUG
-  if (LoadsToTypes.empty()) {
-    LLVM_DEBUG(dbgs() << "Did not find any loads from spec const buffer.\n");
-  } else {
-    LLVM_DEBUG(dbgs() << "Replaced: " << LoadsToTypes.size()
-                      << " loads from spec const buffer.\n");
-    LLVM_DEBUG(dbgs() << "Load to global variable mappings:\n");
-    for (auto &LTT : LoadsToTypes) {
-      LLVM_DEBUG(dbgs() << "\tLoad:\n");
-      LLVM_DEBUG(LTT.first->dump());
-      LLVM_DEBUG(dbgs() << "\tGlobal Variable:\n");
-      LLVM_DEBUG(TypesAndOffsetsToBlob[LTT.second]->dump());
-      LLVM_DEBUG(dbgs() << "\n");
+  LLVM_DEBUG({
+    if (LoadsToTypes.empty()) {
+      dbgs() << "Did not find any loads from spec const buffer.\n";
+    } else {
+      dbgs() << "Replaced: " << LoadsToTypes.size()
+             << " loads from spec const buffer.\n";
+      dbgs() << "Load to global variable mappings:\n";
+      for (auto &LTT : LoadsToTypes) {
+        dbgs() << "\tLoad:\n";
+        LTT.first->dump();
+        dbgs() << "\tGlobal Variable:\n";
+        TypesAndOffsetsToBlob[LTT.second]->dump();
+        dbgs() << "\n";
+      }
     }
-  }
-  LLVM_DEBUG(dbgs() << "\n\n");
-#endif
+    dbgs() << "\n\n";
+  });
 
   // Reset the state.
   TypesAndOffsets.clear();

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -157,7 +157,9 @@ isDeviceBinaryTypeSupported(const context &C,
   return true;
 }
 
-static const char *getFormatStr(sycl::detail::pi::PiDeviceBinaryType Format) {
+// getFormatStr is used for debug-printing, so it may be unused.
+[[maybe_unused]] static const char *
+getFormatStr(sycl::detail::pi::PiDeviceBinaryType Format) {
   switch (Format) {
   case PI_DEVICE_BINARY_TYPE_NONE:
     return "none";


### PR DESCRIPTION
This commit avoids the following warnings in post-commit testing:
 * SYCLSpecConstMaterializer had a loop purely for debug printing. If `NDEBUG` is defined, the loop variable is unused, which causes a warning. To address this, the use of `LLVM_DEBUG` is moved to outside the full debug printing body.
 * In program_manager, debug printing now checks whether debug printing is enabled using `if constexpr`. This now means that `getFormatStr` is unused, which in turn causes a warning. This commit marks it as potentially unused to avoid this warning.