### PR TITLE
[SYCL][E2E] fixed UR FileCheck conditions to match new traces

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -117,14 +117,13 @@ if(SYCL_UR_USE_FETCH_CONTENT)
   endfunction()
 
   set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 00f958f375205fd86309f95b925141cf664ff955
-  # Merge: cc2d5909 98a67a2e
-  # Author: aarongreig <aaron.greig@codeplay.com>
-  # Date:   Wed Oct 2 09:51:21 2024 +0100
-  #     Merge pull request #2139 from nrspruit/zeHandle_copy_dependencies
-  #     [L0] Pass and track event dependencies required before executing Memory
-  #     Copy buffer inits
-  set(UNIFIED_RUNTIME_TAG 00f958f375205fd86309f95b925141cf664ff955)
+  # commit 7aba70bc5c6bf82a6e5f7cdd3623eb8f46fcff40
+  # Merge: 1f13d2ce cf5994a1
+  # Author: Piotr Balcer <piotr.balcer@intel.com>
+  # Date:   Thu Oct 3 10:47:01 2024 +0200
+  #     Merge pull request #2101 from lslusarczyk/fix-interleaved-urtraces
+  #     Fix mixed output of adapter and regular traces
+  set(UNIFIED_RUNTIME_TAG 7aba70bc5c6bf82a6e5f7cdd3623eb8f46fcff40)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need

--- a/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
+++ b/sycl/test-e2e/Basic/alloc_pinned_host_memory.cpp
@@ -34,6 +34,6 @@ int main() {
   }
 }
 
-// CHECK:---> urMemBufferCreate
-// CHECK:---> urMemBufferCreate
+// CHECK: <--- urMemBufferCreate
+// CHECK: <--- urMemBufferCreate
 // CHECK-SAME: UR_MEM_FLAG_ALLOC_HOST_POINTER

--- a/sycl/test-e2e/Basic/buffer/native_buffer_creation_flags.cpp
+++ b/sycl/test-e2e/Basic/buffer/native_buffer_creation_flags.cpp
@@ -20,7 +20,7 @@ int main() {
   Q.submit([&](handler &Cgh) {
     // Now that we have a read-write host allocation, check that the native
     // buffer is created with the UR_MEM_FLAG_USE_HOST_POINTER flag.
-    // CHECK: urMemBufferCreate
+    // CHECK: <--- urMemBufferCreate
     // CHECK-SAME: UR_MEM_FLAG_USE_HOST_POINTER
     auto BufAcc = Buf.get_access<access::mode::read>(Cgh);
     Cgh.single_task<Foo>([=]() { int A = BufAcc[0]; });

--- a/sycl/test-e2e/Basic/buffer/subbuffer_overlap.cpp
+++ b/sycl/test-e2e/Basic/buffer/subbuffer_overlap.cpp
@@ -16,13 +16,13 @@ int main() {
   for (auto &e : sycl::host_accessor{b})
     e = idx++ % size;
 
-  // CHECK: urMemBufferPartition
+  // CHECK: <--- urMemBufferPartition
   // CHECK: .origin = 256, .size = 64
   q.submit([&](sycl::handler &cgh) {
     sycl::accessor acc{sub1, cgh};
     cgh.parallel_for(size, [=](auto id) { acc[id] += 1; });
   });
-  // CHECK: urMemBufferPartition
+  // CHECK: <--- urMemBufferPartition
   // CHECK: .origin = 256, .size = 128
   q.submit([&](sycl::handler &cgh) {
     sycl::accessor acc{sub2, cgh};

--- a/sycl/test-e2e/Basic/enqueue_barrier.cpp
+++ b/sycl/test-e2e/Basic/enqueue_barrier.cpp
@@ -56,7 +56,7 @@ int main() {
   return 0;
 }
 
-// CHECK:---> urEnqueueEventsWaitWithBarrier
-// CHECK:---> urEnqueueEventsWaitWithBarrier
-// CHECK:---> urEnqueueEventsWaitWithBarrier
-// CHECK:---> urEnqueueEventsWaitWithBarrier
+// CHECK: <--- urEnqueueEventsWaitWithBarrier
+// CHECK: <--- urEnqueueEventsWaitWithBarrier
+// CHECK: <--- urEnqueueEventsWaitWithBarrier
+// CHECK: <--- urEnqueueEventsWaitWithBarrier

--- a/sycl/test-e2e/Basic/event_release.cpp
+++ b/sycl/test-e2e/Basic/event_release.cpp
@@ -29,8 +29,8 @@ int main() {
   // Buffer destruction triggers execution graph cleanup, check that both
   // events (one for launching the kernel and one for memory transfer to host)
   // are released.
-  // CHECK: urEventRelease
-  // CHECK: urEventRelease
+  // CHECK: <--- urEventRelease
+  // CHECK: <--- urEventRelease
   assert(Val == Gold);
   // CHECK: End of main scope
   std::cout << "End of main scope" << std::endl;

--- a/sycl/test-e2e/Basic/fill_accessor_ur.cpp
+++ b/sycl/test-e2e/Basic/fill_accessor_ur.cpp
@@ -129,19 +129,19 @@ int main() {
 }
 
 // CHECK: start testFill_Buffer1D
-// CHECK: urEnqueueMemBufferFill
+// CHECK: <--- urEnqueueMemBufferFill
 // CHECK: start testFill_Buffer1D -- OFFSET
-// CHECK: urEnqueueMemBufferFill
+// CHECK: <--- urEnqueueMemBufferFill
 
 // CHECK: start testFill_Buffer2D
-// CHECK: urEnqueueMemBufferFill
+// CHECK: <--- urEnqueueMemBufferFill
 // CHECK: start testFill_Buffer2D -- OFFSET
-// CHECK: urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 
 // CHECK: start testFill_Buffer3D
-// CHECK: urEnqueueMemBufferFill
+// CHECK: <--- urEnqueueMemBufferFill
 // CHECK: start testFill_Buffer3D -- OFFSET
-// CHECK: urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 
 // CHECK: start testFill_ZeroDim
-// CHECK: urEnqueueMemBufferFill
+// CHECK: <--- urEnqueueMemBufferFill

--- a/sycl/test-e2e/Basic/host-task-dependency.cpp
+++ b/sycl/test-e2e/Basic/host-task-dependency.cpp
@@ -178,15 +178,15 @@ int main() {
 }
 
 // launch of Gen kernel
-// CHECK:---> urKernelCreate
+// CHECK: <--- urKernelCreate
 // CHECK: NameGen
-// CHECK:---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // prepare for host task
-// CHECK:---> urEnqueueMemBuffer{{Map|Read}}
+// CHECK: <--- urEnqueueMemBuffer{{Map|Read}}
 // launch of Copier kernel
-// CHECK:---> urKernelCreate
+// CHECK: <--- urKernelCreate
 // CHECK: Copier
-// CHECK:---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 
 // CHECK:Third buffer [  0] = 0
 // CHECK:Third buffer [  1] = 1

--- a/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api.cpp
+++ b/sycl/test-e2e/Basic/kernel_bundle/kernel_bundle_api.cpp
@@ -150,26 +150,26 @@ int main() {
 
     sycl::kernel_bundle<sycl::bundle_state::object> KernelBundleObject1 =
         sycl::compile(KernelBundleInput1, KernelBundleInput1.get_devices());
-    // CHECK:---> urProgramCreate
+    // CHECK:<--- urProgramCreate
     // CHECK-SAME:, .phProgram = {{.*}} ([[PROGRAM_HANDLE1:[0-9a-fA-Fx]+]])
     // CHECK-SAME: -> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urProgramCompile
+    // CHECK:<--- urProgramCompile
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE1]]
 
     sycl::kernel_bundle<sycl::bundle_state::object> KernelBundleObject2 =
         sycl::compile(KernelBundleInput2, KernelBundleInput2.get_devices());
-    // CHECK:---> urProgramCreate
+    // CHECK:<--- urProgramCreate
     // CHECK-SAME:, .phProgram = {{.*}} ([[PROGRAM_HANDLE2:[0-9a-fA-Fx]+]])
     // CHECK-SAME: -> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urProgramCompile(
+    // CHECK:<--- urProgramCompile(
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE2]]
 
     sycl::kernel_bundle<sycl::bundle_state::executable> KernelBundleExecutable =
         sycl::link({KernelBundleObject1, KernelBundleObject2},
                    KernelBundleObject1.get_devices());
-    // CHECK:---> urProgramLink{{.*}} -> UR_RESULT_SUCCESS;
+    // CHECK:<--- urProgramLink{{.*}} -> UR_RESULT_SUCCESS;
     // UR tracing doesn't allow checking for all input programs so far.
 
     assert(KernelBundleExecutable.has_kernel(Kernel1ID));
@@ -179,14 +179,14 @@ int main() {
         KernelBundleExecutable2 =
             sycl::build(KernelBundleInput1, KernelBundleInput1.get_devices());
 
-    // CHECK:---> urProgramCreate
+    // CHECK:<--- urProgramCreate
     // CHECK-SAME:, .phProgram = {{.*}} ([[PROGRAM_HANDLE3:[0-9a-fA-Fx]+]])
     // CHECK-SAME: -> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urProgramBuild(
+    // CHECK:<--- urProgramBuild(
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE3]]
     //
-    // CHECK:---> urProgramRetain(
+    // CHECK:<--- urProgramRetain(
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE3]]
     // CHECK-SAME:-> UR_RESULT_SUCCESS;
 
@@ -204,31 +204,31 @@ int main() {
     sycl::kernel_bundle KernelBundleExecutable =
         sycl::get_kernel_bundle<sycl::bundle_state::executable>(Ctx, {Dev},
                                                                 {Kernel3ID});
-    // CHECK:---> urProgramCreate
+    // CHECK:<--- urProgramCreate
     // CHECK-SAME:, .phProgram = {{.*}} ([[PROGRAM_HANDLE4:[0-9a-fA-Fx]+]])
     // CHECK-SAME: -> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urProgramBuild(
+    // CHECK:<--- urProgramBuild(
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE4]]
     //
-    // CHECK:---> urProgramRetain(
+    // CHECK:<--- urProgramRetain(
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE4]]
     // CHECK-SAME:-> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urKernelCreate(
+    // CHECK:<--- urKernelCreate(
     // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE4]]
     // CHECK-SAME: .pKernelName = {{[0-9a-fA-Fx]+}} (_ZTS11Kernel3Name)
     // CHECK-SAME: .phKernel = {{[0-9a-fA-Fx]+}}  ([[KERNEL_HANDLE:[0-9a-fA-Fx]+]])
     // CHECK-SAME: -> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urKernelRetain(
+    // CHECK:<--- urKernelRetain(
     // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
     // CHECK-SAME:-> UR_RESULT_SUCCESS;
     //
-    // CHECK:---> urEnqueueKernelLaunch(
+    // CHECK:<--- urEnqueueKernelLaunch(
     // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
     //
-    // CHECK:---> urKernelRelease(
+    // CHECK:<--- urKernelRelease(
     // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
     // CHECK-SAME:-> UR_RESULT_SUCCESS;
 

--- a/sycl/test-e2e/Basic/queue/release.cpp
+++ b/sycl/test-e2e/Basic/queue/release.cpp
@@ -14,12 +14,12 @@ int main() {
   return 0;
 }
 
-// CHECK: ---> urEnqueueKernelLaunch(
+// CHECK: <--- urEnqueueKernelLaunch(
 // FIXME the order of these 2 varies between plugins due to a Level Zero
 // specific queue workaround.
