### PR TITLE
[SYCL][E2E] Remove unnecessary custom device selector from InvokeSimd tests

### DIFF
--- a/sycl/test-e2e/InvokeSimd/invoke_simd_conv.cpp
+++ b/sycl/test-e2e/InvokeSimd/invoke_simd_conv.cpp
@@ -50,20 +50,6 @@ template <class SimdElemT>
   return calc(val);
 }
 
-int ESIMD_selector_v(const device &device) {
-  if (const char *dev_filter = getenv("ONEAPI_DEVICE_SELECTOR")) {
-    std::string filter_string(dev_filter);
-    if (filter_string.find("gpu") != std::string::npos)
-      return device.is_gpu() ? 1000 : -1;
-    std::cerr << "Supported 'ONEAPI_DEVICE_SELECTOR' env var values is "
-                 "'*:gpu' and  '"
-              << filter_string << "' does not contain such substrings.\n";
-    return -1;
-  }
-  // If "ONEAPI_DEVICE_SELECTOR" not defined, only allow gpu device
-  return device.is_gpu() ? 1000 : -1;
-}
-
 inline auto createExceptionHandler() {
   return [](exception_list l) {
     for (auto ep : l) {
@@ -147,7 +133,7 @@ template <class SpmdT, class SimdElemT, bool IsUniform> bool test(queue q) {
 }
 
 int main(void) {
-  queue q(ESIMD_selector_v, createExceptionHandler());
+  queue q(default_selector_v, createExceptionHandler());
 
   auto dev = q.get_device();
   std::cout << "Running on " << dev.get_info<sycl::info::device::name>()

--- a/sycl/test-e2e/InvokeSimd/invoke_simd_smoke.cpp
+++ b/sycl/test-e2e/InvokeSimd/invoke_simd_smoke.cpp
@@ -55,20 +55,6 @@ ESIMD_CALLEE(float *A, esimd::simd<float, VL> b, int i) SYCL_ESIMD_FUNCTION {
 
 float SPMD_CALLEE(float *A, float b, int i) { return A[i] + b; }
 
-int ESIMD_selector_v(const device &device) {
-  if (const char *dev_filter = getenv("ONEAPI_DEVICE_SELECTOR")) {
-    std::string filter_string(dev_filter);
-    if (filter_string.find("gpu") != std::string::npos)
-      return device.is_gpu() ? 1000 : -1;
-    std::cerr << "Supported 'ONEAPI_DEVICE_SELECTOR' env var values is "
-                 "'*:gpu' and  '"
-              << filter_string << "' does not contain such substrings.\n";
-    return -1;
-  }
-  // If "ONEAPI_DEVICE_SELECTOR" not defined, only allow gpu device
-  return device.is_gpu() ? 1000 : -1;
-}
-
 inline auto createExceptionHandler() {
   return [](exception_list l) {
     for (auto ep : l) {
@@ -94,7 +80,7 @@ template <bool use_func_directly> bool test() {
   constexpr unsigned Size = 1024;
   constexpr unsigned GroupSize = 4 * VL;
 
-  queue q(ESIMD_selector_v, createExceptionHandler());
+  queue q(default_selector_v, createExceptionHandler());
 
   auto dev = q.get_device();
   std::cout << "Running with use_func_directly = " << use_func_directly


### PR DESCRIPTION
The local lit configuration specifies that a GPU device is required to run InvokeSimd tests, so the default selector works just fine. In addition, the custom selector in the tests could only select GPUs.