### PR TITLE
[SYCL] Fix XPASS of Matrix test on new GPU driver

### DIFF
--- a/sycl/test-e2e/Matrix/get_coord_int8_matB.cpp
+++ b/sycl/test-e2e/Matrix/get_coord_int8_matB.cpp
@@ -9,7 +9,7 @@
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// XFAIL: cpu, gpu-intel-dg2
+// XFAIL: cpu
 
 #include "common.hpp"
 #include "get_coord_int8_matB_impl.hpp"


### PR DESCRIPTION
It's passing in the new driver uplift:

https://github.com/intel/llvm/actions/runs/10164787306/job/28112343861