### PR TITLE
[SYCL] Default-initialize UR structs used in handler_impl

### DIFF
--- a/sycl/source/detail/handler_impl.hpp
+++ b/sycl/source/detail/handler_impl.hpp
@@ -123,15 +123,15 @@ public:
   bool MKernelUsesClusterLaunch = false;
 
   // Extra information for bindless image copy
-  ur_image_desc_t MSrcImageDesc;
-  ur_image_desc_t MDstImageDesc;
-  ur_image_format_t MSrcImageFormat;
-  ur_image_format_t MDstImageFormat;
-  ur_exp_image_copy_flags_t MImageCopyFlags;
+  ur_image_desc_t MSrcImageDesc = {};
+  ur_image_desc_t MDstImageDesc = {};
+  ur_image_format_t MSrcImageFormat = {};
+  ur_image_format_t MDstImageFormat = {};
+  ur_exp_image_copy_flags_t MImageCopyFlags = {};
 
-  ur_rect_offset_t MSrcOffset;
-  ur_rect_offset_t MDestOffset;
-  ur_rect_region_t MCopyExtent;
+  ur_rect_offset_t MSrcOffset = {};
+  ur_rect_offset_t MDestOffset = {};
+  ur_rect_region_t MCopyExtent = {};
 
   // Extra information for semaphore interoperability
   ur_exp_external_semaphore_handle_t MExternalSemaphore;


### PR DESCRIPTION
The C-style structs used by the `handler_impl` for bindless images are not initialized. Although their values get initialized later in execution, when it is decided this information is actually used, leaving these values uninitialized still leave the possibility of vulnerabilities. This PR initializes them.

I'd like to bring attention to the fact that we could also use `std::optional` here, although that'll increase the size used for each field here. Zero initializing these structs is also an option, although I noticed many of these structs have default values, so I default initialized instead. If `std::optional` or zero initializing would be a better option here, please let me know and I'll make the changes. Thanks!