### PR TITLE
[DeviceSanitizer] Fix device image contains both ESIMD kernel and SYCL kernel

### DIFF
--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -33,6 +33,8 @@ bool isModuleUsingAsan(const Module &M) {
   for (const auto &F : M) {
     if (F.getCallingConv() != CallingConv::SPIR_KERNEL)
       continue;
+    if (F.arg_size() == 0)
+      continue;
     const auto *LastArg = F.getArg(F.arg_size() - 1);
     if (LastArg->getName() == "__asan_launch")
       return true;

--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -28,8 +28,16 @@ constexpr int DebugModuleProps = 0;
 #endif
 
 namespace llvm::sycl {
+
 bool isModuleUsingAsan(const Module &M) {
-  return M.getGlobalVariable("__AsanLaunchInfo") != nullptr;
+  for (const auto &F : M) {
+    if (F.getCallingConv() != CallingConv::SPIR_KERNEL)
+      continue;
+    const auto *LastArg = F.getArg(F.arg_size() - 1);
+    if (LastArg->getName() == "__asan_launch")
+      return true;
+  }
+  return false;
 }
 
 // This function traverses over reversed call graph by BFS algorithm.

--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -29,12 +29,7 @@ constexpr int DebugModuleProps = 0;
 
 namespace llvm::sycl {
 bool isModuleUsingAsan(const Module &M) {
-  NamedMDNode *MD = M.getNamedMetadata("device.sanitizer");
-  if (MD == nullptr)
-    return false;
-  assert(MD->getNumOperands() != 0);
-  auto *MDVal = cast<MDString>(MD->getOperand(0)->getOperand(0));
-  return MDVal->getString() == "asan";
+  return M.getGlobalVariable("__AsanLaunchInfo") != nullptr;
 }
 
 // This function traverses over reversed call graph by BFS algorithm.

--- a/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
+++ b/llvm/lib/Transforms/IPO/DeadArgumentElimination.cpp
@@ -93,10 +93,6 @@ bool isMustTailCalleeAnalyzable(const CallBase &CB) {
   return CB.getCalledFunction() && !CB.getCalledFunction()->isDeclaration();
 }
 
-bool isModuleUsingAsan(const Module &M) {
-  return M.getGlobalVariable("__AsanLaunchInfo") != nullptr;
-}
-
 } // end anonymous namespace
 
 char DAE::ID = 0;
@@ -544,10 +540,10 @@ void DeadArgumentEliminationPass::surveyFunction(const Function &F) {
     return;
   }
 
-  // Don't touch spir_kernels in sanitized kernel. The "__asan_launch" argument
-  // needs to be present at all times, even if it's not used.
+  // Don't touch sanitized functions. The "__asan_launch" argument needs to be
+  // present at all times, even if it's not used.
   if (F.getCallingConv() == CallingConv::SPIR_KERNEL &&
-      isModuleUsingAsan(*F.getParent())) {
+      F.hasFnAttribute(Attribute::SanitizeAddress)) {
     markLive(F);
     return;
   }

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1282,8 +1282,8 @@ static void ExtendSpirKernelArgs(Module &M, FunctionAnalysisManager &FAM) {
   SmallVector<Function *> SpirFixupFuncs;
   for (Function &F : M) {
     // FIXME: We don't have a way to check if the kernel has been extended
-    // on Unified Runtime, so we always append a new argument (_AsanLaunchInfo).
-    // At the same time, we always extend spir_kernels at here as well.
+    // on Unified Runtime, so we always extend spir_kernels here, even it will
+    // not be instrumented by any asan function.
     if (F.getCallingConv() == CallingConv::SPIR_KERNEL)
       SpirFixupFuncs.emplace_back(&F);
   }
@@ -1347,7 +1347,6 @@ static void ExtendSpirKernelArgs(Module &M, FunctionAnalysisManager &FAM) {
         return;
       SmallVector<Metadata *, 8> NewMD(Node->operands());
       NewMD.emplace_back(NewV);
-      // NewMD.emplace_back(ConstantAsMetadata::get(NewV));
       NewF->setMetadata(MDName, llvm::MDNode::get(NewF->getContext(), NewMD));
     };
 

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1281,8 +1281,10 @@ struct FunctionStackPoisoner : public InstVisitor<FunctionStackPoisoner> {
 static void ExtendSpirKernelArgs(Module &M, FunctionAnalysisManager &FAM) {
   SmallVector<Function *> SpirFixupFuncs;
   for (Function &F : M) {
-    if (F.getCallingConv() == CallingConv::SPIR_KERNEL &&
-        F.hasFnAttribute(Attribute::SanitizeAddress)) {
+    // FIXME: We don't have a way to check if the kernel has been extended
+    // on Unified Runtime, so we always append a new argument (_AsanLaunchInfo).
+    // At the same time, we always extend spir_kernels at here as well.
+    if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
       SpirFixupFuncs.emplace_back(&F);
     }
   }
@@ -1340,18 +1342,34 @@ static void ExtendSpirKernelArgs(Module &M, FunctionAnalysisManager &FAM) {
     // Fixup metadata
     IRBuilder<> Builder(M.getContext());
 
-    auto FixupMetadata = [&NewF](StringRef MDName, Constant *NewV) {
+    auto FixupMetadata = [&NewF](StringRef MDName, Metadata *NewV) {
       auto *Node = NewF->getMetadata(MDName);
       if (!Node)
         return;
       SmallVector<Metadata *, 8> NewMD(Node->operands());
-      NewMD.emplace_back(ConstantAsMetadata::get(NewV));
+      NewMD.emplace_back(NewV);
+      // NewMD.emplace_back(ConstantAsMetadata::get(NewV));
       NewF->setMetadata(MDName, llvm::MDNode::get(NewF->getContext(), NewMD));
     };
 
-    FixupMetadata("kernel_arg_buffer_location", Builder.getInt32(-1));
-    FixupMetadata("kernel_arg_runtime_aligned", Builder.getFalse());
-    FixupMetadata("kernel_arg_exclusive_ptr", Builder.getFalse());
+    FixupMetadata("kernel_arg_buffer_location",
+                  ConstantAsMetadata::get(Builder.getInt32(-1)));
+    FixupMetadata("kernel_arg_runtime_aligned",
+                  ConstantAsMetadata::get(Builder.getFalse()));
+    FixupMetadata("kernel_arg_exclusive_ptr",
+                  ConstantAsMetadata::get(Builder.getFalse()));
+
+    FixupMetadata(
+        "kernel_arg_addr_space",
+        ConstantAsMetadata::get(Builder.getInt32(kSpirOffloadGlobalAS)));
+    FixupMetadata("kernel_arg_access_qual",
+                  MDString::get(M.getContext(), "read_write"));
+    FixupMetadata("kernel_arg_type", MDString::get(M.getContext(), "void*"));
+    FixupMetadata("kernel_arg_base_type",
+                  MDString::get(M.getContext(), "void*"));
+    FixupMetadata("kernel_arg_type_qual", MDString::get(M.getContext(), ""));
+    FixupMetadata("kernel_arg_accessor_ptr",
+                  ConstantAsMetadata::get(Builder.getFalse()));
 
     SpirFuncs.emplace_back(F, NewF);
   }
@@ -1413,22 +1431,14 @@ PreservedAnalyses AddressSanitizerPass::run(Module &M,
       ClUseStackSafety ? &MAM.getResult<StackSafetyGlobalAnalysis>(M) : nullptr;
 
   if (Triple(M.getTargetTriple()).isSPIROrSPIRV()) {
-    bool HasESIMDKernel = false;
+    ExtendSpirKernelArgs(M, FAM);
 
-    // ESIMD kernel doesn't support noinline functions, so we can't
-    // support sanitizer for it
     for (Function &F : M)
       if (F.hasMetadata("sycl_explicit_simd")) {
+        // FIXME: ESIMD kernel doesn't support noinline functions, so we can't
+        // support sanitizer for it
         F.removeFnAttr(Attribute::SanitizeAddress);
-        HasESIMDKernel = true;
       }
-
-    // FIXME: we can't check if the kernel is ESIMD kernel at UR, so we
-    // have to disable ASan completely in this case
-    if (HasESIMDKernel)
-      return PreservedAnalyses::all();
-
-    ExtendSpirKernelArgs(M, FAM);
   }
 
   for (Function &F : M) {

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/sycl_esimd.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/sycl_esimd.ll
@@ -3,15 +3,23 @@
 target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64"
 target triple = "spir64-unknown-unknown"
 
-@__spirv_BuiltInGlobalInvocationId = external addrspace(1) constant <3 x i64>
-
-; Function Attrs: sanitize_address
-define spir_kernel void @esimd_kernel() #0 !sycl_explicit_simd !1 {
+define spir_kernel void @sycl_kernel(ptr addrspace(1) %p) #0 {
+; CHECK-LABEL: define spir_kernel void @sycl_kernel(ptr addrspace(1) %p, ptr addrspace(1) %__asan_launch) #0
 entry:
-  %0 = load i64, ptr addrspace(1) getelementptr inbounds (i8, ptr addrspace(1) @__spirv_BuiltInGlobalInvocationId, i64 8), align 8
+  %0 = load i32, ptr addrspace(1) %p, align 4
+  ; CHECK: store ptr addrspace(1) %__asan_launch, ptr addrspace(3) @__AsanLaunchInfo, align 8
+  ; CHECK: call void @__asan_load4
   ret void
 }
-; CHECK-NOT: {{ sanitize_address }}
+
+define spir_kernel void @esimd_kernel(ptr addrspace(1) %p) #0 !sycl_explicit_simd !1 {
+; CHECK-LABEL: define spir_kernel void @esimd_kernel(ptr addrspace(1) %p, ptr addrspace(1) %__asan_launch) #0
+entry:
+  %0 = load i32, ptr addrspace(1) %p, align 4
+  ; CHECK-NOT: store ptr addrspace(1) %__asan_launch, ptr addrspace(3) @__AsanLaunchInfo, align 8
+  ; CHECK-NOT: call void @__asan_load4
+  ret void
+}
 
 attributes #0 = { sanitize_address }
 !1 = !{}


### PR DESCRIPTION
We don't have a way to check if the kernel has been extended on Unified Runtime, so we always extend kernel argument for ESIMD kernel and SYCL kernel, even it will not be instrumented by any asan functions