### PR TITLE
[SYCL] Add fp16 aspect to AOT spir64_x86_64 device config

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
+++ b/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
@@ -157,7 +157,7 @@ def : TargetInfo<"__TestDeprecatedAspectList",
 
 def : TargetInfo<"spir64", [], [], "", "", 1>;
 def : TargetInfo<"spir64_gen", [], [], "", "", 1>;
-def : TargetInfo<"spir64_x86_64", [AspectFp64, AspectAtomic64], [4, 8, 16, 32, 64], "", "", 1>;
+def : TargetInfo<"spir64_x86_64", [AspectFp16, AspectFp64, AspectAtomic64], [4, 8, 16, 32, 64], "", "", 1>;
 def : TargetInfo<"spir64_fpga", [], [], "", "", 1>;
 def : TargetInfo<"x86_64", [], [], "", "", 1>;
 // Examples of how to use a combination of explicitly specified values + predefined lists

--- a/sycl/test-e2e/AOT/double.cpp
+++ b/sycl/test-e2e/AOT/double.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: ocloc, opencl-aot, any-device-is-cpu
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN: %if cpu %{ %{run} %t.x86.out %}
 
 // ocloc on windows does not have support for PVC/CFL, so this command will
 // result in an error when on windows. (In general, there is no support

--- a/sycl/test-e2e/AOT/half.cpp
+++ b/sycl/test-e2e/AOT/half.cpp
@@ -4,6 +4,7 @@
 // REQUIRES: ocloc, opencl-aot, any-device-is-cpu
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
+// RUN: %if cpu %{ %{run} %t.x86.out %}
 
 // ocloc on windows does not have support for PVC/CFL, so this command will
 // result in an error when on windows. (In general, there is no support


### PR DESCRIPTION
The commit addresses the issue that fp16 modules are being filtered out for `spir64_x86_64` target while it does has aspect `fp16`.

The error message looks like below:
```
env ONEAPI_DEVICE_SELECTOR=opencl:cpu  /...build/tools/sycl/test-e2e/AOT/Output/half.cpp.tmp.x86.out
# executed command: env ONEAPI_DEVICE_SELECTOR=opencl:cpu /.../build/tools/sycl/test-e2e/AOT/Output/half.cpp.tmp.x86.out
# .---command stderr------------
# | terminate called after throwing an instance of 'sycl::_V1::exception'
# |   what():  No kernel named _ZTSZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_EUlvE_ was found
# `-----------------------------
# error: command failed with exit status: -6
```