### PR TITLE
[SYCL][E2E] Reenable old tests

### DIFF
--- a/sycl/test-e2e/Basic/buffer/buffer_release.cpp
+++ b/sycl/test-e2e/Basic/buffer/buffer_release.cpp
@@ -1,6 +1,4 @@
 // REQUIRES: cpu
-// UNSUPPORTED: windows
-//   DeferredMemory Destruction not presently supported on Windows.
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Basic/buffer/subbuffer.cpp
+++ b/sycl/test-e2e/Basic/buffer/subbuffer.cpp
@@ -1,6 +1,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// See https://github.com/intel/llvm/issues/15151
+// UNSUPPORTED: (opencl && gpu)
+
 //
 //==---------- subbuffer.cpp --- sub-buffer basic test ---------------------==//
 //

--- a/sycl/test-e2e/Basic/buffer/subbuffer.cpp
+++ b/sycl/test-e2e/Basic/buffer/subbuffer.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: (opencl && gpu)
-
 //
 //==---------- subbuffer.cpp --- sub-buffer basic test ---------------------==//
 //

--- a/sycl/test-e2e/Basic/build_log.cpp
+++ b/sycl/test-e2e/Basic/build_log.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: opencl || level_zero, gpu, ocloc
-// UNSUPPORTED: gpu-intel-dg1 || windows
+// UNSUPPORTED: gpu-intel-dg1
 //
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device dg1" %s -o %t.out
 // RUN: env SYCL_RT_WARNING_LEVEL=2 %{run} %t.out 2>&1 | FileCheck %s

--- a/sycl/test-e2e/Basic/enqueue_barrier.cpp
+++ b/sycl/test-e2e/Basic/enqueue_barrier.cpp
@@ -1,10 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s
 
-// The test is failing sporadically on Windows OpenCL RTs
-// Disabling on windows until fixed
-// UNSUPPORTED: windows
-
 #include <sycl/ext/intel/fpga_device_selector.hpp>
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/Basic/event_profiling_info.cpp
+++ b/sycl/test-e2e/Basic/event_profiling_info.cpp
@@ -10,9 +10,6 @@
 //
 //===----------------------------------------------------------------------===//
 
-// Fails there.
-// UNSUPPORTED: opencl && arch-intel_gpu_pvc
-
 #include <cassert>
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
+++ b/sycl/test-e2e/Basic/image/image_accessor_readsampler.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: aspect-ext_intel_legacy_image
-// UNSUPPORTED: cuda || hip || (windows && level_zero)
-// unsupported on windows (level-zero) due to fail of Jenkins/pre-ci-windows
+// UNSUPPORTED: cuda || hip
 // CUDA cannot support SYCL 1.2.1 images.
 //
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/Basic/image/image_max_size.cpp
+++ b/sycl/test-e2e/Basic/image/image_max_size.cpp
@@ -2,9 +2,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: cuda || hip || (windows && opencl && gpu)
+// UNSUPPORTED: cuda || hip
 // CUDA does not support info::device::image3d_max_width query.
-// TODO: Irregular runtime fails on Windows/opencl:gpu require analysis.
 
 // The test checks that 'image' with max allowed sizes is handled correctly.
 

--- a/sycl/test-e2e/Basic/image/image_sample.cpp
+++ b/sycl/test-e2e/Basic/image/image_sample.cpp
@@ -1,8 +1,7 @@
 // REQUIRES: aspect-ext_intel_legacy_image
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-// Temporarily disable test on Windows due to regressions in GPU driver.
-// UNSUPPORTED: hip, windows
+// UNSUPPORTED: hip
 
 #include <sycl/accessor_image.hpp>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/CompositeDevice/composite_device.cpp
+++ b/sycl/test-e2e/CompositeDevice/composite_device.cpp
@@ -2,7 +2,6 @@
 // RUN: env ZE_FLAT_DEVICE_HIERARCHY=COMBINED %{run} %t.out
 // RUN: env ZE_FLAT_DEVICE_HIERARCHY=COMPOSITE %{run} %t.out
 // RUN: env ZE_FLAT_DEVICE_HIERARCHY=FLAT %{run} %t.out
-// UNSUPPORTED: (windows && level_zero)
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/composite_device.hpp>

--- a/sycl/test-e2e/DiscardEvents/invalid_event.cpp
+++ b/sycl/test-e2e/DiscardEvents/invalid_event.cpp
@@ -1,6 +1,3 @@
-// Same hang as on Basic/barrier_order.cpp tracked in
-// https://github.com/intel/llvm/issues/7330.
-// UNSUPPORTED: opencl && gpu
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
This commit reenables a selection of tests that have previously been disabled, most for different reasons.

Additionally, the subbuffer test still seems to fail on Gen12 OpenCL, so this commit adds a comment with a link to the GH issue.