### PR TITLE
[SYCL][E2E] Disable and fix address sanitizer tests for DG2

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
@@ -2,6 +2,9 @@
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
 // RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
 
+// See https://github.com/intel/llvm/issues/15449
+// UNSUPPORTED: gpu-intel-dg2
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
@@ -2,6 +2,9 @@
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
 // RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
 
+// See https://github.com/intel/llvm/issues/15449
+// UNSUPPORTED: gpu-intel-dg2
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/usm.hpp>

--- a/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
@@ -8,6 +8,8 @@
 
 #include <sycl/detail/core.hpp>
 
+#include <sycl/ext/oneapi/experimental/address_cast.hpp>
+
 int main() {
   sycl::queue Q;
   constexpr std::size_t N = 4;
@@ -18,8 +20,7 @@ int main() {
         sycl::nd_range<1>(N, 1), [=](sycl::nd_item<1> item) {
           auto private_array =
               sycl::ext::oneapi::experimental::static_address_cast<
-                  sycl::access::address_space::private_space,
-                  sycl::access::decorated::no>(array);
+                  sycl::access::address_space::private_space>(array);
           private_array[0] = 0;
         });
     Q.wait();


### PR DESCRIPTION
This commit disables the AddressSanitizer/invalid-argument/out-of-bounds.cpp and sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp tests for DG2, following the enabling of address sanitizer tests for DG2 in https://github.com/intel/llvm/pull/14891.

Additionally, it fixes the compilation failure in
sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp which should hopefully allow it to pass as expected.