### PR TITLE
[SYCL][E2E] Enable device_architecture_on_host for accelerator

### DIFF
--- a/sycl/test-e2e/DeviceArchitecture/device_architecture_on_host.cpp
+++ b/sycl/test-e2e/DeviceArchitecture/device_architecture_on_host.cpp
@@ -1,5 +1,3 @@
-// UNSUPPORTED: accelerator
-
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
Now that sycl_ext_oneapi_device_architecture returns unknown for unknown architectures, the test should work for all device targets. This commit enables it for accelerator.