### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-9eeeee1

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-2e6ebc3",
-      "version": "2e6ebc3",
-      "updated_at": "2024-07-28T03:46:07Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1747533183/zip",
+      "github_tag": "igc-dev-9eeeee1",
+      "version": "9eeeee1",
+      "updated_at": "2024-08-01T02:11:53Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1762827700/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift