### PR TITLE
[SYCL] Workaround for device assertion bug on Windows GPU

### DIFF
--- a/sycl/include/sycl/detail/device_assert_win.hpp
+++ b/sycl/include/sycl/detail/device_assert_win.hpp
@@ -8,6 +8,16 @@
 
 #pragma once
 
+// Normal workflow for device assertions on Windows GPU does not work as
+// expected, most likely because the SPV_EXT_relaxed_printf_string_address_space
+// extension is not supported by IGC More specifically, the _wassert function
+// seems to allocate the file and expression buffers on private memory and not
+// constant memory which catches IGC by surprise. Therefore, we define this
+// header file to explicitly redefine assert on Windows so that it directly
+// calls __devicelib_assert_fail and not _wassert.
+// TODO: Delete this header file and its inclusion in <sycl/sycl.hpp> once the
+// extension is supported by IGC.
+
 #ifdef __SYCL_DEVICE_ONLY__
 #include <CL/__spirv/spirv_vars.hpp>
 #include <cassert>

--- a/sycl/include/sycl/detail/device_assert_win.hpp
+++ b/sycl/include/sycl/detail/device_assert_win.hpp
@@ -18,6 +18,8 @@
 // Unfortunately, for this workaround to work, it must not be succeeded 
 // by an include of <cassert> or <assert.h> because these two headers
 // do not have include guards and will redefine the assert macro.
+// This means that whenever a user wants to use device asserts on Windows,
+// they must make sure to always include <sycl/sycl.hpp> last.
 // TODO: Delete this header file and its inclusion in <sycl/sycl.hpp> once the
 // extension is supported by IGC.
 

--- a/sycl/include/sycl/detail/device_assert_win.hpp
+++ b/sycl/include/sycl/detail/device_assert_win.hpp
@@ -1,0 +1,29 @@
+//==--- device_assert_win.hpp - Redefinition of device assert on Windows---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#ifdef __SYCL_DEVICE_ONLY__
+#include <CL/__spirv/spirv_vars.hpp>
+#include <cassert>
+#endif
+
+#if defined(_WIN32) && defined(__SYCL_DEVICE_ONLY__) && defined(assert)
+extern "C" __DPCPP_SYCL_EXTERNAL void
+__devicelib_assert_fail(const char *, const char *, int32_t, const char *,
+                        uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
+                        uint64_t);
+#undef assert
+#define assert(e)                                                              \
+  (e) ? void(0)                                                                \
+      : __devicelib_assert_fail(                                               \
+            #e, __FILE__, __LINE__, nullptr, __spirv_GlobalInvocationId_x(),   \
+            __spirv_GlobalInvocationId_y(), __spirv_GlobalInvocationId_z(),    \
+            __spirv_LocalInvocationId_x(), __spirv_LocalInvocationId_y(),      \
+            __spirv_LocalInvocationId_z());
+#endif

--- a/sycl/include/sycl/detail/device_assert_win.hpp
+++ b/sycl/include/sycl/detail/device_assert_win.hpp
@@ -8,27 +8,32 @@
 
 #pragma once
 
-// Normal workflow for device assertions on Windows GPU does not work as
+// Normal workflow for device assertions on Windows does not work as
 // expected, most likely because the SPV_EXT_relaxed_printf_string_address_space
 // extension is not supported by IGC More specifically, the _wassert function
 // seems to allocate the file and expression buffers on private memory and not
 // constant memory which catches IGC by surprise. Therefore, we define this
 // header file to explicitly redefine assert on Windows so that it directly
 // calls __devicelib_assert_fail and not _wassert.
+// Unfortunately, for this workaround to work, it must not be succeeded 
+// by an include of <cassert> or <assert.h> because these two headers
+// do not have include guards and will redefine the assert macro.
 // TODO: Delete this header file and its inclusion in <sycl/sycl.hpp> once the
 // extension is supported by IGC.
 
 #ifdef __SYCL_DEVICE_ONLY__
 #include <CL/__spirv/spirv_vars.hpp>
 #include <cassert>
-#endif
 
-#if defined(_WIN32) && defined(__SYCL_DEVICE_ONLY__) && defined(assert)
+#if defined(_WIN32) && defined(assert)
 extern "C" __DPCPP_SYCL_EXTERNAL void
 __devicelib_assert_fail(const char *, const char *, int32_t, const char *,
                         uint64_t, uint64_t, uint64_t, uint64_t, uint64_t,
                         uint64_t);
 #undef assert
