### PR TITLE
[SYCL][E2E] Fix warnings from using GNU style options with MSVC compiler driver

### DIFF
--- a/sycl/test-e2e/AOT/fpga-aoc-archive-early2.cpp
+++ b/sycl/test-e2e/AOT/fpga-aoc-archive-early2.cpp
@@ -18,10 +18,10 @@
 ////////////////////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
 // Build any image archive binaries from early archives.
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_sub.a   -o %t_early_image_sub.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_add.a   -o %t_early_image_add.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_sub_x.a -o %t_early_image_sub_x.a
-// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image %t_early_add_x.a -o %t_early_image_add_x.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image -Wno-unused-command-line-argument %t_early_sub.a   -o %t_early_image_sub.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image -Wno-unused-command-line-argument %t_early_add.a   -o %t_early_image_add.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image -Wno-unused-command-line-argument %t_early_sub_x.a -o %t_early_image_sub_x.a
+// RUN: %clangxx -fintelfpga -fsycl -fsycl-link=image -Wno-unused-command-line-argument %t_early_add_x.a -o %t_early_image_add_x.a
 ////////////////////////////////////////////////////////////////////////////////
 // Use a variety of archive orders
 ////////////////////////////////////////////////////////////////////////////////

--- a/sycl/test-e2e/BFloat16/bfloat16_vec_builtins.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_vec_builtins.cpp
@@ -1,4 +1,5 @@
-// RUN: %{build} -fno-fast-math -o %t.out
+// DEFINE: %{mathflags} = %if cl_options %{/clang:-fno-fast-math%} %else %{-fno-fast-math%}
+// RUN: %{build} %{mathflags} -o %t.out
 // RUN: %{run} %t.out
 
 // Test new, ABI-breaking for all platforms.

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_aocx.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_aocx.cpp
@@ -20,7 +20,7 @@
 // AOCX with source
 // RUN: %clangxx -fsycl -fintelfpga %S/Inputs/fpga_host.cpp %t_image.a -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clangxx -fsycl -fintelfpga %t.o %t_image.a -o %t_aocx_obj.out
+// RUN: %clangxx -fsycl -fintelfpga %t.o %t_image.a -Wno-unused-command-line-argument -o %t_aocx_obj.out
 //
 // RUN: %{run} %t_aocx_src.out
 // RUN: %{run} %t_aocx_obj.out

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_aocx_win.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_aocx_win.cpp
@@ -21,7 +21,7 @@
 // AOCX with source
 // RUN: %clangxx -fsycl -fintelfpga -DHOST_PART %S/Inputs/fpga_host.cpp %t_image.lib -o %t_aocx_src.out
 // AOCX with object
-// RUN: %clangxx -fsycl -fintelfpga %t.obj %t_image.lib -o %t_aocx_obj.out
+// RUN: %clangxx -fsycl -fintelfpga %t.obj %t_image.lib -Wno-unused-command-line-argument -o %t_aocx_obj.out
 //
 // RUN: %{run} %t_aocx_src.out
 // RUN: %{run} %t_aocx_obj.out

--- a/sycl/test-e2e/Basic/group_async_copy.cpp
+++ b/sycl/test-e2e/Basic/group_async_copy.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -std=c++17 -o %t.run
+// RUN: %{build} %cxx_std_optionc++17 -o %t.run
 // RUN: %{run} %t.run
 
 // Windows doesn't yet have full shutdown(). Skipping TC MemLeak tests.

--- a/sycl/test-e2e/Basic/group_async_copy_legacy.cpp
+++ b/sycl/test-e2e/Basic/group_async_copy_legacy.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -std=c++17 -o %t.run -Wno-deprecated-declarations
+// RUN: %{build} %cxx_std_optionc++17 -o %t.run -Wno-deprecated-declarations
 // RUN: %{run} %t.run
 
 // Variant of group_asymc_copy.cpp using legacy multi_ptr and the corresponding

--- a/sycl/test-e2e/Basic/group_local_id.cpp
+++ b/sycl/test-e2e/Basic/group_local_id.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu
 
