### PR TITLE
[SYCL] Disable fast math in math_ops and marray_common tests

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_common.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_common.cpp
@@ -1,4 +1,6 @@
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -o %t_preview.out %}
 // RUN: %if preview-breaking-changes-supported %{ %{run} %t_preview.out%}

--- a/sycl/test-e2e/syclcompat/math/math_ops.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_ops.cpp
@@ -20,7 +20,9 @@
  *    tests for non-vectorized math helper functions
  **************************************************************************/
 
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 
 #include <syclcompat/dims.hpp>


### PR DESCRIPTION
We've seen those tests failing when release testing. It boils down to the fact that `icpx` will by default (with no user input) enable fast math mode.
* `marray_common.cpp` - uses golden values alongside allowed delta, however in fast math mode the calculation error is greater than the delta
* `math_ops.cpp` - uses `isnan`, which compilers are not obliged to honour in fast math mode.

If nothing else, those tests are a perfect example of how forcing fast math mode on can cause non-obvious errors in, otherwise sound, user code when floating point types are being used.