### PR TITLE
[SYCL] Guard access to MCreateShadowCopy

### DIFF
--- a/sycl/source/detail/sycl_mem_obj_t.cpp
+++ b/sycl/source/detail/sycl_mem_obj_t.cpp
@@ -228,8 +228,11 @@ void SYCLMemObjT::detachMemoryObject(
 
 void SYCLMemObjT::handleWriteAccessorCreation() {
   const auto InitialUserPtr = MUserPtr;
-  MCreateShadowCopy();
-  MCreateShadowCopy = []() -> void {};
+  {
+    std::lock_guard<std::mutex> Lock(MCreateShadowCopyMtx);
+    MCreateShadowCopy();
+    MCreateShadowCopy = []() -> void {};
+  }
   if (MRecord != nullptr && MUserPtr != InitialUserPtr) {
     for (auto &it : MRecord->MAllocaCommands) {
       if (it->MMemAllocation == InitialUserPtr) {

--- a/sycl/test-e2e/Regression/multithread_write_accessor.cpp
+++ b/sycl/test-e2e/Regression/multithread_write_accessor.cpp
@@ -1,0 +1,35 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+#include <sycl/sycl.hpp>
+
+#include <cassert>
+#include <thread>
+#include <vector>
+
+constexpr int NThreads = 8;
+
+class KernelA;
+
+void threadFunction(sycl::buffer<int, 1> &Buf) {
+  sycl::queue Q;
+  Q.submit([&](sycl::handler &Cgh) {
+    auto Acc = Buf.get_access<sycl::access::mode::read_write>(Cgh);
+    Cgh.single_task<class KernelA>([=]() { Acc[0] += 1; });
+  });
+}
+int main() {
+  std::vector<std::thread> Threads;
+  Threads.reserve(NThreads);
+
+  int Val = 0;
+  {
+    sycl::buffer<int, 1> Buf(&Val, sycl::range<1>(1));
+    sycl::queue Q;
+
+    for (int I = 0; I < NThreads; ++I)
+      Threads.emplace_back(threadFunction, std::ref(Buf));
+    for (auto &t : Threads)
+      t.join();
+  }
+  assert(Val == NThreads);
+}

--- a/sycl/test-e2e/Regression/multithread_write_accessor.cpp
+++ b/sycl/test-e2e/Regression/multithread_write_accessor.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
 
 #include <cassert>
 #include <thread>


### PR DESCRIPTION
Fixes a flaky failure when getting write access to a buffer from multiple threads.