### PR TITLE
[SYCL][E2E] Reenable ze_debug cases

### DIFF
--- a/sycl/test-e2e/KernelAndProgram/multiple-kernel-linking.cpp
+++ b/sycl/test-e2e/KernelAndProgram/multiple-kernel-linking.cpp
@@ -1,5 +1,4 @@
 // UNSUPPORTED: hip
-// UNSUPPORTED: ze_debug
 
 // RUN: %{build} -fno-sycl-early-optimizations -fsycl-device-code-split=per_kernel -o %t_per_kernel.out
 // RUN: %{build} -fno-sycl-early-optimizations -fsycl-device-code-split=per_source -o %t_per_source.out

--- a/sycl/test-e2e/Regression/commandlist/gpu.cpp
+++ b/sycl/test-e2e/Regression/commandlist/gpu.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: gpu, linux
 
-// UNSUPPORTED: ze_debug
-
 // RUN: %clangxx -Wno-error=vla-cxx-extension -fsycl -fsycl-targets=%{sycl_triple} %S/Inputs/FindPrimesSYCL.cpp %S/Inputs/main.cpp -o %t.out -lpthread
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/SubGroup/sub_group_as.cpp
+++ b/sycl/test-e2e/SubGroup/sub_group_as.cpp
@@ -3,8 +3,6 @@
 //
 // RUN: %{build} -DUSE_DEPRECATED_LOCAL_ACC -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
-//
-// UNSUPPORTED: ze_debug
 
 #include <cassert>
 #include <cstdint>

--- a/sycl/test-e2e/SubGroup/sub_group_as_vec.cpp
+++ b/sycl/test-e2e/SubGroup/sub_group_as_vec.cpp
@@ -3,8 +3,6 @@
 //
 // RUN: %{build} -DUSE_DEPRECATED_LOCAL_ACC -o %t.out
 // RUN: %{run} %t.out
-//
-// UNSUPPORTED: ze_debug
 
 #include "helper.hpp"
 #include <cassert>

--- a/sycl/test-e2e/SubGroupMask/Basic.cpp
+++ b/sycl/test-e2e/SubGroupMask/Basic.cpp
@@ -6,8 +6,6 @@
 // GroupNonUniformBallot capability is supported on Intel GPU only
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: ze_debug
-
 //==---------- Basic.cpp - sub-group mask basic test -----------*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/SubGroupMask/GroupSize.cpp
+++ b/sycl/test-e2e/SubGroupMask/GroupSize.cpp
@@ -5,8 +5,6 @@
 // GroupNonUniformBallot capability is supported on Intel GPU only
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: ze_debug
-
 //==- GroupSize.cpp - sub-group mask dependency on group size --*- C++ -*---==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.


### PR DESCRIPTION
This commit reenables a selection of tests for ze_debug as they no longer seem to be failing for this option.