### PR TITLE
[SYCL] Fix XPTI/basic_event_collection_linux failure

### DIFF
--- a/sycl/test-e2e/XPTI/basic_event_collection_linux.cpp
+++ b/sycl/test-e2e/XPTI/basic_event_collection_linux.cpp
@@ -3,9 +3,6 @@
 // RUN: %{build} -o %t.out
 // RUN: env UR_ENABLE_LAYERS=UR_LAYER_TRACING env XPTI_TRACE_ENABLE=1 env XPTI_FRAMEWORK_DISPATCHER=%xptifw_dispatcher env XPTI_SUBSCRIBERS=%t_collector.so %{run} %t.out | FileCheck %s
 
-// TODO: Reenable, see https://github.com/intel/llvm/issues/14744
-// UNSUPPORTED: windows, linux
-
 #include "basic_event_collection.inc"
 //
 // CHECK: xptiTraceInit: Stream Name = ur
@@ -41,8 +38,7 @@
 // CHECK-NEXT: Edge create
 // CHECK-DAG:   queue_id : {{.*}}
 // CHECK-DAG:   event : {{.*}}
-// CHECK-DAG:   kernel_name : virtual_node[{{.*}}]
-// CHECK-NEXT: Task begin
+// CHECK: Task begin
 // CHECK-DAG:    queue_id : {{.*}}
 // CHECK-DAG:    sym_line_no : {{.*}}
 // CHECK-DAG:    sym_source_file_name : {{.*}}


### PR DESCRIPTION
The test was expecting 'kernel_name' metadata on an edge_create event which should not exist

It was still sometimes matching anyway but appears to have been a fluke and not intended behavior.

Fixes https://github.com/intel/llvm/issues/14744