### PR TITLE
[UR] Handle cases where UR can't provide IP ver.

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -688,22 +688,31 @@ struct get_device_info_impl<
     ext::oneapi::experimental::info::device::architecture> {
   static ext::oneapi::experimental::architecture get(const DeviceImplPtr &Dev) {
     backend CurrentBackend = Dev->getBackend();
-    if (Dev->is_gpu() && (backend::ext_oneapi_level_zero == CurrentBackend ||
-                          backend::opencl == CurrentBackend)) {
-      auto MapArchIDToArchName = [](const int arch) {
-        for (const auto &Item : IntelGPUArchitectures) {
-          if (Item.first == arch)
-            return Item.second;
-        }
-        return ext::oneapi::experimental::architecture::unknown;
-      };
+    auto LookupIPVersion = [&](auto &ArchList)
+        -> std::optional<ext::oneapi::experimental::architecture> {
       uint32_t DeviceIp;
-      Dev->getPlugin()->call(
+      ur_result_t Err = Dev->getPlugin()->call_nocheck(
           urDeviceGetInfo, Dev->getHandleRef(),
           UrInfoCode<
               ext::oneapi::experimental::info::device::architecture>::value,
           sizeof(DeviceIp), &DeviceIp, nullptr);
-      return MapArchIDToArchName(DeviceIp);
+      if (Err == UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION) {
+        // Not all devices support this device info query
+        return std::nullopt;
+      }
+      Dev->getPlugin()->checkUrResult(Err);
+
+      for (const auto &Item : ArchList) {
+        if (Item.first == static_cast<int>(DeviceIp))
+          return Item.second;
+      }
+      return std::nullopt;
+    };
+
+    if (Dev->is_gpu() && (backend::ext_oneapi_level_zero == CurrentBackend ||
+                          backend::opencl == CurrentBackend)) {
+      return LookupIPVersion(IntelGPUArchitectures)
+          .value_or(ext::oneapi::experimental::architecture::unknown);
     } else if (Dev->is_gpu() && (backend::ext_oneapi_cuda == CurrentBackend ||
                                  backend::ext_oneapi_hip == CurrentBackend)) {
       auto MapArchIDToArchName = [](const char *arch) {
@@ -726,20 +735,8 @@ struct get_device_info_impl<
           DeviceArchCopy.substr(0, DeviceArchCopy.find(":"));
       return MapArchIDToArchName(DeviceArchSubstr.data());
     } else if (Dev->is_cpu() && backend::opencl == CurrentBackend) {
-      auto MapArchIDToArchName = [](const int arch) {
-        for (const auto &Item : IntelCPUArchitectures) {
-          if (Item.first == arch)
-            return Item.second;
-        }
-        return sycl::ext::oneapi::experimental::architecture::x86_64;
-      };
-      uint32_t DeviceIp;
-      Dev->getPlugin()->call(
-          urDeviceGetInfo, Dev->getHandleRef(),
-          UrInfoCode<
-              ext::oneapi::experimental::info::device::architecture>::value,
-          sizeof(DeviceIp), &DeviceIp, nullptr);
-      return MapArchIDToArchName(DeviceIp);
+      return LookupIPVersion(IntelCPUArchitectures)
+          .value_or(ext::oneapi::experimental::architecture::x86_64);
     } // else is not needed
     // TODO: add support of other architectures by extending with else if
     return ext::oneapi::experimental::architecture::unknown;

--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -14,6 +14,7 @@ add_sycl_unittest(ExtensionsTests OBJECT
   DiscardEvent.cpp
   ProfilingTag.cpp
   KernelProperties.cpp
+  NoDeviceIPVersion.cpp
 )
 
 add_subdirectory(CommandGraph)

--- a/sycl/unittests/Extensions/NoDeviceIPVersion.cpp
+++ b/sycl/unittests/Extensions/NoDeviceIPVersion.cpp
@@ -1,0 +1,38 @@
+//==------------------- NoDeviceIPVersion.cpp ------------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#include "sycl/ext/oneapi/experimental/device_architecture.hpp"
+#include <gtest/gtest.h>
+#include <helpers/UrMock.hpp>
+#include <sycl/sycl.hpp>
+
+static ur_result_t afterDeviceGetInfo(void *pParams) {
+  auto params = *static_cast<ur_device_get_info_params_t *>(pParams);
+  if (*params.ppropName == UR_DEVICE_INFO_IP_VERSION) {
+    return UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION;
+  }
+  return UR_RESULT_SUCCESS;
+}
+
+namespace syclex = sycl::ext::oneapi::experimental;
+TEST(NoDeviceIPVersionTest, NoDeviceIPVersion) {
+  sycl::unittest::UrMock<> Mock;
+  mock::getCallbacks().set_after_callback("urDeviceGetInfo",
+                                          &afterDeviceGetInfo);
+  sycl::platform Plt = sycl::platform();
+  auto Dev = Plt.get_devices()[0];
+  if (Dev.get_backend() != sycl::backend::opencl &&
+      Dev.get_backend() != sycl::backend::ext_oneapi_level_zero) {
+    GTEST_SKIP();
+  }
+
+  syclex::architecture DevArch =
+      Dev.get_info<syclex::info::device::architecture>();
+  ASSERT_TRUE(DevArch == syclex::architecture::unknown ||
+              DevArch == syclex::architecture::x86_64);
+}


### PR DESCRIPTION
UR may respond with `UR_RESULT_ERROR_UNSUPPORTED_ENUMERATION` when querying for the device's IP version. This patch handles that case by falling back to unknown or x86_64.

Closes: #15149