### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-427a492

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-97f373a",
-      "version": "97f373a",
-      "updated_at": "2024-08-25T22:46:47Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1852379596/zip",
+      "github_tag": "igc-dev-427a492",
+      "version": "427a492",
+      "updated_at": "2024-08-27T03:48:42Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1857739280/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift