### PR TITLE
[SYCL] Add missing test dependency on FileCheck

### DIFF
--- a/sycl/test/CMakeLists.txt
+++ b/sycl/test/CMakeLists.txt
@@ -90,7 +90,7 @@ add_lit_testsuite(check-sycl-dumps "Running ABI dump tests only"
   ${CMAKE_CURRENT_BINARY_DIR}
   ARGS ${RT_TEST_ARGS}
   PARAMS "SYCL_LIB_DUMPS_ONLY=True"
-  DEPENDS sycl-runtime-libraries llvm-readobj
+  DEPENDS FileCheck sycl-runtime-libraries llvm-readobj
   EXCLUDE_FROM_CHECK_ALL
   )
 


### PR DESCRIPTION
e.g.
```
$ ninja check-sycl-dumps
 [...]
 # .---command stderr------------
 # | 'FileCheck': command not found
 # `-----------------------------
 # error: command failed with exit status: 127
```