### PR TITLE
[SYCL][E2E] Move launch_policy_lmem.cpp to UNSUPPORTED on XFAILed platforms

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -27,7 +27,7 @@
 // RUN: %{run} %t.out
 
 // https://github.com/intel/llvm/issues/15275
-// XFAIL: linux && opencl && (gpu-intel-gen12 || gpu-intel-dg2)
+// UNSUPPORTED: linux && opencl && (gpu-intel-gen12 || gpu-intel-dg2)
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/properties/properties.hpp>


### PR DESCRIPTION
It's XPASSing in the nightly somehow, but fails in pre/postcommit.

https://github.com/intel/llvm/actions/runs/10731711170/job/29762580737