### PR TITLE
[SYCL][Graph] Support sycl_ext_oneapi_enqueue_functions

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_graph.asciidoc
@@ -1990,6 +1990,12 @@ code `invalid` if a user tries to add them to a graph.
 Removing this restriction is something we may look at for future revisions of
 `sycl_ext_oneapi_graph`.
 
+==== sycl_ext_oneapi_enqueue_functions
+
+The command submission functions defined in
+link:../experimental/sycl_ext_oneapi_enqueue_functions.asciidoc[sycl_ext_oneapi_enqueue_functions]
+can be used to add nodes to a graph when creating a graph from queue recording.
+
 == Examples and Usage Guide
 
 Detailed code examples and usage guidelines are provided in the

--- a/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions.cpp
@@ -1,0 +1,59 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests the enqueue free function kernel shortcuts.
+
+#include "../graph_common.hpp"
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+#include <sycl/properties/all_properties.hpp>
+
+int main() {
+  queue InOrderQueue{property::queue::in_order{}};
+
+  using T = int;
+
+  T *PtrA = malloc_device<T>(Size, InOrderQueue);
+  T *PtrB = malloc_device<T>(Size, InOrderQueue);
+  T *PtrC = malloc_device<T>(Size, InOrderQueue);
+
+  exp_ext::command_graph Graph{InOrderQueue};
+  Graph.begin_recording(InOrderQueue);
+
+  T Pattern = 42;
+  exp_ext::fill(InOrderQueue, PtrA, Pattern, Size);
+
+  exp_ext::single_task(InOrderQueue, [=]() {
+    for (size_t i = 0; i < Size; ++i) {
+      PtrB[i] = i;
+    }
+  });
+
+  exp_ext::parallel_for(
+      InOrderQueue, sycl::range<1>{Size},
+      [=](sycl::item<1> Item) { PtrC[Item] = PtrA[Item] * PtrB[Item]; });
+
+  std::vector<T> Output(Size);
+  exp_ext::copy(InOrderQueue, PtrC, Output.data(), Size);
+
+  Graph.end_recording();
+
+  auto GraphExec = Graph.finalize();
+
+  InOrderQueue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+  InOrderQueue.wait_and_throw();
+
+  free(PtrA, InOrderQueue);
+  free(PtrB, InOrderQueue);
+  free(PtrC, InOrderQueue);
+
+  for (size_t i = 0; i < Size; i++) {
+    T Ref = Pattern * i;
+    assert(Output[i] == Ref);
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions_submit.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions_submit.cpp
@@ -1,0 +1,75 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests the enqueue free function using buffers and submit
+
+#include "../graph_common.hpp"
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+
+int main() {
+  queue Queue{};
+
+  using T = int;
+
+  buffer<T> BufferA{range<1>{Size}};
+  BufferA.set_write_back(false);
+  buffer<T> BufferB{range<1>{Size}};
+  BufferB.set_write_back(false);
+  buffer<T> BufferC{range<1>{Size}};
+  BufferC.set_write_back(false);
+
+  const T Pattern = 42;
+  {
+
+    exp_ext::command_graph Graph{
+        Queue.get_context(),
+        Queue.get_device(),
+        {exp_ext::property::graph::assume_buffer_outlives_graph{}}};
+
+    Graph.begin_recording(Queue);
+
+    exp_ext::submit(Queue, [&](handler &CGH) {
+      accessor AccA{BufferA, CGH, write_only};
+      exp_ext::single_task(CGH, [=]() {
+        for (size_t i = 0; i < Size; i++) {
+          AccA[i] = Pattern;
+        }
+      });
+    });
+
+    exp_ext::submit(Queue, [&](handler &CGH) {
+      accessor AccB{BufferB, CGH, write_only};
+      exp_ext::parallel_for(CGH, range<1>{Size},
+                            [=](item<1> Item) { AccB[Item] = Item; });
+    });
+
+    exp_ext::submit(Queue, [&](handler &CGH) {
+      accessor AccA{BufferA, CGH, read_only};
+      accessor AccB{BufferB, CGH, read_only};
+      accessor AccC{BufferC, CGH, write_only};
+      exp_ext::parallel_for(CGH, range<1>{Size}, [=](item<1> Item) {
+        AccC[Item] = AccA[Item] * AccB[Item];
+      });
+    });
+
+    Graph.end_recording();
+
+    auto GraphExec = Graph.finalize();
+
+    Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+    Queue.wait_and_throw();
+  }
+
+  host_accessor HostAcc(BufferC);
+
+  for (size_t i = 0; i < Size; i++) {
+    T Ref = Pattern * i;
+    assert(HostAcc[i] == Ref);
+  }
+
+  return 0;
+}

--- a/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions_submit_with_event.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/ext_oneapi_enqueue_functions_submit_with_event.cpp
@@ -1,0 +1,68 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+// Extra run to check for leaks in Level Zero using UR_L0_LEAKS_DEBUG
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+// Extra run to check for immediate-command-list in Level Zero
+// RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
+
+// Tests the enqueue free function using USM and submit_with_event for
+// dependencies
+
+#include "../graph_common.hpp"
+#include <sycl/ext/oneapi/experimental/enqueue_functions.hpp>
+
+int main() {
+  queue Queue{};
+
+  using T = int;
+
+  T *PtrA = malloc_device<T>(Size, Queue);
+  T *PtrB = malloc_device<T>(Size, Queue);
+  T *PtrC = malloc_device<T>(Size, Queue);
+
+  exp_ext::command_graph Graph{Queue};
+  Graph.begin_recording(Queue);
+
+  T Pattern = 42;
+  event NodeA = exp_ext::submit_with_event(
+      Queue, [&](handler &CGH) { exp_ext::fill(CGH, PtrA, Pattern, Size); });
+
+  event NodeB = exp_ext::submit_with_event(Queue, [&](handler &CGH) {
+    exp_ext::single_task(CGH, [=]() {
+      for (size_t i = 0; i < Size; ++i) {
+        PtrB[i] = i;
+      }
+    });
+  });
+
+  event NodeC = exp_ext::submit_with_event(Queue, [&](handler &CGH) {
+    CGH.depends_on({NodeA, NodeB});
+    exp_ext::parallel_for(CGH, range<1>{Size}, [=](item<1> Item) {
+      PtrC[Item] = PtrA[Item] * PtrB[Item];
+    });
+  });
+
+  std::vector<T> Output(Size);
+  exp_ext::submit_with_event(Queue, [&](handler &CGH) {
+    CGH.depends_on(NodeC);
+    exp_ext::copy(CGH, PtrC, Output.data(), Size);
+  });
+
+  Graph.end_recording();
+
+  auto GraphExec = Graph.finalize();
+
+  Queue.submit([&](handler &CGH) { CGH.ext_oneapi_graph(GraphExec); });
+  Queue.wait_and_throw();
+
+  free(PtrA, Queue);
+  free(PtrB, Queue);
+  free(PtrC, Queue);
+
+  for (size_t i = 0; i < Size; i++) {
+    T Ref = Pattern * i;
+    assert(Output[i] == Ref);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
Add tests to verify support for using the [sycl_ext_oneapi_enqueue_functions](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_functions.asciidoc) extension to add nodes to a graph in queue recording.