### PR TITLE
Fix UR program metadata initialization

### DIFF
--- a/sycl/source/detail/device_binary_image.cpp
+++ b/sycl/source/detail/device_binary_image.cpp
@@ -185,6 +185,11 @@ void RTDeviceBinaryImage::init(sycl_device_binary Bin) {
   HostPipes.init(Bin, __SYCL_PROPERTY_SET_SYCL_HOST_PIPES);
   VirtualFunctions.init(Bin, __SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS);
 
+  for (const auto &Prop : ProgramMetadata) {
+    ProgramMetadataUR.push_back(
+        ur::mapDeviceBinaryPropertyToProgramMetadata(Prop));
+  }
+
   ImageId = ImageCounter++;
 }
 

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -500,10 +500,9 @@ std::pair<ur_program_handle_t, bool> ProgramManager::getOrCreateURProgram(
     // Get program metadata from properties
     std::vector<ur_program_metadata_t> ProgMetadataVector;
     for (const RTDeviceBinaryImage *Img : AllImages) {
-      auto ProgMetadata = Img->getProgramMetadata();
+      auto ProgMetadata = Img->getProgramMetadataUR();
       for (const auto &Prop : ProgMetadata) {
-        ProgMetadataVector.push_back(
-            ur::mapDeviceBinaryPropertyToProgramMetadata(Prop));
+        ProgMetadataVector.push_back(Prop);
       }
     }
     // TODO: Build for multiple devices once supported by program manager

--- a/sycl/test-e2e/Basic/reqd_work_group_size.cpp
+++ b/sycl/test-e2e/Basic/reqd_work_group_size.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: linux, windows
-
 #include <sycl/detail/core.hpp>
 
 #include <iostream>


### PR DESCRIPTION
In #14145 we accidentally started dropping all program properties by not correctly initializing the UR metadata.

Fixes #14841 
