### PR TITLE
[SYCL][NFC] Drop unused type traits from public headers

### DIFF
--- a/sycl/include/sycl/detail/common.hpp
+++ b/sycl/include/sycl/detail/common.hpp
@@ -287,12 +287,6 @@ size_t getLinearIndex(const T<Dims> &Index, const U<Dims> &Range) {
   return LinearIndex;
 }
 
-template <typename T> struct InlineVariableHelper {
-  static constexpr T value{};
-};
-
-template <typename T> constexpr T InlineVariableHelper<T>::value;
-
 // The function extends or truncates number of dimensions of objects of id
 // or ranges classes. When extending the new values are filled with
 // DefaultValue, truncation just removes extra values.

--- a/sycl/include/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/sycl/detail/generic_type_lists.hpp
@@ -119,59 +119,6 @@ using scalar_vector_floating_list =
 using floating_list =
     tl_append<scalar_floating_list, vector_floating_list, marray_floating_list>;
 
-// geometric floating point types
-using scalar_geo_half_list = type_list<half>;
-
-using scalar_geo_float_list = type_list<float>;
-
-using scalar_geo_double_list = type_list<double>;
-
-using vector_geo_half_list =
-    type_list<vec<half, 1>, vec<half, 2>, vec<half, 3>, vec<half, 4>>;
-
-using vector_geo_float_list =
-    type_list<vec<float, 1>, vec<float, 2>, vec<float, 3>, vec<float, 4>>;
-
-using vector_geo_double_list =
-    type_list<vec<double, 1>, vec<double, 2>, vec<double, 3>, vec<double, 4>>;
-
-using marray_geo_float_list =
-    type_list<marray<float, 2>, marray<float, 3>, marray<float, 4>>;
-
-using marray_geo_double_list =
-    type_list<marray<double, 2>, marray<double, 3>, marray<double, 4>>;
-
-using geo_half_list = tl_append<scalar_geo_half_list, vector_geo_half_list>;
-
-using geo_float_list = tl_append<scalar_geo_float_list, vector_geo_float_list>;
-
-using geo_double_list =
-    tl_append<scalar_geo_double_list, vector_geo_double_list>;
-
-using scalar_geo_list = tl_append<scalar_geo_half_list, scalar_geo_float_list,
-                                  scalar_geo_double_list>;
-
-using vector_geo_list = tl_append<vector_geo_half_list, vector_geo_float_list,
-                                  vector_geo_double_list>;
-
-using marray_geo_list =
-    tl_append<marray_geo_float_list, marray_geo_double_list>;
-
-using geo_list = tl_append<scalar_geo_list, vector_geo_list>;
-
-// cross floating point types
-using cross_half_list = type_list<vec<half, 3>, vec<half, 4>>;
-
-using cross_float_list = type_list<vec<float, 3>, vec<float, 4>>;
-
-using cross_double_list = type_list<vec<double, 3>, vec<double, 4>>;
-
-using cross_floating_list =
-    tl_append<cross_float_list, cross_double_list, cross_half_list>;
-
-using cross_marray_list = type_list<marray<float, 3>, marray<float, 4>,
-                                    marray<double, 3>, marray<double, 4>>;
-
 using scalar_default_char_list = type_list<char>;
 
 using vector_default_char_list =
@@ -197,10 +144,6 @@ using marray_signed_char_list =
               marray<signed char, 3>, marray<signed char, 4>,
               marray<signed char, 8>, marray<signed char, 16>>;
 
-using signed_char_list =
-    tl_append<scalar_signed_char_list, vector_signed_char_list,
-              marray_signed_char_list>;
-
 using scalar_unsigned_char_list = type_list<unsigned char>;
 
 using vector_unsigned_char_list =
@@ -212,24 +155,6 @@ using marray_unsigned_char_list =
     type_list<marray<unsigned char, 1>, marray<unsigned char, 2>,
               marray<unsigned char, 3>, marray<unsigned char, 4>,
               marray<unsigned char, 8>, marray<unsigned char, 16>>;
-
-using unsigned_char_list =
-    tl_append<scalar_unsigned_char_list, vector_unsigned_char_list,
-              marray_unsigned_char_list>;
-
-using scalar_char_list =
-    tl_append<scalar_default_char_list, scalar_signed_char_list,
-              scalar_unsigned_char_list>;
-
-using vector_char_list =
-    tl_append<vector_default_char_list, vector_signed_char_list,
-              vector_unsigned_char_list>;
-
-using marray_char_list =
-    tl_append<marray_default_char_list, marray_signed_char_list,
-              marray_unsigned_char_list>;
-
-using char_list = tl_append<scalar_char_list, vector_char_list>;
 
 // short int types
 using scalar_signed_short_list = type_list<signed short>;
