### PR TITLE
[SYCL][HIP] Fix hardcoded ROCm path in lit tests

### DIFF
--- a/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
+++ b/sycl/test-e2e/EnqueueNativeCommand/custom-command-hip.cpp
@@ -1,6 +1,6 @@
 // FIXME: the rocm include path and link path are highly platform dependent,
 // we should set this with some variable instead.
-// RUN: %{build} -o %t.out -I/opt/rocm/include -L/opt/rocm/lib -lamdhip64
+// RUN: %{build} -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
 // RUN: %{run} %t.out
 // REQUIRES: hip
 

--- a/sycl/test-e2e/HostInteropTask/interop-task-hip.cpp
+++ b/sycl/test-e2e/HostInteropTask/interop-task-hip.cpp
@@ -1,6 +1,6 @@
 // FIXME: the rocm include path and link path are highly platform dependent,
 // we should set this with some variable instead.
-// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out -I/opt/rocm/include -L/opt/rocm/lib -lamdhip64
+// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out -I%rocm_path/include -L%rocm_path/lib -lamdhip64
 // RUN: %{run} %t.out
 // REQUIRES: hip
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -566,7 +566,9 @@ if "hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":
     arch_flag = (
         "-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=" + config.amd_arch
     )
-    config.substitutions.append(("%rocm_path", os.environ.get("ROCM_PATH", "/opt/rocm")))
+    config.substitutions.append(
+        ("%rocm_path", os.environ.get("ROCM_PATH", "/opt/rocm"))
+    )
 elif "hip:gpu" in config.sycl_devices and config.hip_platform == "NVIDIA":
     config.available_features.add("hip_nvidia")
     arch_flag = ""

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -566,6 +566,7 @@ if "hip:gpu" in config.sycl_devices and config.hip_platform == "AMD":
     arch_flag = (
         "-Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=" + config.amd_arch
     )
+    config.substitutions.append(("%rocm_path", os.environ.get("ROCM_PATH", "/opt/rocm")))
 elif "hip:gpu" in config.sycl_devices and config.hip_platform == "NVIDIA":
     config.available_features.add("hip_nvidia")
     arch_flag = ""


### PR DESCRIPTION
This patch fixes running the interop HIP tests on setups where the ROCm installation is not in `/opt/rocm`.