### PR TITLE
[SYCL][Doc] Update revision of SYCL spec

### DIFF
--- a/sycl/doc/extensions/template.asciidoc
+++ b/sycl/doc/extensions/template.asciidoc
@@ -10,6 +10,7 @@
 :encoding: utf-8
 :lang: en
 :dpcpp: pass:[DPC++]
+:endnote: &#8212;{nbsp}end{nbsp}note
 
 // Set the default source code type in this document to C++,
 // for syntax highlighting purposes.  This is needed because
@@ -36,7 +37,7 @@ https://github.com/intel/llvm/issues
 
 == Dependencies
 
-This extension is written against the SYCL 2020 revision 8 specification.  All
+This extension is written against the SYCL 2020 revision 9 specification.  All
 references below to the "core SYCL specification" or to section numbers in the
 SYCL specification refer to that revision.
 


### PR DESCRIPTION
The current version of the SYCL 2020 specification is now rev 9. Also define `endnote` which nore specs are starting to use.