### PR TITLE
[SYCL][UR] Pull in update that changes urDeviceCreateWithNativeHandle.

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -117,13 +117,13 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit d8f1c98e48e98ea2f6a227af82366734fcde977e
-  # Merge: 6e8efa3d 9e824480
+  # commit 0342c95cbe1dae72e874821698b3726dbe3db284
+  # Merge: d7e0fad5 a4c6e912
   # Author: Omar Ahmed <omar.ahmed@codeplay.com>
-  # Date:   Wed Aug 14 11:46:59 2024 +0100
-  #     Merge pull request #1946 from callumfare/callum/update_ur_trace_env_var
-  #     Update expected values of SYCL_UR_TRACE environment variable
-  set(UNIFIED_RUNTIME_TAG d8f1c98e48e98ea2f6a227af82366734fcde977e)
+  # Date:   Thu Aug 15 17:50:02 2024 +0100
+  #     Merge pull request #1953 from aarongreig/aaron/changeDeviceCreateWithNativeParam
+  #     Change urDeviceCreateWithNativeHandle to take an adapter handle.
+  set(UNIFIED_RUNTIME_TAG 0342c95cbe1dae72e874821698b3726dbe3db284)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -84,8 +84,8 @@ __SYCL_EXPORT device make_device(ur_native_handle_t NativeHandle,
   const auto &Plugin = getPlugin(Backend);
 
   ur_device_handle_t UrDevice = nullptr;
-  Plugin->call(urDeviceCreateWithNativeHandle, NativeHandle, nullptr, nullptr,
-               &UrDevice);
+  Plugin->call(urDeviceCreateWithNativeHandle, NativeHandle,
+               Plugin->getUrAdapter(), nullptr, &UrDevice);
   // Construct the SYCL device from UR device.
   return detail::createSyclObjFromImpl<device>(
       std::make_shared<device_impl>(UrDevice, Plugin));

--- a/sycl/source/backend/level_zero.cpp
+++ b/sycl/source/backend/level_zero.cpp
@@ -24,7 +24,7 @@ __SYCL_EXPORT device make_device(const platform &Platform,
   // Create UR device first.
   ur_device_handle_t UrDevice;
   Plugin->call(urDeviceCreateWithNativeHandle, NativeHandle,
-               PlatformImpl->getHandleRef(), nullptr, &UrDevice);
+               Plugin->getUrAdapter(), nullptr, &UrDevice);
 
   return detail::createSyclObjFromImpl<device>(
       PlatformImpl->getOrMakeDeviceImpl(UrDevice, PlatformImpl));

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -42,8 +42,8 @@ device_impl::device_impl(ur_native_handle_t InteropDeviceHandle,
     // Get UR device from the raw device handle.
     // NOTE: this is for OpenCL interop only (and should go away).
     // With SYCL-2020 BE generalization "make" functions are used instead.
-    Plugin->call(urDeviceCreateWithNativeHandle, InteropDeviceHandle, nullptr,
-                 nullptr, &MDevice);
+    Plugin->call(urDeviceCreateWithNativeHandle, InteropDeviceHandle,
+                 Plugin->getUrAdapter(), nullptr, &MDevice);
     InteroperabilityConstructor = true;
   }
 

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -39,7 +39,7 @@ device::device(cl_device_id DeviceId) {
   ur_device_handle_t Device;
   Plugin->call(urDeviceCreateWithNativeHandle,
                detail::ur::cast<ur_native_handle_t>(DeviceId),
-               Plugin->getUrPlatforms()[0], nullptr, &Device);
+               Plugin->getUrAdapter(), nullptr, &Device);
   auto Platform =
       detail::platform_impl::getPlatformFromUrDevice(Device, Plugin);
   impl = Platform->getOrMakeDeviceImpl(Device, Platform);


### PR DESCRIPTION
The api now takes a ur_adapter_handle_t instead of a ur_platform_handle_t, which is easier for sycl RT to correctly provide and enables a fix for a few instances where we were illegally passing nullptr.