### PR TITLE
[SYCL][E2E] XFAIL launch_policy_lmem.cpp

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -23,7 +23,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-
 // https://github.com/intel/llvm/issues/15275
 // XFAIL: gpu-intel-gen12 || gpu-intel-dg2
 

--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -24,7 +24,7 @@
 // RUN: %{run} %t.out
 
 // https://github.com/intel/llvm/issues/15275
-// XFAIL: gpu-intel-gen12 || gpu-intel-dg2
+// XFAIL: linux && (gpu-intel-gen12 || gpu-intel-dg2)
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>

--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -23,6 +23,10 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
+
+// https://github.com/intel/llvm/issues/15275
+// XFAIL: gpu-intel-gen12 || gpu-intel-dg2
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>
 #include <sycl/group_barrier.hpp>


### PR DESCRIPTION
Failing in new driver, see https://github.com/intel/llvm/issues/15275.

It will XPASS in this PR, but once this is merged I will immediately merge the driver update PR.