### PR TITLE
[SYCL] Fix Kernel Compiler OpenCLC_Supports_Extension

### DIFF
--- a/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
@@ -340,27 +340,31 @@ bool OpenCLC_Supports_Extension(
         "trouble parsing query returned from CL_DEVICE_EXTENSIONS_WITH_VERSION "
         "- extension not followed by colon (:)");
   }
-  colon++; // move it forward
 
-  size_t space = ExtensionByVersionLog.find(' ', colon); // could be npos
+  // Note that VersionPtr is an optional parameter in
+  // ext_oneapi_supports_cl_extension().
+  if (VersionPtr) {
+    colon++; // move it forward
 
-  size_t count = (space == std::string::npos) ? space : (space - colon);
+    size_t space = ExtensionByVersionLog.find(' ', colon); // could be npos
 
-  std::string versionStr = ExtensionByVersionLog.substr(colon, count);
-  std::vector<std::string> versionVec =
-      sycl::detail::split_string(versionStr, '.');
-  if (versionVec.size() != 3) {
-    throw sycl::exception(
-        rt_errc,
-        "trouble parsing query returned from  "
-        "CL_DEVICE_EXTENSIONS_WITH_VERSION - version string unexpected: " +
-            versionStr);
+    size_t count = (space == std::string::npos) ? space : (space - colon);
+
+    std::string versionStr = ExtensionByVersionLog.substr(colon, count);
+    std::vector<std::string> versionVec =
+        sycl::detail::split_string(versionStr, '.');
+    if (versionVec.size() != 3) {
+      throw sycl::exception(
+          rt_errc,
+          "trouble parsing query returned from  "
+          "CL_DEVICE_EXTENSIONS_WITH_VERSION - version string unexpected: " +
+              versionStr);
+    }
+
+    VersionPtr->major = std::stoi(versionVec[0]);
+    VersionPtr->minor = std::stoi(versionVec[1]);
+    VersionPtr->patch = std::stoi(versionVec[2]);
   }
-
-  VersionPtr->major = std::stoi(versionVec[0]);
-  VersionPtr->minor = std::stoi(versionVec[1]);
-  VersionPtr->patch = std::stoi(versionVec[2]);
-
   return true;
 }
 

--- a/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
+++ b/sycl/source/detail/kernel_compiler/kernel_compiler_opencl.cpp
@@ -343,28 +343,29 @@ bool OpenCLC_Supports_Extension(
 
   // Note that VersionPtr is an optional parameter in
   // ext_oneapi_supports_cl_extension().
-  if (VersionPtr) {
-    colon++; // move it forward
+  if (!VersionPtr)
+    return true;
 
-    size_t space = ExtensionByVersionLog.find(' ', colon); // could be npos
+  colon++; // move it forward
 
-    size_t count = (space == std::string::npos) ? space : (space - colon);
+  size_t space = ExtensionByVersionLog.find(' ', colon); // could be npos
 
-    std::string versionStr = ExtensionByVersionLog.substr(colon, count);
-    std::vector<std::string> versionVec =
-        sycl::detail::split_string(versionStr, '.');
-    if (versionVec.size() != 3) {
-      throw sycl::exception(
-          rt_errc,
-          "trouble parsing query returned from  "
-          "CL_DEVICE_EXTENSIONS_WITH_VERSION - version string unexpected: " +
-              versionStr);
-    }
+  size_t count = (space == std::string::npos) ? space : (space - colon);
 
-    VersionPtr->major = std::stoi(versionVec[0]);
-    VersionPtr->minor = std::stoi(versionVec[1]);
-    VersionPtr->patch = std::stoi(versionVec[2]);
+  std::string versionStr = ExtensionByVersionLog.substr(colon, count);
+  std::vector<std::string> versionVec =
+      sycl::detail::split_string(versionStr, '.');
+  if (versionVec.size() != 3) {
+    throw sycl::exception(
+        rt_errc,
+        "trouble parsing query returned from  "
+        "CL_DEVICE_EXTENSIONS_WITH_VERSION - version string unexpected: " +
+            versionStr);
   }
+
+  VersionPtr->major = std::stoi(versionVec[0]);
+  VersionPtr->minor = std::stoi(versionVec[1]);
+  VersionPtr->patch = std::stoi(versionVec[2]);
   return true;
 }
 

--- a/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
@@ -41,6 +41,26 @@ int main() {
            "version not updated");
   }
 
+  // test without version pointer
+  bool has_bf16_conversion =
+      d.ext_oneapi_supports_cl_extension("cl_intel_bf16_conversion");
+  std::cout << "has_bf16_conversion: " << has_bf16_conversion << std::endl;
+  bool has_subgroup_matrix_multiply_accumulate =
+      d.ext_oneapi_supports_cl_extension(
+          "cl_intel_subgroup_matrix_multiply_accumulate");
+  std::cout << "has_subgroup_matrix_multiply_accumulate: "
+            << has_subgroup_matrix_multiply_accumulate << std::endl;
+  bool has_subgroup_matrix_multiply_accumulate_tensor_float32 =
+      d.ext_oneapi_supports_cl_extension(
+          "cl_intel_subgroup_matrix_multiply_accumulate_tensor_float32");
+  std::cout << "has_subgroup_matrix_multiply_accumulate_tensor_float32: "
+            << has_subgroup_matrix_multiply_accumulate_tensor_float32
+            << std::endl;
+  bool has_subgroup_2d_block_io =
+      d.ext_oneapi_supports_cl_extension("cl_intel_subgroup_2d_block_io");
+  std::cout << "has_subgroup_2d_block_io: " << has_subgroup_2d_block_io
+            << std::endl;
+
   // no supported devices support EMBEDDED_PROFILE at this time.
   assert(d.ext_oneapi_cl_profile() == "FULL_PROFILE" &&
          "unexpected cl_profile");


### PR DESCRIPTION
The optional parameter `VersionPtr` is `nullptr` by default. But, the code assumes it is a valid pointer.
So, the fix is to guard with an `if` conditional phrase.