### PR TITLE
[SYCL] Rename `detail::memcpy` to `detail::memcpy_no_adl`

### DIFF
--- a/sycl/include/sycl/bit_cast.hpp
+++ b/sycl/include/sycl/bit_cast.hpp
@@ -61,7 +61,7 @@ constexpr
   static_assert(std::is_trivially_default_constructible<To>::value,
                 "To must be trivially default constructible");
   To to;
-  sycl::detail::memcpy(&to, &from, sizeof(To));
+  sycl::detail::memcpy_no_adl(&to, &from, sizeof(To));
   return to;
 #endif
 }

--- a/sycl/include/sycl/detail/group_sort_impl.hpp
+++ b/sycl/include/sycl/detail/group_sort_impl.hpp
@@ -495,28 +495,28 @@ public:
 
     operator T() const {
       T value{0};
-      detail::memcpy(&value, MPtr, sizeof(T));
+      detail::memcpy_no_adl(&value, MPtr, sizeof(T));
       return value;
     }
 
     T operator++(int) noexcept {
       T value{0};
-      detail::memcpy(&value, MPtr, sizeof(T));
+      detail::memcpy_no_adl(&value, MPtr, sizeof(T));
       T value_before = value++;
-      detail::memcpy(MPtr, &value, sizeof(T));
+      detail::memcpy_no_adl(MPtr, &value, sizeof(T));
       return value_before;
     }
 
     T operator++() noexcept {
       T value{0};
-      detail::memcpy(&value, MPtr, sizeof(T));
+      detail::memcpy_no_adl(&value, MPtr, sizeof(T));
       ++value;
-      detail::memcpy(MPtr, &value, sizeof(T));
+      detail::memcpy_no_adl(MPtr, &value, sizeof(T));
       return value;
     }
 
     ReferenceObj &operator=(const T &value) noexcept {
-      detail::memcpy(MPtr, &value, sizeof(T));
+      detail::memcpy_no_adl(MPtr, &value, sizeof(T));
       return *this;
     }
 
@@ -531,7 +531,7 @@ public:
     }
 
     void copy(const ReferenceObj &value) noexcept {
-      detail::memcpy(MPtr, value.MPtr, sizeof(T));
+      detail::memcpy_no_adl(MPtr, value.MPtr, sizeof(T));
     }
 
   private:

