### PR TITLE
[NFC] Ensure only one SPV file is generated in bitreverse lowering tests

### DIFF
--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -8,8 +8,9 @@
 // Ensure that SPV_KHR_bit_instructions is disabled so that translator
 // will lower llvm.bitreverse.* intrinsics instead of relying on SPIRV
 // BitReverse instruction.
-// Also build executable with SPV dump.
-// RUN: %{build} -Wno-error=psabi -Wno-error=constant-conversion -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir
+// Also build executable with SPV dump.  Use -fno-sycl-allow-device-dependencies to
+// ensure that only one SPV file is generated.
+// RUN: %{build} -Wno-error=psabi -Wno-error=constant-conversion -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir -fno-sycl-allow-device-dependencies
 
 // Rename SPV file to explictly known filename.
 // RUN: mv %t.spvdir/*.spv %t.spvdir/dump.spv

--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -13,8 +13,9 @@
 // Ensure that SPV_KHR_bit_instructions is disabled so that translator
 // will lower llvm.bitreverse.* intrinsics instead of relying on SPIRV
 // BitReverse instruction.
-// Also build executable with SPV dump.
-// RUN: %{build} -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir
+// Also build executable with SPV dump.  Use -fno-sycl-allow-device-dependencies to
+// ensure that only one SPV file is generated.
+// RUN: %{build} -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir -fno-sycl-allow-device-dependencies
 
 // Rename SPV file to explictly known filename.
 // RUN: mv %t.spvdir/*.spv %t.spvdir/dump.spv


### PR DESCRIPTION
Bitreverse lowering tests check a SPV file to ensure that SPIRV bitreverse insn is not used.
Ensure that only one SPV file is generated to facilitate SPV file checking.  Use -fno-sycl-allow-device-dependencies
to ensure only one file is generated.