-// CHECK-DAG: ---> urEventRelease(
-// CHECK-DAG: ---> urQueueRelease(
-// CHECK: ---> urContextRelease(
-// CHECK: ---> urKernelRelease(
-// CHECK: ---> urProgramRelease(
-// CHECK: ---> urDeviceRelease(
+// CHECK-DAG: <--- urEventRelease(
+// CHECK-DAG: <--- urQueueRelease(
+// CHECK: <--- urContextRelease(
+// CHECK: <--- urKernelRelease(
+// CHECK: <--- urProgramRelease(
+// CHECK: <--- urDeviceRelease(

--- a/sycl/test-e2e/Basic/stream/release_resources_test.cpp
+++ b/sycl/test-e2e/Basic/stream/release_resources_test.cpp
@@ -16,7 +16,7 @@ int main() {
   {
     queue Queue;
 
-    // CHECK:---> urMemRelease
+    // CHECK: <--- urMemRelease
     Queue.submit([&](handler &CGH) {
       stream Out(1024, 80, CGH);
       CGH.parallel_for<class test_cleanup1>(

--- a/sycl/test-e2e/Basic/subdevice_pi.cpp
+++ b/sycl/test-e2e/Basic/subdevice_pi.cpp
@@ -51,7 +51,7 @@ static bool check_separate(device dev, buffer<int, 1> buf,
   std::vector<device> subdevices = partition(dev);
   assert(subdevices.size() > 1);
   // CHECK-SEPARATE: Create sub devices
-  // CHECK-SEPARATE: ---> urDevicePartition
+  // CHECK-SEPARATE: <--- urDevicePartition
 
   log_pi("Test sub device 0");
   {
@@ -59,11 +59,11 @@ static bool check_separate(device dev, buffer<int, 1> buf,
     use_mem(buf, q0);
   }
   // CHECK-SEPARATE: Test sub device 0
-  // CHECK-SEPARATE: ---> urContextCreate
-  // CHECK-SEPARATE: ---> urQueueCreate
-  // CHECK-SEPARATE: ---> urMemBufferCreate
-  // CHECK-SEPARATE: ---> urEnqueueKernelLaunch
-  // CHECK-SEPARATE: ---> urQueueFinish
+  // CHECK-SEPARATE: <--- urContextCreate
+  // CHECK-SEPARATE: <--- urQueueCreate
+  // CHECK-SEPARATE: <--- urMemBufferCreate
+  // CHECK-SEPARATE: <--- urEnqueueKernelLaunch
+  // CHECK-SEPARATE: <--- urQueueFinish
 
   log_pi("Test sub device 1");
   {
@@ -71,16 +71,16 @@ static bool check_separate(device dev, buffer<int, 1> buf,
     use_mem(buf, q1);
   }
   // CHECK-SEPARATE: Test sub device 1
-  // CHECK-SEPARATE: ---> urContextCreate
-  // CHECK-SEPARATE: ---> urQueueCreate
-  // CHECK-SEPARATE: ---> urMemBufferCreate
+  // CHECK-SEPARATE: <--- urContextCreate
+  // CHECK-SEPARATE: <--- urQueueCreate
+  // CHECK-SEPARATE: <--- urMemBufferCreate
   //
   // Verify that we have a memcpy between subdevices in this case
-  // CHECK-SEPARATE: ---> urEnqueueMemBuffer{{Map|Read}}
-  // CHECK-SEPARATE: ---> urEnqueueMemBufferWrite
+  // CHECK-SEPARATE: <--- urEnqueueMemBuffer{{Map|Read}}
+  // CHECK-SEPARATE: <--- urEnqueueMemBufferWrite
   //
-  // CHECK-SEPARATE: ---> urEnqueueKernelLaunch
-  // CHECK-SEPARATE: ---> urQueueFinish
+  // CHECK-SEPARATE: <--- urEnqueueKernelLaunch
+  // CHECK-SEPARATE: <--- urQueueFinish
 
   return true;
 }
@@ -91,14 +91,14 @@ static bool check_shared_context(device dev, buffer<int, 1> buf,
   std::vector<device> subdevices = partition(dev);
   assert(subdevices.size() > 1);
   // CHECK-SHARED: Create sub devices
-  // CHECK-SHARED: ---> urDevicePartition
+  // CHECK-SHARED: <--- urDevicePartition
 
   // Shared context: queues are bound to specific subdevices, but
   // memory does not migrate
   log_pi("Create shared context");
   context shared_context(subdevices);
   // CHECK-SHARED: Create shared context
-  // CHECK-SHARED: ---> urContextCreate
+  // CHECK-SHARED: <--- urContextCreate
   //
   // Make sure that a single context is created: see --implicit-check-not above.
 
@@ -108,14 +108,14 @@ static bool check_shared_context(device dev, buffer<int, 1> buf,
     use_mem(buf, q0);
   }
   // CHECK-SHARED: Test sub device 0
-  // CHECK-SHARED: ---> urQueueCreate
-  // CHECK-SHARED: ---> urMemBufferCreate
+  // CHECK-SHARED: <--- urQueueCreate
+  // CHECK-SHARED: <--- urMemBufferCreate
   //
   // Make sure that a single buffer is created (and shared between subdevices):
   // see --implicit-check-not above.
   //
-  // CHECK-SHARED: ---> urEnqueueKernelLaunch
-  // CHECK-SHARED: ---> urQueueFinish
+  // CHECK-SHARED: <--- urEnqueueKernelLaunch
+  // CHECK-SHARED: <--- urQueueFinish
 
   log_pi("Test sub device 1");
   {
@@ -123,10 +123,10 @@ static bool check_shared_context(device dev, buffer<int, 1> buf,
     use_mem(buf, q1);
   }
   // CHECK-SHARED: Test sub device 1
-  // CHECK-SHARED: ---> urQueueCreate
-  // CHECK-SHARED: ---> urEnqueueKernelLaunch
-  // CHECK-SHARED: ---> urQueueFinish
-  // CHECK-SHARED: ---> urEnqueueMemBufferRead
+  // CHECK-SHARED: <--- urQueueCreate
+  // CHECK-SHARED: <--- urEnqueueKernelLaunch
+  // CHECK-SHARED: <--- urQueueFinish
+  // CHECK-SHARED: <--- urEnqueueMemBufferRead
 
   return true;
 }
@@ -137,7 +137,7 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
   std::vector<device> subdevices = partition(dev);
   assert(subdevices.size() > 1);
   // CHECK-FUSED: Create sub devices
-  // CHECK-FUSED: ---> urDevicePartition
+  // CHECK-FUSED: <--- urDevicePartition
 
   // Fused context: same as shared context, but also includes the root device
   log_pi("Create fused context");
@@ -147,7 +147,7 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
   devices.push_back(subdevices[1]);
   context fused_context(devices);
   // CHECK-FUSED: Create fused context
-  // CHECK-FUSED: ---> urContextCreate
+  // CHECK-FUSED: <--- urContextCreate
   //
   // Make sure that a single context is created: see --implicit-check-not above.
 
@@ -157,14 +157,14 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
     use_mem(buf, q);
   }
   // CHECK-FUSED: Test root device
-  // CHECK-FUSED: ---> urQueueCreate
-  // CHECK-FUSED: ---> urMemBufferCreate
+  // CHECK-FUSED: <--- urQueueCreate
+  // CHECK-FUSED: <--- urMemBufferCreate
   //
   // Make sure that a single buffer is created (and shared between subdevices
   // *and* the root device): see --implicit-check-not above.
   //
-  // CHECK-FUSED: ---> urEnqueueKernelLaunch
-  // CHECK-FUSED: ---> urQueueFinish
+  // CHECK-FUSED: <--- urEnqueueKernelLaunch
+  // CHECK-FUSED: <--- urQueueFinish
 
   log_pi("Test sub device 0");
   {
@@ -172,9 +172,9 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
     use_mem(buf, q0);
   }
   // CHECK-FUSED: Test sub device 0
-  // CHECK-FUSED: ---> urQueueCreate
-  // CHECK-FUSED: ---> urEnqueueKernelLaunch
-  // CHECK-FUSED: ---> urQueueFinish
+  // CHECK-FUSED: <--- urQueueCreate
+  // CHECK-FUSED: <--- urEnqueueKernelLaunch
+  // CHECK-FUSED: <--- urQueueFinish
 
   log_pi("Test sub device 1");
   {
@@ -182,10 +182,10 @@ static bool check_fused_context(device dev, buffer<int, 1> buf,
     use_mem(buf, q1);
   }
   // CHECK-FUSED: Test sub device 1
-  // CHECK-FUSED: ---> urQueueCreate
-  // CHECK-FUSED: ---> urEnqueueKernelLaunch
-  // CHECK-FUSED: ---> urQueueFinish
-  // CHECK-FUSED: ---> urEnqueueMemBufferRead
+  // CHECK-FUSED: <--- urQueueCreate
+  // CHECK-FUSED: <--- urEnqueueKernelLaunch
+  // CHECK-FUSED: <--- urQueueFinish
+  // CHECK-FUSED: <--- urEnqueueMemBufferRead
 
   return true;
 }

--- a/sycl/test-e2e/Basic/use_pinned_host_memory.cpp
+++ b/sycl/test-e2e/Basic/use_pinned_host_memory.cpp
@@ -43,5 +43,5 @@ int main() {
   }
 }
 
-// CHECK:---> urMemBufferCreate
+// CHECK: <--- urMemBufferCreate
 // CHECK-SAME: UR_MEM_FLAG_ALLOC_HOST_POINTER

--- a/sycl/test-e2e/DeviceCodeSplit/grf.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf.cpp
@@ -16,19 +16,17 @@
 // REQUIRES: arch-intel_gpu_pvc
 
 // RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
-// Don't use SYCL_UR_TRACE as the output from the L0 adapter logging interferes
-// with the regular UR traces we are checking.
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
 // RUN: %{build} -DUSE_NEW_API=1 -o %t.out
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
 // RUN: %{build} -DUSE_AUTO_GRF=1 -Wno-error=deprecated-declarations -o %t.out
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
 // RUN: %{build} -DUSE_NEW_API=1 -DUSE_AUTO_GRF=1 -o %t.out
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
 #include "../helpers.hpp"
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/DeviceCodeSplit/grf.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf.cpp
@@ -137,16 +137,16 @@ int main(void) {
   return 0;
 }
 
-// CHECK-LABEL: ---> urProgramBuild
+// CHECK-LABEL: <--- urProgramBuild
 // CHECK-WITH-VAR-SAME: -g
 // CHECK-SAME: -> UR_RESULT_SUCCESS
 
-// CHECK: ---> urKernelCreate({{.*}}SingleGRF{{.*}}-> UR_RESULT_SUCCESS
+// CHECK: <--- urKernelCreate({{.*}}SingleGRF{{.*}}-> UR_RESULT_SUCCESS
 
-// CHECK-NO-VAR: urProgramBuild{{.*}}-ze-opt-large-register-file
-// CHECK-WITH-VAR: urProgramBuild{{.*}}-g -ze-opt-large-register-file
-// CHECK-AUTO-NO-VAR: urProgramBuild{{.*}}-ze-intel-enable-auto-large-GRF-mode
-// CHECK-AUTO-WITH-VAR: urProgramBuild{{.*}}-g -ze-intel-enable-auto-large-GRF-mode
+// CHECK-NO-VAR: <--- urProgramBuild{{.*}}-ze-opt-large-register-file
+// CHECK-WITH-VAR: <--- urProgramBuild{{.*}}-g -ze-opt-large-register-file
+// CHECK-AUTO-NO-VAR: <--- urProgramBuild{{.*}}-ze-intel-enable-auto-large-GRF-mode
+// CHECK-AUTO-WITH-VAR: <--- urProgramBuild{{.*}}-g -ze-intel-enable-auto-large-GRF-mode
 // CHECK-SAME: -> UR_RESULT_SUCCESS
 
-// CHECK: ---> urKernelCreate({{.*}}SpecifiedGRF{{.*}}-> UR_RESULT_SUCCESS
+// CHECK: <--- urKernelCreate({{.*}}SpecifiedGRF{{.*}}-> UR_RESULT_SUCCESS

--- a/sycl/test-e2e/DeviceLib/assert-windows.cpp
+++ b/sycl/test-e2e/DeviceLib/assert-windows.cpp
@@ -20,7 +20,7 @@
 // [{{[0-3]}},0,0], local id: [{{[0-3]}},0,0] Assertion `accessorC[wiID] == 0 &&
 // "Invalid value"` failed.
 //
-// CHECK-FALLBACK: ---> urProgramLink
+// CHECK-FALLBACK: <--- urProgramLink
 
 #include "../helpers.hpp"
 #include <array>

--- a/sycl/test-e2e/DiscardEvents/discard_events_accessors.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_accessors.cpp
@@ -6,11 +6,11 @@
 // urEnqueueKernelLaunch for USM kernel using local accessor, but
 // is not `nullptr` for kernel using buffer accessor.
 //
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: .phEvent = nullptr
 //
-// CHECK-NOT: ---> urEnqueueKernelLaunch({{.*}}.phEvent = nullptr
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK-NOT: <--- urEnqueueKernelLaunch({{.*}}.phEvent = nullptr
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // CHECK: The test passed.

--- a/sycl/test-e2e/DiscardEvents/discard_events_using_assert.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_using_assert.cpp
@@ -8,8 +8,8 @@
 // The test checks that the last parameter is not `nullptr` for
 // urEnqueueKernelLaunch.
 //
-// CHECK-NOT: ---> urEnqueueKernelLaunch({{.*}}.phEvent = nullptr
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK-NOT: <--- urEnqueueKernelLaunch({{.*}}.phEvent = nullptr
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // CHECK: The test passed.

--- a/sycl/test-e2e/DiscardEvents/discard_events_using_assert_ndebug.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_using_assert_ndebug.cpp
@@ -5,7 +5,7 @@
 // The test checks that the last parameter is `nullptr` for
 // urEnqueueKernelLaunch.
 //
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: .phEvent = nullptr
 //
 // CHECK: The test passed.

--- a/sycl/test-e2e/DiscardEvents/discard_events_usm.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_usm.cpp
@@ -16,77 +16,77 @@
 //       Since it is a warning it is safe to ignore for this test.
 //
 // Everything that follows TestQueueOperations()
-// CHECK: ---> urEnqueueUSMFill
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: .phEvent = nullptr
 //
 // Level-zero backend doesn't use urEnqueueUSMFill
-// CHECK-L0: ---> urEnqueueKernelLaunch
+// CHECK-L0: <--- urEnqueueKernelLaunch
 // CHECK-L0: .phEvent = nullptr
-// CHECK-OTHER: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK-OTHER: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
 //
 // ---> urEnqueueUSMMemcpy(
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueUSMPrefetch
+// CHECK: <--- urEnqueueUSMPrefetch
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueUSMAdvise
+// CHECK: <--- urEnqueueUSMAdvise
 // CHECK: .phEvent = nullptr
 // CHECK: -> {{UR_RESULT_SUCCESS|UR_RESULT_ERROR_ADAPTER_SPECIFIC}}
 //
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: .phEvent = nullptr
 //
 // RegularQueue
-// CHECK-NOT: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMFill
+// CHECK-NOT: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK: ---> urEnqueueEventsWait
+// CHECK: <--- urEnqueueEventsWait
 // CHECK: .phEvent = nullptr
 //
 // Everything that follows TestQueueOperationsViaSubmit()
-// CHECK: ---> urEnqueueUSMFill
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: .phEvent = nullptr
 //
 // Level-zero backend doesn't use urEnqueueUSMFill
-// CHECK-L0: ---> urEnqueueKernelLaunch
+// CHECK-L0: <--- urEnqueueKernelLaunch
 // CHECK-L0: .phEvent = nullptr
-// CHECK-OTHER: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK-OTHER: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
 //
 // ---> urEnqueueUSMMemcpy(
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueUSMPrefetch
+// CHECK: <--- urEnqueueUSMPrefetch
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueUSMAdvise
+// CHECK: <--- urEnqueueUSMAdvise
 // CHECK: .phEvent = nullptr
 // CHECK-SAME: ) -> {{UR_RESULT_SUCCESS|UR_RESULT_ERROR_ADAPTER_SPECIFIC}}
 //
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: .phEvent = nullptr
 //
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: .phEvent = nullptr
 //
 // RegularQueue
-// CHECK-NOT: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMFill
+// CHECK-NOT: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK: ---> urEnqueueEventsWait
+// CHECK: <--- urEnqueueEventsWait
 // CHECK: .phEvent = nullptr
 //
 // CHECK: The test passed.

--- a/sycl/test-e2e/DiscardEvents/discard_events_usm_ooo_queue.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_usm_ooo_queue.cpp
@@ -16,101 +16,101 @@
 //       Since it is a warning it is safe to ignore for this test.
 //
 // Everything that follows TestQueueOperations()
-// CHECK-NOT: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMFill
+// CHECK-NOT: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK-NOT: <--- urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // Level-zero backend doesn't use urEnqueueUSMFill
-// CHECK-L0: ---> urEnqueueKernelLaunch
+// CHECK-L0: <--- urEnqueueKernelLaunch
 // CHECK-L0: .phEvent = {{[0-9a-f]+}}
-// CHECK-OTHER: ---> urEnqueueUSMFill({{.*}} .phEvent = {{[0-9a-f]+}}
+// CHECK-OTHER: <--- urEnqueueUSMFill({{.*}} .phEvent = {{[0-9a-f]+}}
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // ---> urEnqueueUSMMemcpy(
-// CHECK-NOT: ---> urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK-NOT: <--- urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueUSMPrefetch({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMPrefetch
+// CHECK-NOT: <--- urEnqueueUSMPrefetch({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMPrefetch
 // CHECK: -> {{UR_RESULT_SUCCESS|UR_RESULT_ERROR_ADAPTER_SPECIFIC}}
 //
-// CHECK-NOT: ---> urEnqueueUSMAdvise({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMAdvise
+// CHECK-NOT: <--- urEnqueueUSMAdvise({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMAdvise
 // CHECK: -> {{UR_RESULT_SUCCESS|UR_RESULT_ERROR_ADAPTER_SPECIFIC}}
 //
-// CHECK-NOT: ---> urEnqueueEventsWaitWithBarrier({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueEventsWaitWithBarrier
+// CHECK-NOT: <--- urEnqueueEventsWaitWithBarrier({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueEventsWaitWithBarrier
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK-NOT: <--- urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK-NOT: <--- urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // RegularQueue
-// CHECK-NOT: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMFill
+// CHECK-NOT: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueEventsWait({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueEventsWait
+// CHECK-NOT: <--- urEnqueueEventsWait({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueEventsWait
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // Everything that follows TestQueueOperationsViaSubmit()
-// CHECK-NOT: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMFill
+// CHECK-NOT: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK-NOT: <--- urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // Level-zero backend doesn't use urEnqueueUSMFill
-// CHECK-L0: ---> urEnqueueKernelLaunch
+// CHECK-L0: <--- urEnqueueKernelLaunch
 // CHECK-L0: .phEvent = {{[0-9a-f]+}}
-// CHECK-OTHER: ---> urEnqueueUSMFill({{.*}} .phEvent = {{[0-9a-f]+}}
+// CHECK-OTHER: <--- urEnqueueUSMFill({{.*}} .phEvent = {{[0-9a-f]+}}
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // ---> urEnqueueUSMMemcpy(
-// CHECK-NOT: ---> urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMMemcpy
+// CHECK-NOT: <--- urEnqueueUSMMemcpy({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMMemcpy
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueUSMPrefetch({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMPrefetch
+// CHECK-NOT: <--- urEnqueueUSMPrefetch({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMPrefetch
 // CHECK: ) -> {{UR_RESULT_SUCCESS|UR_RESULT_ERROR_ADAPTER_SPECIFIC}}
 //
-// CHECK-NOT: ---> urEnqueueUSMAdvise({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMAdvise
+// CHECK-NOT: <--- urEnqueueUSMAdvise({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMAdvise
 // CHECK: ) -> {{UR_RESULT_SUCCESS|UR_RESULT_ERROR_ADAPTER_SPECIFIC}}
 //
-// CHECK-NOT: ---> urEnqueueEventsWaitWithBarrier({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueEventsWaitWithBarrier
+// CHECK-NOT: <--- urEnqueueEventsWaitWithBarrier({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueEventsWaitWithBarrier
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK-NOT: <--- urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueKernelLaunch
+// CHECK-NOT: <--- urEnqueueKernelLaunch({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // RegularQueue
-// CHECK-NOT: ---> urEnqueueUSMFill({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueUSMFill
+// CHECK-NOT: <--- urEnqueueUSMFill({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueUSMFill
 // CHECK: -> UR_RESULT_SUCCESS
 //
-// CHECK-NOT: ---> urEnqueueEventsWait({{.*}} .phEvent = nullptr
-// CHECK: ---> urEnqueueEventsWait
+// CHECK-NOT: <--- urEnqueueEventsWait({{.*}} .phEvent = nullptr
+// CHECK: <--- urEnqueueEventsWait
 // CHECK: -> UR_RESULT_SUCCESS
 //
 // CHECK: The test passed.

--- a/sycl/test-e2e/ESIMD/esimd_check_vc_codegen.cpp
+++ b/sycl/test-e2e/ESIMD/esimd_check_vc_codegen.cpp
@@ -94,4 +94,4 @@ int main(void) {
 // Don't use -NEXT here to split the line because we need to allow for the
 // possbility of a BuildExp( that fails with UNSUPPORTED followed by a Build(
 // that results in SUCCESS
-// CHECK: ---> urProgramBuild{{(Exp)?}}({{.*}}-vc-codegen{{.*}} -> UR_RESULT_SUCCESS
+// CHECK: <--- urProgramBuild{{(Exp)?}}({{.*}}-vc-codegen{{.*}} -> UR_RESULT_SUCCESS

--- a/sycl/test-e2e/ESIMD/grf.cpp
+++ b/sycl/test-e2e/ESIMD/grf.cpp
@@ -16,16 +16,14 @@
 // REQUIRES: arch-intel_gpu_pvc
 //             invokes 'urProgramBuild'/'urKernelCreate'
 // RUN: %{build} -o %t.out
-// Don't use SYCL_UR_TRACE as the output from the L0 adapter logging interferes
-// with the regular UR traces we are checking.
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
 // RUN: %{build} -DUSE_NEW_API=1 -o %t.out
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
 // RUN: %{build} -DUSE_AUTO -o %t.out
-// RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
-// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
+// RUN: env SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
+// RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" SYCL_UR_TRACE=2 %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
 #include "esimd_test_utils.hpp"
 
 #if defined(USE_NEW_API) || defined(USE_AUTO)

--- a/sycl/test-e2e/ESIMD/grf.cpp
+++ b/sycl/test-e2e/ESIMD/grf.cpp
@@ -156,16 +156,16 @@ int main(void) {
 
 // Regular SYCL kernel is compiled without -vc-codegen option
 
-// CHECK-NOT: ---> urProgramBuild{{.*}}-vc-codegen
-// CHECK-WITH-VAR: ---> urProgramBuild{{.*}}-g
-// CHECK: ---> urKernelCreate({{.*}}{{.*}}SyclKernel
+// CHECK-NOT: <--- urProgramBuild{{.*}}-vc-codegen
+// CHECK-WITH-VAR: <--- urProgramBuild{{.*}}-g
+// CHECK: <--- urKernelCreate({{.*}}{{.*}}SyclKernel
 
 // For ESIMD kernels, -vc-codegen option is always preserved,
 // regardless of SYCL_PROGRAM_COMPILE_OPTIONS value.
 
 // CHECK-NO-VAR-LABEL: -vc-codegen -disable-finalizer-msg
 // CHECK-WITH-VAR: -g -vc-codegen -disable-finalizer-msg
-// CHECK-LABEL: ---> urKernelCreate({{.*}}EsimdKernel{{.*}}-> UR_RESULT_SUCCESS
+// CHECK-LABEL: <--- urKernelCreate({{.*}}EsimdKernel{{.*}}-> UR_RESULT_SUCCESS
 
 // Kernels requesting GRF are grouped into separate module and compiled
 // with the respective option regardless of SYCL_PROGRAM_COMPILE_OPTIONS value.
@@ -174,6 +174,6 @@ int main(void) {
 // CHECK-WITH-VAR: -g -vc-codegen -disable-finalizer-msg -doubleGRF
 // CHECK-AUTO-NO-VAR: -vc-codegen -disable-finalizer-msg -ze-intel-enable-auto-large-GRF-mode
 // CHECK-AUTO-WITH-VAR: -g -vc-codegen -disable-finalizer-msg -ze-intel-enable-auto-large-GRF-mode
-// CHECK-LABEL: ---> urKernelCreate(
+// CHECK-LABEL: <--- urKernelCreate(
 // CHECK-SAME: EsimdKernelSpecifiedGRF
 // CHECK-SAME: -> UR_RESULT_SUCCESS

--- a/sycl/test-e2e/ESIMD/spec_const/spec_const_redefine.cpp
+++ b/sycl/test-e2e/ESIMD/spec_const/spec_const_redefine.cpp
@@ -91,7 +91,7 @@ int main(int argc, char **argv) {
 }
 
 // --- Check that only two JIT compilation happened:
-// CHECK-COUNT-2: ---> urProgramBuildExp
-// CHECK-NOT: ---> urProgramBuildExp
+// CHECK-COUNT-2: <--- urProgramBuildExp
+// CHECK-NOT: <--- urProgramBuildExp
 // --- Check that the test completed with expected results:
 // CHECK: passed

--- a/sycl/test-e2e/ESIMD/sycl_esimd_mix.cpp
+++ b/sycl/test-e2e/ESIMD/sycl_esimd_mix.cpp
@@ -122,22 +122,22 @@ int main(void) {
 // Some backends will call urProgramBuild and some will call 
 // urProgramBuildExp depending on urProgramBuildExp support.
 
-// CHECK-LABEL: ---> urProgramBuild{{(Exp)?}}
+// CHECK-LABEL: <--- urProgramBuild{{(Exp)?}}
 // CHECK-NOT: -vc-codegen
 // CHECK-WITH-VAR: -g
 // CHECK-NOT: -vc-codegen
 // CHECK: {{.*}}-> UR_RESULT_SUCCESS
-// CHECK-LABEL: ---> urKernelCreate
+// CHECK-LABEL: <--- urKernelCreate
 // CHECK: {{.*}}SyclKernel
 // CHECK: {{.*}}-> UR_RESULT_SUCCESS
 
 // For ESIMD kernels, -vc-codegen option is always preserved,
 // regardless of SYCL_PROGRAM_COMPILE_OPTIONS value.
 
-// CHECK-LABEL: ---> urProgramBuild{{(Exp)?}}
+// CHECK-LABEL: <--- urProgramBuild{{(Exp)?}}
 // CHECK-NO-VAR: -vc-codegen
 // CHECK-WITH-VAR: -g -vc-codegen
 // CHECK: {{.*}}-> UR_RESULT_SUCCESS
-// CHECK-LABEL: ---> urKernelCreate
+// CHECK-LABEL: <--- urKernelCreate
 // CHECK: {{.*}}EsimdKernel
 // CHECK: {{.*}}-> UR_RESULT_SUCCESS

--- a/sycl/test-e2e/EnqueueFunctions/barrier.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/barrier.cpp
@@ -50,5 +50,5 @@ int main() {
   return 0;
 }
 
-// CHECK-COUNT-4:---> urEnqueueEventsWaitWithBarrier
-// CHECK-NOT:---> urEnqueueEventsWaitWithBarrier
+// CHECK-COUNT-4: <--- urEnqueueEventsWaitWithBarrier
+// CHECK-NOT: <--- urEnqueueEventsWaitWithBarrier

--- a/sycl/test-e2e/EnqueueFunctions/mem_advise.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/mem_advise.cpp
@@ -36,5 +36,5 @@ int main() {
   return 0;
 }
 
-// CHECK-COUNT-3:---> urEnqueueUSMAdvise
-// CHECK-NOT:---> urEnqueueUSMAdvise
+// CHECK-COUNT-3: <--- urEnqueueUSMAdvise
+// CHECK-NOT: <--- urEnqueueUSMAdvise

--- a/sycl/test-e2e/EnqueueFunctions/prefetch.cpp
+++ b/sycl/test-e2e/EnqueueFunctions/prefetch.cpp
@@ -35,5 +35,5 @@ int main() {
   return 0;
 }
 
-// CHECK-COUNT-3:---> urEnqueueUSMPrefetch
-// CHECK-NOT:---> urEnqueueUSMPrefetch
+// CHECK-COUNT-3: <--- urEnqueueUSMPrefetch
+// CHECK-NOT: <--- urEnqueueUSMPrefetch

--- a/sycl/test-e2e/Graph/Explicit/kernel_bundle.cpp
+++ b/sycl/test-e2e/Graph/Explicit/kernel_bundle.cpp
@@ -5,27 +5,27 @@
 // Checks the UR call trace to ensure that the bundle kernel of the single task
 // is used.
 
-// CHECK:---> urProgramCreateWithIL(
+// CHECK:<--- urProgramCreateWithIL(
 // CHECK-SAME: .phProgram = {{.*}} ([[PROGRAM_HANDLE1:[0-9a-fA-Fx]+]])
 
 //
-// CHECK:---> urProgramBuildExp(
+// CHECK:<--- urProgramBuildExp(
 // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE1]]
 //
-// CHECK:---> urProgramRetain(.hProgram = [[PROGRAM_HANDLE1]]) -> UR_RESULT_SUCCESS
+// CHECK:<--- urProgramRetain(.hProgram = [[PROGRAM_HANDLE1]]) -> UR_RESULT_SUCCESS
 
-// CHECK:---> urKernelCreate(
+// CHECK:<--- urKernelCreate(
 // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE1]]
 // CHECK-SAME: .pKernelName = {{.*}} (_ZTS11Kernel1Name)
 // CHECK-SAME: .phKernel = {{.*}} ([[KERNEL_HANDLE:[0-9a-fA-Fx]+]])
 // CHECK-SAME: -> UR_RESULT_SUCCESS
 //
-// CHECK:---> urKernelRetain(.hKernel = [[KERNEL_HANDLE]]) -> UR_RESULT_SUCCESS
+// CHECK:<--- urKernelRetain(.hKernel = [[KERNEL_HANDLE]]) -> UR_RESULT_SUCCESS
 //
-// CHECK:---> urCommandBufferAppendKernelLaunchExp(
+// CHECK:<--- urCommandBufferAppendKernelLaunchExp(
 // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
 //
-// CHECK:---> urKernelRelease(.hKernel = [[KERNEL_HANDLE]]) -> UR_RESULT_SUCCESS
+// CHECK:<--- urKernelRelease(.hKernel = [[KERNEL_HANDLE]]) -> UR_RESULT_SUCCESS
 
 #define GRAPH_E2E_EXPLICIT
 

--- a/sycl/test-e2e/Graph/Explicit/memadvise.cpp
+++ b/sycl/test-e2e/Graph/Explicit/memadvise.cpp
@@ -10,14 +10,14 @@
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls.
 
-// CHECK: urCommandBufferAppendUSMAdviseExp
+// CHECK: <--- urCommandBufferAppendUSMAdviseExp
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER:]]
 // CHECK-SAME: .pMemory = 0x[[#%x,PTR:]]
 // CHECK-SAME: .size = 400
 // CHECK-SAME: .pSyncPoint = {{.*}} (0x[[#%x,ADVISE_SYNC_POINT:]])
 // CHECK-SAME: -> UR_RESULT_SUCCESS
 
-// CHECK: urCommandBufferAppendKernelLaunchExp(
+// CHECK: <--- urCommandBufferAppendKernelLaunchExp(
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER]]
 // CHECK-SAME: .hKernel = 0x[[#%x,KERNEL:]]
 // CHECK-SAME: .workDim = 1

--- a/sycl/test-e2e/Graph/Explicit/prefetch.cpp
+++ b/sycl/test-e2e/Graph/Explicit/prefetch.cpp
@@ -10,13 +10,13 @@
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls
 
-// CHECK: urCommandBufferAppendUSMPrefetchExp(
+// CHECK: <--- urCommandBufferAppendUSMPrefetchExp(
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER:]]
 // CHECK-SAME: .pMemory = 0x[[#%x,PTR:]]
 // CHECK-SAME: .size = 400
 // CHECK-SAME: .pSyncPoint = {{.*}} (0x[[#%x,PREFETCH_SYNC_POINT:]])
 
-// CHECK: urCommandBufferAppendKernelLaunchExp(
+// CHECK: <--- urCommandBufferAppendKernelLaunchExp(
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER]]
 // CHECK-SAME: .hKernel = 0x[[#%x,KERNEL:]]
 // CHECK-SAME: .workDim = 1

--- a/sycl/test-e2e/Graph/RecordReplay/kernel_bundle.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/kernel_bundle.cpp
@@ -5,31 +5,31 @@
 // Checks the UR call trace to ensure that the bundle kernel of the single task
 // is used.
 
-// CHECK:---> urProgramCreateWithIL(
+// CHECK:<--- urProgramCreateWithIL(
 // CHECK-SAME: .phProgram = {{.*}} ([[PROGRAM_HANDLE1:[0-9a-fA-Fx]+]])
 // CHECK-SAME: -> UR_RESULT_SUCCESS;
 //
-// CHECK:---> urProgramBuildExp(
+// CHECK:<--- urProgramBuildExp(
 // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE1]]
 //
-// CHECK:---> urProgramRetain(
+// CHECK:<--- urProgramRetain(
 // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE1]]
 // CHECK-SAME: -> UR_RESULT_SUCCESS;
 
-// CHECK:---> urKernelCreate(
+// CHECK:<--- urKernelCreate(
 // CHECK-SAME: .hProgram = [[PROGRAM_HANDLE1]]
 // CHECK-SAME: .pKernelName = {{[0-9a-fA-Fx]+}} (_ZTS11Kernel1Name)
 // CHECK-SAME: .phKernel = {{[0-9a-fA-Fx]+}}  ([[KERNEL_HANDLE:[0-9a-fA-Fx]+]])
 // CHECK-SAME: -> UR_RESULT_SUCCESS;
 //
-// CHECK:---> urKernelRetain(
+// CHECK:<--- urKernelRetain(
 // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
 // CHECK-SAME: -> UR_RESULT_SUCCESS;
 //
-// CHECK:---> urCommandBufferAppendKernelLaunchExp(
+// CHECK:<--- urCommandBufferAppendKernelLaunchExp(
 // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
 //
-// CHECK:---> urKernelRelease(
+// CHECK:<--- urKernelRelease(
 // CHECK-SAME: .hKernel = [[KERNEL_HANDLE]]
 // CHECK-SAME: -> UR_RESULT_SUCCESS;
 

--- a/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/memadvise.cpp
@@ -10,13 +10,13 @@
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls.
 
-// CHECK: urCommandBufferAppendUSMAdviseExp
+// CHECK: <--- urCommandBufferAppendUSMAdviseExp
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER:]]
 // CHECK-SAME: .pMemory = 0x[[#%x,PTR:]]
 // CHECK-SAME: .size = 400
 // CHECK-SAME: .pSyncPoint = {{.*}} (0x[[#%x,ADVISE_SYNC_POINT:]])
 
-// CHECK: urCommandBufferAppendKernelLaunchExp(
+// CHECK: <--- urCommandBufferAppendKernelLaunchExp(
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER]]
 // CHECK-SAME: .hKernel = 0x[[#%x,KERNEL:]]
 // CHECK-SAME: .workDim = 1

--- a/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/prefetch.cpp
@@ -10,13 +10,13 @@
 // impact results but only performances, we verify
 // that a node is correctly added by checking UR function calls
 
-// CHECK: urCommandBufferAppendUSMPrefetchExp(
+// CHECK: <--- urCommandBufferAppendUSMPrefetchExp(
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER:]]
 // CHECK-SAME: .pMemory = 0x[[#%x,PTR:]]
 // CHECK-SAME: .size = 400
 // CHECK-SAME: .pSyncPoint = {{.*}} (0x[[#%x,PREFETCH_SYNC_POINT:]])
 
