### PR TITLE
[SYCL] Simplify arguments to computeModuleProperties

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/ComputeModuleRuntimeInfo.h
+++ b/llvm/include/llvm/SYCLLowerIR/ComputeModuleRuntimeInfo.h
@@ -34,9 +34,7 @@ using EntryPointSet = SetVector<Function *>;
 
 PropSetRegTy computeModuleProperties(const Module &M,
                                      const EntryPointSet &EntryPoints,
-                                     const GlobalBinImageProps &GlobProps,
-                                     bool SpecConstsMet,
-                                     bool IsSpecConstantDefault);
+                                     const GlobalBinImageProps &GlobProps);
 
 std::string computeModuleSymbolTable(const Module &M,
                                      const EntryPointSet &EntryPoints);

--- a/llvm/include/llvm/SYCLLowerIR/SpecConstants.h
+++ b/llvm/include/llvm/SYCLLowerIR/SpecConstants.h
@@ -72,6 +72,16 @@ public:
   collectSpecConstantDefaultValuesMetadata(const Module &M,
                                            std::vector<char> &DefaultValues);
 
+  // Name of the metadata which holds a list of all specialization constants
+  // (with associated information) encountered in the module
+  static constexpr char SPEC_CONST_MD_STRING[] =
+      "sycl.specialization-constants";
+
+  // Name of the metadata which indicates this module was proccessed with the
+  // default values handing mode.
+  static constexpr char SPEC_CONST_DEFAULT_VAL_MODULE_MD_STRING[] =
+      "sycl.specialization-constants-default-values-module";
+
 private:
   HandlingMode Mode;
 };

--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -138,9 +138,7 @@ uint32_t getKernelWorkGroupNumDim(const Function &Func) {
 
 PropSetRegTy computeModuleProperties(const Module &M,
                                      const EntryPointSet &EntryPoints,
-                                     const GlobalBinImageProps &GlobProps,
-                                     bool SpecConstsMet,
-                                     bool IsSpecConstantDefault) {
+                                     const GlobalBinImageProps &GlobProps) {
 
   PropSetRegTy PropSet;
   {
@@ -152,6 +150,10 @@ PropSetRegTy computeModuleProperties(const Module &M,
     PropSet.add(PropSetRegTy::SYCL_DEVICE_REQUIREMENTS,
                 computeDeviceRequirements(M, EntryPoints).asMap());
   }
+  auto *SpecConstsMD =
+      M.getNamedMetadata(SpecConstantsPass::SPEC_CONST_MD_STRING);
+  bool SpecConstsMet =
+      SpecConstsMD != nullptr && SpecConstsMD->getNumOperands() != 0;
   if (SpecConstsMet) {
     // extract spec constant maps per each module
     SpecIDMapTy TmpSpecIDMap;
@@ -369,7 +371,10 @@ PropSetRegTy computeModuleProperties(const Module &M,
   if (!HostPipePropertyMap.empty()) {
     PropSet.add(PropSetRegTy::SYCL_HOST_PIPES, HostPipePropertyMap);
   }
-
+  bool IsSpecConstantDefault =
+      M.getNamedMetadata(
+          SpecConstantsPass::SPEC_CONST_DEFAULT_VAL_MODULE_MD_STRING) !=
+      nullptr;
   if (IsSpecConstantDefault)
     PropSet.add(PropSetRegTy::SYCL_MISC_PROP, "specConstsReplacedWithDefault",
                 1);

--- a/llvm/lib/SYCLLowerIR/SpecConstants.cpp
+++ b/llvm/lib/SYCLLowerIR/SpecConstants.cpp
@@ -47,9 +47,6 @@ constexpr char SPIRV_GET_SPEC_CONST_VAL[] = "__spirv_SpecConstant";
 constexpr char SPIRV_GET_SPEC_CONST_COMPOSITE[] =
     "__spirv_SpecConstantComposite";
 
-// Name of the metadata which holds a list of all specialization constants (with
-// associated information) encountered in the module
-constexpr char SPEC_CONST_MD_STRING[] = "sycl.specialization-constants";
 // Name of the metadata which holds a default value list of all specialization
 // constants encountered in the module
 constexpr char SPEC_CONST_DEFAULT_VAL_MD_STRING[] =
@@ -1028,6 +1025,9 @@ PreservedAnalyses SpecConstantsPass::run(Module &M,
       M.getOrInsertNamedMetadata(SPEC_CONST_DEFAULT_VAL_MD_STRING);
   for (const auto &P : DefaultsMetadata)
     MDDefaults->addOperand(P);
+
+  if (Mode == HandlingMode::default_values)
+    M.getOrInsertNamedMetadata(SPEC_CONST_DEFAULT_VAL_MODULE_MD_STRING);
 
   return IRModified ? PreservedAnalyses::none() : PreservedAnalyses::all();
 }

--- a/llvm/test/tools/sycl-post-link/spec-constants/default-value/bool.ll
+++ b/llvm/test/tools/sycl-post-link/spec-constants/default-value/bool.ll
@@ -6,6 +6,7 @@
 
 ; CHECK: %bool1 = trunc i8 1 to i1
 ; CHECK: %frombool = zext i1 %bool1 to i8
+; CHECK: !sycl.specialization-constants-default-values-module = !{}
 ; CHECK-LOG: sycl.specialization-constants
 ; CHECK-LOG:[[UNIQUE_PREFIX:[0-9a-zA-Z]+]]={0, 0, 1}
 ; CHECK-LOG: sycl.specialization-constants-default-values

--- a/llvm/tools/sycl-post-link/sycl-post-link.cpp
+++ b/llvm/tools/sycl-post-link/sycl-post-link.cpp
@@ -307,9 +307,8 @@ std::string saveModuleIR(Module &M, int I, StringRef Suff) {
 std::string saveModuleProperties(module_split::ModuleDesc &MD,
                                  const GlobalBinImageProps &GlobProps, int I,
                                  StringRef Suff, StringRef Target = "") {
-  auto PropSet = computeModuleProperties(MD.getModule(), MD.entries(),
-                                         GlobProps, MD.Props.SpecConstsMet,
-                                         MD.isSpecConstantDefault());
+  auto PropSet =
+      computeModuleProperties(MD.getModule(), MD.entries(), GlobProps);
 
   std::string NewSuff = Suff.str();
   if (!Target.empty()) {


### PR DESCRIPTION
Computing information about spec consts is difficult for callers when module properties generation and splitting are separate. Simplify it by storing information in module we can use invisibly to the caller.

This will be used for thinLTO, where we split early and compute module properties later. 

This should be basically NFC.