### PR TITLE
[SYCL] Fix abi-neutrality test for older libstdc++ versions

### DIFF
--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -23,8 +23,7 @@
 // CHECK-NEXT:         0 |       struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl _M_impl
 // CHECK-NEXT:         0 |         class std::allocator<class std::basic_string<char> > (base) (empty)
 // CHECK-NEXT:         0 |           class {{(std::__new_allocator|__gnu_cxx::new_allocator)}}<class std::basic_string<char> > (base) (empty)
-// CHECK-NEXT:         0 |         struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl_data (base)
-
+// CHECK-NEXT:         0 |         {{(struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl_data \(base\)|pointer _M_start)}}
 
 // CHECK: 0 | struct sycl::ext::oneapi::experimental::include_files
 // CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key<sycl::ext::oneapi::experimental::detail::IncludeFiles> (base) (empty)
@@ -34,8 +33,7 @@
 // CHECK-NEXT:         0 |       struct std::_Vector_base<struct std::pair<class std::basic_string<char>, class std::basic_string<char> >, class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > >::_Vector_impl _M_impl
 // CHECK-NEXT:         0 |         class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > (base) (empty)
 // CHECK-NEXT:         0 |           class {{(std::__new_allocator|__gnu_cxx::new_allocator)}}<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > (base) (empty)
-// CHECK-NEXT:         0 |         struct std::_Vector_base<struct std::pair<class std::basic_string<char>, class std::basic_string<char> >, class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > >::_Vector_impl_data (base)
-
+// CHECK-NEXT:         0 |         {{(struct std::_Vector_base<struct std::pair<class std::basic_string<char>, class std::basic_string<char> >, class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > >::_Vector_impl_data \(base\)|pointer _M_start)}}
 
 // CHECK: 0 | struct sycl::ext::oneapi::experimental::registered_kernel_names
 // CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key<sycl::ext::oneapi::experimental::detail::RegisteredKernelNames> (base) (empty)
@@ -45,6 +43,6 @@
 // CHECK-NEXT:         0 |       struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl _M_impl
 // CHECK-NEXT:         0 |         class std::allocator<class std::basic_string<char> > (base) (empty)
 // CHECK-NEXT:         0 |           class {{(std::__new_allocator|__gnu_cxx::new_allocator)}}<class std::basic_string<char> > (base) (empty)
-// CHECK-NEXT:         0 |         struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl_data (base)
+// CHECK-NEXT:         0 |         {{(struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl_data \(base\)|pointer _M_start)}}
 
 #include <sycl/sycl.hpp>


### PR DESCRIPTION
Layout is slightly different on systems like RHEL8 with older libstdc++. Adjust regexp accordingly.