### PR TITLE
[SYCL] Fix ESIMD split detection in module properties computation

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/ModuleSplitter.h
+++ b/llvm/include/llvm/SYCLLowerIR/ModuleSplitter.h
@@ -37,6 +37,8 @@ class OptionCategory;
 
 namespace module_split {
 
+constexpr char SYCL_ESIMD_SPLIT_MD_NAME[] = "sycl-split-status";
+
 extern cl::OptionCategory &getModuleSplitCategory();
 
 enum IRSplitMode {
@@ -220,6 +222,8 @@ public:
       Reqs = computeDeviceRequirements(getModule(), entries());
     return *Reqs;
   }
+
+  void saveSplitInformationAsMetadata();
 
 #ifndef NDEBUG
   void verifyESIMDProperty() const;

--- a/llvm/include/llvm/SYCLLowerIR/ModuleSplitter.h
+++ b/llvm/include/llvm/SYCLLowerIR/ModuleSplitter.h
@@ -37,7 +37,7 @@ class OptionCategory;
 
 namespace module_split {
 
-constexpr char SYCL_ESIMD_SPLIT_MD_NAME[] = "sycl-split-status";
+constexpr char SYCL_ESIMD_SPLIT_MD_NAME[] = "sycl-esimd-split-status";
 
 extern cl::OptionCategory &getModuleSplitCategory();
 

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/assert.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/assert.ll
@@ -37,7 +37,7 @@ entry:
 }
 
 attributes #0 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="foo.cpp" "sycl-optlevel"="2" "uniform-work-group-size"="true" }
-attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="/localdisk2/nsarnie/llvm_assert2/libdevice/fallback-cassert.cpp" "sycl-optlevel"="2" }
+attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="bar.cpp" "sycl-optlevel"="2" }
 attributes #2 = { convergent nounwind }
 
 !0 = !{}

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/assert.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/assert.ll
@@ -1,0 +1,43 @@
+; RUN: sycl-post-link -properties -split-esimd  -S < %s -o %t.table
+; RUN: FileCheck %s -input-file=%t_esimd_0.prop
+
+; Verify we mark a image with an ESIMD kernel with the isEsimdImage property
+
+; CHECK: isEsimdImage=1|1
+
+target datalayout = "e-i64:64-v16:16-v24:32-v32:32-v48:64-v96:128-v192:256-v256:256-v512:512-v1024:1024-n8:16:32:64-G1"
+target triple = "spir64-unknown-unknown"
+
+%"struct.sycl::_V1::detail::AssertHappened" = type { i32, [257 x i8], [257 x i8], [129 x i8], i32, i64, i64, i64, i64, i64, i64 }
+%"class.sycl::_V1::id" = type { %"class.sycl::_V1::detail::array" }
+%"class.sycl::_V1::detail::array" = type { [1 x i64] }
+
+@.str = private unnamed_addr addrspace(1) constant [10 x i8] c"Id != 400\00", align 1
+@.str.1 = private unnamed_addr addrspace(1) constant [8 x i8] c"foo.cpp\00", align 1
+@__PRETTY_FUNCTION__ = private unnamed_addr addrspace(1) constant [56 x i8] c"auto main()::(anonymous class)::operator()(id<1>) const\00", align 1
+@SPIR_AssertHappenedMem = linkonce_odr dso_local addrspace(1) global %"struct.sycl::_V1::detail::AssertHappened" zeroinitializer, align 8
+
+declare void @llvm.assume(i1 noundef) #2
+
+define weak_odr dso_local spir_kernel void @esimd_kernel() local_unnamed_addr #0 !sycl_explicit_simd !0 {
+entry:
+  tail call spir_func void @__assert_fail(ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @.str to ptr addrspace(4)), ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @.str.1 to ptr addrspace(4)), i32 noundef 13, ptr addrspace(4) noundef addrspacecast (ptr addrspace(1) @__PRETTY_FUNCTION__ to ptr addrspace(4))) #12
+  ret void
+}
+
+define weak dso_local spir_func void @__assert_fail(ptr addrspace(4) noundef %expr, ptr addrspace(4) noundef %file, i32 noundef %line, ptr addrspace(4) noundef %func) #1 {
+entry:
+  tail call spir_func void @__devicelib_assert_fail(ptr addrspace(4) noundef %expr, ptr addrspace(4) noundef %file, i32 noundef %line, ptr addrspace(4) noundef %func) #1
+  ret void
+}
+
+define weak dso_local spir_func void @__devicelib_assert_fail(ptr addrspace(4) noundef %expr, ptr addrspace(4) noundef %file, i32 noundef %line, ptr addrspace(4) noundef %func) #2 {
+entry:                                 
+  ret void
+}
+
+attributes #0 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="foo.cpp" "sycl-optlevel"="2" "uniform-work-group-size"="true" }
+attributes #1 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" "sycl-module-id"="/localdisk2/nsarnie/llvm_assert2/libdevice/fallback-cassert.cpp" "sycl-optlevel"="2" }
+attributes #2 = { convergent nounwind }
+
+!0 = !{}

--- a/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
+++ b/llvm/test/tools/sycl-post-link/sycl-esimd/basic-esimd-lower.ll
@@ -55,7 +55,7 @@ attributes #0 = { "sycl-module-id"="a.cpp" }
 ; CHECK-NO-LOWERING: }
 
 ; With -O0, we only lower ESIMD code, but no other optimizations
-; CHECK-O0: define dso_local spir_kernel void @ESIMD_kernel() #{{[0-9]}} !sycl_explicit_simd !3 !intel_reqd_sub_group_size !4 {
+; CHECK-O0: define dso_local spir_kernel void @ESIMD_kernel() #{{[0-9]}} !sycl_explicit_simd !{{[0-9]}} !intel_reqd_sub_group_size !{{[0-9]}} {
 ; CHECK-O0: entry:
 ; CHECK-O0:   %0 = load <3 x i64>, {{.*}} addrspacecast {{.*}} @__spirv_BuiltInGlobalInvocationId
 ; CHECK-O0:   %1 = extractelement <3 x i64> %0, i64 0


### PR DESCRIPTION
We need to know if a module is an ESIMD split or not split at all to set some image properties.

Right now we compute if a module is ESIMD or not by looking at the functions in the module and checking they are all ESIMD, except for allowed exceptions.

A new exception was found related to using `assert` in user code where there is a scalar SYCL function that correctly remains in the ESIMD split. The end result is we don't set the ESIMD property because we don't think this is the ESIMD split and do the wrong thing at runtime. Instead of just adding this new exception to the list, I reworked what I consider to be flaky logic (that I wrote originally, whoops) to figure out the splits.

Just save metadata in the module of what kind of split it is before we try to compute module properties. 

We already do something similar for the spec constant default split, and I moved that to a centralized place as part of this change.

The reason we don't just pass in the `ModuleDesc` object as an argument is because we want to untie properties creation from the `sycl-post-link` tool so that it can be called in other places (which we will do for thinLTO).