### PR TITLE
[DeviceSanitizer] Fix wrong test for nullptr detection

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
@@ -15,7 +15,7 @@
 
 int main() {
   sycl::queue Q;
-  constexpr std::size_t N = 2;
+  constexpr std::size_t N = 4;
   int *array = nullptr;
 
   Q.submit([&](sycl::handler &h) {

--- a/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
@@ -11,8 +11,6 @@
 
 #include <sycl/detail/core.hpp>
 
-#include <sycl/ext/oneapi/experimental/address_cast.hpp>
-
 int main() {
   sycl::queue Q;
   constexpr std::size_t N = 4;

--- a/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/global_nullptr.cpp
@@ -15,17 +15,12 @@
 
 int main() {
   sycl::queue Q;
-  constexpr std::size_t N = 4;
+  constexpr std::size_t N = 2;
   int *array = nullptr;
 
   Q.submit([&](sycl::handler &h) {
     h.parallel_for<class MyKernel>(
-        sycl::nd_range<1>(N, 1), [=](sycl::nd_item<1> item) {
-          auto private_array =
-              sycl::ext::oneapi::experimental::static_address_cast<
-                  sycl::access::address_space::private_space>(array);
-          private_array[0] = 0;
-        });
+        sycl::nd_range<1>(N, 1), [=](sycl::nd_item<1> item) { array[0] = 0; });
     Q.wait();
   });
   // CHECK: ERROR: DeviceSanitizer: null-pointer-access on Unknown Memory


### PR DESCRIPTION
The content of "global_nullptr.cpp" was same with "private_nullptr.cpp".
This patch fix this.