### PR TITLE
[SYCL][ESIMD] Simplify the copy_to() and copy_from() implementation

### DIFF
--- a/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortK.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortK.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: python3 %S/instruction_count.py %t.dir 3452 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
-// RUN: echo "Baseline from driver version 1.3.29138"
+// RUN: python3 %S/instruction_count.py %t.dir 2914 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
+// RUN: echo "Baseline from driver version 1.3.30872"
 
 #include "../BitonicSortK.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortKv2.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/BitonicSortKv2.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: python3 %S/instruction_count.py %t.dir 3456 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
-// RUN: echo "Baseline from driver version 1.3.29138"
+// RUN: python3 %S/instruction_count.py %t.dir 2969 ZTSZZN11BitonicSort5SolveEPjS0_jENKUlRN4sycl3_V17handlerEE0_clES4_E5Merge.asm
+// RUN: echo "Baseline from driver version 1.3.30872"
 
 #include "../BitonicSortKv2.cpp"

--- a/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
+++ b/sycl/test-e2e/ESIMD/PerformanceTests/matrix_transpose.cpp
@@ -10,7 +10,7 @@
 
 // RUN: mkdir -p %t.dir && %{build} -o %t.dir/exec.out
 // RUN: env IGC_DumpToCustomDir=%t.dir IGC_ShaderDumpEnable=1 %{run} %t.dir/exec.out
-// RUN: python3 %S/instruction_count.py %t.dir 1280 ZTSZZ7runTestjjjRdS_ENKUlRN4sycl3_V17handlerEE_clES3_E3K16.asm
-// RUN: echo "Baseline from driver version 1.3.29138"
+// RUN: python3 %S/instruction_count.py %t.dir %if igc-dev %{ 1059 %} %else %{ 1116 %} ZTSZZ7runTestjjjRdS_ENKUlRN4sycl3_V17handlerEE_clES3_E3K16.asm
+// RUN: echo "Baseline from driver version 1.3.30872"
 
 #include "../matrix_transpose.cpp"

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful.cpp
@@ -1,4 +1,4 @@
-//==----- simd_copy_to_from.cpp  - DPC++ ESIMD simd::copy_to/from test -----==//
+//==- simd_copy_to_from_stateful.cpp  - DPC++ ESIMD simd::copy_to/from test ==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -6,18 +6,24 @@
 //
 //===----------------------------------------------------------------------===//
 // UNSUPPORTED: arch-intel_gpu_pvc
-// RUN: %{build} -o %t.out
+// Use -O2 to avoid huge stack usage under -O0.
+// RUN: %{build} -O2 -fno-sycl-esimd-force-stateless-mem -o %t.out
 // RUN: %{run} %t.out
 
 // This test checks simd::copy_from/to methods with alignment flags.
 
 #include "../esimd_test_utils.hpp"
 
+#include <algorithm>
 #include <array>
 #include <cstdlib>
+#include <iostream>
+#include <sycl/builtins_esimd.hpp>
 #ifdef _WIN32
 #include <malloc.h>
 #endif // _WIN32
+
+#include <sycl/ext/intel/esimd.hpp>
 
 // Workaround for absense of std::aligned_alloc on Windows.
 #ifdef _WIN32

--- a/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful_pvc.cpp
+++ b/sycl/test-e2e/ESIMD/api/simd_copy_to_from_stateful_pvc.cpp
@@ -1,0 +1,17 @@
+//==----- simd_copy_to_from_stateful_pvc.cpp  - DPC++ ESIMD on-device test -==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+// REQUIRES: arch-intel_gpu_pvc
+// RUN: %{build} -fno-sycl-esimd-force-stateless-mem -o %t.out
+// RUN: %{run} %t.out
+
+// This test checks simd::copy_from/to methods with alignment flags
+// and in stateful mode. PVC variant of the test - adds tfloat32.
+
+#define USE_TF32
+
+#include "simd_copy_to_from.cpp"


### PR DESCRIPTION
We can use block_load and block_store for these functions now in most cases, except when stateful mode is enabled and we're using accessors due to alignment and size requirements.

We also see better performance as seen in the perf test updates with fewer instructions.

The tests were written by Slava in an earlier version of this PR.