### PR TITLE
[CI] Fix level_zero deb file name in install_drivers.sh script

### DIFF
--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -128,7 +128,7 @@ InstallIGFX () {
     | grep -v "u18" \
     | wget -qi -
   get_release oneapi-src/level-zero $L0_TAG \
-    | grep ".*deb" \
+    | grep ".*u22\.04.*deb" \
     | wget -qi -
   dpkg -i *.deb && rm *.deb *.sum
   IS_IGC_DEV=$(CheckIGCdevTag $IGCTAG)


### PR DESCRIPTION
Level Zero started building for ubuntu 24.04 as well as 22.04, so we need to update our script to download the 22.04 one, as we use 22.04 for our docker images.

See https://github.com/oneapi-src/level-zero/releases/tag/v1.17.44