### PR TITLE
[SYCL] Move driver related `__CUDA_ARCH__` test to Driver folder from Preprocessor

### DIFF
--- a/clang/test/Driver/sycl-cuda-arch-macro.cpp
+++ b/clang/test/Driver/sycl-cuda-arch-macro.cpp
@@ -1,0 +1,3 @@
+// RUN: %clangxx %s -fsycl -nocudalib -fno-sycl-libspirv -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --offload-arch=sm_80 -E -dM \
+// RUN: | FileCheck --check-prefix=CHECK-CUDA-ARCH-MACRO %s
+// CHECK-CUDA-ARCH-MACRO-NOT: #define __CUDA_ARCH__ {{[0-9]+}}

--- a/clang/test/Preprocessor/sycl-macro.cpp
+++ b/clang/test/Preprocessor/sycl-macro.cpp
@@ -8,8 +8,6 @@
 // RUN: --check-prefix=CHECK-NO-SYCL_FIT_IN_INT %s
 // RUN: %clang_cc1 %s  -triple nvptx64-nvidia-cuda -target-cpu sm_80 -fsycl-is-device -E -dM | FileCheck \
 // RUN: --check-prefix=CHECK-CUDA %s -DARCH_CODE=800
-// RUN: %clangxx %s -fsycl -nocudalib -fsycl-targets=nvptx64-nvidia-cuda -Xsycl-target-backend --offload-arch=sm_80 -E -dM | FileCheck \
-// RUN: --check-prefix=CHECK-CUDA-SYCL-DRIVER %s
 // RUN: %clang_cc1 %s  -triple amdgcn-amd-amdhsa -target-cpu gfx906 -fsycl-is-device -E -dM | FileCheck --check-prefix=CHECK-HIP %s
 
 // RUN: %clang_cc1 %s  -triple nvptx64-nvidia-cuda -target-cpu sm_90a -fsycl-is-device -E -dM | FileCheck --check-prefix=CHECK-CUDA-FEATURE %s
@@ -37,8 +35,6 @@
 
 // CHECK-CUDA:#define __SYCL_CUDA_ARCH__ [[ARCH_CODE]]
 // CHECK-CUDA-NOT:#define __CUDA_ARCH__ {{[0-9]+}}
-
-// CHECK-CUDA-SYCL-DRIVER-NOT: #define __CUDA_ARCH__ {{[0-9]+}}
 
 // CHECK-HIP:#define __CUDA_ARCH__ 0
 


### PR DESCRIPTION
This PR moves the driver invocation test that checks `__CUDA_ARCH__` does not get defined and ensures that it doesn't require the `libspirv-nvptx64-nvidia-cuda` bitcode files by passing `-fno-sycl-libspirv` to the `%clangxx` command.