### PR TITLE
[CI] Fix code formatting workflow

### DIFF
--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -216,6 +216,17 @@ class ClangFormatHelper(FormatHelper):
             cf_cmd.append(args.start_rev)
             cf_cmd.append(args.end_rev)
 
+        # Gather the extension of all modified files and pass them explicitly to git-clang-format.
+        # This prevents git-clang-format from applying its own filtering rules on top of ours.
+        extensions = set()
+        for file in cpp_files:
+            _, ext = os.path.splitext(file)
+            extensions.add(
+                ext.strip(".")
+            )  # Exclude periods since git-clang-format takes extensions without them
+        cf_cmd.append("--extensions")
+        cf_cmd.append(",".join(extensions))
+
         cf_cmd.append("--")
         cf_cmd += cpp_files
 

--- a/llvm/utils/git/code-format-helper.py
+++ b/llvm/utils/git/code-format-helper.py
@@ -216,17 +216,6 @@ class ClangFormatHelper(FormatHelper):
             cf_cmd.append(args.start_rev)
             cf_cmd.append(args.end_rev)
 
-        # Gather the extension of all modified files and pass them explicitly to git-clang-format.
-        # This prevents git-clang-format from applying its own filtering rules on top of ours.
-        extensions = set()
-        for file in cpp_files:
-            _, ext = os.path.splitext(file)
-            extensions.add(
-                ext.strip(".")
-            )  # Exclude periods since git-clang-format takes extensions without them
-        cf_cmd.append("--extensions")
-        cf_cmd.append("'{}'".format(",".join(extensions)))
-
         cf_cmd.append("--")
         cf_cmd += cpp_files
 


### PR DESCRIPTION
The code formatting workflow broke just before pulldown from LLVM trunk.
This PR cherry-picks the relevant commits from LLVM trunk to fix the bug: https://github.com/llvm/llvm-project/commit/b3c450d4dc8f21f70a4fa35bdcbd4bfaf852ccd7 and https://github.com/llvm/llvm-project/commit/9572388a849c494d45df334f9facd8ee6663953f

Example run: https://github.com/intel/llvm/pull/14998
Fixes https://github.com/intel/llvm/issues/14737
