### PR TITLE
[SYCL] Rename virtual function properties

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/virtual_functions.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/virtual_functions.hpp
@@ -13,8 +13,10 @@ struct indirectly_callable_key {
                                                       Set>;
 };
 
-template <typename Set = void>
-inline constexpr indirectly_callable_key::value_t<Set> indirectly_callable;
+inline constexpr indirectly_callable_key::value_t<void> indirectly_callable;
+
+template <typename Set>
+inline constexpr indirectly_callable_key::value_t<Set> indirectly_callable_in;
 
 struct calls_indirectly_key {
   template <typename First = void, typename... SetIds>
@@ -23,8 +25,11 @@ struct calls_indirectly_key {
                                                       First, SetIds...>;
 };
 
-template <typename First = void, typename... Rest>
-inline constexpr calls_indirectly_key::value_t<First, Rest...> calls_indirectly;
+inline constexpr calls_indirectly_key::value_t<void> assume_indirect_calls;
+
+template <typename First, typename... Rest>
+inline constexpr calls_indirectly_key::value_t<First, Rest...>
+    assume_indirect_calls_to;
 
 template <> struct is_property_key<indirectly_callable_key> : std::true_type {};
 template <> struct is_property_key<calls_indirectly_key> : std::true_type {};
@@ -57,6 +62,9 @@ struct PropertyMetaInfo<indirectly_callable_key::value_t<Set>> {
 
 template <typename First, typename... Rest>
 struct PropertyMetaInfo<calls_indirectly_key::value_t<First, Rest...>> {
+  static_assert(
+      sizeof...(Rest) == 0,
+      "assume_indirect_calls_to property only supports a single set for now");
   static constexpr const char *name = "calls-indirectly";
   static constexpr const char *value =
 #ifdef __SYCL_DEVICE_ONLY__

--- a/sycl/test-e2e/VirtualFunctions/2/1/1/missing-overrides.cpp
+++ b/sycl/test-e2e/VirtualFunctions/2/1/1/missing-overrides.cpp
@@ -14,52 +14,52 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void increment(int *) { /* do nothhing */
   }
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void multiply(int *) { /* do nothhing */
   }
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void substract(int *) { /* do nothhing */
   }
 };
 
 class IncrementBy1 : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 1; }
 };
 
 class IncrementBy1AndSubstractBy2 : public IncrementBy1 {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void substract(int *Data) override { *Data -= 2; }
 };
 
 class MultiplyBy2 : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void multiply(int *Data) override { *Data *= 2; }
 };
 
 class MultiplyBy2AndIncrementBy8 : public MultiplyBy2 {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 8; }
 };
 
 class SubstractBy4 : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void substract(int *Data) override { *Data -= 4; }
 };
 
 class SubstractBy4AndMultiplyBy4 : public SubstractBy4 {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void multiply(int *Data) override { *Data *= 4; }
 };
 
@@ -83,7 +83,7 @@ int main() try {
 
   sycl::queue q(asyncHandler);
 
-  constexpr oneapi::properties props{oneapi::calls_indirectly<>};
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 6; ++TestCase) {
     int HostData = 42;
     int Data = HostData;

--- a/sycl/test-e2e/VirtualFunctions/2/1/1/more-complex-hierarchy.cpp
+++ b/sycl/test-e2e/VirtualFunctions/2/1/1/more-complex-hierarchy.cpp
@@ -14,35 +14,35 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class AbstractOp {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void applyOp(int *) = 0;
 };
 
 class IncrementOp : public AbstractOp {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void applyOp(int *Data) final override { increment(Data); }
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void increment(int *) = 0;
 };
 
 class IncrementBy1 : public IncrementOp {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 1; }
 };
 
 class IncrementBy2 : public IncrementOp {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 2; }
 };
 
 class IncrementBy4 : public IncrementOp {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 4; }
 };
 
 class IncrementBy8 : public IncrementOp {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 8; }
 };
 
@@ -62,7 +62,7 @@ int main() try {
 
   sycl::queue q(asyncHandler);
 
-  constexpr oneapi::properties props{oneapi::calls_indirectly<>};
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 4; ++TestCase) {
     int HostData = 42;
     int Data = HostData;

--- a/sycl/test-e2e/VirtualFunctions/2/1/1/simple-hierarchy.cpp
+++ b/sycl/test-e2e/VirtualFunctions/2/1/1/simple-hierarchy.cpp
@@ -14,22 +14,22 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class BaseIncrement {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void increment(int *Data) { *Data += 1; }
 };
 
 class IncrementBy2 : public BaseIncrement {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 2; }
 };
 
 class IncrementBy4 : public BaseIncrement {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 4; }
 };
 
 class IncrementBy8 : public BaseIncrement {
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 8; }
 };
 
