### PR TITLE
[NFCI] Refactor `sycl::vec`'s variadic ctor

### DIFF
--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -193,7 +193,10 @@ private:
       // and returns values of the underlying vector of some of the operands. On
       // the other hand, `getValue()` gives correct results. This can be changed
       // to using `operator[]` once the bug is fixed.
-      return std::array{static_cast<DataT_>(V.getValue(Is))...};
+      if constexpr (detail::is_swizzle_v<T>)
+        return std::array{static_cast<DataT_>(V.getValue(Is))...};
+      else
+        return std::array{static_cast<DataT_>(V[Is])...};
     }
 
   public:

--- a/sycl/include/sycl/vector.hpp
+++ b/sycl/include/sycl/vector.hpp
@@ -186,51 +186,23 @@ private:
                            std::false_type> {};
 
   // Utility trait for creating an std::array from an vector argument.
-  template <typename DataT_, typename T, std::size_t... Is>
-  static constexpr std::array<DataT_, sizeof...(Is)>
-  VecToArray(const vec<T, sizeof...(Is)> &V, std::index_sequence<Is...>) {
-    return {static_cast<DataT_>(V[Is])...};
-  }
-  template <typename DataT_, typename T, int N, typename T2, typename T3,
-            template <typename> class T4, int... T5, std::size_t... Is>
-  static constexpr std::array<DataT_, sizeof...(Is)>
-  VecToArray(const detail::SwizzleOp<vec<T, N>, T2, T3, T4, T5...> &V,
-             std::index_sequence<Is...>) {
-    return {static_cast<DataT_>(V.getValue(Is))...};
-  }
-  template <typename DataT_, typename T, int N, typename T2, typename T3,
-            template <typename> class T4, int... T5, std::size_t... Is>
-  static constexpr std::array<DataT_, sizeof...(Is)>
-  VecToArray(const detail::SwizzleOp<const vec<T, N>, T2, T3, T4, T5...> &V,
-             std::index_sequence<Is...>) {
-    return {static_cast<DataT_>(V.getValue(Is))...};
-  }
-  template <typename DataT_, typename T, int N>
-  static constexpr std::array<DataT_, N>
-  FlattenVecArgHelper(const vec<T, N> &A) {
-    return VecToArray<DataT_>(A, std::make_index_sequence<N>());
-  }
-  template <typename DataT_, typename T, int N, typename T2, typename T3,
-            template <typename> class T4, int... T5>
-  static constexpr std::array<DataT_, sizeof...(T5)> FlattenVecArgHelper(
-      const detail::SwizzleOp<vec<T, N>, T2, T3, T4, T5...> &A) {
-    return VecToArray<DataT_>(A, std::make_index_sequence<sizeof...(T5)>());
-  }
-  template <typename DataT_, typename T, int N, typename T2, typename T3,
-            template <typename> class T4, int... T5>
-  static constexpr std::array<DataT_, sizeof...(T5)> FlattenVecArgHelper(
-      const detail::SwizzleOp<const vec<T, N>, T2, T3, T4, T5...> &A) {
-    return VecToArray<DataT_>(A, std::make_index_sequence<sizeof...(T5)>());
-  }
-  template <typename DataT_, typename T>
-  static constexpr auto FlattenVecArgHelper(const T &A) {
-    // static_cast required to avoid narrowing conversion warning
-    // when T = unsigned long int and DataT_ = int.
-    return std::array<DataT_, 1>{static_cast<DataT_>(A)};
-  }
-  template <typename DataT_, typename T> struct FlattenVecArg {
+  template <typename DataT_, typename T> class FlattenVecArg {
+    template <std::size_t... Is>
+    static constexpr auto helper(const T &V, std::index_sequence<Is...>) {
+      // FIXME: Swizzle's `operator[]` for expression trees seems to be broken
+      // and returns values of the underlying vector of some of the operands. On
+      // the other hand, `getValue()` gives correct results. This can be changed
+      // to using `operator[]` once the bug is fixed.
+      return std::array{static_cast<DataT_>(V.getValue(Is))...};
+    }
+
+  public:
     constexpr auto operator()(const T &A) const {
-      return FlattenVecArgHelper<DataT_>(A);
+      if constexpr (detail::is_vec_or_swizzle_v<T>) {
+        return helper(A, std::make_index_sequence<T ::size()>());
+      } else {
+        return std::array{static_cast<DataT_>(A)};
+      }
     }
   };
 
@@ -238,69 +210,6 @@ private:
   template <typename DataT_, typename... ArgTN>
   using VecArgArrayCreator =
       detail::ArrayCreator<DataT_, FlattenVecArg, ArgTN...>;
-
-#define __SYCL_ALLOW_VECTOR_SIZES(num_elements)                                \
-  template <int Counter, int MaxValue, typename DataT_, class... tail>         \
-  struct SizeChecker<Counter, MaxValue, vec<DataT_, num_elements>, tail...>    \
-      : std::conditional_t<                                                    \
-            Counter + (num_elements) <= MaxValue,                              \
-            SizeChecker<Counter + (num_elements), MaxValue, tail...>,          \
-            std::false_type> {};                                               \
-  template <int Counter, int MaxValue, typename DataT_, typename T2,           \
-            typename T3, template <typename> class T4, int... T5,              \
-            class... tail>                                                     \
-  struct SizeChecker<                                                          \
-      Counter, MaxValue,                                                       \
-      detail::SwizzleOp<vec<DataT_, num_elements>, T2, T3, T4, T5...>,         \
-      tail...>                                                                 \
-      : std::conditional_t<                                                    \
-            Counter + sizeof...(T5) <= MaxValue,                               \
-            SizeChecker<Counter + sizeof...(T5), MaxValue, tail...>,           \
-            std::false_type> {};                                               \
-  template <int Counter, int MaxValue, typename DataT_, typename T2,           \
-            typename T3, template <typename> class T4, int... T5,              \
-            class... tail>                                                     \
-  struct SizeChecker<                                                          \
-      Counter, MaxValue,                                                       \
-      detail::SwizzleOp<const vec<DataT_, num_elements>, T2, T3, T4, T5...>,   \
-      tail...>                                                                 \
-      : std::conditional_t<                                                    \
-            Counter + sizeof...(T5) <= MaxValue,                               \
-            SizeChecker<Counter + sizeof...(T5), MaxValue, tail...>,           \
-            std::false_type> {};
-
-  __SYCL_ALLOW_VECTOR_SIZES(1)
-  __SYCL_ALLOW_VECTOR_SIZES(2)
-  __SYCL_ALLOW_VECTOR_SIZES(3)
-  __SYCL_ALLOW_VECTOR_SIZES(4)
-  __SYCL_ALLOW_VECTOR_SIZES(8)
-  __SYCL_ALLOW_VECTOR_SIZES(16)
-#undef __SYCL_ALLOW_VECTOR_SIZES
-
-  // TypeChecker is needed for vec(const argTN &... args) ctor to validate args.
-  template <typename T, typename DataT_>
-  struct TypeChecker : std::is_convertible<T, DataT_> {};
-#define __SYCL_ALLOW_VECTOR_TYPES(num_elements)                                \
-  template <typename DataT_>                                                   \
-  struct TypeChecker<vec<DataT_, num_elements>, DataT_> : std::true_type {};   \
-  template <typename DataT_, typename T2, typename T3,                         \
-            template <typename> class T4, int... T5>                           \
-  struct TypeChecker<                                                          \
-      detail::SwizzleOp<vec<DataT_, num_elements>, T2, T3, T4, T5...>, DataT_> \
-      : std::true_type {};                                                     \
-  template <typename DataT_, typename T2, typename T3,                         \
-            template <typename> class T4, int... T5>                           \
-  struct TypeChecker<                                                          \
-      detail::SwizzleOp<const vec<DataT_, num_elements>, T2, T3, T4, T5...>,   \
-      DataT_> : std::true_type {};
-
-  __SYCL_ALLOW_VECTOR_TYPES(1)
-  __SYCL_ALLOW_VECTOR_TYPES(2)
-  __SYCL_ALLOW_VECTOR_TYPES(3)
-  __SYCL_ALLOW_VECTOR_TYPES(4)
-  __SYCL_ALLOW_VECTOR_TYPES(8)
-  __SYCL_ALLOW_VECTOR_TYPES(16)
-#undef __SYCL_ALLOW_VECTOR_TYPES
 
   template <int... Indexes>
   using Swizzle =
@@ -313,13 +222,25 @@ private:
                         detail::GetOp, Indexes...>;
 
   // Shortcuts for args validation in vec(const argTN &... args) ctor.
-  template <typename... argTN>
-  using EnableIfSuitableTypes = typename std::enable_if_t<
-      std::conjunction_v<TypeChecker<argTN, DataT>...>>;
+  template <typename CtorArgTy>
+  static constexpr bool AllowArgTypeInVariadicCtor = []() constexpr {
+    // FIXME: This logic implements the behavior of the previous implementation.
+    if constexpr (detail::is_vec_or_swizzle_v<CtorArgTy>) {
+      if constexpr (CtorArgTy::size() == 1)
+        return std::is_convertible_v<typename CtorArgTy::element_type, DataT>;
+      else
+        return std::is_same_v<typename CtorArgTy::element_type, DataT>;
+    } else {
+      return std::is_convertible_v<CtorArgTy, DataT>;
+    }
+  }();
 
-  template <typename... argTN>
-  using EnableIfSuitableNumElements =
-      typename std::enable_if_t<SizeChecker<0, NumElements, argTN...>::value>;
+  template <typename T> static constexpr int num_elements() {
+    if constexpr (detail::is_vec_or_swizzle_v<T>)
+      return T::size();
+    else
+      return 1;
+  }
 
   // Element type for relational operator return value.
   using rel_t = detail::select_cl_scalar_integral_signed_t<DataT>;
@@ -349,8 +270,10 @@ public:
 
   // Constructor from values of base type or vec of base type. Checks that
   // base types are match and that the NumElements == sum of lengths of args.
-  template <typename... argTN, typename = EnableIfSuitableTypes<argTN...>,
-            typename = EnableIfSuitableNumElements<argTN...>>
+  template <typename... argTN,
+            typename = std::enable_if_t<
+                ((AllowArgTypeInVariadicCtor<argTN> && ...)) &&
+                ((num_elements<argTN>() + ...)) == NumElements>>
   constexpr vec(const argTN &...args)
       : vec{VecArgArrayCreator<DataT, argTN...>::Create(args...),
             std::make_index_sequence<NumElements>()} {}


### PR DESCRIPTION
I think previous implementation was based on C++14 or even C++11 standard. We can do better now.