### PR TITLE
[SYCL] Avoid releasing UR objects on sycl destruction on windows

### DIFF
--- a/sycl/source/detail/device_image_impl.hpp
+++ b/sycl/source/detail/device_image_impl.hpp
@@ -311,8 +311,15 @@ public:
   ~device_image_impl() {
     try {
       if (MProgram) {
+#ifdef _WIN32
+        if (!sycl::detail::GlobalHandler::instance().isUrTearDowned) {
+          const PluginPtr &Plugin = getSyclObjImpl(MContext)->getPlugin();
+          Plugin->call(urProgramRelease, MProgram);
+        }
+#else
         const PluginPtr &Plugin = getSyclObjImpl(MContext)->getPlugin();
         Plugin->call(urProgramRelease, MProgram);
+#endif
       }
       if (MSpecConstsBuffer) {
         std::lock_guard<std::mutex> Lock{MSpecConstAccessMtx};

--- a/sycl/source/detail/global_handler.cpp
+++ b/sycl/source/detail/global_handler.cpp
@@ -303,6 +303,7 @@ void GlobalHandler::drainThreadPool() {
 // accidentally retain device handles. etc
 void shutdown_win() {
   GlobalHandler *&Handler = GlobalHandler::getInstancePtr();
+  Handler->isUrTearDowned = true;
   Handler->unloadPlugins();
 }
 #else

--- a/sycl/source/detail/global_handler.hpp
+++ b/sycl/source/detail/global_handler.hpp
@@ -50,6 +50,7 @@ public:
   /// as runtime library is loaded (i.e. untill `DllMain` or
   /// `__attribute__((destructor))` is called).
   static GlobalHandler &instance();
+  bool isUrTearDowned = false;
 
   GlobalHandler(const GlobalHandler &) = delete;
   GlobalHandler(GlobalHandler &&) = delete;

--- a/sycl/source/detail/kernel_impl.cpp
+++ b/sycl/source/detail/kernel_impl.cpp
@@ -58,8 +58,15 @@ kernel_impl::kernel_impl(ur_kernel_handle_t Kernel, ContextImplPtr ContextImpl,
 
 kernel_impl::~kernel_impl() {
   try {
+#ifdef _WIN32
+    if (!sycl::detail::GlobalHandler::instance().isUrTearDowned) {
+      // TODO catch an exception and put it to list of asynchronous exceptions
+      getPlugin()->call(urKernelRelease, MKernel);
+    }
+#else
     // TODO catch an exception and put it to list of asynchronous exceptions
     getPlugin()->call(urKernelRelease, MKernel);
+#endif
   } catch (std::exception &e) {
     __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~kernel_impl", e);
   }

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -102,8 +102,15 @@ public:
     ~ProgramBuildResult() {
       try {
         if (Val) {
+#ifdef _WIN32
+          if (!sycl::detail::GlobalHandler::instance().isUrTearDowned) {
+            ur_result_t Err = Plugin->call_nocheck(urProgramRelease, Val);
+            __SYCL_CHECK_UR_CODE_NO_EXC(Err);
+          }
+#else
           ur_result_t Err = Plugin->call_nocheck(urProgramRelease, Val);
           __SYCL_CHECK_UR_CODE_NO_EXC(Err);
+#endif
         }
       } catch (std::exception &e) {
         __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~ProgramBuildResult",
@@ -140,8 +147,15 @@ public:
     ~KernelBuildResult() {
       try {
         if (Val.first) {
+#ifdef _WIN32
+          if (!sycl::detail::GlobalHandler::instance().isUrTearDowned) {
+            ur_result_t Err = Plugin->call_nocheck(urKernelRelease, Val.first);
+            __SYCL_CHECK_UR_CODE_NO_EXC(Err);
+          }
+#else
           ur_result_t Err = Plugin->call_nocheck(urKernelRelease, Val.first);
           __SYCL_CHECK_UR_CODE_NO_EXC(Err);
+#endif
         }
       } catch (std::exception &e) {
         __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~KernelBuildResult", e);


### PR DESCRIPTION
SYCL-RT depends currently on the call to `DLLMain` to begin its destruction on windows. However, when sycl-rt `DLLMain` is called, UR have already began its destruction on another thread and in case of level_zero, level_zero_loader.dll also began its destruction far before that, this would lead to race condition and access violations. as when release of UR objects begin either level_zero loader/UR adapter/UR loader have been unloaded already.

So, this PR is a guard for that to not call UR objects release when sycl-rt began its destruction.