### PR TITLE
[SYCL] Switch NativePrograms back to using multimap

### DIFF
--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -229,7 +229,7 @@ ProgramManager::createURProgram(const RTDeviceBinaryImage &Img,
   {
     std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);
     // associate the UR program with the image it was created for
-    NativePrograms[Res] = &Img;
+    NativePrograms.insert({Res, &Img});
   }
 
   Ctx->addDeviceGlobalInitializer(Res, {Device}, &Img);
@@ -840,7 +840,7 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
 
     {
       std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);
-      NativePrograms[BuiltProgram.get()] = &Img;
+      NativePrograms.insert({BuiltProgram.get(), &Img});
       for (RTDeviceBinaryImage *LinkedImg : DeviceImagesToLink) {
         NativePrograms.insert({BuiltProgram.get(), LinkedImg});
       }
@@ -2500,7 +2500,7 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
     {
       std::lock_guard<std::mutex> Lock(MNativeProgramsMutex);
-      NativePrograms[BuiltProgram.get()] = &Img;
+      NativePrograms.insert({BuiltProgram.get(), &Img});
     }
 
     ContextImpl->addDeviceGlobalInitializer(BuiltProgram.get(), Devs, &Img);

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -398,7 +398,7 @@ private:
   // the underlying program disposed of), so the map can't be used in any way
   // other than binary image lookup with known live UrProgram as the key.
   // NOTE: access is synchronized via the MNativeProgramsMutex
-  std::unordered_map<ur_program_handle_t, const RTDeviceBinaryImage *>
+  std::unordered_multimap<ur_program_handle_t, const RTDeviceBinaryImage *>
       NativePrograms;
 
   /// Protects NativePrograms that can be changed by class' methods.


### PR DESCRIPTION
4f86ab replaced `insert` with `[]` in order to fix a pointer re-use issue, however that was not the correct fix. Instead, a multimap was incorrectly converted to a regular map during the PI->UR conversion.

This change reverts the rest of 4f86ab (besides the test, which is still valid), and converts NativePrograms back to a multimap.

---

Thanks to @AlexeySachkov for finding the real issue in https://github.com/intel/llvm/pull/14873#issuecomment-2268881513