### PR TITLE
[SYCL] Fix `std::exp(complex<double>)` edge case on Windows

### DIFF
--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -395,7 +395,7 @@ short _Exp(double *px, double y,
   if (*px < -HUGE_EXP || y == 0.0) // certain underflow
     *px = 0.0;
   else if (HUGE_EXP < *px) { // certain overflow
-    *px = _Inf._Double;
+    *px = _Inf._Double * (y < 0.F ? -1.F : 1.F);
     ret = _INFCODE;
   } else { // xexp won't overflow
     double g = *px * invln2;


### PR DESCRIPTION
This is a follow-up for intel/llvm#15162

There are no new tests added with this PR, because we already have this edge case covered by existing tests here:

https://github.com/intel/llvm/blob/3e98b3a09254863423f82d10aa7d40a8b64dbdd3/sycl/test-e2e/DeviceLib/std_complex_math_fp64_test.cpp#L202

But we don't have a Windows machine with a GPU which supports `fp64` and therefoere this edge case went unnoticed by our CI. The change was locally tested in the right environment.

Patch-By: Justin Cai <justin.cai@intel.com>