### PR TITLE
[SYCL][Doc] Fix syntax errors in documentation

### DIFF
--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -705,12 +705,12 @@ static constexpr size_t WGSIZE = 16;
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void iota(float start, float *ptr) {
   // Get the ID of this kernel iteration.
-  size_t id = syclext::this_work_item::get_nd_item().get_global_linear_id();
+  size_t id = syclext::this_work_item::get_nd_item<1>().get_global_linear_id();
 
   ptr[id] = start + static_cast<float>(id);
 }
 
-void main() {
+int main() {
   sycl::queue q;
   sycl::context ctxt = q.get_context();
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_memory.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_memory.asciidoc
@@ -457,7 +457,7 @@ constexpr size_t WGSIZE = 256;
 
 SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((syclexp::nd_range_kernel<1>))
 void mykernel(syclexp::work_group_memory<int[WGSIZE]> mem) {
-  size_t id = syclext::this_work_item::get_nd_item().get_local_linear_id();
+  size_t id = syclext::this_work_item::get_nd_item<1>().get_local_linear_id();
 
   // Each work-item has its own dedicated element of the device local memory
   // array.


### PR DESCRIPTION
Fix a couple syntax errors in the examples of some extension specifications.