### PR TITLE
[SYCL][ESIMD] Fix driver check in two tests

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_dg2_pvc_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_acc_dg2_pvc_cmpxchg.cpp
@@ -7,7 +7,7 @@
 //===---------------------------------------------------------------------===//
 
 // REQUIRES: arch-intel_gpu_pvc || gpu-intel-dg2
-// REQUIRES-INTEL-DRIVER: win: 101.5660
+// REQUIRES-INTEL-DRIVER: lin: 29803
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_usm_dg2_pvc_cmpxchg.cpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/atomic_update_usm_dg2_pvc_cmpxchg.cpp
@@ -7,7 +7,7 @@
 //===---------------------------------------------------------------------===//
 
 // REQUIRES: arch-intel_gpu_pvc || gpu-intel-dg2
-// REQUIRES-INTEL-DRIVER: win: 101.5660
+// REQUIRES-INTEL-DRIVER: lin: 29803
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
When using L0 we always see the x.y.zzzzz style version, even on Windows. These tests were incorrectly running on Windows because of this problem.