### PR TITLE
Revert "[UR][DeviceSantizer] Enable Symoblizer for UR santizer layer (#14513)

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -30,7 +30,6 @@ option(SYCL_UMF_DISABLE_HWLOC
 set(UR_BUILD_EXAMPLES OFF CACHE BOOL "Build example applications." FORCE)
 set(UR_BUILD_TESTS OFF CACHE BOOL "Build unit tests." FORCE)
 set(UR_BUILD_XPTI_LIBS OFF)
-set(UR_ENABLE_SYMBOLIZER ON CACHE BOOL "Enable symbolizer for sanitizer layer.")
 set(UR_ENABLE_TRACING ON)
 
 if("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-minus1.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-minus1.cpp
@@ -27,7 +27,3 @@ int main() {
 // CHECK-HOST:   [[ADDR]] is located inside of Host USM region {{\[0x.*, 0x.*\)}}
 // CHECK-SHARED: [[ADDR]] is located inside of Shared USM region {{\[0x.*, 0x.*\)}}
 // CHECK-DEVICE: [[ADDR]] is located inside of Device USM region {{\[0x.*, 0x.*\)}}
-// CHECK: allocated here:
-// CHECK-HOST: in main {{.*bad-free-minus1.cpp:}}[[@LINE-15]]
-// CHECK-SHARED: in main {{.*bad-free-minus1.cpp:}}[[@LINE-14]]
-// CHECK-DEVICE: in main {{.*bad-free-minus1.cpp:}}[[@LINE-13]]

--- a/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-plus1.cpp
+++ b/sycl/test-e2e/AddressSanitizer/bad-free/bad-free-plus1.cpp
@@ -25,9 +25,5 @@ int main() {
   // CHECK-HOST:   [[ADDR]] is located inside of Host USM region {{\[0x.*, 0x.*\)}}
   // CHECK-SHARED: [[ADDR]] is located inside of Shared USM region {{\[0x.*, 0x.*\)}}
   // CHECK-DEVICE: [[ADDR]] is located inside of Device USM region {{\[0x.*, 0x.*\)}}
-  // CHECK:  allocated here:
-  // CHECK-HOST: in main {{.*bad-free-plus1.cpp:}}[[@LINE-13]]
-  // CHECK-SHARED: in main {{.*bad-free-plus1.cpp:}}[[@LINE-12]]
-  // CHECK-DEVICE: in main {{.*bad-free-plus1.cpp:}}[[@LINE-11]]
   return 0;
 }

--- a/sycl/test-e2e/AddressSanitizer/double-free/double-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/double-free/double-free.cpp
@@ -30,8 +30,4 @@ int main() {
 // CHECK-SHARED: [[ADDR]] is located inside of Shared USM region {{\[0x.*, 0x.*\)}}
 // CHECK-DEVICE: [[ADDR]] is located inside of Device USM region {{\[0x.*, 0x.*\)}}
 // CHECK: freed here
-// CHECH: in main {{.*double-free.cpp:}}[@LINE-33]
 // CHECK: previously allocated here
-// CHECK-HOST: in main {{.*double-free.cpp:}}[[@LINE-19]]
-// CHECK-SHARED: in main {{.*double-free.cpp:}}[[@LINE-18]]
-// CHECK-DEVICE: in main {{.*double-free.cpp:}}[[@LINE-17]]

--- a/sycl/test-e2e/AddressSanitizer/use-after-free/quarantine-no-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/use-after-free/quarantine-no-free.cpp
@@ -46,9 +46,7 @@ int main() {
   // CHECK:   #0 {{.*}} {{.*quarantine-no-free.cpp}}:[[@LINE-5]]
   // CHECK: [[ADDR]] is located inside of Device USM region [{{0x.*}}, {{0x.*}})
   // CHECK: allocated here:
-  // CHECK: in main {{.*quarantine-no-free.cpp}}:[[@LINE-27]]
   // CHECK: released here:
-  // CHECK: in main {{.*quarantine-no-free.cpp}}:[[@LINE-25]]
 
   return 0;
 }

--- a/sycl/test-e2e/AddressSanitizer/use-after-free/use-after-free.cpp
+++ b/sycl/test-e2e/AddressSanitizer/use-after-free/use-after-free.cpp
@@ -21,9 +21,7 @@ int main() {
   // CHECK:   #0 {{.*}} {{.*use-after-free.cpp:}}[[@LINE-5]]
   // CHECK: [[ADDR]] is located inside of Device USM region [{{0x.*}}, {{0x.*}})
   // CHECK: allocated here:
-  // CHECK: in main {{.*use-after-free.cpp:}}[[@LINE-14]]
   // CHECK: released here:
-  // CHECK: in main {{.*use-after-free.cpp:}}[[@LINE-15]]
 
   return 0;
 }


### PR DESCRIPTION
Reverts intel/llvm#14513

This reverts commit 56b1410652d39deba76c3d7075d0c1e93d732232.

Build in postcommit broken https://github.com/intel/llvm/actions/runs/10196353773