### PR TITLE
[SYCL] Fix in-order queue dependencies for no scheduler path

### DIFF
--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -229,7 +229,8 @@ static std::string commandToName(Command::CommandType Type) {
 #endif
 
 std::vector<ur_event_handle_t>
-Command::getUrEvents(const std::vector<EventImplPtr> &EventImpls, const QueueImplPtr& CommandQueue, bool IsHostTaskCommand) {
+Command::getUrEvents(const std::vector<EventImplPtr> &EventImpls,
+                     const QueueImplPtr &CommandQueue, bool IsHostTaskCommand) {
   std::vector<ur_event_handle_t> RetUrEvents;
   for (auto &EventImpl : EventImpls) {
     auto Handle = EventImpl->getHandle();
@@ -873,7 +874,7 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
 #endif
   // Exit if already enqueued
   if (MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess)
-    return true; 
+    return true;
 
   // If the command is blocked from enqueueing
   if (MIsBlockable && MEnqueueStatus == EnqueueResultT::SyclEnqueueBlocked) {

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -2864,7 +2864,6 @@ ur_result_t ExecCGCommand::enqueueImpCommandBuffer() {
 }
 
 ur_result_t ExecCGCommand::enqueueImp() {
-   std::cout <<"cgTypeToString = " << cgTypeToString(MCommandGroup->getType()) <<std::endl;
   if (MCommandBuffer) {
     return enqueueImpCommandBuffer();
   } else {

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -873,9 +873,7 @@ bool Command::enqueue(EnqueueResultT &EnqueueResult, BlockingT Blocking,
 #endif
   // Exit if already enqueued
   if (MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess)
-    return true;
-
- 
+    return true; 
 
   // If the command is blocked from enqueueing
   if (MIsBlockable && MEnqueueStatus == EnqueueResultT::SyclEnqueueBlocked) {
@@ -2573,8 +2571,6 @@ void enqueueImpKernel(
 
   std::shared_ptr<kernel_impl> SyclKernelImpl;
   std::shared_ptr<device_image_impl> DeviceImageImpl;
-
-  
 
   // Use kernel_bundle if available unless it is interop.
   // Interop bundles can't be used in the first branch, because the kernels

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -242,7 +242,8 @@ public:
   getUrEvents(const std::vector<EventImplPtr> &EventImpls) const;
 
   static std::vector<ur_event_handle_t>
-  getUrEvents(const std::vector<EventImplPtr> &EventImpls, const QueueImplPtr& CommandQueue, bool IsHostTaskCommand);
+  getUrEvents(const std::vector<EventImplPtr> &EventImpls,
+              const QueueImplPtr &CommandQueue, bool IsHostTaskCommand);
   /// Collect UR events from EventImpls and filter out some of them in case of
   /// in order queue. Does blocking enqueue if event is expected to produce ur
   /// event but has empty native handle.

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -240,6 +240,9 @@ public:
   /// in order queue
   std::vector<ur_event_handle_t>
   getUrEvents(const std::vector<EventImplPtr> &EventImpls) const;
+
+  static std::vector<ur_event_handle_t>
+  getUrEvents(const std::vector<EventImplPtr> &EventImpls, const QueueImplPtr& CommandQueue, bool IsHostTaskCommand);
   /// Collect UR events from EventImpls and filter out some of them in case of
   /// in order queue. Does blocking enqueue if event is expected to produce ur
   /// event but has empty native handle.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -258,8 +258,7 @@ event handler::finalize() {
       // the graph is not changed, then this faster path is used to submit
       // kernel bypassing scheduler and avoiding CommandGroup, Command objects
       // creation.
-
-      std::vector<ur_event_handle_t> RawEvents;
+      std::vector<ur_event_handle_t> RawEvents = detail::Command::getUrEvents(impl->CGData.MEvents, MQueue, false);
       detail::EventImplPtr NewEvent;
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -258,7 +258,8 @@ event handler::finalize() {
       // the graph is not changed, then this faster path is used to submit
       // kernel bypassing scheduler and avoiding CommandGroup, Command objects
       // creation.
-      std::vector<ur_event_handle_t> RawEvents = detail::Command::getUrEvents(impl->CGData.MEvents, MQueue, false);
+      std::vector<ur_event_handle_t> RawEvents =
+          detail::Command::getUrEvents(impl->CGData.MEvents, MQueue, false);
       detail::EventImplPtr NewEvent;
 
 #ifdef XPTI_ENABLE_INSTRUMENTATION

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -143,11 +143,11 @@ TEST_F(SchedulerTest, TwoInOrderQueuesOnSameContext) {
 
   context Ctx{Plt};
   queue InOrderQueueFirst{Ctx, default_selector_v, property::queue::in_order()};
-  queue InOrderQueueSecond{Ctx, default_selector_v, property::queue::in_order()};
+  queue InOrderQueueSecond{Ctx, default_selector_v,
+                           property::queue::in_order()};
 
-  event EvFirst = InOrderQueueFirst.submit([&](sycl::handler &CGH) {
-    CGH.single_task<TestKernel<>>([] {});
-  });
+  event EvFirst = InOrderQueueFirst.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel<>>([] {}); });
   std::ignore = InOrderQueueSecond.submit([&](sycl::handler &CGH) {
     CGH.depends_on(EvFirst);
     CGH.single_task<TestKernel<>>([] {});
@@ -172,9 +172,8 @@ TEST_F(SchedulerTest, InOrderQueueNoSchedulerPath) {
   context Ctx{Plt};
   queue InOrderQueue{Ctx, default_selector_v, property::queue::in_order()};
 
-  event EvFirst = InOrderQueue.submit([&](sycl::handler &CGH) {
-    CGH.single_task<TestKernel<>>([] {});
-  });
+  event EvFirst = InOrderQueue.submit(
+      [&](sycl::handler &CGH) { CGH.single_task<TestKernel<>>([] {}); });
   std::ignore = InOrderQueue.submit([&](sycl::handler &CGH) {
     // even adding explicit dependency
     CGH.depends_on(EvFirst);

--- a/sycl/unittests/scheduler/InOrderQueueDeps.cpp
+++ b/sycl/unittests/scheduler/InOrderQueueDeps.cpp
@@ -175,7 +175,6 @@ TEST_F(SchedulerTest, InOrderQueueNoSchedulerPath) {
   event EvFirst = InOrderQueue.submit(
       [&](sycl::handler &CGH) { CGH.single_task<TestKernel<>>([] {}); });
   std::ignore = InOrderQueue.submit([&](sycl::handler &CGH) {
-    // even adding explicit dependency
     CGH.depends_on(EvFirst);
     CGH.single_task<TestKernel<>>([] {});
   });
@@ -184,7 +183,8 @@ TEST_F(SchedulerTest, InOrderQueueNoSchedulerPath) {
 
   ASSERT_EQ(KernelEventListSize.size(), 2u);
   EXPECT_EQ(KernelEventListSize[0] /*EventsCount*/, 0u);
-  // no deps is passed to backend even when explicit dependency specified
+  // native device events for device kernel submitted to the same in-order queue
+  // don't need to be explicitly passed as dependencies
   EXPECT_EQ(KernelEventListSize[1] /*EventsCount*/, 0u);
 }
 


### PR DESCRIPTION
Runtime could submit kernel directly to scheduler if no buffers/streams are used and if event dependencies are already handled by queue (in case if it is in-order one). Although check if dependencies are submitted to the same queue was missed. Now we add events submitted to another queue but on the same context to event list in kernel launching.