### PR TITLE
[SYCL][COMPAT][E2E] Removes std++20 usage from syclcompat e2e tests

### DIFF
--- a/sycl/test-e2e/syclcompat/lit.local.cfg
+++ b/sycl/test-e2e/syclcompat/lit.local.cfg
@@ -4,4 +4,4 @@ for substitution in config.substitutions:
   if substitution[0] == "%clangxx":
     original_clangxx=substitution[1]
 config.substitutions.insert(0,
-  ("%clangxx", original_clangxx + ' -Wno-error=c++20-extensions -Wno-error=#warnings -Wno-error=deprecated-declarations'))
+  ("%clangxx", original_clangxx + ' -Wno-error=#warnings -Wno-error=deprecated-declarations'))


### PR DESCRIPTION
Removes c++20 features from the e2e tests to avoid introducing c++20 in SYCLcompat by accident