### PR TITLE
[SYCL][ESIMD][E2E] Fix memleak in copyto_copyfrom USM tests

### DIFF
--- a/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/copyto_copyfrom.hpp
+++ b/sycl/test-e2e/ESIMD/unified_memory_api/Inputs/copyto_copyfrom.hpp
@@ -83,6 +83,7 @@ bool testUSM(queue Q, uint32_t Groups, uint32_t Threads,
 
   bool Passed = verify(Out, Size, N);
 
+  sycl::free(In, Q);
   sycl::free(Out, Q);
 
   return Passed;


### PR DESCRIPTION
Easy fix, verified with UR_L0_LEAKS_DEBUG=1