### PR TITLE
[UR] Enable hwloc in UMF linux build

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -23,9 +23,6 @@ option(SYCL_UR_USE_FETCH_CONTENT
 set(SYCL_UR_SOURCE_DIR
   "" CACHE PATH "Path to root of Unified Runtime repository")
 
-option(SYCL_UMF_DISABLE_HWLOC
-  "Disable hwloc support in UMF" ON)
-
 # Here we override the defaults to disable building tests from unified-runtime
 set(UR_BUILD_EXAMPLES OFF CACHE BOOL "Build example applications." FORCE)
 set(UR_BUILD_TESTS OFF CACHE BOOL "Build unit tests." FORCE)
@@ -149,8 +146,6 @@ elseif(SYCL_UR_USE_FETCH_CONTENT)
   if(WIN32)
     set(UMF_BUILD_SHARED_LIBRARY OFF CACHE INTERNAL "Build UMF shared library")
     set(UMF_LINK_HWLOC_STATICALLY ON CACHE INTERNAL "static HWLOC")
-  else()
-    set(UMF_DISABLE_HWLOC ${SYCL_UMF_DISABLE_HWLOC} CACHE INTERNAL "Disable hwloc for UMF")
   endif()
 
   fetch_adapter_source(level_zero


### PR DESCRIPTION
~~Update UR to statically link UMF with hwloc on Linux.~~
This will enable hwloc support in UMF on Linux.

~~Also, always use the v2.9.3 hwloc version for hwloc builds.~~