### PR TITLE
[CI] Give sycl user permission to do GPU reset in HIP/CUDA docker images

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -79,7 +79,7 @@ jobs:
           - name: NVIDIA/CUDA
             runner: '["Linux", "cuda"]'
             image: ghcr.io/intel/llvm/ubuntu2204_build:latest
-            image_options: -u 1001 --gpus all --cap-add SYS_ADMIN
+            image_options: -u 1001 --gpus all --privileged --cap-add SYS_ADMIN
             target_devices: ext_oneapi_cuda:gpu
           - name: Intel
             runner: '["Linux", "gen12"]'

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -144,7 +144,7 @@ jobs:
       name: CUDA E2E
       runner: '["aws_cuda-${{ github.run_id }}-${{ github.run_attempt }}"]'
       image: ghcr.io/intel/llvm/ubuntu2204_build:latest-0300ac924620a51f76c4929794637b82790f12ab
-      image_options: -u 1001 --gpus all --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
+      image_options: -u 1001 --gpus all --privileged --cap-add SYS_ADMIN --env NVIDIA_DISABLE_REQUIRE=1
       target_devices: ext_oneapi_cuda:gpu
       ref: ${{ github.sha }}
       merge_ref: ''

--- a/.github/workflows/sycl-post-commit.yml
+++ b/.github/workflows/sycl-post-commit.yml
@@ -76,7 +76,7 @@ jobs:
           - name: AMD/HIP
             runner: '["Linux", "amdgpu"]'
             image: ghcr.io/intel/llvm/ubuntu2204_build:latest-0300ac924620a51f76c4929794637b82790f12ab
-            image_options: -u 1001 --device=/dev/dri --device=/dev/kfd
+            image_options: -u 1001 --device=/dev/dri --device=/dev/kfd --privileged
             target_devices: ext_oneapi_hip:gpu
             reset_intel_gpu: false
             # Use static build because of shared lld packaging issue

--- a/devops/containers/ubuntu2204_build.Dockerfile
+++ b/devops/containers/ubuntu2204_build.Dockerfile
@@ -39,6 +39,8 @@ RUN groupadd -g 1001 sycl && useradd sycl -u 1001 -g 1001 -m -s /bin/bash
 # Add sycl user to video/irc groups so that it can access GPU
 RUN usermod -aG video sycl
 RUN usermod -aG irc sycl
+# Allow sycl user to run as sudo
+RUN echo "sycl  ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers
 
 COPY scripts/docker_entrypoint.sh /docker_entrypoint.sh
 


### PR DESCRIPTION
I'm working on adding GPU reset support for AMD/NVIDIA to hopefully improve runner stability. 

In order to run the commands to reset the GPU, we need `sudo`.

We also [need](https://github.com/intel/llvm/blob/sycl/.github/workflows/sycl-linux-run-tests.yml#L160) `sudo` to reset on Intel GPUs, and we have already [granted](https://github.com/intel/llvm/blob/sycl/devops/containers/ubuntu2204_base.Dockerfile#L20C11-L20C39) the `sycl` user `sudo` permission in the [Docker image](https://github.com/intel/llvm/blob/sycl/devops/containers/ubuntu2204_intel_drivers.Dockerfile#L2) used for Intel GPUs. 

However the image used for AMD and NVIDIA does not inherit from the `ubuntu2204_base` Dockerfile like the Intel GPU image does so we need to add the same thing there.

We also need to use the `--privileged` docker flag for AMD/NVIDIA. Again, we already do this for Intel GPUs. We need it to access the `sysfs` interface to do a GPU reset.