### PR TITLE
[SYCL][NFC] Fix InOrderQueueIsolatedDeps when run repeatedly

### DIFF
--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -107,6 +107,7 @@ TEST_F(SchedulerTest, InOrderQueueIsolatedDeps) {
   sycl::platform Plt = sycl::platform();
   mock::getCallbacks().set_before_callback(
       "urEnqueueEventsWaitWithBarrier", &redefinedEnqueueEventsWaitWithBarrier);
+  BarrierCalled = false;
 
   context Ctx{Plt.get_devices()[0]};
   queue Q1{Ctx, default_selector_v, property::queue::in_order()};


### PR DESCRIPTION
The test needs to reset the variable used to check when a UR call is made.