### PR TITLE
[SYCL][E2E] Fix buffer_location test for GPU

### DIFF
--- a/sycl/test-e2e/USM/buffer_location.cpp
+++ b/sycl/test-e2e/USM/buffer_location.cpp
@@ -1,4 +1,4 @@
-// UNSUPPORTED: gpu
+// REQUIRES: aspect-usm_device_allocations
 // RUN: %{build} -o %t1.out
 // RUN: %{run} %t1.out
 
@@ -72,7 +72,10 @@ int main() {
   });
   e2.wait();
 
-  if (*test_src_ptr != dst_val) {
+  int res_val = 0;
+  q.copy(test_src_ptr, &res_val, 1).wait();
+
+  if (res_val != dst_val) {
     return -1;
   }
 


### PR DESCRIPTION
This commit fixes and issue in buffer_location where the code would attempt to read from a device USM allocation. According to the SYCL specification, these allocations must be explicitly copied to/from host.