### PR TITLE
[SYCL][E2E] Fix shuffle_marray XOR permute shuffle for uneven SG

### DIFF
--- a/sycl/test-e2e/GroupAlgorithm/shuffle_marray.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/shuffle_marray.cpp
@@ -107,7 +107,11 @@ int main() {
     }
 
     std::cout << "Checking results for shuffle-xor" << std::endl;
-    for (size_t LID = 0; LID < SubGroupSize; ++LID) {
+    // XOR permutating shuffles shuffle in pairs, but in the cases where the
+    // sub-group size is uneven the last element will not have a partner and as
+    // such its result is UB.
+    unsigned EvenClampedSubGroupSize = SubGroupSize - (SubGroupSize % 2);
+    for (size_t LID = 0; LID < EvenClampedSubGroupSize; ++LID) {
       size_t GID = GIDOffset + LID;
       MarrayT Expected{0};
       for (int I = 0; I < NumElems; ++I)


### PR DESCRIPTION
This commit fixes a case for XOR permute shuffles in sycl/test-e2e/GroupAlgorithm/shuffle_marray.cpp when sub-group sizes are uneven.