### PR TITLE
[SYCL][E2E] Enable discard_events_using_assert and build-log for leak

### DIFF
--- a/sycl/test-e2e/DiscardEvents/discard_events_using_assert.cpp
+++ b/sycl/test-e2e/DiscardEvents/discard_events_using_assert.cpp
@@ -1,7 +1,6 @@
 // FIXME unsupported on CUDA and HIP until fallback libdevice becomes available
 // UNSUPPORTED: cuda || hip
 //
-// UNSUPPORTED: ze_debug
 // RUN: %{build} -o %t.out
 //
 // RUN: env SYCL_UR_TRACE=2 %{run} %t.out &> %t.txt ; FileCheck %s --input-file %t.txt

--- a/sycl/test-e2e/KernelAndProgram/build-log.cpp
+++ b/sycl/test-e2e/KernelAndProgram/build-log.cpp
@@ -1,5 +1,5 @@
 // for CUDA and HIP the failure happens at compile time, not during runtime
-// UNSUPPORTED: cuda || hip || ze_debug
+// UNSUPPORTED: cuda || hip
 // TODO: rewrite this into a unit-test
 
 // RUN: %{build} -DGPU -o %t_gpu.out


### PR DESCRIPTION
sycl/test-e2e/DiscardEvents/discard_events_using_assert.cpp and sycl/test-e2e/KernelAndProgram/build-log.cpp no longer show leaks when run with SYCL_UR_TRACE, so they can once again be enabled for ze_debug.