### PR TITLE
[SYCL] Fix use of removed ArchType enum

### DIFF
--- a/sycl-fusion/passes/kernel-fusion/SYCLSpecConstMaterializer.cpp
+++ b/sycl-fusion/passes/kernel-fusion/SYCLSpecConstMaterializer.cpp
@@ -14,6 +14,7 @@
 #include <llvm/ADT/StringRef.h>
 #include <llvm/Support/CommandLine.h>
 #include <llvm/Support/Debug.h>
+#include <llvm/TargetParser/Triple.h>
 
 #define DEBUG_TYPE "sycl-spec-const-materializer"
 
@@ -298,9 +299,8 @@ PreservedAnalyses SYCLSpecConstMaterializer::run(Function &F,
   // Invariant: This pass is only intended to operate on SYCL kernels being
   // compiled to either `nvptx{,64}-nvidia-cuda`, or `amdgcn-amd-amdhsa`
   // triples.
-  auto AT = TargetHelpers::getArchType(*Mod);
-  if (TargetHelpers::ArchType::Cuda != AT &&
-      TargetHelpers::ArchType::AMDHSA != AT) {
+  Triple T(Mod->getTargetTriple());
+  if (!T.isNVPTX() && !T.isAMDGCN()) {
     LLVM_DEBUG(dbgs() << "Unsupported architecture\n");
     return PreservedAnalyses::all();
   }


### PR DESCRIPTION
Two concurrent PRs added a new use of and simultaneously removed this enum. Commit 63c61d85 added a new use, while dc37699b was trying to delete it.