### PR TITLE
[SYCL][E2E] Enable passing UNSUPPORTED:gpu tests

### DIFF
--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -4,8 +4,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: gpu
-
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -4,6 +4,9 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
+// See https://github.com/intel/llvm/issues/15398
+// UNSUPPORTED: gpu-intel-gen12
+
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.

--- a/sycl/test-e2e/Printf/mixed-address-space.cpp
+++ b/sycl/test-e2e/Printf/mixed-address-space.cpp
@@ -10,7 +10,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 
-// UNSUPPORTED: gpu
 // CHECK: Constant addrspace literal
 // CHECK: Generic addrspace literal
 

--- a/sycl/test-e2e/Printf/percent-symbol.cpp
+++ b/sycl/test-e2e/Printf/percent-symbol.cpp
@@ -14,9 +14,6 @@
 // RUN: %{build} -o %t.constant.out -DTEST_CONSTANT_AS
 // RUN: %{run} %t.constant.out | FileCheck %s
 //
-// FIXME: Enable on GPU once %% conversion is supported there
-// UNSUPPORTED: gpu
-//
 // CHECK: %c %s %d %i %o %x %X %u
 // CHECK-NEXT: %f %F %e %E %a %A %g %G %n %p
 

--- a/sycl/test-e2e/USM/align.cpp
+++ b/sycl/test-e2e/USM/align.cpp
@@ -1,15 +1,6 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: gpu
-
-// E2E tests for annotated USM allocation functions with alignment arguments
-// that are not powers of 2. Note this test does not work on gpu because some
-// tests expect non-templated aligned_alloc_xxx functions to return nullptr,
-// e.g. when the alignment argument is not a power of 2, while they fail to do
-// so when run on gpu. This maybe because the gpu runtime has different
-// behavior. Therefore, GPU is unsupported until issue #12638 gets resolved.
-
 #include <sycl/detail/core.hpp>
 #include <sycl/usm.hpp>
 


### PR DESCRIPTION
This commit enables a selection of tests with UNSUPPORTED:gpu that seems to have been fixed since their disablement.

Additionally, it restricts expected failure of image_array to just Gen12, with tracker https://github.com/intel/llvm/issues/15398.