### PR TITLE
[SYCL] Rename SYCL_ENABLE_PLUGINS to SYCL_ENABLE_BACKENDS

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -59,14 +59,14 @@ def do_configure(args):
     llvm_enable_sphinx = "OFF"
     llvm_build_shared_libs = "OFF"
     llvm_enable_lld = "OFF"
-    sycl_enabled_plugins = ["opencl"]
+    sycl_enabled_backends = ["opencl"]
     sycl_preview_lib = "ON"
 
     sycl_enable_xpti_tracing = "ON"
     xpti_enable_werror = "OFF"
 
     if sys.platform != "darwin":
-        sycl_enabled_plugins.append("level_zero")
+        sycl_enabled_backends.append("level_zero")
 
     # lld is needed on Windows or for the HIP plugin on AMD
     if platform.system() == "Windows" or (args.hip and args.hip_platform == "AMD"):
@@ -80,7 +80,7 @@ def do_configure(args):
         llvm_targets_to_build += ";NVPTX"
         libclc_targets_to_build = libclc_nvidia_target_names
         libclc_gen_remangled_variants = "ON"
-        sycl_enabled_plugins.append("cuda")
+        sycl_enabled_backends.append("cuda")
 
     if args.hip:
         if args.hip_platform == "AMD":
@@ -93,7 +93,7 @@ def do_configure(args):
         libclc_gen_remangled_variants = "ON"
 
         sycl_build_pi_hip_platform = args.hip_platform
-        sycl_enabled_plugins.append("hip")
+        sycl_enabled_backends.append("hip")
 
     if args.native_cpu:
         if args.native_cpu_libclc_targets:
@@ -101,7 +101,7 @@ def do_configure(args):
         else:
             libclc_build_native = "ON"
         libclc_gen_remangled_variants = "ON"
-        sycl_enabled_plugins.append("native_cpu")
+        sycl_enabled_backends.append("native_cpu")
 
     # all llvm compiler targets don't require 3rd party dependencies, so can be
     # built/tested even if specific runtimes are not available
@@ -153,7 +153,7 @@ def do_configure(args):
             libclc_gen_remangled_variants = "ON"
 
     if args.enable_plugin:
-        sycl_enabled_plugins += args.enable_plugin
+        sycl_enabled_backends += args.enable_plugin
 
     if args.disable_preview_lib:
         sycl_preview_lib = "OFF"
@@ -188,7 +188,7 @@ def do_configure(args):
         "-DLLVM_ENABLE_LLD={}".format(llvm_enable_lld),
         "-DXPTI_ENABLE_WERROR={}".format(xpti_enable_werror),
         "-DSYCL_CLANG_EXTRA_FLAGS={}".format(sycl_clang_extra_flags),
-        "-DSYCL_ENABLE_PLUGINS={}".format(";".join(set(sycl_enabled_plugins))),
+        "-DSYCL_ENABLE_BACKENDS={}".format(";".join(set(sycl_enabled_backends))),
         "-DSYCL_ENABLE_EXTENSION_JIT={}".format(sycl_enable_jit),
         "-DSYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB={}".format(sycl_preview_lib),
         "-DBUG_REPORT_URL=https://github.com/intel/llvm/issues",

--- a/libdevice/cmake/modules/SYCLLibdevice.cmake
+++ b/libdevice/cmake/modules/SYCLLibdevice.cmake
@@ -167,7 +167,7 @@ if (NOT MSVC)
     sycl-compiler)
 endif()
 
-if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+if("native_cpu" IN_LIST SYCL_ENABLE_BACKENDS)
   if (NOT DEFINED NATIVE_CPU_DIR)
     message( FATAL_ERROR "Undefined UR variable NATIVE_CPU_DIR. The name may have changed." )
   endif()