-// RUN: %{build} -std=c++17 -o %t.out
+// RUN: %{build} %cxx_std_optionc++17 -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/multisource.cpp
+++ b/sycl/test-e2e/Basic/multisource.cpp
@@ -9,14 +9,14 @@
 // Separate kernel sources and host code sources
 // RUN: %{build} -c -o %t.kernel.o -DINIT_KERNEL -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -Wno-unused-command-line-argument -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code
 // RUN: %{build} -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -Wno-unused-command-line-argument -o %t.fat
 // RUN: %{run} %t.fat
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/multisource_spv_obj.cpp
+++ b/sycl/test-e2e/Basic/multisource_spv_obj.cpp
@@ -11,21 +11,21 @@
 // Separate kernel sources and host code sources
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.kernel.o -DINIT_KERNEL -DCALC_KERNEL
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.kernel.o %t.main.o -Wno-unused-command-line-argument -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -Wno-unused-command-line-argument -o %t.fat
 // RUN: %{run} %t.fat
 
 // Multiple sources with kernel code, mixed SPIR-V and LLVM-IR objects
 // RUN: %{build} -fsycl-device-obj=spirv -c -o %t.init.o -DINIT_KERNEL
 // RUN: %{build} -fsycl-device-obj=llvmir -c -o %t.calc.o -DCALC_KERNEL
 // RUN: %{build} -c -o %t.main.o -DMAIN_APP
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -o %t.fat
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.init.o %t.calc.o %t.main.o -Wno-unused-command-line-argument -o %t.fat
 // RUN: %{run} %t.fat
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
+++ b/sycl/test-e2e/Basic/spirv_device_obj_smoke.cpp
@@ -1,6 +1,6 @@
 // UNSUPPORTED: cuda || hip
 // RUN: %clangxx -fsycl -fsycl-device-obj=spirv -c -o %t.o %s
-// RUN: %clangxx -fsycl -o %t.out %t.o
+// RUN: %clangxx -fsycl -Wno-unused-command-line-argument -o %t.out %t.o
 // RUN: %{run} %t.out
 
 // This test verifies SPIR-V based fat objects.

--- a/sycl/test-e2e/Basic/vector/byte.cpp
+++ b/sycl/test-e2e/Basic/vector/byte.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -std=c++17 -o %t.out
+// RUN: %{build} %cxx_std_optionc++17 -o %t.out
 // RUN: %{run} %t.out
 
 // RUN: %if preview-breaking-changes-supported %{ %{build} -fpreview-breaking-changes -std=c++17 -o %t2.out %}

--- a/sycl/test-e2e/Config/config.cpp
+++ b/sycl/test-e2e/Config/config.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} %debug_option %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %debug_option %no_opt -o %t.out
 // RUN: echo SYCL_PRINT_EXECUTION_GRAPH=always > %t.cfg
 // RUN: env SYCL_CONFIG_FILE_NAME=%t.cfg %t.out
 // RUN: cat *.dot > /dev/null

--- a/sycl/test-e2e/Config/config.cpp
+++ b/sycl/test-e2e/Config/config.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} %debug_option -O0 -o %t.out
+// RUN: %{build} %debug_option %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: echo SYCL_PRINT_EXECUTION_GRAPH=always > %t.cfg
 // RUN: env SYCL_CONFIG_FILE_NAME=%t.cfg %t.out
 // RUN: cat *.dot > /dev/null

--- a/sycl/test-e2e/Config/env_vars.cpp
+++ b/sycl/test-e2e/Config/env_vars.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl
 // Env vars are used to pass OpenCL-specific flags to PI compiling/linking.
 //
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %no_opt -o %t.out
 //
 // RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" %{run} %t.out
 // RUN: env SYCL_PROGRAM_APPEND_COMPILE_OPTIONS="-g" %{run} %t.out

--- a/sycl/test-e2e/Config/env_vars.cpp
+++ b/sycl/test-e2e/Config/env_vars.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl
 // Env vars are used to pass OpenCL-specific flags to PI compiling/linking.
 //
-// RUN: %{build} -O0 -o %t.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 //
 // RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" %{run} %t.out
 // RUN: env SYCL_PROGRAM_APPEND_COMPILE_OPTIONS="-g" %{run} %t.out

--- a/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
+++ b/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
@@ -4,12 +4,12 @@
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...
 // RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict %{mathflags}
