### PR TITLE
[Driver][SYCL] Use existing option for device-only and some cleanup

### DIFF
--- a/clang/include/clang/Basic/DiagnosticDriverKinds.td
+++ b/clang/include/clang/Basic/DiagnosticDriverKinds.td
@@ -219,8 +219,6 @@ def warn_drv_mismatch_fpga_archive : Warning<
 def warn_drv_sycl_native_cpu_and_targets: Warning<
   "-fsycl-targets=native_cpu overrides SYCL targets option">,
   InGroup<SyclNativeCPUTargets>;
-def err_drv_unsupported_opt_sycl : Error<
-  "option '%0' not supported with SYCL compilation">;
 def err_drv_argument_only_allowed_with : Error<
   "invalid argument '%0' only allowed with '%1'">;
 def err_drv_opt_unsupported_input_type : Error<

--- a/clang/include/clang/Driver/Options.td
+++ b/clang/include/clang/Driver/Options.td
@@ -6779,7 +6779,7 @@ def fintelfpga : Flag<["-"], "fintelfpga">,
   MarshallingInfoFlag<LangOpts<"IntelFPGA">>,
   HelpText<"Perform ahead-of-time compilation for FPGA">;
 def fsycl_device_only : Flag<["-"], "fsycl-device-only">,
-  HelpText<"Compile SYCL kernels for device">;
+  Alias<offload_device_only>, HelpText<"Compile SYCL kernels for device">;
 def fsycl_embed_ir : Flag<["-"], "fsycl-embed-ir">,
   HelpText<"Embed LLVM IR for runtime kernel fusion">;
 defm sycl_esimd_force_stateless_mem : BoolFOption<"sycl-esimd-force-stateless-mem",

