### PR TITLE
[SYCL][E2E][Bindless] Fix cast to char failing with -werror

### DIFF
--- a/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
+++ b/sycl/test-e2e/bindless_images/vulkan_interop/sampled_images.cpp
@@ -281,7 +281,7 @@ bool run_test(sycl::range<NDims> dims, sycl::range<NDims> localSize,
                             (void **)&inputStagingData));
   auto getInputValue = [&](int i) -> DType {
     if (CType == sycl::image_channel_type::unorm_int8)
-      return 255;
+      return static_cast<DType>(255);
     if constexpr (std::is_integral_v<DType>)
       i = i % std::numeric_limits<DType>::max();
     return i;


### PR DESCRIPTION
Fix cast to char emitting a warning causing an error when -werror is used.