### PR TITLE
[DevSan] Unpoison local/private shadow memory before function return

### DIFF
--- a/libdevice/sanitizer_utils.cpp
+++ b/libdevice/sanitizer_utils.cpp
@@ -52,6 +52,9 @@ extern SYCL_EXTERNAL __SYCL_LOCAL__ void *
 __spirv_GenericCastToPtrExplicit_ToLocal(void *, int);
 extern SYCL_EXTERNAL __SYCL_PRIVATE__ void *
 __spirv_GenericCastToPtrExplicit_ToPrivate(void *, int);
+
+extern SYCL_EXTERNAL __attribute__((convergent)) void
+__spirv_ControlBarrier(uint32_t Execution, uint32_t Memory, uint32_t Semantics);
 #endif // __USE_SPIR_BUILTIN__
 
 static const __SYCL_CONSTANT__ char __asan_shadow_value_start[] =
@@ -781,19 +784,7 @@ __asan_set_shadow_static_local(uptr ptr, size_t size,
   // if size != aligned_size, then the buffer tail of ptr is not aligned
   uptr aligned_size = RoundUpTo(size, ASAN_SHADOW_GRANULARITY);
 
-  // Set user zone to zero
-  {
-    auto shadow_begin = MemToShadow(ptr, ADDRESS_SPACE_LOCAL);
-    auto shadow_end = MemToShadow(ptr + size, ADDRESS_SPACE_LOCAL);
-    if (__AsanDebug)
-      __spirv_ocl_printf(__mem_set_shadow_local, shadow_begin, shadow_end, 0);
-    while (shadow_begin <= shadow_end) {
-      *((__SYCL_GLOBAL__ u8 *)shadow_begin) = 0;
-      ++shadow_begin;
-    }
-  }
-
-  // Set left red zone
+  // Set red zone
   {
     auto shadow_address = MemToShadow(ptr + aligned_size, ADDRESS_SPACE_LOCAL);
     auto count = (size_with_redzone - aligned_size) >> ASAN_SHADOW_SCALE;
@@ -816,6 +807,36 @@ __asan_set_shadow_static_local(uptr ptr, size_t size,
       __spirv_ocl_printf(__mem_set_shadow_local, shadow_end, shadow_end, value);
     *shadow_end = value;
   }
+}
+
+static __SYCL_CONSTANT__ const char __mem_unpoison_shadow_static_local_begin[] =
+    "[kernel] BEGIN __asan_unpoison_shadow_static_local\n";
+static __SYCL_CONSTANT__ const char __mem_unpoison_shadow_static_local_end[] =
+    "[kernel] END   __asan_unpoison_shadow_static_local\n";
+
+DEVICE_EXTERN_C_NOINLINE void
+__asan_unpoison_shadow_static_local(uptr ptr, size_t size,
+                                    size_t size_with_redzone) {
+  if (__AsanDebug)
+    __spirv_ocl_printf(__mem_unpoison_shadow_static_local_begin);
+
+  auto shadow_begin = MemToShadow(ptr + size, ADDRESS_SPACE_LOCAL);
+  auto shadow_end = MemToShadow(ptr + size_with_redzone, ADDRESS_SPACE_LOCAL);
+
+  if (__AsanDebug)
+    __spirv_ocl_printf(__mem_set_shadow_local, shadow_begin, shadow_end, 0);
+
+  __spirv_ControlBarrier(__spv::Scope::Workgroup, __spv::Scope::Workgroup,
+                         __spv::MemorySemanticsMask::SequentiallyConsistent |
+                             __spv::MemorySemanticsMask::WorkgroupMemory);
+
+  while (shadow_begin <= shadow_end) {
+    *((__SYCL_GLOBAL__ u8 *)shadow_begin) = 0;
+    ++shadow_begin;
+  }
+
+  if (__AsanDebug)
+    __spirv_ocl_printf(__mem_unpoison_shadow_static_local_end);
 }
 
 static __SYCL_CONSTANT__ const char __mem_local_arg[] =
@@ -860,6 +881,44 @@ __asan_set_shadow_dynamic_local(uptr ptr, uint32_t num_args) {
 
   if (__AsanDebug)
     __spirv_ocl_printf(__mem_set_shadow_dynamic_local_end);
+}
+
+static __SYCL_CONSTANT__ const char __mem_unpoison_shadow_dynamic_local_begin[] =
+    "[kernel] BEGIN __asan_unpoison_shadow_dynamic_local\n";
+static __SYCL_CONSTANT__ const char __mem_unpoison_shadow_dynamic_local_end[] =
+    "[kernel] END   __asan_unpoison_shadow_dynamic_local\n";
+
+DEVICE_EXTERN_C_NOINLINE void
+__asan_unpoison_shadow_dynamic_local(uptr ptr, uint32_t num_args) {
+  if (__AsanDebug)
+    __spirv_ocl_printf(__mem_unpoison_shadow_dynamic_local_begin);
+
+  auto *launch_info = (__SYCL_GLOBAL__ const LaunchInfo *)__AsanLaunchInfo;
+  if (num_args != launch_info->NumLocalArgs) {
+    __spirv_ocl_printf(__mem_report_arg_count_incorrect, num_args,
+                       launch_info->NumLocalArgs);
+    return;
+  }
+
+  uptr *args = (uptr *)ptr;
+  if (__AsanDebug)
+    __spirv_ocl_printf(__mem_launch_info, launch_info,
+                       launch_info->LocalShadowOffset,
+                       launch_info->LocalShadowOffsetEnd,
+                       launch_info->NumLocalArgs, launch_info->LocalArgs);
+
+  for (uint32_t i = 0; i < num_args; ++i) {
+    auto *local_arg = &launch_info->LocalArgs[i];
+    if (__AsanDebug)
+      __spirv_ocl_printf(__mem_local_arg, i, local_arg->Size,
+                         local_arg->SizeWithRedZone);
+
+    __asan_unpoison_shadow_static_local(args[i], local_arg->Size,
+                                        local_arg->SizeWithRedZone);
+  }
+
+  if (__AsanDebug)
+    __spirv_ocl_printf(__mem_unpoison_shadow_dynamic_local_end);
 }
 
 ///

--- a/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
+++ b/llvm/lib/Transforms/Instrumentation/AddressSanitizer.cpp
@@ -829,8 +829,10 @@ struct AddressSanitizer {
   bool maybeInsertAsanInitAtFunctionEntry(Function &F);
   bool maybeInsertDynamicShadowAtFunctionEntry(Function &F);
   void markEscapedLocalAllocas(Function &F);
-  void instrumentSyclStaticLocalMemory(CallInst *CI);
-  bool instrumentSyclDynamicLocalMemory(Function &F);
+  void instrumentSyclStaticLocalMemory(CallInst *CI,
+                                       ArrayRef<Instruction *> RetVec);
+  bool instrumentSyclDynamicLocalMemory(Function &F,
+                                        ArrayRef<Instruction *> RetVec);
 
   GlobalVariable *GetOrCreateGlobalString(Module &M, StringRef Name,
                                           StringRef Value,
@@ -879,7 +881,9 @@ private:
   FunctionCallee AsanHandleNoReturnFunc;
   FunctionCallee AsanPtrCmpFunction, AsanPtrSubFunction;
   FunctionCallee AsanSetShadowStaticLocalFunc;
+  FunctionCallee AsanUnpoisonShadowStaticLocalFunc;
   FunctionCallee AsanSetShadowDynamicLocalFunc;
+  FunctionCallee AsanUnpoisonShadowDynamicLocalFunc;
   Constant *AsanShadowGlobal;
   StringMap<GlobalVariable *> GlobalStringMap;
   Constant *AsanLaunchInfo;
@@ -1609,7 +1613,8 @@ static uint64_t getSizeAndRedzoneSizeForLocal(uint64_t Size,
 }
 
 // Instument static local memory
-void AddressSanitizer::instrumentSyclStaticLocalMemory(CallInst *CI) {
+void AddressSanitizer::instrumentSyclStaticLocalMemory(
+    CallInst *CI, ArrayRef<Instruction *> RetVec) {
   InstrumentationIRBuilder IRB(CI->getNextNode());
   auto *Size = cast<ConstantInt>(CI->getArgOperand(0));
   auto *Alignment = cast<ConstantInt>(CI->getArgOperand(1));
@@ -1630,18 +1635,29 @@ void AddressSanitizer::instrumentSyclStaticLocalMemory(CallInst *CI) {
   //   uptr beg,
   //   size_t size,
   //   size_t size_with_redzone,
-  //   uptr launch_info
   // )
-  IRB.CreateCall(
-      AsanSetShadowStaticLocalFunc,
-      {IRB.CreatePointerCast(NewCI, IntptrTy), Size, SizeWithRedZone});
+  auto LocalAddr = IRB.CreatePointerCast(NewCI, IntptrTy);
+  IRB.CreateCall(AsanSetShadowStaticLocalFunc,
+                 {LocalAddr, Size, SizeWithRedZone});
+
+  // __asan_unpoison_shadow_static_local(
+  //   uptr beg,
+  //   size_t size,
+  //   size_t size_with_redzone,
+  // )
+  for (Instruction *Ret : RetVec) {
+    IRBuilder<> IRBRet(Ret);
+    IRBRet.CreateCall(AsanUnpoisonShadowStaticLocalFunc,
+                      {LocalAddr, Size, SizeWithRedZone});
+  }
 
   CI->replaceAllUsesWith(NewCI);
   CI->eraseFromParent();
 }
 
 // Instument dynamic local memory
-bool AddressSanitizer::instrumentSyclDynamicLocalMemory(Function &F) {
+bool AddressSanitizer::instrumentSyclDynamicLocalMemory(
+    Function &F, ArrayRef<Instruction *> RetVec) {
   InstrumentationIRBuilder IRB(F.getEntryBlock().getFirstNonPHI());
 
   // Save "__asan_launch" into local memory "__AsanLaunchInfo"
@@ -1667,9 +1683,18 @@ bool AddressSanitizer::instrumentSyclDynamicLocalMemory(Function &F) {
         IRB.CreateGEP(IntptrTy, ArgsArray, ConstantInt::get(Int32Ty, i));
     IRB.CreateStore(IRB.CreatePointerCast(LocalArgs[i], IntptrTy), StoreDest);
   }
+
+  auto ArgsArrayAddr = IRB.CreatePointerCast(ArgsArray, IntptrTy);
   IRB.CreateCall(AsanSetShadowDynamicLocalFunc,
-                 {IRB.CreatePointerCast(ArgsArray, IntptrTy),
-                  ConstantInt::get(Int32Ty, LocalArgs.size())});
+                 {ArgsArrayAddr, ConstantInt::get(Int32Ty, LocalArgs.size())});
+
+  for (Instruction *Ret : RetVec) {
+    IRBuilder<> IRBRet(Ret);
+    IRBRet.CreateCall(
+        AsanUnpoisonShadowDynamicLocalFunc,
+        {ArgsArrayAddr, ConstantInt::get(Int32Ty, LocalArgs.size())});
+  }
+
   return true;
 }
 
@@ -3263,12 +3288,28 @@ void AddressSanitizer::initializeCallbacks(Module &M, const TargetLibraryInfo *T
         M.getOrInsertFunction("__asan_set_shadow_static_local", IRB.getVoidTy(),
                               IntptrTy, IntptrTy, IntptrTy);
 
+    // __asan_unpoison_shadow_static_local(
+    //   uptr ptr,
+    //   size_t size,
+    // )
+    AsanUnpoisonShadowStaticLocalFunc =
+        M.getOrInsertFunction("__asan_unpoison_shadow_static_local",
+                              IRB.getVoidTy(), IntptrTy, IntptrTy, IntptrTy);
+
     // __asan_set_shadow_dynamic_local(
     //   uptr ptr,
     //   uint32_t num_args
     // )
     AsanSetShadowDynamicLocalFunc = M.getOrInsertFunction(
         "__asan_set_shadow_dynamic_local", IRB.getVoidTy(), IntptrTy, Int32Ty);
+
+    // __asan_unpoison_shadow_dynamic_local(
+    //   uptr ptr,
+    //   uint32_t num_args
+    // )
+    AsanUnpoisonShadowDynamicLocalFunc =
+        M.getOrInsertFunction("__asan_unpoison_shadow_dynamic_local",
+                              IRB.getVoidTy(), IntptrTy, Int32Ty);
 
     AsanLaunchInfo = M.getOrInsertGlobal(
         "__AsanLaunchInfo", IntptrTy->getPointerTo(kSpirOffloadGlobalAS), [&] {
@@ -3512,12 +3553,7 @@ bool AddressSanitizer::instrumentFunction(Function &F,
                     F.getDataLayout(), RTCI);
     FunctionModified = true;
   }
-  if (TargetTriple.isSPIROrSPIRV()) {
-    for (auto *CI : SyclAllocateLocalMemoryCalls) {
-      instrumentSyclStaticLocalMemory(CI);
-      FunctionModified = true;
-    }
-  } else {
+  if (!TargetTriple.isSPIROrSPIRV()) {
     for (auto *Inst : IntrinToInstrument) {
       if (!suppressInstrumentationSiteForDebug(NumInstrumented))
         instrumentMemIntrinsic(Inst, RTCI);
@@ -3543,9 +3579,15 @@ bool AddressSanitizer::instrumentFunction(Function &F,
   if (ChangedStack || !NoReturnCalls.empty())
     FunctionModified = true;
 
-  // We need to instrument dynamic local arguments after stack poisoner
-  if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
-    FunctionModified |= instrumentSyclDynamicLocalMemory(F);
+  // We need to instrument dynamic/static local arguments after stack poisoner
+  if (TargetTriple.isSPIROrSPIRV()) {
+    for (auto *CI : SyclAllocateLocalMemoryCalls) {
+      instrumentSyclStaticLocalMemory(CI, FSP.RetVec);
+      FunctionModified = true;
+    }
+    if (F.getCallingConv() == CallingConv::SPIR_KERNEL) {
+      FunctionModified |= instrumentSyclDynamicLocalMemory(F, FSP.RetVec);
+    }
   }
 
   LLVM_DEBUG(dbgs() << "ASAN done instrumenting: " << FunctionModified << " "
@@ -4083,15 +4125,6 @@ void FunctionStackPoisoner::processStaticAllocas() {
   // Poison the stack red zones at the entry.
   Value *ShadowBase =
       ASan.memToShadow(LocalStackBase, IRB, kSpirOffloadPrivateAS);
-
-  // FIXME: For device sanitizer, we always cleanup shadow memory before using
-  // it. So, unpoison stack before ret instructions is unnecessary.
-  if (TargetTriple.isSPIROrSPIRV()) {
-    SmallVector<uint8_t, 64> ShadowMask(ShadowAfterScope.size(), 1);
-    SmallVector<uint8_t, 64> ShadowBytes(ShadowAfterScope.size(), 0);
-    copyToShadow(ShadowMask, ShadowBytes, IRB, ShadowBase, true);
-  }
-
   // As mask we must use most poisoned case: red zones and after scope.
   // As bytes we can use either the same or just red zones only.
   copyToShadow(ShadowAfterScope, ShadowAfterScope, IRB, ShadowBase,

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/instrument_local_addess_space.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/instrument_local_addess_space.ll
@@ -16,6 +16,7 @@ entry:
   ; CHECK:      [[T0:%.*]] = call ptr addrspace(3) @__sycl_allocateLocalMemory(i64 32, i64 8)
   ; CHECK-NEXT: [[T1:%.*]] = ptrtoint ptr addrspace(3) [[T0]] to i64
   ; CHECK-NEXT: call void @__asan_set_shadow_static_local(i64 [[T1]], i64 16, i64 32)
+  ; CHECK-NEXT: call void @__asan_unpoison_shadow_static_local(i64 %1, i64 16, i64 32)
   ret void
 }
 
@@ -28,6 +29,7 @@ entry:
   ; CHECK-NEXT: store i64 [[T1]], ptr [[T0]], align 8
   ; CHECK-NEXT: [[T2:%.*]] = ptrtoint ptr %local_args to i64
   ; CHECK-NEXT: call void @__asan_set_shadow_dynamic_local(i64 [[T2]], i32 1)
+  ; CHECK: call void @__asan_unpoison_shadow_dynamic_local(i64 %2, i32 1)
   ret void
 }
 

--- a/llvm/test/Instrumentation/AddressSanitizer/SPIRV/instrument_private_address_space.ll
+++ b/llvm/test/Instrumentation/AddressSanitizer/SPIRV/instrument_private_address_space.ll
@@ -21,16 +21,15 @@ define spir_kernel void @kernel() #0 {
 entry:
   %p.i = alloca [4 x i32], align 4
   ; CHECK: %shadow_ptr = call i64 @__asan_mem_to_shadow(i64 %0, i32 0)
-  ; CHECK: call void @__asan_set_shadow_private(i64 %4, i64 4, i8 0)
-  ; CHECK: call void @__asan_set_shadow_private(i64 %5, i64 2, i8 -15)
-  ; CHECK: call void @__asan_set_shadow_private(i64 %6, i64 1, i8 -13)
+  ; CHECK: call void @__asan_set_shadow_private(i64 %4, i64 2, i8 -15)
+  ; CHECK: call void @__asan_set_shadow_private(i64 %5, i64 1, i8 -13)
   call void @llvm.lifetime.start.p0(i64 16, ptr nonnull %p.i)
   call void @llvm.memcpy.p0.p1.i64(ptr align 4 %p.i, ptr addrspace(1) align 4 @__const._ZZZ4mainENKUlRN4sycl3_V17handlerEE_clES2_ENKUlvE_clEv.p, i64 16, i1 false)
   %arraydecay.i = getelementptr inbounds [4 x i32], ptr %p.i, i64 0, i64 0
   %0 = addrspacecast ptr %arraydecay.i to ptr addrspace(4)
   %call.i = call spir_func i32 @_Z3fooPii(ptr addrspace(4) %0)
-  ; CHECK: call void @__asan_set_shadow_private(i64 %8, i64 2, i8 0)
-  ; CHECK: call void @__asan_set_shadow_private(i64 %9, i64 1, i8 0)
+  ; CHECK: call void @__asan_set_shadow_private(i64 %7, i64 2, i8 0)
+  ; CHECK: call void @__asan_set_shadow_private(i64 %8, i64 1, i8 0)
   ret void
 }
 


### PR DESCRIPTION
If we don't unpoison shadow memory, and the corresponding memory is re-uesed and not instrumented may cause false positive report.