### PR TITLE
[SYCL][NFC] Fix typo in InstantiateKernelOnHost name

### DIFF
--- a/sycl/include/sycl/detail/cg_types.hpp
+++ b/sycl/include/sycl/detail/cg_types.hpp
@@ -154,8 +154,8 @@ runKernelWithArg(KernelType KernelName, ArgType Arg) {
 // The pure virtual class aimed to store lambda/functors of any type.
 class HostKernelBase {
 public:
-  // NOTE: InstatitateKernelOnHost() should not be called.
-  virtual void InstatitateKernelOnHost() = 0;
+  // NOTE: InstantiateKernelOnHost() should not be called.
+  virtual void InstantiateKernelOnHost() = 0;
   // Return pointer to the lambda object.
   // Used to extract captured variables.
   virtual char *getPtr() = 0;
@@ -177,8 +177,8 @@ public:
   // This function is needed for host-side compilation to keep kernels
   // instantitated. This is important for debuggers to be able to associate
   // kernel code instructions with source code lines.
-  // NOTE: InstatitateKernelOnHost() should not be called.
-  void InstatitateKernelOnHost() override {
+  // NOTE: InstantiateKernelOnHost() should not be called.
+  void InstantiateKernelOnHost() override {
     if constexpr (std::is_same_v<KernelArgType, void>) {
       runKernelWithoutArg(MKernel);
     } else if constexpr (std::is_same_v<KernelArgType, sycl::id<Dims>>) {

--- a/sycl/test/abi/vtable.cpp
+++ b/sycl/test/abi/vtable.cpp
@@ -9,13 +9,13 @@
 // Guide for further instructions.
 
 void foo(sycl::detail::HostKernelBase &HKB) {
-  HKB.InstatitateKernelOnHost();
+  HKB.InstantiateKernelOnHost();
 }
 // CHECK:      Vtable for 'sycl::detail::HostKernelBase' (6 entries).
 // CHECK-NEXT:   0 | offset_to_top (0)
 // CHECK-NEXT:   1 | sycl::detail::HostKernelBase RTTI
 // CHECK-NEXT:       -- (sycl::detail::HostKernelBase, 0) vtable address --
-// CHECK-NEXT:   2 | void sycl::detail::HostKernelBase::InstatitateKernelOnHost() [pure]
+// CHECK-NEXT:   2 | void sycl::detail::HostKernelBase::InstantiateKernelOnHost() [pure]
 // CHECK-NEXT:   3 | char *sycl::detail::HostKernelBase::getPtr() [pure]
 // CHECK-NEXT:   4 | sycl::detail::HostKernelBase::~HostKernelBase() [complete]
 // CHECK-NEXT:   5 | sycl::detail::HostKernelBase::~HostKernelBase() [deleting]


### PR DESCRIPTION
This commit fixes a typo in the host-side instantiation of kernel functions, InstantiateKernelOnHost.