### PR TITLE
[SYCL][E2E] Fix regression in tests

### DIFF
--- a/sycl/test-e2e/DeviceDependencies/free_function_kernels.cpp
+++ b/sycl/test-e2e/DeviceDependencies/free_function_kernels.cpp
@@ -1,7 +1,7 @@
 // Ensure -fsycl-allow-device-dependencies can work with free function kernels.
 
 // REQUIRES: aspect-usm_shared_allocations
-// RUN: %{build} -o %t.out -fsycl-allow-device-dependencies
+// RUN: %{build} -o %t.out -fsycl-allow-device-image-dependencies
 // RUN: %{run} %t.out
 
 // The name mangling for free function kernels currently does not work with PTX.

--- a/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/bitreverse.cpp
@@ -8,9 +8,9 @@
 // Ensure that SPV_KHR_bit_instructions is disabled so that translator
 // will lower llvm.bitreverse.* intrinsics instead of relying on SPIRV
 // BitReverse instruction.
-// Also build executable with SPV dump.  Use -fno-sycl-allow-device-dependencies to
+// Also build executable with SPV dump.  Use -fno-sycl-allow-device-image-dependencies to
 // ensure that only one SPV file is generated.
-// RUN: %{build} -Wno-error=psabi -Wno-error=constant-conversion -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir -fno-sycl-allow-device-dependencies
+// RUN: %{build} -Wno-error=psabi -Wno-error=constant-conversion -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir -fno-sycl-allow-device-image-dependencies
 
 // Rename SPV file to explictly known filename.
 // RUN: mv %t.spvdir/*.spv %t.spvdir/dump.spv

--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -13,9 +13,9 @@
 // Ensure that SPV_KHR_bit_instructions is disabled so that translator
 // will lower llvm.bitreverse.* intrinsics instead of relying on SPIRV
 // BitReverse instruction.
-// Also build executable with SPV dump.  Use -fno-sycl-allow-device-dependencies to
+// Also build executable with SPV dump.  Use -fno-sycl-allow-device-image-dependencies to
 // ensure that only one SPV file is generated.
-// RUN: %{build} -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir -fno-sycl-allow-device-dependencies
+// RUN: %{build} -o %t.out -O2 -Xspirv-translator --spirv-ext=-SPV_KHR_bit_instructions -fsycl-dump-device-code=%t.spvdir -fno-sycl-allow-device-image-dependencies
 
 // Rename SPV file to explictly known filename.
 // RUN: mv %t.spvdir/*.spv %t.spvdir/dump.spv


### PR DESCRIPTION
intel/llvm#15407 deprecated a flag without updating its uses in tests which fail due to `-Werror`.