### PR TITLE
[SYCL][E2E] Mark free_function tests unsupported on HIP

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/free_function_apis.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_apis.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 
 // The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda, hip
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
+++ b/sycl/test-e2e/KernelAndProgram/free_function_kernels.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 
 // The name mangling for free function kernels currently does not work with PTX.
-// UNSUPPORTED: cuda
+// UNSUPPORTED: cuda, hip
 
 // This test tests free function kernel code generation and execution.
 


### PR DESCRIPTION
Those tests currently fail on AMD devices. To enable them, [sycl_ext_oneapi_free_function_kernels.asciidoc](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc) needs to be investigated how to make it work for HIP backend.