### PR TITLE
[SYCL] Fix `bfloat16` to compile with clang < 9.0.0

### DIFF
--- a/sycl/include/sycl/ext/oneapi/bfloat16.hpp
+++ b/sycl/include/sycl/ext/oneapi/bfloat16.hpp
@@ -92,10 +92,10 @@ protected:
 
 public:
   bfloat16() = default;
+  ~bfloat16() = default;
   constexpr bfloat16(const bfloat16 &) = default;
   constexpr bfloat16(bfloat16 &&) = default;
   constexpr bfloat16 &operator=(const bfloat16 &rhs) = default;
-  ~bfloat16() = default;
 
 private:
   static detail::Bfloat16StorageT from_float_fallback(const float &a) {


### PR DESCRIPTION
```
struct A {  // Fails to compile with clang 8.0.1, ok 9.0.0
    constexpr A& operator=(const A&) = default;
    ~A() = default;
};
struct B {  // Ok with either version
    ~B() = default;
    constexpr B& operator=(const B&) = default;
};

int main() {
    A a;
    B b;
    return 0;
}
```

Since the workaround isn't hurting readability/maintenance might just do it even if the support for such old clang is questionable.