### PR TITLE
Reenable check_resource_leak test

### DIFF
--- a/sycl/test-e2e/Assert/check_resource_leak.cpp
+++ b/sycl/test-e2e/Assert/check_resource_leak.cpp
@@ -5,8 +5,7 @@
 // UNSUPPORTED: opencl && gpu
 
 // TODO: Fails at JIT compilation for some reason.
-// TODO: Reenable windows/linux, see https://github.com/intel/llvm/issues/14598
-// UNSUPPORTED: hip, windows, linux
+// UNSUPPORTED: hip
 #define SYCL_FALLBACK_ASSERT 1
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
This test probably was fixed by other test fixes. Related to issue [14806](https://github.com/intel/llvm/issues/14806)