### PR TITLE
[SYCL] Fix Coverity null reference hits, divide by 0 hits

### DIFF
--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -201,7 +201,7 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
   if (UrProgram == nullptr)
     throw sycl::exception(
         sycl::make_error_code(sycl::errc::build),
-        "urProgramCreateWithNativeHandle resulted in a null program handle");
+        "urProgramCreateWithNativeHandle resulted in a null program handle.");
 
   if (ContextImpl->getBackend() == backend::opencl)
     Plugin->call(urProgramRetain, UrProgram);

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -198,6 +198,11 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
 
   Plugin->call(urProgramCreateWithNativeHandle, NativeHandle,
                ContextImpl->getHandleRef(), &Properties, &UrProgram);
+  if (UrProgram == nullptr)
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::build),
+        "urProgramCreateWithNativeHandle resulted in a null program handle");
+
   if (ContextImpl->getBackend() == backend::opencl)
     Plugin->call(urProgramRetain, UrProgram);
 

--- a/sycl/source/backend.cpp
+++ b/sycl/source/backend.cpp
@@ -200,7 +200,7 @@ make_kernel_bundle(ur_native_handle_t NativeHandle,
                ContextImpl->getHandleRef(), &Properties, &UrProgram);
   if (UrProgram == nullptr)
     throw sycl::exception(
-        sycl::make_error_code(sycl::errc::build),
+        sycl::make_error_code(sycl::errc::invalid),
         "urProgramCreateWithNativeHandle resulted in a null program handle.");
 
   if (ContextImpl->getBackend() == backend::opencl)

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -458,7 +458,7 @@ public:
     if (UrProgram == nullptr)
       throw sycl::exception(
           sycl::make_error_code(errc::build),
-          "urProgramCreateWithIL resulted in a null program handle");
+          "urProgramCreateWithIL resulted in a null program handle.");
 
     std::string XsFlags = extractXsFlags(BuildOptions);
     auto Res =

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -455,6 +455,10 @@ public:
     Plugin->call(urProgramCreateWithIL, ContextImpl->getHandleRef(),
                  spirv.data(), spirv.size(), nullptr, &UrProgram);
     // program created by urProgramCreateWithIL is implicitly retained.
+    if (UrProgram == nullptr)
+      throw sycl::exception(
+          sycl::make_error_code(errc::build),
+          "urProgramCreateWithIL resulted in a null program handle");
 
     std::string XsFlags = extractXsFlags(BuildOptions);
     auto Res =

--- a/sycl/source/detail/kernel_bundle_impl.hpp
+++ b/sycl/source/detail/kernel_bundle_impl.hpp
@@ -457,7 +457,7 @@ public:
     // program created by urProgramCreateWithIL is implicitly retained.
     if (UrProgram == nullptr)
       throw sycl::exception(
-          sycl::make_error_code(errc::build),
+          sycl::make_error_code(errc::invalid),
           "urProgramCreateWithIL resulted in a null program handle.");
 
     std::string XsFlags = extractXsFlags(BuildOptions);

--- a/sycl/source/detail/plugin.hpp
+++ b/sycl/source/detail/plugin.hpp
@@ -69,7 +69,8 @@ public:
       ur_result = call_nocheck(urAdapterGetLastError, MAdapter, &message, &adapter_error);
 
       // If the warning level is greater then 2 emit the message
-      if (detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() >= 2) {
+      if (message != nullptr &&
+          detail::SYCLConfig<detail::SYCL_RT_WARNING_LEVEL>::get() >= 2) {
         std::clog << message << std::endl;
       }
 

--- a/sycl/source/virtual_mem.cpp
+++ b/sycl/source/virtual_mem.cpp
@@ -58,6 +58,9 @@ __SYCL_EXPORT size_t get_mem_granularity(const device &SyclDevice,
   Plugin->call(urVirtualMemGranularityGetInfo, ContextImpl->getHandleRef(),
                DeviceImpl->getHandleRef(), GranularityQuery, sizeof(size_t),
                &Granularity, nullptr);
+  assert(
+      Granularity == 0 &&
+      "Unexpected granularity query result: memory granularity shouldn't be 0");
   return Granularity;
 }
 

--- a/sycl/source/virtual_mem.cpp
+++ b/sycl/source/virtual_mem.cpp
@@ -59,8 +59,9 @@ __SYCL_EXPORT size_t get_mem_granularity(const device &SyclDevice,
                DeviceImpl->getHandleRef(), GranularityQuery, sizeof(size_t),
                &Granularity, nullptr);
   if (Granularity == 0)
-    throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
-                          "Unexpected granularity result: memory granularity shouldn't be 0.");
+    throw sycl::exception(
+        sycl::make_error_code(sycl::errc::invalid),
+        "Unexpected granularity result: memory granularity shouldn't be 0.");
   return Granularity;
 }
 

--- a/sycl/source/virtual_mem.cpp
+++ b/sycl/source/virtual_mem.cpp
@@ -60,7 +60,7 @@ __SYCL_EXPORT size_t get_mem_granularity(const device &SyclDevice,
                &Granularity, nullptr);
   assert(
       Granularity == 0 &&
-      "Unexpected granularity query result: memory granularity shouldn't be 0");
+      "Unexpected granularity query result: memory granularity shouldn't be 0.");
   return Granularity;
 }
 

--- a/sycl/source/virtual_mem.cpp
+++ b/sycl/source/virtual_mem.cpp
@@ -58,9 +58,9 @@ __SYCL_EXPORT size_t get_mem_granularity(const device &SyclDevice,
   Plugin->call(urVirtualMemGranularityGetInfo, ContextImpl->getHandleRef(),
                DeviceImpl->getHandleRef(), GranularityQuery, sizeof(size_t),
                &Granularity, nullptr);
-  assert(
-      Granularity == 0 &&
-      "Unexpected granularity query result: memory granularity shouldn't be 0.");
+  if (Granularity == 0)
+    throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
+                          "Unexpected granularity result: memory granularity shouldn't be 0.");
   return Granularity;
 }
 


### PR DESCRIPTION
This PR fixes many Coverity hits:
- Adds checks ensuring potentially nullable values are not dereferenced
- Adds a sanity check on get_mem_granularity, ensuring memory granularity can never be 0
  - This is done to fix a divide by 0 coverity hit, as the return result of get_mem_granularity is used directly in division.
  
I'd like to bring attention to the error codes I am using, especially in backend.cpp, in `make_kernel_bundle`. I am using `errc:build` as according to the SYCL 2020 spec, this is for errors "from an online compile or link operation when compiling, linking, or building a kernel bundle for a device". However, in the specifications for `make_kernel_bundle`, the SYCL 2020 spec states:
> Throws an exception with the errc::invalid error code if any error is produced by the [SYCL backend](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#backend).

I am not sure which error to go with, but `errc::invalid` seemed confusing as it is meant for "when the application passes an invalid value as a parameter to a SYCL API function or calls a SYCL API function in some invalid way", which is not what's happening here. This is why in my current changes, I am using `errc::build`. If this is unacceptable, please let me know and I will make changes. Thanks in advance!