### PR TITLE
[CI][CODEOWNERS] Adjust CODEOWNERS for SYCL Graph

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -139,8 +139,9 @@ sycl/include/sycl/ext/oneapi/experimental/graph.hpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.cpp @intel/sycl-graphs-reviewers
 sycl/source/detail/graph_impl.hpp @intel/sycl-graphs-reviewers
 sycl/unittests/Extensions/CommandGraph/ @intel/sycl-graphs-reviewers
-sycl/doc/design/CommandGraph.md @intel/sycl-graphs-reviewers
 sycl/test-e2e/Graph @intel/sycl-graphs-reviewers
+sycl/doc/design/CommandGraph.md @intel/sycl-graphs-reviewers
+sycl/doc/syclgraph/ @intel/sycl-graphs-reviewers
 sycl/doc/extensions/**/sycl_ext_oneapi_graph.asciidoc @intel/sycl-graphs-reviewers
 
 # syclcompat library

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -141,8 +141,8 @@ sycl/source/detail/graph_impl.hpp @intel/sycl-graphs-reviewers
 sycl/unittests/Extensions/CommandGraph/ @intel/sycl-graphs-reviewers
 sycl/test-e2e/Graph @intel/sycl-graphs-reviewers
 sycl/doc/design/CommandGraph.md @intel/sycl-graphs-reviewers
-sycl/doc/syclgraph/ @intel/sycl-graphs-reviewers
 sycl/doc/extensions/**/sycl_ext_oneapi_graph.asciidoc @intel/sycl-graphs-reviewers
+sycl/doc/syclgraph/ @intel/sycl-graphs-reviewers
 
 # syclcompat library
 sycl/**/syclcompat/ @intel/syclcompat-lib-reviewers


### PR DESCRIPTION
This commit assigns the codeowners for the SYCL Graph code to the
intel/sycl-graphs-reviewers team.
