### PR TITLE
[SYCL][E2E LIT] Remove append_path=True from config.extra_environment handling

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -122,7 +122,7 @@ if config.extra_environment:
     for env_pair in config.extra_environment.split(","):
         [var, val] = env_pair.split("=", 1)
         if val:
-            llvm_config.with_environment(var, val, append_path=os.path.isabs(val))
+            llvm_config.with_environment(var, val)
             lit_config.note("\t" + var + "=" + val)
         else:
             lit_config.note("\tUnset " + var)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -122,7 +122,7 @@ if config.extra_environment:
     for env_pair in config.extra_environment.split(","):
         [var, val] = env_pair.split("=", 1)
         if val:
-            llvm_config.with_environment(var, val, append_path=True)
+            llvm_config.with_environment(var, val, os.path.isabs(val))
             lit_config.note("\t" + var + "=" + val)
         else:
             lit_config.note("\tUnset " + var)

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -122,7 +122,7 @@ if config.extra_environment:
     for env_pair in config.extra_environment.split(","):
         [var, val] = env_pair.split("=", 1)
         if val:
-            llvm_config.with_environment(var, val, os.path.isabs(val))
+            llvm_config.with_environment(var, val, append_path=os.path.isabs(val))
             lit_config.note("\t" + var + "=" + val)
         else:
             lit_config.note("\tUnset " + var)


### PR DESCRIPTION
When append_path is True, value is normalized to lowercase on Windows at
https://github.com/llvm-mirror/llvm/blob/2c4ca6832fa6b306ee6a7010bfb80a3f2596f824/utils/lit/lit/llvm/config.py#L139
For env value that isn't a path, the normalization is unexpected.

For env value that is a path, it doesn't make sense to append_path
unconditionally. Test driver should append path when necessary before
setting a env.