### PR TITLE
[CI] Remove Doxygen docs from intel.github.io/llvm-docs/

### DIFF
--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -1,4 +1,4 @@
-name: Generate Doxygen documentation
+name: Generate documentation
 
 on:
   schedule:

--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -25,7 +25,7 @@ jobs:
         path: repo
     - name: Install deps
       run: |
-        sudo apt-get install -y doxygen graphviz ssh ninja-build libhwloc-dev
+        sudo apt-get install -y graphviz ssh ninja-build libhwloc-dev
         sudo pip3 install -r repo/llvm/docs/requirements.txt
     - name: Build Docs
       run: |

--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -33,8 +33,6 @@ jobs:
         cd $GITHUB_WORKSPACE/build
         python $GITHUB_WORKSPACE/repo/buildbot/configure.py -w $GITHUB_WORKSPACE \
         -s $GITHUB_WORKSPACE/repo -o $GITHUB_WORKSPACE/build -t Release --docs
-        cmake --build . --target doxygen-sycl
-        cmake --build . --target doxygen-clang
         cmake --build . --target docs-sycl-html
         cmake --build . --target docs-clang-html
     - name: Deploy
@@ -52,9 +50,7 @@ jobs:
         git rm -rf .
         touch .nojekyll
         yes | \cp -rf $GITHUB_WORKSPACE/build/tools/sycl/doc/html/* .
-        mv $GITHUB_WORKSPACE/build/tools/sycl/doc/doxygen/html doxygen/
         mv $GITHUB_WORKSPACE/build/tools/clang/docs/html clang/
-        mv $GITHUB_WORKSPACE/build/tools/clang/docs/doxygen/html clang_doxygen/
         git config --global user.name "iclsrc"
         git config --global user.email "ia.compiler.tools.git@intel.com"
         git add .

--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -55,4 +55,4 @@ jobs:
         git config --global user.email "ia.compiler.tools.git@intel.com"
         git add .
         git diff-index --quiet HEAD || git commit --amend -m "Update docs" -s
-        git push
+        git push -f

--- a/.github/workflows/sycl-docs.yml
+++ b/.github/workflows/sycl-docs.yml
@@ -55,4 +55,4 @@ jobs:
         git config --global user.email "ia.compiler.tools.git@intel.com"
         git add .
         git diff-index --quiet HEAD || git commit --amend -m "Update docs" -s
-        git push -f
+        git push

--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -116,7 +116,6 @@ def do_configure(args):
         llvm_enable_assertions = "OFF"
 
     if args.docs:
-        llvm_enable_doxygen = "ON"
         llvm_enable_sphinx = "ON"
 
     if args.shared_libs:

--- a/sycl/doc/extensions/supported/sycl_ext_intel_esimd/README.md
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_esimd/README.md
@@ -16,7 +16,6 @@ vectorization is expressed explicitly in the code by the programmer.
 Please see the additional resources on the Intel DPC++ project's github:
 
 1) [ESIMD Extension Specification](./sycl_ext_intel_esimd.md)
-1) [ESIMD API/doxygen reference](https://intel.github.io/llvm-docs/doxygen/group__sycl__esimd.html)
 1) [Examples](./examples/README.md)
 1) [ESIMD end-to-end LIT tests](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/ESIMD/)
 1) [Implementation and API Restrictions](./sycl_ext_intel_esimd.md#implementation-restrictions)

--- a/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd.md
@@ -38,7 +38,6 @@
   - [Other restrictions](#other-restrictions)
 
 ## Other content:
-* [ESIMD API/doxygen reference](https://intel.github.io/llvm-docs/doxygen/group__sycl__esimd.html)
 * [Examples](./examples/README.md)
 * [ESIMD LIT tests - working code examples](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/ESIMD/)
 
@@ -162,7 +161,6 @@ The element type must either be a vectorizable type or the `sycl::half` type.
 The set of vectorizable types is the
 set of fundamental SYCL arithmetic types excluding `bool`. The length of the
 vector is the second template parameter.
-See the complete [API reference](https://intel.github.io/llvm-docs/doxygen/classcl_1_1____ESIMD__NS_1_1simd.html#details) for the `simd` class for more details.
 
 ESIMD compiler back-end does the best it can to map each `simd` class object to a
 contiguous block of registers in the general register file (GRF).
@@ -350,8 +348,6 @@ reduction operations are supported:
 - multiply
 - maximum
 - minimum
-
-See more details on the API documentation [page TODO](https://intel.github.io/llvm-docs/doxygen).
 
 ### Memory access APIs
 
@@ -598,9 +594,6 @@ Many memory access APIs accept offsets as arguments, which are used to determine
 actual memory location for the access. Offsets are always expressed in bytes
 rather than element units.
 
-See more details in the API documentation
-[page TODO](https://intel.github.io/llvm-docs/doxygen).
-
 ### Math operations
 
 #### Extended math
@@ -648,10 +641,6 @@ ESIMD supports the following non-standard math functions implemented in hardware
 - Count leading zeroes - `lzd`.
 - Plane equation - `plane`. Solves a component-wise plane equation
   `w = p*u + q*v + r` where `u`, `v`, `w` are vectors and `p`, `q`, `r` are scalars.
-
-
-See more details in the API documentation
-[page TODO](https://intel.github.io/llvm-docs/doxygen).
 
 ### Dot Product Accumulate Systolic - `DPAS` API
 
@@ -869,9 +858,6 @@ There are other useful miscellaneous APIs provided by ESIMD.
 - Count bits - `cbit`.
 - Find least significant set bit - `fbl`.
 - Find most significant set bit - `fbh`.
-
-See more details in the API documentation
-[page TODO](https://intel.github.io/llvm-docs/doxygen).
 
 <br>
 

--- a/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd_functions.md
+++ b/sycl/doc/extensions/supported/sycl_ext_intel_esimd/sycl_ext_intel_esimd_functions.md
@@ -22,7 +22,6 @@ See more general ESIMD documentation [here](./sycl_ext_intel_esimd.md).
 
 ## Other content:
 * [General ESIMD documentation](./sycl_ext_intel_esimd.md)
-* [ESIMD API/doxygen reference](https://intel.github.io/llvm-docs/doxygen/group__sycl__esimd.html)
 * [Examples](./examples/README.md)
 * [ESIMD LIT tests - working code examples](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/ESIMD/)
 

--- a/sycl/doc/index.rst
+++ b/sycl/doc/index.rst
@@ -15,7 +15,6 @@ Using oneAPI DPC++ for Application Development
    Extensions <https://github.com/intel/llvm/tree/sycl/sycl/doc/extensions>
    syclcompat/README.md
    FAQ
-   User API Reference <https://intel.github.io/llvm-docs/doxygen/group__sycl__api.html>
    EnvironmentVariables
    MultiTileCardWithLevelZero
    syclgraph/SYCLGraphUsageGuide
@@ -26,9 +25,7 @@ Design Documents for the oneAPI DPC++ Compiler
 .. toctree::
    :maxdepth: 1
 
-   API Reference <https://intel.github.io/llvm-docs/doxygen>
    Clang Documentation <https://intel.github.io/llvm-docs/clang>
-   Clang API Reference <https://intel.github.io/llvm-docs/clang_doxygen>
    design/CompilerAndRuntimeDesign
    design/KernelParameterPassing
    design/PluginInterface


### PR DESCRIPTION
Prequel of https://github.com/intel/llvm/pull/15483

This PR removes Doxygen docs/links from intel.github.io/llvm-docs/. This is done to reduce the size of the website so that it can be hosted via artifacts in #15483. [intel/llvm-docs](https://github.com/intel/llvm-docs) repository will soon be decommissioned.