### PR TITLE
[CI] Fix CI issues caused by recent UR version bump

### DIFF
--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -30,7 +30,7 @@ jobs:
       CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}
     steps:
     - name: Install dependencies
-      run: brew install ccache ninja
+      run: brew install ccache ninja hwloc
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.build_ref }}

--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -99,13 +99,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 3d8fe8d298cec8db624fc230fa5c0e19865aa6f1
-  # Merge: e8c9f3db 0a259f33
+  # commit 2baf095188b235bb2b0a0140f0187d2041aef4b0
+  # Merge: 3d8fe8d2 58f85278
   # Author: Piotr Balcer <piotr.balcer@intel.com>
-  # Date:   Thu Jul 25 15:13:00 2024 +0200
-  #     Merge pull request #1430 from igchor/umf_dynamic_linking
-  #     Bump UMF version and switch to dynamic linking
-  set(UNIFIED_RUNTIME_TAG 3d8fe8d298cec8db624fc230fa5c0e19865aa6f1)
+  # Date:   Fri Jul 26 12:06:22 2024 +0200
+  #     Merge pull request #1900 from kswiecicki/umf-version-bump
+  #     Bump UMF version
+  set(UNIFIED_RUNTIME_TAG 58f85278a4ebf37742dd10afb3350580b0b1d9d7)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need


### PR DESCRIPTION
`hwloc` became a dependency after https://github.com/intel/llvm/pull/13343 was merged. CI infrastructure has been updated to have `hwloc` installed, but it's still missing on macOS runner.

Additionally, UMF compile options caused errors on SYCL runners that should be resolved after UR version bump included in this patch.

Logs: https://github.com/intel/llvm/actions/runs/10106492701/job/27948711331 and https://github.com/intel/llvm/actions/runs/10106492701/job/27948711538.