### PR TITLE
[SYCL][E2E] Reenable flaky L0 tests

### DIFF
--- a/sycl/test-e2e/HostInteropTask/host-task-two-queues.cpp
+++ b/sycl/test-e2e/HostInteropTask/host-task-two-queues.cpp
@@ -1,8 +1,5 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
-//
-// TODO: Flaky fail on Level Zero that is why mark as unsupported temporarily.
-// UNSUPPORTED: level_zero
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/Plugin/sycl-ls.cpp
+++ b/sycl/test-e2e/Plugin/sycl-ls.cpp
@@ -12,5 +12,3 @@
 // The test crashed on CUDA CI machines with the latest OpenCL GPU RT
 // (21.19.19792).
 // UNSUPPORTED: cuda
-// Temporarily disable on L0 due to fails in CI
-// UNSUPPORTED: level_zero


### PR DESCRIPTION
The two tests reenabled in this test were disabled due to flaky failure on L0. This commit tries to reenable them.