### PR TITLE
[NewOffload] Do not wrap redundant compile/link options

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1057,20 +1057,15 @@ wrapSYCLBinariesFromFile(std::vector<module_split::SplitModule> &SplitModules,
   M.setTargetTriple(
       Args.getLastArgValue(OPT_host_triple_EQ, sys::getDefaultTargetTriple()));
 
-  auto CompileOptionsFromImage =
-      Args.getLastArgValue(OPT_sycl_backend_compile_options_from_image_EQ);
-  auto LinkOptionsFromImage =
-      Args.getLastArgValue(OPT_sycl_backend_link_options_from_image_EQ);
   auto CompileOptionsFromSYCLBackendCompileOptions =
       Args.getLastArgValue(OPT_sycl_backend_compile_options_EQ);
   auto LinkOptionsFromSYCLTargetLinkOptions =
       Args.getLastArgValue(OPT_sycl_target_link_options_EQ);
 
   StringRef CompileOptions(
-      Args.MakeArgString(CompileOptionsFromImage.str() +
-                         CompileOptionsFromSYCLBackendCompileOptions.str()));
-  StringRef LinkOptions(Args.MakeArgString(
-      LinkOptionsFromImage.str() + LinkOptionsFromSYCLTargetLinkOptions.str()));
+      Args.MakeArgString(CompileOptionsFromSYCLBackendCompileOptions.str()));
+  StringRef LinkOptions(
+      Args.MakeArgString(LinkOptionsFromSYCLTargetLinkOptions.str()));
   offloading::SYCLWrappingOptions WrappingOptions;
   WrappingOptions.CompileOptions = CompileOptions;
   WrappingOptions.LinkOptions = LinkOptions;

--- a/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
@@ -4,3 +4,7 @@
 // RUN: %clangxx -fsycl -fsycl-device-code-split=per_source -fsycl-targets=spir64_x86_64 -I %S/Inputs -o %t.out %S/split-per-source-main.cpp %S/Inputs/split-per-source-second-file.cpp \
 // RUN: -fsycl-dead-args-optimization --offload-new-driver
 // RUN: %{run} %t.out
+
+// Test -O0 with `--offload-new-driver`
+// RUN: %clangxx -O0 -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
+// RUN: %{run} %t.out


### PR DESCRIPTION
In AOT mode there is no need to pass over compile options and linking options.
It resolves new failure in the New Offload Model.