### PR TITLE
[DeviceSanitizer] Fix addr space mismatch for byval arguments

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -3731,8 +3731,12 @@ void FunctionStackPoisoner::copyArgsPassedByValToAllocas() {
       const Align Alignment =
           DL.getValueOrABITypeAlignment(Arg.getParamAlign(), Ty);
 
+      unsigned int AS = Triple(F.getParent()->getTargetTriple()).isSPIROrSPIRV()
+                            ? Arg.getType()->getPointerAddressSpace()
+                            : DL.getAllocaAddrSpace();
+
       AllocaInst *AI = IRB.CreateAlloca(
-          Ty, nullptr,
+          Ty, AS, nullptr,
           (Arg.hasName() ? Arg.getName() : "Arg" + Twine(Arg.getArgNo())) +
               ".byval");
       AI->setAlignment(Alignment);

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/byval_arg.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/byval_arg.ll
@@ -1,0 +1,15 @@
+; RUN: opt < %s -passes=asan -asan-instrumentation-with-call-threshold=0 -asan-stack=0 -asan-globals=0 -asan-use-after-return=never -asan-stack-dynamic-alloca=0 -asan-mapping-scale=4 -S | FileCheck %s
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+%struct.Input = type { i32, i32, i32, i32, i32, i32, i32, i32, i32, i32, i32 }
+
+; Function Attrs: sanitize_address
+define spir_func void @test(ptr addrspace(4) byval(%struct.Input) %input) #0 {
+entry:
+  ; CHECK: inttoptr i64 %1 to ptr addrspace(4)
+  ret void
+}
+
+attributes #0 = { sanitize_address }


### PR DESCRIPTION
If a function argument has byval attribute, asan pass will alloca a memory in function
body and copy the argument's value to it. We need to make sure the argument and alloca
memory have the same address space to avoid type mismatch problem.