### PR TITLE
[SYCL] Fix -Wstring-concatenation in integration headers

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6188,11 +6188,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
   O << "const char* const kernel_names[] = {\n";
 
   for (unsigned I = 0; I < KernelDescs.size(); I++) {
-    O << "  \"" << KernelDescs[I].Name << "\"";
-
-    if (I < KernelDescs.size() - 1)
-      O << ",";
-    O << "\n";
+    O << "  \"" << KernelDescs[I].Name << "\",\n";
   }
   // Add a sentinel to avoid warning if the collection is empty
   // (similar to what we do for kernel_signatures below).

--- a/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
+++ b/clang/test/CodeGenSYCL/int-header-empty-signatures.cpp
@@ -6,7 +6,7 @@
 
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
-// CHECK-NEXT:   "_ZTSZ4mainE1K"
+// CHECK-NEXT:   "_ZTSZ4mainE1K",
 // CHECK-NEXT:   ""
 // CHECK-NEXT: };
 

--- a/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-acc-array-ih.cpp
@@ -14,7 +14,7 @@
 
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
-// CHECK-NEXT:   "_ZTSZ4mainE8kernel_A"
+// CHECK-NEXT:   "_ZTSZ4mainE8kernel_A",
 // CHECK-NEXT:   ""
 // CHECK-NEXT: };
 

--- a/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-member-acc-array-ih.cpp
@@ -14,7 +14,7 @@
 
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
-// CHECK-NEXT:   "_ZTSZ4mainE8kernel_C"
+// CHECK-NEXT:   "_ZTSZ4mainE8kernel_C",
 // CHECK-NEXT:   ""
 // CHECK-NEXT: };
 

--- a/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
+++ b/clang/test/CodeGenSYCL/kernel-param-pod-array-ih.cpp
@@ -15,7 +15,7 @@
 // CHECK-NEXT: const char* const kernel_names[] = {
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_B",
 // CHECK-NEXT:   "_ZTSZ4mainE8kernel_C",
-// CHECK-NEXT:   "_ZTSZ4mainE8kernel_D"
+// CHECK-NEXT:   "_ZTSZ4mainE8kernel_D",
 // CHECK-NEXT:   ""
 // CHECK-NEXT: };
 

--- a/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
+++ b/clang/test/CodeGenSYCL/union-kernel-param-ih.cpp
@@ -14,7 +14,7 @@
 
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
-// CHECK-NEXT:   "_ZTSZ4mainE8kernel_A"
+// CHECK-NEXT:   "_ZTSZ4mainE8kernel_A",
 // CHECK-NEXT:   ""
 // CHECK-NEXT: };
 

--- a/clang/test/CodeGenSYCL/wrapped-accessor.cpp
+++ b/clang/test/CodeGenSYCL/wrapped-accessor.cpp
@@ -11,7 +11,7 @@
 
 // CHECK: static constexpr
 // CHECK-NEXT: const char* const kernel_names[] = {
-// CHECK-NEXT:   "_ZTSZ4mainE14wrapped_access"
+// CHECK-NEXT:   "_ZTSZ4mainE14wrapped_access",
 // CHECK-NEXT:   ""
 // CHECK-NEXT: };
 


### PR DESCRIPTION
A sentinel value added in #15175 fixed the problem of empty arrays, but for non-empty arrays was just concatenated to the last valid value. This produced warnings when compiling SYCL applications, and also meant that there is no sentinel value in the non-empty arrays.