### PR TITLE
[SYCL][E2E] Use `%threads_lib` expansion instead of custom expansion in Graph test

### DIFF
--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build_pthread_inc} -o %t.out
+// RUN: %{build} %threads_lib -o %t.out
 // RUN: %{run} %t.out
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=0 %{l0_leak_check} %{run} %t.out 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 // Extra run to check for immediate-command-list in Level Zero

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -186,11 +186,6 @@ class SYCLEndToEndTest(lit.formats.ShTest):
         else:
             substitutions.append(("%{l0_leak_check}", "env UR_L0_LEAKS_DEBUG=1"))
 
-        compilation_cmd_pthread = (
-            "%clangxx -pthread -fsycl -fsycl-targets=%{sycl_triple} %s"
-        )
-        substitutions.append(("%{build_pthread_inc}", compilation_cmd_pthread))
-
         def get_extra_env(sycl_devices):
             # Note: It's possible that the system has a device from below but
             # current llvm-lit invocation isn't configured to include it. We


### PR DESCRIPTION
Removes custom expansion only used in this test, in favor of using %threads_lib. The custom expansion used `-pthread` explicitly, which produced an unknown argument warning when running using the clang-cl driver.