### PR TITLE
[SYCL][Driver][thinLTO] Don't pass -emit-only-kernels-as-entry-points to sycl-post-link in early splitting

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10788,7 +10788,10 @@ static void getTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
        !isSYCLNativeCPU(TC)) &&
       // When supporting dynamic linking, non-kernels in a device image can be
       // called.
-      !supportDynamicLinking(TCArgs) && !Triple.isNVPTX() && !Triple.isAMDGPU())
+      !supportDynamicLinking(TCArgs) && !Triple.isNVPTX() &&
+      !Triple.isAMDGPU()
+      // With thinLTO, final entry point handing is done in clang-linker-wrapper
+      && (!IsUsingLTO || LTOMode != LTOK_Thin))
     addArgs(PostLinkArgs, TCArgs, {"-emit-only-kernels-as-entry-points"});
 
   if (!Triple.isAMDGCN())

--- a/clang/test/Driver/sycl-lto.cpp
+++ b/clang/test/Driver/sycl-lto.cpp
@@ -9,9 +9,10 @@
 // CHECK_SPLIT_ERROR: '-fsycl-device-code-split=off' is not supported when '-foffload-lto=thin' is set with '-fsycl'
 
 // Verify there's no error and we see the expected cc1 flags and tool invocations with the new offload driver.
-// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | FileCheck -check-prefix=CHECK_SUPPORTED %s
+// RUN: %clangxx -fsycl --offload-new-driver -foffload-lto=thin %s -### 2>&1 | \
+// RUN: FileCheck -check-prefix=CHECK_SUPPORTED -implicit-check-not=-emit-only-kernels-as-entry-points %s
 // CHECK_SUPPORTED: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown" {{.*}} "-flto=thin" "-flto-unit"
-// CHECK_SUPPORTED: sycl-post-link{{.*}}
+// CHECK_SUPPORTED: sycl-post-link
 // CHECK_SUPPORTED-NOT: -properties
 // CHECK_SUPPORTED-NEXT: file-table-tform{{.*}}
 // CHECK_SUPPORTED-NEXT: llvm-foreach{{.*}} "--" {{.*}}clang{{.*}} "-fsycl-is-device"{{.*}} "-flto=thin" "-flto-unit"


### PR DESCRIPTION
In early splitting with thinLTO, we could be generating an `.o` to be linked in with other files later. Right now, passing `-emit-only-kernels-as-entry-points` to `sycl-post-link` can cause functions to get dropped even though they are used by some other `.o`.

We will need to prune non-entry points inside the thinLTO processing inside `clang-linker-wrapper`, but that's not implemented yet.