### PR TITLE
Revert "[SYCL][E2E] XFAIL launch_policy_lmem.cpp on Arc (#14975)"

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -23,9 +23,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/14974
-// XFAIL: gpu-intel-dg2
-
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/group_barrier.hpp>


### PR DESCRIPTION
This reverts commit 050687a46b98212bc049f3b4b88b3207e7f5345f.

Somehow it's passing now.