### PR TITLE
[SYCL][Graph] Bump L0 UR Tag

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -117,13 +117,13 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit e02d78ba74efd21219b18f4083cf9afc14a16759
-  # Merge: e50a4ddc c12957bd
+  # commit 26f1dfc0b187763bc739537bdd0d8c76f32bd48e
+  # Merge: 89dc3a56 2dbe0800
   # Author: Omar Ahmed <omar.ahmed@codeplay.com>
-  # Date:   Fri Aug 9 15:41:55 2024 +0100
-  #     Merge pull request #1933 from nrspruit/fix_driver_version_check
-  #     [L0] Fix Driver Version check to use extension and tuple check
-  set(UNIFIED_RUNTIME_TAG e02d78ba74efd21219b18f4083cf9afc14a16759)
+  # Date:   Tue Aug 13 11:12:55 2024 +0100
+  #     Merge pull request #1960 from Bensuo/ewan/imm_command_list_fix
+  #     Command-buffer immediate command-list CTS fix
+  set(UNIFIED_RUNTIME_TAG 26f1dfc0b187763bc739537bdd0d8c76f32bd48e)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need


### PR DESCRIPTION
Tests UR PR https://github.com/oneapi-src/unified-runtime/pull/1960 for fixing a UR CTS bug in the L0 adapter for command-buffers.