### PR TITLE
[SYCL][E2E] Move kernel_and_bundle.cpp test to unsupported

### DIFF
--- a/sycl/test-e2e/AmdNvidiaJIT/kernel_and_bundle.cpp
+++ b/sycl/test-e2e/AmdNvidiaJIT/kernel_and_bundle.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda || hip
 
 // https://github.com/intel/llvm/issues/14989
-// XFAIL: hip_amd
+// UNSUPPORTED: hip_amd
 
 // RUN: %{build} -fsycl-embed-ir -o %t.out
 // RUN: env SYCL_JIT_AMDGCN_PTX_KERNELS=1 env SYCL_JIT_COMPILER_DEBUG="sycl-spec-const-materializer" %{run} %t.out &> %t.txt ; FileCheck %s --input-file %t.txt


### PR DESCRIPTION
It [passes](https://github.com/intel/llvm/actions/runs/10295214614/job/28494750636) in the nightly somehow but fails in postcommit.

https://github.com/intel/llvm/issues/14989
