### PR TITLE
[SYCL][E2E] Disable AddressSanitizer/nullpointer/global_nullptr.cpp on DG2

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
@@ -6,6 +6,9 @@
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
 // RUN: %{run} not %t 2>&1 | FileCheck %s
 
+// See https://github.com/intel/llvm/issues/15453
+// UNSUPPORTED: gpu-intel-dg2
+
 #include <sycl/detail/core.hpp>
 
 #include <sycl/ext/oneapi/experimental/address_cast.hpp>


### PR DESCRIPTION
The sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp test had compilation errors whe first enabled on DG2. The compilation error was fixed in https://github.com/intel/llvm/pull/15450, but the test fails during execution on DG2. This commit disables the test for DG2.

See https://github.com/intel/llvm/issues/15453.