### PR TITLE
[SYCL] Add work-around for event leak in profiling tag

### DIFF
--- a/sycl/test-e2e/ProfilingTag/profile_tag_leak.cpp
+++ b/sycl/test-e2e/ProfilingTag/profile_tag_leak.cpp
@@ -1,0 +1,18 @@
+// REQUIRES: level_zero
+
+// RUN: %{build} -o %t.out
+// RUN: %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK
+
+// Regression test to avoid the reintroduction of a leak in L0 in the profiling
+// tags when using barriers to ensure ordering on out-of-order queues.
+
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/oneapi/experimental/profiling_tag.hpp>
+
+int main() {
+  sycl::queue Queue;
+  sycl::event TagE =
+      sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
+  Queue.wait();
+  return 0;
+}


### PR DESCRIPTION
Due to a bug in the L0 UR adapter, the profiling tag extension leaks UR events on out-of-order queues. This is not due to the profiling tag events themselves, but rather due to the need for a barrier enforcing correct ordering of the inserted tag. Since the barrier ensures completion prior to the profiling tag executing, the output event is not needed, but the L0 adapter leaks the event if no output event is specified. To combat this, this work-around passes an output event and immediately frees it after the barrier has been submitted.

See https://github.com/oneapi-src/unified-runtime/issues/1947.