### PR TITLE
[SYCL] Drop UrArray from unit-tests

### DIFF
--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -62,22 +62,17 @@ static sycl::unittest::UrImage generateDeviceGlobalImage() {
 
   // Insert remaining device global info into the binary.
   UrPropertySet PropSet;
-  UrProperty DevGlobInfo =
-      makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0);
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 std::move(DevGlobInfo));
+                 makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0));
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
-
-  std::vector<UrOffloadEntry> Entries =
-      makeEmptyKernels({DeviceGlobalTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({DeviceGlobalTestKernelName}),
               std::move(PropSet)};
 
   return Img;
@@ -93,22 +88,18 @@ static sycl::unittest::UrImage generateDeviceGlobalImgScopeImage() {
 
   // Insert remaining device global info into the binary.
   UrPropertySet PropSet;
-  UrProperty DevGlobInfo =
-      makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1);
-  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 std::move(DevGlobInfo));
+  PropSet.insert(
+      __SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
+      makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1));
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
-
-  std::vector<UrOffloadEntry> Entries =
-      makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({DeviceGlobalImgScopeTestKernelName}),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -65,11 +65,11 @@ static sycl::unittest::UrImage generateDeviceGlobalImage() {
   UrProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0);
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 UrArray<UrProperty>{std::move(DevGlobInfo)});
+                 std::move(DevGlobInfo));
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
@@ -96,11 +96,11 @@ static sycl::unittest::UrImage generateDeviceGlobalImgScopeImage() {
   UrProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1);
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 UrArray<UrProperty>{std::move(DevGlobInfo)});
+                 std::move(DevGlobInfo));
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -132,7 +132,7 @@ static sycl::unittest::UrImage generateMemopsImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(
       {USMFillHelperKernelNameLong, USMFillHelperKernelNameChar,
        USMMemcpyHelperKernelNameLong, USMMemcpyHelperKernelNameChar});
 

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -50,7 +50,7 @@ static sycl::unittest::UrImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::string &VFSets, bool UsesVFSets, unsigned char Magic) {
   sycl::unittest::UrPropertySet PropSet;
-  sycl::unittest::UrArray<sycl::unittest::UrProperty> Props;
+  std::vector<sycl::unittest::UrProperty> Props;
   uint64_t PropSize = VFSets.size();
   std::vector<char> Storage(/* bytes for size */ 8 + PropSize +
                             /* null terminator */ 1);
@@ -69,7 +69,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::UrArray<sycl::unittest::UrOffloadEntry> Entries =
+  std::vector<sycl::unittest::UrOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::UrImage Img{

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -50,7 +50,6 @@ static sycl::unittest::UrImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::string &VFSets, bool UsesVFSets, unsigned char Magic) {
   sycl::unittest::UrPropertySet PropSet;
-  std::vector<sycl::unittest::UrProperty> Props;
   uint64_t PropSize = VFSets.size();
   std::vector<char> Storage(/* bytes for size */ 8 + PropSize +
                             /* null terminator */ 1);
@@ -64,13 +63,9 @@ generateImage(std::initializer_list<std::string> KernelNames,
   sycl::unittest::UrProperty Prop(PropName, Storage,
                                   SYCL_PROPERTY_TYPE_BYTE_ARRAY);
 
-  Props.push_back(Prop);
-  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS, std::move(Props));
+  PropSet.insert(__SYCL_PROPERTY_SET_SYCL_VIRTUAL_FUNCTIONS, std::move(Prop));
 
   std::vector<unsigned char> Bin{Magic};
-
-  std::vector<sycl::unittest::UrOffloadEntry> Entries =
-      sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::UrImage Img{
       SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
@@ -78,7 +73,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
       "",                                  // Compile options
       "",                                  // Link options
       std::move(Bin),
-      std::move(Entries),
+      sycl::unittest::makeEmptyKernels(KernelNames),
       std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -32,7 +32,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -24,7 +24,8 @@ MOCK_INTEGRATION_HEADER(TestKernelACC)
 
 static sycl::unittest::UrImage
 generateDefaultImage(std::initializer_list<std::string> KernelNames,
-                     const std::vector<sycl::aspect> &Aspects, const std::vector<int> &ReqdWGSize = {}) {
+                     const std::vector<sycl::aspect> &Aspects,
+                     const std::vector<int> &ReqdWGSize = {}) {
   using namespace sycl::unittest;
 
   UrPropertySet PropSet;
@@ -32,14 +33,12 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels(KernelNames),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -37,7 +37,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -37,14 +37,12 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
-
   UrImage Img{BinaryType, // Format
               DeviceTargetSpec,
               "", // Compile options
               "", // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels(KernelNames),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -46,7 +46,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   static unsigned char NImage = 0;
   std::vector<unsigned char> Bin{NImage++};
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -46,14 +46,12 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   static unsigned char NImage = 0;
   std::vector<unsigned char> Bin{NImage++};
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
-
   UrImage Img{BinaryType, // Format
               DeviceTargetSpec,
               "", // Compile options
               "", // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels(KernelNames),
               std::move(PropSet)};
   const void *BinaryPtr = Img.getBinaryPtr();
   TrackedImages.insert(BinaryPtr);

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -55,7 +55,7 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(Kernels);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(Kernels);
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -55,14 +55,12 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(Kernels);
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels(Kernels),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -49,7 +49,7 @@ static sycl::unittest::UrImage generateImageWithSpecConsts() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({"SpecializationConstant_TestKernel"});
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -86,7 +86,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -109,7 +109,7 @@ static sycl::unittest::UrImage generateCopierKernelImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -86,14 +86,12 @@ static sycl::unittest::UrImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({KernelName}),
               std::move(PropSet)};
 
   return Img;
@@ -109,14 +107,12 @@ static sycl::unittest::UrImage generateCopierKernelImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({CopierKernelName}),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/helpers/UrImage.hpp
+++ b/sycl/unittests/helpers/UrImage.hpp
@@ -149,14 +149,14 @@ public:
     // Value must be an all-zero 32-bit mask, which would mean that no fallback
     // libraries are needed to be loaded.
     UrProperty DeviceLibReqMask("", Data, SYCL_PROPERTY_TYPE_UINT32);
-    insert(__SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK, DeviceLibReqMask);
+    insert(__SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK, std::move(DeviceLibReqMask));
   }
 
   /// Adds a new array of properties to the set.
   ///
   /// \param Name is a property array name. See ur.hpp for list of known names.
   /// \param Props is an array of property values.
-  void insert(const std::string &Name, std::vector<UrProperty> Props) {
+  void insert(const std::string &Name, std::vector<UrProperty> &&Props) {
     MNames.push_back(Name);
     MMockPropertiesStorage.push_back(Props);
     MNativePropertiesStorage.push_back(
@@ -185,7 +185,7 @@ public:
   ///
   /// \param Name is a property array name. See ur.hpp for list of known names.
   /// \param Prop is a property value.
-  void insert(const std::string &Name, const UrProperty &Prop) {
+  void insert(const std::string &Name, UrProperty &&Prop) {
     insert(Name, {Prop});
   }
 
@@ -217,7 +217,8 @@ public:
           const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
           std::vector<char> Manifest, std::vector<unsigned char> Binary,
-          std::vector<UrOffloadEntry> OffloadEntries, UrPropertySet PropertySet)
+          std::vector<UrOffloadEntry> &&OffloadEntries,
+          UrPropertySet PropertySet)
       : MVersion(Version), MKind(Kind), MFormat(Format),
         MDeviceTargetSpec(DeviceTargetSpec), MCompileOptions(CompileOptions),
         MLinkOptions(LinkOptions), MManifest(std::move(Manifest)),
@@ -240,7 +241,7 @@ public:
   UrImage(uint8_t Format, const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
           std::vector<unsigned char> Binary,
-          std::vector<UrOffloadEntry> OffloadEntries,
+          std::vector<UrOffloadEntry> &&OffloadEntries,
           UrPropertySet PropertySet)
       : UrImage(SYCL_DEVICE_BINARY_VERSION,
                 SYCL_DEVICE_BINARY_OFFLOAD_KIND_SYCL, Format, DeviceTargetSpec,

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -61,7 +61,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -61,15 +61,12 @@ static sycl::unittest::UrImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries =
-      makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"}),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -78,7 +78,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -78,14 +78,12 @@ static sycl::unittest::UrImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "-compile-img",                      // Compile options
               "-link-img",                         // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({"BuildOptsTestKernel"}),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -39,11 +39,11 @@ static sycl::unittest::UrImage generateDefaultImage() {
   UrProperty HostPipeInfo =
       makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int));
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_HOST_PIPES,
-                 UrArray<UrProperty>{std::move(HostPipeInfo)});
+                 std::move(HostPipeInfo));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -36,21 +36,17 @@ static sycl::unittest::UrImage generateDefaultImage() {
                                    "test_host_pipe_unique_id");
 
   UrPropertySet PropSet;
-  UrProperty HostPipeInfo =
-      makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int));
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_HOST_PIPES,
-                 std::move(HostPipeInfo));
+                 makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int)));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
-
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({"TestKernel"}),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -37,10 +37,9 @@ KERNEL_INFO(AOTCaseKernel)
 } // namespace sycl
 
 namespace {
-sycl::unittest::UrArray<sycl::unittest::UrProperty>
+  std::vector<sycl::unittest::UrProperty>
 createPropertySet(const std::vector<std::string> &Symbols) {
-  sycl::unittest::UrPropertySet PropSet;
-  sycl::unittest::UrArray<sycl::unittest::UrProperty> Props;
+  std::vector<sycl::unittest::UrProperty> Props;
   for (const std::string &Symbol : Symbols) {
     std::vector<char> Storage(sizeof(uint32_t));
     uint32_t Val = 1;
@@ -70,7 +69,7 @@ sycl::unittest::UrImage generateImage(
                    createPropertySet(ImportedSymbols));
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::UrArray<sycl::unittest::UrOffloadEntry> Entries =
+  std::vector<sycl::unittest::UrOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::UrImage Img{BinType,

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -58,14 +58,14 @@ static sycl::unittest::UrImage generateEAMTestKernelImage() {
   std::vector<unsigned char> KernelEAM{0b00000101};
   UrProperty EAMKernelPOI = makeKernelParamOptInfo(
       EAMTestKernelName, EAMTestKernelNumArgs, KernelEAM);
-  UrArray<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  std::vector<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -85,7 +85,7 @@ static sycl::unittest::UrImage generateEAMTestKernel2Image() {
 
   std::vector<unsigned char> Bin{6, 7, 8, 9, 10, 11}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -105,14 +105,14 @@ static sycl::unittest::UrImage generateEAMTestKernel3Image() {
   std::vector<unsigned char> KernelEAM{0b00001010};
   UrProperty EAMKernelPOI = makeKernelParamOptInfo(
       EAMTestKernel3Name, EAMTestKernelNumArgs, KernelEAM);
-  UrArray<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  std::vector<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel3Name});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel3Name});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -65,14 +65,12 @@ static sycl::unittest::UrImage generateEAMTestKernelImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({EAMTestKernelName}),
               std::move(PropSet)};
 
   return Img;
@@ -85,14 +83,12 @@ static sycl::unittest::UrImage generateEAMTestKernel2Image() {
 
   std::vector<unsigned char> Bin{6, 7, 8, 9, 10, 11}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({EAMTestKernel2Name}),
               std::move(PropSet)};
 
   return Img;
@@ -112,14 +108,12 @@ static sycl::unittest::UrImage generateEAMTestKernel3Image() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel3Name});
-
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
               "",                                  // Compile options
               "",                                  // Link options
               std::move(Bin),
-              std::move(Entries),
+              makeEmptyKernels({EAMTestKernel3Name}),
               std::move(PropSet)};
 
   return Img;

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -64,14 +64,14 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   UrProperty EAMKernelPOI =
       makeKernelParamOptInfo(sycl::detail::KernelInfo<T>::getName(),
                              EAMTestKernelNumArgs1, KernelEAM1);
-  UrArray<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  std::vector<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({sycl::detail::KernelInfo<T>::getName()});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -109,7 +109,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({"StreamAUXCmdsWait_TestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format


### PR DESCRIPTION
`UrArray` is a wrapper intended to extend lifetime of mock objects so that native objects referncing mock data can be accessed by SYCL RT without any issues.

This commit removes the wrapper to simplify writing unit-tests: essentially there is now one less custom class to care about, collections of properties and entry points are now handled using regular `std::vector` and initializer lists.

The cost of this is a slightly more complicated implementation for `UrPropertySet` and `UrImage` that now need to replicate functionality of that extra storage from `UrArray`.