### PR TITLE
Testing PR: [UR] link with hwloc statically by default

### DIFF
--- a/sycl/plugins/unified_runtime/CMakeLists.txt
+++ b/sycl/plugins/unified_runtime/CMakeLists.txt
@@ -98,22 +98,23 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/igchor/unified-runtime.git")
   # commit 2baf095188b235bb2b0a0140f0187d2041aef4b0
   # Merge: 3d8fe8d2 58f85278
   # Author: Piotr Balcer <piotr.balcer@intel.com>
   # Date:   Fri Jul 26 12:06:22 2024 +0200
   #     Merge pull request #1900 from kswiecicki/umf-version-bump
   #     Bump UMF version
-  set(UNIFIED_RUNTIME_TAG 58f85278a4ebf37742dd10afb3350580b0b1d9d7)
+  set(UNIFIED_RUNTIME_TAG 2a806d73a9bc78d65d7863ae8829541c8a42ac55)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need
   # to link statically on windows
   if(WIN32)
     set(UMF_BUILD_SHARED_LIBRARY OFF CACHE INTERNAL "Build UMF shared library")
-    set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
   endif()
+
+  set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
 
   fetch_adapter_source(level_zero
     ${UNIFIED_RUNTIME_REPO}


### PR DESCRIPTION
Hwloc package is not avalable on certain distros (e.g. RHEL). To avoid forcing users to install hwloc from sources, link statically with hwloc (and build hwloc as part of the UR build).