### PR TITLE
[SYCL][E2E] Enable annotated usm tests on GPU

### DIFF
--- a/sycl/test-e2e/Annotated_usm/annotated_usm_align.cpp
+++ b/sycl/test-e2e/Annotated_usm/annotated_usm_align.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: gpu
-
 // This e2e test checks the alignment of the annotated USM allocation (host &
 // device) in various cases
 

--- a/sycl/test-e2e/Annotated_usm/annotated_usm_negative.cpp
+++ b/sycl/test-e2e/Annotated_usm/annotated_usm_negative.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: gpu
-
 // Check expected runtime exception thrown for invalid input of annotated USM
 // allocations. Note this test does not work on gpu because the shared
 // allocation tests are expected to raise an error when the target device does

--- a/sycl/test-e2e/Annotated_usm/annotated_usm_shared_align.cpp
+++ b/sycl/test-e2e/Annotated_usm/annotated_usm_shared_align.cpp
@@ -2,8 +2,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: gpu
-
 // This e2e test checks the alignment of the annotated shared USM allocation in
 // various cases
 


### PR DESCRIPTION
Some of the annoated USM tests were disabled on GPU, but based on PVC testing, these seem to be working for GPU now. This commit enables these tests.