@@ -243,10 +168,6 @@ using marray_signed_short_list =
     type_list<marray<signed short, 1>, marray<signed short, 2>,
               marray<signed short, 3>, marray<signed short, 4>,
               marray<signed short, 8>, marray<signed short, 16>>;
-
-using signed_short_list =
-    tl_append<scalar_signed_short_list, vector_signed_short_list,
-              marray_signed_short_list>;
 
 using scalar_unsigned_short_list = type_list<unsigned short>;
 
@@ -571,29 +492,13 @@ using signed_basic_list =
 
 using scalar_unsigned_basic_list = tl_append<scalar_unsigned_integer_list>;
 
-using vector_unsigned_basic_list = tl_append<vector_unsigned_integer_list>;
-
-using marray_unsigned_basic_list = tl_append<marray_unsigned_integer_list>;
-
 using unsigned_basic_list =
-    tl_append<scalar_unsigned_basic_list, vector_unsigned_basic_list,
-              marray_unsigned_basic_list>;
-
-using scalar_basic_list =
-    tl_append<scalar_signed_basic_list, scalar_unsigned_basic_list>;
+    tl_append<scalar_unsigned_basic_list, vector_unsigned_integer_list,
+              marray_unsigned_integer_list>;
 
 using vector_basic_list =
-    tl_append<vector_signed_basic_list, vector_unsigned_basic_list>;
+    tl_append<vector_signed_basic_list, vector_unsigned_integer_list>;
 
