### PR TITLE
[SYCL][Graph] Reenable L0 interop test on PVC

### DIFF
--- a/sycl/test-e2e/Graph/Explicit/interop-level-zero-launch-kernel.cpp
+++ b/sycl/test-e2e/Graph/Explicit/interop-level-zero-launch-kernel.cpp
@@ -9,9 +9,6 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out %S/../Inputs/Kernels/saxpy.spv 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: arch-intel_gpu_pvc
-
 #define GRAPH_E2E_EXPLICIT
 
 #include "../Inputs/interop-level-zero-launch-kernel.cpp"

--- a/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-launch-kernel.cpp
+++ b/sycl/test-e2e/Graph/RecordReplay/interop-level-zero-launch-kernel.cpp
@@ -9,9 +9,6 @@
 // Extra run to check for immediate-command-list in Level Zero
 // RUN: %if level_zero %{env SYCL_PI_LEVEL_ZERO_USE_IMMEDIATE_COMMANDLISTS=1 %{l0_leak_check} %{run} %t.out %S/../Inputs/Kernels/saxpy.spv 2>&1 | FileCheck %s --implicit-check-not=LEAK %}
 
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: arch-intel_gpu_pvc
-
 #define GRAPH_E2E_RECORD_REPLAY
 
 #include "../Inputs/interop-level-zero-launch-kernel.cpp"


### PR DESCRIPTION
Re-enable the interop-level-zero-launch-kernel.cpp E2E test on PVC by making the following correctness changes to the native L0 code:

* Both `zeKernelSetGroupSize` and `ZeGroupCount` were set to have 1024 in the X dimensions when this is the total size of the USM allocation, and therefore the number of work items we want. Updated to use `zeKernelSuggestGroupSize` to work calculate the correct group sizes and count.
* Update `zeKernelSetArgumentValue` call so that the size parameter is the size of the pointer rather than size of the USM allocation.