--- a/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
@@ -26,7 +26,7 @@ option(NATIVECPU_OCK_USE_FETCHCONTENT "Use FetchContent to acquire oneAPI Constr
 option(NATIVECPU_USE_OCK "Use the oneAPI Construction Kit for Native CPU" ON)
 
 # Don't fetch OCK if Native CPU is not enabled.
-if(NOT "native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+if(NOT "native_cpu" IN_LIST SYCL_ENABLE_BACKENDS)
   set(NATIVECPU_USE_OCK Off CACHE BOOL "Use the oneAPI Construction Kit for Native CPU" FORCE)
 endif()
 

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -16,10 +16,10 @@ if (NOT SYCL_COVERAGE_PATH)
   set(SYCL_COVERAGE_PATH "${CMAKE_CURRENT_BINARY_DIR}/profiles")
 endif()
 
-# If SYCL_ENABLE_PLUGINS is undefined, we default to enabling OpenCL and Level
-# Zero plugins.
-if (NOT DEFINED SYCL_ENABLE_PLUGINS)
-  set(SYCL_ENABLE_PLUGINS "opencl;level_zero")
+# If SYCL_ENABLE_BACKENDS is undefined, we default to enabling OpenCL and Level
+# Zero backends.
+if (NOT DEFINED SYCL_ENABLE_BACKENDS)
+  set(SYCL_ENABLE_BACKENDS "opencl;level_zero")
 endif()
 
 # Option to enable JIT, this in turn makes kernel fusion and spec constant
@@ -167,19 +167,19 @@ install(DIRECTORY ${OpenCL_INCLUDE_DIR}/CL
 option(SYCL_ENABLE_MAJOR_RELEASE_PREVIEW_LIB "Enable build of the SYCL major release preview library" ON)
 
 # Needed for feature_test.hpp
-if ("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   set(SYCL_BUILD_BACKEND_CUDA ON)
 endif()
-if ("hip" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   set(SYCL_BUILD_BACKEND_HIP ON)
 endif()
-if ("opencl" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("opencl" IN_LIST SYCL_ENABLE_BACKENDS)
   set(SYCL_BUILD_BACKEND_OPENCL ON)
 endif()
-if ("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   set(SYCL_BUILD_BACKENDLEVEL_ZERO ON)
 endif()
-if ("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("native_cpu" IN_LIST SYCL_ENABLE_BACKENDS)
   set(SYCL_BUILD_BACKEND_NATIVE_CPU ON)
 endif()
 
@@ -483,7 +483,7 @@ if("libclc" IN_LIST LLVM_ENABLE_PROJECTS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS libspirv-builtins)
 endif()
 
-if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
   list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
   if( LIBCLC_FOUND EQUAL -1 )
@@ -495,7 +495,7 @@ if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
   list(APPEND SYCL_TOOLCHAIN_DEPLOY_COMPONENTS ur_adapter_cuda)
 endif()
 
-if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
+if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   # Ensure that libclc is enabled.
   list(FIND LLVM_ENABLE_PROJECTS libclc LIBCLC_FOUND)
   if( LIBCLC_FOUND EQUAL -1 )

--- a/sycl/CMakeLists.txt
+++ b/sycl/CMakeLists.txt
@@ -16,6 +16,11 @@ if (NOT SYCL_COVERAGE_PATH)
   set(SYCL_COVERAGE_PATH "${CMAKE_CURRENT_BINARY_DIR}/profiles")
 endif()
 
+if (SYCL_ENABLE_PLUGINS)
+  message(WARNING "SYCL_ENABLE_PLUGINS has been renamed, please use SYCL_ENABLE_BACKENDS instead")
+  set(SYCL_ENABLE_BACKENDS "${SYCL_ENABLE_PLUGINS}" CACHE STRING "Backends enabled for SYCL" FORCE)
+endif()
+
 # If SYCL_ENABLE_BACKENDS is undefined, we default to enabling OpenCL and Level
 # Zero backends.
 if (NOT DEFINED SYCL_ENABLE_BACKENDS)

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -18,9 +18,9 @@ set(SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_TAG
 
 # Options to disable use of FetchContent to include Unified Runtime source code
 # to improve developer workflow.
-option(SYCL_PI_UR_USE_FETCH_CONTENT
+option(SYCL_UR_USE_FETCH_CONTENT
   "Use FetchContent to acquire the Unified Runtime source code" ON)
-set(SYCL_PI_UR_SOURCE_DIR
+set(SYCL_UR_SOURCE_DIR
   "" CACHE PATH "Path to root of Unified Runtime repository")
 
 option(SYCL_UMF_DISABLE_HWLOC
@@ -33,24 +33,24 @@ set(UR_BUILD_XPTI_LIBS OFF)
 set(UR_ENABLE_SYMBOLIZER ON CACHE BOOL "Enable symbolizer for sanitizer layer.")
 set(UR_ENABLE_TRACING ON)
 
-if("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
+if("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_L0 ON)
 endif()
-if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_CUDA ON)
 endif()
-if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
+if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_HIP ON)
   if (SYCL_ENABLE_EXTENSION_JIT)
     set(UR_ENABLE_COMGR ON)
   endif()
 endif()
-if("opencl" IN_LIST SYCL_ENABLE_PLUGINS)
+if("opencl" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_OPENCL ON)
   set(UR_OPENCL_ICD_LOADER_LIBRARY OpenCL-ICD CACHE FILEPATH
     "Path of the OpenCL ICD Loader library" FORCE)
 endif()
-if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+if("native_cpu" IN_LIST SYCL_ENABLE_BACKENDS)
   set(UR_BUILD_ADAPTER_NATIVE_CPU ON)
 endif()
 
@@ -70,15 +70,15 @@ else()
   set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wno-error")
 endif()
 
-if(SYCL_PI_UR_USE_FETCH_CONTENT)
+if(SYCL_UR_USE_FETCH_CONTENT)
   include(FetchContent)
 
   # The fetch_adapter_source function can be used to perform a separate content
-  # fetch for a UR adapter, this allows development of adapters to be decoupled
+  # fetch for a UR adapter (backend), this allows development of adapters to be decoupled
   # from each other.
   #
   # A separate content fetch will not be performed if:
-  # * The adapter name is not present in the SYCL_ENABLE_PLUGINS variable.
+  # * The adapter name is not present in the SYCL_ENABLE_BACKENDS variable.
   # * The repo and tag provided match the values of the
   #   UNIFIED_RUNTIME_REPO/UNIFIED_RUNTIME_TAG variables
   #
@@ -87,7 +87,7 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   #   * repo - A valid Git URL of a Unified Runtime repo
   #   * tag - A valid Git branch/tag/commit in the Unified Runtime repo
   function(fetch_adapter_source name repo tag)
-    if(NOT ${name} IN_LIST SYCL_ENABLE_PLUGINS)
+    if(NOT ${name} IN_LIST SYCL_ENABLE_BACKENDS)
       return()
     endif()
     if(repo STREQUAL UNIFIED_RUNTIME_REPO AND
@@ -179,24 +179,24 @@ if(SYCL_PI_UR_USE_FETCH_CONTENT)
   set(UNIFIED_RUNTIME_SOURCE_DIR
     "${unified-runtime_SOURCE_DIR}" CACHE PATH
     "Path to Unified Runtime Headers" FORCE)
-elseif(SYCL_PI_UR_SOURCE_DIR)
-  # SYCL_PI_UR_USE_FETCH_CONTENT is OFF and SYCL_PI_UR_SOURCE_DIR has been set,
+elseif(SYCL_UR_SOURCE_DIR)
+  # SYCL_UR_USE_FETCH_CONTENT is OFF and SYCL_UR_SOURCE_DIR has been set,
   # use the external Unified Runtime source directory.
   set(UNIFIED_RUNTIME_SOURCE_DIR
-    "${SYCL_PI_UR_SOURCE_DIR}" CACHE PATH
+    "${SYCL_UR_SOURCE_DIR}" CACHE PATH
     "Path to Unified Runtime Headers" FORCE)
   add_subdirectory(
     ${UNIFIED_RUNTIME_SOURCE_DIR}
     ${CMAKE_CURRENT_BINARY_DIR}/unified-runtime)
 else()
-  # SYCL_PI_UR_USE_FETCH_CONTENT is OFF and SYCL_PI_UR_SOURCE_DIR has not been
+  # SYCL_UR_USE_FETCH_CONTENT is OFF and SYCL_UR_SOURCE_DIR has not been
   # set, check if the fallback local directory exists.
   if(NOT EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/unified-runtime)
     message(FATAL_ERROR
-      "SYCL_PI_UR_USE_FETCH_CONTENT is disabled but no alternative Unified \
+      "SYCL_UR_USE_FETCH_CONTENT is disabled but no alternative Unified \
       Runtime source directory has been provided, either:
 
-      * Set -DSYCL_PI_UR_SOURCE_DIR=/path/to/unified-runtime
+      * Set -DSYCL_UR_SOURCE_DIR=/path/to/unified-runtime
       * Clone the UR repo in ${CMAKE_CURRENT_SOURCE_DIR}/unified-runtime")
   endif()
   # The fallback local directory for the Unified Runtime repository has been
@@ -269,26 +269,26 @@ function(add_sycl_ur_adapter NAME)
     SYCL_TOOLCHAIN_INSTALL_COMPONENTS ur_adapter_${NAME})
 endfunction()
 
-if("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
+if("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   add_sycl_ur_adapter(level_zero)
 
   # TODO: L0 adapter does other... things in its cmake - make sure they get
   # added to the new build system
 endif()
 
-if("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   add_sycl_ur_adapter(cuda)
 endif()
 
-if("hip" IN_LIST SYCL_ENABLE_PLUGINS)
+if("hip" IN_LIST SYCL_ENABLE_BACKENDS)
   add_sycl_ur_adapter(hip)
 endif()
 
-if("opencl" IN_LIST SYCL_ENABLE_PLUGINS)
+if("opencl" IN_LIST SYCL_ENABLE_BACKENDS)
   add_sycl_ur_adapter(opencl)
 endif()
 
-if("native_cpu" IN_LIST SYCL_ENABLE_PLUGINS)
+if("native_cpu" IN_LIST SYCL_ENABLE_BACKENDS)
   add_sycl_ur_adapter(native_cpu)
 
   # Deal with OCK option

--- a/sycl/doc/GetStartedGuide.md
+++ b/sycl/doc/GetStartedGuide.md
@@ -354,16 +354,16 @@ control which revision of Unified Runtime should be used when building DPC++:
 * `SYCL_PI_UR_OVERRIDE_FETCH_CONTENT_TAG` is a variable which can be used to
   override the `UNIFIED_RUNTIME_TAG` variable used by `FetchContent` to attain
   the Unified Runtime source code.
-* `SYCL_PI_UR_USE_FETCH_CONTENT` is an option to control if CMake should use
+* `SYCL_UR_USE_FETCH_CONTENT` is an option to control if CMake should use
   `FetchContent` to pull in the Unified Runtime repository, it defaults to `ON`.
   When set to `OFF`, `FetchContent` will not be used, instead:
-  * The path specified by variable `SYCL_PI_UR_SOURCE_DIR` will be used with
+  * The path specified by variable `SYCL_UR_SOURCE_DIR` will be used with
     `add_directory()`. This can be used to point at an adjacent directory
     containing a clone of the Unified Runtime repository.
   * The path `sycl/plugins/unified_runtime/unified-runtime` will be used, if it
     exists. This can be used as-if an in-tree build.
-* `SYCL_PI_UR_SOURCE_DIR` is a variable used to specify the path to the Unified
-  Runtime repository when `SYCL_PI_UR_USE_FETCH_CONTENT` is set of `OFF`.
+* `SYCL_UR_SOURCE_DIR` is a variable used to specify the path to the Unified
+  Runtime repository when `SYCL_UR_USE_FETCH_CONTENT` is set of `OFF`.
 
 ### Build DPC++ libclc with a custom toolchain
 
@@ -784,7 +784,7 @@ ONEAPI_DEVICE_SELECTOR=cuda:* ./simple-sycl-app-cuda.exe
 The default is the OpenCL backend if available.
 
 **NOTE**: `nvptx64-nvidia-cuda` is usable with `-fsycl-targets`
-if clang was built with the cmake option `SYCL_ENABLE_PLUGINS=cuda`.
+if clang was built with the cmake option `SYCL_ENABLE_BACKENDS=cuda`.
 
 ### Build DPC++ application with CMake
 

--- a/sycl/tools/sycl-trace/CMakeLists.txt
+++ b/sycl/tools/sycl-trace/CMakeLists.txt
@@ -10,7 +10,7 @@ link_llvm_libs(sycl-trace
   LLVMSupport
 )
 
-if ("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   add_library(ze_trace_collector SHARED
     ze_trace_collector.cpp
   )
@@ -20,7 +20,7 @@ if ("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
   add_dependencies(sycl-trace ze_trace_collector)
 endif()
 
-if ("cuda" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("cuda" IN_LIST SYCL_ENABLE_BACKENDS)
   add_library(cuda_trace_collector SHARED
     cuda_trace_collector.cpp
   )
@@ -41,7 +41,7 @@ add_library(sycl_ur_trace_collector SHARED
 find_package(Python3 REQUIRED)
 
 # To get L0 loader
-if ("level_zero" IN_LIST SYCL_ENABLE_PLUGINS)
+if ("level_zero" IN_LIST SYCL_ENABLE_BACKENDS)
   target_link_libraries(ze_trace_collector PRIVATE LevelZeroLoader-Headers)
   target_compile_definitions(ze_trace_collector PRIVATE SYCL_HAS_LEVEL_ZERO)
   target_link_libraries(ze_trace_collector PRIVATE xptifw)


### PR DESCRIPTION
Rename `SYCL_ENABLE_PLUGINS` to `SYCL_ENABLE_BACKENDS`

Also rename `SYCL_PI_UR_USE_FETCH_CONTENT` to `SYCL_UR_USE_FETCH_CONTENT`
and `SYCL_PI_UR_SOURCE_DIR` to `SYCL_UR_SOURCE_DIR`

For https://github.com/intel/llvm/issues/14927