### PR TITLE
[SYCL][NFC] Sink codeLocationCallback to ur.cpp

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -10,7 +10,6 @@
 
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL_ALWAYS_INLINE
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
-#include <ur_api.h>                           // for ur_code_location_t
 
 #include <array>       // for array
 #include <cassert>     // for assert
@@ -95,8 +94,6 @@ private:
   unsigned long MLineNo;
   unsigned long MColumnNo;
 };
-
-ur_code_location_t codeLocationCallback(void *);
 
 /// @brief Data type that manages the code_location information in TLS
 /// @details As new SYCL features are added, they all enable the propagation of

--- a/sycl/source/detail/common.cpp
+++ b/sycl/source/detail/common.cpp
@@ -8,8 +8,6 @@
 
 #include <sycl/detail/common.hpp>
 
-#include <ur_api.h>
-
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
@@ -27,16 +25,6 @@ tls_code_loc_t::tls_code_loc_t() {
   // Check TLS to see if a previously stashed code_location object is
   // available; if so, we are in a local scope.
   MLocalScope = GCodeLocTLS.fileName() && GCodeLocTLS.functionName();
-}
-
-ur_code_location_t codeLocationCallback(void *) {
-  ur_code_location_t codeloc;
-  codeloc.columnNumber = GCodeLocTLS.columnNumber();
-  codeloc.lineNumber = GCodeLocTLS.lineNumber();
-  codeloc.functionName = GCodeLocTLS.functionName();
-  codeloc.sourceFile = GCodeLocTLS.fileName();
-
-  return codeloc;
 }
 
 /// @brief Constructor to use at the top level of the calling stack

--- a/sycl/source/detail/ur.cpp
+++ b/sycl/source/detail/ur.cpp
@@ -23,6 +23,7 @@
 #include <sycl/detail/stl_type_traits.hpp>
 #include <sycl/detail/ur.hpp>
 #include <sycl/version.hpp>
+#include <ur_api.h>
 
 #include <bitset>
 #include <cstdarg>
@@ -72,6 +73,16 @@ void *getPluginOpaqueData([[maybe_unused]] void *OpaqueDataParam) {
       make_error_code(errc::feature_not_supported),
       "This operation is not supported by any existing backends.");
   return nullptr;
+}
+
+ur_code_location_t codeLocationCallback(void *) {
+  ur_code_location_t codeloc;
+  codeloc.columnNumber = GCodeLocTLS.columnNumber();
+  codeloc.lineNumber = GCodeLocTLS.lineNumber();
+  codeloc.functionName = GCodeLocTLS.functionName();
+  codeloc.sourceFile = GCodeLocTLS.fileName();
+
+  return codeloc;
 }
 
 namespace ur {


### PR DESCRIPTION
The codeLocationCallback function is only used in ur.cpp, so there is no
need to have it in common.hpp/cpp.
