### PR TITLE
Reenable discard_events_l0_inorder test

### DIFF
--- a/sycl/test-e2e/DiscardEvents/discard_events_l0_inorder.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_l0_inorder.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: level_zero
 //
-// https://github.com/intel/llvm/issues/14121
-// UNSUPPORTED: gpu-intel-dg2
-//
 // RUN: %{build} -o %t.out
 //
 // RUN: env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 SYCL_PI_LEVEL_ZERO_BATCH_SIZE=0 ONEAPI_DEVICE_SELECTOR="level_zero:*" %{run} %t.out


### PR DESCRIPTION
Related to issue [14121](https://github.com/intel/llvm/issues/14121)

This test probably fixed by one of the fixes submitted as I tested it on L0 ARC device and it was passing normally.