### PR TITLE
[SYCL] Added assertions to prevent null pointer dereferences

### DIFF
--- a/sycl/source/detail/memory_manager.cpp
+++ b/sycl/source/detail/memory_manager.cpp
@@ -1157,6 +1157,8 @@ static void memcpyFromDeviceGlobalUSM(
     size_t NumBytes, size_t Offset, void *Dest,
     const std::vector<ur_event_handle_t> &DepEvents,
     ur_event_handle_t *OutEvent, const detail::EventImplPtr &OutEventImpl) {
+  assert(Queue && "Copying from device global USM must be called with a valid "
+                  "device queue");
   // Get or allocate USM memory for the device_global. Since we are reading from
   // it, we need it initialized if it has not been yet.
   DeviceGlobalUSMMem &DeviceGlobalUSM =

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3233,6 +3233,7 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     return UR_RESULT_SUCCESS;
   }
   case CGType::ProfilingTag: {
+    assert(MQueue && "Profiling tag requires a valid queue");
     const auto &Plugin = MQueue->getPlugin();
     // If the queue is not in-order, we need to insert a barrier. This barrier
     // does not need output events as it will implicitly enforce the following


### PR DESCRIPTION
This was pointed out by Coverity: it would seem that some functions are missing assertions to prevent dereferencing null pointers.