### PR TITLE
[SYCL][E2E] Add comment with issue for inline ASM leaks

### DIFF
--- a/sycl/test-e2e/InlineAsm/Negative/asm_bad_opcode.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_bad_opcode.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_bad_operand_syntax.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_bad_operand_syntax.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_duplicate_label.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_duplicate_label.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_illegal_exec_size.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_illegal_exec_size.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_missing_label.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_missing_label.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_missing_region.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_missing_region.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_simple.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_simple.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_undefined_decl.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_undefined_decl.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_undefined_pred.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_undefined_pred.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/InlineAsm/Negative/asm_wrong_declare.cpp
+++ b/sycl/test-e2e/InlineAsm/Negative/asm_wrong_declare.cpp
@@ -1,8 +1,10 @@
 // UNSUPPORTED: cuda || hip
-// UNSUPPORTED: ze_debug
 // REQUIRES: gpu,linux,sg-16
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
+
+// See https://github.com/oneapi-src/unified-runtime/issues/1990
+// UNSUPPORTED: ze_debug
 
 #include "../include/asmhelper.h"
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
The tests in sycl/test-e2e/InlineAsm/Negative are disabled due to reported module leaks. The reason for this "leak" is because the modules fail to build, and as such are never actually created. The false positive has been reported in
https://github.com/oneapi-src/unified-runtime/issues/1990. This commit adds a link to this issue in the affected tests.