### PR TITLE
[SYCL] Disable clang pedantic diagnostics in header/footer

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6053,6 +6053,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   O << "#include <sycl/detail/defines_elementary.hpp>\n";
   O << "#include <sycl/detail/kernel_desc.hpp>\n";
   O << "#include <sycl/ext/oneapi/experimental/free_function_traits.hpp>\n";
+
   O << "\n";
 
   LangOptions LO;
@@ -6143,8 +6144,9 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   // main() function.
 
   if (NeedToEmitDeviceGlobalRegistration) {
+    // Supress the reserved identifier diagnostic that clang generates
+    // for the construct below.
     EmitPragmaDiagnosticPush(O, "-Wreserved-identifier");
-
     O << "namespace {\n";
 
     O << "class __sycl_device_global_registration {\n";
@@ -6156,7 +6158,6 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     O << "} // namespace\n";
 
     O << "\n";
-
     EmitPragmaDiagnosticPop(O);
   }
 
@@ -6164,6 +6165,8 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   // whose sole purpose is to run its constructor before the application's
   // main() function.
   if (NeedToEmitHostPipeRegistration) {
+    // Supress the reserved identifier diagnostic that clang generates
+    // for the construct below.
     EmitPragmaDiagnosticPush(O, "-Wreserved-identifier");
     O << "namespace {\n";
 
@@ -6742,6 +6745,8 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     OS << "#include <sycl/detail/device_global_map.hpp>\n";
     DeviceGlobOS.flush();
     OS << "namespace sycl::detail {\n";
+    // Supress the old-style case diagnostic that clang generates
+    // for the construct below in DeviceGlobalsBuf.
     EmitPragmaDiagnosticPush(OS, "-Wold-style-cast");
     OS << "namespace {\n";
     OS << "__sycl_device_global_registration::__sycl_device_global_"
@@ -6759,6 +6764,8 @@ bool SYCLIntegrationFooter::emit(raw_ostream &OS) {
     OS << "#include <sycl/detail/host_pipe_map.hpp>\n";
     HostPipesOS.flush();
     OS << "namespace sycl::detail {\n";
+    // Supress the old-style case diagnostic that clang generates
+    // for the construct below in HostPipesBuf.
     EmitPragmaDiagnosticPush(OS, "-Wold-style-cast");
     OS << "namespace {\n";
     OS << "__sycl_host_pipe_registration::__sycl_host_pipe_"

--- a/clang/test/CodeGenSYCL/device_global_int_footer_header.cpp
+++ b/clang/test/CodeGenSYCL/device_global_int_footer_header.cpp
@@ -16,13 +16,20 @@ int main() {
 // CHECK-HEADER: namespace sycl {
 // CHECK-HEADER-NEXT: inline namespace _V1 {
 // CHECK-HEADER-NEXT: namespace detail {
-// CHECK-HEADER-NEXT: namespace {
+// CHECK-HEADER: #ifdef __clang__
+// CHECK-HEADER-NEXT: #pragma clang diagnostic push
+// CHECK-HEADER-NEXT: #pragma clang diagnostic ignored "-Wreserved-identifier"
+// CHECK-HEADER-NEXT: #endif // defined(__clang__)
+// CHECK-HEADER: namespace {
 // CHECK-HEADER-NEXT: class __sycl_device_global_registration {
 // CHECK-HEADER-NEXT: public:
 // CHECK-HEADER-NEXT:   __sycl_device_global_registration() noexcept;
 // CHECK-HEADER-NEXT: };
 // CHECK-HEADER-NEXT: __sycl_device_global_registration __sycl_device_global_registrar;
 // CHECK-HEADER-NEXT: } // namespace
+// CHECK-HEADER: #ifdef __clang__
+// CHECK-HEADER-NEXT: #pragma clang diagnostic pop
+// CHECK-HEADER-NEXT: #endif // defined(__clang__)
 // CHECK-HEADER: } // namespace detail
 // CHECK-HEADER: } // namespace _V1
 // CHECK-HEADER: } // namespace sycl
@@ -49,7 +56,11 @@ int main() {
 
 // CHECK-FOOTER: #include <sycl/detail/device_global_map.hpp>
 // CHECK-FOOTER: namespace sycl::detail {
-// CHECK-FOOTER-NEXT: namespace {
+// CHECK-FOOTER: #ifdef __clang__
+// CHECK-FOOTER-NEXT: #pragma clang diagnostic push
+// CHECK-FOOTER-NEXT: #pragma clang diagnostic ignored "-Wold-style-cast"
+// CHECK-FOOTER-NEXT: #endif // defined(__clang__)
+// CHECK-FOOTER: namespace {
 // CHECK-FOOTER-NEXT: __sycl_device_global_registration::__sycl_device_global_registration() noexcept {
 
 extern device_global<int> Basic;

--- a/clang/test/CodeGenSYCL/device_global_int_footer_header.cpp
+++ b/clang/test/CodeGenSYCL/device_global_int_footer_header.cpp
@@ -122,3 +122,6 @@ struct HasVarTemplate {
 } // namespace
 const auto x = HasVarTemplate::VarTempl<int>.get();
 // CHECK-FOOTER-NEXT: device_global_map::add((void *)&::__sycl_detail::__shim_[[SHIM1]](), "THE_PREFIX____ZN12_GLOBAL__N_114HasVarTemplate8VarTemplIiEE");
+// CHECK-FOOTER: #ifdef __clang__
+// CHECK-FOOTER-NEXT: #pragma clang diagnostic pop
+// CHECK-FOOTER-NEXT: #endif // defined(__clang__)

--- a/clang/test/CodeGenSYCL/device_globals_with_spec_ids.cpp
+++ b/clang/test/CodeGenSYCL/device_globals_with_spec_ids.cpp
@@ -249,7 +249,7 @@ struct Wrapper {
 // CHECK: #include <sycl/detail/spec_const_integration.hpp>
 // CHECK-NEXT: #include <sycl/detail/device_global_map.hpp>
 // CHECK-NEXT: namespace sycl::detail {
-// CHECK-NEXT: namespace {
+// CHECK: namespace {
 // CHECK-NEXT: __sycl_device_global_registration::__sycl_device_global_registration() noexcept {
 // CHECK-NEXT: device_global_map::add((void *)&::b, "_Z1b");
 // CHECK-NEXT: device_global_map::add((void *)&::Wrapper::b, "_ZN7Wrapper1bE");
@@ -260,4 +260,4 @@ struct Wrapper {
 // CHECK-NEXT: device_global_map::add((void *)&::outer::__sycl_detail::__shim_[[SHIM11]](), "____ZN5outer12_GLOBAL__N_15inner12_GLOBAL__N_17Wrapper1cE");
 // CHECK-NEXT: }
 // CHECK-NEXT: } // namespace (unnamed)
-// CHECK-NEXT: } // namespace sycl::detail
+// CHECK: } // namespace sycl::detail

--- a/clang/test/CodeGenSYCL/host_pipe_int_footer_header.cpp
+++ b/clang/test/CodeGenSYCL/host_pipe_int_footer_header.cpp
@@ -23,7 +23,7 @@ void foo() {
 // CHECK-HEADER: namespace sycl {
 // CHECK-HEADER-NEXT: inline namespace _V1 {
 // CHECK-HEADER-NEXT: namespace detail {
-// CHECK-HEADER-NEXT: namespace {
+// CHECK-HEADER: namespace {
 // CHECK-HEADER-NEXT: class __sycl_host_pipe_registration {
 // CHECK-HEADER-NEXT: public:
 // CHECK-HEADER-NEXT: __sycl_host_pipe_registration() noexcept;
@@ -37,7 +37,7 @@ void foo() {
 // CHECK-FOOTER: #include <sycl/detail/defines_elementary.hpp>
 // CHECK-FOOTER: #include <sycl/detail/host_pipe_map.hpp>
 // CHECK-FOOTER-NEXT: namespace sycl::detail {
-// CHECK-FOOTER-NEXT: namespace {
+// CHECK-FOOTER: namespace {
 // CHECK-FOOTER-NEXT: __sycl_host_pipe_registration::__sycl_host_pipe_registration() noexcept {
 
 // CHECK-FOOTER: host_pipe_map::add((void *)&::sycl::ext::intel::experimental::host_pipe<HPInt, int>::__pipe, "THE_PREFIX____ZN4sycl3_V13ext5intel12experimental9host_pipeIZZZ3foovENKUlRNS0_7handlerEE_clES6_ENKUlvE_clEvE5HPIntiE6__pipeE");

--- a/clang/test/CodeGenSYCL/int_header_without_kernels.cpp
+++ b/clang/test/CodeGenSYCL/int_header_without_kernels.cpp
@@ -12,7 +12,7 @@ using namespace sycl::ext::oneapi;
 // CHECK-HEADER: namespace sycl {
 // CHECK-HEADER-NEXT: inline namespace _V1 {
 // CHECK-HEADER-NEXT: namespace detail {
-// CHECK-HEADER-NEXT: namespace {
+// CHECK-HEADER: namespace {
 // CHECK-HEADER-NEXT: class __sycl_device_global_registration {
 // CHECK-HEADER-NEXT: public:
 // CHECK-HEADER-NEXT:   __sycl_device_global_registration() noexcept;
@@ -27,7 +27,7 @@ using namespace sycl::ext::oneapi;
 
 // CHECK-FOOTER: #include <sycl/detail/device_global_map.hpp>
 // CHECK-FOOTER: namespace sycl::detail {
-// CHECK-FOOTER-NEXT: namespace {
+// CHECK-FOOTER: namespace {
 // CHECK-FOOTER-NEXT: __sycl_device_global_registration::__sycl_device_global_registration() noexcept {
 
 device_global<int> Basic;
@@ -35,4 +35,4 @@ device_global<int> Basic;
 
 // CHECK-FOOTER-NEXT: }
 // CHECK-FOOTER-NEXT: }
-// CHECK-FOOTER-NEXT: }
+// CHECK-FOOTER: }

--- a/sycl/test/basic_tests/header_footer_diagnostics.cpp
+++ b/sycl/test/basic_tests/header_footer_diagnostics.cpp
@@ -5,7 +5,4 @@
 
 #include <sycl/sycl.hpp>
 sycl::ext::oneapi::experimental::device_global<int> devGlobVar;
-int main(int argc, char** argv)
-{
-  return 0;
-}
+int main(int argc, char** argv) { return 0; }

--- a/sycl/test/basic_tests/header_footer_diagnostics.cpp
+++ b/sycl/test/basic_tests/header_footer_diagnostics.cpp
@@ -5,4 +5,4 @@
 
 #include <sycl/sycl.hpp>
 sycl::ext::oneapi::experimental::device_global<int> devGlobVar;
-int main(int argc, char** argv) { return 0; }
+int main(int argc, char **argv) { return 0; }

--- a/sycl/test/basic_tests/header_footer_diagnostics.cpp
+++ b/sycl/test/basic_tests/header_footer_diagnostics.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -fsycl -Wreserved-identifier -Wold-style-cast -Werror %s
+// RUN: %clangxx -fsycl -Werror=reserved-identifier -Werror=old-style-cast %s
 
 // Check that the generated header and footer files do not generate
 // errors when pedantic warnings are enabled.

--- a/sycl/test/basic_tests/header_footer_diagnostics.cpp
+++ b/sycl/test/basic_tests/header_footer_diagnostics.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl -Wreserved-identifier -Wold-style-cast -Werror %s
+
+// Check that the generated header and footer files do not generate
+// errors when pedantic warnings are enabled.
+
+#include <sycl/sycl.hpp>
+sycl::ext::oneapi::experimental::device_global<int> devGlobVar;
+int main(int argc, char** argv)
+{
+  return 0;
+}


### PR DESCRIPTION
When -Wreserved-identifer or -Wold-style-cast is enabled, some of the constructs used in
integration headers and footers for device_globals and host_pipes trigger a diagnostic.
This change adds a pragma to the generated files that suppress the diagnostic prior to
the construct and reenabled the diagnostic after.