-using marray_basic_list =
-    tl_append<marray_signed_basic_list, marray_unsigned_basic_list>;
-
-using basic_list =
-    tl_append<scalar_basic_list, vector_basic_list, marray_basic_list>;
-
-// nan builtin types
-using nan_list = tl_append<gtl::unsigned_short_list, gtl::unsigned_int_list,
-                           gtl::unsigned_long_integer_list>;
 } // namespace gtl
 namespace gvl {
 // address spaces

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -66,73 +66,6 @@ inline constexpr bool is_svgenfloat_v =
     is_contained_v<T, gtl::scalar_vector_floating_list>;
 
 template <typename T>
-inline constexpr bool is_mgenfloat_v =
-    is_marray_v<T> && is_svgenfloat_v<get_elem_type_t<T>>;
-
-template <typename T>
-inline constexpr bool is_gengeofloat_v = is_contained_v<T, gtl::geo_float_list>;
-
-template <typename T>
-inline constexpr bool is_gengeodouble_v =
-    is_contained_v<T, gtl::geo_double_list>;
-
-template <typename T>
-inline constexpr bool is_gengeomarrayfloat_v =
-    is_contained_v<T, gtl::marray_geo_float_list>;
-
-template <typename T>
-inline constexpr bool is_gengeomarray_v =
-    is_contained_v<T, gtl::marray_geo_list>;
-
-template <typename T>
-inline constexpr bool is_gengeohalf_v = is_contained_v<T, gtl::geo_half_list>;
-
-template <typename T>
-inline constexpr bool is_vgengeofloat_v =
-    is_contained_v<T, gtl::vector_geo_float_list>;
-
-template <typename T>
-inline constexpr bool is_vgengeodouble_v =
-    is_contained_v<T, gtl::vector_geo_double_list>;
-
-template <typename T>
-inline constexpr bool is_vgengeohalf_v =
-    is_contained_v<T, gtl::vector_geo_half_list>;
-
-template <typename T>
-inline constexpr bool is_sgengeo_v = is_contained_v<T, gtl::scalar_geo_list>;
-
-template <typename T>
-inline constexpr bool is_vgengeo_v = is_contained_v<T, gtl::vector_geo_list>;
-
-template <typename T>
-inline constexpr bool is_gencrossfloat_v =
-    is_contained_v<T, gtl::cross_float_list>;
-
-template <typename T>
-inline constexpr bool is_gencrossdouble_v =
-    is_contained_v<T, gtl::cross_double_list>;
-
-template <typename T>
-inline constexpr bool is_gencrosshalf_v =
-    is_contained_v<T, gtl::cross_half_list>;
-
-template <typename T>
-inline constexpr bool is_gencross_v =
-    is_contained_v<T, gtl::cross_floating_list>;
-
-template <typename T>
-inline constexpr bool is_gencrossmarray_v =
-    is_contained_v<T, gtl::cross_marray_list>;
-
-template <typename T>
-inline constexpr bool is_ugenint_v = is_contained_v<T, gtl::unsigned_int_list>;
-
-template <typename T>
-inline constexpr bool is_intn_v =
-    is_contained_v<T, gtl::vector_signed_int_list>;
-
-template <typename T>
 inline constexpr bool is_genint_v = is_contained_v<T, gtl::signed_int_list>;
 
 template <typename T>
@@ -142,26 +75,8 @@ template <typename T>
 using is_geninteger = std::bool_constant<is_geninteger_v<T>>;
 
 template <typename T>
-inline constexpr bool is_igeninteger_v =
-    is_contained_v<T, gtl::signed_integer_list>;
-
-template <typename T>
-using is_igeninteger = std::bool_constant<is_igeninteger_v<T>>;
-
-template <typename T>
-inline constexpr bool is_ugeninteger_v =
-    is_contained_v<T, gtl::unsigned_integer_list>;
-
-template <typename T>
-using is_ugeninteger = std::bool_constant<is_ugeninteger_v<T>>;
-
-template <typename T>
 inline constexpr bool is_sgeninteger_v =
     is_contained_v<T, gtl::scalar_integer_list>;
-
-template <typename T>
-inline constexpr bool is_vgeninteger_v =
-    is_contained_v<T, gtl::vector_integer_list>;
 
 template <typename T>
 inline constexpr bool is_sigeninteger_v =
@@ -172,85 +87,7 @@ inline constexpr bool is_sugeninteger_v =
     is_contained_v<T, gtl::scalar_unsigned_integer_list>;
 
 template <typename T>
-inline constexpr bool is_vigeninteger_v =
-    is_contained_v<T, gtl::vector_signed_integer_list>;
-
-template <typename T>
-inline constexpr bool is_vugeninteger_v =
-    is_contained_v<T, gtl::vector_unsigned_integer_list>;
-
-template <typename T>
 inline constexpr bool is_genbool_v = is_contained_v<T, gtl::bool_list>;
-
-template <typename T>
-inline constexpr bool is_gentype_v = is_contained_v<T, gtl::basic_list>;
-
-template <typename T>
-inline constexpr bool is_vgentype_v = is_contained_v<T, gtl::vector_basic_list>;
-
-template <typename T>
-inline constexpr bool is_sgentype_v = is_contained_v<T, gtl::scalar_basic_list>;
-
-template <typename T>
-inline constexpr bool is_igeninteger8bit_v =
-    is_gen_based_on_type_sizeof_v<T, 1, is_igeninteger>;
-
-template <typename T>
-inline constexpr bool is_igeninteger16bit_v =
-    is_gen_based_on_type_sizeof_v<T, 2, is_igeninteger>;
-
-template <typename T>
-inline constexpr bool is_igeninteger32bit_v =
-    is_gen_based_on_type_sizeof_v<T, 4, is_igeninteger>;
-
-template <typename T>
-inline constexpr bool is_igeninteger64bit_v =
-    is_gen_based_on_type_sizeof_v<T, 8, is_igeninteger>;
-
-template <typename T>
-inline constexpr bool is_ugeninteger8bit_v =
-    is_gen_based_on_type_sizeof_v<T, 1, is_ugeninteger>;
-
-template <typename T>
-inline constexpr bool is_ugeninteger16bit_v =
-    is_gen_based_on_type_sizeof_v<T, 2, is_ugeninteger>;
-
-template <typename T>
-inline constexpr bool is_ugeninteger32bit_v =
-    is_gen_based_on_type_sizeof_v<T, 4, is_ugeninteger>;
-
-template <typename T>
-inline constexpr bool is_ugeninteger64bit_v =
-    is_gen_based_on_type_sizeof_v<T, 8, is_ugeninteger>;
-
-template <typename T>
-inline constexpr bool is_genintptr_v =
-    is_pointer_v<T> && is_genint_v<remove_pointer_t<T>> &&
-    is_address_space_compliant_v<T, gvl::nonconst_address_space_list>;
-
-template <typename T, access::address_space AddressSpace,
-          access::decorated IsDecorated>
-inline constexpr bool is_genintptr_marray_v =
-    std::is_same_v<T, sycl::marray<marray_element_t<T>, T::size()>> &&
-    is_genint_v<marray_element_t<remove_pointer_t<T>>> &&
-    is_address_space_compliant_v<multi_ptr<T, AddressSpace, IsDecorated>,
-                                 gvl::nonconst_address_space_list> &&
-    (IsDecorated == access::decorated::yes ||
-     IsDecorated == access::decorated::no);
-
-template <typename T>
-inline constexpr bool is_genfloatptr_v =
-    is_pointer_v<T> && is_genfloat_v<remove_pointer_t<T>> &&
-    is_address_space_compliant_v<T, gvl::nonconst_address_space_list>;
-
-template <typename T, access::address_space AddressSpace,
-          access::decorated IsDecorated>
-inline constexpr bool is_genfloatptr_marray_v =
-    is_mgenfloat_v<T> &&
-    is_address_space_compliant_v<multi_ptr<T, AddressSpace, IsDecorated>,
-                                 gvl::nonconst_address_space_list> &&
-    (IsDecorated == access::decorated::yes ||
-     IsDecorated == access::decorated::no);
 
 template <typename T>
 using is_byte = typename

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -441,27 +441,6 @@ struct remove_pointer : remove_pointer_impl<std::remove_cv_t<T>> {};
 
 template <typename T> using remove_pointer_t = typename remove_pointer<T>::type;
 
-// is_address_space_compliant
-template <typename T, typename SpaceList>
-struct is_address_space_compliant_impl : std::false_type {};
-
-template <typename T, typename SpaceList>
-struct is_address_space_compliant_impl<T *, SpaceList> : std::true_type {};
-
-template <typename T, typename SpaceList, access::address_space Space,
-          access::decorated DecorateAddress>
-struct is_address_space_compliant_impl<multi_ptr<T, Space, DecorateAddress>,
-                                       SpaceList>
-    : std::bool_constant<is_one_of_spaces<Space, SpaceList>::value> {};
-
-template <typename T, typename SpaceList>
-struct is_address_space_compliant
-    : is_address_space_compliant_impl<std::remove_cv_t<T>, SpaceList> {};
-
-template <typename T, typename SpaceList>
-inline constexpr bool is_address_space_compliant_v =
-    is_address_space_compliant<T, SpaceList>::value;
-
 // make_type_t
 template <typename T, typename TL> struct make_type_impl {
   using type = find_same_size_type_t<TL, T>;
@@ -514,6 +493,8 @@ struct make_larger_impl<marray<T, N>, marray<T, N>> {
   using type = std::conditional_t<found, new_type, void>;
 };
 
+// TODO: this type trait is not used anyweher in SYCL headers and it should
+// be moved to the library code
 template <typename T> struct make_larger {
   using type = typename make_larger_impl<T, T>::type;
 };
@@ -529,13 +510,6 @@ using const_if_const_AS =
 template <access::address_space AS, class DataT>
 using const_if_const_AS = DataT;
 #endif
-
-template <typename T> struct function_traits {};
-
-template <typename Ret, typename... Args> struct function_traits<Ret(Args...)> {
-  using ret_type = Ret;
-  using args_type = std::tuple<Args...>;
-};
 
 // No first_type_t due to
 // https://open-std.org/jtc1/sc22/wg21/docs/cwg_active.html#1430.

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -28,6 +28,7 @@
 #include <map>
 #include <memory>
 #include <set>
+#include <type_traits>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -297,7 +298,7 @@ private:
   ProgramManager(ProgramManager const &) = delete;
   ProgramManager &operator=(ProgramManager const &) = delete;
 
-  using ProgramPtr = std::unique_ptr<remove_pointer_t<ur_program_handle_t>,
+  using ProgramPtr = std::unique_ptr<std::remove_pointer_t<ur_program_handle_t>,
                                      decltype(&::urProgramRelease)>;
   ProgramPtr build(ProgramPtr Program, const ContextImplPtr Context,
                    const std::string &CompileOptions,

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -23,15 +23,6 @@ int main() {
   static_assert(d::is_genfloat_v<s::opencl::cl_float> == true);
   static_assert(d::is_genfloat_v<s::vec<s::opencl::cl_float, 4>> == true);
 
-  static_assert(d::is_ugenint_v<s::vec<s::opencl::cl_float, 4>> == false);
-  static_assert(d::is_ugenint_v<s::float4> == false);
-
-  static_assert(d::is_ugenint_v<s::opencl::cl_uint> == true);
-  static_assert(d::is_ugenint_v<unsigned int> == true);
-
-  static_assert(d::is_ugenint_v<s::vec<s::opencl::cl_uint, 3>> == true);
-  static_assert(d::is_ugenint_v<s::uint3> == true);
-
   static_assert(d::is_half_v<s::half>);
 
   static_assert(d::is_bfloat16_v<sycl::ext::oneapi::bfloat16>);
@@ -51,19 +42,6 @@ int main() {
   is_sgenfloat
   is_vgenfloat
 
-  is_gengeofloat
-  is_gengeodouble
-  is_gengeohalf
-
-  is_vgengeofloat
-  is_vgengeodouble
-  is_vgengeohalf
-
-  is_gencrossfloat
-  is_gencrossdouble
-  is_gencrosshalf
-  is_gencross
-
   is_charn
   is_scharn
   is_ucharn
@@ -77,8 +55,6 @@ int main() {
   is_ugenshort
 
   is_uintn
-  is_ugenint
-  is_intn
   is_genint
   */
 
@@ -92,31 +68,11 @@ int main() {
   is_ugenlonginteger
 
   is_geninteger
-  is_igeninteger
-  is_ugeninteger
   is_sgeninteger
-  is_vgeninteger
 
 
   is_sigeninteger
   is_sugeninteger
-  is_vigeninteger
-  is_vugeninteger
-
-  is_gentype
-
-  is_igeninteger8bit
-  is_igeninteger16bit
-  is_igeninteger32bit
-  is_igeninteger64bit
-
-  is_ugeninteger8bit
-  is_ugeninteger16bit
-  is_ugeninteger32bit
-  is_ugeninteger64bit
-
-  is_genintptr
-  is_genfloatptr
 
   unsing_integeral_to_float_point
   float_point_to_sign_integeral

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -52,11 +52,6 @@ void test_vector_element_t() {
 }
 
 template <typename T, typename CheckedT, bool Expected = true>
-void test_make_signed_t() {
-  static_assert(is_same<d::make_signed_t<T>, CheckedT>::value == Expected, "");
-}
-
-template <typename T, typename CheckedT, bool Expected = true>
 void test_make_unsigned_t() {
   static_assert(is_same<d::make_unsigned_t<T>, CheckedT>::value == Expected,
                 "");
@@ -150,15 +145,6 @@ int main() {
   test_vector_element_t<const s::int2, const int>();
   test_vector_element_t<volatile s::int2, volatile int>();
   test_vector_element_t<const volatile s::int2, const volatile int>();
-
-  test_make_signed_t<int, int>();
-  test_make_signed_t<const int, const int>();
-  test_make_signed_t<unsigned int, int>();
-  test_make_signed_t<const unsigned int, const int>();
-  test_make_signed_t<s::int2, s::int2>();
-  test_make_signed_t<const s::int2, const s::int2>();
-  test_make_signed_t<s::uint2, s::int2>();
-  test_make_signed_t<const s::uint2, const s::int2>();
 
   test_make_unsigned_t<int, unsigned int>();
   test_make_unsigned_t<const int, const unsigned int>();

--- a/sycl/test/type_traits/type_traits.cpp
+++ b/sycl/test/type_traits/type_traits.cpp
@@ -72,12 +72,6 @@ void test_remove_pointer_t() {
                 "");
 }
 
-template <typename T, typename SpaceList, bool Expected = true>
-void test_is_address_space_compliant() {
-  static_assert(d::is_address_space_compliant<T, SpaceList>::value == Expected,
-                "");
-}
-
 template <typename T, int Checked, bool Expected = true>
 void test_vector_size() {
   static_assert((d::vector_size<T>::value == Checked) == Expected, "");
@@ -101,22 +95,6 @@ int main() {
   test_remove_pointer_t<s::float2 *, s::float2>();
   test_remove_pointer_t<s::constant_ptr<s::int2>, s::int2>();
   test_remove_pointer_t<s::constant_ptr<s::float2>, s::float2>();
-
-  test_is_address_space_compliant<int *, d::gvl::nonconst_address_space_list>();
-  test_is_address_space_compliant<float *,
-                                  d::gvl::nonconst_address_space_list>();
-  test_is_address_space_compliant<s::constant_ptr<int>,
-                                  d::gvl::nonconst_address_space_list, false>();
-  test_is_address_space_compliant<s::constant_ptr<float>,
-                                  d::gvl::nonconst_address_space_list, false>();
-  test_is_address_space_compliant<s::int2 *,
-                                  d::gvl::nonconst_address_space_list>();
-  test_is_address_space_compliant<s::float2 *,
-                                  d::gvl::nonconst_address_space_list>();
-  test_is_address_space_compliant<s::constant_ptr<s::int2>,
-                                  d::gvl::nonconst_address_space_list, false>();
-  test_is_address_space_compliant<s::constant_ptr<s::float2>,
-                                  d::gvl::nonconst_address_space_list, false>();
 
   test_is_integral<int>();
   test_is_integral<s::int2>();


### PR DESCRIPTION
Even if think that some of them might be useful one day, I would still prefer to drop them. SYCL headers a *very* heavy and they are one of the main reasons why SYCL compilation is so slow comparing to regular C++.