### PR TITLE
[SYCL] Make range::size() exception-free

### DIFF
--- a/sycl/include/sycl/range.hpp
+++ b/sycl/include/sycl/range.hpp
@@ -56,7 +56,7 @@ public:
   size_t size() const {
     size_t size = 1;
     for (int i = 0; i < Dimensions; ++i) {
-      size *= this->get(i);
+      size *= this->common_array[i];
     }
     return size;
   }


### PR DESCRIPTION
There is no need to use the detail::array::get() with bounds checking as it is guaranteed that we don't go out-of-bounds in this case, so just use underlying storage directly to calculate the size.

This is also necessary because accessor::size() and buffer::size() methods are noexcept by spec and their implementation use range::size();