### PR TITLE
[SYCL][E2E] Re-enable dll-detach-order.cpp

### DIFF
--- a/sycl/test-e2e/Plugin/dll-detach-order.cpp
+++ b/sycl/test-e2e/Plugin/dll-detach-order.cpp
@@ -1,9 +1,6 @@
 // REQUIRES: windows
 // RUN: env SYCL_UR_TRACE=1 sycl-ls | FileCheck %s
 
-// TODO: Reenable on Windows, see https://github.com/intel/llvm/issues/14768
-// UNSUPPORTED: windows
-
 // ensure that the plugins are detached AFTER urLoaderTearDown is done executing
 
 // CHECK: ---> DLL_PROCESS_DETACH syclx.dll


### PR DESCRIPTION
Fixes #14767 

This test passes against all adapters both on my own machine and Github CI and should now be re-enabled.