### PR TITLE
[SYCL][Bindless] Fix dx12 interop samples for new external type names

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
@@ -108,11 +108,11 @@ void DX12InteropTest::importDX12SharedMemoryHandle(size_t allocationSize) {
       syclexp::external_mem_handle_type::win32_nt_dx12_resource,
       allocationSize};
 
-  m_syclInteropMemHandle =
+  m_syclExternalMemHandle =
       syclexp::import_external_memory(extMemDesc, m_syclQueue);
 
   m_syclImageMemHandle = syclexp::map_external_image_memory(
-      m_syclInteropMemHandle, m_syclImageDesc, m_syclQueue);
+      m_syclExternalMemHandle, m_syclImageDesc, m_syclQueue);
 
   m_syclImageHandle =
       syclexp::create_image(m_syclImageMemHandle, m_syclImageDesc, m_syclQueue);
@@ -123,7 +123,7 @@ void DX12InteropTest::importDX12SharedSemaphoreHandle() {
       extSemDesc{m_sharedSemaphoreHandle,
                  syclexp::external_semaphore_handle_type::win32_nt_dx12_fence};
 
-  m_syclInteropSemaphoreHandle =
+  m_syclExternalSemaphoreHandle =
       syclexp::import_external_semaphore(extSemDesc, m_syclQueue);
 }
 
@@ -131,7 +131,7 @@ void DX12InteropTest::callSYCLKernel() {
 #ifdef TEST_SEMAPHORE_IMPORT
   // Wait for imported semaphore. This semaphore was signalled at the
   // end of `populateDX12Texture`.
-  m_syclQueue.ext_oneapi_wait_external_semaphore(m_syclInteropSemaphoreHandle,
+  m_syclQueue.ext_oneapi_wait_external_semaphore(m_syclExternalSemaphoreHandle,
                                                  m_sharedFenceValue);
 #endif
 
@@ -168,7 +168,7 @@ void DX12InteropTest::callSYCLKernel() {
 
   // Signal imported semaphore.
   m_syclQueue.submit([&](sycl::handler &cgh) {
-    cgh.ext_oneapi_signal_external_semaphore(m_syclInteropSemaphoreHandle,
+    cgh.ext_oneapi_signal_external_semaphore(m_syclExternalSemaphoreHandle,
                                              m_sharedFenceValue);
   });
 

--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.h
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.h
@@ -87,8 +87,8 @@ private:
   sycl::queue m_syclQueue;
   sycl::device m_syclDevice;
   syclexp::image_descriptor m_syclImageDesc;
-  syclexp::interop_mem_handle m_syclInteropMemHandle;
-  syclexp::interop_semaphore_handle m_syclInteropSemaphoreHandle;
+  syclexp::external_mem m_syclExternalMemHandle;
+  syclexp::external_semaphore m_syclExternalSemaphoreHandle;
   syclexp::image_mem_handle m_syclImageMemHandle;
   syclexp::unsampled_image_handle m_syclImageHandle;
 };


### PR DESCRIPTION
- fix for https://github.com/intel/llvm/pull/14444