### PR TITLE
[DeviceSanitizer] Fix the problem of asan-stack=0 not working as expected.

### DIFF
--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -1072,8 +1072,11 @@ struct FunctionStackPoisoner : public InstVisitor<FunctionStackPoisoner> {
         DIB(*F.getParent(), /*AllowUnresolved*/ false), C(ASan.C),
         IntptrTy(ASan.IntptrTy), IntptrPtrTy(PointerType::get(IntptrTy, 0)),
         Mapping(ASan.Mapping),
-        PoisonStack((ClStack || ClSpirOffloadPrivates) &&
-                    !Triple(F.getParent()->getTargetTriple()).isAMDGPU()) {}
+        PoisonStack(
+            Triple(F.getParent()->getTargetTriple()).isSPIROrSPIRV()
+                ? ClSpirOffloadPrivates
+                : (ClStack &&
+                   !Triple(F.getParent()->getTargetTriple()).isAMDGPU())) {}
 
   bool runOnFunction() {
     if (!PoisonStack)

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
@@ -1,8 +1,8 @@
 ; Make sure we can turn off asan-stack on host target without the interfering of spirv related flag
-; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-STACK
-; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-STACK
-; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-NOSTACK
-; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-NOSTACK
+; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-NOSTACK
+; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-NOSTACK
+; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-STACK
+; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-STACK
 
 target triple = "x86_64-unknown-linux-gnu"
 

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
@@ -1,0 +1,24 @@
+; Make sure we can turn off asan-stack on host target without the interfering of spirv related flag
+; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-STACK
+; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-STACK
+; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-NOSTACK
+; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-NOSTACK
+
+target triple = "x86_64-unknown-linux-gnu"
+
+define dso_local i32 @main(i32 noundef %argc) {
+entry:
+  %retval = alloca i32, align 4
+  %argc.addr = alloca i32, align 4
+  %a = alloca [10 x i32], align 16
+  store i32 0, ptr %retval, align 4
+  store i32 %argc, ptr %argc.addr, align 4
+  %0 = load i32, ptr %argc.addr, align 4
+  %idxprom = sext i32 %0 to i64
+  %arrayidx = getelementptr inbounds [10 x i32], ptr %a, i64 0, i64 %idxprom
+  %1 = load i32, ptr %arrayidx, align 4
+  ret i32 %1
+}
+
+; CHECK-STACK: __asan_stack_malloc_1
+; CHECK-NOSTACK-NOT:  __asan_stack_malloc_1

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
@@ -1,8 +1,8 @@
 ; Make sure we can turn off asan-stack on host target without the interfering of spirv related flag
-; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-NOSTACK
-; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-NOSTACK
-; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=0 -S | FileCheck %s --prefix=CHECK-STACK
-; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=1 -S | FileCheck %s --prefix=CHECK-STACK
+; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=0 -S | FileCheck %s --check-prefix=CHECK-NOSTACK
+; RUN: opt < %s -passes=asan -asan-stack=0 -asan-spir-privates=1 -S | FileCheck %s --check-prefix=CHECK-NOSTACK
+; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=0 -S | FileCheck %s --check-prefix=CHECK-STACK
+; RUN: opt < %s -passes=asan -asan-stack=1 -asan-spir-privates=1 -S | FileCheck %s --check-prefix=CHECK-STACK
 
 target triple = "x86_64-unknown-linux-gnu"
 

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/non-spirv-turn-off-asan-stack.ll
@@ -6,19 +6,39 @@
 
 target triple = "x86_64-unknown-linux-gnu"
 
-define dso_local i32 @main(i32 noundef %argc) {
+; Function Attrs: noinline nounwind optnone sanitize_address uwtable
+define dso_local i32 @main(i32 noundef %argc) #0 {
 entry:
   %retval = alloca i32, align 4
   %argc.addr = alloca i32, align 4
   %a = alloca [10 x i32], align 16
   store i32 0, ptr %retval, align 4
   store i32 %argc, ptr %argc.addr, align 4
+  call void @llvm.lifetime.start.p0(i64 40, ptr %a) #2
   %0 = load i32, ptr %argc.addr, align 4
-  %idxprom = sext i32 %0 to i64
+  %add = add nsw i32 %0, 1
+  %idxprom = sext i32 %add to i64
   %arrayidx = getelementptr inbounds [10 x i32], ptr %a, i64 0, i64 %idxprom
   %1 = load i32, ptr %arrayidx, align 4
+  call void @llvm.lifetime.end.p0(i64 40, ptr %a) #2
   ret i32 %1
 }
 
-; CHECK-STACK: __asan_stack_malloc_1
-; CHECK-NOSTACK-NOT:  __asan_stack_malloc_1
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.start.p0(i64 immarg, ptr nocapture) #1
+
+; Function Attrs: nocallback nofree nosync nounwind willreturn memory(argmem: readwrite)
+declare void @llvm.lifetime.end.p0(i64 immarg, ptr nocapture) #1
+
+attributes #0 = { noinline nounwind optnone sanitize_address uwtable "approx-func-fp-math"="true" "frame-pointer"="all" "loopopt-pipeline"="light" "min-legal-vector-width"="0" "no-signed-zeros-fp-math"="true" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "target-cpu"="x86-64" "target-features"="+cmov,+cx8,+fxsr,+mmx,+sse,+sse2,+x87" "tune-cpu"="generic" "unsafe-fp-math"="true" }
+attributes #1 = { nocallback nofree nosync nounwind willreturn memory(argmem: readwrite) }
+attributes #2 = { nounwind }
+
+!llvm.module.flags = !{!0, !1, !2}
+
+!0 = !{i32 1, !"wchar_size", i32 4}
+!1 = !{i32 7, !"uwtable", i32 2}
+!2 = !{i32 7, !"frame-pointer", i32 2}
+
+; CHECK-STACK: call i64 @__asan_stack_malloc_1(i64 128)
+; CHECK-NOSTACK-NOT:  call i64 @__asan_stack_malloc_1(i64 128)


### PR DESCRIPTION
The logic of `ClSpirOffloadPrivates` controlling`PoisonStack` is problematic, lead to host sanitizer cannot disable the stack instrument with `-asan-stack=0`.