### PR TITLE
[SYCL][ESIMD][E2E] Fix test warning about divide by zero

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_store_2d.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/lsc_store_2d.hpp
@@ -40,20 +40,10 @@ template <unsigned int N> constexpr unsigned int getNextPowerOf2() {
 }
 template <> constexpr unsigned int getNextPowerOf2<0>() { return 0; }
 
-// Compute the data size for 2d block load or store.
-template <typename T, int NBlocks, int Height, int Width, bool Transposed,
-          bool Transformed>
-constexpr int get_lsc_block_2d_data_size() {
-  if (Transformed)
-    return roundUpNextMultiple<Height, 4 / sizeof(T)>() *
-           getNextPowerOf2<Width>() * NBlocks;
-  return Width * Height * NBlocks;
-}
-
 template <int case_num, typename T, uint32_t Groups, uint32_t Threads,
           int BlockWidth, int BlockHeight = 1,
-          int N = get_lsc_block_2d_data_size<T, 1u, BlockHeight, BlockWidth,
-                                             false, false>(),
+          int N = __ESIMD_DNS::get_lsc_block_2d_data_size<
+              T, 1u, BlockHeight, BlockWidth, false, false>(),
           cache_hint L1H = cache_hint::none, cache_hint L2H = cache_hint::none>
 bool test(unsigned SurfaceWidth, unsigned SurfaceHeight, unsigned SurfacePitch,
           int X, int Y) {


### PR DESCRIPTION
The problem was this was a runtime if and not `if constexpr`. This function was copy-pasted from the ESIMD headers, and the headers one was already fixed to be `if constexpr`, so just use that.

Closes: https://github.com/intel/llvm/issues/14877