### PR TITLE
[SYCL][E2E] Remove deprecated use of `accessor::get_pointer` 

### DIFF
--- a/sycl/test-e2e/Basic/offset-accessor-get_pointer.cpp
+++ b/sycl/test-e2e/Basic/offset-accessor-get_pointer.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
+// RUN: %{build} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t.out
 // RUN: %{run} %t.out
 
 // Per the SYCL 2020 spec (4.7.6.12 and others)

--- a/sycl/test-e2e/DiscardEvents/discard_events_accessors.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_accessors.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
+// RUN: %{build} -o %t.out
 //
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out &> %t.txt ; FileCheck %s --input-file %t.txt
 //
@@ -60,7 +60,7 @@ int main(int Argc, const char *Argv[]) {
       CGH.parallel_for<class kernel_using_local_memory>(
           NDRange, [=](sycl::nd_item<1> ndi) {
             size_t i = ndi.get_global_id(0);
-            int *Ptr = LocalAcc.get_pointer();
+            int *Ptr = LocalAcc.get_multi_ptr<access::decorated::no>().get();
             Ptr[i] = i + 5;
             Harray[i] = Ptr[i] + 5;
           });

--- a/sycl/test-e2e/GroupAlgorithm/different_types.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/different_types.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} -Wno-error=deprecated-declarations -fsycl-device-code-split=per_kernel -I . -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -I . -o %t.out
 // RUN: %{run} %t.out
 
 #include "../helpers.hpp"
@@ -28,8 +28,10 @@ void test(queue &q, const InputContainer &input, InitT init,
       const auto g = it.get_group();
       const auto sg = it.get_sub_group();
       const auto idx = it.get_local_id();
-      const auto begin = a_in.get_pointer();
-      const auto end = a_in.get_pointer() + N;
+      const auto begin =
+          a_in.template get_multi_ptr<access::decorated::no>().get();
+      const auto end =
+          a_in.template get_multi_ptr<access::decorated::no>().get() + N;
 
       a_reduce_out[0] = reduce_over_group(g, a_in[idx], init, binary_op);
       a_reduce_out[1] = joint_reduce(g, begin, end, init, binary_op);


### PR DESCRIPTION
- replaced with `get_multi_ptr().get()` in `DiscardEvents/discard_events_accessors.cpp` and `GroupAlgorithm/different_types.cpp`
- Use `-DSYCL2020_DISABLE_DEPRECATION_WARNINGS` in place of `-Wno-error=deprecated-declarations` in `Basic/offset-accessor-get_pointer.cpp` due to `accessor::get_pointer`'s deliberate use. This brings it in line with `Basic/multi_ptr_legacy.cpp` which also uses it deliberately.