### PR TITLE
[SYCL][doc] Fix a spelling mistake in any_device_has_v aspect trait

### DIFF
--- a/sycl/doc/design/DeviceAspectTraitDesign.md
+++ b/sycl/doc/design/DeviceAspectTraitDesign.md
@@ -112,7 +112,7 @@ to generate test cases, ensuring that specializations exist for all aspects:
 
 ```c++
 #define __SYCL_ASPECT(ASPECT, ASPECT_VAL)                                          \
-  constexpr bool CheckAnyDeviceHas##ASPECT = any_devices_has_v<aspect::ASPECT>;    \
+  constexpr bool CheckAnyDeviceHas##ASPECT = any_device_has_v<aspect::ASPECT>;     \
   constexpr bool CheckAllDevicesHave##ASPECT = all_devices_have_v<aspect::ASPECT>;
 
 #include <sycl/info/aspects.def>


### PR DESCRIPTION
Fixed a mistake in the `DeviceAspectTraitDesign.md` oneAPI design document where  `any_device_has_v` was misspelled as `any_devices_has_v`.