### PR TITLE
[SYCL] Fix windows exp(complex) edge case

### DIFF
--- a/libdevice/msvc_math.cpp
+++ b/libdevice/msvc_math.cpp
@@ -195,7 +195,7 @@ short _FExp(float *px, float y,
   if (*px < -hugexp || y == 0.0F) { // certain underflow
     *px = 0.0F;
   } else if (hugexp < *px) { // certain overflow
-    *px = _FInf._Float;
+    *px = _FInf._Float * (y < 0.F ? -1.F : 1.F);
     ret = _INFCODE;
   } else { // xexp won't overflow
     float g = *px * invln2;

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: gpu
+// UNSUPPORTED: hip | cuda
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/cmath_fp64_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: hip | cuda
+// UNSUPPORTED: hip || cuda
 
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
 

--- a/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
+++ b/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
@@ -1,5 +1,5 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: gpu
+// UNSUPPORTED: hip | cuda
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...

--- a/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
+++ b/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
@@ -1,5 +1,5 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: hip | cuda
+// UNSUPPORTED: hip || cuda
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: gpu
+// UNSUPPORTED: hip | cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -82,8 +82,16 @@ complex<double> ref1_results[] = {complex<double>(-1., 1.),
                                   complex<double>(0, 0.761594155955765),
                                   complex<double>(M_PI_2, 0.),
                                   complex<double>(M_PI_2, 0.549306144334055),
+// The MSVC implementation of tanh does not obey
+// tanh(-inf + nan * i)  == 1 + 0*i or
+// tanh(-inf + -inf * i) == 1 + 0*i.
+#ifndef _WIN32
                                   complex<double>(-1., 0.),
                                   complex<double>(-1., 0.),
+#else
+                                  0.,
+                                  0.,
+#endif
                                   complex<double>(-1., 0.),
                                   complex<double>(INFINITY, 0.),
                                   complex<double>(INFINITY, INFINITY),
@@ -177,9 +185,17 @@ int device_complex_test(s::queue &deviceQueue) {
         buf_out1_access[index++] = std::tan(complex<double>(0., 1.));
         buf_out1_access[index++] = std::asin(complex<double>(1., 0.));
         buf_out1_access[index++] = std::atan(complex<double>(0., 2.));
+        // The MSVC implementation of tanh does not obey
+        // tanh(-inf + nan * i)  == 1 + 0*i or
+        // tanh(-inf + -inf * i) == 1 + 0*i.
+#ifndef _WIN32
         buf_out1_access[index++] = std::tanh(complex<double>(-INFINITY, NAN));
         buf_out1_access[index++] =
             std::tanh(complex<double>(-INFINITY, -INFINITY));
+#else
+        buf_out1_access[index++] = 0.;
+        buf_out1_access[index++] = 0.;
+#endif
         buf_out1_access[index++] = std::tanh(complex<double>(-INFINITY, -2.));
         buf_out1_access[index++] = std::exp(complex<double>(1e6, 0.));
         buf_out1_access[index++] = std::exp(complex<double>(1e6, 0.1));

--- a/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp
@@ -1,5 +1,5 @@
 // REQUIRES: aspect-fp64
-// UNSUPPORTED: hip | cuda
+// UNSUPPORTED: hip || cuda
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -1,5 +1,5 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: cuda | hip
+// UNSUPPORTED: hip || cuda
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
+++ b/sycl/test-e2e/DeviceLib/std_complex_math_test.cpp
@@ -1,5 +1,5 @@
 // DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
-// UNSUPPORTED: gpu
+// UNSUPPORTED: cuda | hip
 // RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
There are three test cases that added in https://github.com/intel/llvm/pull/14329 that do not match the expected result on Windows. This is due to the fact the supporting the std math functions on device Windows is partially determined by the MSVC implementation of the math functions. 

- `tanh(-inf + nan * i)` and `tanh(-inf + -inf * i)` should both be `1 + 0*i`, but the MSVC implementation does not obey this equation even on host. This PR changes the test to ignore these cases on windows.
- `exp(1e6 + -0.1*i)` should be `inf + -inf*i`, but was `inf + inf*i`. This equation holds for MSVC implementation on host. Indeed this was problem with an implementation of the `_FExp` helper function that `exp(std::complex)` is implemented with. This is fixed in this PR.

Additionally, this PR changes some of DeviceLib tests were changed from being unsupported on GPU to just be unsupported on HIP or CUDA.