### PR TITLE
[NFC] Rename ext_codeplay_enqueue_native_command to ext_oneapi_enqueue_native_command

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,12 +116,13 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit bc1a28ede0df7f837047b632e00437587672c134
+  # commit 99489ad46853c24a078d7ad35259cc6278498fe5
+  # Merge: 3e762e00 3f13f69e
   # Author: Omar Ahmed <omar.ahmed@codeplay.com>
-  # Date:   Mon Jul 29 16:44:58 2024 +0100
-  #     Merge pull request #1819 from DBDuncan/sean/rename-interop-to-external
-  #    [Bindless][Exp] Rename interop related structs/funcs with "external"
-  set(UNIFIED_RUNTIME_TAG bc1a28ede0df7f837047b632e00437587672c134)
+  # Date:   Wed Jul 31 13:23:29 2024 +0100
+  #    Merge pull request #1880 from hdelan/l0-native-enqueue
+  #    [L0] L0 impl for enqueue native command
+  set(UNIFIED_RUNTIME_TAG 99489ad46853c24a078d7ad35259cc6278498fe5)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc
@@ -1,4 +1,4 @@
-= sycl_ext_codeplay_enqueue_native_command
+= sycl_ext_oneapi_enqueue_native_command
 
 :source-highlighter: coderay
 :coderay-linenums-mode: table
@@ -66,7 +66,7 @@ This extension is derived from the experimental AdaptiveCpp extension,
 `enqueue_custom_operation` which is documented
 https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/enqueue-custom-operation.md[here].
 
-The goal of `ext_codeplay_enqueue_native_command` is to integrate interop
+The goal of `ext_oneapi_enqueue_native_command` is to integrate interop
 work within the SYCL runtime's creation of the asynchronous SYCL DAG. As such,
 the user defined lambda must only enqueue asynchronous, as opposed to
 synchronous, backend work within the user lambda. Asynchronous work must only
@@ -75,11 +75,11 @@ be submitted to the native queue obtained from
 
 === Differences with `host_task`
 
-A callable submitted to `ext_codeplay_enqueue_native_command` won't wait
+A callable submitted to `ext_oneapi_enqueue_native_command` won't wait
 on its dependent events to execute. The dependencies passed to an
-`ext_codeplay_enqueue_native_command` submission will result in dependencies being
+`ext_oneapi_enqueue_native_command` submission will result in dependencies being
 implicitly handled in the backend API, using the native queue object associated
-with the SYCL queue that the `sycl_ext_codeplay_enqueue_native_command` is
+with the SYCL queue that the `sycl_ext_oneapi_enqueue_native_command` is
 submitted to. This gives different synchronization guarantees from normal SYCL
 `host_task` s, which guarantee that the `host_task` callable will only begin
 execution once all of its dependent events have completed.
