### PR TITLE
[SYCL] Discard unsupported platforms output in sycl-ls test

### DIFF
--- a/sycl/test-e2e/Plugin/sycl-ls.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls.cpp
@@ -1,4 +1,4 @@
-// RUN: sycl-ls --verbose | grep "Device \[" | wc -l >%t.verbose.out
+// RUN: sycl-ls --verbose | awk '{print}/Unsupported Platforms:/{exit}' | grep "Device \[" | wc -l >%t.verbose.out
 // RUN: sycl-ls | wc -l >%t.concise.out
 // RUN: diff %t.verbose.out %t.concise.out
 


### PR DESCRIPTION
Make sure that the devices that belong to unsupported platforms are not counted, this is required to match the number of devices when `sycl-ls` is run in and out of the `verbose` mode.