### PR TITLE
[SYCL][ESIMD] Disable hardware_dispatch on DG2

### DIFF
--- a/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
+++ b/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
@@ -6,9 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // XFAIL: igc-dev
-// REQUIRES: ocloc
-// https://github.com/intel/llvm/issues/15096
-// XFAIL: gpu-intel-dg2
+// REQUIRES: ocloc && arch-intel_gpu_tgllp
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp %s -o %t.out
 // RUN: %t.out
 

--- a/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
+++ b/sycl/test-e2e/ESIMD/hardware_dispatch.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 // XFAIL: igc-dev
 // REQUIRES: ocloc
+// https://github.com/intel/llvm/issues/15096
+// XFAIL: gpu-intel-dg2
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp %s -o %t.out
 // RUN: %t.out
 


### PR DESCRIPTION
The test requires gen12 but we were running it on DG2.

Closes: https://github.com/intel/llvm/issues/15096