### PR TITLE
[SYCL] Fix diagnostic about non-external function/variable

### DIFF
--- a/clang/include/clang/Basic/DiagnosticSemaKinds.td
+++ b/clang/include/clang/Basic/DiagnosticSemaKinds.td
@@ -12467,9 +12467,8 @@ def err_sycl_function_attribute_mismatch : Error<
 def err_sycl_x_y_z_arguments_must_be_one : Error<
   "all %0 attribute arguments must be '1' when the %1 attribute argument is '0'">;
 def err_sycl_attribute_internal_decl
-    : Error<"%0 attribute cannot be applied to a "
-            "static %select{function|variable}1 or %select{function|variable}1 "
-            "in an anonymous namespace">;
+    : Error<"%0 attribute cannot be applied to a %select{function|variable}1"
+            " without external linkage">;
 def err_sycl_attribute_not_device_global
     : Error<"%0 attribute can only be applied to 'device_global' variables">;
 def err_fpga_attribute_incorrect_variable

--- a/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
+++ b/clang/test/SemaSYCL/device-indirectly-callable-attr.cpp
@@ -12,15 +12,20 @@ int N;
 void
 bar() {}
 
-[[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a static function or function in an anonymous namespace}}
+[[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a function without external linkage}}
 static void
 func1() {}
 
 namespace {
-[[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a static function or function in an anonymous namespace}}
+[[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a function without external linkage}}
 void
 func2() {}
+
+struct UnnX {};
 }
+
+[[intel::device_indirectly_callable]] // expected-error {{'device_indirectly_callable' attribute cannot be applied to a function without external linkage}}
+void func4(UnnX) {}
 
 class A {
   [[intel::device_indirectly_callable]] A() {}

--- a/clang/test/SemaSYCL/device_global_external.cpp
+++ b/clang/test/SemaSYCL/device_global_external.cpp
@@ -5,7 +5,7 @@
 using namespace sycl::ext::oneapi;
 
 SYCL_EXTERNAL device_global<int> glob;
-// expected-error@+1{{'sycl_device' attribute cannot be applied to a static variable or variable in an anonymous namespace}}
+// expected-error@+1{{'sycl_device' attribute cannot be applied to a variable without external linkage}}
 SYCL_EXTERNAL static device_global<float> static_glob;
 
 namespace foo {
@@ -20,9 +20,14 @@ struct RandomStruct {
 SYCL_EXTERNAL RandomStruct S;
 
 namespace {
-// expected-error@+1{{'sycl_device' attribute cannot be applied to a static variable or variable in an anonymous namespace}}
+// expected-error@+1{{'sycl_device' attribute cannot be applied to a variable without external linkage}}
 SYCL_EXTERNAL device_global<int> same_name;
+
+struct UnnX {};
 } // namespace
+
+// expected-error@+1{{'sycl_device' attribute cannot be applied to a variable without external linkage}}
+SYCL_EXTERNAL device_global<UnnX> dg_x;
 
 // expected-error@+1{{'sycl_device' attribute can only be applied to 'device_global' variables}}
 SYCL_EXTERNAL int AAA;

--- a/clang/test/SemaSYCL/sycl-device.cpp
+++ b/clang/test/SemaSYCL/sycl-device.cpp
@@ -12,13 +12,18 @@ int N;
 __attribute__((sycl_device(3))) // expected-error {{'sycl_device' attribute takes no arguments}}
 void bar() {}
 
-__attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a static function or function in an anonymous namespace}}
+__attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a function without external linkage}}
 static void func1() {}
 
 namespace {
-  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a static function or function in an anonymous namespace}}
+  __attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a function without external linkage}}
   void func2() {}
+
+  struct UnnX {};
 }
+
+__attribute__((sycl_device)) // expected-error {{'sycl_device' attribute cannot be applied to a function without external linkage}}
+  void func4(UnnX) {}
 
 class A {
   __attribute__((sycl_device))


### PR DESCRIPTION
We were issuing a diagnostic when applying attributes like [[sycl_device]] or [[intel::device_indirectly_callable]] on functions/variables without external linkage - but the diagnostic text assumed that this occurred only with static entities or entities within unnamed namespaces.

The following example demonstrates a case where the previous diagnostic text was misleading:

```
namespace {
  struct S {};
}

[[sycl_device]] void foo(S);
```