### PR TITLE
[SPIR-V] Revert "[SPIR-V] Add W/A for readnone function parameter attribute (#7669)"

### DIFF
--- a/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
+++ b/llvm-spirv/lib/SPIRV/SPIRVWriter.cpp
@@ -917,10 +917,7 @@ SPIRVFunction *LLVMToSPIRVBase::transFunctionDecl(Function *F) {
     if (Attrs.hasParamAttr(ArgNo, Attribute::ReadOnly))
       BA->addAttr(FunctionParameterAttributeNoWrite);
     if (Attrs.hasParamAttr(ArgNo, Attribute::ReadNone))
-      // TODO: intel/llvm customization
-      // see https://github.com/intel/llvm/issues/7592
-      // Need to return FunctionParameterAttributeNoReadWrite
-      BA->addAttr(FunctionParameterAttributeNoWrite);
+      BA->addAttr(FunctionParameterAttributeNoReadWrite);
     if (Attrs.hasParamAttr(ArgNo, Attribute::ZExt))
       BA->addAttr(FunctionParameterAttributeZext);
     if (Attrs.hasParamAttr(ArgNo, Attribute::SExt))

--- a/llvm-spirv/test/transcoding/builtin_function_readnone_attr.ll
+++ b/llvm-spirv/test/transcoding/builtin_function_readnone_attr.ll
@@ -9,9 +9,9 @@
 ; CHECK-SPIRV: Name [[#B:]] "b"
 ; CHECK-SPIRV: Decorate [[#A]] FuncParamAttr 5
 ; CHECK-SPIRV: Decorate [[#A]] FuncParamAttr 6
-; CHECK-SPIRV: Decorate [[#B]] FuncParamAttr 5
+; CHECK-SPIRV: Decorate [[#B]] FuncParamAttr 7
 
-; CHECK-LLVM: {{.*}}void @test_builtin_readnone(ptr nocapture readonly %{{.*}}, ptr nocapture readonly %{{.*}})
+; CHECK-LLVM: {{.*}}void @test_builtin_readnone(ptr nocapture readonly %{{.*}}, ptr nocapture readnone %{{.*}})
 
 target datalayout = "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-f80:128-n8:16:32:64-S128"
 target triple = "spir-unknown-unknown"


### PR DESCRIPTION
This reverts commit f87204892e58d7ffe73e80edbb631603d51f6a7f.