### PR TITLE
[SYCL] remove `alignedAllocHost`'s `Kind` param

### DIFF
--- a/sycl/include/sycl/detail/usm_impl.hpp
+++ b/sycl/include/sycl/detail/usm_impl.hpp
@@ -22,10 +22,6 @@ __SYCL_EXPORT void *alignedAlloc(size_t Alignment, size_t Bytes,
                                  sycl::usm::alloc Kind,
                                  const code_location &CL);
 
-__SYCL_EXPORT void *alignedAllocHost(size_t Alignment, size_t Bytes,
-                                     const context &Ctxt,
-                                     const code_location &CL);
-
 __SYCL_EXPORT void free(void *Ptr, const context &Ctxt,
                         const code_location &CL);
 

--- a/sycl/include/sycl/detail/usm_impl.hpp
+++ b/sycl/include/sycl/detail/usm_impl.hpp
@@ -23,7 +23,7 @@ __SYCL_EXPORT void *alignedAlloc(size_t Alignment, size_t Bytes,
                                  const code_location &CL);
 
 __SYCL_EXPORT void *alignedAllocHost(size_t Alignment, size_t Bytes,
-                                     const context &Ctxt, sycl::usm::alloc Kind,
+                                     const context &Ctxt,
                                      const code_location &CL);
 
 __SYCL_EXPORT void free(void *Ptr, const context &Ctxt,

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -35,10 +35,10 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const sycl::context &Ctxt,
                        const sycl::detail::code_location &CodeLoc) {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   // Stash the code location information and propagate
-  detail::tls_code_loc_t CL(CodeLoc);
-  XPTIScope PrepareNotify((void *)alignedAllocHost,
-                          (uint16_t)xpti::trace_point_type_t::node_create,
-                          SYCL_MEM_ALLOC_STREAM_NAME, "malloc_host");
+  sycl::detail::tls_code_loc_t CL(CodeLoc);
+  sycl::detail::XPTIScope PrepareNotify(
+      (void *)alignedAllocHost, (uint16_t)xpti::trace_point_type_t::node_create,
+      sycl::detail::SYCL_MEM_ALLOC_STREAM_NAME, "malloc_host");
   PrepareNotify.addMetadata([&](auto TEvent) {
     xpti::addMetadata(TEvent, "sycl_device_name", std::string("Host"));
     xpti::addMetadata(TEvent, "sycl_device", 0);

--- a/sycl/source/detail/usm/usm_impl.cpp
+++ b/sycl/source/detail/usm/usm_impl.cpp
@@ -41,7 +41,7 @@ extern xpti::trace_event_data_t *GSYCLGraphEvent;
 namespace usm {
 
 void *alignedAllocHost(size_t Alignment, size_t Size, const context &Ctxt,
-                       alloc Kind, const property_list &PropList,
+                       const property_list &PropList,
                        const detail::code_location &CodeLoc) {
 #ifdef XPTI_ENABLE_INSTRUMENTATION
   // Stash the code location information and propagate
@@ -77,8 +77,6 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const context &Ctxt,
   const PluginPtr &Plugin = CtxImpl->getPlugin();
   ur_result_t Error = UR_RESULT_ERROR_INVALID_VALUE;
 
-  switch (Kind) {
-  case alloc::host: {
     ur_usm_desc_t UsmDesc{};
     UsmDesc.align = Alignment;
 
@@ -99,17 +97,6 @@ void *alignedAllocHost(size_t Alignment, size_t Size, const context &Ctxt,
 
     Error = Plugin->call_nocheck(urUSMHostAlloc, C, &UsmDesc,
                                  /* pool= */ nullptr, Size, &RetVal);
-
-    break;
-  }
-  case alloc::device:
-  case alloc::shared:
-  case alloc::unknown: {
-    RetVal = nullptr;
-    Error = UR_RESULT_ERROR_INVALID_VALUE;
-    break;
-  }
-  }
 
   // Error is for debugging purposes.
   // The spec wants a nullptr returned, not an exception.
@@ -351,27 +338,25 @@ void free(void *ptr, const queue &Q, const detail::code_location &CodeLoc) {
 
 void *malloc_host(size_t Size, const context &Ctxt,
                   const detail::code_location &CodeLoc) {
-  return detail::usm::alignedAllocHost(0, Size, Ctxt, alloc::host,
-                                       property_list{}, CodeLoc);
+  return detail::usm::alignedAllocHost(0, Size, Ctxt, property_list{}, CodeLoc);
 }
 
 void *malloc_host(size_t Size, const context &Ctxt,
                   const property_list &PropList,
                   const detail::code_location &CodeLoc) {
-  return detail::usm::alignedAllocHost(0, Size, Ctxt, alloc::host, PropList,
-                                       CodeLoc);
+  return detail::usm::alignedAllocHost(0, Size, Ctxt, PropList, CodeLoc);
 }
 
 void *malloc_host(size_t Size, const queue &Q,
                   const detail::code_location &CodeLoc) {
-  return detail::usm::alignedAllocHost(0, Size, Q.get_context(), alloc::host,
+  return detail::usm::alignedAllocHost(0, Size, Q.get_context(),
                                        property_list{}, CodeLoc);
 }
 
 void *malloc_host(size_t Size, const queue &Q, const property_list &PropList,
                   const detail::code_location &CodeLoc) {
-  return detail::usm::alignedAllocHost(0, Size, Q.get_context(), alloc::host,
-                                       PropList, CodeLoc);
+  return detail::usm::alignedAllocHost(0, Size, Q.get_context(), PropList,
+                                       CodeLoc);
 }
 
 void *malloc_shared(size_t Size, const device &Dev, const context &Ctxt,
@@ -401,28 +386,28 @@ void *malloc_shared(size_t Size, const queue &Q, const property_list &PropList,
 
 void *aligned_alloc_host(size_t Alignment, size_t Size, const context &Ctxt,
                          const detail::code_location &CodeLoc) {
-  return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, alloc::host,
-                                       property_list{}, CodeLoc);
+  return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, property_list{},
+                                       CodeLoc);
 }
 
 void *aligned_alloc_host(size_t Alignment, size_t Size, const context &Ctxt,
                          const property_list &PropList,
                          const detail::code_location &CodeLoc) {
-  return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, alloc::host,
-                                       PropList, CodeLoc);
+  return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, PropList,
+                                       CodeLoc);
 }
 
 void *aligned_alloc_host(size_t Alignment, size_t Size, const queue &Q,
                          const detail::code_location &CodeLoc) {
   return detail::usm::alignedAllocHost(Alignment, Size, Q.get_context(),
-                                       alloc::host, property_list{}, CodeLoc);
+                                       property_list{}, CodeLoc);
 }
 
 void *aligned_alloc_host(size_t Alignment, size_t Size, const queue &Q,
                          const property_list &PropList,
                          const detail::code_location &CodeLoc) {
   return detail::usm::alignedAllocHost(Alignment, Size, Q.get_context(),
-                                       alloc::host, PropList, CodeLoc);
+                                       PropList, CodeLoc);
 }
 
 void *aligned_alloc_shared(size_t Alignment, size_t Size, const device &Dev,
@@ -460,15 +445,14 @@ void *malloc(size_t Size, const device &Dev, const context &Ctxt, alloc Kind,
              const property_list &PropList,
              const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(0, Size, Ctxt, Kind, PropList,
-                                         CodeLoc);
+    return detail::usm::alignedAllocHost(0, Size, Ctxt, PropList, CodeLoc);
   return detail::usm::alignedAlloc(0, Size, Ctxt, Dev, Kind, PropList, CodeLoc);
 }
 
 void *malloc(size_t Size, const device &Dev, const context &Ctxt, alloc Kind,
              const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(0, Size, Ctxt, Kind, property_list{},
+    return detail::usm::alignedAllocHost(0, Size, Ctxt, property_list{},
                                          CodeLoc);
   return detail::usm::alignedAlloc(0, Size, Ctxt, Dev, Kind, property_list{},
                                    CodeLoc);
@@ -477,7 +461,7 @@ void *malloc(size_t Size, const device &Dev, const context &Ctxt, alloc Kind,
 void *malloc(size_t Size, const queue &Q, alloc Kind,
              const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(0, Size, Q.get_context(), Kind,
+    return detail::usm::alignedAllocHost(0, Size, Q.get_context(),
                                          property_list{}, CodeLoc);
   return detail::usm::alignedAlloc(0, Size, Q.get_context(), Q.get_device(),
                                    Kind, property_list{}, CodeLoc);
@@ -487,8 +471,8 @@ void *malloc(size_t Size, const queue &Q, alloc Kind,
              const property_list &PropList,
              const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(0, Size, Q.get_context(), Kind,
-                                         PropList, CodeLoc);
+    return detail::usm::alignedAllocHost(0, Size, Q.get_context(), PropList,
+                                         CodeLoc);
   return detail::usm::alignedAlloc(0, Size, Q.get_context(), Q.get_device(),
                                    Kind, PropList, CodeLoc);
 }
@@ -497,8 +481,8 @@ void *aligned_alloc(size_t Alignment, size_t Size, const device &Dev,
                     const context &Ctxt, alloc Kind,
                     const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, Kind,
-                                         property_list{}, CodeLoc);
+    return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, property_list{},
+                                         CodeLoc);
 
   return detail::usm::alignedAlloc(Alignment, Size, Ctxt, Dev, Kind,
                                    property_list{}, CodeLoc);
@@ -509,7 +493,7 @@ void *aligned_alloc(size_t Alignment, size_t Size, const device &Dev,
                     const property_list &PropList,
                     const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, Kind, PropList,
+    return detail::usm::alignedAllocHost(Alignment, Size, Ctxt, PropList,
                                          CodeLoc);
   return detail::usm::alignedAlloc(Alignment, Size, Ctxt, Dev, Kind, PropList,
                                    CodeLoc);
@@ -518,7 +502,7 @@ void *aligned_alloc(size_t Alignment, size_t Size, const device &Dev,
 void *aligned_alloc(size_t Alignment, size_t Size, const queue &Q, alloc Kind,
                     const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(Alignment, Size, Q.get_context(), Kind,
+    return detail::usm::alignedAllocHost(Alignment, Size, Q.get_context(),
                                          property_list{}, CodeLoc);
   return detail::usm::alignedAlloc(Alignment, Size, Q.get_context(),
                                    Q.get_device(), Kind, property_list{},
@@ -529,7 +513,7 @@ void *aligned_alloc(size_t Alignment, size_t Size, const queue &Q, alloc Kind,
                     const property_list &PropList,
                     const detail::code_location &CodeLoc) {
   if (Kind == alloc::host)
-    return detail::usm::alignedAllocHost(Alignment, Size, Q.get_context(), Kind,
+    return detail::usm::alignedAllocHost(Alignment, Size, Q.get_context(),
                                          PropList, CodeLoc);
   return detail::usm::alignedAlloc(Alignment, Size, Q.get_context(),
                                    Q.get_device(), Kind, PropList, CodeLoc);


### PR DESCRIPTION
`alignedAllocHost` was introduced as part of what was described as a bugfix in 01869a033a76 wherin `alignedAlloc` was simply renamed to `alignedAllocHost`, but the `Kind` parameter (host|device|shared) was left unchanged, and the bugfix actually appears to be in the calling code. I'm not quite sure what happened there, but in any case we shouldn't have a `Kind` parameter if we only ever intend to work on the host (indeed the existing code treats Kind == host as an invariant, returning an error otherwise).

It looks like a couple of other people tried to work around this when adding other features (e.g. in 7df39237b30) but didn't fix this due to perceived ABI breaks. However, this function hasn't been exposed as part of the abi due to a declaration / definition mismatch between the header and implementation, so it was never callable in the first place.

Thus, this is a putatively NFC cleanup, but it's a change to the SYCL runtime ABI so not "genuine-NFC".