@@ -89,7 +89,7 @@ In this example:
 ```
 q.submit([&](sycl::handler &cgh) {
     cgh.depends_on(dep_event);
-    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle &h) {
+    cgh.ext_oneapi_enqueue_native_command([=](sycl::interop_handle &h) {
       printf("This will print before dep_event has completed.\n");
       // This stream has been synchronized with dep_event's underlying
       // hipEvent_t
@@ -112,7 +112,7 @@ will only happen once the host task's dependent events are observed to be
 complete on the host.
 
 A SYCL event returned by a submission of a
-`ext_codeplay_enqueue_native_command` command is only complete once the
+`ext_oneapi_enqueue_native_command` command is only complete once the
 asynchronous work enqueued to the native queue obtained through
 `interop_handle::get_native_queue()` has completed.
 
@@ -147,7 +147,7 @@ class:
 ```c++
 class handler {
   template <typename Func>
-  void ext_codeplay_enqueue_native_command(Func&& interopCallable);
+  void ext_oneapi_enqueue_native_command(Func&& interopCallable);
 };
 ```
 
@@ -156,7 +156,7 @@ parameter of type `interop_handle`.
 
 _Effects_: The `interopCallable` object is called exactly once, and this call
 may be made asynchronously even after the calling thread returns from
-`ext_codeplay_enqueue_native_command`.
+`ext_oneapi_enqueue_native_command`.
 
 The call to `interopCallable` may submit one or more asynchronous tasks to the
 native backend object obtained from `interop_handle::get_native_queue`, and
@@ -189,7 +189,7 @@ sycl::queue q;
 q.submit([&](sycl::handler &cgh) {
     sycl::accessor acc{buf, cgh};
 
-    cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle &h) {
+    cgh.ext_oneapi_enqueue_native_command([=](sycl::interop_handle &h) {
       // Can extract device pointers from accessors
       void *native_mem = h.get_native_mem<sycl::backend::hip>(acc);
       // Can extract stream
@@ -211,7 +211,7 @@ q.wait();
 
 === sycl_ext_oneapi_graph
 
-`ext_codeplay_enqueue_native_command`
+`ext_oneapi_enqueue_native_command`
 cannot be used in graph nodes. A synchronous exception will be thrown with error
 code `invalid` if a user tries to add them to a graph.
 

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc
@@ -54,10 +54,10 @@ specification.*
 == Backend support status
 
 This extension is currently implemented in {dpcpp} only for GPU devices and
-only when using the CUDA or HIP backends.  Attempting to use this extension in
-kernels that run on other devices or backends may result in undefined
-behavior.  Be aware that the compiler is not able to issue a diagnostic to
-warn you if this happens.
+only when using the Level Zero, CUDA, HIP backends.  Attempting to use this
+extension in kernels that run on other devices or backends may result in
+undefined behavior.  Be aware that the compiler is not able to issue a
+diagnostic to warn you if this happens.
 
 
 == Overview
@@ -86,16 +86,14 @@ execution once all of its dependent events have completed.
 
 In this example:
 
-```
+```c++
 q.submit([&](sycl::handler &cgh) {
     cgh.depends_on(dep_event);
     cgh.ext_oneapi_enqueue_native_command([=](sycl::interop_handle &h) {
-      printf("This will print before dep_event has completed.\n");
-      // This stream has been synchronized with dep_event's underlying
-      // hipEvent_t
-      hipStream_t stream = h.get_native_queue<sycl::backend::hip>();
-      hipMemcpyAsync(target_ptr, native_mem, test_size * sizeof(int),
-                      hipMemcpyDeviceToHost, stream);
+      printf("This may print before dep_event has completed.\n");
+      auto command_list = h.get_native_queue<sycl::backend::level_zero>();
+      zeCommandListAppendMemoryCopy(
+              command_list, dstmem, srcmem, sz, nullptr, 0, nullptr);
     });
   });
 q.wait()
@@ -180,6 +178,27 @@ queue, aside from the queue that is associated with this handler. If it does
 any of these things, the behavior is undefined.
 
 == Example
+
+```c++
+sycl::queue q;
+q.submit([&](sycl::handler &cgh) {
+    sycl::accessor acc{buf, cgh};
+    cgh.ext_oneapi_enqueue_native_command([=](sycl::interop_handle &h) {
+      // Can extract device mem from accessor
+      auto src = IH.get_native_mem<backend::ext_oneapi_level_zero>(acc);
+      auto command_list = h.get_native_queue<sycl::backend::level_zero>();
+
+      // Can enqueue arbitrary backend operations. This could also be a kernel
+      // launch or call to a library that enqueues operations on the stream etc
+      //
+      // Important: Enqueuing a *synchronous* backend operation results in
+      // undefined behavior.
+      zeCommandListAppendMemoryCopy(
+              command_list, dst, src, sz, nullptr, 0, nullptr);
+    });
+  });
+q.wait();
+```
 
 This example demonstrates how to use this extension to enqueue asynchronous
 native tasks on the HIP backend.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc
@@ -88,12 +88,17 @@ In this example:
 
 ```c++
 q.submit([&](sycl::handler &cgh) {
+    sycl::accessor acc_src{buf_src, cgh};
+    sycl::accessor acc_dst{buf_dst, cgh};
     cgh.depends_on(dep_event);
     cgh.ext_oneapi_enqueue_native_command([=](sycl::interop_handle &h) {
       printf("This may print before dep_event has completed.\n");
+      auto src = IH.get_native_mem<backend::ext_oneapi_level_zero>(acc_src);
+      auto dst = IH.get_native_mem<backend::ext_oneapi_level_zero>(acc_dst);
       auto command_list = h.get_native_queue<sycl::backend::level_zero>();
       zeCommandListAppendMemoryCopy(
-              command_list, dstmem, srcmem, sz, nullptr, 0, nullptr);
+              command_list, dst, src, sizeof(T) * acc_src.get_count(), nullptr,
+              0, nullptr);
     });
   });
 q.wait()
