### PR TITLE
[SYCL][E2E][Joint Matrix] Make half tests UNSUPPORTED on some arch

### DIFF
--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/element_wise_all_ops_half.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 // SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
-// UNSUPPORTED: gpu-intel-dg2
+// SYCL Joint Matrix fp16 operations are not supported on SPR
+// UNSUPPORTED: gpu-intel-dg2, arch-intel_cpu_spr
+
 // REQUIRES: aspect-fp16
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/element_wise_all_ops_half.cpp
@@ -14,7 +14,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: cpu
+// XFAIL: arch-intel_cpu_gnr
 
 #include "../../common.hpp"
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/element_wise_all_ops_half.cpp
@@ -14,7 +14,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: arch-intel_cpu_gnr
+// XFAIL: cpu
 
 #include "../../common.hpp"
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_half.cpp
@@ -6,7 +6,9 @@
 //
 //===----------------------------------------------------------------------===//
 // SG size = 32 is not currently supported for SYCL Joint Matrix by IGC on DG2
-// UNSUPPORTED: gpu-intel-dg2
+// SYCL Joint Matrix fp16 operations are not supported on SPR
+// UNSUPPORTED: gpu-intel-dg2, arch-intel_cpu_spr
+
 // REQUIRES: aspect-fp16
 // REQUIRES: aspect-ext_intel_matrix
 // REQUIRES-INTEL-DRIVER: lin: 27501, win: 101.4943

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_half.cpp
@@ -14,7 +14,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: cpu
+// XFAIL: arch-intel_cpu_gnr
 
 #include "../../common.hpp"
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/SG32/joint_matrix_half.cpp
@@ -14,7 +14,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: arch-intel_cpu_gnr
+// XFAIL: cpu
 
 #include "../../common.hpp"
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/element_wise_all_ops_half.cpp
@@ -8,6 +8,9 @@
 // REQUIRES: aspect-fp16
 // REQUIRES: aspect-ext_intel_matrix
 
+// SYCL Joint Matrix fp16 operations are not supported on SPR
+// UNSUPPORTED: arch-intel_cpu_spr
+
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/element_wise_all_ops_half.cpp
@@ -11,7 +11,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: arch-intel_cpu_gnr
+// XFAIL: cpu
 
 #include "../common.hpp"
 #include "../element_wise_all_ops_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/element_wise_all_ops_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/element_wise_all_ops_half.cpp
@@ -11,7 +11,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: cpu
+// XFAIL: arch-intel_cpu_gnr
 
 #include "../common.hpp"
 #include "../element_wise_all_ops_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/joint_matrix_half.cpp
@@ -8,6 +8,9 @@
 // REQUIRES: aspect-fp16
 // REQUIRES: aspect-ext_intel_matrix
 
+// SYCL Joint Matrix fp16 operations are not supported on SPR
+// UNSUPPORTED: arch-intel_cpu_spr
+
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/joint_matrix_half.cpp
@@ -11,7 +11,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: cpu
+// XFAIL: arch-intel_cpu_gnr
 
 #include "../common.hpp"
 #include "../joint_matrix_half_impl.hpp"

--- a/sycl/test-e2e/Matrix/SPVCooperativeMatrix/joint_matrix_half.cpp
+++ b/sycl/test-e2e/Matrix/SPVCooperativeMatrix/joint_matrix_half.cpp
@@ -11,7 +11,7 @@
 // RUN: %{build} -D__SPIRV_USE_COOPERATIVE_MATRIX -o %t.out
 // RUN: %{run} %t.out
 
-// XFAIL: arch-intel_cpu_gnr
+// XFAIL: cpu
 
 #include "../common.hpp"
 #include "../joint_matrix_half_impl.hpp"


### PR DESCRIPTION
Add UNSUPPORTED for SPR for Joint Matrix fp16 tests in SPVCooperativeMatrix folder to avoid unexpected pass.