### PR TITLE
[SYCL] Fix OpenCL C to spirv kernel_compiler for the multi-device case

### DIFF
--- a/sycl/test-e2e/KernelCompiler/multi_device.cpp
+++ b/sycl/test-e2e/KernelCompiler/multi_device.cpp
@@ -1,0 +1,30 @@
+// REQUIRES: (opencl || level_zero)
+// RUN: %{build} -o %t.out
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=3 %{run} %t.out
+
+#include <sycl/detail/core.hpp>
+
+// Test to check that bundle is buildable from OpenCL source if there are
+// multiple devices in the context.
+
+auto constexpr CLSource = R"===(
+__kernel void Kernel1(int in, __global int *out) {
+  out[0] = in;
+}
+
+__kernel void Kernel2(short in, __global short *out) {
+  out[0] = in;
+}
+)===";
+
+int main() {
+  sycl::platform Platform;
+  auto Context = Platform.ext_oneapi_get_default_context();
+
+  auto SourceKB =
+      sycl::ext::oneapi::experimental::create_kernel_bundle_from_source(
+          Context, sycl::ext::oneapi::experimental::source_language::opencl,
+          CLSource);
+  auto ExecKB = sycl::ext::oneapi::experimental::build(SourceKB);
+  return 0;
+}


### PR DESCRIPTION
Currently if there is only single device in the context then kernel
compiler passes ip version of that device via -device option to ocloc
when compiling OpenCL program to spirv to let ocloc enable all extensions
supported by that device. Problem is that ocloc -spv_only doesn't produce
spirv file when multiple devices are provided via  -device option.
That's why in this case  enable common extensions supported by all devices
manually. To do that use ocloc query to get common supported features
for the list of devices and then process the return and enable features
via ocloc -internal_options -cl-ext=+feature1,...
