### PR TITLE
[SYCL][AMD] Propagate metadata in createURProgram

### DIFF
--- a/sycl/source/detail/device_binary_image.cpp
+++ b/sycl/source/detail/device_binary_image.cpp
@@ -178,6 +178,11 @@ void RTDeviceBinaryImage::init(sycl_device_binary Bin) {
   KernelParamOptInfo.init(Bin, __SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO);
   AssertUsed.init(Bin, __SYCL_PROPERTY_SET_SYCL_ASSERT_USED);
   ProgramMetadata.init(Bin, __SYCL_PROPERTY_SET_PROGRAM_METADATA);
+  // Convert ProgramMetadata into the UR format
+  for (const auto &Prop : ProgramMetadata) {
+    ProgramMetadataUR.push_back(
+        ur::mapDeviceBinaryPropertyToProgramMetadata(Prop));
+  }
   ExportedSymbols.init(Bin, __SYCL_PROPERTY_SET_SYCL_EXPORTED_SYMBOLS);
   ImportedSymbols.init(Bin, __SYCL_PROPERTY_SET_SYCL_IMPORTED_SYMBOLS);
   DeviceGlobals.init(Bin, __SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS);

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -216,7 +216,11 @@ ProgramManager::createURProgram(const RTDeviceBinaryImage &Img,
         "SPIR-V online compilation is not supported in this context");
 
   // Get program metadata from properties
-  auto ProgMetadata = Img.getProgramMetadataUR();
+  std::vector<ur_program_metadata_t> ProgMetadataVector;
+  for (const auto &Prop : Img.getProgramMetadata()) {
+    ProgMetadataVector.push_back(
+        ur::mapDeviceBinaryPropertyToProgramMetadata(Prop));
+  }
 
   // Load the image
   const ContextImplPtr Ctx = getSyclObjImpl(Context);
@@ -224,7 +228,7 @@ ProgramManager::createURProgram(const RTDeviceBinaryImage &Img,
       Format == SYCL_DEVICE_BINARY_TYPE_SPIRV
           ? createSpirvProgram(Ctx, RawImg.BinaryStart, ImgSize)
           : createBinaryProgram(Ctx, Device, RawImg.BinaryStart, ImgSize,
-                                ProgMetadata);
+                                ProgMetadataVector);
 
   {
     std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);

--- a/sycl/test-e2e/Basic/reqd_work_group_size.cpp
+++ b/sycl/test-e2e/Basic/reqd_work_group_size.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: linux, windows
-
 #include <sycl/detail/core.hpp>
 
 #include <iostream>

--- a/sycl/test-e2e/DeviceGlobal/device_global_arrow.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_arrow.cpp
@@ -3,8 +3,7 @@
 //
 // The OpenCL GPU backends do not currently support device_global backend
 // calls.
-// TODO: Reenable linux/windows, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: opencl && gpu, linux, windows
+// UNSUPPORTED: opencl && gpu
 //
 // Tests operator-> on device_global.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_device_only.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_device_only.cpp
@@ -3,8 +3,7 @@
 //
 // The OpenCL GPU backends do not currently support device_global backend
 // calls.
-// TODO: Reenable linux/windows, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: opencl && gpu, linux, windows
+// UNSUPPORTED: opencl && gpu
 //
 // Tests basic device_global access through device kernels.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough.cpp
@@ -3,8 +3,7 @@
 //
 // The OpenCL GPU backends do not currently support device_global backend
 // calls.
-// TODO: Reenable linux/windows, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: opencl && gpu, linux, windows
+// UNSUPPORTED: opencl && gpu
 //
 // Tests the passthrough of operators on device_global.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_subscript.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_subscript.cpp
@@ -3,8 +3,7 @@
 //
 // The OpenCL GPU backends do not currently support device_global backend
 // calls.
-// TODO: Reenable linux/windows, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: opencl && gpu, linux, windows
+// UNSUPPORTED: opencl && gpu
 //
 // Tests operator[] on device_global.
 

--- a/sycl/test-e2e/KernelFusion/lit.local.cfg
+++ b/sycl/test-e2e/KernelFusion/lit.local.cfg
@@ -2,7 +2,7 @@ import platform
 
 config.required_features += ['fusion']
 # TODO: Reenable hip, see https://github.com/intel/llvm/issues/14598
-config.unsupported_features += ['accelerator', 'hip']
+config.unsupported_features += ['accelerator']
 
 # TODO: enable on Windows once kernel fusion is supported on Windows.
 if platform.system() != "Linux":

--- a/sycl/test-e2e/KernelFusion/lit.local.cfg
+++ b/sycl/test-e2e/KernelFusion/lit.local.cfg
@@ -1,7 +1,6 @@
 import platform
 
 config.required_features += ['fusion']
-# TODO: Reenable hip, see https://github.com/intel/llvm/issues/14598
 config.unsupported_features += ['accelerator']
 
 # TODO: enable on Windows once kernel fusion is supported on Windows.

--- a/sycl/test-e2e/NewOffloadDriver/diamond_shape.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/diamond_shape.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: fusion
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: hip
 
 // RUN: %{build} %{embed-ir} -O2 --offload-new-driver -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
SYCL properties weren't converted when calling creatreURProgram, leading to issue in finalization during KernelFusion for AMD.

Fixes #14841