### PR TITLE
[CI] Fix Nightly Windows E2E testing

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -120,7 +120,7 @@ jobs:
     if: |
       always()
       && !cancelled()
-      && needs.build.outputs.build_conclusion == 'success'
+      && needs.build-win.outputs.build_conclusion == 'success'
     uses: ./.github/workflows/sycl-windows-run-tests.yml
     with:
       name: Intel GEN12 Graphics with Level Zero


### PR DESCRIPTION
This typo caused the job to always get skipped.

Confirmed this fixes it [here](https://github.com/intel/llvm/actions/runs/10405372513/job/28818960269) compared to [before](https://github.com/intel/llvm/actions/runs/10398087484/job/28796039560).