### PR TITLE
[SYCL] Add sync for host task after barrier

### DIFF
--- a/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
+++ b/sycl/unittests/scheduler/HostTaskAndBarrier.cpp
@@ -196,7 +196,8 @@ TEST_F(BarrierHandlingWithHostTask, BarrierHostTaskKernel) {
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
   EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
   auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
-  ASSERT_EQ(HostTaskWaitList.size(), 0u);
+  ASSERT_EQ(HostTaskWaitList.size(), 1u);
+  EXPECT_EQ(HostTaskWaitList[0], BarrierEventImpl);
   EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
 
   sycl::event KernelEvent = AddTask(TestCGType::KERNEL_TASK);
@@ -225,7 +226,8 @@ TEST_F(BarrierHandlingWithHostTask, BarrierKernelHostTask) {
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
   EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
   auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
-  ASSERT_EQ(HostTaskWaitList.size(), 0u);
+  ASSERT_EQ(HostTaskWaitList.size(), 1u);
+  EXPECT_EQ(HostTaskWaitList[0], BarrierEventImpl);
   EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
 
   MainLock.unlock();
@@ -272,7 +274,8 @@ TEST_F(BarrierHandlingWithHostTask, KernelBarrierHostTask) {
   sycl::event HTEvent = AddTask(TestCGType::HOST_TASK);
   EventImplPtr HostTaskEventImpl = sycl::detail::getSyclObjImpl(HTEvent);
   auto HostTaskWaitList = HostTaskEventImpl->getWaitList();
-  ASSERT_EQ(HostTaskWaitList.size(), 0u);
+  ASSERT_EQ(HostTaskWaitList.size(), 1u);
+  EXPECT_EQ(HostTaskWaitList[0], BarrierEventImpl);
   EXPECT_EQ(HostTaskEventImpl->isEnqueued(), true);
 
   MainLock.unlock();


### PR DESCRIPTION
  PR includes the following fixes:
  * When submitting a command to an out-of-order queue we don't need to add the dependency from the last barrier to the scheduler if command is enqueued via UR because that means that UR backend will take care of the command from barrier.
  
  * We used to update the last barrier only if barrier which is being submitted to the sycl::queue is not enqueued to the backend which is not correct, because there might be host tasks following that barrier which have to depend on it.