### PR TITLE
[SYCL][E2E] Enable UNSUPPORTED:accelerator tests

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -13,6 +13,7 @@
 // RUN:  %if preview-breaking-changes-supported %{  %{run} %t2.out  %}
 
 // Currently the feature isn't supported on FPGA.
+// See https://github.com/intel/llvm/issues/15264.
 // UNSUPPORTED: accelerator
 #include "bfloat16_builtins.hpp"
 

--- a/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins.cpp
@@ -12,9 +12,6 @@
 // RUN:  %if preview-breaking-changes-supported %{  %clangxx -fsycl -fpreview-breaking-changes -fsycl-targets=%{sycl_triple} %if any-device-is-cuda %{ -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_80 %} %s -o %t2.out %{mathflags} %}
 // RUN:  %if preview-breaking-changes-supported %{  %{run} %t2.out  %}
 
-// Currently the feature isn't supported on FPGA.
-// See https://github.com/intel/llvm/issues/15264.
-// UNSUPPORTED: accelerator
 #include "bfloat16_builtins.hpp"
 
 int main() {

--- a/sycl/test-e2e/BFloat16/bfloat16_builtins_cuda_generic.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_builtins_cuda_generic.cpp
@@ -10,8 +10,6 @@
 // RUN:  %if any-device-is-cuda %{ %if preview-breaking-changes-supported %{  %clangxx -fsycl -fpreview-breaking-changes -fsycl-targets=%{sycl_triple}  -Xsycl-target-backend=nvptx64-nvidia-cuda --cuda-gpu-arch=sm_75  %s -o %t3.out %{mathflags} %} %}
 // RUN:  %if any-device-is-cuda %{ %if preview-breaking-changes-supported %{  %{run} %t3.out  %} %}
 
-// Currently the feature isn't supported on FPGA.
-// UNSUPPORTED: accelerator
 #include "bfloat16_builtins.hpp"
 
 int main() {

--- a/sycl/test-e2e/BFloat16/bfloat16_conversions.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_conversions.cpp
@@ -3,6 +3,7 @@
 
 // Currently the feature is supported only on CPU and GPU, natively or by
 // software emulation.
+// See https://github.com/intel/llvm/issues/15264.
 // UNSUPPORTED: accelerator
 
 //==---------- bfloat16_conversions.cpp - SYCL bfloat16 type test ---------==//

--- a/sycl/test-e2e/BFloat16/bfloat16_conversions.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_conversions.cpp
@@ -1,11 +1,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// Currently the feature is supported only on CPU and GPU, natively or by
-// software emulation.
-// See https://github.com/intel/llvm/issues/15264.
-// UNSUPPORTED: accelerator
-
 //==---------- bfloat16_conversions.cpp - SYCL bfloat16 type test ---------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/BFloat16/bfloat16_example.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example.cpp
@@ -7,9 +7,6 @@
 // CUDA is not compatible with SPIR.
 // UNSUPPORTED: cuda
 
-// See https://github.com/intel/llvm/issues/15264.
-// UNSUPPORTED: accelerator
-
 // RUN: %clangxx -fsycl %s -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/BFloat16/bfloat16_example.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example.cpp
@@ -3,8 +3,11 @@
 ///
 
 // REQUIRES: opencl-aot, ocloc, gpu-intel-gen9
-// UNSUPPORTED: cuda
+
 // CUDA is not compatible with SPIR.
+// UNSUPPORTED: cuda
+
+// See https://github.com/intel/llvm/issues/15264.
 // UNSUPPORTED: accelerator
 
 // RUN: %clangxx -fsycl %s -o %t.out

--- a/sycl/test-e2e/BFloat16/bfloat16_type.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_type.cpp
@@ -3,9 +3,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// TODO currently the feature isn't supported on FPGA.
-// UNSUPPORTED: accelerator
-
 //==----------- bfloat16_type.cpp - SYCL bfloat16 type test ----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/BFloat16/bfloat16_vec.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_vec.cpp
@@ -6,9 +6,8 @@
 //
 //===----------------------------------------------------------------------===//
 
-// TODO currently the feature isn't supported on FPGA.
 // TODO enable opaque pointers support on CPU.
-// UNSUPPORTED: cpu || accelerator
+// UNSUPPORTED: cpu
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -3,7 +3,7 @@
 // RUN: %{run} %t.out
 //
 // RUN: %{build} -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -Wno-error=pointer-to-int-cast -fno-builtin -fsycl-device-lib-jit-link -o %t.out
-// RUN: %if (!gpu && !accelerator) %{ %{run} %t.out %}
+// RUN: %if !gpu %{ %{run} %t.out %}
 
 #include <cassert>
 #include <cstdint>

--- a/sycl/test-e2e/DeviceLib/string_test.cpp
+++ b/sycl/test-e2e/DeviceLib/string_test.cpp
@@ -3,9 +3,7 @@
 // RUN: %{run} %t.out
 //
 // RUN: %{build} -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -Wno-error=pointer-to-int-cast -fno-builtin -fsycl-device-lib-jit-link -o %t.out
-// RUN: %if !gpu %{ %{run} %t.out %}
-
-// UNSUPPORTED: accelerator
+// RUN: %if (!gpu && !accelerator) %{ %{run} %t.out %}
 
 #include <cassert>
 #include <cstdint>

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/group_and_joint_sort.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/group_sort/group_and_joint_sort.cpp
@@ -1,7 +1,6 @@
 // REQUIRES: sg-8
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
-// UNSUPPORTED: accelerator
 
 // The test verifies sort API extension.
 // Currently it checks the following combinations:

--- a/sycl/test-e2e/KernelAndProgram/spec_constants_after_link.cpp
+++ b/sycl/test-e2e/KernelAndProgram/spec_constants_after_link.cpp
@@ -1,9 +1,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// FIXME: ACC devices use emulation path, which is not yet supported
-// UNSUPPORTED: accelerator
-
 // HIP backend does not currently implement linking.
 // UNSUPPORTED: hip
 

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_opencl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_opencl.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: (opencl || level_zero)
-// UNSUPPORTED: accelerator
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -8,9 +8,6 @@
 
 // REQUIRES: (opencl || level_zero)
 
-// See https://github.com/intel/llvm/issues/15267.
-// UNSUPPORTED: accelerator
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -7,6 +7,8 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: (opencl || level_zero)
+
+// See https://github.com/intel/llvm/issues/15267.
 // UNSUPPORTED: accelerator
 
 // RUN: %{build} -o %t.out

--- a/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_capabilities.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: ocloc && (opencl || level_zero)
-// UNSUPPORTED: accelerator
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
+++ b/sycl/test-e2e/KernelCompiler/opencl_queries.cpp
@@ -7,7 +7,6 @@
 //===----------------------------------------------------------------------===//
 
 // REQUIRES: ocloc && (opencl || level_zero)
-// UNSUPPORTED: accelerator
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/Regression/unoptimized_stream.cpp
+++ b/sycl/test-e2e/Regression/unoptimized_stream.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -O0 -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 #include <sycl/detail/core.hpp>
 
 #include <sycl/stream.hpp>

--- a/sycl/test-e2e/SpecConstants/2020/handler-api.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/handler-api.cpp
@@ -10,9 +10,6 @@
 // RUN: %{build} -Wno-error=unused-command-line-argument -o %t.out -fsycl-dead-args-optimization
 // RUN: %{run} %t.out
 
-// FIXME: ACC devices use emulation path, which is not yet supported
-// UNSUPPORTED: accelerator
-
 #include <cstdlib>
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/SpecConstants/2020/kernel-bundle-api.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/kernel-bundle-api.cpp
@@ -9,8 +9,7 @@
 //
 // RUN: %{build} -o %t.out -fsycl-dead-args-optimization
 // RUN: %{run} %t.out
-// FIXME: ACC devices use emulation path, which is not yet supported
-// UNSUPPORTED: accelerator
+//
 // UNSUPPORTED: hip
 
 #include <cstdlib>

--- a/sycl/test-e2e/SpecConstants/2020/vector-convolution-demo.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/vector-convolution-demo.cpp
@@ -1,8 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: accelerator
-
 // This test checks the spenario of using specialization constants with an
 // 'array of array' as well as a 'stuct with an array of array' types for
 // vector convolution as it is described in chapter 4.9.5. Specialization


### PR DESCRIPTION
This commit enables tests that have been marked UNSUPPORTED for accelerator targets.