### PR TITLE
[SYCL][ClangLinkerWrapper] Fix read of invalid memory

### DIFF
--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -1471,8 +1471,12 @@ Error extractBundledObjects(StringRef Filename, const ArgList &Args,
           llvm::MemoryBuffer::getFileOrSTDIN(*UnbundledFile, /*isText=*/true);
       if (std::error_code EC = ObjList.getError())
         return createFileError(*UnbundledFile, EC);
-      (*ObjList)->getBuffer().split(ObjectFilePaths, '\n', /*MaxSplit=*/-1,
-                                    /*KeepEmpty=*/false);
+      // Create a copy of the list we can reference even after we close
+      // the file.
+      StringRef UnbundledArchiveList =
+          Args.MakeArgString((*ObjList)->getBuffer());
+      UnbundledArchiveList.split(ObjectFilePaths, '\n', /*MaxSplit=*/-1,
+                                 /*KeepEmpty=*/false);
     } else {
       ObjectFilePaths.push_back(*UnbundledFile);
     }


### PR DESCRIPTION
The problem was the buffer gets freed when we go out of the `if` because the `unique_ptr` is created there, so just make a copy that will stay alive as long as we need it. Confirmed fix with valgrind.

This is already tested by `sycl/test-e2e/NewOffloadDriver/multisource.cpp` and it fails sporadically which led me to this fix.