-// RUN: %clangxx %t_host.o %t_device.o -o %t.out %sycl_options %{mathflags}
+// RUN: %clangxx %t_host.o %t_device.o -Wno-unused-command-line-argument -o %t.out %sycl_options %{mathflags}
 // RUN: %{run} %t.out
 
 // RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...
 // RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict %{mathflags}
-// RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -o %t_fp64.out %sycl_options %{mathflags}
+// RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -Wno-unused-command-line-argument -o %t_fp64.out %sycl_options %{mathflags}
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/rotate.cpp
+++ b/sycl/test-e2e/ESIMD/rotate.cpp
@@ -6,9 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 
-// RUN: %{build} -fsycl-device-code-split=per_kernel -std=c++20 -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel %cxx_std_optionc++20 -o %t.out
 // RUN: %{run} %t.out
-// RUN: %{build} -fsycl-device-code-split=per_kernel -std=c++20 -o %t1.out -DEXP
+// RUN: %{build} -fsycl-device-code-split=per_kernel %cxx_std_optionc++20 -o %t1.out -DEXP
 // RUN: %{run} %t1.out
 
 // This is a basic test to validate the ror/rol functions.

--- a/sycl/test-e2e/ESIMD/slm_alloc.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc.cpp
@@ -8,7 +8,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} -O0 -o %t.3.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // This is end-to-end test for the slm_allocator API used together with the

