### PR TITLE
[SYCL] Deprecate old `sycl_ext_oneapi_group_load_store`

### DIFF
--- a/sycl/doc/extensions/deprecated/sycl_ext_oneapi_group_load_store.asciidoc
+++ b/sycl/doc/extensions/deprecated/sycl_ext_oneapi_group_load_store.asciidoc
@@ -23,12 +23,8 @@ NOTE: Khronos(R) is a registered trademark and SYCL(TM) and SPIR(TM) are
 trademarks of The Khronos Group Inc.  OpenCL(TM) is a trademark of Apple Inc.
 used by permission by Khronos.
 
-NOTE: This extension is experimental: interfaces are subject to change later.
-
-NOTE: This extension documents functionality that predates SYCL 2020's formal
-extension mechanism. Work is underway to align the extension with SYCL 2020;
-the documentation in its current state does not reflect the intended long-term
-direction of the extension.
+NOTE: This extension has been replaced with a new version under the same name
+that completely changed the interfaces.
 
 == Notice
 

--- a/sycl/include/sycl/sub_group.hpp
+++ b/sycl/include/sycl/sub_group.hpp
@@ -209,6 +209,7 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
   // Method for decorated pointer
   template <typename CVT, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<!std::is_same<remove_decoration_t<T>, T>::value, T>
   load(CVT *cv_src) const {
     T *src = const_cast<T *>(cv_src);
@@ -219,6 +220,7 @@ struct sub_group {
 
   // Method for raw pointer
   template <typename CVT, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<std::is_same<remove_decoration_t<T>, T>::value, T>
   load(CVT *cv_src) const {
     T *src = const_cast<T *>(cv_src);
@@ -240,6 +242,7 @@ struct sub_group {
   }
 #else  //__SYCL_DEVICE_ONLY__
   template <typename CVT, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   T load(CVT *src) const {
     (void)src;
     throw sycl::exception(make_error_code(errc::feature_not_supported),
@@ -249,6 +252,7 @@ struct sub_group {
 
   template <typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value, T>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
@@ -269,6 +273,7 @@ struct sub_group {
 
   template <typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value, T>
   load(const multi_ptr<CVT, Space, IsDecorated> cv_src) const {
@@ -286,6 +291,7 @@ struct sub_group {
 #if defined(__NVPTX__) || defined(__AMDGCN__)
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value,
       vec<T, N>>
@@ -301,6 +307,7 @@ struct sub_group {
 #else  // __NVPTX__ || __AMDGCN__
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N != 1 && N != 3 && N != 16,
@@ -313,6 +320,7 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 16,
@@ -327,6 +335,7 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 3,
@@ -341,6 +350,7 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
           N == 1,
@@ -354,6 +364,7 @@ struct sub_group {
 #else  // __SYCL_DEVICE_ONLY__
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value,
       vec<T, N>>
@@ -366,6 +377,7 @@ struct sub_group {
 
   template <int N, typename CVT, access::address_space Space,
             access::decorated IsDecorated, typename T = std::remove_cv_t<CVT>>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_load instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value,
       vec<T, N>>
@@ -388,6 +400,7 @@ struct sub_group {
 #ifdef __SYCL_DEVICE_ONLY__
   // Method for decorated pointer
   template <typename T>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<!std::is_same<remove_decoration_t<T>, T>::value>
   store(T *dst, const remove_decoration_t<T> &x) const {
     store(sycl::multi_ptr<remove_decoration_t<T>,
@@ -398,6 +411,7 @@ struct sub_group {
 
   // Method for raw pointer
   template <typename T>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<std::is_same<remove_decoration_t<T>, T>::value>
   store(T *dst, const remove_decoration_t<T> &x) const {
 
@@ -421,7 +435,9 @@ struct sub_group {
 #endif // __NVPTX__ || __AMDGCN__
   }
 #else  //__SYCL_DEVICE_ONLY__
-  template <typename T> void store(T *dst, const T &x) const {
+  template <typename T>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
+  void store(T *dst, const T &x) const {
     (void)dst;
     (void)x;
     throw sycl::exception(make_error_code(errc::feature_not_supported),
@@ -431,6 +447,7 @@ struct sub_group {
 
   template <typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const T &x) const {
@@ -450,6 +467,7 @@ struct sub_group {
 
   template <typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const T &x) const {
@@ -467,6 +485,7 @@ struct sub_group {
 #if defined(__NVPTX__) || defined(__AMDGCN__)
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {
@@ -477,6 +496,7 @@ struct sub_group {
 #else // __NVPTX__ || __AMDGCN__
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N != 1 && N != 3 && N != 16>
@@ -486,6 +506,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N == 1>
@@ -495,6 +516,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N == 3>
@@ -506,6 +528,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value &&
       N == 16>
@@ -519,6 +542,7 @@ struct sub_group {
 #else  // __SYCL_DEVICE_ONLY__
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForGlobalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {
@@ -531,6 +555,7 @@ struct sub_group {
 
   template <int N, typename T, access::address_space Space,
             access::decorated DecorateAddress>
+  __SYCL_DEPRECATED("Use sycl::ext::oneapi::experimental::group_store instead.")
   std::enable_if_t<
       sycl::detail::sub_group::AcceptableForLocalLoadStore<T, Space>::value>
   store(multi_ptr<T, Space, DecorateAddress> dst, const vec<T, N> &x) const {

--- a/sycl/test-e2e/InvokeSimd/Feature/popcnt_emu.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/popcnt_emu.cpp
@@ -36,6 +36,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -126,9 +127,9 @@ int main(void) {
             } else {
               res = id % 2;
             }
-            sg.store(out_accessor.get_multi_ptr<access::decorated::yes>() +
-                         offset,
-                     res);
+            group_store(sg, res,
+                        out_accessor.get_multi_ptr<access::decorated::yes>() +
+                            offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
@@ -102,9 +102,11 @@ template <class T, class QueueTY> bool test(QueueTY q) {
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
 
-            T va = sg.load(
-                acca.template get_multi_ptr<access::decorated::yes>().get() +
-                offset);
+            T va;
+            group_load(sg,
+                       acca.template get_multi_ptr<access::decorated::yes>() +
+                           offset,
+                       va);
             T vc = invoke_simd(sg, SIMD_CALLEE_scale<T>, va, uniform{n});
             group_store(
                 sg, vc,

--- a/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/scale.cpp
@@ -23,6 +23,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -105,10 +106,10 @@ template <class T, class QueueTY> bool test(QueueTY q) {
                 acca.template get_multi_ptr<access::decorated::yes>().get() +
                 offset);
             T vc = invoke_simd(sg, SIMD_CALLEE_scale<T>, va, uniform{n});
-            sg.store(
+            group_store(
+                sg, vc,
                 accc.template get_multi_ptr<access::decorated::yes>().get() +
-                    offset,
-                vc);
+                    offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Feature/void_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Feature/void_retval.cpp
@@ -22,6 +22,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -102,10 +103,9 @@ int main(void) {
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vb = sg.load(
-                PB.get_multi_ptr<access::decorated::yes>().get() + offset);
+            float va, vb;
+            group_load(sg, PA.get_multi_ptr<access::decorated::yes>().get() + offset, va);
+            group_load(sg, PB.get_multi_ptr<access::decorated::yes>().get() + offset, vb);
             // We need to get a pointer to the starting address of where the
             // result of the vector addition should be stored in/written back to
             // C. Returns the index (ordinal number) of the work-group to which

--- a/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_spill.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/call_vadd_1d_spill.cpp
@@ -17,6 +17,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -108,22 +109,22 @@ bool test(QueueTY q, float *A, float *B, float *C, float *P, float *Q, float *R,
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vb = sg.load(
-                PB.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vp = sg.load(
-                PP.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vq = sg.load(
-                PQ.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vr = sg.load(
-                PR.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vx = sg.load(
-                PX.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vy = sg.load(
-                PY.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vz = sg.load(
-                PZ.get_multi_ptr<access::decorated::yes>().get() + offset);
+            auto Load = [&](auto Acc) {
+              float res;
+              group_load(sg,
+                         Acc.template get_multi_ptr<access::decorated::yes>() +
+                             offset,
+                         res);
+              return res;
+            };
+            float va = Load(PA);
+            float vb = Load(PB);
+            float vp = Load(PP);
+            float vq = Load(PQ);
+            float vr = Load(PR);
+            float vx = Load(PX);
+            float vy = Load(PY);
+            float vz = Load(PZ);
 
             float vc;
 
@@ -134,8 +135,9 @@ bool test(QueueTY q, float *A, float *B, float *C, float *P, float *Q, float *R,
               vc = SPMD_CALLEE_doVadd(va, vb, vx, vy, vx, vy, vx, vy, vx, vy,
                                       vp, vq, vr, vz);
             }
-            sg.store(PC.get_multi_ptr<access::decorated::yes>().get() + offset,
-                     vc);
+            group_store(sg, vc,
+                        PC.get_multi_ptr<access::decorated::yes>().get() +
+                            offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
+++ b/sycl/test-e2e/InvokeSimd/Regression/debug_symbols.cpp
@@ -12,6 +12,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -84,18 +85,16 @@ int main(void) {
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vb = sg.load(
-                PB.get_multi_ptr<access::decorated::yes>().get() + offset);
+            float va, vb;
+            group_load(sg, PA.get_multi_ptr<access::decorated::yes>().get() + offset, va);
+            group_load(sg, PB.get_multi_ptr<access::decorated::yes>().get() + offset, vb);
 
             // Invoke SIMD function:
             // va values from each work-item are combined into a simd<float,
             // VL>. vb values from each work-item are combined into a
             // simd<float, VL>.
             float vc = invoke_simd(sg, SIMD_CALLEE_doVadd, va, vb);
-            sg.store(PC.get_multi_ptr<access::decorated::yes>().get() + offset,
-                     vc);
+            group_store(sg, vc, PC.get_multi_ptr<access::decorated::yes>() + offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Spec/ESIMD_to_unmarked_function.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/ESIMD_to_unmarked_function.cpp
@@ -30,6 +30,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -118,19 +119,16 @@ int main(void) {
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vb = sg.load(
-                PB.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vc;
+            float va, vb, vc;
+            group_load(sg, PA.get_multi_ptr<access::decorated::yes>() + offset, va);
+            group_load(sg, PB.get_multi_ptr<access::decorated::yes>() + offset, vb);
 
             if constexpr (use_invoke_simd) {
               vc = invoke_simd(sg, SIMD_CALLEE_doVadd, va, vb);
             } else {
               vc = doVadd(va, vb);
             }
-            sg.store(PC.get_multi_ptr<access::decorated::yes>().get() + offset,
-                     vc);
+            group_store(sg, vc, PC.get_multi_ptr<access::decorated::yes>() + offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Spec/function_overloads.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/function_overloads.cpp
@@ -24,6 +24,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -115,9 +116,8 @@ int main(void) {
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vc;
+            float va, vc;
+            group_load(sg, PA.get_multi_ptr<access::decorated::yes>() + offset, va);
 
             // Invoke SIMD function:
             if constexpr (scale_scalar)
@@ -129,8 +129,8 @@ int main(void) {
                   simd<float, VL>, simd<float, VL>)>(sg, SIMD_CALLEE_scale, va,
                                                      n);
 
-            sg.store(PC.get_multi_ptr<access::decorated::yes>().get() + offset,
-                     vc);
+            group_store(sg, vc,
+                        PC.get_multi_ptr<access::decorated::yes>() + offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Spec/nested_ESIMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/nested_ESIMD_to_ESIMD.cpp
@@ -17,6 +17,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -102,19 +103,17 @@ int main(void) {
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vb = sg.load(
-                PB.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vc;
+            float va, vb, vc;
+            group_load(sg, PA.get_multi_ptr<access::decorated::yes>() + offset, va);
+            group_load(sg, PB.get_multi_ptr<access::decorated::yes>() + offset, vb);
 
             if constexpr (use_invoke_simd) {
               vc = invoke_simd(sg, SIMD_CALLEE_doVadd, va, vb);
             } else {
               vc = SPMD_CALLEE_doVadd(va, vb);
             }
-            sg.store(PC.get_multi_ptr<access::decorated::yes>().get() + offset,
-                     vc);
+            group_store(sg, vc,
+                        PC.get_multi_ptr<access::decorated::yes>() + offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Spec/nested_SPMD_to_ESIMD.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/nested_SPMD_to_ESIMD.cpp
@@ -16,6 +16,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -107,19 +108,17 @@ int main(void) {
 
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
-            float va = sg.load(
-                PA.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vb = sg.load(
-                PB.get_multi_ptr<access::decorated::yes>().get() + offset);
-            float vc;
+            float va, vb, vc;
+            group_load(sg, PA.get_multi_ptr<access::decorated::yes>() + offset, va);
+            group_load(sg, PB.get_multi_ptr<access::decorated::yes>() + offset, vb);
 
             if constexpr (use_invoke_simd) {
               vc = nested_SPMD_to_ESIMD(sg, va, vb);
             } else {
               vc = SPMD_CALLEE_doVadd(va, vb);
             }
-            sg.store(PC.get_multi_ptr<access::decorated::yes>().get() + offset,
-                     vc);
+            group_store(sg, vc,
+                        PC.get_multi_ptr<access::decorated::yes>() + offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/uniform_retval.cpp
@@ -49,6 +49,7 @@
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
 
 #include <functional>
@@ -171,10 +172,11 @@ template <class T, bool return_SIMD, class QueueTY> bool test(QueueTY q) {
             unsigned int offset = g.get_group_id() * g.get_local_range() +
                                   sg.get_group_id() * sg.get_max_local_range();
 
-            T va = sg.load(
-                acca.template get_multi_ptr<access::decorated::yes>().get() +
-                offset);
-            T vc;
+            T va, vc;
+            group_load(sg,
+                       acca.template get_multi_ptr<access::decorated::yes>() +
+                           offset,
+                       va);
 
             if constexpr (return_SIMD)
               vc = invoke_simd(sg, SIMD_CALLEE_return_uniform_SIMD<T>, va,
@@ -183,10 +185,9 @@ template <class T, bool return_SIMD, class QueueTY> bool test(QueueTY q) {
               vc = invoke_simd(sg, SIMD_CALLEE_return_uniform_scalar<T>, va,
                                uniform{n});
 
-            sg.store(
-                accc.template get_multi_ptr<access::decorated::yes>().get() +
-                    offset,
-                vc);
+            group_store(sg, vc,
+                        accc.template get_multi_ptr<access::decorated::yes>() +
+                            offset);
           });
     });
     e.wait();

--- a/sycl/test-e2e/Matrix/slm_utils.hpp
+++ b/sycl/test-e2e/Matrix/slm_utils.hpp
@@ -5,6 +5,9 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+#include <sycl/ext/oneapi/experimental/group_load_store.hpp>
+
 template <unsigned int colsA, unsigned int colsB, unsigned int MCache2,
           unsigned int NCache2, unsigned int KCache2, unsigned int vnniFactor,
           size_t SGs, typename TOperand, access::address_space space>
@@ -14,6 +17,7 @@ slm_read_write(multi_ptr<TOperand, space, access::decorated::yes> pA,
                local_accessor<TOperand, 2> tileA,
                local_accessor<TOperand, 2> tileB, sub_group sg, unsigned int k2,
                size_t m2, size_t n2, size_t sgSize) {
+  using namespace sycl::ext::oneapi::experimental;
   // Number of elements to be loaded into SLM per WI
   size_t elemsPerLoadA = KCache2 / sgSize;
   for (int i = 0; i < MCache2 / SGs; i++) {
@@ -22,22 +26,22 @@ slm_read_write(multi_ptr<TOperand, space, access::decorated::yes> pA,
         k2 * KCache2;
     size_t LocOffsetA = (sg.get_group_id() * (MCache2 / SGs) + i) * KCache2;
 
-    if (elemsPerLoadA == 2) {
-      vec<TOperand, 2> slmVecA = sg.load<2>(pA + GlOffsetA);
-      sg.store<2>(tileA.template get_multi_ptr<sycl::access::decorated::no>() +
-                      LocOffsetA,
-                  slmVecA);
-    } else if (elemsPerLoadA == 4) {
-      vec<TOperand, 4> slmVecA = sg.load<4>(pA + GlOffsetA);
-      sg.store<4>(tileA.template get_multi_ptr<sycl::access::decorated::no>() +
-                      LocOffsetA,
-                  slmVecA);
-    } else if (elemsPerLoadA == 1) {
-      TOperand slmScaA = sg.load(pA + GlOffsetA);
+    auto SrcA = pA + GlOffsetA;
+    auto DstA = tileA.template get_multi_ptr<sycl::access::decorated::no>() +
+                LocOffsetA;
 
-      sg.store(tileA.template get_multi_ptr<sycl::access::decorated::no>() +
-                   LocOffsetA,
-               slmScaA);
+    if (elemsPerLoadA == 2) {
+      vec<TOperand, 2> slmVecA;
+      group_load(sg, SrcA, slmVecA, properties(data_placement_striped));
+      group_store(sg, slmVecA, DstA, properties(data_placement_striped));
+    } else if (elemsPerLoadA == 4) {
+      vec<TOperand, 4> slmVecA;
+      group_load(sg, SrcA, slmVecA, properties(data_placement_striped));
+      group_store(sg, slmVecA, DstA, properties(data_placement_striped));
+    } else if (elemsPerLoadA == 1) {
+      vec<TOperand, 1> slmVecA;
+      group_load(sg, SrcA, slmVecA, properties(data_placement_striped));
+      group_store(sg, slmVecA, DstA, properties(data_placement_striped));
     } else
       assert(elemsPerLoadA == 1 || elemsPerLoadA == 2 || elemsPerLoadA == 4);
   }
@@ -53,18 +57,17 @@ slm_read_write(multi_ptr<TOperand, space, access::decorated::yes> pA,
   size_t LocOffsetB =
       ((uint)(sg.get_group_id() / sgsPerRow)) * NCache2 * vnniFactor +
       (sg.get_group_id() % sgsPerRow) * elemsPerLoadB * sgSize;
+  auto SrcB = pB + GlOffsetB;
+  auto DstB =
+      tileB.template get_multi_ptr<sycl::access::decorated::no>() + LocOffsetB;
   if (elemsPerLoadB == 16) {
-    vec<TOperand, 16> slmVecB = sg.load<16>(pB + GlOffsetB);
-
-    sg.store<16>(tileB.template get_multi_ptr<sycl::access::decorated::no>() +
-                     LocOffsetB,
-                 slmVecB);
+    vec<TOperand, 16> slmVecB;
+    group_load(sg, SrcB, slmVecB, properties(data_placement_striped));
+    group_store(sg, slmVecB, DstB, properties(data_placement_striped));
   } else if (elemsPerLoadB == 8) {
-    vec<TOperand, 8> slmVecB = sg.load<8>(pB + GlOffsetB);
-
-    sg.store<8>(tileB.template get_multi_ptr<sycl::access::decorated::no>() +
-                    LocOffsetB,
-                slmVecB);
+    vec<TOperand, 8> slmVecB;
+    group_load(sg, SrcB, slmVecB, properties(data_placement_striped));
+    group_store(sg, slmVecB, DstB, properties(data_placement_striped));
   } else
     assert(elemsPerLoadB == 8 || elemsPerLoadB == 16);
 }

--- a/sycl/test-e2e/SubGroup/sub_group_as.cpp
+++ b/sycl/test-e2e/SubGroup/sub_group_as.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
 //
 // RUN: %{build} -DUSE_DEPRECATED_LOCAL_ACC -o %t.out -Wno-deprecated-declarations

--- a/sycl/test-e2e/SubGroup/sub_group_as_vec.cpp
+++ b/sycl/test-e2e/SubGroup/sub_group_as_vec.cpp
@@ -1,7 +1,7 @@
-// RUN: %{build} -o %t.out
+// RUN: %{build} -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
 //
-// RUN: %{build} -DUSE_DEPRECATED_LOCAL_ACC -o %t.out
+// RUN: %{build} -DUSE_DEPRECATED_LOCAL_ACC -o %t.out -Wno-deprecated-declarations
 // RUN: %{run} %t.out
 
 #include "helper.hpp"

--- a/sycl/test/warnings/deprecated_group_load_store.cpp
+++ b/sycl/test/warnings/deprecated_group_load_store.cpp
@@ -1,0 +1,35 @@
+// Ignore unexpected warnings because for some reason FE emits the warning
+// twice, once for `load`, then for `load<template-params>`.
+// RUN: %clangxx -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=warning,note %s -o %t.out
+
+#include <sycl/sycl.hpp>
+
+SYCL_EXTERNAL auto test_load(sycl::sub_group sg, int *p) {
+  // expected-warning@+1 {{'load' is deprecated: Use sycl::ext::oneapi::experimental::group_load instead.}}
+  return sg.load(p);
+}
+
+SYCL_EXTERNAL auto test_load(sycl::sub_group sg, sycl::decorated_global_ptr<int> p) {
+  // expected-warning@+1 {{'load' is deprecated: Use sycl::ext::oneapi::experimental::group_load instead.}}
+  return sg.load(p);
+}
+
+SYCL_EXTERNAL auto test_vec_load(sycl::sub_group sg, sycl::decorated_global_ptr<int> p) {
+  // expected-warning@+1 {{'load' is deprecated: Use sycl::ext::oneapi::experimental::group_load instead.}}
+  return sg.load<4>(p);
+}
+
+SYCL_EXTERNAL auto test_store(sycl::sub_group sg, int *p) {
+  // expected-warning@+1 {{'store' is deprecated: Use sycl::ext::oneapi::experimental::group_store instead.}}
+  return sg.store(p, 42);
+}
+
+SYCL_EXTERNAL auto test_vec_store(sycl::sub_group sg, sycl::decorated_global_ptr<int> p) {
+  // expected-warning@+1 {{'store' is deprecated: Use sycl::ext::oneapi::experimental::group_store instead.}}
+  return sg.store(p, 42);
+}
+
+SYCL_EXTERNAL auto test_vec_store(sycl::sub_group sg, sycl::decorated_global_ptr<int> p, sycl::vec<int, 4> v) {
+  // expected-warning@+1 {{'store' is deprecated: Use sycl::ext::oneapi::experimental::group_store instead.}}
+  return sg.store(p, v);
+}


### PR DESCRIPTION
Newer version is under `proposed/`, I'm going to move it to `experimental/` in a separate PR for a cleaner `git diff`.