### PR TITLE
[SYCL] Include sycl path in Bindless image hpp

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bindless_images_mem_handle.hpp
+++ b/sycl/include/sycl/ext/oneapi/bindless_images_mem_handle.hpp
@@ -8,7 +8,7 @@
 
 #pragma once
 
-#include "ur_api.h"
+#include "sycl/ur_api.h"
 
 namespace sycl {
 inline namespace _V1 {


### PR DESCRIPTION
Fix debug build issue
 [-Werror,-Wmicrosoft-include] llvm\include\sycl\handler.hpp:52:
