### PR TITLE
[NFC][SYCL] Remove multiple definitions of ComputeValidFooterFileID.

### DIFF
--- a/clang/include/clang/Basic/SourceManager.h
+++ b/clang/include/clang/Basic/SourceManager.h
@@ -906,6 +906,19 @@ public:
   /// Get the file ID for the precompiled preamble if there is one.
   FileID getPreambleFileID() const { return PreambleFileID; }
 
+  ///  Get the file ID for the integration footer.
+  FileID ComputeValidFooterFileID(StringRef Footer) {
+    FileID FooterFileID;
+    llvm::Expected<FileEntryRef> ExpectedFileRef =
+        getFileManager().getFileRef(Footer);
+    if (ExpectedFileRef) {
+      FooterFileID = getOrCreateFileID(ExpectedFileRef.get(),
+                                       SrcMgr::CharacteristicKind::C_User);
+    }
+    assert(FooterFileID.isValid() && "expecting a valid footer FileID");
+    return FooterFileID;
+  }
+
   //===--------------------------------------------------------------------===//
   // Methods to create new FileID's and macro expansions.
   //===--------------------------------------------------------------------===//

--- a/clang/lib/Frontend/PrintPreprocessedOutput.cpp
+++ b/clang/lib/Frontend/PrintPreprocessedOutput.cpp
@@ -904,18 +904,6 @@ struct UnknownPragmaHandler : public PragmaHandler {
 };
 } // end anonymous namespace
 
-FileID ComputeValidFooterFileID(SourceManager &SM, StringRef Footer) {
-  FileID FooterFileID;
-  llvm::Expected<FileEntryRef> ExpectedFileRef =
-      SM.getFileManager().getFileRef(Footer);
-  if (ExpectedFileRef) {
-    FooterFileID = SM.getOrCreateFileID(ExpectedFileRef.get(),
-                                        SrcMgr::CharacteristicKind::C_User);
-  }
-  assert(FooterFileID.isValid() && "expecting a valid footer FileID");
-  return FooterFileID;
-}
-
 static void PrintIncludeFooter(Preprocessor &PP, SourceLocation Loc,
                                std::string Footer,
                                PrintPPOutputPPCallbacks *Callbacks) {
@@ -923,7 +911,7 @@ static void PrintIncludeFooter(Preprocessor &PP, SourceLocation Loc,
   PresumedLoc UserLoc = SourceMgr.getPresumedLoc(Loc);
   if (UserLoc.isInvalid())
     return;
-  FileID FooterFileID = ComputeValidFooterFileID(SourceMgr, Footer);
+  FileID FooterFileID = SourceMgr.ComputeValidFooterFileID(Footer);
   StringRef FooterContentBuffer = SourceMgr.getBufferData(FooterFileID);
   // print out the name of the integration footer.
   Callbacks->WriteFooterInfo(Footer);

--- a/clang/lib/Lex/PPLexerChange.cpp
+++ b/clang/lib/Lex/PPLexerChange.cpp
@@ -326,18 +326,6 @@ void Preprocessor::diagnoseMissingHeaderInUmbrellaDir(const Module &Mod) {
   }
 }
 
-static FileID ComputeValidFooterFileID(SourceManager &SM, StringRef Footer) {
-  FileID FooterFileID;
-  llvm::Expected<FileEntryRef> ExpectedFileRef =
-      SM.getFileManager().getFileRef(Footer);
-  if (ExpectedFileRef) {
-    FooterFileID = SM.getOrCreateFileID(ExpectedFileRef.get(),
-                                        SrcMgr::CharacteristicKind::C_User);
-  }
-  assert(FooterFileID.isValid() && "expecting a valid footer FileID");
-  return FooterFileID;
-}
-
 /// HandleEndOfFile - This callback is invoked when the lexer hits the end of
 /// the current file.  This either returns the EOF token or pops a level off
 /// the include stack and keeps going.
@@ -552,8 +540,8 @@ bool Preprocessor::HandleEndOfFile(Token &Result, bool isEndOfMacro) {
     SourceManager &SourceMgr = getSourceManager();
     SourceLocation Loc = CurLexer->getFileLoc();
 
-    FileID FooterFileID = ComputeValidFooterFileID(
-        SourceMgr, getPreprocessorOpts().IncludeFooter);
+    FileID FooterFileID =
+        SourceMgr.ComputeValidFooterFileID(getPreprocessorOpts().IncludeFooter);
     if (!FooterFileID.isInvalid() && !IncludeFooterProcessed) {
       IncludeFooterProcessed = true;
       // Mark the footer file as included


### PR DESCRIPTION
The same functionality was needed at the 2 different places, and I inadvertently created 2 functions. This patch refactors it.