@@ -47,7 +47,7 @@ int main() try {
 
   sycl::queue q(asyncHandler);
 
-  constexpr oneapi::properties props{oneapi::calls_indirectly<>};
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 4; ++TestCase) {
     int HostData = 42;
     int Data = HostData;

--- a/sycl/test-e2e/VirtualFunctions/2/2/single-construct-single-use.cpp
+++ b/sycl/test-e2e/VirtualFunctions/2/2/single-construct-single-use.cpp
@@ -16,7 +16,7 @@ class BaseIncrement {
 public:
   BaseIncrement(int Mod, int /* unused */ = 42) : Mod(Mod) {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void increment(int *Data) { *Data += 1 + Mod; }
 
 protected:
@@ -27,7 +27,7 @@ class IncrementBy2 : public BaseIncrement {
 public:
   IncrementBy2(int Mod, int /* unused */) : BaseIncrement(Mod) {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 2 + Mod; }
 };
 
@@ -36,7 +36,7 @@ public:
   IncrementBy4(int Mod, int ExtraMod)
       : BaseIncrement(Mod), ExtraMod(ExtraMod) {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 4 + Mod + ExtraMod; }
 
 private:
@@ -47,7 +47,7 @@ class IncrementBy8 : public BaseIncrement {
 public:
   IncrementBy8(int Mod, int /* unused */) : BaseIncrement(Mod) {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void increment(int *Data) override { *Data += 8 + Mod; }
 };
 
@@ -66,7 +66,7 @@ int main() try {
   sycl::queue q(asyncHandler);
 
   // TODO: cover uses case when objects are passed through USM
-  constexpr oneapi::properties props{oneapi::calls_indirectly<>};
+  constexpr oneapi::properties props{oneapi::assume_indirect_calls};
   for (unsigned TestCase = 0; TestCase < 4; ++TestCase) {
     int HostData = 42;
     int Data = HostData;

--- a/sycl/test/virtual-functions/calls-indirectly-ir.cpp
+++ b/sycl/test/virtual-functions/calls-indirectly-ir.cpp
@@ -16,7 +16,7 @@
 // template argument ignoring the rest. This will be fixed in a follow-up
 // patches and the test should be updated to reflect that, because current
 // behavior is not correct.
-// CHECK: define {{.*}}KMultiple{{.*}} #[[#ATTR_SET_INT]]
+// CHECK-disabled: define {{.*}}KMultiple{{.*}} #[[#ATTR_SET_INT]]
 //
 // CHECK-DAG: attributes #[[#ATTR_SET_DEFAULT]] {{.*}} "calls-indirectly"="_ZTSv"
 // CHECK-DAG: attributes #[[#ATTR_SET_INT]] {{.*}} "calls-indirectly"="_ZTSi"
@@ -40,18 +40,22 @@ class KMultiple;
 int main() {
   sycl::queue q;
 
-  oneapi::properties props_empty{oneapi::calls_indirectly<>};
-  oneapi::properties props_int{oneapi::calls_indirectly<int>};
-  oneapi::properties props_void{oneapi::calls_indirectly<void>};
-  oneapi::properties props_user_defined{oneapi::calls_indirectly<user_defined>};
-  oneapi::properties props_multiple{
-      oneapi::calls_indirectly<int, user_defined>};
+  oneapi::properties props_empty{oneapi::assume_indirect_calls};
+  oneapi::properties props_int{oneapi::assume_indirect_calls_to<int>};
+  oneapi::properties props_void{oneapi::assume_indirect_calls_to<void>};
+  oneapi::properties props_user_defined{
+      oneapi::assume_indirect_calls_to<user_defined>};
+  // assume_indirect_calls_to is currently limited to a single set, so this test
+  // is disabled.
+  // FIXME: re-enable once the restriction is lifted.
+  // oneapi::properties props_multiple{
+  //    oneapi::assume_indirect_calls_to<int, user_defined>};
 
   q.single_task<KEmpty>(props_empty, [=]() {});
   q.single_task<KInt>(props_int, [=]() {});
   q.single_task<KVoid>(props_void, [=]() {});
   q.single_task<KUserDefined>(props_user_defined, [=]() {});
-  q.single_task<KMultiple>(props_multiple, [=]() {});
+  // q.single_task<KMultiple>(props_multiple, [=]() {});
 
   return 0;
 }

--- a/sycl/test/virtual-functions/diagnostics-negative.cpp
+++ b/sycl/test/virtual-functions/diagnostics-negative.cpp
@@ -10,7 +10,7 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void foo() const {}
 
   virtual void bar() const {}
@@ -18,7 +18,7 @@ public:
 
 class Derived : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void foo() const override {}
 
   void bar() const override {}

--- a/sycl/test/virtual-functions/diagnostics-positive.cpp
+++ b/sycl/test/virtual-functions/diagnostics-positive.cpp
@@ -11,16 +11,16 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void foo() {}
 };
 
 class Derived : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void foo() override {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<void>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<void>)
   virtual void bar() {}
 };
 
@@ -28,16 +28,16 @@ class SubDerived : public Derived {
 public:
   void foo() override {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<int>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<int>)
   void bar() override {}
 };
 
 class SubSubDerived : public SubDerived {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void foo() override {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<Base>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<Base>)
   void bar() override {}
 };
 
@@ -55,10 +55,10 @@ int main() {
   // The exact arguments passed to calls_indirectly property don't matter,
   // because we have no way of connecting a virtual call with a particular
   // property set, but we test different properties here just in case.
-  oneapi::properties props_empty{oneapi::calls_indirectly<>};
-  oneapi::properties props_void{oneapi::calls_indirectly<void>};
-  oneapi::properties props_int{oneapi::calls_indirectly<int>};
-  oneapi::properties props_base{oneapi::calls_indirectly<Base>};
+  oneapi::properties props_empty{oneapi::assume_indirect_calls};
+  oneapi::properties props_void{oneapi::assume_indirect_calls_to<void>};
+  oneapi::properties props_int{oneapi::assume_indirect_calls_to<int>};
+  oneapi::properties props_base{oneapi::assume_indirect_calls_to<Base>};
 
   char *Storage = sycl::malloc_device<char>(128, q);
 

--- a/sycl/test/virtual-functions/indirectly-callable-ir.cpp
+++ b/sycl/test/virtual-functions/indirectly-callable-ir.cpp
@@ -24,7 +24,7 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual int foo();
 };
 
@@ -32,9 +32,9 @@ int Base::foo() { return 42; }
 
 class Derived : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<void>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<void>)
   virtual int bar();
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   int foo() override;
 };
 
@@ -46,7 +46,7 @@ class SubDerived : public Derived {
 public:
   int foo() override { return 44; }
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<int>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<int>)
   int bar() override;
 };
 
@@ -54,10 +54,10 @@ int SubDerived::bar() { return 1; }
 
 class SubSubDerived : public SubDerived {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   int foo() override;
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<Base>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<Base>)
   int bar() override;
 };
 

