### PR TITLE
[CI] Fix HIP postcommit

### DIFF
--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -42,8 +42,23 @@ jobs:
       cxx: clang++
       merge_ref: ''
 
+  build-lin-static:
+    name: Linux (Self build + static libraries + no-assertions)
+    if: github.repository == 'intel/llvm'
+    uses: ./.github/workflows/sycl-linux-build.yml
+    with:
+      build_cache_root: "/__w/llvm"
+      build_cache_suffix: sprod_static
+      build_artifact_suffix: sprod_static
+      build_configure_extra_args: --no-assertions --hip --cuda --native_cpu --cmake-opt="-DSYCL_ENABLE_STACK_PRINTING=ON" --cmake-opt="-DSYCL_LIB_WITH_DEBUG_SYMBOL=ON"
+      # Docker image has last nightly pre-installed and added to the PATH
+      build_image: "ghcr.io/intel/llvm/sycl_ubuntu2204_nightly:build"
+      cc: clang
+      cxx: clang++
+      merge_ref: ''
+
   e2e-lin:
-    needs: [build-lin]
+    needs: [build-lin, build-lin-static]
     if: ${{ always() && !cancelled() && needs.build-lin.outputs.build_conclusion == 'success' }}
     strategy:
       fail-fast: false
@@ -53,14 +68,21 @@ jobs:
             runner: '["Linux", "gen12"]'
             extra_lit_opts: --param gpu-intel-gen12=True
             target_devices: level_zero:gpu;opencl:fpga
+            reset_gpu: true
           - name: Intel Arc A-Series Graphics with Level Zero
             runner: '["Linux", "arc"]'
             extra_lit_opts: --param matrix-xmx8=True --param gpu-intel-dg2=True
+            reset_gpu: true
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2204_build:latest-0300ac924620a51f76c4929794637b82790f12ab
             image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
             target_devices: ext_oneapi_hip:gpu
+            reset_gpu: false
+            # Use static build because of shared lld packaging issue
+            sycl_toolchain_artifact: sycl_linux_sprod_static
+            sycl_toolchain_archive: ${{ needs.build-lin-static.outputs.artifact_archive_name }}
+            sycl_toolchain_decompress_command: ${{ needs.build-lin-static.outputs.artifact_decompress_command }}
           # Performance tests below. Specifics:
           #  - only run performance tests (use LIT_FILTER env)
           #  - ask llvm-lit to show all the output, even for PASS (-a)
@@ -72,19 +94,21 @@ jobs:
             env: '{"LIT_FILTER":"PerformanceTests/"}'
             extra_lit_opts: -a -j 1 --param enable-perf-tests=True --param gpu-intel-gen12=True
             target_devices: all
+            reset_gpu: true
           - name: Perf tests on Intel Arc A-Series Graphics system
             runner: '["Linux", "arc"]'
             env: '{"LIT_FILTER":"PerformanceTests/"}'
             extra_lit_opts: -a -j 1 --param enable-perf-tests=True
             target_devices: all
+            reset_gpu: true
     uses: ./.github/workflows/sycl-linux-run-tests.yml
     with:
       name: ${{ matrix.name }}
       runner: ${{ matrix. runner }}
-      image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
-      image_options: -u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN
+      image: ${{ matrix.image || 'ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest' }}
+      image_options: ${{ matrix.image_options || '-u 1001 --device=/dev/dri --privileged --cap-add SYS_ADMIN' }}
       target_devices: ${{ matrix.target_devices || 'level_zero:gpu' }}
-      reset_gpu: true
+      reset_gpu: ${{ matrix.reset_gpu }}
 
       extra_lit_opts: ${{ matrix.extra_lit_opts }}
       env: ${{ matrix.env || '{}' }}
@@ -92,9 +116,9 @@ jobs:
       ref: ${{ github.sha }}
       merge_ref: ''
 
-      sycl_toolchain_artifact: sycl_linux_sprod_shared
-      sycl_toolchain_archive: ${{ needs.build-lin.outputs.artifact_archive_name }}
-      sycl_toolchain_decompress_command: ${{ needs.build-lin.outputs.artifact_decompress_command }}
+      sycl_toolchain_artifact: ${{ matrix.sycl_toolchain_artifact || 'sycl_linux_sprod_shared' }}
+      sycl_toolchain_archive: ${{ matrix.sycl_toolchain_archive || needs.build-lin.outputs.artifact_archive_name }}
+      sycl_toolchain_decompress_command: ${{ matrix.sycl_toolchain_decompress_command || needs.build-lin.outputs.artifact_decompress_command }}
 
   build-win:
     if: |


### PR DESCRIPTION
We need `reset_gpu` to be false, to use the correct image, and to use a static library build becuase `lld` is not packaged correctly into the binary for shared library build. 

I'll investigate the `lld` issue separately (https://github.com/intel/llvm/issues/14986), but let's unbreak CI.
