### PR TITLE
[SYCL][NATIVECPU] Fix any mux abi calls to be abi conformant

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/FixABIMuxBuiltinsSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/FixABIMuxBuiltinsSYCLNativeCPU.h
@@ -1,0 +1,30 @@
+//===---- FixABIMuxBuiltins.h - Fixup ABI issues with called mux builtins ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Fixes up the ABI for any mux builtins which meet the architecture
+// ABI but not the mux_* usage. For now this is restricted to mux_shuffle* 
+// builtins which take a float2 input.
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+
+namespace llvm {
+
+class FixABIMuxBuiltinsPass final
+    : public llvm::PassInfoMixin<FixABIMuxBuiltinsPass> {
+ public:
+  llvm::PreservedAnalyses run(llvm::Module &, llvm::ModuleAnalysisManager &);
+};
+
+} // namespace llvm
+

--- a/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
@@ -3,7 +3,7 @@ add_llvm_component_library(LLVMSYCLNativeCPUUtils
   PrepareSYCLNativeCPU.cpp
   RenameKernelSYCLNativeCPU.cpp
   ConvertToMuxBuiltinsSYCLNativeCPU.cpp
-
+  FixABIMuxBuiltinsSYCLNativeCPU.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/SYCLLowerIR

--- a/llvm/lib/SYCLNativeCPUUtils/FixABIMuxBuiltinsSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/FixABIMuxBuiltinsSYCLNativeCPU.cpp
@@ -1,0 +1,128 @@
+//===-- FixABIMuxBuiltinsSYCLNativeCPU.cpp - Fixup mux ABI issues       ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Fixes up the ABI for any mux builtins which meet the architecture
+// ABI but not the mux_* usage. For now this is restricted to mux_shuffle*
+// builtins which take a float2 input.
+//
+//===----------------------------------------------------------------------===//
+
+#include <llvm/IR/IRBuilder.h>
+#include <llvm/IR/Module.h>
+#include <llvm/IR/Type.h>
+#include <llvm/SYCLLowerIR/FixABIMuxBuiltinsSYCLNativeCPU.h>
+
+#define DEBUG_TYPE "fix-abi-mux-builtins"
+
+using namespace llvm;
+
+PreservedAnalyses FixABIMuxBuiltinsPass::run(Module &M,
+                                             ModuleAnalysisManager &AM) {
+  bool Changed = false;
+
+  // Decide if a function needs updated and if so what parameters need changing,
+  // as well as the return value
+  auto functionNeedsFixing =
+      [&M](
+          Function &F,
+          llvm::SmallVectorImpl<std::pair<unsigned int, llvm::Type *>> &updates,
+          llvm::Type *&RetVal) {
+        updates.clear();
+        // At the moment only cover sub groups
+        if (F.getName().starts_with("__mux_sub_group")) {
+          RetVal = F.getReturnType();
+          // TODO: Support a richer set of fixing parameters by comparing the
+          // name against expected parameter and building up replacements.
+          bool Ret = false;
+          unsigned int ArgIndex = 0;
+          // Check if the mux function expects 2x vector i32. We know if this
+          // has double parameters they need fixed up. For other cases if there
+          // are byval parameters they need fixed up too.
+          bool IsV2I32 = F.getName().ends_with("_v2i32");
+          for (auto &Arg : F.args()) {
+            if (IsV2I32 && Arg.getType()->isDoubleTy()) {
+              auto *ReplType = llvm::FixedVectorType::get(
+                  llvm::Type::getInt32Ty(F.getContext()), 2);
+              updates.push_back(
+                  std::pair<unsigned int, llvm::Type *>(ArgIndex, ReplType));
+              RetVal = ReplType;
+              Ret = true;
+            } else if (Arg.hasByValAttr()) {
+              updates.push_back(std::pair<unsigned int, llvm::Type *>(
+                  ArgIndex, Arg.getParamByValType()));
+              Ret = true;
+            }
+            ArgIndex++;
+          }
+          return Ret;
+        }
+        return false;
+      };
+
+  llvm::SmallVector<Function *, 4> FuncsToProcess;
+  for (auto &F : M.functions()) {
+    FuncsToProcess.push_back(&F);
+  }
+
+  for (auto *F : FuncsToProcess) {
+    llvm::SmallVector<std::pair<unsigned int, llvm::Type *>, 4> ArgUpdates;
+    llvm::Type *RetType = nullptr;
+    if (!functionNeedsFixing(*F, ArgUpdates, RetType)) {
+      continue;
+    }
+    if (!F->isDeclaration()) {
+      continue;
+    }
+    Changed = true;
+    IRBuilder<> ir(BasicBlock::Create(F->getContext(), "", F));
+
+    std::string OrigName = F->getName().str();
+    F->setName(F->getName() + "_abi_wrapper");
+    llvm::SmallVector<Type *, 8> Args;
+    unsigned int ArgIndex = 0;
+    unsigned int UpdateIndex = 0;
+    for (auto &Arg : F->args()) {
+      if (UpdateIndex < ArgUpdates.size() &&
+          std::get<0>(ArgUpdates[UpdateIndex]) == ArgIndex) {
+        Args.push_back(std::get<1>(ArgUpdates[UpdateIndex]));
+        UpdateIndex++;
+      } else {
+        Args.push_back(Arg.getType());
+      }
+      ArgIndex++;
+    }
+
+    FunctionType *FT = FunctionType::get(RetType, Args, false);
+    Function *NewFunc = Function::Create(FT, F->getLinkage(), OrigName, M);
+    llvm::SmallVector<Value *, 8> CallArgs;
+    auto NewFuncArgItr = NewFunc->args().begin();
+    for (auto &Arg : F->args()) {
+      if (Arg.getType() != (*NewFuncArgItr).getType()) {
+        if (Arg.hasByValAttr()) {
+          Value *ArgLoad = ir.CreateLoad((*NewFuncArgItr).getType(), &Arg);
+          CallArgs.push_back(ArgLoad);
+        } else {
+          Value *ArgCast = ir.CreateBitCast(&Arg, (*NewFuncArgItr).getType());
+          CallArgs.push_back(ArgCast);
+        }
+      } else {
+        CallArgs.push_back(&Arg);
+      }
+      NewFuncArgItr++;
+    }
+
+    Value *Res = ir.CreateCall(NewFunc, CallArgs);
+    // If the return type is different to the initial function, then bitcast it.
+    if (F->getReturnType() != RetType) {
+      Res = ir.CreateBitCast(Res, F->getReturnType());
+    }
+    ir.CreateRet(Res);
+  }
+
+  return Changed ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 #include "llvm/SYCLLowerIR/ConvertToMuxBuiltinsSYCLNativeCPU.h"
+#include "llvm/SYCLLowerIR/FixABIMuxBuiltinsSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/PrepareSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/RenameKernelSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
@@ -63,6 +64,7 @@ void llvm::sycl::utils::addSYCLNativeCPUBackendPasses(
   MPM.addPass(ConvertToMuxBuiltinsSYCLNativeCPUPass());
 #ifdef NATIVECPU_USE_OCK
   MPM.addPass(compiler::utils::TransferKernelMetadataPass());
+  MPM.addPass(FixABIMuxBuiltinsPass());
   // Always enable vectorizer, unless explictly disabled or -O0 is set.
   if (OptLevel != OptimizationLevel::O0 && !SYCLNativeCPUNoVecz) {
     MAM.registerPass([] { return vecz::TargetInfoAnalysis(); });

--- a/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PrepareSYCLNativeCPU.cpp
@@ -464,13 +464,17 @@ PreservedAnalyses PrepareSYCLNativeCPUPass::run(Module &M,
     F->eraseFromParent();
     ModuleChanged = true;
   }
-  for (auto It = M.begin(); It != M.end();) {
-    auto Curr = It++;
-    Function &F = *Curr;
-    if (F.getNumUses() == 0 && F.isDeclaration() &&
-        F.getName().starts_with("__mux_")) {
-      F.eraseFromParent();
-      ModuleChanged = true;
+
+  // We do these twice because we create abi wrappers for mux which may show up
+  // before we've removed their user
+  for (unsigned int i = 0; i < 2; i++) {
+    for (auto It = M.begin(); It != M.end();) {
+      auto Curr = It++;
+      Function &F = *Curr;
+      if (F.getNumUses() == 0 && F.getName().starts_with("__mux_")) {
+        F.eraseFromParent();
+        ModuleChanged = true;
+      }
     }
   }
 

--- a/sycl/test/check_device_code/native_cpu/shuffle_abi.cpp
+++ b/sycl/test/check_device_code/native_cpu/shuffle_abi.cpp
@@ -1,0 +1,94 @@
+// REQUIRES: native_cpu_ock && linux
+// RUN: %clangxx -target x86_64-unknown-linux-gnu -fsycl -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-opt -mllvm -inline-threshold=500 -mllvm -sycl-native-cpu-no-vecz -mllvm -sycl-native-dump-device-ir %s | FileCheck %s
+
+// Tests that sub-group shuffles work even when abi is different to what is expected
+
+#include <sycl/detail/core.hpp>
+#include <sycl/group_algorithm.hpp>
+#include <sycl/marray.hpp>
+
+static constexpr size_t NumElems = 5;
+static constexpr size_t NumWorkItems = 64;
+
+
+// CHECK: define internal double @__mux_sub_group_shuffle_up_v2i32_abi_wrapper
+// CHECK: %[[UPV2I32_BITCAST_OP0:[0-9]+]] = bitcast double %0 to <2 x i32>
+// CHECK: %[[UPV2I32_BITCAST_OP1:[0-9]+]] = bitcast double %1 to <2 x i32>
+// CHECK: %[[UPV2I32_CALL_SHUFFLE:[0-9]+]] = call <2 x i32> @__mux_sub_group_shuffle_up_v2i32(<2 x i32> %[[UPV2I32_BITCAST_OP0]], <2 x i32> %[[UPV2I32_BITCAST_OP1]]
+// CHECK: %[[UPV2I32_BITCAST_RESULT:[0-9]+]] = bitcast <2 x i32> %[[UPV2I32_CALL_SHUFFLE]] to double
+// CHECK: ret double %[[UPV2I32_BITCAST_RESULT]]
+
+// CHECK: define internal double @__mux_sub_group_shuffle_down_v2i32_abi_wrapper
+// CHECK: %[[DOWNV2I32_BITCAST_OP0:[0-9]+]] = bitcast double %0 to <2 x i32>
+// CHECK: %[[DOWNV2I32_BITCAST_OP1:[0-9]+]] = bitcast double %1 to <2 x i32>
+// CHECK: %[[DOWNV2I32_CALL_SHUFFLE:[0-9]+]] = call <2 x i32> @__mux_sub_group_shuffle_down_v2i32(<2 x i32> %[[DOWNV2I32_BITCAST_OP0]], <2 x i32> %[[DOWNV2I32_BITCAST_OP1]]
+// CHECK: %[[DOWNV2I32_BITCAST_RESULT:[0-9]+]] = bitcast <2 x i32> %[[DOWNV2I32_CALL_SHUFFLE]] to double
+// CHECK: ret double %[[DOWNV2I32_BITCAST_RESULT]]
+
+// CHECK: define internal double @__mux_sub_group_shuffle_xor_v2i32_abi_wrapper(double noundef %0, i32 noundef %1)
+
+// CHECK-DAG: define internal <8 x float> @__mux_sub_group_shuffle_up_v8f32_abi_wrapper(ptr noundef byval(<8 x float>) align 32 %0, ptr noundef byval(<8 x float>) align 32 %1
+// CHECK:   %[[UPV8F32_BYVAL_LOAD_OP0:[0-9]+]] = load <8 x float>, ptr %0, align 32
+// CHECK:   %[[UPV8F32_BYVAL_LOAD_OP1:[0-9]+]] = load <8 x float>, ptr %1, align 32
+// CHECK:   %[[UPV8F32_CALL_SHUFFLE:[0-9]+]] = call <8 x float> @__mux_sub_group_shuffle_up_v8f32(<8 x float> %[[UPV8F32_BYVAL_LOAD_OP0]], <8 x float> %[[UPV8F32_BYVAL_LOAD_OP1]], i32 %2)
+// CHECK:   ret <8 x float> %[[UPV8F32_CALL_SHUFFLE:[0-9]+]]
+
+// CHECK-DAG: define internal <8 x float> @__mux_sub_group_shuffle_down_v8f32_abi_wrapper(ptr noundef byval(<8 x float>) align 32 %0, ptr noundef byval(<8 x float>) align 32 %1
+// CHECK:   %[[DOWNV8F32_BYVAL_LOAD_OP0:[0-9]+]] = load <8 x float>, ptr %0, align 32
+// CHECK:   %[[DOWNV8F32_BYVAL_LOAD_OP1:[0-9]+]] = load <8 x float>, ptr %1, align 32
+// CHECK:   %[[DOWNV8F32_CALL_SHUFFLE:[0-9]+]] = call <8 x float> @__mux_sub_group_shuffle_down_v8f32(<8 x float> %[[DOWNV8F32_BYVAL_LOAD_OP0]], <8 x float> %[[DOWNV8F32_BYVAL_LOAD_OP1]], i32 %2)
+// CHECK:   ret <8 x float> %[[DOWNV8F32_CALL_SHUFFLE:[0-9]+]]
+
+// CHECK-DAG: define internal <8 x float> @__mux_sub_group_shuffle_xor_v8f32_abi_wrapper(ptr noundef byval(<8 x float>) align 32 %0
+
+template <typename ShiftType>
+void ShiftLeftRightTest()
+{
+  sycl::queue Q;
+
+  ShiftType ShiftLeftRes[NumWorkItems];
+  ShiftType ShiftRightRes[NumWorkItems];
+  ShiftType PermuteXorRes[NumWorkItems];
+  ShiftType SelectRes[NumWorkItems];
+  unsigned SubGroupSize = 0;
+
+  {
+    sycl::buffer<ShiftType, 1> ShiftLeftResBuff{ShiftLeftRes, NumWorkItems};
+    sycl::buffer<ShiftType, 1> ShiftRightResBuff{ShiftRightRes, NumWorkItems};
+    sycl::buffer<ShiftType, 1> PermuteXorResBuff{PermuteXorRes, NumWorkItems};
+    sycl::buffer<ShiftType, 1> SelectResBuff{SelectRes, NumWorkItems};
+    sycl::buffer<unsigned, 1> SubGroupSizeBuff{&SubGroupSize, 1};
+
+    Q.submit([&](sycl::handler &CGH) {
+      sycl::accessor ShiftLeftResAcc{ShiftLeftResBuff, CGH, sycl::write_only};
+      sycl::accessor ShiftRightResAcc{ShiftRightResBuff, CGH, sycl::write_only};
+      sycl::accessor PermuteXorResAcc{PermuteXorResBuff, CGH, sycl::write_only};
+      sycl::accessor SubGroupSizeAcc{SubGroupSizeBuff, CGH, sycl::write_only};
+
+      CGH.parallel_for(
+          sycl::nd_range<1>{sycl::range<1>{NumWorkItems},
+                            sycl::range<1>{NumWorkItems}},
+          [=](sycl::nd_item<1> It) {
+            int GID = It.get_global_linear_id();
+            int ValueOffset = GID * NumElems;
+            ShiftType ItemVal{0};
+            for (int I = 0; I < NumElems; ++I)
+              ItemVal[I] = ValueOffset + I;
+
+            sycl::sub_group SG = It.get_sub_group();
+            if (GID == 0)
+              SubGroupSizeAcc[0] = SG.get_local_linear_range();
+
+            ShiftLeftResAcc[GID] = sycl::shift_group_left(SG, ItemVal);
+            ShiftRightResAcc[GID] = sycl::shift_group_right(SG, ItemVal);
+            PermuteXorResAcc[GID] = sycl::permute_group_by_xor(SG, ItemVal, 1);
+          });
+    });
+  }
+}
+
+int main() {
+  ShiftLeftRightTest<sycl::vec<int, 2>>();
+  ShiftLeftRightTest<sycl::vec<float, 8>>();  
+  return 0;
+}


### PR DESCRIPTION
Native cpu can make calls to mux builtins such as shuffle which are ABI compliant but are not what is expected by ock passes. This fixes them up by making the created function headers a wrapper which calls the correct mux functions.

This currently only handle a small number of cases for shuffle such as when a vector i2 is replaced with double or byval is used. It will be expanded over time.