-// CHECK: urCommandBufferAppendKernelLaunchExp(
+// CHECK: <--- urCommandBufferAppendKernelLaunchExp(
 // CHECK-SAME: .hCommandBuffer = 0x[[#%x,COMMAND_BUFFER]]
 // CHECK-SAME: .hKernel = 0x[[#%x,KERNEL:]]
 // CHECK-SAME: .workDim = 1

--- a/sycl/test-e2e/InorderQueue/in_order_ext_oneapi_submit_barrier.cpp
+++ b/sycl/test-e2e/InorderQueue/in_order_ext_oneapi_submit_barrier.cpp
@@ -4,7 +4,7 @@
 // Test to check that we don't insert unnecessary urEnqueueEventsWaitWithBarrier
 // calls if queue is in-order and wait list is empty.
 
-// CHECK-NOT: ---> urEnqueueEventsWaitWithBarrier
+// CHECK-NOT: <--- urEnqueueEventsWaitWithBarrier
 
 #include <condition_variable>
 

--- a/sycl/test-e2e/KernelAndProgram/cache_env_vars.cpp
+++ b/sycl/test-e2e/KernelAndProgram/cache_env_vars.cpp
@@ -25,12 +25,12 @@
 // Some backends will call urProgramBuild and some will call
 // urProgramBuildExp depending on urProgramBuildExp support.
 
