### PR TITLE
Update Unified Runtime version

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -117,13 +117,13 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit d0a50523006fa6f283da6a36811081add3bb22fc
-  # Merge: 804851e4 04deb8b3
-  # Author: Omar Ahmed <omar.ahmed@codeplay.com>
-  # Date:   Tue Aug 20 16:28:30 2024 +0100
-  #    Merge pull request #1940 from RossBrunton/ross/urcall
-  #    [XPTI] Use `ur.call` rather than `ur` in XPTI
-  set(UNIFIED_RUNTIME_TAG d0a50523006fa6f283da6a36811081add3bb22fc)
+  # commit 9c58db2eb68f19999caff8da5a211e8bd7fa0626
+  # Merge: d0a50523 19a7a989
+  # Author: Igor Chorążewicz <igor.chorazewicz@intel.com>
+  # Date:   Tue Aug 20 14:20:10 2024 -0700
+  #     Merge pull request #1993 from lukaszstolarczuk/bump-umf-w-hwloc-fix
+  #     [common] Bump UMF version
+  set(UNIFIED_RUNTIME_TAG 9c58db2eb68f19999caff8da5a211e8bd7fa0626)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need


### PR DESCRIPTION
To include UMF's hwloc configure fixes and ze device stype fix.

See: https://github.com/oneapi-src/unified-memory-framework/pull/678
See: https://github.com/oneapi-src/unified-memory-framework/pull/685

ref: https://github.com/oneapi-src/unified-runtime/pull/1993