### PR TITLE
[SYCL] Add host kernel instantiation for debuggers

### DIFF
--- a/sycl/test/abi/vtable.cpp
+++ b/sycl/test/abi/vtable.cpp
@@ -8,6 +8,18 @@
 // Changing vtable breaks ABI. If this test fails, please, refer to ABI Policy
 // Guide for further instructions.
 
+void foo(sycl::detail::HostKernelBase &HKB) {
+  HKB.InstatitateKernelOnHost();
+}
+// CHECK:      Vtable for 'sycl::detail::HostKernelBase' (6 entries).
+// CHECK-NEXT:   0 | offset_to_top (0)
+// CHECK-NEXT:   1 | sycl::detail::HostKernelBase RTTI
+// CHECK-NEXT:       -- (sycl::detail::HostKernelBase, 0) vtable address --
+// CHECK-NEXT:   2 | void sycl::detail::HostKernelBase::InstatitateKernelOnHost() [pure]
+// CHECK-NEXT:   3 | char *sycl::detail::HostKernelBase::getPtr() [pure]
+// CHECK-NEXT:   4 | sycl::detail::HostKernelBase::~HostKernelBase() [complete]
+// CHECK-NEXT:   5 | sycl::detail::HostKernelBase::~HostKernelBase() [deleting]
+
 void foo(sycl::detail::PropertyWithDataBase *Prop) { delete Prop; }
 // CHECK:    Vtable for 'sycl::detail::PropertyWithDataBase' (4 entries).
 // CHECK-NEXT:   0 | offset_to_top (0)


### PR DESCRIPTION
The changes in https://github.com/intel/llvm/pull/14460 removed the seemingly unused functions for running kernels on on host. However, this turned out to be used by debuggers as they need the kernel code to be in the host executable.

This commit adds a simplified version of the kernel instantiation that the aforementioned patch removed.