-// CHECK-BUILD-NOT: urProgramCreateWithBinary(
-// CHECK-BUILD: urProgramCreateWithIL(
-// CHECK-BUILD: urProgramBuild{{(Exp)?}}(
+// CHECK-BUILD-NOT: <--- urProgramCreateWithBinary(
+// CHECK-BUILD: <--- urProgramCreateWithIL(
+// CHECK-BUILD: <--- urProgramBuild{{(Exp)?}}(
 
-// CHECK-CACHE-NOT: urProgramCreateWithIL(
-// CHECK-CACHE: urProgramCreateWithBinary(
-// CHECK-CACHE: urProgramBuild{{(Exp)?}}(
+// CHECK-CACHE-NOT: <--- urProgramCreateWithIL(
+// CHECK-CACHE: <--- urProgramCreateWithBinary(
+// CHECK-CACHE: <--- urProgramBuild{{(Exp)?}}(
 
 #include "cache_env_vars.hpp"

--- a/sycl/test-e2e/KernelAndProgram/cache_env_vars_lin.cpp
+++ b/sycl/test-e2e/KernelAndProgram/cache_env_vars_lin.cpp
@@ -24,12 +24,12 @@
 
 // Some backends will call urProgramBuild and some will call urProgramBuildExp depending on urProgramBuildExp support.
 
