### PR TITLE
[Extractor] Add quiet option to offload extractor

### DIFF
--- a/clang/tools/clang-offload-extract/ClangOffloadExtract.cpp
+++ b/clang/tools/clang-offload-extract/ClangOffloadExtract.cpp
@@ -62,6 +62,11 @@ to the stem:
       )"),
                  cl::cat(ClangOffloadExtractCategory));
 
+static cl::opt<bool>
+    Quiet("q", cl::init(false),
+          cl::desc(R"(Do not print the names of generated files)"),
+          cl::cat(ClangOffloadExtractCategory));
+
 // Create an alias for the deprecated option, so legacy use still works
 static cl::alias FileNameStemAlias(
     "output", cl::desc("Deprecated option, replaced by option '--stem'"),
@@ -262,8 +267,10 @@ linked fat binary, and store them in separate files.
     OffloadName.erase(0, OffloadPrefix.length());
 
     // Tell user that we are saving an image.
-    outs() << "Section '" + OffloadName + "': Image " << ImgCnt++
-           << "'-> File '" + FileName + "'\n";
+    if (!Quiet) {
+      outs() << "Section '" + OffloadName + "': Image " << ImgCnt++
+             << "'-> File '" + FileName + "'\n";
+    }
 
     // Write image data to the output
     std::error_code EC;


### PR DESCRIPTION
Add a "q" flag for clang-offload-extract that supresses printing. For use in cmake or script files that don't want to display the generated files.