### PR TITLE
[SYCL] Also check for use of SYCL_PI_TRACE on Linux

### DIFF
--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -355,13 +355,6 @@ void shutdown_late() {
 extern "C" __SYCL_EXPORT BOOL WINAPI DllMain(HINSTANCE hinstDLL,
                                              DWORD fdwReason,
                                              LPVOID lpReserved) {
-  // TODO: Remove from public header files and implementation during the next
-  // ABI Breaking window.
-  if (std::getenv("SYCL_PI_TRACE")) {
-    std::cerr << "SYCL_PI_TRACE has been removed use SYCL_UR_TRACE instead\n";
-    std::exit(1);
-  }
-
   bool PrintUrTrace =
       sycl::detail::ur::trace(sycl::detail::ur::TraceLevel::TRACE_CALLS);
 

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -91,6 +91,13 @@ std::vector<PluginPtr> &initializeUr(ur_loader_config_handle_t LoaderConfig) {
   // std::call_once is blocking all other threads if a thread is already
   // creating a vector of plugins. So, no additional lock is needed.
   std::call_once(PluginsInitDone, [&]() {
+    // TODO: Remove this SYCL_PI_TRACE notification in the first patch release
+    // after the next ABI breaking window.
+    if (std::getenv("SYCL_PI_TRACE")) {
+      std::cerr << "SYCL_PI_TRACE has been removed use SYCL_UR_TRACE instead\n";
+      std::exit(1);
+    }
+
     initializePlugins(GlobalHandler::instance().getPlugins(), LoaderConfig);
   });
   return GlobalHandler::instance().getPlugins();


### PR DESCRIPTION
As part of removing the plugin interface a check was added for the use of the `SYCL_PI_TRACE` environment variable. However, this was only applied on the Windows path. This patch moves this check to a common path for both Windows and Linux.
