### PR TITLE
[SYCL][E2E] Redisable image_array test for all GPUs

### DIFF
--- a/sycl/test-e2e/Basic/image/image_array.cpp
+++ b/sycl/test-e2e/Basic/image/image_array.cpp
@@ -5,7 +5,7 @@
 // RUN: %{run} %t.out
 
 // See https://github.com/intel/llvm/issues/15398
-// UNSUPPORTED: gpu-intel-gen12
+// UNSUPPORTED: gpu
 
 //==------------------- image.cpp - SYCL image basic test -----------------==//
 //


### PR DESCRIPTION
https://github.com/intel/llvm/pull/15391 enabled the image_array test for all other GPU devices than Gen12. However, in post-commit the test seems to fail on arc sporadically. As such this commit disables it again.