### PR TITLE
[SYCL][E2E] Fix L0 barrier test to handle counting events

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_barrier_optimization.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_barrier_optimization.cpp
@@ -55,7 +55,7 @@ int main() {
 
     // CHECK: Test2
     // CHECK: ---> urEnqueueEventsWaitWithBarrier
-    // CHECK: ZE ---> {{zeEventCreate|zeEventHostReset}}
+    // CHECK-OPT: ZE ---> {{zeEventCreate|zeEventHostReset}}
     // CHECK: ZE ---> zeCommandListAppendWaitOnEvents
     // CHECK: ZE ---> zeCommandListAppendSignalEvent
     // CHECK: ) -> UR_RESULT_SUCCESS


### PR DESCRIPTION
- Test2 in level_zero_barrier_optimization.cpp will only see Event Create or Host Reset if counting events are not used from the cache, which is default for immediate command list and in order list use.
- counting events cannot be reset so neither of these prints would be seen so this is optional.