### PR TITLE
[SYCLLowerIR] Fix size_t/uint64_t confusion

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLCreateNVVMAnnotations.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLCreateNVVMAnnotations.cpp
@@ -54,7 +54,7 @@ decomposeWGMetadata(const MDNode &Node, const Function &F) {
     NDim = getSingleIntMetadata(*NDimMD).value_or(3);
   assert(NDim >= 1 && NDim <= 3 && "Invalid work-group dimensionality");
 
-  std::array<std::optional<size_t>, 3> Ops;
+  std::array<std::optional<uint64_t>, 3> Ops;
   for (unsigned I = 0, E = std::min(Node.getNumOperands(), NDim); I != E; I++) {
     if (auto *C = mdconst::dyn_extract<ConstantInt>(Node.getOperand(I)))
       Ops[I] = C->getZExtValue();


### PR DESCRIPTION
This was quite rightly breaking the post-commit MacOS build.