### PR TITLE
[CI][CTS] Turn on test_queue & spec_constants

### DIFF
--- a/devops/cts_exclude_filter_L0_GPU
+++ b/devops/cts_exclude_filter_L0_GPU
@@ -3,6 +3,3 @@ kernel_bundle
 marray
 # Fix: https://github.com/intel/llvm/pull/14622
 optional_kernel_features
-# https://github.com/intel/llvm/issues/14819
-queue
-spec_constants

--- a/devops/cts_exclude_filter_OCL_CPU
+++ b/devops/cts_exclude_filter_OCL_CPU
@@ -5,6 +5,3 @@ marray
 math_builtin_api
 # https://github.com/intel/llvm/issues/13574
 hierarchical
-# https://github.com/intel/llvm/issues/14819
-queue
-spec_constants


### PR DESCRIPTION
https://github.com/intel/llvm/issues/14819 has been fixed, so turning the tests back on.