### PR TITLE
[SYCL][ESIMD][E2E] Enable frem double test

### DIFF
--- a/sycl/test-e2e/ESIMD/frem.cpp
+++ b/sycl/test-e2e/ESIMD/frem.cpp
@@ -92,10 +92,8 @@ int main() {
   bool passed = true;
 
   passed &= test<float>(q);
-  // TODO: Enable when driver issue fixed
-#if 0
   if (q.get_device().has(sycl::aspect::fp64))
     passed &= test<double>(q);
-#endif
+
   return passed ? 0 : 1;
 }


### PR DESCRIPTION
It's fixed in a newer driver, same driver version. Not used in CI yet.