### PR TITLE
[SYCL][NATIVECPU] Update Native CPU attributes test

### DIFF
--- a/sycl/test/check_device_code/native_cpu/native_cpu_attrs.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_attrs.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: native_cpu_ock
-// RUN: %clangxx -fsycl -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-native-dump-device-ir %s | FileCheck %s
+// RUN: %clangxx -fsycl -fsycl-targets=native_cpu -Xclang -sycl-std=2020 -mllvm -sycl-native-dump-device-ir %s &> %t.ll
+// RUN: FileCheck %s --input-file %t.ll --check-prefix=CHECK-WG-BARRIER
+// RUN: FileCheck %s --input-file %t.ll
 
 #include "sycl.hpp"
 using namespace sycl;
@@ -18,7 +20,10 @@ int main() {
 
 }
 
-//CHECK-NOT: @__mux_work_group_barrier
+// Currently Native CPU uses the WorkItemLoops pass from the oneAPI
+// Construction Kit to materialize barriers, so the builtin shouldn't 
+// be referenced anymore in the module.
+// CHECK-WG-BARRIER-NOT: @__mux_work_group_barrier
 
-//CHECK-DAG: define{{.*}}@__mux_mem_barrier{{.*}}#[[ATTR_MEM:[0-9]+]]
-//CHECK-DAG: [[ATTR_MEM]]{{.*}}convergent
+// CHECK-DAG: define{{.*}}@__mux_mem_barrier{{.*}}#[[ATTR_MEM:[0-9]+]]
+// CHECK-DAG: [[ATTR_MEM]]{{.*}}convergent

--- a/sycl/test/check_device_code/native_cpu/native_cpu_attrs.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_attrs.cpp
@@ -11,17 +11,12 @@ int main() {
   deviceQueue.submit([&](handler &h) {
     h.parallel_for<Test>(
         r, [=](nd_item<2> it) { 
-          it.barrier(access::fence_space::local_space);
-          //CHECK-DAG: call void @__mux_work_group_barrier({{.*}})
           atomic_fence(memory_order::acquire, memory_scope::work_group);
           //CHECK-DAG: call void @__mux_mem_barrier({{.*}})
         });
   });
 
 }
-
-//CHECK-DAG: define{{.*}}@__mux_work_group_barrier{{.*}}#[[ATTR:[0-9]+]]
-//CHECK-DAG: [[ATTR]]{{.*}}convergent
 
 //CHECK-DAG: define{{.*}}@__mux_mem_barrier{{.*}}#[[ATTR_MEM:[0-9]+]]
 //CHECK-DAG: [[ATTR_MEM]]{{.*}}convergent

--- a/sycl/test/check_device_code/native_cpu/native_cpu_attrs.cpp
+++ b/sycl/test/check_device_code/native_cpu/native_cpu_attrs.cpp
@@ -18,5 +18,7 @@ int main() {
 
 }
 
+//CHECK-NOT: @__mux_work_group_barrier
+
 //CHECK-DAG: define{{.*}}@__mux_mem_barrier{{.*}}#[[ATTR_MEM:[0-9]+]]
 //CHECK-DAG: [[ATTR_MEM]]{{.*}}convergent


### PR DESCRIPTION
Removes the check for `__mux_work_group_barrier` since on Native CPU work group barriers are materialized by OCK's WorkItemLoopPass, and since now we correctly remove unused functions from the module, there are no more references to `__mux_work_group_barrier`.