### PR TITLE
[SYCL][E2E] Add USM requirements to USM/align test

### DIFF
--- a/sycl/test-e2e/USM/align.cpp
+++ b/sycl/test-e2e/USM/align.cpp
@@ -1,3 +1,5 @@
+// REQUIRES: aspect-usm_shared_allocations,aspect-usm_device_allocations,aspect-usm_host_allocations
+
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
The USM/align.cpp E2E test does not correctly require USM support on the device it runs on. This commit adds the requirements.

Fixes https://github.com/intel/llvm/issues/15444