### PR TITLE
[GHA] Uplift Linux GPU RT version to 24.35.30872.22

### DIFF
--- a/devops/dependencies.json
+++ b/devops/dependencies.json
@@ -1,15 +1,15 @@
 {
   "linux": {
     "compute_runtime": {
-      "github_tag": "24.31.30508.7",
-      "version": "24.31.30508.7",
-      "url": "https://github.com/intel/compute-runtime/releases/tag/24.31.30508.7",
+      "github_tag": "24.35.30872.22",
+      "version": "24.35.30872.22",
+      "url": "https://github.com/intel/compute-runtime/releases/tag/24.35.30872.22",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "igc": {
-      "github_tag": "igc-1.0.17384.11",
-      "version": "1.0.17384.11",
-      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.17384.11",
+      "github_tag": "igc-1.0.17537.20",
+      "version": "1.0.17537.20",
+      "url": "https://github.com/intel/intel-graphics-compiler/releases/tag/igc-1.0.17537.20",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "cm": {
@@ -19,9 +19,9 @@
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "level_zero": {
-      "github_tag": "v1.17.42",
-      "version": "v1.17.42",
-      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.17.42",
+      "github_tag": "v1.17.44",
+      "version": "v1.17.44",
+      "url": "https://github.com/oneapi-src/level-zero/releases/tag/v1.17.44",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     },
     "tbb": {


### PR DESCRIPTION
Scheduled drivers uplift