### PR TITLE
[SYCL] Add LIT regression test for ambiguous call to `memcpy`

### DIFF
--- a/sycl/test/regression/ambigious-memcpy.cpp
+++ b/sycl/test/regression/ambigious-memcpy.cpp
@@ -1,16 +1,17 @@
-// detail::memcpy, even though in a different namespace, can cause ambiguity with libc's memcpy, due to argument dependent lookup (ADL). This compile-only test checks for ambigiouity in call to detail::memcpy.
+// detail::memcpy, even though in a different namespace, can cause ambiguity
+// with libc's memcpy, due to argument dependent lookup (ADL). This compile-only
+// test checks for ambigiouity in call to detail::memcpy.
 
-// RUN: %clang -fsycl -fsycl-device-only %s -o %s.out
+// RUN: %clang -fsycl -fsycl-device-only -fsyntax-only %s
 
 #include <sycl/vector.hpp>
 
-template <typename T>
-void foo(T *dst, T *src, size_t count) {
-	          memcpy(dst, src, count * sizeof(T));
+template <typename T> void foo(T *dst, T *src, size_t count) {
+  memcpy(dst, src, count * sizeof(T));
 }
 
 using T = sycl::vec<int, 1>;
 
 SYCL_EXTERNAL void bar(T *dst, T *src, size_t count) {
-	          foo(dst, src, count * sizeof(T));
+  foo(dst, src, count * sizeof(T));
 }

--- a/sycl/test/regression/ambigious-memcpy.cpp
+++ b/sycl/test/regression/ambigious-memcpy.cpp
@@ -1,0 +1,16 @@
+// detail::memcpy, even though in a different namespace, can cause ambiguity with libc's memcpy, due to argument dependent lookup (ADL). This compile-only test checks for ambigiouity in call to detail::memcpy.
+
+// RUN: %clang -fsycl -fsycl-device-only %s -o %s.out
+
+#include <sycl/vector.hpp>
+
+template <typename T>
+void foo(T *dst, T *src, size_t count) {
+	          memcpy(dst, src, count * sizeof(T));
+}
+
+using T = sycl::vec<int, 1>;
+
+SYCL_EXTERNAL void bar(T *dst, T *src, size_t count) {
+	          foo(dst, src, count * sizeof(T));
+}

--- a/sycl/test/regression/ambigious-memcpy.cpp
+++ b/sycl/test/regression/ambigious-memcpy.cpp
@@ -1,8 +1,8 @@
+// RUN: %clang -fsycl -fsycl-device-only -fsyntax-only %s
+
 // detail::memcpy, even though in a different namespace, can cause ambiguity
 // with libc's memcpy, due to argument dependent lookup (ADL). This compile-only
-// test checks for ambigiouity in call to detail::memcpy.
-
-// RUN: %clang -fsycl -fsycl-device-only -fsyntax-only %s
+// test checks for ambiguity in call to detail::memcpy.
 
 #include <sycl/vector.hpp>
 


### PR DESCRIPTION
`detail::memcpy`, even though in a different namespace, can cause ambiguity with libc's memcpy, due to argument dependent lookup (ADL). This compile-only
test checks for ambiguity in call to `detail::memcpy`.

As discussed in https://github.com/intel/llvm/pull/14836#issuecomment-2266136834