### PR TITLE
[SYCL][E2E] Reenable L0 tests for sycl-ls, get_native_ze and device_num

### DIFF
--- a/sycl/test-e2e/Basic/interop/get_native_ze.cpp
+++ b/sycl/test-e2e/Basic/interop/get_native_ze.cpp
@@ -2,9 +2,6 @@
 // RUN: %{build} %level_zero_options -o %t.ze.out
 // RUN: %{run} %t.ze.out
 
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero
-
 #include <level_zero/ze_api.h>
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Plugin/sycl-ls-gpu-default-any.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls-gpu-default-any.cpp
@@ -20,5 +20,3 @@
 // This test checks that a valid GPU is returned by sycl-ls by default if one
 // is present.
 // UNSUPPORTED: hip
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero

--- a/sycl/test-e2e/Plugin/sycl-ls-gpu-level-zero.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls-gpu-level-zero.cpp
@@ -13,5 +13,3 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero

--- a/sycl/test-e2e/Regression/device_num.cpp
+++ b/sycl/test-e2e/Regression/device_num.cpp
@@ -5,9 +5,6 @@
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:2" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
 // RUN: env ONEAPI_DEVICE_SELECTOR="*:3" env TEST_DEV_CONFIG_FILE_NAME=%t1.conf %{run-unfiltered-devices} %t.out
 
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero
-
 #include "../helpers.hpp"
 #include <fstream>
 #include <iostream>


### PR DESCRIPTION
A handful of L0 tests were disabled with bd3370af22cd49f3bde48254b5a659fe9c0634bd a while ago, so it is time to retry enabling them.