### PR TITLE
[SYCL][NFC] plugin.hpp code cleanup

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -80,7 +80,7 @@ device_impl::~device_impl() {
     // TODO catch an exception and put it to list of asynchronous exceptions
     const PluginPtr &Plugin = getPlugin();
     ur_result_t Err = Plugin->call_nocheck(urDeviceRelease, MDevice);
-    __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
+    __SYCL_CHECK_UR_CODE_NO_EXC(Err);
   } catch (std::exception &e) {
     __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~device_impl", e);
   }

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -103,7 +103,7 @@ public:
       try {
         if (Val) {
           ur_result_t Err = Plugin->call_nocheck(urProgramRelease, Val);
-          __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
+          __SYCL_CHECK_UR_CODE_NO_EXC(Err);
         }
       } catch (std::exception &e) {
         __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~ProgramBuildResult",
@@ -141,7 +141,7 @@ public:
       try {
         if (Val.first) {
           ur_result_t Err = Plugin->call_nocheck(urKernelRelease, Val.first);
-          __SYCL_CHECK_OCL_CODE_NO_EXC(Err);
+          __SYCL_CHECK_UR_CODE_NO_EXC(Err);
         }
       } catch (std::exception &e) {
         __SYCL_REPORT_EXCEPTION_TO_STREAM("exception in ~KernelBuildResult", e);

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -1,4 +1,4 @@
-//==------------------------- plugin.hpp - SYCL platform -------------------==//
+//==- plugin.hpp -----------------------------------------------------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -7,24 +7,23 @@
 //===----------------------------------------------------------------------===//
 
 #pragma once
+
 #include <detail/config.hpp>
-#include <memory>
-#include <mutex>
 #include <sycl/backend_types.hpp>
 #include <sycl/detail/common.hpp>
+#include <sycl/detail/iostream_proxy.hpp>
 #include <sycl/detail/type_traits.hpp>
 #include <sycl/detail/ur.hpp>
-
 #include <ur_api.h>
-
 #ifdef XPTI_ENABLE_INSTRUMENTATION
 // Include the headers necessary for emitting traces using the trace framework
 #include "xpti/xpti_trace_framework.h"
 #endif
 
-#include <sycl/detail/iostream_proxy.hpp>
+#include <memory>
+#include <mutex>
 
-#define __SYCL_REPORT_UR_ERR_TO_STREAM(expr)                                   \
+#define __SYCL_CHECK_UR_CODE_NO_EXC(expr)                                      \
   {                                                                            \
     auto code = expr;                                                          \
     if (code != UR_RESULT_SUCCESS) {                                           \
@@ -32,8 +31,6 @@
                 << std::endl;                                                  \
     }                                                                          \
   }
-
-#define __SYCL_CHECK_OCL_CODE_NO_EXC(X) __SYCL_REPORT_UR_ERR_TO_STREAM(X)
 
 namespace sycl {
 inline namespace _V1 {

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -105,8 +105,7 @@ std::vector<PluginPtr> &initializeUr(ur_loader_config_handle_t LoaderConfig) {
 
 static void initializePlugins(std::vector<PluginPtr> &Plugins,
                               ur_loader_config_handle_t LoaderConfig) {
-#define CHECK_UR_SUCCESS(Call)                                                 \
-  __SYCL_CHECK_OCL_CODE_NO_EXC(Call)
+#define CHECK_UR_SUCCESS(Call) __SYCL_CHECK_UR_CODE_NO_EXC(Call)
 
   bool OwnLoaderConfig = false;
   // If we weren't provided with a custom config handle create our own.


### PR DESCRIPTION
Replace the name of OCL specific macro to reflect the move from OpenCL
API to UR API.