+#if defined(NDEBUG)
+#define assert(e) ((void)0)
+#else
 #define assert(e)                                                              \
   (e) ? void(0)                                                                \
       : __devicelib_assert_fail(                                               \
@@ -36,4 +41,6 @@ __devicelib_assert_fail(const char *, const char *, int32_t, const char *,
             __spirv_GlobalInvocationId_y(), __spirv_GlobalInvocationId_z(),    \
             __spirv_LocalInvocationId_x(), __spirv_LocalInvocationId_y(),      \
             __spirv_LocalInvocationId_z());
+#endif
+#endif
 #endif

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -22,7 +22,6 @@
 #include <sycl/builtins.hpp>
 #include <sycl/context.hpp>
 #include <sycl/define_vendors.hpp>
-#include <sycl/detail/device_assert_win.hpp>
 #include <sycl/device.hpp>
 #include <sycl/device_aspect_traits.hpp>
 #include <sycl/device_selector.hpp>
@@ -116,3 +115,5 @@
 #include <sycl/ext/oneapi/virtual_mem/physical_mem.hpp>
 #include <sycl/ext/oneapi/virtual_mem/virtual_mem.hpp>
 #include <sycl/ext/oneapi/weak_object.hpp>
+
+#include <sycl/detail/device_assert_win.hpp>

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -116,4 +116,6 @@
 #include <sycl/ext/oneapi/virtual_mem/virtual_mem.hpp>
 #include <sycl/ext/oneapi/weak_object.hpp>
 
+// This header should be included last in order for
+// device assertions to work correctly on Windows.
 #include <sycl/detail/device_assert_win.hpp>

--- a/sycl/include/sycl/sycl.hpp
+++ b/sycl/include/sycl/sycl.hpp
@@ -22,6 +22,7 @@
 #include <sycl/builtins.hpp>
 #include <sycl/context.hpp>
 #include <sycl/define_vendors.hpp>
+#include <sycl/detail/device_assert_win.hpp>
 #include <sycl/device.hpp>
 #include <sycl/device_aspect_traits.hpp>
 #include <sycl/device_selector.hpp>

--- a/sycl/test-e2e/Assert/assert_in_kernels_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels_win.cpp
@@ -15,3 +15,4 @@
 // CHECK-ACC: The test ended.
 
 #include "assert_in_kernels.hpp"
+#include <sycl/detail/device_assert_win.hpp>

--- a/sycl/test-e2e/Assert/assert_in_kernels_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_kernels_win.cpp
@@ -1,5 +1,3 @@
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 // REQUIRES: windows
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -o %t.out
 // Shouldn't fail on ACC as fallback assert isn't enqueued there

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus.hpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus.hpp
@@ -3,6 +3,7 @@
 #include <sycl/detail/core.hpp>
 
 #include <sycl/builtins.hpp>
+#include <sycl/detail/device_assert_win.hpp>
 
 #ifdef DEFINE_NDEBUG_INFILE1
 #define NDEBUG

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus.hpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus.hpp
@@ -3,7 +3,6 @@
 #include <sycl/detail/core.hpp>
 
 #include <sycl/builtins.hpp>
-#include <sycl/detail/device_assert_win.hpp>
 
 #ifdef DEFINE_NDEBUG_INFILE1
 #define NDEBUG

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_one_ndebug_win.cpp
@@ -1,5 +1,3 @@
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 // REQUIRES: windows
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%{sycl_triple} -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out
 // Shouldn't fail on ACC as fallback assert isn't enqueued there

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_win.cpp
@@ -1,5 +1,3 @@
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 // REQUIRES: windows
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -I %S/Inputs %S/Inputs/kernels_in_file2.cpp -o %t.out
 // Shouldn't fail on ACC as fallback assert isn't enqueued there

--- a/sycl/test-e2e/Assert/assert_in_multiple_tus_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_multiple_tus_win.cpp
@@ -14,3 +14,4 @@
 // CHECK-ACC: The test ended.
 
 #include "assert_in_multiple_tus.hpp"
+#include <sycl/detail/device_assert_win.hpp>

--- a/sycl/test-e2e/Assert/assert_in_one_kernel_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_one_kernel_win.cpp
@@ -13,3 +13,4 @@
 // CHECK-ACC:  The test ended.
 
 #include "assert_in_one_kernel.hpp"
+#include <sycl/detail/device_assert_win.hpp>

--- a/sycl/test-e2e/Assert/assert_in_one_kernel_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_one_kernel_win.cpp
@@ -1,5 +1,3 @@
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 // REQUIRES: windows
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -o %t.out
 // Shouldn't fail on ACC as fallback assert isn't enqueued there

--- a/sycl/test-e2e/Assert/assert_in_simultaneous_kernels_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneous_kernels_win.cpp
@@ -1,5 +1,3 @@
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 // REQUIRES: windows
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -o %t.out %threads_lib
 //

--- a/sycl/test-e2e/Assert/assert_in_simultaneous_kernels_win.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneous_kernels_win.cpp
@@ -22,3 +22,4 @@
 // CHECK-ACC:  The test ended.
 
 #include "assert_in_simultaneous_kernels.hpp"
+#include <sycl/detail/device_assert_win.hpp>

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -4,8 +4,6 @@
 // FIXME: Remove XFAIL one intel/llvm#11364 is resolved
 // XFAIL: (opencl && gpu)
 //
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 //
 // RUN: %{build} -DSYCL_FALLBACK_ASSERT=1 -I %S/Inputs %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 //

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus.cpp
@@ -38,7 +38,7 @@
 #undef NDEBUG
 #endif
 
-#include <cassert>
+#include <sycl/detail/device_assert_win.hpp>
 
 using namespace sycl;
 using namespace sycl::access;

--- a/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
+++ b/sycl/test-e2e/Assert/assert_in_simultaneously_multiple_tus_one_ndebug.cpp
@@ -5,8 +5,6 @@
 // FIXME: Remove XFAIL one intel/llvm#11364 is resolved
 // XFAIL: (opencl && gpu)
 //
-// https://github.com/intel/llvm/issues/12797
-// UNSUPPORTED: windows
 //
 // RUN: %clangxx -DSYCL_FALLBACK_ASSERT=1 -fsycl -fsycl-targets=%{sycl_triple} -DDEFINE_NDEBUG_INFILE2 -I %S/Inputs %S/assert_in_simultaneously_multiple_tus.cpp %S/Inputs/kernels_in_file2.cpp -o %t.out %threads_lib
 // RUN: %if cpu %{ %{run} %t.out &> %t.cpu.txt ; FileCheck %s --input-file %t.cpu.txt %}


### PR DESCRIPTION
Asserts on Windows GPU do not work correctly, often by not printing any kind of information about the failed assertion and the guilty work-item information. This PR attempts to fix that through a workaround. My understanding is that once `SPV_EXT_relaxed_printf_string_address_space` is supported by IGC, then we can remove this workaround.