### PR TITLE
[SYCL][E2E] Change `%no_opt` expansion to `%O0`

### DIFF
--- a/sycl/test-e2e/Config/config.cpp
+++ b/sycl/test-e2e/Config/config.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} %debug_option %no_opt -o %t.out
+// RUN: %{build} %debug_option %O0 -o %t.out
 // RUN: echo SYCL_PRINT_EXECUTION_GRAPH=always > %t.cfg
 // RUN: env SYCL_CONFIG_FILE_NAME=%t.cfg %t.out
 // RUN: cat *.dot > /dev/null

--- a/sycl/test-e2e/Config/env_vars.cpp
+++ b/sycl/test-e2e/Config/env_vars.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl
 // Env vars are used to pass OpenCL-specific flags to PI compiling/linking.
 //
-// RUN: %{build} %no_opt -o %t.out
+// RUN: %{build} %O0 -o %t.out
 //
 // RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" %{run} %t.out
 // RUN: env SYCL_PROGRAM_APPEND_COMPILE_OPTIONS="-g" %{run} %t.out

--- a/sycl/test-e2e/ESIMD/slm_alloc.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc.cpp
@@ -8,7 +8,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} %no_opt -o %t.3.out
+// RUN: %{build} %O0 -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // This is end-to-end test for the slm_allocator API used together with the

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_many_funcs.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} %no_opt -o %t.3.out
+// RUN: %{build} %O0 -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // Checks validity of SLM frame offsets in case of complex call graph with two

--- a/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
+++ b/sycl/test-e2e/ESIMD/slm_alloc_many_kernels_one_func.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.2.out
 
 // Check if the test sill passes with O0
-// RUN: %{build} %no_opt -o %t.3.out
+// RUN: %{build} %O0 -o %t.3.out
 // RUN: %{run} %t.3.out
 
 // Check that SLM frame offset of a function foo called from two kernels Test1

--- a/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
+++ b/sycl/test-e2e/GroupAlgorithm/SYCL2020/reduce_over_group_size.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// RUN: %{build} %no_opt -o %t_O0.out
+// RUN: %{build} %O0 -o %t_O0.out
 // RUN: %{run} %t_O0.out
 
 /*

--- a/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
+++ b/sycl/test-e2e/HierPar/hier_par_wgscope_O0.cpp
@@ -5,7 +5,7 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
-// RUN: %{build} %no_opt -o %t.out
+// RUN: %{build} %O0 -o %t.out
 
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
+++ b/sycl/test-e2e/NewOffloadDriver/aot-cpu.cpp
@@ -6,5 +6,5 @@
 // RUN: %{run} %t.out
 
 // Test -O0 with `--offload-new-driver`
-// RUN: %clangxx %no_opt -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
+// RUN: %clangxx %O0 -fsycl -fsycl-targets=spir64-x86_64 %S/Inputs/aot.cpp
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/is_compatible/is_compatible_with_aspects.cpp
@@ -1,7 +1,7 @@
 // requires: cpu, gpu, accelerator
 // UNSUPPORTED: hip
 // FIXME: enable the test back, see intel/llvm#8146
-// RUN: %{build} -Wno-error=incorrect-sub-group-size %no_opt -o %t.out
+// RUN: %{build} -Wno-error=incorrect-sub-group-size %O0 -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
+++ b/sycl/test-e2e/OptionalKernelFeatures/throw-exception-for-unsupported-aspect.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: cpu
 
-// RUN: %{build} %no_opt -o %t.out
+// RUN: %{build} %O0 -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
+++ b/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: opencl
 
-// RUN: %{build} %no_opt -o %t0.out
+// RUN: %{build} %O0 -o %t0.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t0.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL0 %}
 // RUN: %{build} -O1 -o %t1.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t1.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL1 %}
@@ -9,7 +9,7 @@
 // RUN: %{build} -O3 -o %t3.out
 // RUN: %if !acc %{ env SYCL_UR_TRACE=2 %{run} %t3.out 2>&1 | FileCheck %s --check-prefixes=CHECKOCL3 %}
 
-// RUN: %{build} %no_opt -o %t.out
+// RUN: %{build} %O0 -o %t.out
 // RUN: %{run} %t.out
 
 // This test verifies the propagation of front-end compiler optimization

--- a/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
+++ b/sycl/test-e2e/Regression/2020-spec-constants-debug-info.cpp
@@ -1,5 +1,5 @@
 // RUN: %{build} -g -o %t.out
-// RUN: %{build} -g %no_opt -o %t.out
+// RUN: %{build} -g %O0 -o %t.out
 // RUN: %{build} -g -O2 -o %t.out
 //
 // The idea of this test is to make sure that we can compile the following

--- a/sycl/test-e2e/Regression/DAE-separate-compile.cpp
+++ b/sycl/test-e2e/Regression/DAE-separate-compile.cpp
@@ -5,7 +5,7 @@
 // The test checks that the scenario works correctly.
 //
 // RUN: %{build} -O2 -c -o %t.o
-// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o %no_opt -Wno-unused-command-line-argument -o %t.out
+// RUN: %clangxx -fsycl -fsycl-targets=%{sycl_triple} %t.o %O0 -Wno-unused-command-line-argument -o %t.out
 // RUN: %{run} %t.out
 
 // Failing on HIP AMD, enable after fixed

--- a/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
+++ b/sycl/test-e2e/Regression/default-constructed-local-accessor.cpp
@@ -1,6 +1,6 @@
 // -O0 is necessary; on higher levels of optimization, an error
 // would not occur because of dead argument elimination of the local_accessor.
-// RUN: %{build} -o %t.out %no_opt
+// RUN: %{build} -o %t.out %O0
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Regression/optimization_level_debug_info_intopt.cpp
+++ b/sycl/test-e2e/Regression/optimization_level_debug_info_intopt.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %debug_option %no_opt -o %t.out
+// RUN: %{build} %debug_option %O0 -o %t.out
 // RUN: %{build} %debug_option -O1 -o %t.out
 // RUN: %{build} %debug_option -O2 -o %t.out
 // RUN: %{build} %debug_option -O3 -o %t.out

--- a/sycl/test-e2e/Regression/unoptimized_stream.cpp
+++ b/sycl/test-e2e/Regression/unoptimized_stream.cpp
@@ -1,4 +1,4 @@
-// RUN: %{build} %no_opt -o %t.out
+// RUN: %{build} %O0 -o %t.out
 // RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -357,7 +357,7 @@ if cl_options:
     config.substitutions.append(("%cxx_std_option", "/std:"))
     config.substitutions.append(("%fPIC", ""))
     config.substitutions.append(("%shared_lib", "/LD"))
-    config.substitutions.append(("%no_opt", "/Od"))
+    config.substitutions.append(("%O0", "/Od"))
 else:
     config.substitutions.append(
         (
@@ -382,7 +382,7 @@ else:
         ("%fPIC", ("" if platform.system() == "Windows" else "-fPIC"))
     )
     config.substitutions.append(("%shared_lib", "-shared"))
-    config.substitutions.append(("%no_opt", "-O0"))
+    config.substitutions.append(("%O0", "-O0"))
 
 # Check if user passed verbose-print parameter, if yes, add VERBOSE_PRINT macro
 if "verbose-print" in lit_config.params:


### PR DESCRIPTION
Changes the `%no_opt` expansion introduced in #15364, to `%O0` to reduce confusion in between different methods of disabling optimizations.