### PR TITLE
[NFC][SYCL] Split fpga AOC archive tests to address random timeouts

### DIFF
--- a/sycl/test-e2e/AOT/fpga-aoc-archive-early.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive-early.cpp
@@ -24,23 +24,3 @@
 // RUN: %{run} %t_early.out
 // RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_sub.a %t_early_add_x.a %t_early_sub_x.a %t_early_add.a -o %t_early.out
 // RUN: %{run} %t_early.out
-
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-////////////////////////////////////////////////////////////////////////////////
-// Build any image archive binaries from early archives.
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_sub.a   -o %t_early_image_sub.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_add.a   -o %t_early_image_add.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_sub_x.a -o %t_early_image_sub_x.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_add_x.a -o %t_early_image_add_x.a
-////////////////////////////////////////////////////////////////////////////////
-// Use a variety of archive orders
-////////////////////////////////////////////////////////////////////////////////
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a -o %t_early_image.out
-// RUN: %{run} %t_early_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a -o %t_early_image.out
-// RUN: %{run} %t_early_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a -o %t_early_image.out
-// RUN: %{run} %t_early_image.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a -o %t_early_image.out
-// RUN: %{run} %t_early_image.out

--- a/sycl/test-e2e/AOT/fpga-aoc-archive-early2.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive-early2.cpp
@@ -1,0 +1,35 @@
+// Test compiler behaviors for -fintelfpga with -fsycl-link=early.
+
+// REQUIRES: opencl-aot, accelerator
+
+// Remove any archives
+// RUN: rm -f %t_*.a
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+// Build any early archive binaries.
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub.cpp   -o %t_early_sub.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add.cpp   -o %t_early_add.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub_x.cpp -o %t_early_sub_x.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add_x.cpp -o %t_early_add_x.a
+
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////
+// Build any image archive binaries from early archives.
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_sub.a   -o %t_early_image_sub.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_add.a   -o %t_early_image_add.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_sub_x.a -o %t_early_image_sub_x.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_add_x.a -o %t_early_image_add_x.a
+////////////////////////////////////////////////////////////////////////////////
+// Use a variety of archive orders
+////////////////////////////////////////////////////////////////////////////////
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a -o %t_early_image.out
+// RUN: %{run} %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a %t_early_image_add_x.a -o %t_early_image.out
+// RUN: %{run} %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a %t_early_image_sub.a -o %t_early_image.out
+// RUN: %{run} %t_early_image.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_image_sub.a %t_early_image_add_x.a %t_early_image_sub_x.a %t_early_image_add.a -o %t_early_image.out
+// RUN: %{run} %t_early_image.out

--- a/sycl/test-e2e/AOT/fpga-aoc-archive2.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive2.cpp
@@ -11,21 +11,27 @@
 ////////////////////////////////////////////////////////////////////////////////
 // Build any early archive binaries.
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub.cpp   -o %t_early_sub.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add.cpp   -o %t_early_add.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_sub_x.cpp -o %t_early_sub_x.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=early %S/Inputs/fpga_add_x.cpp -o %t_early_add_x.a
 
 // Build any image archive binaries.
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %S/Inputs/fpga_sub.cpp   -o %t_image_sub.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %S/Inputs/fpga_add.cpp   -o %t_image_add.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %S/Inputs/fpga_sub_x.cpp -o %t_image_sub_x.a
 // RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %S/Inputs/fpga_add_x.cpp -o %t_image_add_x.a
 
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-// Mix early and image archive usage
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_early_add.a %t_image_sub.a %t_early_add_x.a %t_image_sub_x.a -o %t_mix.out
+// Provide some kernels without going through an archive
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %S/Inputs/fpga_add.cpp %t_image_sub.a %t_early_add_x.a %t_image_sub_x.a -o %t_mix.out
 // RUN: %{run} %t_mix.out
-// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %t_image_add.a %t_early_sub.a %t_image_add_x.a %t_early_sub_x.a -o %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %S/Inputs/fpga_add.cpp %t_early_sub.a %t_image_add_x.a %t_early_sub_x.a -o %t_mix.out
+// RUN: %{run} %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %S/Inputs/fpga_add.cpp %S/Inputs/fpga_sub.cpp %t_early_add_x.a %t_image_sub_x.a -o %t_mix.out
+// RUN: %{run} %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %S/Inputs/fpga_add.cpp %S/Inputs/fpga_sub.cpp %t_image_add_x.a %t_early_sub_x.a -o %t_mix.out
+// RUN: %{run} %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %S/Inputs/fpga_add.cpp %t_image_sub.a %S/Inputs/fpga_add_x.cpp %t_image_sub_x.a -o %t_mix.out
+// RUN: %{run} %t_mix.out
+// RUN: %clangxx -fintelfpga -fsycl %S/Inputs/fpga_main.cpp %S/Inputs/fpga_add.cpp %t_image_sub.a %S/Inputs/fpga_add_x.cpp %t_early_sub_x.a -o %t_mix.out
 // RUN: %{run} %t_mix.out

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -815,6 +815,6 @@ for sycl_device in config.sycl_devices:
 try:
     import psutil
 
-    lit_config.maxIndividualTestTime = 600
+    lit_config.maxIndividualTestTime = 1200
 except ImportError:
     pass

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -815,6 +815,6 @@ for sycl_device in config.sycl_devices:
 try:
     import psutil
 
-    lit_config.maxIndividualTestTime = 1200
+    lit_config.maxIndividualTestTime = 600
 except ImportError:
     pass


### PR DESCRIPTION
Split fpga AOC tests fpga-aoc-archive and fpga-aoc-archive-early to address random timeouts even after the initial split in commit 4af4d4b. This update further divides the tests into smaller units to minimize the number of compile and run sequences.