### PR TITLE
[SYCL][Joint Matrix] Additional devices with Joint Matrix support

### DIFF
--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -802,7 +802,9 @@ struct get_device_info_impl<
           {16, 16, 32, 0, 0, 0, matrix_type::fp16, matrix_type::fp16,
            matrix_type::fp32, matrix_type::fp32},
       };
-    else if (architecture::intel_gpu_pvc == DeviceArch)
+    else if ((architecture::intel_gpu_pvc == DeviceArch) ||
+             (architecture::intel_gpu_bmg_g21 == DeviceArch) ||
+             (architecture::intel_gpu_lnl_m == DeviceArch))
       return {
           {8, 0, 0, 0, 16, 32, matrix_type::uint8, matrix_type::uint8,
            matrix_type::sint32, matrix_type::sint32},
@@ -827,7 +829,8 @@ struct get_device_info_impl<
       };
     else if ((architecture::intel_gpu_dg2_g10 == DeviceArch) ||
              (architecture::intel_gpu_dg2_g11 == DeviceArch) ||
-             (architecture::intel_gpu_dg2_g12 == DeviceArch))
+             (architecture::intel_gpu_dg2_g12 == DeviceArch) ||
+             (architecture::intel_gpu_arl_h == DeviceArch))
       return {
           {8, 0, 0, 0, 8, 32, matrix_type::uint8, matrix_type::uint8,
            matrix_type::sint32, matrix_type::sint32},


### PR DESCRIPTION
New Intel GPU devices with matrix support have been added to https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_architecture.asciidoc#new-enumeration-of-architectures, namely:

- Battlemage and Lunar Lake that share same matrix combinations as PVC in the matrix query 

- Arrow Lake H that shares the same matrix combinations  as DG2

Hence, this PR updates the matrix query to includes these 3 new devices.

