### PR TITLE
Remove unused RSBench tests

### DIFF
--- a/sycl/test-e2e/External/RSBench/acc.test
+++ b/sycl/test-e2e/External/RSBench/acc.test
@@ -1,3 +1,0 @@
-REQUIRES: accelerator
-RUN: env SYCL_UR_TRACE=1 %{run} %T/rsbench -s large -l 34 -p 300000 -P 1000 -W 100 -m event
-XFAIL: *

--- a/sycl/test-e2e/External/RSBench/cpu.test
+++ b/sycl/test-e2e/External/RSBench/cpu.test
@@ -1,3 +1,0 @@
-REQUIRES: cpu
-RUN: env SYCL_UR_TRACE=1 %{run} %T/rsbench -s large -l 34 -p 300000 -P 1000 -W 100 -m event
-XFAIL: *

--- a/sycl/test-e2e/External/RSBench/gpu.test
+++ b/sycl/test-e2e/External/RSBench/gpu.test
@@ -1,3 +1,0 @@
-REQUIRES: gpu
-RUN: env SYCL_UR_TRACE=1 %{run} %T/rsbench -s large -l 34 -p 300000 -P 1000 -W 100 -m event
-XFAIL: *


### PR DESCRIPTION
See https://github.com/intel/llvm/issues/14932

These tests were added 4 years ago with XFAIL and have never been enabled.