-// CHECK-BUILD-NOT: urProgramCreateWithBinary(
-// CHECK-BUILD: urProgramCreateWithIL(
-// CHECK-BUILD: urProgramBuild{{(Exp)?}}(
+// CHECK-BUILD-NOT: <--- urProgramCreateWithBinary(
+// CHECK-BUILD: <--- urProgramCreateWithIL(
+// CHECK-BUILD: <--- urProgramBuild{{(Exp)?}}(
 
-// CHECK-CACHE-NOT: urProgramCreateWithIL(
-// CHECK-CACHE: urProgramCreateWithBinary(
-// CHECK-CACHE: urProgramBuild{{(Exp)?}}(
+// CHECK-CACHE-NOT: <--- urProgramCreateWithIL(
+// CHECK-CACHE: <--- urProgramCreateWithBinary(
+// CHECK-CACHE: <--- urProgramBuild{{(Exp)?}}(
 
 #include "cache_env_vars.hpp"

--- a/sycl/test-e2e/KernelAndProgram/cache_env_vars_win.cpp
+++ b/sycl/test-e2e/KernelAndProgram/cache_env_vars_win.cpp
@@ -19,12 +19,12 @@
 // RUN: env SYCL_CACHE_PERSISTENT=1 AppData=%t/cache_dir SYCL_UR_TRACE=2 env -u SYCL_CACHE_DIR %t.out | FileCheck %s --check-prefixes=CHECK-BUILD
 // RUN: env SYCL_CACHE_PERSISTENT=1 AppData=%t/cache_dir SYCL_UR_TRACE=2 env -u SYCL_CACHE_DIR %t.out | FileCheck %s --check-prefixes=CHECK-CACHE
 
-// CHECK-BUILD-NOT: urProgramCreateWithBinary(
-// CHECK-BUILD: urProgramCreateWithIL(
-// CHECK-BUILD: urProgramBuild{{(Exp)?}}(
+// CHECK-BUILD-NOT: <--- urProgramCreateWithBinary(
+// CHECK-BUILD: <--- urProgramCreateWithIL(
+// CHECK-BUILD: <--- urProgramBuild{{(Exp)?}}(
 
-// CHECK-CACHE-NOT: urProgramCreateWithIL(
-// CHECK-CACHE: urProgramCreateWithBinary(
-// CHECK-CACHE: urProgramBuild{{(Exp)?}}(
+// CHECK-CACHE-NOT: <--- urProgramCreateWithIL(
+// CHECK-CACHE: <--- urProgramCreateWithBinary(
+// CHECK-CACHE: <--- urProgramBuild{{(Exp)?}}(
 
 #include "cache_env_vars.hpp"

