### PR TITLE
[SYCL] Reenable deprecated_intel_ext_device for L0

### DIFF
--- a/sycl/test-e2e/DeprecatedFeatures/deprecated_intel_ext_device.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/deprecated_intel_ext_device.cpp
@@ -2,9 +2,6 @@
 // REQUIRES: opencl || level_zero
 // RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
-//
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero
 
 //==--------- intel-ext-device.cpp - SYCL device test ------------==//
 //


### PR DESCRIPTION
The deprecated_intel_ext_device was disabled for L0 a while ago. This commit attempts to reenable it under the expectation that the queries have been fixed in the L0 driver.