### PR TITLE
Disable all Task Sequence tests

### DIFF
--- a/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
+++ b/sycl/test-e2e/TaskSequence/in-order-async-get.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/mult-and-add.cpp
+++ b/sycl/test-e2e/TaskSequence/mult-and-add.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
+++ b/sycl/test-e2e/TaskSequence/multi-kernel-task-function-reuse.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/producer-consumer.cpp
+++ b/sycl/test-e2e/TaskSequence/producer-consumer.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
+++ b/sycl/test-e2e/TaskSequence/struct-array-args-and-return.cpp
@@ -6,6 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
+// FIXME: failure in post-commit, re-enable when fixed:
+// UNSUPPORTED: linux
+
 // REQUIRES: aspect-ext_intel_fpga_task_sequence
 // RUN: %clangxx -fsycl -fintelfpga %s -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
This change disables task sequence tests that are failing in post-commit. The tests will be reenabled when the fpga emulator changes are in.