### PR TITLE
[XPTI] Use GCC diagnostics pragma around getenv

### DIFF
--- a/xpti/include/xpti/xpti_trace_framework.hpp
+++ b/xpti/include/xpti/xpti_trace_framework.hpp
@@ -215,11 +215,15 @@ public:
     // is used to provide more information on deprecated API
     // https://docs.microsoft.com/en-us/cpp/c-runtime-library/security-features-in-the-crt
     // https://docs.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
     __XPTI_INSERT_IF_MSVC(__pragma(warning(suppress : 4996)))
     const char *val = std::getenv(var.c_str());
+#if defined(__GNUC__) || defined(__clang__)
 #pragma GCC diagnostic pop
+#endif
     return val ? val : "";
     // #endif
   }

--- a/xpti/include/xpti/xpti_trace_framework.hpp
+++ b/xpti/include/xpti/xpti_trace_framework.hpp
@@ -215,8 +215,11 @@ public:
     // is used to provide more information on deprecated API
     // https://docs.microsoft.com/en-us/cpp/c-runtime-library/security-features-in-the-crt
     // https://docs.microsoft.com/en-us/cpp/build/reference/sdl-enable-additional-security-checks
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
     __XPTI_INSERT_IF_MSVC(__pragma(warning(suppress : 4996)))
     const char *val = std::getenv(var.c_str());
+#pragma GCC diagnostic pop
     return val ? val : "";
     // #endif
   }


### PR DESCRIPTION
Using `getenv` on Windows is deprecated, creating failures in XPTI e2e tests #15026. This patch adds GCC diagnostics pragma around the use of `getenv` to ignore this warning.