### PR TITLE
[SYCL][ESIMD][E2E] Re-enable ctor_load_usm_fp_extra.cpp

### DIFF
--- a/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_load_usm_fp_extra.cpp
+++ b/sycl/test-e2e/ESIMD/api/functional/ctors/ctor_load_usm_fp_extra.cpp
@@ -15,9 +15,6 @@
 // It is expected for destination simd instance to store a bitwise same data as
 // the reference one.
 
-// https://github.com/intel/llvm/issues/14650
-// UNSUPPORTED: linux
-
 #include "ctor_load_usm.hpp"
 
 using namespace esimd_test::api::functional;


### PR DESCRIPTION
The test was disabled on Linux but the error message shows it failed on Windows:

```
# | ...\llvm\install\bin\clang-offload-wrapper: error: '...\AppData\Local\Temp\lit-tmp-36f_juo7\ctor_load_usm_fp_extra-167ca4_esimd_14.sym': Operation did not complete successfully because the file contains a virus or potentially unwanted software.
```

`AppData` is a Windows folder and the linked PRs show it failing in the Windows job (example [here](https://github.com/intel/llvm/actions/runs/9994419232/job/27630212012))

The test isn't failing on Windows where the issue was reported to occur, so just remove the wrong `UNSUPPORTED` line.

Closes: https://github.com/intel/llvm/issues/14650