### PR TITLE
[SYCL][NFC] Temporarily disable Driver/sycl.c test on Windows

### DIFF
--- a/clang/test/Driver/sycl.c
+++ b/clang/test/Driver/sycl.c
@@ -1,3 +1,6 @@
+// Failing on Windows - temporarily disable
+// REQUIRES: system-linux
+
 // RUN: %clang -### -fsycl -c %s 2>&1 | FileCheck %s --check-prefix=ENABLED
 // RUN: %clang -### -fsycl %s 2>&1 | FileCheck %s --check-prefix=ENABLED
 // RUN: %clang -### -fno-sycl -fsycl %s 2>&1 | FileCheck %s --check-prefix=ENABLED


### PR DESCRIPTION
Test is failing - disable for now until we can find a fix.