### PR TITLE
[SYCL][CPU] Add ext_oneapi_ballot_group aspect to spir64_x86_64 target

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
+++ b/llvm/include/llvm/SYCLLowerIR/DeviceConfigFile.td
@@ -157,7 +157,7 @@ def : TargetInfo<"__TestDeprecatedAspectList",
 
 def : TargetInfo<"spir64", [], [], "", "", 1>;
 def : TargetInfo<"spir64_gen", [], [], "", "", 1>;
-def : TargetInfo<"spir64_x86_64", [AspectFp16, AspectFp64, AspectAtomic64], [4, 8, 16, 32, 64], "", "", 1>;
+def : TargetInfo<"spir64_x86_64", [AspectFp16, AspectFp64, AspectAtomic64, AspectExt_oneapi_ballot_group], [4, 8, 16, 32, 64], "", "", 1>;
 def : TargetInfo<"spir64_fpga", [], [], "", "", 1>;
 def : TargetInfo<"x86_64", [], [], "", "", 1>;
 // Examples of how to use a combination of explicitly specified values + predefined lists

--- a/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
@@ -1,6 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
+// REQUIRES: cpu, gpu
 // REQUIRES: sg-32
 // REQUIRES: aspect-ext_oneapi_ballot_group
 

--- a/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
+++ b/sycl/test-e2e/NonUniformGroups/ballot_group_algorithms.cpp
@@ -1,7 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// REQUIRES: gpu
 // REQUIRES: sg-32
 // REQUIRES: aspect-ext_oneapi_ballot_group
 


### PR DESCRIPTION
The aspect is supported since [OpenCL CPU 2024.2](https://github.com/intel/llvm/releases/download/2024-WW25/oclcpuexp-2024.18.6.0.02_rel.tar.gz)