--- a/sycl/test/virtual-functions/properties-negative.cpp
+++ b/sycl/test/virtual-functions/properties-negative.cpp
@@ -12,10 +12,10 @@ struct user_defined {
 int main() {
   sycl::queue q;
 
-  oneapi::properties props_empty{oneapi::indirectly_callable<>};
-  oneapi::properties props_void{oneapi::indirectly_callable<void>};
-  oneapi::properties props_int{oneapi::indirectly_callable<int>};
-  oneapi::properties props_user{oneapi::indirectly_callable<user_defined>};
+  oneapi::properties props_empty{oneapi::indirectly_callable};
+  oneapi::properties props_void{oneapi::indirectly_callable_in<void>};
+  oneapi::properties props_int{oneapi::indirectly_callable_in<int>};
+  oneapi::properties props_user{oneapi::indirectly_callable_in<user_defined>};
 
   // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} indirectly_callable property cannot be applied to SYCL kernels}}
   q.single_task(props_empty, [=]() {});

--- a/sycl/test/virtual-functions/properties-positive.cpp
+++ b/sycl/test/virtual-functions/properties-positive.cpp
@@ -11,16 +11,16 @@ namespace oneapi = sycl::ext::oneapi::experimental;
 
 class Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   virtual void foo() {}
 };
 
 class Derived : public Base {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void foo() override {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<void>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<void>)
   virtual void bar() {}
 };
 
@@ -28,16 +28,16 @@ class SubDerived : public Derived {
 public:
   void foo() override {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<int>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<int>)
   void bar() override {}
 };
 
 class SubSubDerived : public SubDerived {
 public:
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable)
   void foo() override {}
 
-  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable<Base>)
+  SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(oneapi::indirectly_callable_in<Base>)
   void bar() override {}
 };
 
@@ -48,17 +48,21 @@ int main() {
       oneapi::is_property_key<oneapi::indirectly_callable_key>::value);
   static_assert(oneapi::is_property_key<oneapi::calls_indirectly_key>::value);
 
-  oneapi::properties props_empty{oneapi::calls_indirectly<>};
-  oneapi::properties props_void{oneapi::calls_indirectly<void>};
-  oneapi::properties props_int{oneapi::calls_indirectly<int>};
-  oneapi::properties props_base{oneapi::calls_indirectly<Base>};
-  oneapi::properties props_multiple{oneapi::calls_indirectly<int, Base>};
+  oneapi::properties props_empty{oneapi::assume_indirect_calls};
+  oneapi::properties props_void{oneapi::assume_indirect_calls_to<void>};
+  oneapi::properties props_int{oneapi::assume_indirect_calls_to<int>};
+  oneapi::properties props_base{oneapi::assume_indirect_calls_to<Base>};
+  // assume_indirect_calls_to is currently limited to a single set, so this test
+  // is disabled.
+  // FIXME: re-enable once the restriction is lifted.
+  // oneapi::properties props_multiple{
+  //    oneapi::assume_indirect_calls_to<int, Base>};
 
   q.single_task(props_empty, [=]() {});
   q.single_task(props_void, [=]() {});
   q.single_task(props_int, [=]() {});
   q.single_task(props_base, [=]() {});
-  q.single_task(props_multiple, [=]() {});
+  // q.single_task(props_multiple, [=]() {});
 
   return 0;
 }


### PR DESCRIPTION
Corresponding SYCL extension proposal (intel/llvm#10540) has been recently updated to change naming of properties it introduces.

This patch aligns the implementation with the proposed extension spec.