### PR TITLE
[SYCL][Graph] Fix E2E disabled RUN lines 

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/host_task_last.cpp
+++ b/sycl/test-e2e/Graph/Explicit/host_task_last.cpp
@@ -5,7 +5,7 @@
 
 // Disabled due to https://github.com/intel/llvm/issues/14473
 // Extra run to check for immediate-command-list in Level Zero
-// xRUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// RUNx: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_shared_allocations
 

--- a/sycl/test-e2e/Graph/RecordReplay/host_task_last.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/host_task_last.cpp
@@ -5,7 +5,7 @@
 
 // Disabled due to https://github.com/intel/llvm/issues/14473
 // Extra run to check for immediate-command-list in Level Zero
-// xRUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// RUNx: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
 // REQUIRES: aspect-usm_shared_allocations
 


### PR DESCRIPTION
We were using the `x` prefix to the `RUN` lit command to comment out a `RUN` check. However, LIT still detects this as a `RUN` command, which illustrated in a CI fail of this test recently https://github.com/intel/llvm/actions/runs/10198164930/job/28215254220

Fixed by changing `xRUN` to `RUNx` which I've verified locally is not detected as a `RUN` command by LIT, and can be used to comment the `RUN` command out.

Relates to https://github.com/intel/llvm/issues/14473