@@ -182,19 +187,23 @@ any of these things, the behavior is undefined.
 ```c++
 sycl::queue q;
 q.submit([&](sycl::handler &cgh) {
-    sycl::accessor acc{buf, cgh};
+    sycl::accessor acc_src{buf_src, cgh};
+    sycl::accessor acc_dst{buf_dst, cgh};
     cgh.ext_oneapi_enqueue_native_command([=](sycl::interop_handle &h) {
       // Can extract device mem from accessor
-      auto src = IH.get_native_mem<backend::ext_oneapi_level_zero>(acc);
+      auto src = IH.get_native_mem<backend::ext_oneapi_level_zero>(acc_src);
+      auto dst = IH.get_native_mem<backend::ext_oneapi_level_zero>(acc_dst);
       auto command_list = h.get_native_queue<sycl::backend::level_zero>();
 
       // Can enqueue arbitrary backend operations. This could also be a kernel
-      // launch or call to a library that enqueues operations on the stream etc
+      // launch or call to a library that enqueues operations on the command
+      // list etc.
       //
       // Important: Enqueuing a *synchronous* backend operation results in
       // undefined behavior.
       zeCommandListAppendMemoryCopy(
-              command_list, dst, src, sz, nullptr, 0, nullptr);
+              command_list, dst, src, sizeof(T) * acc_src.get_count(), nullptr,
+              0, nullptr);
     });
   });
 q.wait();
@@ -215,7 +224,7 @@ q.submit([&](sycl::handler &cgh) {
       hipStream_t stream = h.get_native_queue<sycl::backend::hip>();
 
       // Can enqueue arbitrary backend operations. This could also be a kernel
-      // launch or call to a library that enqueues operations on the stream etc
+      // launch or call to a library that enqueues operations on the stream etc.
       //
       // Important: Enqueuing a *synchronous* backend operation results in
       // undefined behavior.

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1943,10 +1943,10 @@ The kernels loaded using
 link:../experimental/sycl_ext_oneapi_kernel_compiler_spirv.asciidoc[sycl_ext_oneapi_kernel_compiler_spirv]
 behave as normal when used in graph nodes.
 
-==== sycl_ext_codeplay_enqueue_native_command
+==== sycl_ext_oneapi_enqueue_native_command
 
-`ext_codeplay_enqueue_native_command`, defined in
-link:../experimental/sycl_ext_codeplay_enqueue_native_command.asciidoc[sycl_ext_codeplay_enqueue_native_command]
+`ext_oneapi_enqueue_native_command`, defined in
+link:../experimental/sycl_ext_oneapi_enqueue_native_command.asciidoc[sycl_ext_oneapi_enqueue_native_command]
 cannot be used in graph nodes. A synchronous exception will be thrown with error
 code `invalid` if a user tries to add them to a graph.
 

--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -55,7 +55,7 @@ enum class UnsupportedGraphFeatures {
   sycl_ext_oneapi_device_global = 6,
   sycl_ext_oneapi_bindless_images = 7,
   sycl_ext_oneapi_experimental_cuda_cluster_launch = 8,
-  sycl_ext_codeplay_enqueue_native_command = 9
+  sycl_ext_oneapi_enqueue_native_command = 9
 };
 
 inline const char *
@@ -80,8 +80,8 @@ UnsupportedFeatureToString(UnsupportedGraphFeatures Feature) {
     return "sycl_ext_oneapi_bindless_images";
   case UGF::sycl_ext_oneapi_experimental_cuda_cluster_launch:
     return "sycl_ext_oneapi_experimental_cuda_cluster_launch";
-  case UGF::sycl_ext_codeplay_enqueue_native_command:
-    return "sycl_ext_codeplay_enqueue_native_command";
+  case UGF::sycl_ext_oneapi_enqueue_native_command:
+    return "sycl_ext_oneapi_enqueue_native_command";
   }
 
   assert(false && "Unhandled graphs feature");

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1867,7 +1867,7 @@ private:
   template <typename FuncT>
   std::enable_if_t<detail::check_fn_signature<std::remove_reference_t<FuncT>,
                                               void(interop_handle)>::value>
-  ext_codeplay_enqueue_native_command_impl(FuncT &&Func) {
+  ext_oneapi_enqueue_native_command_impl(FuncT &&Func) {
     throwIfActionIsCreated();
 
     // Need to copy these rather than move so that we can check associated
@@ -2090,11 +2090,11 @@ public:
   template <typename FuncT>
   std::enable_if_t<detail::check_fn_signature<std::remove_reference_t<FuncT>,
                                               void(interop_handle)>::value>
-  ext_codeplay_enqueue_native_command(FuncT &&Func) {
+  ext_oneapi_enqueue_native_command(FuncT &&Func) {
     throwIfGraphAssociated<
         ext::oneapi::experimental::detail::UnsupportedGraphFeatures::
-            sycl_ext_codeplay_enqueue_native_command>();
-    ext_codeplay_enqueue_native_command_impl(Func);
+            sycl_ext_oneapi_enqueue_native_command>();
+    ext_oneapi_enqueue_native_command_impl(Func);
   }
 
   /// Defines and invokes a SYCL kernel function for the specified range and

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3196,7 +3196,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
         detail::getSyclObjImpl(MQueue->get_device())->getHandleRef(),
         UR_DEVICE_INFO_ENQUEUE_NATIVE_COMMAND_SUPPORT_EXP,
         sizeof(NativeCommandSupport), &NativeCommandSupport, nullptr);
-    assert(NativeCommandSupport && "ext_codeplay_enqueue_native_command is not "
+    assert(NativeCommandSupport && "ext_oneapi_enqueue_native_command is not "
                                    "supported on this device");
     MQueue->getPlugin()->call(urEnqueueNativeCommandExp, MQueue->getHandleRef(),
                               InteropFreeFunc, &CustomOpData, ReqMems.size(),

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-cuda.cpp
@@ -51,7 +51,7 @@ void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
       if (Q.get_backend() != IH.get_backend())
         throw;
     };
-    CGH.ext_codeplay_enqueue_native_command(Func);
+    CGH.ext_oneapi_enqueue_native_command(Func);
   });
 }
 
@@ -85,7 +85,7 @@ void test_ht_buffer(queue &Q) {
   Q.submit([&](handler &CGH) {
     auto Acc = Buffer.get_access<mode::write>(CGH);
     auto Func = [=](interop_handle IH) { /*A no-op */ };
-    CGH.ext_codeplay_enqueue_native_command(Func);
+    CGH.ext_oneapi_enqueue_native_command(Func);
   });
 }
 

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
@@ -57,7 +57,7 @@ void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
       if (Q.get_backend() != IH.get_backend())
         throw;
     };
-    CGH.ext_codeplay_enqueue_native_command(Func);
+    CGH.ext_oneapi_enqueue_native_command(Func);
   });
 }
 
@@ -91,7 +91,7 @@ void test_ht_buffer(queue &Q) {
   Q.submit([&](handler &CGH) {
     auto Acc = Buffer.get_access<mode::write>(CGH);
     auto Func = [=](interop_handle IH) { /*A no-op */ };
-    CGH.ext_codeplay_enqueue_native_command(Func);
+    CGH.ext_oneapi_enqueue_native_command(Func);
   });
 }
 

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-level-zero.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-level-zero.cpp
@@ -1,0 +1,134 @@
+// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
+// RUN: %{run} %t.out
+// REQUIRES: level_zero
+
+// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
+// UNSUPPORTED: windows
+
+#include "ze_api.h"
+
+#include <iostream>
+#include <sycl/backend.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/interop_handle.hpp>
+
+using namespace sycl;
+using namespace sycl::access;
+
+static constexpr size_t BUFFER_SIZE = 1024;
+
+template <typename T> class Modifier;
+
+template <typename T> class Init;
+
+template <typename BufferT, typename ValueT>
+void checkBufferValues(BufferT Buffer, ValueT Value) {
+  auto Acc = Buffer.get_host_access();
+  for (size_t Idx = 0; Idx < Acc.get_count(); ++Idx) {
+    if (Acc[Idx] != Value) {
+      std::cerr << "buffer[" << Idx << "] = " << Acc[Idx]
+                << ", expected val = " << Value << '\n';
+      exit(1);
+    }
+  }
+}
+
+template <typename DataT>
+void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
+  Q.submit([&](handler &CGH) {
+    auto SrcA = Src.template get_access<mode::read>(CGH);
+    auto DstA = Dst.template get_access<mode::write>(CGH);
+
+    auto Func = [=](interop_handle IH) {
+      auto CommandList = IH.get_native_queue<backend::ext_oneapi_level_zero>();
+      auto SrcMem = IH.get_native_mem<backend::ext_oneapi_level_zero>(SrcA);
+      auto DstMem = IH.get_native_mem<backend::ext_oneapi_level_zero>(DstA);
+
+      // If L0 interop becomes a real use case we should make a new UR entry
+      // point to propagate events into and out of the the interop func.
+      if (zeCommandListAppendMemoryCopy(
+              CommandList, DstMem, SrcMem, sizeof(DataT) * SrcA.get_count(),
+              nullptr, 0, nullptr) != ZE_RESULT_SUCCESS)
+        throw;
+      if (Q.get_backend() != IH.get_backend())
+        throw;
+    };
+    CGH.ext_oneapi_enqueue_native_command(Func);
+  });
+}
+
+template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
+  Q.submit([&](handler &CGH) {
+    auto Acc = B.template get_access<mode::read_write>(CGH);
+
+    auto Kernel = [=](item<1> Id) { Acc[Id] += 1; };
+
+    CGH.parallel_for<Modifier<DataT>>(Acc.get_count(), Kernel);
+  });
+}
+
+template <typename DataT, DataT B1Init, DataT B2Init>
+void init(buffer<DataT, 1> &B1, buffer<DataT, 1> &B2, queue &Q) {
+  Q.submit([&](handler &CGH) {
+    auto Acc1 = B1.template get_access<mode::write>(CGH);
+    auto Acc2 = B2.template get_access<mode::write>(CGH);
+
+    CGH.parallel_for<Init<DataT>>(BUFFER_SIZE, [=](item<1> Id) {
+      Acc1[Id] = B1Init;
+      Acc2[Id] = B2Init;
+    });
+  });
+}
+
+// Check that a single host-interop-task with a buffer will work.
+void test_ht_buffer(queue &Q) {
+  buffer<int, 1> Buffer{BUFFER_SIZE};
+
+  Q.submit([&](handler &CGH) {
+    auto Acc = Buffer.get_access<mode::write>(CGH);
+    auto Func = [=](interop_handle IH) { /*A no-op */ };
+    CGH.ext_oneapi_enqueue_native_command(Func);
+  });
+}
+
+// A test that uses level_zero interop to copy data from buffer A to buffer B,
+// by getting level_zero ptrs and calling the cuMemcpyWithAsync. Then run a SYCL
+// kernel that modifies the data in place for B, e.g. increment one, then copy
+// back to buffer A. Run it on a loop, to ensure the dependencies and the
+// reference counting of the objects is not leaked.
+void test_ht_kernel_dependencies(queue &Q) {
+  static constexpr int COUNT = 4;
+  buffer<int, 1> Buffer1{BUFFER_SIZE};
+  buffer<int, 1> Buffer2{BUFFER_SIZE};
+
+  // Init the buffer with a'priori invalid data.
+  init<int, -1, -2>(Buffer1, Buffer2, Q);
+
+  // Repeat a couple of times.
+  for (size_t Idx = 0; Idx < COUNT; ++Idx) {
+    copy(Buffer1, Buffer2, Q);
+    modify(Buffer2, Q);
+    copy(Buffer2, Buffer1, Q);
+  }
+
+  checkBufferValues(Buffer1, COUNT - 1);
+  checkBufferValues(Buffer2, COUNT - 1);
+}
+
+void tests(queue &Q) {
+  test_ht_buffer(Q);
+  test_ht_kernel_dependencies(Q);
+}
+
+int main() {
+  queue Q([](sycl::exception_list ExceptionList) {
+    if (ExceptionList.size() != 1) {
+      std::cerr << "Should be one exception in exception list" << std::endl;
+      std::abort();
+    }
+    std::rethrow_exception(*ExceptionList.begin());
+  });
+  tests(Q);
+  std::cout << "Test PASSED" << std::endl;
+  return 0;
+}

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-level-zero.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-level-zero.cpp
@@ -3,9 +3,6 @@
 
 // REQUIRES: level_zero, level_zero_dev_kit
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: windows
-
 #include <level_zero/ze_api.h>
 
 #include <iostream>
@@ -25,7 +22,7 @@ template <typename T> class Init;
 template <typename BufferT, typename ValueT>
 void checkBufferValues(BufferT Buffer, ValueT Value) {
   auto Acc = Buffer.get_host_access();
-  for (size_t Idx = 0; Idx < Acc.get_count(); ++Idx) {
+  for (size_t Idx = 0; Idx < Acc.size(); ++Idx) {
     if (Acc[Idx] != Value) {
       std::cerr << "buffer[" << Idx << "] = " << Acc[Idx]
                 << ", expected val = " << Value << '\n';
@@ -47,9 +44,9 @@ void copy(buffer<DataT, 1> &Src, buffer<DataT, 1> &Dst, queue &Q) {
 
       // If L0 interop becomes a real use case we should make a new UR entry
       // point to propagate events into and out of the the interop func.
-      if (zeCommandListAppendMemoryCopy(
-              CommandList, DstMem, SrcMem, sizeof(DataT) * SrcA.get_count(),
-              nullptr, 0, nullptr) != ZE_RESULT_SUCCESS)
+      if (zeCommandListAppendMemoryCopy(CommandList, DstMem, SrcMem,
+                                        sizeof(DataT) * SrcA.size(), nullptr, 0,
+                                        nullptr) != ZE_RESULT_SUCCESS)
         throw;
       if (Q.get_backend() != IH.get_backend())
         throw;
@@ -64,7 +61,7 @@ template <typename DataT> void modify(buffer<DataT, 1> &B, queue &Q) {
 
     auto Kernel = [=](item<1> Id) { Acc[Id] += 1; };
 
-    CGH.parallel_for<Modifier<DataT>>(Acc.get_count(), Kernel);
+    CGH.parallel_for<Modifier<DataT>>(Acc.size(), Kernel);
   });
 }
 

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-level-zero.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-level-zero.cpp
@@ -1,11 +1,12 @@
-// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
+// RUN: %{build} %level_zero_options -o %t.out
 // RUN: %{run} %t.out
-// REQUIRES: level_zero
+
+// REQUIRES: level_zero, level_zero_dev_kit
 
 // TODO: Reenable, see https://github.com/intel/llvm/issues/14598
 // UNSUPPORTED: windows
 
-#include "ze_api.h"
+#include <level_zero/ze_api.h>
 
 #include <iostream>
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-multiple-dev-cuda.cpp
@@ -35,7 +35,7 @@ int main() {
 
     Q.submit([&](handler &CGH) {
       accessor Acc{Buf, CGH, read_write};
-      CGH.ext_codeplay_enqueue_native_command([=](interop_handle IH) {
+      CGH.ext_oneapi_enqueue_native_command([=](interop_handle IH) {
         auto Ptr = IH.get_native_mem<backend::ext_oneapi_cuda>(Acc);
         auto Stream = IH.get_native_queue<backend::ext_oneapi_cuda>();
         int Tmp = 0;

--- a/sycl/unittests/Extensions/CommandGraph/Exceptions.cpp
+++ b/sycl/unittests/Extensions/CommandGraph/Exceptions.cpp
@@ -406,12 +406,12 @@ TEST_F(CommandGraphTest, BindlessExceptionCheck) {
   sycl::free(ImgMemUSM, Ctxt);
 }
 
-// ext_codeplay_enqueue_native_command isn't supported with SYCL graphs
+// ext_oneapi_enqueue_native_command isn't supported with SYCL graphs
 TEST_F(CommandGraphTest, EnqueueCustomCommandCheck) {
   std::error_code ExceptionCode = make_error_code(sycl::errc::success);
   try {
     Graph.add([&](sycl::handler &CGH) {
-      CGH.ext_codeplay_enqueue_native_command([=](sycl::interop_handle IH) {});
+      CGH.ext_oneapi_enqueue_native_command([=](sycl::interop_handle IH) {});
     });
   } catch (exception &Exception) {
     ExceptionCode = Exception.code();


### PR DESCRIPTION
Now that level zero supports this extension as of 
https://github.com/oneapi-src/unified-runtime/pull/1880, this extension should be a oneapi
ext instead of a codeplay one.