### PR TITLE
[SYCL] Mark arguments as potentially unused

### DIFF
--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -153,7 +153,7 @@ struct PromotionInformation {
 
 using PromotionMap = std::unordered_map<SYCLMemObjI *, PromotionInformation>;
 
-template <typename Obj> Promotion getPromotionTarget(const Obj &obj) {
+template <typename Obj> Promotion getPromotionTarget(const Obj &) {
   return Promotion::None;
 }
 
@@ -710,7 +710,7 @@ ur_kernel_handle_t jit_compiler::materializeSpecConstants(
 std::unique_ptr<detail::CG>
 jit_compiler::fuseKernels(QueueImplPtr Queue,
                           std::vector<ExecCGCommand *> &InputKernels,
-                          const property_list &PropList) {
+                          const property_list &) {
   if (!isAvailable()) {
     printPerformanceWarning("JIT library not available");
     return nullptr;


### PR DESCRIPTION
Fix compilation failure in post-commit CI due to some arguments currently being unused.