### PR TITLE
[SYCL] Skip subgroup tests when subgroup size doesn't divide local size

### DIFF
--- a/sycl/test-e2e/SubGroup/barrier.cpp
+++ b/sycl/test-e2e/SubGroup/barrier.cpp
@@ -53,6 +53,10 @@ void check(queue &Queue, size_t G = 240, size_t L = 60) {
     host_accessor sgsizeacc(sgsizebuf);
 
     size_t sg_size = sgsizeacc[0];
+    if (L % sg_size != 0) {
+      std::cout << "Sub group size doesn't divide local size, skipping.\n";
+      return;
+    }
     int WGid = -1, SGid = 0;
     T add = 0;
     for (int j = 0; j < G; j++) {

--- a/sycl/test-e2e/SubGroup/common.cpp
+++ b/sycl/test-e2e/SubGroup/common.cpp
@@ -45,7 +45,11 @@ void check(queue &Queue, unsigned int G, unsigned int L) {
     host_accessor syclacc(syclbuf);
     host_accessor sgsizeacc(sgsizebuf);
     unsigned int sg_size = sgsizeacc[0];
-    unsigned int num_sg = L / sg_size + (L % sg_size ? 1 : 0);
+    if (L % sg_size != 0) {
+      std::cout << "Sub group size doesn't divide local size, skipping.\n";
+      return;
+    }
+    unsigned int num_sg = L / sg_size;
     for (int j = 0; j < G; j++) {
       unsigned int group_id = j % L / sg_size;
       unsigned int local_range =


### PR DESCRIPTION
Skips tests in `Subgroup/barrier.cpp` and `Subgroup/common.cpp` when the maximum sub group size doesn't divide the local size.