### PR TITLE
Forbid optimizations in __devicelib_assert_fail function

### DIFF
--- a/libdevice/wrapper.h
+++ b/libdevice/wrapper.h
@@ -25,7 +25,7 @@ void *__devicelib_memset(void *dest, int c, size_t n);
 DEVICE_EXTERN_C
 int __devicelib_memcmp(const void *s1, const void *s2, size_t n);
 DEVICE_EXTERN_C
-__attribute__((noinline, optnone)) void
+__attribute__((noinline, optnone, naked)) void
 __devicelib_assert_fail(const char *expr, const char *file, int32_t line,
                         const char *func, uint64_t gid0, uint64_t gid1,
                         uint64_t gid2, uint64_t lid0, uint64_t lid1,

--- a/libdevice/wrapper.h
+++ b/libdevice/wrapper.h
@@ -25,9 +25,10 @@ void *__devicelib_memset(void *dest, int c, size_t n);
 DEVICE_EXTERN_C
 int __devicelib_memcmp(const void *s1, const void *s2, size_t n);
 DEVICE_EXTERN_C
-void __devicelib_assert_fail(const char *expr, const char *file, int32_t line,
-                             const char *func, uint64_t gid0, uint64_t gid1,
-                             uint64_t gid2, uint64_t lid0, uint64_t lid1,
-                             uint64_t lid2);
+__attribute__((noinline, optnone)) void
+__devicelib_assert_fail(const char *expr, const char *file, int32_t line,
+                        const char *func, uint64_t gid0, uint64_t gid1,
+                        uint64_t gid2, uint64_t lid0, uint64_t lid1,
+                        uint64_t lid2);
 #endif // __SPIR__ || __SPIRV__ || __NVPTX__
 #endif // __LIBDEVICE_WRAPPER_H__

--- a/libdevice/wrapper.h
+++ b/libdevice/wrapper.h
@@ -25,7 +25,7 @@ void *__devicelib_memset(void *dest, int c, size_t n);
 DEVICE_EXTERN_C
 int __devicelib_memcmp(const void *s1, const void *s2, size_t n);
 DEVICE_EXTERN_C
-__attribute__((noinline, optnone, naked)) void
+__attribute__((noinline, optnone)) void
 __devicelib_assert_fail(const char *expr, const char *file, int32_t line,
                         const char *func, uint64_t gid0, uint64_t gid1,
                         uint64_t gid2, uint64_t lid0, uint64_t lid1,


### PR DESCRIPTION
With optimizations enabled for the `__devicelib_assert_fail` function, the device assertions are not being triggered. This PR forbids optimizations to get correct behavior for device assertions.