### PR TITLE
[SYCL] Add a sentinel empty string to kernel names array

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6169,6 +6169,9 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
       O << ",";
     O << "\n";
   }
+  // Add a sentinel to avoid warning if the collection is empty
+  // (similar to what we do for kernel_signatures below).
+  O << "  \"\",\n";
   O << "};\n\n";
 
   O << "// array representing signatures of all kernels defined in the\n";

--- a/clang/test/CodeGenSYCL/free_function_int_header.cpp
+++ b/clang/test/CodeGenSYCL/free_function_int_header.cpp
@@ -49,6 +49,7 @@ template <> void ff_3<double>(double *ptr, double start, double end) {
 // CHECK-NEXT:   {{.*}}__sycl_kernel_ff_3IiEvPT_S0_S0_
 // CHECK-NEXT:   {{.*}}__sycl_kernel_ff_3IfEvPT_S0_S0_
 // CHECK-NEXT:   {{.*}}__sycl_kernel_ff_3IdEvPT_S0_S0_
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK:      const kernel_param_desc_t kernel_signatures[] = {

--- a/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
+++ b/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
@@ -7,6 +7,7 @@
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE1K"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK: static constexpr

--- a/clang/test/CodeGenSYCL/integration_header.cpp
+++ b/clang/test/CodeGenSYCL/integration_header.cpp
@@ -22,6 +22,7 @@
 // CHECK-NEXT:   "_ZTSZ4mainE16accessor_in_base"
 // CHECK-NEXT:   "_ZTSZ4mainE15annotated_types"
 // CHECK-NEXT:   "_ZTS10FinalClass"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 //
 // CHECK: static constexpr

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
@@ -15,6 +15,7 @@
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_A"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK: static constexpr

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
@@ -15,6 +15,7 @@
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_C"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK: static constexpr

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
@@ -16,6 +16,7 @@
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_B",
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_C",
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_D"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK: static constexpr

--- a/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
+++ b/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
@@ -15,6 +15,7 @@
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_A"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK: static constexpr

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -12,6 +12,7 @@
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE14wrapped_access"
+// CHECK-NEXT:   ""
 // CHECK-NEXT: };
 
 // CHECK: static constexpr


### PR DESCRIPTION
We create a kernel_names array in the integration header even when the list of names is empty.
This leads to diagnostics about zero-length arrays in pedantic modes.   This change adds an empty
string as a sentinel node to all kernel_names arrays so the array is never empty.