--- a/sycl/test-e2e/KernelAndProgram/disable-caching.cpp
+++ b/sycl/test-e2e/KernelAndProgram/disable-caching.cpp
@@ -21,66 +21,66 @@ constexpr specialization_id<int> spec_id;
 
 int main() {
   queue q;
-  // CHECK: urProgramCreate
-  // CHECK-NOT: urProgramRetain
-  // CHECK: urKernelCreate
-  // CHECK-NOT: urKernelRetain
-  // CHECK: urEnqueueKernelLaunch
-  // CHECK: urKernelRelease
-  // CHECK: urProgramRelease
-  // CHECK: urEventWait
+  // CHECK: <--- urProgramCreate
+  // CHECK-NOT: <--- urProgramRetain
+  // CHECK: <--- urKernelCreate
+  // CHECK-NOT: <--- urKernelRetain
+  // CHECK: <--- urEnqueueKernelLaunch
+  // CHECK: <--- urKernelRelease
+  // CHECK: <--- urProgramRelease
+  // CHECK: <--- urEventWait
 
-  // CHECK-CACHE: urProgramCreate
-  // CHECK-CACHE: urProgramRetain
-  // CHECK-CACHE-NOT: urProgramRetain
-  // CHECK-CACHE: urKernelCreate
-  // CHECK-CACHE: urKernelRetain
-  // CHECK-CACHE-NOT: urKernelCreate
-  // CHECK-CACHE: urEnqueueKernelLaunch
-  // CHECK-CACHE: urKernelRelease
-  // CHECK-CACHE: urProgramRelease
-  // CHECK-CACHE: urEventWait
+  // CHECK-CACHE: <--- urProgramCreate
+  // CHECK-CACHE: <--- urProgramRetain
+  // CHECK-CACHE-NOT: <--- urProgramRetain
+  // CHECK-CACHE: <--- urKernelCreate
+  // CHECK-CACHE: <--- urKernelRetain
+  // CHECK-CACHE-NOT: <--- urKernelCreate
+  // CHECK-CACHE: <--- urEnqueueKernelLaunch
+  // CHECK-CACHE: <--- urKernelRelease
+  // CHECK-CACHE: <--- urProgramRelease
+  // CHECK-CACHE: <--- urEventWait
   q.single_task([] {}).wait();
 
-  // CHECK: urProgramCreate
-  // CHECK-NOT: urProgramRetain
-  // CHECK: urKernelCreate
-  // CHECK-NOT: urKernelRetain
-  // CHECK: urEnqueueKernelLaunch
-  // CHECK: urKernelRelease
-  // CHECK: urProgramRelease
-  // CHECK: urEventWait
+  // CHECK: <--- urProgramCreate
+  // CHECK-NOT: <--- urProgramRetain
+  // CHECK: <--- urKernelCreate
+  // CHECK-NOT: <--- urKernelRetain
+  // CHECK: <--- urEnqueueKernelLaunch
+  // CHECK: <--- urKernelRelease
+  // CHECK: <--- urProgramRelease
+  // CHECK: <--- urEventWait
 
-  // CHECK-CACHE: urProgramCreate
-  // CHECK-CACHE: urProgramRetain
-  // CHECK-CACHE-NOT: urProgramRetain
-  // CHECK-CACHE: urKernelCreate
-  // CHECK-CACHE: urKernelRetain
-  // CHECK-CACHE-NOT: urKernelCreate
-  // CHECK-CACHE: urEnqueueKernelLaunch
-  // CHECK-CACHE: urKernelRelease
-  // CHECK-CACHE: urProgramRelease
-  // CHECK-CACHE: urEventWait
+  // CHECK-CACHE: <--- urProgramCreate
+  // CHECK-CACHE: <--- urProgramRetain
+  // CHECK-CACHE-NOT: <--- urProgramRetain
+  // CHECK-CACHE: <--- urKernelCreate
+  // CHECK-CACHE: <--- urKernelRetain
+  // CHECK-CACHE-NOT: <--- urKernelCreate
+  // CHECK-CACHE: <--- urEnqueueKernelLaunch
+  // CHECK-CACHE: <--- urKernelRelease
+  // CHECK-CACHE: <--- urProgramRelease
+  // CHECK-CACHE: <--- urEventWait
 
-  // CHECK: urProgramCreate
-  // CHECK-NOT: urProgramRetain
-  // CHECK: urKernelCreate
-  // CHECK-NOT: urKernelRetain
-  // CHECK: urEnqueueKernelLaunch
-  // CHECK: urKernelRelease
-  // CHECK: urProgramRelease
-  // CHECK: urEventWait
+  // CHECK: <--- urProgramCreate
+  // CHECK-NOT: <--- urProgramRetain
+  // CHECK: <--- urKernelCreate
+  // CHECK-NOT: <--- urKernelRetain
+  // CHECK: <--- urEnqueueKernelLaunch
+  // CHECK: <--- urKernelRelease
+  // CHECK: <--- urProgramRelease
+  // CHECK: <--- urEventWait
 
-  // CHECK-CACHE: urProgramCreate
-  // CHECK-CACHE: urProgramRetain
-  // CHECK-CACHE-NOT: urProgramRetain
-  // CHECK-CACHE: urKernelCreate
-  // CHECK-CACHE: urKernelRetain
-  // CHECK-CACHE-NOT: urKernelCreate
-  // CHECK-CACHE: urEnqueueKernelLaunch
-  // CHECK-CACHE: urKernelRelease
-  // CHECK-CACHE: urProgramRelease
-  // CHECK-CACHE: urEventWait
+  // CHECK-CACHE: <--- urProgramCreate
+  // CHECK-CACHE: <--- urProgramRetain
+  // CHECK-CACHE-NOT: <--- urProgramRetain
+  // CHECK-CACHE: <--- urKernelCreate
+  // CHECK-CACHE: <--- urKernelRetain
+  // CHECK-CACHE-NOT: <--- urKernelCreate
+  // CHECK-CACHE: <--- urEnqueueKernelLaunch
+  // CHECK-CACHE: <--- urKernelRelease
+  // CHECK-CACHE: <--- urProgramRelease
+  // CHECK-CACHE: <--- urEventWait
   auto *p = malloc_device<int>(1, q);
   for (int i = 0; i < 2; ++i)
     q.submit([&](handler &cgh) {
@@ -94,9 +94,9 @@ int main() {
 }
 
 // (Program cache releases)
-// CHECK-CACHE: urKernelRelease
-// CHECK-CACHE: urKernelRelease
-// CHECK-CACHE: urKernelRelease
-// CHECK-CACHE: urProgramRelease
-// CHECK-CACHE: urProgramRelease
-// CHECK-CACHE: urProgramRelease
+// CHECK-CACHE: <--- urKernelRelease
+// CHECK-CACHE: <--- urKernelRelease
+// CHECK-CACHE: <--- urKernelRelease
+// CHECK-CACHE: <--- urProgramRelease
+// CHECK-CACHE: <--- urProgramRelease
+// CHECK-CACHE: <--- urProgramRelease

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options-env.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options-env.cpp
@@ -9,8 +9,8 @@
 
 #include "kernel-bundle-merge-options.hpp"
 
-// CHECK: urProgramBuild{{.*}}{{[^bar]*}}-DENV_COMPILE_OPTS -DENV_APPEND_COMPILE_OPTS{{[^bar]*}}-DENV_LINK_OPTS -DENV_APPEND_LINK_OPTS{{[^bar]*}}
+// CHECK: <--- urProgramBuild{{.*}}{{[^bar]*}}-DENV_COMPILE_OPTS -DENV_APPEND_COMPILE_OPTS{{[^bar]*}}-DENV_LINK_OPTS -DENV_APPEND_LINK_OPTS{{[^bar]*}}
 
-// CHECK: urProgramCompile{{.*}}{{[^bar]*}}-DENV_COMPILE_OPTS -DENV_APPEND_COMPILE_OPTS{{[^bar]*}}
+// CHECK: <--- urProgramCompile{{.*}}{{[^bar]*}}-DENV_COMPILE_OPTS -DENV_APPEND_COMPILE_OPTS{{[^bar]*}}
 
-// CHECK: urProgramLink{{.*}}{{[^bar]*}}-DENV_LINK_OPTS -DENV_APPEND_LINK_OPTS{{[^bar]*}}
+// CHECK: <--- urProgramLink{{.*}}{{[^bar]*}}-DENV_LINK_OPTS -DENV_APPEND_LINK_OPTS{{[^bar]*}}

--- a/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
+++ b/sycl/test-e2e/KernelAndProgram/kernel-bundle-merge-options.cpp
@@ -9,12 +9,12 @@
 
 #include "kernel-bundle-merge-options.hpp"
 
-// CHECK: urProgramBuild
+// CHECK: <--- urProgramBuild
 // CHECK-SAME: -g
 
 // TODO: Uncomment when build options are properly passed to compile and link
 //       commands for kernel_bundle
-// xCHECK: urProgramCompile(
+// xCHECK: <--- urProgramCompile(
 // xCHECK-SAME: -g
-// xCHECK: urProgramLink(
+// xCHECK: <--- urProgramLink(
 // xCHECK-SAME: -g

--- a/sycl/test-e2e/KernelAndProgram/target_compile_fast.cpp
+++ b/sycl/test-e2e/KernelAndProgram/target_compile_fast.cpp
@@ -4,11 +4,11 @@
 // RUN: env SYCL_UR_TRACE=2 %{run} %t_with.out 2>&1 | FileCheck %if !gpu || hip || cuda %{ --check-prefix=CHECK-WITHOUT %} %else %{ --check-prefix=CHECK-INTEL-GPU-WITH %} %s
 // RUN: env SYCL_UR_TRACE=2 %{run} %t_without.out 2>&1 | FileCheck --implicit-check-not=-igc_opts %s
 
-// CHECK-INTEL-GPU-WITH: ---> urProgramBuild
+// CHECK-INTEL-GPU-WITH: <--- urProgramBuild
 // CHECK-INTEL-GPU-WITH-SAME: -igc_opts 'PartitionUnit=1,SubroutineThreshold=50000'
 
-// CHECK-WITHOUT-NOT: ---> urProgramBuild{{.*}}-igc_opts{{.*}} -> UR_RESULT_SUCCESS
-// CHECK-WITHOUT: ---> urProgramBuild{{.*}} -> UR_RESULT_SUCCESS
+// CHECK-WITHOUT-NOT: <--- urProgramBuild{{.*}}-igc_opts{{.*}} -> UR_RESULT_SUCCESS
+// CHECK-WITHOUT: <--- urProgramBuild{{.*}} -> UR_RESULT_SUCCESS
 
 #include <sycl/detail/core.hpp>
 

--- a/sycl/test-e2e/KernelAndProgram/target_register_alloc_mode.cpp
+++ b/sycl/test-e2e/KernelAndProgram/target_register_alloc_mode.cpp
@@ -8,7 +8,7 @@
 // RUN: env SYCL_UR_TRACE=2 %{run} %t_without.out 2>&1 | FileCheck %if system-windows %{ --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %} %else %{ --check-prefix=CHECK-OPT %} %s
 // RUN: env SYCL_UR_TRACE=2 %{run} %t_default.out 2>&1 | FileCheck --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %s
 
-// CHECK-OPT: ---> urProgramBuildExp(
+// CHECK-OPT: <--- urProgramBuildExp(
 // CHECK-SAME-OPT: -ze-intel-enable-auto-large-GRF-mode
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Plugin/adapter-release.cpp
+++ b/sycl/test-e2e/Plugin/adapter-release.cpp
@@ -1,4 +1,4 @@
 // ensure that urAdapterRelease is called
 
 // RUN: env SYCL_UR_TRACE=2 sycl-ls | FileCheck %s
-// CHECK: ---> urAdapterRelease
+// CHECK: <--- urAdapterRelease

--- a/sycl/test-e2e/Plugin/dll-detach-order.cpp
+++ b/sycl/test-e2e/Plugin/dll-detach-order.cpp
@@ -6,7 +6,7 @@
 // CHECK: ---> DLL_PROCESS_DETACH syclx.dll
 
 // whatever adapter THIS is
-// CHECK: ---> urAdapterRelease(
+// CHECK: ---> urAdapterRelease
 // CHECK: <LOADER>[INFO]: unloaded adapter
 
-// CHECK: ---> urLoaderTearDown(
+// CHECK: ---> urLoaderTearDown

--- a/sycl/test-e2e/Plugin/enqueue-arg-order-buffer.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-buffer.cpp
@@ -408,23 +408,23 @@ int main() {
 // ----------- BUFFERS
 
 // CHECK-LABEL: start copyD2H-buffer
-// CHECK: ---> urEnqueueMemBufferRead({{.*}} .size = 64,
-// CHECK: ---> urEnqueueMemBufferReadRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}, .bufferRowPitch = 64,
-// CHECK: ---> urEnqueueMemBufferReadRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 3}, .bufferRowPitch = 64, .bufferSlicePitch = 320,
+// CHECK: <--- urEnqueueMemBufferRead({{.*}} .size = 64,
+// CHECK: <--- urEnqueueMemBufferReadRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}, .bufferRowPitch = 64,
+// CHECK: <--- urEnqueueMemBufferReadRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 3}, .bufferRowPitch = 64, .bufferSlicePitch = 320,
 // CHECK: end copyD2H-buffer
 
 // CHECK-LABEL: start copyH2D-buffer
-// CHECK: ---> urEnqueueMemBufferWrite({{.*}} .size = 64,
-// CHECK: ---> urEnqueueMemBufferWriteRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}, .bufferRowPitch = 64, .bufferSlicePitch = 0, .hostRowPitch = 64, 
-// CHECK: ---> urEnqueueMemBufferWriteRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 3}, .bufferRowPitch = 64, .bufferSlicePitch = 320, .hostRowPitch = 64, .hostSlicePitch = 320,
+// CHECK: <--- urEnqueueMemBufferWrite({{.*}} .size = 64,
+// CHECK: <--- urEnqueueMemBufferWriteRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}, .bufferRowPitch = 64, .bufferSlicePitch = 0, .hostRowPitch = 64, 
+// CHECK: <--- urEnqueueMemBufferWriteRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 3}, .bufferRowPitch = 64, .bufferSlicePitch = 320, .hostRowPitch = 64, .hostSlicePitch = 320,
 // CHECK: end copyH2D-buffer
 
 // CHECK-LABEL: start copyD2D-buffer
-// CHECK: ---> urEnqueueMemBufferCopy({{.*}} .size = 64
-// CHECK: ---> urEnqueueMemBufferCopyRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}, .srcRowPitch = 64, .srcSlicePitch = 320, .dstRowPitch = 64, .dstSlicePitch = 320
+// CHECK: <--- urEnqueueMemBufferCopy({{.*}} .size = 64
+// CHECK: <--- urEnqueueMemBufferCopyRect({{.*}} .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}, .srcRowPitch = 64, .srcSlicePitch = 320, .dstRowPitch = 64, .dstSlicePitch = 320
 // CHECK: .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 3}, .srcRowPitch = 64, .srcSlicePitch = 320, .dstRowPitch = 64, .dstSlicePitch = 320
 // CHECK: end copyD2D-buffer
 
 // CHECK-LABEL: start testFill Buffer
-// CHECK :---> urEnqueueMemBufferFill({{.*}} .patternSize = 4, .offset = 0, .size = 64,
+// CHECK: <--- urEnqueueMemBufferFill({{.*}} .patternSize = 4, .offset = 0, .size = 64,
 // CHECK: end testFill Buffer

--- a/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
@@ -303,28 +303,28 @@ int main() {
 // clang-format off
 //CHECK: start copyD2H-Image
 //CHECK: -- 1D
-//CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
-//CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
+//CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
+//CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
 //CHECK: about to destruct 1D
-//CHECK: ---> urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
+//CHECK: <--- urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
 //CHECK: -- 2D
-//CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE2D, .width = 16, .height = 5, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 0
-//CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE2D, .width = 16, .height = 5, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 0
+//CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE2D, .width = 16, .height = 5, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 0
+//CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE2D, .width = 16, .height = 5, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 0
 //CHECK: about to destruct 2D
-//CHECK: ---> urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 1}, .rowPitch = 256
+//CHECK: <--- urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 1}, .rowPitch = 256
 //CHECK: -- 3D
-//CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE3D, .width = 16, .height = 5, .depth = 3, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 
-//CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE3D, .width = 16, .height = 5, .depth = 3, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 
+//CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE3D, .width = 16, .height = 5, .depth = 3, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 
+//CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE3D, .width = 16, .height = 5, .depth = 3, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 
 //CHECK: about to destruct 3D
-//CHECK: ---> urEnqueueMemImageRead({{.*}}.region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 3}, .rowPitch = 256, .slicePitch = 1280
+//CHECK: <--- urEnqueueMemImageRead({{.*}}.region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 3}, .rowPitch = 256, .slicePitch = 1280
 //CHECK: end copyD2H-Image
 
 // CHECK: start copyH2D-image
 // CHECK: -- 1D
-// CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
-// CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
-// CHECK: ---> urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 0, .slicePitch = 0, .numMipLevel = 0, .numSamples = 0
-// CHECK: ---> urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
+// CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
+// CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 256, .slicePitch = 256, .numMipLevel = 0, .numSamples = 0
+// CHECK: <--- urMemImageCreate({{.*}} .type = UR_MEM_TYPE_IMAGE1D, .width = 16, .height = 1, .depth = 1, .arraySize = 0, .rowPitch = 0, .slicePitch = 0, .numMipLevel = 0, .numSamples = 0
+// CHECK: <--- urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
 // The order of the following calls may vary since some of them are made by a
 // host task (in a separate thread). Don't check for the actual function name
 // as it may be interleaved with other tracing output.
@@ -333,7 +333,7 @@ int main() {
 // CHECK-DAG: .region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
 // CHECK-DAG: .region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
 // CHECK: about to destruct 1D
-// CHECK: ---> urEnqueueMemImageRead({{.*}}.region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
+// CHECK: <--- urEnqueueMemImageRead({{.*}}.region = (struct ur_rect_region_t){.width = 16, .height = 1, .depth = 1}
 // CHECK: -- 2D
 // The order of the following calls may vary since some of them are made by a
 // host task (in a separate thread). Don't check for the actual function name
@@ -347,7 +347,7 @@ int main() {
 // CHECK-DAG: .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 1}
 // CHECK-DAG: .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 1}
 // CHECK: about to destruct 2D
-// CHECK: ---> urEnqueueMemImageRead({{.*}}.region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 1}
+// CHECK: <--- urEnqueueMemImageRead({{.*}}.region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 1}
 // CHECK: -- 3D
 // CHECK-DAG: .type = UR_MEM_TYPE_IMAGE3D, .width = 16, .height = 5, .depth = 3, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 0
 // CHECK-DAG: .type = UR_MEM_TYPE_IMAGE3D, .width = 16, .height = 5, .depth = 3, .arraySize = 0, .rowPitch = 256, .slicePitch = 1280, .numMipLevel = 0, .numSamples = 0
@@ -361,7 +361,7 @@ int main() {
 // CHECK-DAG: .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 3}, .rowPitch = 256, .slicePitch = 1280
 // CHECK-DAG: .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 3}, .rowPitch = 256, .slicePitch = 1280
 // CHECK: about to destruct 3D
-// CHECK: ---> urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 3}, .rowPitch = 256, .slicePitch = 1280
+// CHECK: <--- urEnqueueMemImageRead({{.*}} .region = (struct ur_rect_region_t){.width = 16, .height = 5, .depth = 3}, .rowPitch = 256, .slicePitch = 1280
 
 // CHECK: end copyH2D-image
 // clang-format on

--- a/sycl/test-e2e/Plugin/level_zero_batch_event_status.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_batch_event_status.cpp
@@ -26,7 +26,7 @@
 // CHECK:  ZE ---> zeCommandListClose
 // CHECK:  ZE ---> zeCommandQueueExecuteCommandLists
 // CHECK: ---> urEventGetInfo
-// CHECK-NOT: urEventsWait
+// CHECK-NOT: ---> urEventsWait
 // CHECK: ---> urEnqueueKernelLaunch
 // CHECK: ZE ---> zeCommandListAppendLaunchKernel
 // CHECK: ---> urQueueFinish

--- a/sycl/test-e2e/Plugin/level_zero_usm_device_read_only.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_usm_device_read_only.cpp
@@ -17,7 +17,7 @@ int main(int argc, char *argv[]) {
   auto ptr1 =
       malloc_shared<int>(1, Q, ext::oneapi::property::usm::device_read_only());
   // CHECK: ---> urUSMSharedAlloc
-  // CHECK-SAME:ZE ---> zeMemAllocShared
+  // CHECK:ZE ---> zeMemAllocShared
 
   auto ptr2 = aligned_alloc_shared<int>(
       1, 1, Q, ext::oneapi::property::usm::device_read_only());

--- a/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-level-zero.cpp
+++ b/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-level-zero.cpp
@@ -28,5 +28,5 @@ int main() {
   return 0;
 }
 
-// CHECK0: ---> urProgramBuild{{.*}}-ze-opt-disable{{.*}}-> UR_RESULT_SUCCESS
-// CHECK1: ---> urProgramBuild{{.*}}-ze-opt-level=2{{.*}}-> UR_RESULT_SUCCESS
+// CHECK0: <--- urProgramBuild{{.*}}-ze-opt-disable{{.*}}-> UR_RESULT_SUCCESS
+// CHECK1: <--- urProgramBuild{{.*}}-ze-opt-level=2{{.*}}-> UR_RESULT_SUCCESS

--- a/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
+++ b/sycl/test-e2e/PropagateOptionsToBackend/sycl-opt-level-opencl.cpp
@@ -31,7 +31,7 @@ int main() {
   return 0;
 }
 
-// CHECKOCL0: urProgramBuild{{.*}}-cl-opt-disable
-// CHECKOCL1-NOT: urProgramBuild{{.*}}-cl-opt-disable
-// CHECKOCL2-NOT: urProgramBuild{{.*}}-cl-opt-disable
-// CHECKOCL3-NOT: urProgramBuild{{.*}}-cl-opt-disable
+// CHECKOCL0: <--- urProgramBuild{{.*}}-cl-opt-disable
+// CHECKOCL1-NOT: <--- urProgramBuild{{.*}}-cl-opt-disable
+// CHECKOCL2-NOT: <--- urProgramBuild{{.*}}-cl-opt-disable
+// CHECKOCL3-NOT: <--- urProgramBuild{{.*}}-cl-opt-disable

--- a/sycl/test-e2e/Regression/context_is_destroyed_after_exception.cpp
+++ b/sycl/test-e2e/Regression/context_is_destroyed_after_exception.cpp
@@ -32,4 +32,4 @@ int main() {
   return 0;
 }
 
-// CHECK:---> urContextRelease(
+// CHECK: <--- urContextRelease(

--- a/sycl/test-e2e/Regression/image_access.cpp
+++ b/sycl/test-e2e/Regression/image_access.cpp
@@ -45,5 +45,5 @@ int main() {
   return 0;
 }
 
-// CHECK:---> urMemImageCreate
-// CHECK:---> urEnqueueMemImageRead
+// CHECK: <--- urMemImageCreate
+// CHECK: <--- urEnqueueMemImageRead

--- a/sycl/test-e2e/Regression/implicit_kernel_bundle_image_filtering.cpp
+++ b/sycl/test-e2e/Regression/implicit_kernel_bundle_image_filtering.cpp
@@ -43,7 +43,7 @@ int main() {
 }
 
 // --- Check that only a single program is built:
-// CHECK: ---> urProgramBuildExp
-// CHECK-NOT: ---> urProgramBuildExp
+// CHECK: <--- urProgramBuildExp
+// CHECK-NOT: <--- urProgramBuildExp
 // --- Check that the test completed with expected results:
 // CHECK: passed

--- a/sycl/test-e2e/Regression/pi_release.cpp
+++ b/sycl/test-e2e/Regression/pi_release.cpp
@@ -12,5 +12,5 @@ int main() {
   return 0;
 }
 
-// CHECK: urQueueRelease
-// CHECK: urContextRelease
+// CHECK: <--- urQueueRelease
+// CHECK: <--- urContextRelease

--- a/sycl/test-e2e/Scheduler/HostAccDestruction.cpp
+++ b/sycl/test-e2e/Scheduler/HostAccDestruction.cpp
@@ -35,5 +35,5 @@ int main() {
 }
 
 // CHECK:host acc destructor call
-// CHECK:---> urEnqueueKernelLaunch
+// CHECK: <--- urEnqueueKernelLaunch
 // CHECK:end of scope

--- a/sycl/test-e2e/Scheduler/InOrderQueueDeps.cpp
+++ b/sycl/test-e2e/Scheduler/InOrderQueueDeps.cpp
@@ -38,15 +38,15 @@ int main() {
 
   // Sequential submissions to the same in-order queue should not result in any
   // event dependencies.
-  // CHECK: urEnqueueKernelLaunch
+  // CHECK: <--- urEnqueueKernelLaunch
   // CHECK-SAME: .numEventsInWaitList = 0
   submitKernel(InOrderQueueA, Buf);
-  // CHECK: urEnqueueKernelLaunch
+  // CHECK: <--- urEnqueueKernelLaunch
   // CHECK-SAME: .numEventsInWaitList = 0
   submitKernel(InOrderQueueA, Buf);
   // Submisssion to a different in-order queue should explicitly depend on the
   // previous command group.
-  // CHECK: urEnqueueKernelLaunch
+  // CHECK: <--- urEnqueueKernelLaunch
   // CHECK-SAME: .numEventsInWaitList = 1
   submitKernel(InOrderQueueB, Buf);
 

--- a/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
+++ b/sycl/test-e2e/Scheduler/MemObjRemapping.cpp
@@ -28,7 +28,7 @@ int main() {
 
   {
     // Check access mode flags
-    // CHECK: urEnqueueMemBufferMap
+    // CHECK: <--- urEnqueueMemBufferMap
     // CHECK: .mapFlags = UR_MAP_FLAG_READ
     auto AccA = BufA.get_access<access::mode::read>();
     for (std::size_t I = 0; I < Size; ++I) {
@@ -36,15 +36,15 @@ int main() {
     }
   }
   {
-    // CHECK: urEnqueueMemUnmap
-    // CHECK: urEnqueueMemBufferMap
+    // CHECK: <--- urEnqueueMemUnmap
+    // CHECK: <--- urEnqueueMemBufferMap
     // CHECK: .mapFlags = UR_MAP_FLAG_READ | UR_MAP_FLAG_WRITE
     auto AccA = BufA.get_access<access::mode::write>();
     for (std::size_t I = 0; I < Size; ++I)
       AccA[I] = 2 * I;
   }
 
-  // CHECK-NOT: urEnqueueMemBufferMap
+  // CHECK-NOT: <--- urEnqueueMemBufferMap
   auto AccA = BufA.get_access<access::mode::read>();
   for (std::size_t I = 0; I < Size; ++I) {
     assert(AccA[I] == 2 * I);

--- a/sycl/test-e2e/Scheduler/ReleaseResourcesTest.cpp
+++ b/sycl/test-e2e/Scheduler/ReleaseResourcesTest.cpp
@@ -46,11 +46,11 @@ int main() {
   return Failed;
 }
 
-// CHECK:---> urContextCreate
-// CHECK:---> urQueueCreate
-// CHECK:---> urProgramCreate
-// CHECK:---> urKernelCreate
-// CHECK:---> urQueueRelease
-// CHECK:---> urContextRelease
-// CHECK:---> urKernelRelease
-// CHECK:---> urProgramRelease
+// CHECK: <--- urContextCreate
+// CHECK: <--- urQueueCreate
+// CHECK: <--- urProgramCreate
+// CHECK: <--- urKernelCreate
+// CHECK: <--- urQueueRelease
+// CHECK: <--- urContextRelease
+// CHECK: <--- urKernelRelease
+// CHECK: <--- urProgramRelease

--- a/sycl/test-e2e/Scheduler/SubBufferRemapping.cpp
+++ b/sycl/test-e2e/Scheduler/SubBufferRemapping.cpp
@@ -6,12 +6,12 @@
 // correct alloca, even in the case of sub-buffer accessors in host tasks.
 
 // CHECK: == fills completed
-// CHECK: urEnqueueMemBufferMap
-// CHECK: urEnqueueMemBufferMap
+// CHECK: <--- urEnqueueMemBufferMap
+// CHECK: <--- urEnqueueMemBufferMap
 // CHECK-SAME: .mapFlags = UR_MAP_FLAG_READ
 
 // CHECK: == between host accesses
-// CHECK: urEnqueueMemBufferMap
+// CHECK: <--- urEnqueueMemBufferMap
 // CHECK-SAME: .mapFlags = UR_MAP_FLAG_READ
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/SharedLib/use_when_link_verify_cache.cpp
+++ b/sycl/test-e2e/SharedLib/use_when_link_verify_cache.cpp
@@ -50,19 +50,19 @@ void run() {
 }
 int main() {
 #ifdef FOO_FIRST
-  // CHECK-FIRST: urProgramBuild
+  // CHECK-FIRST: <--- urProgramBuild
   // CHECK-FIRST: Foo: 1
   // CHECK-FIRST: Foo: 1
   assert(foo() == 1);
   assert(foo() == 1);
 #endif
-  // CHECK: urProgramBuild
+  // CHECK: <--- urProgramBuild
   // CHECK: Main: 2
   // CHECK: Main: 2
   run();
   run();
 #ifndef FOO_FIRST
-  // CHECK-LAST: urProgramBuild
+  // CHECK-LAST: <--- urProgramBuild
   // CHECK-LAST: Foo: 1
   // CHECK-LAST: Foo: 1
   assert(foo() == 1);

--- a/sycl/test-e2e/SharedLib/use_with_dlopen_verify_cache.cpp
+++ b/sycl/test-e2e/SharedLib/use_with_dlopen_verify_cache.cpp
@@ -61,7 +61,7 @@ void run() {
 }
 int main() {
 #ifdef RUN_FIRST
-  // CHECK-FIRST: urProgramBuild
+  // CHECK-FIRST: <--- urProgramBuild
   // CHECK-FIRST: Main: 2
   // CHECK-FIRST: Main: 2
   run();
@@ -77,21 +77,21 @@ int main() {
   *(void **)(&func) = dlsym(handle, "_Z3foov");
 
 #ifdef RUN_MIDDLE_BEFORE
-  // CHECK-MIDDLE-BEFORE: urProgramBuild
+  // CHECK-MIDDLE-BEFORE: <--- urProgramBuild
   // CHECK-MIDDLE-BEFORE: Main: 2
   // CHECK-MIDDLE-BEFORE: Main: 2
   run();
   run();
 #endif
 
-  // CHECK: urProgramBuild
+  // CHECK: <--- urProgramBuild
   // CHECK: Foo: 1
   // CHECK: Foo: 1
   assert(func() == 1);
   assert(func() == 1);
 
 #ifdef RUN_MIDDLE_AFTER
-  // CHECK-MIDDLE-AFTER: urProgramBuild
+  // CHECK-MIDDLE-AFTER: <--- urProgramBuild
   // CHECK-MIDDLE-AFTER: Main: 2
   // CHECK-MIDDLE-AFTER: Main: 2
   run();
@@ -101,7 +101,7 @@ int main() {
   dlclose(handle);
 
 #ifdef RUN_LAST
-  // CHECK-LAST: urProgramBuild
+  // CHECK-LAST: <--- urProgramBuild
   // CHECK-LAST: Main: 2
   // CHECK-LAST: Main: 2
   run();

--- a/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/image_selection.cpp
@@ -69,35 +69,35 @@ int main() {
   // a real pointer in urKernelSetArgMemObj.
 
   // CHECK-DEFAULT: Submission 0
-  // CHECK-DEFAULT: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT: Default value of specialization constant was used.
 
   // CHECK-DEFAULT: Submission 1
-  // CHECK-DEFAULT: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT: New specialization constant value was set.
 
   // CHECK-DEFAULT: Submission 2
-  // CHECK-DEFAULT: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT: Default value of specialization constant was used.
 
   // CHECK-DEFAULT: Submission 3
-  // CHECK-DEFAULT: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT: New specialization constant value was set.
 
   // CHECK-ENABLED: Submission 0
-  // CHECK-ENABLED: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
+  // CHECK-ENABLED: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
   // CHECK-ENABLED: Default value of specialization constant was used.
 
   // CHECK-ENABLED: Submission 1
-  // CHECK-ENABLED: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-ENABLED: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-ENABLED: New specialization constant value was set.
 
   // CHECK-ENABLED: Submission 2
-  // CHECK-ENABLED: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
+  // CHECK-ENABLED: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
   // CHECK-ENABLED: Default value of specialization constant was used.
 
   // CHECK-ENABLED: Submission 3
-  // CHECK-ENABLED: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-ENABLED: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-ENABLED: New specialization constant value was set.
 
   // CHECK-MIX: Submission 0
@@ -137,11 +137,11 @@ int main() {
   // default, that's why nullptr is set as 4th parameter of
   // urKernelSetArgMemObj.
   // CHECK-DEFAULT: Kernel bundle
-  // CHECK-DEFAULT: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = {{(0x)?[0-9,a-f,A-F]+}}) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT: Default value of specialization constant was used.
 
   // CHECK-ENABLED: Kernel bundle
-  // CHECK-ENABLED: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
+  // CHECK-ENABLED: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
   // CHECK-ENABLED: Default value of specialization constant was used.
 
   // CHECK-MIX: Kernel bundle
@@ -169,7 +169,7 @@ int main() {
   // constants. We are verifying that by checking the 4th parameter is set to
   // zero.
   // CHECK-DEFAULT-EXPLICIT-SET: Default value was explicitly set
-  // CHECK-DEFAULT-EXPLICIT-SET: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT-EXPLICIT-SET: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT-EXPLICIT-SET: Default value of specialization constant was used.
   std::cout << "Default value was explicitly set" << std::endl;
   Q.submit([&](sycl::handler &cgh) {
@@ -192,7 +192,7 @@ int main() {
   // values of specialization constants. We are verifying that by checking the
   // 4th parameter is set to zero.
   // CHECK-DEFAULT-BACK-TO-DEFAULT: Changed to new value and then default value was explicitly set
-  // CHECK-DEFAULT-BACK-TO-DEFAULT: ---> urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
+  // CHECK-DEFAULT-BACK-TO-DEFAULT: <--- urKernelSetArgMemObj({{.*}}, .hArgValue = nullptr) -> UR_RESULT_SUCCESS;
   // CHECK-DEFAULT-BACK-TO-DEFAULT: Default value of specialization constant was used.
   std::cout << "Changed to new value and then default value was explicitly set"
             << std::endl;

--- a/sycl/test-e2e/SpecConstants/2020/non_native/SpecConstBuffer.cpp
+++ b/sycl/test-e2e/SpecConstants/2020/non_native/SpecConstBuffer.cpp
@@ -20,5 +20,5 @@ int main() {
   });
   Q.wait();
   return 0;
-  // CHECK: urMemRelease
+  // CHECK: <--- urMemRelease
 }

--- a/sycl/test-e2e/Tracing/buffer_printers.cpp
+++ b/sycl/test-e2e/Tracing/buffer_printers.cpp
@@ -8,7 +8,7 @@
 
 // Test image-specific printers of the Plugin Interace
 //
-//CHECK: ---> urEnqueueMemBufferCopyRect(
+//CHECK: <--- urEnqueueMemBufferCopyRect(
 //CHECK-SAME: .srcOrigin = (struct ur_rect_offset_t){.x = 64, .y = 5, .z = 0}
 //CHECK-SAME: .dstOrigin = (struct ur_rect_offset_t){.x = 0, .y = 0, .z = 0}
 //CHECK-SAME: .region = (struct ur_rect_region_t){.width = 64, .height = 5, .depth = 1}
@@ -36,7 +36,7 @@ int main() {
     });
   }
 
-  // CHECK: ---> urMemBufferPartition(
+  // CHECK: <--- urMemBufferPartition(
   // CHECK-SAME: .origin = 128, .size = 32
 
   constexpr unsigned Size = 64;

--- a/sycl/test-e2e/Tracing/image_printers.cpp
+++ b/sycl/test-e2e/Tracing/image_printers.cpp
@@ -5,9 +5,9 @@
 
 // Test image-specific printers of the Plugin Interace
 //
-// CHECK: ---> urMemImageCreate(
+// CHECK: <--- urMemImageCreate(
 // CHECK-SAME:   image_desc w/h/d : 4 / 4 / 1  --  arrSz/row/slice : 0 / 64 / 256  --  num_mip_lvls/num_smpls/image_type : 0 / 0 / 4337
-// CHECK: ---> urEnqueueMemBufferReadRect(
+// CHECK: <--- urEnqueueMemBufferReadRect(
 // CHECK-SAME:   ur_rect_offset_t x/y/z : 0/0/0
 // CHECK-SAME:   ur_rect_region_t width/height/depth : 4/4/1
 


### PR DESCRIPTION
Issue with ugly interleaved Level0 adapter and Level0 Unified Runtime traces, that is https://github.com/oneapi-src/unified-runtime/issues/2002 issue, has been fixed in https://github.com/oneapi-src/unified-runtime/pull/2101.

This PR adds necessary changes to e2e tests to make them pass with modified tracing in L0 Adapter.
This PR also reverts https://github.com/intel/llvm/pull/15167 which disabled some traces because of the bug which is now fixed, so traces can be restored.