### PR TITLE
[SYCL][NFC] Detach unit-tests naming from PI

### DIFF
--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -71,11 +71,11 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImage() {
   MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0);
   PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 PiArray<MockProperty>{std::move(DevGlobInfo)});
+                 Array<MockProperty>{std::move(DevGlobInfo)});
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<MockOffloadEntry> Entries =
+  Array<MockOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalTestKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
@@ -102,11 +102,11 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImgScopeImage() {
   MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1);
   PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 PiArray<MockProperty>{std::move(DevGlobInfo)});
+                 Array<MockProperty>{std::move(DevGlobInfo)});
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<MockOffloadEntry> Entries =
+  Array<MockOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -59,7 +59,7 @@ struct KernelInfo<DeviceGlobalImgScopeTestKernel>
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateDeviceGlobalImage() {
+static sycl::unittest::MockDeviceImage generateDeviceGlobalImage() {
   using namespace sycl::unittest;
 
   // Call device global map initializer explicitly to mimic the integration
@@ -78,7 +78,7 @@ static sycl::unittest::PiImage generateDeviceGlobalImage() {
   PiArray<PiOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalTestKernelName});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -89,7 +89,7 @@ static sycl::unittest::PiImage generateDeviceGlobalImage() {
   return Img;
 }
 
-static sycl::unittest::PiImage generateDeviceGlobalImgScopeImage() {
+static sycl::unittest::MockDeviceImage generateDeviceGlobalImgScopeImage() {
   using namespace sycl::unittest;
 
   // Call device global map initializer explicitly to mimic the integration
@@ -109,7 +109,7 @@ static sycl::unittest::PiImage generateDeviceGlobalImgScopeImage() {
   PiArray<PiOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -121,7 +121,7 @@ static sycl::unittest::PiImage generateDeviceGlobalImgScopeImage() {
 }
 
 namespace {
-sycl::unittest::PiImage Imgs[] = {generateDeviceGlobalImage(),
+sycl::unittest::MockDeviceImage Imgs[] = {generateDeviceGlobalImage(),
                                   generateDeviceGlobalImgScopeImage()};
 sycl::unittest::PiImageArray<2> ImgArray{Imgs};
 

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -78,13 +78,14 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImage() {
   Array<MockOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalTestKernelName});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }
@@ -109,13 +110,14 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImgScopeImage() {
   Array<MockOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -75,7 +75,7 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<PiOffloadEntry> Entries =
+  PiArray<MockOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalTestKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
@@ -106,7 +106,7 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImgScopeImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<PiOffloadEntry> Entries =
+  PiArray<MockOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -13,7 +13,7 @@
 #include "detail/kernel_program_cache.hpp"
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -67,11 +67,11 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImage() {
   sycl::detail::device_global_map::add(&DeviceGlobal, DeviceGlobalName);
 
   // Insert remaining device global info into the binary.
-  PiPropertySet PropSet;
-  PiProperty DevGlobInfo =
+  MockPropertySet PropSet;
+  MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0);
   PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 PiArray<PiProperty>{std::move(DevGlobInfo)});
+                 PiArray<MockProperty>{std::move(DevGlobInfo)});
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
@@ -98,11 +98,11 @@ static sycl::unittest::MockDeviceImage generateDeviceGlobalImgScopeImage() {
                                        DeviceGlobalImgScopeName);
 
   // Insert remaining device global info into the binary.
-  PiPropertySet PropSet;
-  PiProperty DevGlobInfo =
+  MockPropertySet PropSet;
+  MockProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1);
   PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 PiArray<PiProperty>{std::move(DevGlobInfo)});
+                 PiArray<MockProperty>{std::move(DevGlobInfo)});
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -11,7 +11,7 @@
 #include <detail/queue_impl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -128,7 +128,7 @@ struct KernelInfo<class __usmmemcpy2d<unsigned char>>
 static sycl::unittest::MockDeviceImage generateMemopsImage() {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -136,13 +136,14 @@ static sycl::unittest::MockDeviceImage generateMemopsImage() {
       {USMFillHelperKernelNameLong, USMFillHelperKernelNameChar,
        USMMemcpyHelperKernelNameLong, USMMemcpyHelperKernelNameChar});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -132,7 +132,7 @@ static sycl::unittest::MockDeviceImage generateMemopsImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(
       {USMFillHelperKernelNameLong, USMFillHelperKernelNameChar,
        USMMemcpyHelperKernelNameLong, USMMemcpyHelperKernelNameChar});
 

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -125,7 +125,7 @@ struct KernelInfo<class __usmmemcpy2d<unsigned char>>
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateMemopsImage() {
+static sycl::unittest::MockDeviceImage generateMemopsImage() {
   using namespace sycl::unittest;
 
   PiPropertySet PropSet;
@@ -136,7 +136,7 @@ static sycl::unittest::PiImage generateMemopsImage() {
       {USMFillHelperKernelNameLong, USMFillHelperKernelNameChar,
        USMMemcpyHelperKernelNameLong, USMMemcpyHelperKernelNameChar});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -148,7 +148,7 @@ static sycl::unittest::PiImage generateMemopsImage() {
 }
 
 namespace {
-sycl::unittest::PiImage Imgs[] = {generateMemopsImage()};
+sycl::unittest::MockDeviceImage Imgs[] = {generateMemopsImage()};
 sycl::unittest::PiImageArray<1> ImgArray{Imgs};
 
 size_t LastMemopsQuery = 0;

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -132,7 +132,7 @@ static sycl::unittest::MockDeviceImage generateMemopsImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(
+  Array<MockOffloadEntry> Entries = makeEmptyKernels(
       {USMFillHelperKernelNameLong, USMFillHelperKernelNameChar,
        USMMemcpyHelperKernelNameLong, USMMemcpyHelperKernelNameChar});
 

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -47,8 +47,8 @@ KERNEL_INFO(KernelG)
 static sycl::unittest::MockDeviceImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::string &VFSets, bool UsesVFSets, unsigned char Magic) {
-  sycl::unittest::PiPropertySet PropSet;
-  sycl::unittest::PiArray<sycl::unittest::PiProperty> Props;
+  sycl::unittest::MockPropertySet PropSet;
+  sycl::unittest::PiArray<sycl::unittest::MockProperty> Props;
   uint64_t PropSize = VFSets.size();
   std::vector<char> Storage(/* bytes for size */ 8 + PropSize +
                             /* null terminator */ 1);
@@ -59,7 +59,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
   Storage.back() = '\0';
   const std::string PropName =
       UsesVFSets ? "uses-virtual-functions-set" : "virtual-functions-set";
-  sycl::unittest::PiProperty Prop(PropName, Storage,
+  sycl::unittest::MockProperty Prop(PropName, Storage,
                                   PI_PROPERTY_TYPE_BYTE_ARRAY);
 
   Props.push_back(Prop);

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -1,7 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <helpers/RuntimeLinkingCommon.hpp>
 

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -44,7 +44,7 @@ KERNEL_INFO(KernelG)
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage
+static sycl::unittest::MockDeviceImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::string &VFSets, bool UsesVFSets, unsigned char Magic) {
   sycl::unittest::PiPropertySet PropSet;
@@ -71,7 +71,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
   sycl::unittest::PiArray<sycl::unittest::PiOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
-  sycl::unittest::PiImage Img{
+  sycl::unittest::MockDeviceImage Img{
       PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
       __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
       "",                                     // Compile options
@@ -102,7 +102,7 @@ static constexpr unsigned PROGRAM_F1 = 53;
 // Device images with no entires are ignored by SYCL RT during registration.
 // Therefore, we have to provide some kernel names to make the test work, even
 // if we don't really have them/use them.
-static sycl::unittest::PiImage Imgs[] = {
+static sycl::unittest::MockDeviceImage Imgs[] = {
     generateImage({"KernelA"}, "set-a", /* uses vf set */ true, PROGRAM_A),
     generateImage({"DummyKernel0"}, "set-a", /* provides vf set */ false,
                   PROGRAM_A0),

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -48,7 +48,7 @@ static sycl::unittest::MockDeviceImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::string &VFSets, bool UsesVFSets, unsigned char Magic) {
   sycl::unittest::MockPropertySet PropSet;
-  sycl::unittest::PiArray<sycl::unittest::MockProperty> Props;
+  sycl::unittest::Array<sycl::unittest::MockProperty> Props;
   uint64_t PropSize = VFSets.size();
   std::vector<char> Storage(/* bytes for size */ 8 + PropSize +
                             /* null terminator */ 1);
@@ -68,7 +68,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::PiArray<sycl::unittest::MockOffloadEntry> Entries =
+  sycl::unittest::Array<sycl::unittest::MockOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::MockDeviceImage Img{

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -68,7 +68,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::PiArray<sycl::unittest::PiOffloadEntry> Entries =
+  sycl::unittest::PiArray<sycl::unittest::MockOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::MockDeviceImage Img{

--- a/sycl/unittests/SYCL2020/DeviceGetInfoAspects.cpp
+++ b/sycl/unittests/SYCL2020/DeviceGetInfoAspects.cpp
@@ -8,7 +8,7 @@
 
 #include <sycl/sycl.hpp>
 
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/SYCL2020/DeviceGetInfoAspects.cpp
+++ b/sycl/unittests/SYCL2020/DeviceGetInfoAspects.cpp
@@ -8,7 +8,6 @@
 
 #include <sycl/sycl.hpp>
 
-#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -27,7 +27,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
                      const std::vector<sycl::aspect> &Aspects, const std::vector<int> &ReqdWGSize = {}) {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   addDeviceRequirementsProps(PropSet, Aspects, ReqdWGSize);
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -32,7 +32,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -22,7 +22,7 @@ MOCK_INTEGRATION_HEADER(TestKernelCPUValidReqdWGSize3D)
 MOCK_INTEGRATION_HEADER(TestKernelGPU)
 MOCK_INTEGRATION_HEADER(TestKernelACC)
 
-static sycl::unittest::PiImage
+static sycl::unittest::MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,
                      const std::vector<sycl::aspect> &Aspects, const std::vector<int> &ReqdWGSize = {}) {
   using namespace sycl::unittest;
@@ -34,7 +34,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -45,7 +45,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   return Img;
 }
 
-static sycl::unittest::PiImage Imgs[7] = {
+static sycl::unittest::MockDeviceImage Imgs[7] = {
     // Images for validating checks based on max_work_group_size + aspects
     generateDefaultImage({"TestKernelCPU"}, {sycl::aspect::cpu},
                          {32}), // 32 <= 256 (OK)

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -32,7 +32,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  Array<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -24,7 +24,8 @@ MOCK_INTEGRATION_HEADER(TestKernelACC)
 
 static sycl::unittest::MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,
-                     const std::vector<sycl::aspect> &Aspects, const std::vector<int> &ReqdWGSize = {}) {
+                     const std::vector<sycl::aspect> &Aspects,
+                     const std::vector<int> &ReqdWGSize = {}) {
   using namespace sycl::unittest;
 
   MockPropertySet PropSet;
@@ -34,13 +35,14 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -1,7 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -31,7 +31,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
                      const std::vector<sycl::aspect> &Aspects = {}) {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   if (!Aspects.empty())
     addDeviceRequirementsProps(PropSet, Aspects);
 

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -37,7 +37,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -11,7 +11,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -24,7 +24,7 @@ MOCK_INTEGRATION_HEADER(TestKernel)
 MOCK_INTEGRATION_HEADER(TestKernelExeOnly)
 MOCK_INTEGRATION_HEADER(TestKernelWithAspects)
 
-static sycl::unittest::PiImage
+static sycl::unittest::MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,
                      pi_device_binary_type BinaryType,
                      const char *DeviceTargetSpec,
@@ -39,7 +39,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
-  PiImage Img{BinaryType, // Format
+  MockDeviceImage Img{BinaryType, // Format
               DeviceTargetSpec,
               "", // Compile options
               "", // Link options
@@ -50,7 +50,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   return Img;
 }
 
-static sycl::unittest::PiImage Imgs[] = {
+static sycl::unittest::MockDeviceImage Imgs[] = {
     generateDefaultImage({"TestKernel"}, PI_DEVICE_BINARY_TYPE_SPIRV,
                          __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64),
     generateDefaultImage({"TestKernelExeOnly"}, PI_DEVICE_BINARY_TYPE_NATIVE,

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -37,7 +37,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  Array<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -41,7 +41,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
                      const char *DeviceTargetSpec) {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
 
   static unsigned char NImage = 0;
   std::vector<unsigned char> Bin{NImage++};

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -49,12 +49,12 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   Array<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{BinaryType, // Format
-              DeviceTargetSpec,
-              "", // Compile options
-              "", // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+                      DeviceTargetSpec,
+                      "", // Compile options
+                      "", // Link options
+                      std::move(Bin),
+                      std::move(Entries),
+                      std::move(PropSet)};
   const void *BinaryPtr = Img.getBinaryPtr();
   TrackedImages.insert(BinaryPtr);
 

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -35,7 +35,7 @@ MOCK_INTEGRATION_HEADER(KernelE)
 namespace {
 
 std::set<const void *> TrackedImages;
-sycl::unittest::PiImage
+sycl::unittest::MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,
                      pi_device_binary_type BinaryType,
                      const char *DeviceTargetSpec) {
@@ -48,7 +48,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
-  PiImage Img{BinaryType, // Format
+  MockDeviceImage Img{BinaryType, // Format
               DeviceTargetSpec,
               "", // Compile options
               "", // Link options
@@ -69,7 +69,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 // Image 5: input, KernelE
 // Image 6: exe, KernelE
 // Image 7: exe. KernelE
-sycl::unittest::PiImage Imgs[] = {
+sycl::unittest::MockDeviceImage Imgs[] = {
     generateDefaultImage({"KernelA", "KernelB"}, PI_DEVICE_BINARY_TYPE_SPIRV,
                          __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64),
     generateDefaultImage({"KernelA"}, PI_DEVICE_BINARY_TYPE_NATIVE,

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -46,7 +46,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   static unsigned char NImage = 0;
   std::vector<unsigned char> Bin{NImage++};
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -11,7 +11,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -46,7 +46,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   static unsigned char NImage = 0;
   std::vector<unsigned char> Bin{NImage++};
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  Array<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -51,7 +51,7 @@ static sycl::unittest::MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> Kernels) {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -47,7 +47,7 @@ struct KernelInfo<ServiceKernel1> : public unittest::MockKernelInfoBase {
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage
+static sycl::unittest::MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> Kernels) {
   using namespace sycl::unittest;
 
@@ -57,7 +57,7 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels(Kernels);
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -68,7 +68,7 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
   return Img;
 }
 
-static sycl::unittest::PiImage Imgs[2] = {
+static sycl::unittest::MockDeviceImage Imgs[2] = {
     generateDefaultImage({"KernelID_TestKernel1", "KernelID_TestKernel3"}),
     generateDefaultImage(
         {"KernelID_TestKernel2",

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -9,7 +9,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -57,13 +57,14 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels(Kernels);
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -55,7 +55,7 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(Kernels);
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(Kernels);
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -55,7 +55,7 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(Kernels);
+  Array<MockOffloadEntry> Entries = makeEmptyKernels(Kernels);
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -37,7 +37,7 @@ template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateImageWithSpecConsts() {
+static sycl::unittest::MockDeviceImage generateImageWithSpecConsts() {
   using namespace sycl::unittest;
 
   std::vector<char> SpecConstData;
@@ -52,7 +52,7 @@ static sycl::unittest::PiImage generateImageWithSpecConsts() {
   PiArray<PiOffloadEntry> Entries =
       makeEmptyKernels({"SpecializationConstant_TestKernel"});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -63,7 +63,7 @@ static sycl::unittest::PiImage generateImageWithSpecConsts() {
   return Img;
 }
 
-static sycl::unittest::PiImage Img = generateImageWithSpecConsts();
+static sycl::unittest::MockDeviceImage Img = generateImageWithSpecConsts();
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 TEST(SpecializationConstant, DefaultValuesAreSet) {

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -49,7 +49,7 @@ static sycl::unittest::MockDeviceImage generateImageWithSpecConsts() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries =
+  PiArray<MockOffloadEntry> Entries =
       makeEmptyKernels({"SpecializationConstant_TestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -52,13 +52,14 @@ static sycl::unittest::MockDeviceImage generateImageWithSpecConsts() {
   Array<MockOffloadEntry> Entries =
       makeEmptyKernels({"SpecializationConstant_TestKernel"});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -49,7 +49,7 @@ static sycl::unittest::MockDeviceImage generateImageWithSpecConsts() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries =
+  Array<MockOffloadEntry> Entries =
       makeEmptyKernels({"SpecializationConstant_TestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -41,10 +41,10 @@ static sycl::unittest::MockDeviceImage generateImageWithSpecConsts() {
   using namespace sycl::unittest;
 
   std::vector<char> SpecConstData;
-  PiProperty SC1 = makeSpecConstant<int>(SpecConstData, "SC1", {0}, {0}, {42});
-  PiProperty SC2 = makeSpecConstant<int>(SpecConstData, "SC2", {1}, {0}, {8});
+  MockProperty SC1 = makeSpecConstant<int>(SpecConstData, "SC1", {0}, {0}, {42});
+  MockProperty SC2 = makeSpecConstant<int>(SpecConstData, "SC2", {1}, {0}, {8});
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   addSpecConstants({SC1, SC2}, std::move(SpecConstData), PropSet);
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -12,7 +12,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/accessor/AccessorPlaceholder.cpp
+++ b/sycl/unittests/accessor/AccessorPlaceholder.cpp
@@ -1,6 +1,6 @@
 #include <gtest/gtest.h>
 
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <numeric>
 #include <sycl/sycl.hpp>

--- a/sycl/unittests/accessor/AccessorPlaceholder.cpp
+++ b/sycl/unittests/accessor/AccessorPlaceholder.cpp
@@ -1,6 +1,5 @@
 #include <gtest/gtest.h>
 
-#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <numeric>
 #include <sycl/sycl.hpp>

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -72,7 +72,7 @@ struct KernelInfo<::sycl::detail::__sycl_service_kernel__::AssertInfoCopier>
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateDefaultImage() {
+static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   static const std::string KernelName = "TestKernel";
@@ -87,7 +87,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -98,7 +98,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
   return Img;
 }
 
-static sycl::unittest::PiImage generateCopierKernelImage() {
+static sycl::unittest::MockDeviceImage generateCopierKernelImage() {
   using namespace sycl::unittest;
 
   static const std::string CopierKernelName =
@@ -110,7 +110,7 @@ static sycl::unittest::PiImage generateCopierKernelImage() {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -121,7 +121,7 @@ static sycl::unittest::PiImage generateCopierKernelImage() {
   return Img;
 }
 
-sycl::unittest::PiImage Imgs[] = {generateDefaultImage(),
+sycl::unittest::MockDeviceImage Imgs[] = {generateDefaultImage(),
                                   generateCopierKernelImage()};
 sycl::unittest::PiImageArray<2> ImgArray{Imgs};
 

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -87,13 +87,14 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }
@@ -110,13 +111,14 @@ static sycl::unittest::MockDeviceImage generateCopierKernelImage() {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -85,7 +85,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({KernelName});
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -108,7 +108,7 @@ static sycl::unittest::MockDeviceImage generateCopierKernelImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -85,7 +85,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({KernelName});
+  Array<MockOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -108,7 +108,7 @@ static sycl::unittest::MockDeviceImage generateCopierKernelImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
+  Array<MockOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -28,7 +28,7 @@
 #include <detail/device_impl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -79,7 +79,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   static const std::string CopierKernelName =
       "_ZTSN2cl4sycl6detail23__sycl_service_kernel__16AssertInfoCopierE";
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
 
   setKernelUsesAssert({KernelName}, PropSet);
 
@@ -104,7 +104,7 @@ static sycl::unittest::MockDeviceImage generateCopierKernelImage() {
   static const std::string CopierKernelName =
       "_ZTSN2cl4sycl6detail23__sycl_service_kernel__16AssertInfoCopierE";
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 

--- a/sycl/unittests/buffer/KernelArgMemObj.cpp
+++ b/sycl/unittests/buffer/KernelArgMemObj.cpp
@@ -9,7 +9,7 @@
 #include <gtest/gtest.h>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 class TestKernelWithMemObj;

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -1,4 +1,4 @@
-//==------------- PiImage.hpp --- PI mock image unit testing library -------==//
+//==----- MockDeviceImage.hpp --- Mock device image for unit testing -------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -72,7 +72,8 @@ class MockOffloadEntry {
 public:
   using NativeType = _pi_offload_entry_struct;
 
-  MockOffloadEntry(const std::string &Name, std::vector<char> Data, int32_t Flags)
+  MockOffloadEntry(const std::string &Name, std::vector<char> Data,
+                   int32_t Flags)
       : MName(Name), MData(std::move(Data)), MFlags(Flags) {
     updateNativeType();
   }
@@ -236,13 +237,16 @@ public:
 
   /// Constructs a SYCL device image of the latest version.
   MockDeviceImage(uint8_t Format, const std::string &DeviceTargetSpec,
-          const std::string &CompileOptions, const std::string &LinkOptions,
-          std::vector<unsigned char> Binary,
-          Array<MockOffloadEntry> OffloadEntries, MockPropertySet PropertySet)
-      : MockDeviceImage(PI_DEVICE_BINARY_VERSION, PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL,
-                Format, DeviceTargetSpec, CompileOptions, LinkOptions, {},
-                std::move(Binary), std::move(OffloadEntries),
-                std::move(PropertySet)) {}
+                  const std::string &CompileOptions,
+                  const std::string &LinkOptions,
+                  std::vector<unsigned char> Binary,
+                  Array<MockOffloadEntry> OffloadEntries,
+                  MockPropertySet PropertySet)
+      : MockDeviceImage(PI_DEVICE_BINARY_VERSION,
+                        PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL, Format,
+                        DeviceTargetSpec, CompileOptions, LinkOptions, {},
+                        std::move(Binary), std::move(OffloadEntries),
+                        std::move(PropertySet)) {}
 
   pi_device_binary_struct convertToNativeType() {
     return pi_device_binary_struct{
@@ -400,7 +404,8 @@ inline void setKernelUsesAssert(const std::vector<std::string> &Names,
 ///
 /// This function overrides the default spec constant values.
 inline void addSpecConstants(Array<MockProperty> SpecConstants,
-                             std::vector<char> ValData, MockPropertySet &Props) {
+                             std::vector<char> ValData,
+                             MockPropertySet &Props) {
   Props.insert(__SYCL_PI_PROPERTY_SET_SPEC_CONST_MAP, std::move(SpecConstants));
 
   MockProperty Prop{"all", std::move(ValData), PI_PROPERTY_TYPE_BYTE_ARRAY};

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -68,22 +68,22 @@ private:
 };
 
 /// Convinience wrapper for _pi_offload_entry_struct.
-class PiOffloadEntry {
+class MockOffloadEntry {
 public:
   using NativeType = _pi_offload_entry_struct;
 
-  PiOffloadEntry(const std::string &Name, std::vector<char> Data, int32_t Flags)
+  MockOffloadEntry(const std::string &Name, std::vector<char> Data, int32_t Flags)
       : MName(Name), MData(std::move(Data)), MFlags(Flags) {
     updateNativeType();
   }
 
-  PiOffloadEntry(const PiOffloadEntry &Src) {
+  MockOffloadEntry(const MockOffloadEntry &Src) {
     MName = Src.MName;
     MData = Src.MData;
     MFlags = Src.MFlags;
     updateNativeType();
   }
-  PiOffloadEntry &operator=(const PiOffloadEntry &Src) {
+  MockOffloadEntry &operator=(const MockOffloadEntry &Src) {
     MName = Src.MName;
     MData = Src.MData;
     MFlags = Src.MFlags;
@@ -227,7 +227,7 @@ public:
           const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
           std::vector<char> Manifest, std::vector<unsigned char> Binary,
-          PiArray<PiOffloadEntry> OffloadEntries, PiPropertySet PropertySet)
+          PiArray<MockOffloadEntry> OffloadEntries, PiPropertySet PropertySet)
       : MVersion(Version), MKind(Kind), MFormat(Format),
         MDeviceTargetSpec(DeviceTargetSpec), MCompileOptions(CompileOptions),
         MLinkOptions(LinkOptions), MManifest(std::move(Manifest)),
@@ -238,7 +238,7 @@ public:
   MockDeviceImage(uint8_t Format, const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
           std::vector<unsigned char> Binary,
-          PiArray<PiOffloadEntry> OffloadEntries, PiPropertySet PropertySet)
+          PiArray<MockOffloadEntry> OffloadEntries, PiPropertySet PropertySet)
       : MockDeviceImage(PI_DEVICE_BINARY_VERSION, PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL,
                 Format, DeviceTargetSpec, CompileOptions, LinkOptions, {},
                 std::move(Binary), std::move(OffloadEntries),
@@ -273,7 +273,7 @@ private:
   std::string MLinkOptions;
   std::vector<char> MManifest;
   std::vector<unsigned char> MBinary;
-  PiArray<PiOffloadEntry> MOffloadEntries;
+  PiArray<MockOffloadEntry> MOffloadEntries;
   PiPropertySet MPropertySet;
 };
 
@@ -423,12 +423,12 @@ inline void addESIMDFlag(PiPropertySet &Props) {
 }
 
 /// Utility function to generate offload entries for kernels without arguments.
-inline PiArray<PiOffloadEntry>
+inline PiArray<MockOffloadEntry>
 makeEmptyKernels(std::initializer_list<std::string> KernelNames) {
-  PiArray<PiOffloadEntry> Entries;
+  PiArray<MockOffloadEntry> Entries;
 
   for (const auto &Name : KernelNames) {
-    PiOffloadEntry E{Name, {}, 0};
+    MockOffloadEntry E{Name, {}, 0};
     Entries.push_back(std::move(E));
   }
   return Entries;
@@ -542,7 +542,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -220,10 +220,10 @@ private:
 
 /// Convenience wrapper around PI internal structures, that manages PI binary
 /// image data lifecycle.
-class PiImage {
+class MockDeviceImage {
 public:
   /// Constructs an arbitrary device image.
-  PiImage(uint16_t Version, uint8_t Kind, uint8_t Format,
+  MockDeviceImage(uint16_t Version, uint8_t Kind, uint8_t Format,
           const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
           std::vector<char> Manifest, std::vector<unsigned char> Binary,
@@ -235,11 +235,11 @@ public:
         MPropertySet(std::move(PropertySet)) {}
 
   /// Constructs a SYCL device image of the latest version.
-  PiImage(uint8_t Format, const std::string &DeviceTargetSpec,
+  MockDeviceImage(uint8_t Format, const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
           std::vector<unsigned char> Binary,
           PiArray<PiOffloadEntry> OffloadEntries, PiPropertySet PropertySet)
-      : PiImage(PI_DEVICE_BINARY_VERSION, PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL,
+      : MockDeviceImage(PI_DEVICE_BINARY_VERSION, PI_DEVICE_BINARY_OFFLOAD_KIND_SYCL,
                 Format, DeviceTargetSpec, CompileOptions, LinkOptions, {},
                 std::move(Binary), std::move(OffloadEntries),
                 std::move(PropertySet)) {}
@@ -283,7 +283,7 @@ template <size_t __NumberOfImages> class PiImageArray {
 public:
   static constexpr size_t NumberOfImages = __NumberOfImages;
 
-  PiImageArray(PiImage *Imgs) {
+  PiImageArray(MockDeviceImage *Imgs) {
     for (size_t Idx = 0; Idx < NumberOfImages; ++Idx)
       MNativeImages[Idx] = Imgs[Idx].convertToNativeType();
 
@@ -536,7 +536,7 @@ addDeviceRequirementsProps(PiPropertySet &Props,
                std::move(Value));
 }
 
-inline PiImage
+inline MockDeviceImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames) {
   PiPropertySet PropSet;
 
@@ -544,7 +544,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames) {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options

--- a/sycl/unittests/helpers/TestKernel.hpp
+++ b/sycl/unittests/helpers/TestKernel.hpp
@@ -9,7 +9,7 @@
 #pragma once
 
 #include "MockKernelInfo.hpp"
-#include "PiImage.hpp"
+#include "MockDeviceImage.hpp"
 
 template <size_t KernelSize = 1> class TestKernel;
 

--- a/sycl/unittests/helpers/TestKernel.hpp
+++ b/sycl/unittests/helpers/TestKernel.hpp
@@ -33,6 +33,6 @@ struct KernelInfo<TestKernel<KernelSize>>
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage Img =
+static sycl::unittest::MockDeviceImage Img =
     sycl::unittest::generateDefaultImage({"TestKernel"});
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -61,7 +61,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries =
+  Array<MockOffloadEntry> Entries =
       makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -54,7 +54,8 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   std::vector<char> SpecConstData;
-  MockProperty SC1 = makeSpecConstant<int>(SpecConstData, "SC1", {0}, {0}, {42});
+  MockProperty SC1 =
+      makeSpecConstant<int>(SpecConstData, "SC1", {0}, {0}, {42});
 
   MockPropertySet PropSet;
   addSpecConstants({SC1}, std::move(SpecConstData), PropSet);
@@ -64,13 +65,14 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   Array<MockOffloadEntry> Entries =
       makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -15,7 +15,7 @@
 #include "detail/kernel_program_cache.hpp"
 #include "sycl/detail/pi.h"
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/sycl.hpp>
 

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -54,9 +54,9 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   std::vector<char> SpecConstData;
-  PiProperty SC1 = makeSpecConstant<int>(SpecConstData, "SC1", {0}, {0}, {42});
+  MockProperty SC1 = makeSpecConstant<int>(SpecConstData, "SC1", {0}, {0}, {42});
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   addSpecConstants({SC1}, std::move(SpecConstData), PropSet);
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -61,7 +61,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries =
+  PiArray<MockOffloadEntry> Entries =
       makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -50,7 +50,7 @@ template <> const char *get_spec_constant_symbolic_ID<SpecConst1>() {
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateDefaultImage() {
+static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   std::vector<char> SpecConstData;
@@ -64,7 +64,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
   PiArray<PiOffloadEntry> Entries =
       makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -75,7 +75,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
   return Img;
 }
 
-static sycl::unittest::PiImage Img = generateDefaultImage();
+static sycl::unittest::MockDeviceImage Img = generateDefaultImage();
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 struct TestCtx {

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -87,13 +87,14 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "-compile-img",                         // Compile options
-              "-link-img",                            // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "-compile-img",                         // Compile options
+      "-link-img",                            // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -78,7 +78,7 @@ static void setupCommonMockAPIs(sycl::unittest::PiMock &Mock) {
   Mock.redefineBefore<PiApiKind::piProgramBuild>(redefinedProgramBuild);
 }
 
-static sycl::unittest::PiImage generateDefaultImage() {
+static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   PiPropertySet PropSet;
@@ -87,7 +87,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "-compile-img",                         // Compile options
               "-link-img",                            // Link options
@@ -98,7 +98,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
   return Img;
 }
 
-sycl::unittest::PiImage Img = generateDefaultImage();
+sycl::unittest::MockDeviceImage Img = generateDefaultImage();
 sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 TEST(KernelBuildOptions, KernelBundleBasic) {

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -12,7 +12,7 @@
 #endif
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/sycl.hpp>
 

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -81,7 +81,7 @@ static void setupCommonMockAPIs(sycl::unittest::PiMock &Mock) {
 static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -85,7 +85,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
+  Array<MockOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -85,7 +85,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -12,7 +12,7 @@
 #include "detail/kernel_bundle_impl.hpp"
 #include "detail/kernel_program_cache.hpp"
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -25,7 +25,7 @@ class MultipleDevsCacheTestKernel;
 
 MOCK_INTEGRATION_HEADER(MultipleDevsCacheTestKernel)
 
-static sycl::unittest::PiImage Img =
+static sycl::unittest::MockDeviceImage Img =
     sycl::unittest::generateDefaultImage({"MultipleDevsCacheTestKernel"});
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};
 

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -12,7 +12,7 @@
 #include "detail/kernel_bundle_impl.hpp"
 #include "detail/kernel_program_cache.hpp"
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/kernel-and-program/OutOfResources.cpp
+++ b/sycl/unittests/kernel-and-program/OutOfResources.cpp
@@ -27,7 +27,7 @@ class OutOfResourcesKernel2;
 MOCK_INTEGRATION_HEADER(OutOfResourcesKernel1)
 MOCK_INTEGRATION_HEADER(OutOfResourcesKernel2)
 
-static sycl::unittest::PiImage Img[2] = {
+static sycl::unittest::MockDeviceImage Img[2] = {
     sycl::unittest::generateDefaultImage({"OutOfResourcesKernel1"}),
     sycl::unittest::generateDefaultImage({"OutOfResourcesKernel2"})};
 

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -45,13 +45,14 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -35,11 +35,11 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   sycl::detail::host_pipe_map::add(Pipe::get_host_ptr(),
                                    "test_host_pipe_unique_id");
 
-  PiPropertySet PropSet;
-  PiProperty HostPipeInfo =
+  MockPropertySet PropSet;
+  MockProperty HostPipeInfo =
       makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int));
   PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_HOST_PIPES,
-                 PiArray<PiProperty>{std::move(HostPipeInfo)});
+                 PiArray<MockProperty>{std::move(HostPipeInfo)});
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -13,7 +13,7 @@
 #include <detail/host_pipe_map_entry.hpp>
 #include <gtest/gtest.h>
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/detail/host_pipe_map.hpp>
 

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -43,7 +43,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -29,7 +29,7 @@ class PipeID;
 using Pipe = sycl::ext::intel::experimental::pipe<PipeID, int, 10,
                                                   default_pipe_properties>;
 
-static sycl::unittest::PiImage generateDefaultImage() {
+static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   sycl::detail::host_pipe_map::add(Pipe::get_host_ptr(),
@@ -45,7 +45,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -126,7 +126,7 @@ protected:
   queue q;
 };
 
-static sycl::unittest::PiImage Img = generateDefaultImage();
+static sycl::unittest::MockDeviceImage Img = generateDefaultImage();
 static sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 TEST_F(PipeTest, Basic) {

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -39,11 +39,11 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   MockProperty HostPipeInfo =
       makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int));
   PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_HOST_PIPES,
-                 PiArray<MockProperty>{std::move(HostPipeInfo)});
+                 Array<MockProperty>{std::move(HostPipeInfo)});
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
+  Array<MockOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/program_manager/BuildLog.cpp
+++ b/sycl/unittests/program_manager/BuildLog.cpp
@@ -12,7 +12,7 @@
 #include <detail/config.hpp>
 #include <detail/context_impl.hpp>
 #include <detail/program_manager/program_manager.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <helpers/ScopedEnvVar.hpp>
 #include <sycl/sycl.hpp>

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -1,7 +1,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <helpers/RuntimeLinkingCommon.hpp>
 

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -70,7 +70,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
                    createPropertySet(ImportedSymbols));
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::PiArray<sycl::unittest::PiOffloadEntry> Entries =
+  sycl::unittest::PiArray<sycl::unittest::MockOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::MockDeviceImage Img{

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -37,10 +37,10 @@ KERNEL_INFO(AOTCaseKernel)
 } // namespace sycl
 
 namespace {
-sycl::unittest::PiArray<sycl::unittest::MockProperty>
+sycl::unittest::Array<sycl::unittest::MockProperty>
 createPropertySet(const std::vector<std::string> &Symbols) {
   sycl::unittest::MockPropertySet PropSet;
-  sycl::unittest::PiArray<sycl::unittest::MockProperty> Props;
+  sycl::unittest::Array<sycl::unittest::MockProperty> Props;
   for (const std::string &Symbol : Symbols) {
     std::vector<char> Storage(sizeof(pi_uint32));
     uint32_t Val = 1;
@@ -70,7 +70,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
                    createPropertySet(ImportedSymbols));
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::PiArray<sycl::unittest::MockOffloadEntry> Entries =
+  sycl::unittest::Array<sycl::unittest::MockOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::MockDeviceImage Img{

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -54,7 +54,7 @@ createPropertySet(const std::vector<std::string> &Symbols) {
   return Props;
 }
 
-sycl::unittest::PiImage
+sycl::unittest::MockDeviceImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::vector<std::string> &ExportedSymbols,
               const std::vector<std::string> &ImportedSymbols,
@@ -73,7 +73,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
   sycl::unittest::PiArray<sycl::unittest::PiOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
-  sycl::unittest::PiImage Img{
+  sycl::unittest::MockDeviceImage Img{
       BinType,
       __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
       "",                                     // Compile options
@@ -95,7 +95,7 @@ static constexpr unsigned MUTUAL_DEP_PRG_B = 17;
 static constexpr unsigned AOT_CASE_PRG_NATIVE = 23;
 static constexpr unsigned AOT_CASE_PRG_DEP_NATIVE = 29;
 
-static sycl::unittest::PiImage Imgs[] = {
+static sycl::unittest::MockDeviceImage Imgs[] = {
     generateImage({"BasicCaseKernel"}, {}, {"BasicCaseKernelDep"},
                   BASIC_CASE_PRG),
     generateImage({"BasicCaseKernelDep"}, {"BasicCaseKernelDep"},

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -37,17 +37,17 @@ KERNEL_INFO(AOTCaseKernel)
 } // namespace sycl
 
 namespace {
-sycl::unittest::PiArray<sycl::unittest::PiProperty>
+sycl::unittest::PiArray<sycl::unittest::MockProperty>
 createPropertySet(const std::vector<std::string> &Symbols) {
-  sycl::unittest::PiPropertySet PropSet;
-  sycl::unittest::PiArray<sycl::unittest::PiProperty> Props;
+  sycl::unittest::MockPropertySet PropSet;
+  sycl::unittest::PiArray<sycl::unittest::MockProperty> Props;
   for (const std::string &Symbol : Symbols) {
     std::vector<char> Storage(sizeof(pi_uint32));
     uint32_t Val = 1;
     auto *DataPtr = reinterpret_cast<char *>(&Val);
     std::uninitialized_copy(DataPtr, DataPtr + sizeof(uint32_t),
                             Storage.data());
-    sycl::unittest::PiProperty Prop(Symbol, Storage, PI_PROPERTY_TYPE_UINT32);
+    sycl::unittest::MockProperty Prop(Symbol, Storage, PI_PROPERTY_TYPE_UINT32);
 
     Props.push_back(Prop);
   }
@@ -61,7 +61,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
               unsigned char Magic,
               sycl::detail::pi::PiDeviceBinaryType BinType =
                   PI_DEVICE_BINARY_TYPE_SPIRV) {
-  sycl::unittest::PiPropertySet PropSet;
+  sycl::unittest::MockPropertySet PropSet;
   if (!ExportedSymbols.empty())
     PropSet.insert(__SYCL_PI_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS,
                    createPropertySet(ExportedSymbols));

--- a/sycl/unittests/program_manager/SubDevices.cpp
+++ b/sycl/unittests/program_manager/SubDevices.cpp
@@ -8,7 +8,7 @@
 
 #include <detail/kernel_bundle_impl.hpp>
 
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -60,13 +60,14 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }
@@ -80,13 +81,14 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernel2Image() {
 
   Array<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -43,7 +43,7 @@ struct KernelInfo<EAMTestKernel2> : public unittest::MockKernelInfoBase {
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateEAMTestKernelImage() {
+static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
   using namespace sycl::unittest;
 
   // Eliminated arguments are 1st and 3rd.
@@ -60,7 +60,7 @@ static sycl::unittest::PiImage generateEAMTestKernelImage() {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -71,7 +71,7 @@ static sycl::unittest::PiImage generateEAMTestKernelImage() {
   return Img;
 }
 
-static sycl::unittest::PiImage generateEAMTestKernel2Image() {
+static sycl::unittest::MockDeviceImage generateEAMTestKernel2Image() {
   using namespace sycl::unittest;
 
   PiPropertySet PropSet;
@@ -80,7 +80,7 @@ static sycl::unittest::PiImage generateEAMTestKernel2Image() {
 
   PiArray<PiOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -91,8 +91,8 @@ static sycl::unittest::PiImage generateEAMTestKernel2Image() {
   return Img;
 }
 
-static sycl::unittest::PiImage EAMImg = generateEAMTestKernelImage();
-static sycl::unittest::PiImage EAM2Img = generateEAMTestKernel2Image();
+static sycl::unittest::MockDeviceImage EAMImg = generateEAMTestKernelImage();
+static sycl::unittest::MockDeviceImage EAM2Img = generateEAMTestKernel2Image();
 static sycl::unittest::PiImageArray<1> EAMImgArray{&EAMImg};
 static sycl::unittest::PiImageArray<1> EAM2ImgArray{&EAM2Img};
 

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -13,7 +13,7 @@
 #include <sycl/sycl.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -58,7 +58,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -78,7 +78,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernel2Image() {
 
   std::vector<unsigned char> Bin{6, 7, 8, 9, 10, 11}; // Random data
 
-  PiArray<PiOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
+  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -48,11 +48,11 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
 
   // Eliminated arguments are 1st and 3rd.
   std::vector<unsigned char> KernelEAM{0b00000101};
-  PiProperty EAMKernelPOI = makeKernelParamOptInfo(
+  MockProperty EAMKernelPOI = makeKernelParamOptInfo(
       EAMTestKernelName, EAMTestKernelNumArgs, KernelEAM);
-  PiArray<PiProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  PiArray<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   PropSet.insert(__SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO,
                  std::move(ImgKPOI));
 
@@ -74,7 +74,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
 static sycl::unittest::MockDeviceImage generateEAMTestKernel2Image() {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
 
   std::vector<unsigned char> Bin{6, 7, 8, 9, 10, 11}; // Random data
 

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -50,7 +50,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
   std::vector<unsigned char> KernelEAM{0b00000101};
   MockProperty EAMKernelPOI = makeKernelParamOptInfo(
       EAMTestKernelName, EAMTestKernelNumArgs, KernelEAM);
-  PiArray<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  Array<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   MockPropertySet PropSet;
   PropSet.insert(__SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO,
@@ -58,7 +58,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernelImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
+  Array<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -78,7 +78,7 @@ static sycl::unittest::MockDeviceImage generateEAMTestKernel2Image() {
 
   std::vector<unsigned char> Bin{6, 7, 8, 9, 10, 11}; // Random data
 
-  PiArray<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
+  Array<MockOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/program_manager/itt_annotations.cpp
+++ b/sycl/unittests/program_manager/itt_annotations.cpp
@@ -10,7 +10,7 @@
 
 #include <detail/config.hpp>
 #include <detail/program_manager/program_manager.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/sycl.hpp>
 

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -56,7 +56,7 @@ struct KernelInfo<EAMTestKernel3> : public unittest::MockKernelInfoBase {
 } // namespace sycl
 
 template <typename T>
-static sycl::unittest::PiImage
+static sycl::unittest::MockDeviceImage
 generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   using namespace sycl::unittest;
 
@@ -75,7 +75,7 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   PiArray<PiOffloadEntry> Entries =
       makeEmptyKernels({sycl::detail::KernelInfo<T>::getName()});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               _cmplOptions,                           // Compile options
               _lnkOptions,                            // Link options
@@ -134,7 +134,7 @@ TEST(Link_Compile_Options, compile_link_Options_Test_empty_options) {
   current_link_options.clear();
   current_compile_options.clear();
   std::string expected_options = "";
-  static sycl::unittest::PiImage DevImage =
+  static sycl::unittest::MockDeviceImage DevImage =
       generateEAMTestKernelImage<EAMTestKernel1>(expected_options,
                                                  expected_options);
   static sycl::unittest::PiImageArray<1> DevImageArray_{&DevImage};
@@ -164,7 +164,7 @@ TEST(Link_Compile_Options, compile_link_Options_Test_filled_options) {
                   "-cl-opt-disable -cl-fp32-correctly-rounded-divide-sqrt",
               expected_link_options_1 =
                   "-cl-denorms-are-zero -cl-no-signed-zeros";
-  static sycl::unittest::PiImage DevImage_1 =
+  static sycl::unittest::MockDeviceImage DevImage_1 =
       generateEAMTestKernelImage<EAMTestKernel2>(expected_compile_options_1,
                                                  expected_link_options_1);
 
@@ -199,7 +199,7 @@ TEST(Link_Compile_Options, check_sycl_build) {
   current_compile_options.clear();
   std::string expected_compile_options = "-cl-opt-disable",
               expected_link_options = "-cl-denorms-are-zero";
-  static sycl::unittest::PiImage DevImage =
+  static sycl::unittest::MockDeviceImage DevImage =
       generateEAMTestKernelImage<EAMTestKernel3>(expected_compile_options,
                                                  expected_link_options);
   static sycl::unittest::PiImageArray<1> DevImageArray{&DevImage};

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -72,7 +72,7 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries =
+  PiArray<MockOffloadEntry> Entries =
       makeEmptyKernels({sycl::detail::KernelInfo<T>::getName()});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -75,13 +75,14 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   Array<MockOffloadEntry> Entries =
       makeEmptyKernels({sycl::detail::KernelInfo<T>::getName()});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              _cmplOptions,                           // Compile options
-              _lnkOptions,                            // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      _cmplOptions,                           // Compile options
+      _lnkOptions,                            // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
   return Img;
 }
 

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -61,12 +61,12 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   using namespace sycl::unittest;
 
   std::vector<unsigned char> KernelEAM1{0b00000101};
-  PiProperty EAMKernelPOI =
+  MockProperty EAMKernelPOI =
       makeKernelParamOptInfo(sycl::detail::KernelInfo<T>::getName(),
                              EAMTestKernelNumArgs1, KernelEAM1);
-  PiArray<PiProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  PiArray<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   PropSet.insert(__SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO,
                  std::move(ImgKPOI));
 

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -64,7 +64,7 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   MockProperty EAMKernelPOI =
       makeKernelParamOptInfo(sycl::detail::KernelInfo<T>::getName(),
                              EAMTestKernelNumArgs1, KernelEAM1);
-  PiArray<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  Array<MockProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   MockPropertySet PropSet;
   PropSet.insert(__SYCL_PI_PROPERTY_SET_KERNEL_PARAM_OPT_INFO,
@@ -72,7 +72,7 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries =
+  Array<MockOffloadEntry> Entries =
       makeEmptyKernels({sycl::detail::KernelInfo<T>::getName()});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -11,7 +11,7 @@
 #include <sycl/detail/defines_elementary.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/queue/GetProfilingInfo.cpp
+++ b/sycl/unittests/queue/GetProfilingInfo.cpp
@@ -16,7 +16,7 @@
 #include <sycl/detail/defines_elementary.hpp>
 
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <helpers/TestKernel.hpp>
 

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -107,7 +107,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<PiOffloadEntry> Entries =
+  PiArray<MockOffloadEntry> Entries =
       makeEmptyKernels({"StreamAUXCmdsWait_TestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -9,7 +9,7 @@
 #include "SchedulerTest.hpp"
 #include "SchedulerTestUtils.hpp"
 #include <helpers/MockKernelInfo.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <cassert>

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -100,7 +100,7 @@ struct KernelInfo<StreamAUXCmdsWait_TestKernel>
 } // namespace _V1
 } // namespace sycl
 
-static sycl::unittest::PiImage generateDefaultImage() {
+static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
   PiPropertySet PropSet;
@@ -110,7 +110,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
   PiArray<PiOffloadEntry> Entries =
       makeEmptyKernels({"StreamAUXCmdsWait_TestKernel"});
 
-  PiImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
               __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                     // Compile options
               "",                                     // Link options
@@ -121,7 +121,7 @@ static sycl::unittest::PiImage generateDefaultImage() {
   return Img;
 }
 
-sycl::unittest::PiImage Img = generateDefaultImage();
+sycl::unittest::MockDeviceImage Img = generateDefaultImage();
 sycl::unittest::PiImageArray<1> ImgArray{&Img};
 
 class EventImplProxyT : public sycl::detail::event_impl {

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -107,7 +107,7 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  PiArray<MockOffloadEntry> Entries =
+  Array<MockOffloadEntry> Entries =
       makeEmptyKernels({"StreamAUXCmdsWait_TestKernel"});
 
   MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -103,7 +103,7 @@ struct KernelInfo<StreamAUXCmdsWait_TestKernel>
 static sycl::unittest::MockDeviceImage generateDefaultImage() {
   using namespace sycl::unittest;
 
-  PiPropertySet PropSet;
+  MockPropertySet PropSet;
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -110,13 +110,14 @@ static sycl::unittest::MockDeviceImage generateDefaultImage() {
   Array<MockOffloadEntry> Entries =
       makeEmptyKernels({"StreamAUXCmdsWait_TestKernel"});
 
-  MockDeviceImage Img{PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
-              __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
-              "",                                     // Compile options
-              "",                                     // Link options
-              std::move(Bin),
-              std::move(Entries),
-              std::move(PropSet)};
+  MockDeviceImage Img{
+      PI_DEVICE_BINARY_TYPE_SPIRV,            // Format
+      __SYCL_PI_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
+      "",                                     // Compile options
+      "",                                     // Link options
+      std::move(Bin),
+      std::move(Entries),
+      std::move(PropSet)};
 
   return Img;
 }

--- a/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueHostTaskDeps.cpp
@@ -9,7 +9,7 @@
 #include "SchedulerTest.hpp"
 #include "SchedulerTestUtils.hpp"
 
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <helpers/TestKernel.hpp>
 

--- a/sycl/unittests/scheduler/RequiredWGSize.cpp
+++ b/sycl/unittests/scheduler/RequiredWGSize.cpp
@@ -10,7 +10,7 @@
 
 #include <detail/config.hpp>
 #include <detail/program_manager/program_manager.hpp>
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/sycl.hpp>
 

--- a/sycl/unittests/stream/stream.cpp
+++ b/sycl/unittests/stream/stream.cpp
@@ -8,7 +8,7 @@
 
 #include <sycl/sycl.hpp>
 
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 
 #include <gtest/gtest.h>

--- a/sycl/unittests/windows/dllmain.cpp
+++ b/sycl/unittests/windows/dllmain.cpp
@@ -12,7 +12,7 @@
  * distinct binary executable.
  */
 
-#include <helpers/PiImage.hpp>
+#include <helpers/MockDeviceImage.hpp>
 #include <helpers/PiMock.hpp>
 #include <sycl/sycl.hpp>
 


### PR DESCRIPTION
This is a by-product of #14145. Our unit tests have mock classes corresponding to device images and other entries our compiler generates. They are all named using `Pi` prefix, but they have nothing to do with Plugin Interface, they are part of our compiler interface.

This patch renames associated files and classes so they do not refer to `Pi` anymore.
This is a mechanical find-and-replace change.