### PR TITLE
[SYCL][E2E][Joint Matrix] Make 2 SG32 tests UNSUPPORTED on Arc

### DIFF
--- a/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_packedB.cpp
+++ b/sycl/test-e2e/Matrix/SG32/joint_matrix_bfloat16_packedB.cpp
@@ -8,6 +8,9 @@
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943
 
+// SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
+// UNSUPPORTED: gpu-intel-dg2
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_bfloat16_packedB.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_bfloat16_packedB.cpp
@@ -8,6 +8,9 @@
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943
 
+// SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
+// UNSUPPORTED: gpu-intel-dg2
+
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
These 2 tests should not be run on DG2, since SG32 is not currently supported there for Joint Matrix. They started to run because we now use aspect to define which tests to run. Hence, adding UNSUPPORTED tag.