### PR TITLE
[UR] Bump UR tag to f31160d

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -117,13 +117,13 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 24a8299efc59c715a1c2dd180692a5e12a12283a
-  # Merge: eb63d1a2 2fea679d
-  # Author: Omar Ahmed <omar.ahmed@codeplay.com>
-  # Date:   Wed Sep 11 10:40:59 2024 +0100
-  #     Merge pull request #2078 from callumfare/callum/fix_device_extensions_fpga
-  #     Add workaround for silently supported OpenCL extensions on Intel FPGA
-  set(UNIFIED_RUNTIME_TAG 24a8299efc59c715a1c2dd180692a5e12a12283a)
+  # commit f31160dea6d142014f441bc4ca5e58e48827490e
+  # Merge: 2bbe9526 64068799
+  # Author: Piotr Balcer <piotr.balcer@intel.com>
+  # Date:   Thu Sep 12 14:19:48 2024 +0200
+  #     Merge pull request #2083 from kswiecicki/xpti-init-fix
+  #     Fix XPTI initialization bug
+  set(UNIFIED_RUNTIME_TAG f31160dea6d142014f441bc4ca5e58e48827490e)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need


### PR DESCRIPTION
Includes a few small fixes:
https://github.com/oneapi-src/unified-runtime/pull/2083
https://github.com/oneapi-src/unified-runtime/pull/2080
https://github.com/oneapi-src/unified-runtime/pull/2072
