### PR TITLE
[SYCL] Disable fast math in marray_geometric and math_vectorized_isgreater_test

### DIFF
--- a/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
+++ b/sycl/test-e2e/Basic/built-ins/marray_geometric.cpp
@@ -1,4 +1,6 @@
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 
 #include "helpers.hpp"

--- a/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
+++ b/sycl/test-e2e/syclcompat/math/math_vectorized_isgreater_test.cpp
@@ -30,7 +30,9 @@
 //
 // ===----------------------------------------------------------------------===//
 
-// RUN: %{build} -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Very much the same as https://github.com/intel/llvm/pull/15223/

* `marray_geometric` - golden values against delta, which in fast math mode is not accurate enough,
* `math_cectorized_isgreater_test` - uses compiler builtins (`__builtin_isgreaterequal`, `__builtin_isgreater`), when combined with fast math mode all bets are off.