### PR TITLE
[SYCL][ESIMD] Move some math operations back to SPIR-V intrinsics

### DIFF
--- a/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
+++ b/llvm/lib/SYCLLowerIR/ESIMD/LowerESIMD.cpp
@@ -1234,21 +1234,6 @@ static Instruction *addCastInstIfNeeded(Instruction *OldI, Instruction *NewI,
   return NewI;
 }
 
-// Translates the following intrinsics:
-//   %res = call float @llvm.fmuladd.f32(float %a, float %b, float %c)
-//   %res = call double @llvm.fmuladd.f64(double %a, double %b, double %c)
-// To
-//   %mul = fmul <type> %a, <type> %b
-//   %res = fadd <type> %mul, <type> %c
-// TODO: Remove when newer GPU driver is used in CI.
-void translateFmuladd(CallInst *CI) {
-  assert(CI->getIntrinsicID() == Intrinsic::fmuladd);
-  IRBuilder<> Bld(CI);
-  auto *Mul = Bld.CreateFMul(CI->getOperand(0), CI->getOperand(1));
-  auto *Res = Bld.CreateFAdd(Mul, CI->getOperand(2));
-  CI->replaceAllUsesWith(Res);
-}
-
 // Translates an LLVM intrinsic to a form, digestable by the BE.
 bool translateLLVMIntrinsic(CallInst *CI) {
   Function *F = CI->getCalledFunction();
@@ -1259,9 +1244,6 @@ bool translateLLVMIntrinsic(CallInst *CI) {
   case Intrinsic::assume:
     // no translation - it will be simply removed.
     // TODO: make use of 'assume' info in the BE
-    break;
-  case Intrinsic::fmuladd:
-    translateFmuladd(CI);
     break;
   default:
     return false; // "intrinsic wasn't translated, keep the original call"

--- a/llvm/test/SYCLLowerIR/ESIMD/lower_llvm_intrin.ll
+++ b/llvm/test/SYCLLowerIR/ESIMD/lower_llvm_intrin.ll
@@ -1,7 +1,7 @@
 ; RUN: opt -passes=LowerESIMD -S < %s | FileCheck %s
 
-; This test checks that LowerESIMD pass correctly lowers some llvm intrinsics
-; which can't be handled by the VC BE.
+; This test checks that LowerESIMD pass does not lower some llvm intrinsics
+; which can now be handled by the VC BE.
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
@@ -10,17 +10,15 @@ declare double @llvm.fmuladd.f64(double %x, double %y, double %z)
 
 define spir_func float @test_fmuladd_f32(float %x, float %y, float %z) {
   %1 = call float @llvm.fmuladd.f32(float %x, float %y, float %z)
-; CHECK: %[[A:[0-9a-zA-Z\._]+]] = fmul float %x, %y
-; CHECK: %[[B:[0-9a-zA-Z\._]+]] = fadd float %[[A]], %z
+; CHECK: %[[A:[0-9a-zA-Z\._]+]] = call float @llvm.fmuladd.f32(float %x, float %y, float %z)
   ret float %1
-; CHECK: ret float %[[B]]
+; CHECK: ret float %[[A]]
 }
 
 define spir_func double @test_fmuladd_f64(double %x, double %y, double %z) {
   %1 = call double @llvm.fmuladd.f64(double %x, double %y, double %z)
-; CHECK: %[[A:[0-9a-zA-Z\._]+]] = fmul double %x, %y
-; CHECK: %[[B:[0-9a-zA-Z\._]+]] = fadd double %[[A]], %z
+; CHECK: %[[A:[0-9a-zA-Z\._]+]] = call double @llvm.fmuladd.f64(double %x, double %y, double %z)
   ret double %1
-; CHECK: ret double %[[B]]
+; CHECK: ret double %[[A]]
 }
 

--- a/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
@@ -13,6 +13,13 @@
 
 /// @cond ESIMD_DETAIL
 
+/// **************************** WARNING ************************************
+/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
+/// it is imperitive to exactly follow the pattern of the existing SPIR-V
+/// intrinsics. If not followed, the declaration may conflict with
+/// the Clang-generated and cause compilation errors.
+/// **************************** WARNING ************************************
+
 #include <sycl/ext/intel/esimd/common.hpp>
 #include <sycl/ext/intel/esimd/detail/types.hpp>
 #include <sycl/ext/intel/esimd/detail/util.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/intrin.hpp
@@ -17,7 +17,7 @@
 /// When declaring new SPIR-V intrinsics (functions starting with __spirv),
 /// it is imperitive to exactly follow the pattern of the existing SPIR-V
 /// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated and cause compilation errors.
+/// the Clang-generated functions and cause compilation errors.
 /// **************************** WARNING ************************************
 
 #include <sycl/ext/intel/esimd/common.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
@@ -32,45 +32,68 @@
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_exp2(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_exp2(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_exp2(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T>
 extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_recip(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_recip(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_recip(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_cos(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_cos(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_cos(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_log2(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_log2(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_log2(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T>
 extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_rsqrt(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_rsqrt(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_rsqrt(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_sin(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_sin(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_sin(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_sqrt(T);
 template <typename T, int N>
 extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_sqrt(__ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_sqrt(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 template <typename T>
 extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_native_powr(T, T);
 template <typename T, int N>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T, N)
-    __spirv_ocl_native_powr(__ESIMD_raw_vec_t(T, N), __ESIMD_raw_vec_t(T, N));
+    __spirv_ocl_native_powr(__ESIMD_raw_vec_t(T, N),
+                            __ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fabs(T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_fabs(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_s_abs(T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_s_abs(__ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fmin(T, T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_fmin(__ESIMD_raw_vec_t(T, N),
+                     __ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fmax(T, T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_fmax(__ESIMD_raw_vec_t(T, N),
+                     __ESIMD_raw_vec_t(T, N)) __ESIMD_INTRIN_END;
 
 // saturation intrinsics
 template <typename T0, typename T1, int SZ>
@@ -101,15 +124,7 @@ template <typename T0, typename T1, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T0, SZ)
     __esimd_sstrunc_sat(__ESIMD_raw_vec_t(T1, SZ) src) __ESIMD_INTRIN_END;
 
-template <typename T, int SZ>
-__ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
-    __esimd_abs(__ESIMD_raw_vec_t(T, SZ) src0) __ESIMD_INTRIN_END;
-
-/// 3 kinds of max
-template <typename T, int SZ>
-__ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
-    __esimd_fmax(__ESIMD_raw_vec_t(T, SZ) src0,
-                 __ESIMD_raw_vec_t(T, SZ) src1) __ESIMD_INTRIN_END;
+/// 3 kinds of max, the missing fmax uses spir-v intrinsics above
 template <typename T, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
     __esimd_umax(__ESIMD_raw_vec_t(T, SZ) src0,
@@ -119,11 +134,7 @@ __ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
     __esimd_smax(__ESIMD_raw_vec_t(T, SZ) src0,
                  __ESIMD_raw_vec_t(T, SZ) src1) __ESIMD_INTRIN_END;
 
-/// 3 kinds of min
-template <typename T, int SZ>
-__ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
-    __esimd_fmin(__ESIMD_raw_vec_t(T, SZ) src0,
-                 __ESIMD_raw_vec_t(T, SZ) src1) __ESIMD_INTRIN_END;
+/// 3 kinds of min, the missing fmin uses spir-v instrinsics above
 template <typename T, int SZ>
 __ESIMD_INTRIN __ESIMD_raw_vec_t(T, SZ)
     __esimd_umin(__ESIMD_raw_vec_t(T, SZ) src0,

--- a/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
@@ -17,7 +17,7 @@
 /// When declaring new SPIR-V intrinsics (functions starting with __spirv),
 /// it is imperitive to exactly follow the pattern of the existing SPIR-V
 /// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated and cause compilation errors.
+/// the Clang-generated functions and cause compilation errors.
 /// **************************** WARNING ************************************
 
 #include <sycl/builtins.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/math_intrin.hpp
@@ -13,6 +13,13 @@
 
 /// @cond ESIMD_DETAIL
 
+/// **************************** WARNING ************************************
+/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
+/// it is imperitive to exactly follow the pattern of the existing SPIR-V
+/// intrinsics. If not followed, the declaration may conflict with
+/// the Clang-generated and cause compilation errors.
+/// **************************** WARNING ************************************
+
 #include <sycl/builtins.hpp>
 #include <sycl/ext/intel/esimd/common.hpp>
 #include <sycl/ext/intel/esimd/detail/elem_type_traits.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -15,7 +15,7 @@
 /// When declaring new SPIR-V intrinsics (functions starting with __spirv),
 /// it is imperitive to exactly follow the pattern of the existing SPIR-V
 /// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated and cause compilation errors.
+/// the Clang-generated functions and cause compilation errors.
 /// **************************** WARNING ************************************
 
 #pragma once

--- a/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/detail/memory_intrin.hpp
@@ -11,6 +11,13 @@
 
 /// @cond ESIMD_DETAIL
 
+/// **************************** WARNING ************************************
+/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
+/// it is imperitive to exactly follow the pattern of the existing SPIR-V
+/// intrinsics. If not followed, the declaration may conflict with
+/// the Clang-generated and cause compilation errors.
+/// **************************** WARNING ************************************
+
 #pragma once
 
 #include <sycl/accessor.hpp>

--- a/sycl/include/sycl/ext/intel/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/math.hpp
@@ -97,7 +97,11 @@ namespace detail {
 template <typename TRes, typename TArg, int SZ>
 ESIMD_NODEBUG ESIMD_INLINE simd<TRes, SZ>
 __esimd_abs_common_internal(simd<TArg, SZ> src0) {
-  simd<TArg, SZ> Result = simd<TArg, SZ>(__esimd_abs<TArg, SZ>(src0.data()));
+  simd<TArg, SZ> Result;
+  if constexpr (detail::is_generic_floating_point_v<TArg>)
+    Result = simd<TArg, SZ>(__spirv_ocl_fabs<TArg, SZ>(src0.data()));
+  else
+    Result = simd<TArg, SZ>(__spirv_ocl_s_abs<TArg, SZ>(src0.data()));
   return convert<TRes>(Result);
 }
 
@@ -181,7 +185,7 @@ __ESIMD_API simd<T, SZ>(max)(simd<T, SZ> src0, simd<T, SZ> src1, Sat sat = {}) {
   constexpr bool is_sat = std::is_same_v<Sat, saturation_on_tag>;
 
   if constexpr (std::is_floating_point<T>::value) {
-    auto Result = __esimd_fmax<T, SZ>(src0.data(), src1.data());
+    auto Result = __spirv_ocl_fmax<T, SZ>(src0.data(), src1.data());
     if constexpr (is_sat)
       Result = __esimd_sat<T, T, SZ>(Result);
     return simd<T, SZ>(Result);
@@ -266,7 +270,7 @@ __ESIMD_API simd<T, SZ>(min)(simd<T, SZ> src0, simd<T, SZ> src1, Sat sat = {}) {
   constexpr bool is_sat = std::is_same_v<Sat, saturation_on_tag>;
 
   if constexpr (std::is_floating_point<T>::value) {
-    auto Result = __esimd_fmin<T, SZ>(src0.data(), src1.data());
+    auto Result = __spirv_ocl_fmin<T, SZ>(src0.data(), src1.data());
     if constexpr (is_sat)
       Result = __esimd_sat<T, T, SZ>(Result);
     return simd<T, SZ>(Result);
@@ -1462,7 +1466,7 @@ template <typename T0, typename T1, int SZ> struct esimd_apply_reduced_max {
   template <typename... T>
   simd<T0, SZ> operator()(simd<T1, SZ> v1, simd<T1, SZ> v2) {
     if constexpr (std::is_floating_point<T1>::value) {
-      return __esimd_fmax<T1, SZ>(v1.data(), v2.data());
+      return __spirv_ocl_fmax<T1, SZ>(v1.data(), v2.data());
     } else if constexpr (std::is_unsigned<T1>::value) {
       return __esimd_umax<T1, SZ>(v1.data(), v2.data());
     } else {
@@ -1475,7 +1479,7 @@ template <typename T0, typename T1, int SZ> struct esimd_apply_reduced_min {
   template <typename... T>
   simd<T0, SZ> operator()(simd<T1, SZ> v1, simd<T1, SZ> v2) {
     if constexpr (std::is_floating_point<T1>::value) {
-      return __esimd_fmin<T1, SZ>(v1.data(), v2.data());
+      return __spirv_ocl_fmin<T1, SZ>(v1.data(), v2.data());
     } else if constexpr (std::is_unsigned<T1>::value) {
       return __esimd_umin<T1, SZ>(v1.data(), v2.data());
     } else {

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
@@ -16,7 +16,7 @@
 /// When declaring new SPIR-V intrinsics (functions starting with __spirv),
 /// it is imperitive to exactly follow the pattern of the existing SPIR-V
 /// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated and cause compilation errors.
+/// the Clang-generated functions and cause compilation errors.
 /// **************************** WARNING ************************************
 
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
@@ -110,10 +110,26 @@ __ESIMD_INTRIN __ESIMD_raw_vec_t(sycl::half, N)
                  __ESIMD_DNS::vector_type_t<uint16_t, N> src2)
         __ESIMD_INTRIN_END;
 
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_fma(T, T, T);
 template <typename T, int N>
-__ESIMD_INTRIN __ESIMD_raw_vec_t(T, N)
-    __esimd_fmadd(__ESIMD_raw_vec_t(T, N) a, __ESIMD_raw_vec_t(T, N) b,
-                  __ESIMD_raw_vec_t(T, N) c) __ESIMD_INTRIN_END;
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_fma(__ESIMD_raw_vec_t(T, N) a, __ESIMD_raw_vec_t(T, N) b,
+                    __ESIMD_raw_vec_t(T, N) c) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_popcount(T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_popcount(__ESIMD_raw_vec_t(T, N) src0) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_ctz(T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_ctz(__ESIMD_raw_vec_t(T, N) src0) __ESIMD_INTRIN_END;
+
+template <typename T> extern __DPCPP_SYCL_EXTERNAL T __spirv_ocl_clz(T);
+template <typename T, int N>
+extern __DPCPP_SYCL_EXTERNAL __ESIMD_raw_vec_t(T, N)
+    __spirv_ocl_clz(__ESIMD_raw_vec_t(T, N) src0) __ESIMD_INTRIN_END;
 
 #undef __ESIMD_raw_vec_t
 #undef __ESIMD_cpp_vec_t

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/math_intrin.hpp
@@ -12,6 +12,13 @@
 
 /// @cond ESIMD_DETAIL
 
+/// **************************** WARNING ************************************
+/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
+/// it is imperitive to exactly follow the pattern of the existing SPIR-V
+/// intrinsics. If not followed, the declaration may conflict with
+/// the Clang-generated and cause compilation errors.
+/// **************************** WARNING ************************************
+
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>
 #include <sycl/ext/intel/esimd/detail/math_intrin.hpp>
 #include <sycl/ext/intel/esimd/detail/types.hpp>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -14,7 +14,7 @@
 /// When declaring new SPIR-V intrinsics (functions starting with __spirv),
 /// it is imperitive to exactly follow the pattern of the existing SPIR-V
 /// intrinsics. If not followed, the declaration may conflict with
-/// the Clang-generated and cause compilation errors.
+/// the Clang-generated functions and cause compilation errors.
 /// **************************** WARNING ************************************
 
 #pragma once

--- a/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/detail/memory_intrin.hpp
@@ -10,6 +10,13 @@
 
 /// @cond ESIMD_DETAIL
 
+/// **************************** WARNING ************************************
+/// When declaring new SPIR-V intrinsics (functions starting with __spirv),
+/// it is imperitive to exactly follow the pattern of the existing SPIR-V
+/// intrinsics. If not followed, the declaration may conflict with
+/// the Clang-generated and cause compilation errors.
+/// **************************** WARNING ************************************
+
 #pragma once
 
 #include <sycl/ext/intel/esimd/detail/defines_elementary.hpp>

--- a/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/esimd/math.hpp
@@ -32,11 +32,7 @@ template <typename T, int N>
 __ESIMD_API std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 8,
                              __ESIMD_NS::simd<T, N>>
 popcount(__ESIMD_NS::simd<T, N> vec) {
-#ifdef __SYCL_DEVICE_ONLY__
-  return __spirv_ocl_popcount(vec.data());
-#else
-  return vec;
-#endif
+  return __spirv_ocl_popcount<T, N>(vec.data());
 }
 
 /// Count the number of leading zeros.
@@ -48,11 +44,7 @@ template <typename T, int N>
 __ESIMD_API std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 8,
                              __ESIMD_NS::simd<T, N>>
 clz(__ESIMD_NS::simd<T, N> vec) {
-#ifdef __SYCL_DEVICE_ONLY__
-  return __spirv_ocl_clz(vec.data());
-#else
-  return vec;
-#endif
+  return __spirv_ocl_clz<T, N>(vec.data());
 }
 
 /// Count the number of trailing zeros.
@@ -63,11 +55,7 @@ template <typename T, int N>
 __ESIMD_API std::enable_if_t<std::is_integral_v<T> && sizeof(T) < 8,
                              __ESIMD_NS::simd<T, N>>
 ctz(__ESIMD_NS::simd<T, N> vec) {
-#ifdef __SYCL_DEVICE_ONLY__
-  return __spirv_ocl_ctz(vec.data());
-#else
-  return vec;
-#endif
+  return __spirv_ocl_ctz<T, N>(vec.data());
 }
 
 /// @} sycl_esimd_bitmanip
@@ -752,7 +740,7 @@ ESIMD_INLINE __ESIMD_NS::simd<T, N> fma(__ESIMD_NS::simd<T, N> a,
   static_assert(__ESIMD_DNS::is_generic_floating_point_v<T>,
                 "fma only supports floating point types");
   using CppT = __ESIMD_DNS::element_type_traits<T>::EnclosingCppT;
-  auto Ret = __esimd_fmadd<__ESIMD_DNS::__raw_t<CppT>, N>(
+  auto Ret = __spirv_ocl_fma<__ESIMD_DNS::__raw_t<CppT>, N>(
       __ESIMD_DNS::convert_vector<CppT, T, N>(a.data()),
       __ESIMD_DNS::convert_vector<CppT, T, N>(b.data()),
       __ESIMD_DNS::convert_vector<CppT, T, N>(c.data()));


### PR DESCRIPTION
This is a partial revert of 0228c2328167244d1ca9a04b8071c69e7e60ebc8, with the root cause that required the revert fixed.

Clang declares SPIR-V intrinsics for many operations, however it only supports vector size 2, 3, 4, 8, and 16 as per [here](https://github.com/intel/llvm/blob/sycl/clang/lib/Sema/SPIRVBuiltins.td#L349). 

On Windows, the ESIMD-declared intrinsics conflicted with the Clang declared intrinsics causing a compilation error and thus the revert in the above commit. We can't use the Clang intrinsics because we support any N including 1 and non-power of 2.

This comment fixes the issue by applying an existing pattern done with other intrinsics declared by SPIR-V, but I originally did these intrinsics in a different way, causing the problem.

This fixes the original issue (as proven by the tests added in the above commit), and allows us to use our intrinsics so all vector sizes are supported.

I added `__ESIMD_INTRIN_END` to all SPIR-V intrinsics including the existing ones because I saw an undefined symbol error on the host-compile with the ones I added and I'm pretty sure the same issue could affect any of them.