### PR TITLE
[SYCL][COMPAT] Convert error names to lower case

### DIFF
--- a/sycl/doc/syclcompat/README.md
+++ b/sycl/doc/syclcompat/README.md
@@ -1544,10 +1544,10 @@ SYCL spec supported by the current SYCL compiler.
 
 The `SYCLCOMPAT_CHECK_ERROR` macro encapsulates an error-handling mechanism for
 expressions that might throw `sycl::exception` and `std::runtime_error`. If no
-exceptions are thrown, it returns `syclcompat::error_code::SUCCESS`. If a
-`sycl::exception` is caught, it returns `syclcompat::error_code::BACKEND_ERROR`.
+exceptions are thrown, it returns `syclcompat::error_code::success`. If a
+`sycl::exception` is caught, it returns `syclcompat::error_code::backend_error`.
 If a `std::runtime_error` exception is caught,
-`syclcompat::error_code::DEFAULT_ERROR` is returned instead. For both cases, it
+`syclcompat::error_code::default_error` is returned instead. For both cases, it
 prints the error message to the standard error stream.
 
 ``` c++
@@ -1580,7 +1580,7 @@ template <int Arg> class syclcompat_kernel_scalar;
 
 
 namespace syclcompat {
-enum error_code { SUCCESS = 0, BACKEND_ERROR = 1, DEFAULT_ERROR = 999 };
+enum error_code { success = 0, backend_error = 1, default_error = 999 };
 }
 
 #define SYCLCOMPAT_CHECK_ERROR(expr)

--- a/sycl/include/syclcompat/defs.hpp
+++ b/sycl/include/syclcompat/defs.hpp
@@ -67,19 +67,19 @@ template <int Arg> class syclcompat_kernel_scalar;
                           SYCLCOMPAT_PATCH_VERSION)
 
 namespace syclcompat {
-enum error_code { SUCCESS = 0, BACKEND_ERROR = 1, DEFAULT_ERROR = 999 };
+enum error_code { success = 0, backend_error = 1, default_error = 999 };
 }
 
 #define SYCLCOMPAT_CHECK_ERROR(expr)                                           \
   [&]() {                                                                      \
     try {                                                                      \
       expr;                                                                    \
-      return syclcompat::error_code::SUCCESS;                                  \
+      return syclcompat::error_code::success;                                  \
     } catch (sycl::exception const &e) {                                       \
       std::cerr << e.what() << std::endl;                                      \
-      return syclcompat::error_code::BACKEND_ERROR;                            \
+      return syclcompat::error_code::backend_error;                            \
     } catch (std::runtime_error const &e) {                                    \
       std::cerr << e.what() << std::endl;                                      \
-      return syclcompat::error_code::DEFAULT_ERROR;                            \
+      return syclcompat::error_code::default_error;                            \
     }                                                                          \
   }()

--- a/sycl/include/syclcompat/defs.hpp
+++ b/sycl/include/syclcompat/defs.hpp
@@ -56,7 +56,7 @@ template <int Arg> class syclcompat_kernel_scalar;
 #endif
 
 #define SYCLCOMPAT_MAJOR_VERSION 0
-#define SYCLCOMPAT_MINOR_VERSION 1
+#define SYCLCOMPAT_MINOR_VERSION 2
 #define SYCLCOMPAT_PATCH_VERSION 0
 
 #define SYCLCOMPAT_MAKE_VERSION(_major, _minor, _patch)                        \

--- a/sycl/test-e2e/syclcompat/defs.cpp
+++ b/sycl/test-e2e/syclcompat/defs.cpp
@@ -54,10 +54,10 @@ void test_check_error() {
     throw std::runtime_error("Expected invalid exception in test_check_error");
   };
 
-  assert(syclcompat::error_code::SUCCESS == SYCLCOMPAT_CHECK_ERROR());
-  assert(syclcompat::error_code::BACKEND_ERROR ==
+  assert(syclcompat::error_code::success == SYCLCOMPAT_CHECK_ERROR());
+  assert(syclcompat::error_code::backend_error ==
          SYCLCOMPAT_CHECK_ERROR(sycl_error_throw()));
-  assert(syclcompat::error_code::DEFAULT_ERROR ==
+  assert(syclcompat::error_code::default_error ==
          SYCLCOMPAT_CHECK_ERROR(runtime_error_throw()));
 }
 


### PR DESCRIPTION
This is done to avoid conflict with upper-case macros redefining e.g. `SUCCESS`. 

I'm also bumping to `0.2.0`.