### PR TITLE
[SYCL][E2E] Reenable subbuffer test for OpenCL GPU

### DIFF
--- a/sycl/test-e2e/Basic/buffer/subbuffer.cpp
+++ b/sycl/test-e2e/Basic/buffer/subbuffer.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: (opencl && gpu)
-
-//
 //==---------- subbuffer.cpp --- sub-buffer basic test ---------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
The sycl/test-e2e/Basic/buffer/subbuffer.cpp test was disabled for OpenCL GPU, but it seems to now pass. This commit reenables it.