### PR TITLE
[SYCL] Optimize sub-group joint_prefetch

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -1025,6 +1025,8 @@ __spirv_CreatePipeFromPipeStorage_write(
 extern __DPCPP_SYCL_EXTERNAL void
 __spirv_ocl_prefetch(const __attribute__((opencl_global)) char *Ptr,
                      size_t NumBytes) noexcept;
+extern __DPCPP_SYCL_EXTERNAL void __spirv_SubgroupBlockPrefetchINTEL(
+    const __attribute__((opencl_global)) char *Ptr, size_t NumBytes) noexcept;
 
 extern __DPCPP_SYCL_EXTERNAL float
     __spirv_ConvertBF16ToFINTEL(uint16_t) noexcept;

--- a/sycl/include/sycl/ext/oneapi/experimental/prefetch.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/prefetch.hpp
@@ -100,7 +100,7 @@ void prefetch_impl(T *ptr, size_t bytes, Properties properties) {
 
 template <typename Group, typename T, typename Properties>
 void joint_prefetch_impl(Group g, T *ptr, size_t bytes, Properties properties) {
-#ifdef __SYCL_DEVICE_ONLY__  && (defined(__SPIR__) || defined(__SPIRV__))
+#if defined(__SYCL_DEVICE_ONLY__) && (defined(__SPIR__) || defined(__SPIRV__))
   if constexpr (std::is_same_v<std::decay_t<Group>, sycl::sub_group>) {
     // sub-group block prefetch behavior is defined for `bytes` which are power
     // of 2 in range [1, 64].

--- a/sycl/test/check_device_code/extensions/sub-group-joint-prefetch.cpp
+++ b/sycl/test/check_device_code/extensions/sub-group-joint-prefetch.cpp
@@ -1,6 +1,7 @@
 // RUN: %clangxx -fsycl-device-only -S -emit-llvm %s -o - | FileCheck %s
 
-#include <sycl/sycl.hpp>
+#include <sycl/sub_group.hpp>
+#include <sycl/ext/oneapi/experimental/prefetch.hpp>
 
 namespace syclex = sycl::ext::oneapi::experimental;
 

--- a/sycl/test/check_device_code/extensions/sub-group-joint-prefetch.cpp
+++ b/sycl/test/check_device_code/extensions/sub-group-joint-prefetch.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl-device-only -S -emit-llvm -Xclang -no-enable-noundef-analysis %s -o - | FileCheck %s
+// RUN: %clangxx -fsycl-device-only -S -emit-llvm %s -o - | FileCheck %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/check_device_code/extensions/sub-group-joint-prefetch.cpp
+++ b/sycl/test/check_device_code/extensions/sub-group-joint-prefetch.cpp
@@ -1,0 +1,25 @@
+// RUN: %clangxx -fsycl-device-only -S -emit-llvm -Xclang -no-enable-noundef-analysis %s -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+
+namespace syclex = sycl::ext::oneapi::experimental;
+
+SYCL_EXTERNAL void
+sub_group_prefetch(sycl::sub_group sg, void *voidPtr, int *intPtr) {
+  auto prop = syclex::properties{syclex::prefetch_hint_L1};
+  syclex::joint_prefetch(sg, voidPtr, 2);
+  // CHECK: call {{.*}}__spirv_SubgroupBlockPrefetchINTEL
+  syclex::joint_prefetch(sg, voidPtr, 2, prop);
+  // CHECK: call {{.*}}__spirv_SubgroupBlockPrefetchINTEL
+
+  syclex::joint_prefetch(sg, intPtr);
+  // CHECK: call {{.*}}__spirv_SubgroupBlockPrefetchINTEL
+  syclex::joint_prefetch(sg, intPtr, prop);
+  // CHECK: call {{.*}}__spirv_SubgroupBlockPrefetchINTEL
+
+  // Check for unoptimized sizes
+  syclex::joint_prefetch(sg, intPtr, 3);
+  // CHECK: call {{.*}}__spirv_ocl_prefetch
+  syclex::joint_prefetch(sg, intPtr, 3, prop);
+  // CHECK: call {{.*}}__spirv_ocl_prefetch
+}


### PR DESCRIPTION
This code change utilizes SPV_INTEL_subgroup_buffer_prefetch extension
to optimize SYCL joint_prefetch.

https://github.com/KhronosGroup/SPIRV-Registry/pull/263/ - SPIR-V
extension specification.
