### PR TITLE
[NFC][E2E] Enable few `vec` tests outside `-fpreview-breaking-changes`

### DIFF
--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_logical.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_logical.cpp
@@ -1,5 +1,4 @@
-// REQUIRES: preview-breaking-changes-supported
-// RUN: %{build} -fpreview-breaking-changes -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Checks scalar/vec logical operator ordering.

--- a/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_relational.cpp
+++ b/sycl/test-e2e/Basic/vector/vec_binary_scalar_order_relational.cpp
@@ -1,5 +1,4 @@
-// REQUIRES: preview-breaking-changes-supported
-// RUN: %{build} -fpreview-breaking-changes -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 // Checks scalar/vec relational operator ordering.


### PR DESCRIPTION
The functionality has been promoted to default during the past ABI breaking window.