### PR TITLE
[SYCL][NFC] Rename support dynamic linking

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10748,7 +10748,7 @@ static void addArgs(ArgStringList &DstArgs, const llvm::opt::ArgList &Alloc,
   }
 }
 
-static bool supportDynamicLinking(const llvm::opt::ArgList &TCArgs) {
+static bool allowDeviceDependencies(const llvm::opt::ArgList &TCArgs) {
   if (TCArgs.hasFlag(options::OPT_fsycl_allow_device_dependencies,
                      options::OPT_fno_sycl_allow_device_dependencies, false))
     return true;
@@ -10782,8 +10782,8 @@ static void getNonTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
                      options::OPT_fsycl_esimd_force_stateless_mem, false))
     addArgs(PostLinkArgs, TCArgs, {"-lower-esimd-force-stateless-mem=false"});
 
-  if (supportDynamicLinking(TCArgs))
-    addArgs(PostLinkArgs, TCArgs, {"-support-dynamic-linking"});
+  if (allowDeviceDependencies(TCArgs))
+    addArgs(PostLinkArgs, TCArgs, {"-allow-device-dependencies"});
 }
 
 // On Intel targets we don't need non-kernel functions as entry points,
@@ -10800,7 +10800,7 @@ static bool shouldEmitOnlyKernelsAsEntryPoints(const ToolChain &TC,
     return true;
   // When supporting dynamic linking, non-kernels in a device image can be
   // called.
-  if (supportDynamicLinking(TCArgs))
+  if (allowDeviceDependencies(TCArgs))
     return false;
   if (Triple.isNVPTX() || Triple.isAMDGPU())
     return false;

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10783,7 +10783,7 @@ static void getNonTripleBasedSYCLPostLinkOpts(const ToolChain &TC,
     addArgs(PostLinkArgs, TCArgs, {"-lower-esimd-force-stateless-mem=false"});
 
   if (allowDeviceDependencies(TCArgs))
-    addArgs(PostLinkArgs, TCArgs, {"-allow-device-dependencies"});
+    addArgs(PostLinkArgs, TCArgs, {"-allow-device-image-dependencies"});
 }
 
 // On Intel targets we don't need non-kernel functions as entry points,

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -177,16 +177,16 @@
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_OPT_NO_PASS %s
 // CHECK_SYCL_POST_LINK_OPT_NO_PASS-NOT: sycl-post-link{{.*}}emit-only-kernels-as-entry-points
 
-/// Check selective passing of -allow-device-dependencies to sycl-post-link tool
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_NO_PASS %s
-// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
-// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
-// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_NO_PASS %s
+/// Check selective passing of -allow-device-image-dependencies to sycl-post-link tool
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADID_PASS %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADID_PASS %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADID_NO_PASS %s
+// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADID_PASS %s
+// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADID_PASS %s
+// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADID_NO_PASS %s
 
-// CHECK_SYCL_POST_LINK_ADD_PASS: sycl-post-link{{.*}}allow-device-dependencies
-// CHECK_SYCL_POST_LINK_ADD_NO_PASS-NOT: sycl-post-link{{.*}}allow-device-dependencies
+// CHECK_SYCL_POST_LINK_ADID_PASS: sycl-post-link{{.*}}allow-device-image-dependencies
+// CHECK_SYCL_POST_LINK_ADID_NO_PASS-NOT: sycl-post-link{{.*}}allow-device-image-dependencies
 
 /// Check for correct handling of -fsycl-fp64-conv-emu option for different targets
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64 -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_WARNING %s

--- a/clang/test/Driver/sycl-offload-old-model.cpp
+++ b/clang/test/Driver/sycl-offload-old-model.cpp
@@ -177,16 +177,16 @@
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_OPT_NO_PASS %s
 // CHECK_SYCL_POST_LINK_OPT_NO_PASS-NOT: sycl-post-link{{.*}}emit-only-kernels-as-entry-points
 
-/// Check selective passing of -support-dynamic-linking to sycl-post-link tool
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_SADD_PASS %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_SADD_PASS %s
-// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_SADD_NO_PASS %s
-// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_SADD_PASS %s
-// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_SADD_PASS %s
-// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_SADD_NO_PASS %s
+/// Check selective passing of -allow-device-dependencies to sycl-post-link tool
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
+// RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_NO_PASS %s
+// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
+// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fsycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_PASS %s
+// RUN: %clang_cl -### -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen -fno-sycl-allow-device-dependencies %s 2>&1 | FileCheck -check-prefix=CHECK_SYCL_POST_LINK_ADD_NO_PASS %s
 
-// CHECK_SYCL_POST_LINK_SADD_PASS: sycl-post-link{{.*}}support-dynamic-linking
-// CHECK_SYCL_POST_LINK_SADD_NO_PASS-NOT: sycl-post-link{{.*}}support-dynamic-linking
+// CHECK_SYCL_POST_LINK_ADD_PASS: sycl-post-link{{.*}}allow-device-dependencies
+// CHECK_SYCL_POST_LINK_ADD_NO_PASS-NOT: sycl-post-link{{.*}}allow-device-dependencies
 
 /// Check for correct handling of -fsycl-fp64-conv-emu option for different targets
 // RUN: %clang -### -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64 -fsycl-fp64-conv-emu %s 2>&1 | FileCheck -check-prefix=CHECK_WARNING %s

--- a/llvm/lib/SYCLLowerIR/ModuleSplitter.cpp
+++ b/llvm/lib/SYCLLowerIR/ModuleSplitter.cpp
@@ -52,9 +52,9 @@ constexpr char SYCL_SCOPE_NAME[] = "<SYCL>";
 constexpr char ESIMD_SCOPE_NAME[] = "<ESIMD>";
 constexpr char ESIMD_MARKER_MD[] = "sycl_explicit_simd";
 
-cl::opt<bool> SupportDynamicLinking{
-    "support-dynamic-linking",
-    cl::desc("Generate device images that are suitable for dynamic linking"),
+cl::opt<bool> AllowDeviceDependencies{
+    "allow-device-dependencies",
+    cl::desc("Allow dependencies between device images"),
     cl::cat(getModuleSplitCategory()), cl::init(false)};
 
 EntryPointsGroupScope selectDeviceCodeGroupScope(const Module &M,
@@ -670,7 +670,7 @@ static bool mustPreserveGV(const GlobalValue &GV) {
     // When dynamic linking is supported, we internalize everything that can
     // not be imported which also means that there is no point of having it
     // visible outside of the current module.
-    if (SupportDynamicLinking)
+    if (AllowDeviceDependencies)
       return canBeImportedFunction(*F);
 
     // Otherwise, we are being even more aggressive: SYCL modules are expected
@@ -715,7 +715,7 @@ void ModuleDesc::cleanup() {
 
   // Callback for internalize can't be a lambda with captures, so we propagate
   // necessary information through the module itself.
-  if (!SupportDynamicLinking)
+  if (!AllowDeviceDependencies)
     for (Function *F : EntryPoints.Functions)
       F->addFnAttr("sycl-entry-point");
 
@@ -1391,7 +1391,7 @@ bool canBeImportedFunction(const Function &F) {
   // of user device code (e.g. _Z38__spirv_JointMatrixWorkItemLength...) In
   // order to be safe and not require perfect name analysis just start with this
   // simple check.
-  if (!SupportDynamicLinking)
+  if (!AllowDeviceDependencies)
     return false;
 
   // SYCL_EXTERNAL property is not recorded for a declaration

--- a/llvm/lib/SYCLLowerIR/ModuleSplitter.cpp
+++ b/llvm/lib/SYCLLowerIR/ModuleSplitter.cpp
@@ -52,8 +52,8 @@ constexpr char SYCL_SCOPE_NAME[] = "<SYCL>";
 constexpr char ESIMD_SCOPE_NAME[] = "<ESIMD>";
 constexpr char ESIMD_MARKER_MD[] = "sycl_explicit_simd";
 
-cl::opt<bool> AllowDeviceDependencies{
-    "allow-device-dependencies",
+cl::opt<bool> AllowDeviceImageDependencies{
+    "allow-device-image-dependencies",
     cl::desc("Allow dependencies between device images"),
     cl::cat(getModuleSplitCategory()), cl::init(false)};
 
@@ -670,7 +670,7 @@ static bool mustPreserveGV(const GlobalValue &GV) {
     // When dynamic linking is supported, we internalize everything that can
     // not be imported which also means that there is no point of having it
     // visible outside of the current module.
-    if (AllowDeviceDependencies)
+    if (AllowDeviceImageDependencies)
       return canBeImportedFunction(*F);
 
     // Otherwise, we are being even more aggressive: SYCL modules are expected
@@ -715,7 +715,7 @@ void ModuleDesc::cleanup() {
 
   // Callback for internalize can't be a lambda with captures, so we propagate
   // necessary information through the module itself.
-  if (!AllowDeviceDependencies)
+  if (!AllowDeviceImageDependencies)
     for (Function *F : EntryPoints.Functions)
       F->addFnAttr("sycl-entry-point");
 
@@ -1391,7 +1391,7 @@ bool canBeImportedFunction(const Function &F) {
   // of user device code (e.g. _Z38__spirv_JointMatrixWorkItemLength...) In
   // order to be safe and not require perfect name analysis just start with this
   // simple check.
-  if (!AllowDeviceDependencies)
+  if (!AllowDeviceImageDependencies)
     return false;
 
   // SYCL_EXTERNAL property is not recorded for a declaration

--- a/llvm/test/tools/sycl-post-link/emit_imported_symbols.ll
+++ b/llvm/test/tools/sycl-post-link/emit_imported_symbols.ll
@@ -1,12 +1,12 @@
 ; This test checks that the -emit-imported-symbols option generates a list of imported symbols
 ; Function names were chosen so that no function with a 'inside' in their function name is imported
-; Note that -emit-imported-symbols will not emit any imported symbols without -allow-device-dependencies.
+; Note that -emit-imported-symbols will not emit any imported symbols without -allow-device-image-dependencies.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Test with -split=kernel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -emit-imported-symbols -split=kernel -S < %s -o %t_kernel.table
+; RUN: sycl-post-link -properties -symbols -allow-device-image-dependencies -emit-imported-symbols -split=kernel -S < %s -o %t_kernel.table
 
 ; RUN: FileCheck %s -input-file=%t_kernel_0.sym --check-prefixes CHECK-KERNEL-SYM-0
 ; RUN: FileCheck %s -input-file=%t_kernel_1.sym --check-prefixes CHECK-KERNEL-SYM-1
@@ -41,11 +41,11 @@
 ; Test with -split=source
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -emit-imported-symbols -split=source -S < %s -o %t_source.table
+; RUN: sycl-post-link -properties -symbols -allow-device-image-dependencies -emit-imported-symbols -split=source -S < %s -o %t_source.table
 ; RUN: FileCheck %s -input-file=%t_source_0.sym --check-prefixes CHECK-SOURCE-SYM-0
 ; RUN: FileCheck %s -input-file=%t_source_0.prop --check-prefixes CHECK-SOURCE-IMPORTED-SYM-0
 
-; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -emit-imported-symbols -split=source -S < %s -o %t_source.table -O0
+; RUN: sycl-post-link -properties -symbols -allow-device-image-dependencies -emit-imported-symbols -split=source -S < %s -o %t_source.table -O0
 ; RUN: FileCheck %s -input-file=%t_source_0.sym --check-prefixes CHECK-SOURCE-SYM-0
 ; RUN: FileCheck %s -input-file=%t_source_0.prop --check-prefixes CHECK-SOURCE-IMPORTED-SYM-0
 

--- a/llvm/test/tools/sycl-post-link/emit_imported_symbols.ll
+++ b/llvm/test/tools/sycl-post-link/emit_imported_symbols.ll
@@ -1,12 +1,12 @@
 ; This test checks that the -emit-imported-symbols option generates a list of imported symbols
 ; Function names were chosen so that no function with a 'inside' in their function name is imported
-; Note that -emit-imported-symbols will not emit any imported symbols without -support-dynamic-linking.
+; Note that -emit-imported-symbols will not emit any imported symbols without -allow-device-dependencies.
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ; Test with -split=kernel
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; RUN: sycl-post-link -properties -symbols -support-dynamic-linking -emit-imported-symbols -split=kernel -S < %s -o %t_kernel.table
+; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -emit-imported-symbols -split=kernel -S < %s -o %t_kernel.table
 
 ; RUN: FileCheck %s -input-file=%t_kernel_0.sym --check-prefixes CHECK-KERNEL-SYM-0
 ; RUN: FileCheck %s -input-file=%t_kernel_1.sym --check-prefixes CHECK-KERNEL-SYM-1
@@ -41,11 +41,11 @@
 ; Test with -split=source
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
-; RUN: sycl-post-link -properties -symbols -support-dynamic-linking -emit-imported-symbols -split=source -S < %s -o %t_source.table
+; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -emit-imported-symbols -split=source -S < %s -o %t_source.table
 ; RUN: FileCheck %s -input-file=%t_source_0.sym --check-prefixes CHECK-SOURCE-SYM-0
 ; RUN: FileCheck %s -input-file=%t_source_0.prop --check-prefixes CHECK-SOURCE-IMPORTED-SYM-0
 
-; RUN: sycl-post-link -properties -symbols -support-dynamic-linking -emit-imported-symbols -split=source -S < %s -o %t_source.table -O0
+; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -emit-imported-symbols -split=source -S < %s -o %t_source.table -O0
 ; RUN: FileCheck %s -input-file=%t_source_0.sym --check-prefixes CHECK-SOURCE-SYM-0
 ; RUN: FileCheck %s -input-file=%t_source_0.prop --check-prefixes CHECK-SOURCE-IMPORTED-SYM-0
 

--- a/llvm/test/tools/sycl-post-link/exclude_external_functions.ll
+++ b/llvm/test/tools/sycl-post-link/exclude_external_functions.ll
@@ -1,8 +1,8 @@
-; Test that when the -support-dynamic-linking option is used,
+; Test that when the -allow-device-dependencies option is used,
 ; dependencies to a function that can be imported do not cause the function
 ; to be added to a device image.
 
-; RUN: sycl-post-link -properties -symbols -support-dynamic-linking -split=kernel -S < %s -o %t.table
+; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -split=kernel -S < %s -o %t.table
 
 
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM-0

--- a/llvm/test/tools/sycl-post-link/exclude_external_functions.ll
+++ b/llvm/test/tools/sycl-post-link/exclude_external_functions.ll
@@ -1,8 +1,8 @@
-; Test that when the -allow-device-dependencies option is used,
+; Test that when the -allow-device-image-dependencies option is used,
 ; dependencies to a function that can be imported do not cause the function
 ; to be added to a device image.
 
-; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -split=kernel -S < %s -o %t.table
+; RUN: sycl-post-link -properties -symbols -allow-device-image-dependencies -split=kernel -S < %s -o %t.table
 
 
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM-0

--- a/llvm/test/tools/sycl-post-link/exclude_external_functions_source.ll
+++ b/llvm/test/tools/sycl-post-link/exclude_external_functions_source.ll
@@ -1,10 +1,10 @@
-; Test that when the -allow-device-dependencies option is used with source splitting,
+; Test that when the -allow-device-image-dependencies option is used with source splitting,
 ; dependencies to a function that can be imported do not cause the function
 ; to be added to a device image.
 ; Also ensure that functions in the same source that can be imported do not get split into
 ; different images.
 
-; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -split=source -S < %s -o %t.table
+; RUN: sycl-post-link -properties -symbols -allow-device-image-dependencies -split=source -S < %s -o %t.table
 
 target triple = "spir64-unknown-unknown"
 

--- a/llvm/test/tools/sycl-post-link/exclude_external_functions_source.ll
+++ b/llvm/test/tools/sycl-post-link/exclude_external_functions_source.ll
@@ -1,10 +1,10 @@
-; Test that when the -support-dynamic-linking option is used with source splitting,
+; Test that when the -allow-device-dependencies option is used with source splitting,
 ; dependencies to a function that can be imported do not cause the function
 ; to be added to a device image.
 ; Also ensure that functions in the same source that can be imported do not get split into
 ; different images.
 
-; RUN: sycl-post-link -properties -symbols -support-dynamic-linking -split=source -S < %s -o %t.table
+; RUN: sycl-post-link -properties -symbols -allow-device-dependencies -split=source -S < %s -o %t.table
 
 target triple = "spir64-unknown-unknown"
 

--- a/llvm/test/tools/sycl-post-link/internalize_functions.ll
+++ b/llvm/test/tools/sycl-post-link/internalize_functions.ll
@@ -1,8 +1,8 @@
-; Test that when -allow-device-dependencies is used
+; Test that when -allow-device-image-dependencies is used
 ; non SYCL_EXTERNAL functions are internalized.
 ; Variables must not be internalized.
 
-; RUN: sycl-post-link -symbols -allow-device-dependencies -split=kernel -S < %s -o %t.table
+; RUN: sycl-post-link -symbols -allow-device-image-dependencies -split=kernel -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM-0
 ; RUN: FileCheck %s -input-file=%t_0.ll  --check-prefixes CHECK-LL-0
 

--- a/llvm/test/tools/sycl-post-link/internalize_functions.ll
+++ b/llvm/test/tools/sycl-post-link/internalize_functions.ll
@@ -1,8 +1,8 @@
-; Test that when -support-dynamic-linking is used
+; Test that when -allow-device-dependencies is used
 ; non SYCL_EXTERNAL functions are internalized.
 ; Variables must not be internalized.
 
-; RUN: sycl-post-link -symbols -support-dynamic-linking -split=kernel -S < %s -o %t.table
+; RUN: sycl-post-link -symbols -allow-device-dependencies -split=kernel -S < %s -o %t.table
 ; RUN: FileCheck %s -input-file=%t_0.sym --check-prefixes CHECK-SYM-0
 ; RUN: FileCheck %s -input-file=%t_0.ll  --check-prefixes CHECK-LL-0
 

--- a/llvm/test/tools/sycl-post-link/virtual-functions/module-cleanup.ll
+++ b/llvm/test/tools/sycl-post-link/virtual-functions/module-cleanup.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -split=auto -properties -emit-exported-symbols \
 ; RUN:     -emit-imported-symbols -emit-only-kernels-as-entry-points \
-; RUN:     -allow-device-dependencies \
+; RUN:     -allow-device-image-dependencies \
 ; RUN:     -S < %s -o %t.table
 ;
 ; Virtual functions require some special handling during module cleanup:

--- a/llvm/test/tools/sycl-post-link/virtual-functions/module-cleanup.ll
+++ b/llvm/test/tools/sycl-post-link/virtual-functions/module-cleanup.ll
@@ -1,6 +1,6 @@
 ; RUN: sycl-post-link -split=auto -properties -emit-exported-symbols \
 ; RUN:     -emit-imported-symbols -emit-only-kernels-as-entry-points \
-; RUN:     -support-dynamic-linking \
+; RUN:     -allow-device-dependencies \
 ; RUN:     -S < %s -o %t.table
 ;
 ; Virtual functions require some special handling during module cleanup:


### PR DESCRIPTION
Rename sycl-post-link option "-support-dynamic-linking" to "-allow-device-image-dependencies".  This is consistent with the clang option that is tied to this sycl-post-link option, and is also consistent with what is being done inside sycl-post-link.