### PR TITLE
[SYCL][E2E] Fix XFAIL condition in launch_policy_lmem.cpp

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -27,7 +27,7 @@
 // RUN: %{run} %t.out
 
 // https://github.com/intel/llvm/issues/15275
-// XFAIL: linux && (gpu-intel-gen12 || gpu-intel-dg2)
+// XFAIL: linux && opencl && (gpu-intel-gen12 || gpu-intel-dg2)
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>


### PR DESCRIPTION
It actually fails on OCL only, not L0.

Fixes postcommit.