--- a/sycl/include/sycl/detail/memcpy.hpp
+++ b/sycl/include/sycl/detail/memcpy.hpp
@@ -13,7 +13,13 @@
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-inline void memcpy(void *Dst, const void *Src, size_t Size) {
+// Using "memcpy_no_adl" function name instead of "memcpy" to prevent
+// ambiguity with libc's memcpy. Even though they are in a different
+// namespace, due to ADL, compiler may lookup "memcpy" symbol in the
+// sycl::detail namespace, like in the following code:
+//    sycl::vec<int , 1> a, b;
+//    memcpy(&a, &b, sizeof(sycl::vec<int , 1>));
+inline void memcpy_no_adl(void *Dst, const void *Src, size_t Size) {
 #ifdef __SYCL_DEVICE_ONLY__
   __builtin_memcpy(Dst, Src, Size);
 #else

--- a/sycl/include/sycl/detail/spirv.hpp
+++ b/sycl/include/sycl/detail/spirv.hpp
@@ -397,9 +397,9 @@ EnableIfGenericBroadcast<T, IdT> GroupBroadcast(Group g, T x, IdT local_id) {
   char *ResultBytes = reinterpret_cast<char *>(&Result);
   auto BroadcastBytes = [=](size_t Offset, size_t Size) {
     uint64_t BroadcastX, BroadcastResult;
-    detail::memcpy(&BroadcastX, XBytes + Offset, Size);
+    detail::memcpy_no_adl(&BroadcastX, XBytes + Offset, Size);
     BroadcastResult = GroupBroadcast(g, BroadcastX, local_id);
-    detail::memcpy(ResultBytes + Offset, &BroadcastResult, Size);
+    detail::memcpy_no_adl(ResultBytes + Offset, &BroadcastResult, Size);
   };
   GenericCall<T>(BroadcastBytes);
   return Result;
@@ -449,9 +449,9 @@ EnableIfGenericBroadcast<T> GroupBroadcast(Group g, T x,
   char *ResultBytes = reinterpret_cast<char *>(&Result);
   auto BroadcastBytes = [=](size_t Offset, size_t Size) {
     uint64_t BroadcastX, BroadcastResult;
-    detail::memcpy(&BroadcastX, XBytes + Offset, Size);
+    detail::memcpy_no_adl(&BroadcastX, XBytes + Offset, Size);
     BroadcastResult = GroupBroadcast(g, BroadcastX, local_id);
-    detail::memcpy(ResultBytes + Offset, &BroadcastResult, Size);
+    detail::memcpy_no_adl(ResultBytes + Offset, &BroadcastResult, Size);
   };
   GenericCall<T>(BroadcastBytes);
   return Result;
@@ -1104,9 +1104,9 @@ EnableIfGenericShuffle<T> Shuffle(GroupT g, T x, id<1> local_id) {
   char *ResultBytes = reinterpret_cast<char *>(&Result);
   auto ShuffleBytes = [=](size_t Offset, size_t Size) {
     ShuffleChunkT ShuffleX, ShuffleResult;
-    detail::memcpy(&ShuffleX, XBytes + Offset, Size);
+    detail::memcpy_no_adl(&ShuffleX, XBytes + Offset, Size);
     ShuffleResult = Shuffle(g, ShuffleX, local_id);
-    detail::memcpy(ResultBytes + Offset, &ShuffleResult, Size);
+    detail::memcpy_no_adl(ResultBytes + Offset, &ShuffleResult, Size);
   };
   GenericCall<T>(ShuffleBytes);
   return Result;
@@ -1119,9 +1119,9 @@ EnableIfGenericShuffle<T> ShuffleXor(GroupT g, T x, id<1> local_id) {
   char *ResultBytes = reinterpret_cast<char *>(&Result);
   auto ShuffleBytes = [=](size_t Offset, size_t Size) {
     ShuffleChunkT ShuffleX, ShuffleResult;
-    detail::memcpy(&ShuffleX, XBytes + Offset, Size);
+    detail::memcpy_no_adl(&ShuffleX, XBytes + Offset, Size);
     ShuffleResult = ShuffleXor(g, ShuffleX, local_id);
-    detail::memcpy(ResultBytes + Offset, &ShuffleResult, Size);
+    detail::memcpy_no_adl(ResultBytes + Offset, &ShuffleResult, Size);
   };
   GenericCall<T>(ShuffleBytes);
   return Result;
@@ -1134,9 +1134,9 @@ EnableIfGenericShuffle<T> ShuffleDown(GroupT g, T x, uint32_t delta) {
   char *ResultBytes = reinterpret_cast<char *>(&Result);
   auto ShuffleBytes = [=](size_t Offset, size_t Size) {
     ShuffleChunkT ShuffleX, ShuffleResult;
-    detail::memcpy(&ShuffleX, XBytes + Offset, Size);
+    detail::memcpy_no_adl(&ShuffleX, XBytes + Offset, Size);
     ShuffleResult = ShuffleDown(g, ShuffleX, delta);
-    detail::memcpy(ResultBytes + Offset, &ShuffleResult, Size);
+    detail::memcpy_no_adl(ResultBytes + Offset, &ShuffleResult, Size);
   };
   GenericCall<T>(ShuffleBytes);
   return Result;
@@ -1149,9 +1149,9 @@ EnableIfGenericShuffle<T> ShuffleUp(GroupT g, T x, uint32_t delta) {
   char *ResultBytes = reinterpret_cast<char *>(&Result);
   auto ShuffleBytes = [=](size_t Offset, size_t Size) {
     ShuffleChunkT ShuffleX, ShuffleResult;
-    detail::memcpy(&ShuffleX, XBytes + Offset, Size);
+    detail::memcpy_no_adl(&ShuffleX, XBytes + Offset, Size);
     ShuffleResult = ShuffleUp(g, ShuffleX, delta);
-    detail::memcpy(ResultBytes + Offset, &ShuffleResult, Size);
+    detail::memcpy_no_adl(ResultBytes + Offset, &ShuffleResult, Size);
   };
   GenericCall<T>(ShuffleBytes);
   return Result;

--- a/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/bfloat16_math.hpp
@@ -26,7 +26,7 @@ namespace detail {
 template <size_t N>
 uint32_t to_uint32_t(sycl::marray<bfloat16, N> x, size_t start) {
   uint32_t res;
-  sycl::detail::memcpy(&res, &x[start], sizeof(uint32_t));
+  sycl::detail::memcpy_no_adl(&res, &x[start], sizeof(uint32_t));
   return res;
 }
 } // namespace detail
@@ -112,7 +112,7 @@ sycl::marray<bfloat16, N> fabs(sycl::marray<bfloat16, N> x) {
     (__SYCL_CUDA_ARCH__ >= 800)
   for (size_t i = 0; i < N / 2; i++) {
     auto partial_res = __clc_fabs(detail::to_uint32_t(x, i * 2));
-    sycl::detail::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+    sycl::detail::memcpy_no_adl(&res[i * 2], &partial_res, sizeof(uint32_t));
   }
 
   if (N % 2) {
@@ -188,7 +188,7 @@ sycl::marray<bfloat16, N> fmin(sycl::marray<bfloat16, N> x,
   for (size_t i = 0; i < N / 2; i++) {
     auto partial_res = __clc_fmin(detail::to_uint32_t(x, i * 2),
                                   detail::to_uint32_t(y, i * 2));
-    sycl::detail::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+    sycl::detail::memcpy_no_adl(&res[i * 2], &partial_res, sizeof(uint32_t));
   }
 
   if (N % 2) {
@@ -270,7 +270,7 @@ sycl::marray<bfloat16, N> fmax(sycl::marray<bfloat16, N> x,
   for (size_t i = 0; i < N / 2; i++) {
     auto partial_res = __clc_fmax(detail::to_uint32_t(x, i * 2),
                                   detail::to_uint32_t(y, i * 2));
-    sycl::detail::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+    sycl::detail::memcpy_no_adl(&res[i * 2], &partial_res, sizeof(uint32_t));
   }
 
   if (N % 2) {
@@ -340,7 +340,7 @@ sycl::marray<bfloat16, N> fma(sycl::marray<bfloat16, N> x,
     auto partial_res =
         __clc_fma(detail::to_uint32_t(x, i * 2), detail::to_uint32_t(y, i * 2),
                   detail::to_uint32_t(z, i * 2));
-    sycl::detail::memcpy(&res[i * 2], &partial_res, sizeof(uint32_t));
+    sycl::detail::memcpy_no_adl(&res[i * 2], &partial_res, sizeof(uint32_t));
   }
 
   if (N % 2) {

--- a/sycl/include/sycl/ext/oneapi/experimental/builtins.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/builtins.hpp
@@ -126,7 +126,7 @@ inline __SYCL_ALWAYS_INLINE
 #else
     auto partial_res = sycl::tanh(sycl::detail::to_vec2(x, i * 2));
 #endif
-    sycl::detail::memcpy(&res[i * 2], &partial_res, sizeof(vec<T, 2>));
+    sycl::detail::memcpy_no_adl(&res[i * 2], &partial_res, sizeof(vec<T, 2>));
   }
   if (N % 2) {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)
@@ -167,7 +167,7 @@ exp2(sycl::marray<half, N> x) __NOEXC {
 #else
     auto partial_res = sycl::exp2(sycl::detail::to_vec2(x, i * 2));
 #endif
-    sycl::detail::memcpy(&res[i * 2], &partial_res, sizeof(vec<half, 2>));
+    sycl::detail::memcpy_no_adl(&res[i * 2], &partial_res, sizeof(vec<half, 2>));
   }
   if (N % 2) {
 #if defined(__SYCL_DEVICE_ONLY__) && defined(__NVPTX__)

--- a/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
+++ b/sycl/include/sycl/ext/oneapi/sub_group_mask.hpp
@@ -111,7 +111,7 @@ struct sub_group_mask {
       size_t RemainingBytes = sizeof(Bits) - BytesCopied;
       size_t BytesToCopy =
           RemainingBytes < sizeof(T) ? RemainingBytes : sizeof(T);
-      sycl::detail::memcpy(reinterpret_cast<char *>(&Bits) + BytesCopied,
+      sycl::detail::memcpy_no_adl(reinterpret_cast<char *>(&Bits) + BytesCopied,
                            &val[I], BytesToCopy);
       BytesCopied += BytesToCopy;
     }


### PR DESCRIPTION
`detail::memcpy`, even though in a different namespace, can cause ambiguity with libc's `memcpy`, due to argument dependent lookup (ADL).
For example, the compiler throws a compilation error due to `memcpy` ambiguity in the following code:
```
#include <sycl/vector.hpp>

template <typename T>
void foo(T *dst, T *src, size_t count) {
          memcpy(dst, src, count * sizeof(T));
}

using T = sycl::vec<int, 1>;

SYCL_EXTERNAL void bar(T *dst, T *src, size_t count) {
          foo(dst, src, count * sizeof(T));
}
```

Compilation error:
```
memcpy_test.cpp:5:4: error: call to 'memcpy' is ambiguous
    5 |           memcpy(dst, src, count * sizeof(T));
      |           ^~~~~~
memcpy_test.cpp:11:4: note: in instantiation of function template specialization 'foo<sycl::vec<int, 1>>' requested here
   11 |           foo(dst, src, count * sizeof(T));
      |           ^
/usr/include/string.h:43:14: note: candidate function
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^
llvm/build/bin/../include/sycl/detail/memcpy.hpp:16:13: note: candidate function
   16 | inline void memcpy(void *Dst, const void *Src, size_t Size) {
      |             ^
1 error generated.
```

To fix this error, this PR renames `detail::memcpy` to `detail::memcpy_no_adl`