### PR TITLE
[SYCL][E2E] Remove 1-tile PVC UNSUPPORTED from tests

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: level_zero
 // REQUIRES: aspect-ext_intel_device_id
-// UNSUPPORTED: gpu-intel-pvc-1T
 // https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc
 

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -1,6 +1,5 @@
 // REQUIRES: aspect-ext_intel_device_id
 // REQUIRES: level_zero
-// UNSUPPORTED: gpu-intel-pvc-1T
 
 // https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc

--- a/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_sub_sub_device.cpp
@@ -2,7 +2,6 @@
 
 // https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc
-// UNSUPPORTED: gpu-intel-pvc-1T
 
 // RUN: %{build} %level_zero_options -o %t.out
 

--- a/sycl/test-e2e/Plugin/sycl-ls-uuid-subdevs.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls-uuid-subdevs.cpp
@@ -2,8 +2,6 @@
  * devices. */
 // REQUIRES:  gpu, level_zero
 
-// UNSUPPORTED: gpu-intel-pvc-1T
-
 // As of now, ZEX_NUMBER_OF_CCS is not working with FLAT hierachy,
 // which is the new default on PVC.
 


### PR DESCRIPTION
This commit removes the UNSUPPORTED marker with 1-tile PVC for a selection of tests. sycl-ls-uuid-subdevs seems to now pass and the rest are XFAIL on PVC which is wider than disabling for just 1-tile.