--- a/clang/lib/Driver/Driver.cpp
+++ b/clang/lib/Driver/Driver.cpp
@@ -393,8 +393,7 @@ phases::ID Driver::getFinalPhase(const DerivedArgList &DAL,
     FinalPhase = phases::Compile;
 
   // -S only runs up to the backend.
-  } else if ((PhaseArg = DAL.getLastArg(options::OPT_S)) ||
-             (PhaseArg = DAL.getLastArg(options::OPT_fsycl_device_only))) {
+  } else if ((PhaseArg = DAL.getLastArg(options::OPT_S))) {
     FinalPhase = phases::Backend;
 
   // -c compilation only runs up to the assembler.
@@ -855,6 +854,19 @@ static bool addSYCLDefaultTriple(Compilation &C,
   return true;
 }
 
+// Special function that checks if -fsycl-device-only was passed on the
+// command line.  -fsycl-device-only is an alias of --offload-device-only.
+static bool hasSYCLDeviceOnly(const ArgList &Args) {
+  if (const Arg *SYCLDeviceOnlyArg =
+          Args.getLastArg(options::OPT_offload_device_only)) {
+    while (SYCLDeviceOnlyArg->getAlias())
+      SYCLDeviceOnlyArg = SYCLDeviceOnlyArg->getAlias();
+    if (SYCLDeviceOnlyArg->getSpelling().contains("sycl-device-only"))
+      return true;
+  }
+  return false;
+}
+
 void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
                                               InputList &Inputs) {
 
@@ -1074,7 +1086,7 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
   bool HasValidSYCLRuntime =
       C.getInputArgs().hasFlag(options::OPT_fsycl, options::OPT_fno_sycl,
                                false) ||
-      C.getInputArgs().hasArg(options::OPT_fsycl_device_only);
+      hasSYCLDeviceOnly(C.getInputArgs());
 
   Arg *SYCLfpga = C.getInputArgs().getLastArg(options::OPT_fintelfpga);
 
@@ -1118,8 +1130,8 @@ void Driver::CreateOffloadingDeviceToolChains(Compilation &C,
     if (!HasValidSYCLRuntime)
       return;
     if (Arg *IncompatArg = C.getInputArgs().getLastArg(OptId))
-      Diag(clang::diag::err_drv_unsupported_opt_sycl)
-          << IncompatArg->getSpelling();
+      Diag(clang::diag::err_drv_argument_not_allowed_with)
+          << IncompatArg->getSpelling() << "-fsycl";
   };
   // -static-libstdc++ is not compatible with -fsycl.
   argSYCLIncompatible(options::OPT_static_libstdcxx);
@@ -1743,13 +1755,12 @@ Compilation *Driver::BuildCompilation(ArrayRef<const char *> ArgList) {
   if (Args.getLastArg(options::OPT_fsycl_dump_device_code_EQ))
     DumpDeviceCode = true;
 
-  if (const Arg *A = Args.getLastArg(
-          options::OPT_offload_host_only, options::OPT_offload_device_only,
-          options::OPT_offload_host_device, options::OPT_fsycl_device_only)) {
+  if (const Arg *A = Args.getLastArg(options::OPT_offload_host_only,
+                                     options::OPT_offload_device_only,
+                                     options::OPT_offload_host_device)) {
     if (A->getOption().matches(options::OPT_offload_host_only))
       Offload = OffloadHost;
-    else if (A->getOption().matches(options::OPT_offload_device_only) ||
-             A->getOption().matches(options::OPT_fsycl_device_only))
+    else if (A->getOption().matches(options::OPT_offload_device_only))
       Offload = OffloadDevice;
     else
       Offload = OffloadHostDevice;
@@ -3124,7 +3135,7 @@ void Driver::BuildInputs(const ToolChain &TC, DerivedArgList &Args,
   Arg *InputTypeArg = nullptr;
   bool IsSYCL =
       Args.hasFlag(options::OPT_fsycl, options::OPT_fno_sycl, false) ||
-      Args.hasArg(options::OPT_fsycl_device_only);
+      hasSYCLDeviceOnly(Args);
 
   // The last /TC or /TP option sets the input type to C or C++ globally.
   if (Arg *TCTP = Args.getLastArgNoClaim(options::OPT__SLASH_TC,

--- a/clang/test/Driver/sycl-MD-default.cpp
+++ b/clang/test/Driver/sycl-MD-default.cpp
@@ -20,4 +20,4 @@
 // RUN:   | FileCheck -check-prefix=CHK-ERROR %s
 // RUN: not %clang_cl -### -MTd -fsycl -c %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-ERROR %s
-// CHK-ERROR: option 'MT{{d*}}' not supported with SYCL compilation
+// CHK-ERROR: invalid argument 'MT{{d*}}' not allowed with '-fsycl'

--- a/clang/test/Driver/sycl-offload-old-model.c
+++ b/clang/test/Driver/sycl-offload-old-model.c
@@ -799,7 +799,7 @@
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-ffreestanding
 // RUN:   not %clang -### -fsycl --no-offload-new-driver -static-libstdc++ %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-static-libstdc++
-// CHK-INCOMPATIBILITY: error: option '[[INCOMPATOPT]]' not supported with SYCL compilation
+// CHK-INCOMPATIBILITY: error: invalid argument '[[INCOMPATOPT]]' not allowed with '-fsycl'
 
 /// Using -fsyntax-only with -fsycl --no-offload-new-driver should not emit IR
 // RUN:   %clang -### -fsycl --no-offload-new-driver -fsyntax-only %s 2>&1 \

--- a/clang/test/Driver/sycl-offload.c
+++ b/clang/test/Driver/sycl-offload.c
@@ -507,7 +507,7 @@
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-ffreestanding
 // RUN:   not %clang -### -fsycl --offload-new-driver -static-libstdc++ %s 2>&1 \
 // RUN:   | FileCheck -check-prefix=CHK-INCOMPATIBILITY %s -DINCOMPATOPT=-static-libstdc++
-// CHK-INCOMPATIBILITY: error: option '[[INCOMPATOPT]]' not supported with SYCL compilation
+// CHK-INCOMPATIBILITY: error: invalid argument '[[INCOMPATOPT]]' not allowed with '-fsycl'
 
 /// Using -fsyntax-only with -fsycl --offload-new-driver should not emit IR
 // RUN:   %clang -### -fsycl --offload-new-driver -fsyntax-only %s 2>&1 \

--- a/sycl/test/basic_tests/accessor/no_offset_error.cpp
+++ b/sycl/test/basic_tests/accessor/no_offset_error.cpp
@@ -1,4 +1,4 @@
-// RUN:  %clangxx -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -emit-llvm -o - %s
+// RUN:  %clangxx -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=note -o - %s
 
 #include <sycl/sycl.hpp>
 

--- a/sycl/test/check_device_code/esimd/slm_init_specconst_size.cpp
+++ b/sycl/test/check_device_code/esimd/slm_init_specconst_size.cpp
@@ -1,4 +1,4 @@
-// RUN: %clangxx -O2 -fsycl -fsycl-device-only -emit-llvm %s -o %t
+// RUN: %clangxx -O2 -fsycl -fsycl-device-only %s -o %t
 // RUN: sycl-post-link -properties -split-esimd -lower-esimd -O2 -S %t -o %t.table
 // RUN: FileCheck %s -input-file=%t_esimd_0.ll
 // Checks that we set 0 as VCSLMSize when slm_init is used with


### PR DESCRIPTION
Update -fsycl-device-only usage to be an alias to --offload-device-only. This requires an additional unique check for SYCL enabling due to the expectation that -fsycl-device-only also implies -fsycl.

Update associated tests that use -fsycl-device-only -emit-llvm.  Our default is already bitcode output, fixing this up aligns better with community expectations when using --offload-device-only.

Also do some variable cleanup to better be in sync with community variable names. And use a more common diagnostic for invalid options with -fsycl.