### PR TITLE
[SYCL] re-enable Scheduler StreamBufferDeallocation unit test

### DIFF
--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -307,12 +307,7 @@ struct AttachSchedulerWrapper {
 };
 
 // Check that stream buffers are released alongside graph cleanup.
-// https://github.com/intel/llvm/issues/15049
-#ifdef _WIN32
-TEST_F(SchedulerTest, DISABLED_StreamBufferDeallocation) {
-#else
 TEST_F(SchedulerTest, StreamBufferDeallocation) {
-#endif
   unittest::UrMock<> Mock;
   platform Plt = sycl::platform();
   context Ctx{Plt};


### PR DESCRIPTION
A month ago, we had a strange intermittent failure of one of the unit tests: https://github.com/intel/llvm/issues/15049  and in response to that we disabled the test.  It is unclear why that might have been failing.

But that was when there were some other disrupting changes, and fallout from that has since been fixed. 


I have retested this on Windows for 100,000 iterations, and not a single failure seen. Tested on the CI, ran successfully there too.

I'd like to reenable this test with this PR. If the CI system starts failing on PR, we can just revert this PR in coming days. 

