### PR TITLE
[clang] Use llvm.used for Device Globals

### DIFF
--- a/clang/lib/CodeGen/CodeGenModule.cpp
+++ b/clang/lib/CodeGen/CodeGenModule.cpp
@@ -2824,7 +2824,7 @@ void CodeGenModule::SetCommonAttributes(GlobalDecl GD, llvm::GlobalValue *GV) {
       const RecordDecl *RD = VD->getType()->getAsRecordDecl();
       if (RD && RD->hasAttr<SYCLDeviceGlobalAttr>() &&
           VD->getFormalLinkage() == Linkage::Internal)
-        addUsedOrCompilerUsedGlobal(GV);
+        LLVMUsed.emplace_back(GV);
     }
   }
 }

--- a/clang/test/CodeGenSYCL/device_global.cpp
+++ b/clang/test/CodeGenSYCL/device_global.cpp
@@ -480,8 +480,7 @@ void bar() {
 // CHECK-INTELFPGA-SAME: ptr addrspace(1) @counter15, ptr addrspace(1) [[ANN_register]]{{.*}}, i32 314, ptr addrspace(1) null
 // CHECK-INTELFPGA-SAME: ptr addrspace(1) @global_wrapper, ptr addrspace(1) [[ANN_memory4_numbanks4_register4]]{{.*}}i32 336, ptr addrspace(1) null
 // CHECK-INTELFPGA-SAME: ptr addrspace(1) @global_wrapper1, ptr addrspace(1) [[ANN_private_copies5_simple_dual_port5_register5]]{{.*}}i32 358, ptr addrspace(1) null
-// CHECK: @llvm.used = appending addrspace(1) global [1 x ptr addrspace(4)] [ptr addrspace(4) addrspacecast (ptr addrspace(1) @[[TEMPL_DEV_GLOB]] to ptr addrspace(4))], section "llvm.metadata"
-// CHECK: @llvm.compiler.used = appending addrspace(1) global [2 x ptr addrspace(4)]
+// CHECK: @llvm.used = appending addrspace(1) global [3 x ptr addrspace(4)] [ptr addrspace(4) addrspacecast (ptr addrspace(1)
 // CHECK-SAME: @_ZL1B
 // CHECK-SAME: @_ZN12_GLOBAL__N_19same_nameE
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
@@ -1,0 +1,31 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+//
+// The OpenCL GPU backends do not currently support device_global backend
+// calls.
+// UNSUPPORTED: opencl && gpu
+//
+// Tests static device_global access through device kernels.
+
+#include "common.hpp"
+
+static device_global<int[4], TestProperties> DeviceGlobalVar;
+
+int main() {
+  queue Q;
+
+  Q.single_task([=]() { DeviceGlobalVar.get()[0] = 42; });
+  // Make sure that the write happens before subsequent read
+  Q.wait();
+
+  int OutVal = 0;
+  {
+    buffer<int, 1> OutBuf(&OutVal, 1);
+    Q.submit([&](handler &CGH) {
+      auto OutAcc = OutBuf.get_access<access::mode::write>(CGH);
+      CGH.single_task([=]() { OutAcc[0] = DeviceGlobalVar.get()[0]; });
+    });
+  }
+  assert(OutVal == 42 && "Read value does not match.");
+  return 0;
+}


### PR DESCRIPTION
`llvm.compiler.used` was getting elided at file-tform stage in compilation
for NVPTX targets, which broke compilation for `static device_global`s.
`llvm.used` seems to be more robust.