### PR TITLE
[DeviceSanitizer] Revert LoopIdiomRecognize changes for asan

### DIFF
--- a/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
+++ b/llvm/lib/Transforms/Scalar/LoopIdiomRecognize.cpp
@@ -292,10 +292,6 @@ bool LoopIdiomRecognize::runOnLoop(Loop *L) {
   if (Name == "memset" || Name == "memcpy")
     return false;
 
-  // Prevent from asan interception in kernel
-  if (Name == "__asan_set_shadow_local_memory")
-    return false;
-
   // Determine if code size heuristics need to be applied.
   ApplyCodeSizeHeuristics =
       L->getHeader()->getParent()->hasOptSize() && UseLIRCodeSizeHeurs;


### PR DESCRIPTION
We added some codes to prevent "LoopIdiomRecognize" from converting loop to memset, so that it won't conflict with host Asan. Now we needn't this fix anymore.