### PR TITLE
[SYCL][UR] Use static cast instead of ur::cast

### DIFF
--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -96,7 +96,7 @@ struct BufferInterop {
   GetNativeObjs(const std::vector<ur_native_handle_t> &Handle) {
     ReturnType ReturnValue = 0;
     if (Handle.size()) {
-      ReturnValue = detail::ur::cast<ReturnType>(Handle[0]);
+      ReturnValue = static_cast<ReturnType>(Handle[0]);
     }
     return ReturnValue;
   }

--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -96,11 +96,7 @@ struct BufferInterop {
   GetNativeObjs(const std::vector<ur_native_handle_t> &Handle) {
     ReturnType ReturnValue = 0;
     if (Handle.size()) {
-#ifdef _WIN32
-      ReturnValue = detail::ur::cast<ReturnType>(Handle[0]);
-#else
-      ReturnValue = static_cast<ReturnType>(Handle[0]);
-#endif
+      ReturnValue = (ReturnType)(Handle[0]);
     }
     return ReturnValue;
   }

--- a/sycl/include/sycl/backend.hpp
+++ b/sycl/include/sycl/backend.hpp
@@ -96,7 +96,11 @@ struct BufferInterop {
   GetNativeObjs(const std::vector<ur_native_handle_t> &Handle) {
     ReturnType ReturnValue = 0;
     if (Handle.size()) {
+#ifdef _WIN32
+      ReturnValue = detail::ur::cast<ReturnType>(Handle[0]);
+#else
       ReturnValue = static_cast<ReturnType>(Handle[0]);
+#endif
     }
     return ReturnValue;
   }

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
@@ -2,9 +2,6 @@
 // RUN: %{run} %t.out
 // REQUIRES: cuda, cuda_dev_kit
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: windows, linux
-
 #include <cuda.h>
 
 #include <iostream>

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} -o %t.out %cuda_options
 // RUN: %{run} %t.out
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: windows
-
 #include <cuda.h>
 
 #include <iostream>


### PR DESCRIPTION
UR cast is using reinterpret cast under the hood, which was failing for an 
unsigned long being cast to an unsigned long long. From the C++ spec:

> An expression of integral, enumeration, pointer, or pointer-to-member 
type can be converted to its own type. The resulting value is the same as 
the value of expression.

Since `unsigned long` is not the same type as `unsigned long long`, the
`reinterpret_cast` fails.

Ping @aarongreig 