### PR TITLE
[SYCL] Optimize handling of compile-time properties

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -1046,6 +1046,11 @@ private:
   /// Process kernel properties.
   ///
   /// Stores information about kernel properties into the handler.
+  ///
+  /// Note: it is important that this function *does not* depend on kernel
+  /// name or kernel type, because then it will be instantiated for every
+  /// kernel, even though body of those instantiated functions could be almost
+  /// the same, thus unnecessary increasing compilation time.
   template <
       bool IsESIMDKernel,
       typename PropertiesT = ext::oneapi::experimental::empty_properties_t>

--- a/sycl/test/virtual-functions/properties-negative.cpp
+++ b/sycl/test/virtual-functions/properties-negative.cpp
@@ -19,7 +19,9 @@ int main() {
 
   // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} indirectly_callable property cannot be applied to SYCL kernels}}
   q.single_task(props_empty, [=]() {});
-  // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} indirectly_callable property cannot be applied to SYCL kernels}}
+  // When both "props_empty" and "props_void" are in use, we won't see the
+  // static assert firing for the second one, because there will be only one
+  // instantiation of handler::processProperties.
   q.single_task(props_void, [=]() {});
   // expected-error-re@sycl/handler.hpp:* {{static assertion failed due to requirement {{.*}} indirectly_callable property cannot be applied to SYCL kernels}}
   q.single_task(props_int, [=]() {});


### PR DESCRIPTION
We perform correctness check of compile-time properties in `handler::processProperties` helper function. That function was specialized by kernel name, meaning that if we have two kernels with absolutely the same properties applied to them there will be two instantiations of `processProperties`. That consumes compilation time for both front-end which has to emit extra isntantiations and for host compilation pass which gets more functions (with the same body!) to handle.

The only use of kernel name within `processProperties` is to check if that kernel is a ESIMD kernel. That can be done at caller side and propagated to `processProperties` as a simple boolean, thus reducing amount of instantiations of that function.

This patch does exactly that.

Please note that this is technically a *functional* change: even though we still process the properties in the same way, we will now emit diagnostics in a slightly different manner: if there are two kernels with the same set of illegal properties there will be only one diagnostic for the first kernel.
Once that first kernel is fixed, the diagnostic will be displayed for the second kernel, i.e. we won't display _all_ violations in a single compilation run.

It seems like we only have one test which exposes that behavior and considering that with C++ it is almost always you should fix the first error first to see what happens to the rest, I don't think that such change in diagnostics is bad enough to outweight potential (even if they are the slightest) compilation time improvements.