### PR TITLE
[SYCL][E2E] Re-enable `Plugin/enqueue-arg-order-image.cpp`

### DIFF
--- a/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
+++ b/sycl/test-e2e/Plugin/enqueue-arg-order-image.cpp
@@ -4,9 +4,6 @@
 // spir-v gen for legacy images at O0 not working
 // UNSUPPORTED: O0
 
-// https://github.com/intel/llvm/issues/11434
-// UNSUPPORTED: gpu-intel-dg2
-
 // RUN: %{build} -o %t.out
 // Native images are created with host pointers only with host unified memory
 // support, enforce it for this test.


### PR DESCRIPTION
Closes https://github.com/intel/llvm/issues/11434. The issue has been fixed in the underlying GPU RT.