--- a/sycl/test-e2e/ESIMD/slm_alloc.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc.cpp
@@ -8,7 +8,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.3.out
+// RUN: %{build} %no_opt -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // This is end-to-end test for the slm_allocator API used together with the

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} -O0 -o %t.3.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // Checks validity of SLM frame offsets in case of complex call graph with two

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.3.out
+// RUN: %{build} %no_opt -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // Checks validity of SLM frame offsets in case of complex call graph with two

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} -O0 -o %t.3.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // Check that SLM frame offset of a function foo called from two kernels Test1

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.3.out
+// RUN: %{build} %no_opt -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // Check that SLM frame offset of a function foo called from two kernels Test1

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %{build} -O0 -o %t_O0.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t_O0.out
 // RUN: %{run} %t_O0.out
 
 /*

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t_O0.out
+// RUN: %{build} %no_opt -o %t_O0.out
 // RUN: %{run} %t_O0.out
 
 /*

--- a/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %no_opt -o %t.out
 
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} -O0 -o %t.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
@@ -6,5 +6,5 @@
 // RUN: %{run} %t.out
 
 // Test -O0 with `--offload-new-driver`
-// RUN: %clangxx -O0 -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
+// RUN: %clangxx %if cl_options %{/Od%} %else %{-O0%} -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
@@ -6,5 +6,5 @@
 // RUN: %{run} %t.out
 
 // Test -O0 with `--offload-new-driver`
-// RUN: %clangxx %if cl_options %{/Od%} %else %{-O0%} -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
+// RUN: %clangxx %no_opt -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/NewOffloadDriver/spirv_device_obj_smoke.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/spirv_device_obj_smoke.cpp
@@ -1,7 +1,7 @@
 // UNSUPPORTED: cuda || hip
 // Test with `--offload-new-driver`
 // RUN: %clangxx -fsycl -fsycl-device-obj=spirv --offload-new-driver -c -o %t.o %s
-// RUN: %clangxx -fsycl --offload-new-driver -o %t.out %t.o
+// RUN: %clangxx -fsycl --offload-new-driver -Wno-unused-command-line-argument -o %t.out %t.o
 // RUN: %{run} %t.out
 
 // This test verifies SPIR-V based fat objects.

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
@@ -1,7 +1,7 @@
 // requires: cpu, gpu, accelerator
 // UNSUPPORTED: hip
 // FIXME: enable the test back, see intel/llvm#8146
-// RUN: %{build} -Wno-error=incorrect-sub-group-size %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} -Wno-error=incorrect-sub-group-size %no_opt -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
@@ -1,7 +1,7 @@
 // requires: cpu, gpu, accelerator
 // UNSUPPORTED: hip
 // FIXME: enable the test back, see intel/llvm#8146
-// RUN: %{build} -Wno-error=incorrect-sub-group-size -O0 -o %t.out
+// RUN: %{build} -Wno-error=incorrect-sub-group-size %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/OptionalKernelFeatures/sycl-external-with-optional-features.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/sycl-external-with-optional-features.cpp
@@ -1,6 +1,6 @@
 // RUN: %{build} -DSOURCE1 -c -o %t1.o
 // RUN: %{build} -DSOURCE2 -c -o %t2.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t1.o %t2.o -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t1.o %t2.o -Wno-unused-command-line-argument -o %t.exe
 // RUN: %{run} %t.exe
 
 #ifdef SOURCE1

--- a/sycl/test-e2e/OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu
 
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %no_opt -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu
 
-// RUN: %{build} -O0 -o %t.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
+++ b/sycl/test-e2e/ProgramManager/uneven_kernel_split.cpp
@@ -4,7 +4,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -I %S/Inputs/ %S/uneven_kernel_split.cpp -c -o %t.o
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -I %S/Inputs/ %S/Inputs/gpu_kernel1.cpp -c -o %t1.o
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -I %S/Inputs/ %S/Inputs/gpu_kernel2.cpp -c -o %t2.o
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts %t.o %t1.o %t2.o -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64,spir64_gen -Xsycl-target-backend=spir64_gen %gpu_aot_target_opts -Wno-unused-command-line-argument %t.o %t1.o %t2.o -o %t.out
 // RUN: %{run} %t.out
 
 // Test require the following device image structure: cpu target device image

--- a/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
+++ b/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
@@ -9,7 +9,7 @@
 // RUN: %{build} -O3 -o %t3.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t3.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL3 %}
 
-// RUN: %{build} -O0 -o %t.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: %{run} %t.out
 
 // This test verifies the propagation of front-end compiler optimization

--- a/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
+++ b/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl
 
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t0.out
+// RUN: %{build} %no_opt -o %t0.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL0 %}
 // RUN: %{build} -O1 -o %t1.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t1.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL1 %}
@@ -9,7 +9,7 @@
 // RUN: %{build} -O3 -o %t3.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t3.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL3 %}
 
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %no_opt -o %t.out
 // RUN: %{run} %t.out
 
 // This test verifies the propagation of front-end compiler optimization

--- a/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
+++ b/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -g -o %t.out
-// RUN: %{build} -g -O0 -o %t.out
+// RUN: %{build} -g %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: %{build} -g -O2 -o %t.out
 //
 // The idea of this test is to make sure that we can compile the following

--- a/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
+++ b/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -g -o %t.out
-// RUN: %{build} -g %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} -g %no_opt -o %t.out
 // RUN: %{build} -g -O2 -o %t.out
 //
 // The idea of this test is to make sure that we can compile the following

--- a/sycl/test-e2e/Regression/DAE-separate-compile.cpp
+++ b/sycl/test-e2e/Regression/DAE-separate-compile.cpp
@@ -5,7 +5,7 @@
 // The test checks that the scenario works correctly.
 //
 // RUN: %{build} -O2 -c -o %t.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o %if cl_options %{/Od%} %else %{-O0%} -Wno-unused-command-line-argument -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o %no_opt -Wno-unused-command-line-argument -o %t.out
 // RUN: %{run} %t.out
 
 // Failing on HIP AMD, enable after fixed

--- a/sycl/test-e2e/Regression/DAE-separate-compile.cpp
+++ b/sycl/test-e2e/Regression/DAE-separate-compile.cpp
@@ -5,7 +5,7 @@
 // The test checks that the scenario works correctly.
 //
 // RUN: %{build} -O2 -c -o %t.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o -O0 -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o %if cl_options %{/Od%} %else %{-O0%} -Wno-unused-command-line-argument -o %t.out
 // RUN: %{run} %t.out
 
 // Failing on HIP AMD, enable after fixed

--- a/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
+++ b/sycl/test-e2e/Regression/compile_on_win_with_mdd.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: windows
 
 // RUN: %clangxx --driver-mode=cl -fsycl /MDd -c %s -o %t.obj
-// RUN: %clangxx --driver-mode=cl -fsycl %t.obj -o %t.out
+// RUN: %clangxx --driver-mode=cl -fsycl %t.obj -Wno-unused-command-line-argument -o %t.out
 // RUN: %{run} %t.out
 
 // The test aims to prevent regressions similar to the one which caused by

--- a/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
+++ b/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
@@ -1,6 +1,6 @@
 // -O0 is necessary; on higher levels of optimization, an error
 // would not occur because of dead argument elimination of the local_accessor.
-// RUN: %{build} -o %t.out %if cl_options %{/Od%} %else %{-O0%}
+// RUN: %{build} -o %t.out %no_opt 
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
+++ b/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
@@ -1,6 +1,6 @@
 // -O0 is necessary; on higher levels of optimization, an error
 // would not occur because of dead argument elimination of the local_accessor.
-// RUN: %{build} -o %t.out %no_opt 
+// RUN: %{build} -o %t.out %no_opt
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
+++ b/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
@@ -1,6 +1,6 @@
 // -O0 is necessary; on higher levels of optimization, an error
 // would not occur because of dead argument elimination of the local_accessor.
-// RUN: %{build} -o %t.out -O0
+// RUN: %{build} -o %t.out %if cl_options %{/Od%} %else %{-O0%}
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Regression/optimization_level_debug_info_intopt.cpp
+++ b/sycl/test-e2e/Regression/optimization_level_debug_info_intopt.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %debug_option -O0 -o %t.out
+// RUN: %{build} %debug_option %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: %{build} %debug_option -O1 -o %t.out
 // RUN: %{build} %debug_option -O2 -o %t.out
 // RUN: %{build} %debug_option -O3 -o %t.out

--- a/sycl/test-e2e/Regression/optimization_level_debug_info_intopt.cpp
+++ b/sycl/test-e2e/Regression/optimization_level_debug_info_intopt.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %debug_option %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %debug_option %no_opt -o %t.out
 // RUN: %{build} %debug_option -O1 -o %t.out
 // RUN: %{build} %debug_option -O2 -o %t.out
 // RUN: %{build} %debug_option -O3 -o %t.out

--- a/sycl/test-e2e/Regression/optimization_level_debug_info_specopt.cpp
+++ b/sycl/test-e2e/Regression/optimization_level_debug_info_specopt.cpp
@@ -1,8 +1,11 @@
-// RUN: %{build} %debug_option -ffp-model=fast -o %t.out
+// DEFINE: %{ffpflags} = %if cl_options %{/clang:-ffp-model=fast%} %else %{-ffp-model=fast%}
+// DEFINE: %{Oz} = %if cl_options %{/clang:-Oz%} %else %{-Oz%}
+// DEFINE: %{O} = %if cl_options %{/clang:-O%} %else %{-O%}
+// RUN: %{build} %debug_option %{ffpflags} -o %t.out
 // RUN: %{build} %debug_option -Os -o %t.out
-// RUN: %{build} %debug_option -Oz -o %t.out
+// RUN: %{build} %debug_option %{Oz} -o %t.out
 // RUN: %{build} %debug_option -Og -o %t.out
-// RUN: %{build} %debug_option -O -o %t.out
+// RUN: %{build} %debug_option %{O} -o %t.out
 
 // NOTE: Tests that debugging information can be generated for all special-name
 // optimization levels.

--- a/sycl/test-e2e/Regression/unoptimized_stream.cpp
+++ b/sycl/test-e2e/Regression/unoptimized_stream.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
+// RUN: %{build} %no_opt -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Regression/unoptimized_stream.cpp
+++ b/sycl/test-e2e/Regression/unoptimized_stream.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -O0 -o %t.out
+// RUN: %{build} %if cl_options %{/Od%} %else %{-O0%} -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/SeparateCompile/same-kernel.cpp
+++ b/sycl/test-e2e/SeparateCompile/same-kernel.cpp
@@ -12,7 +12,7 @@
 // RUN: %{build} -DB_CPP=1 -c -o %t-same-kernel-b.o
 //
 // >> ---- link the full hetero app
-// RUN: %clangxx %t-same-kernel-a.o %t-same-kernel-b.o -o %t-same-kernel.exe -fsycl -fsycl-targets=%{sycl_triple}
+// RUN: %clangxx %t-same-kernel-a.o %t-same-kernel-b.o -Wno-unused-command-line-argument -o %t-same-kernel.exe -fsycl -fsycl-targets=%{sycl_triple}
 // RUN: %{run} %t-same-kernel.exe
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/SeparateCompile/sycl-external-within-staticlib.cpp
+++ b/sycl/test-e2e/SeparateCompile/sycl-external-within-staticlib.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -O3 -DSOURCE3 -c -o %t3.o
 // RUN: rm -f %t.a
 // RUN: llvm-ar crv %t.a %t1.o %t2.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -O3 %t3.o %t.a -o %t1.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -O3 %t3.o %t.a -Wno-unused-command-line-argument -o %t1.exe
 // RUN: %{run} %t1.exe
 
 // Check the repacked case as it can behave differently.
@@ -13,7 +13,7 @@
 // RUN: echo addlib %t.a >> %t.txt
 // RUN: echo save >> %t.txt
 // RUN: cat %t.txt | llvm-ar -M
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -O3 %t3.o %t_repacked.a -o %t2.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} -O3 %t3.o %t_repacked.a -Wno-unused-command-line-argument -o %t2.exe
 // RUN: %{run} %t2.exe
 
 #include <iostream>

--- a/sycl/test-e2e/SeparateCompile/sycl-external.cpp
+++ b/sycl/test-e2e/SeparateCompile/sycl-external.cpp
@@ -2,14 +2,14 @@
 // different object file.
 // RUN: %{build} -DSOURCE1 -c -o %t1.o
 // RUN: %{build} -DSOURCE2 -c -o %t2.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t1.o %t2.o -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t1.o %t2.o -Wno-unused-command-line-argument -o %t.exe
 // RUN: %{run} %t.exe
 //
 // Test2 - check that kernel can call a SYCL_EXTERNAL function defined in a
 // static library.
 // RUN: rm -f %t.a
 // RUN: llvm-ar crv %t.a %t1.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t2.o %t.a -o %t.exe
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t2.o %t.a -Wno-unused-command-line-argument -o %t.exe
 // RUN: %{run} %t.exe
 
 #include <iostream>

--- a/sycl/test-e2e/SeparateCompile/test.cpp
+++ b/sycl/test-e2e/SeparateCompile/test.cpp
@@ -51,7 +51,7 @@
 // RUN: %clangxx -Wno-error=override-module -c wrapper.bc -o wrapper.o
 //
 // >> ---- link the full hetero app
-// RUN: %clangxx wrapper.o a.o b.o -o app.exe %sycl_options
+// RUN: %clangxx wrapper.o a.o b.o -Wno-unused-command-line-argument -o app.exe %sycl_options
 // RUN: %{run} ./app.exe | FileCheck %s
 // CHECK: pass
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -382,6 +382,7 @@ if cl_options:
     config.substitutions.append(("%cxx_std_option", "/std:"))
     config.substitutions.append(("%fPIC", ""))
     config.substitutions.append(("%shared_lib", "/LD"))
+    config.substitutions.append(("%no_opt", "/Od"))
 else:
     config.substitutions.append(
         (
@@ -406,6 +407,7 @@ else:
         ("%fPIC", ("" if platform.system() == "Windows" else "-fPIC"))
     )
     config.substitutions.append(("%shared_lib", "-shared"))
+    config.substitutions.append(("%no_opt", "-O0"))
 
 # Check if user passed verbose-print parameter, if yes, add VERBOSE_PRINT macro
 if "verbose-print" in lit_config.params:


### PR DESCRIPTION
Due to the addition of the `-Werror` flag, these warnings were causing test failures when compiling tests with clang-cl. This patch does the following:

- Add `-Wno-unused-command-line-argument` to linking run lines. This is needed because when testing the MSVC driver the `/EHsc` flag is added to all run lines that call the compiler. This flag however is only needed at the compile stage so it is reported as unused if a run line is only linking.
- Add new expansion for no optimizations `%no_opt`, which is either `-O0` or `/Od` depending on the compiler driver.
- Use the expansion `%cxx_std_option` in place of `-std=`
- For flags that do not necessarily have an MSVC equivalent, prepend `/clang:` to the flag when using MSVC driver.