### PR TITLE
[SYCL][E2E] XFAIL launch_policy_lmem.cpp on Arc

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -23,6 +23,9 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
+// https://github.com/intel/llvm/issues/14974
+// XFAIL: gpu-intel-dg2
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/group_barrier.hpp>


### PR DESCRIPTION
It's failing with the new driver (not yet merged, will merge after this PR is merged)

https://github.com/intel/llvm/issues/14974