### PR TITLE
[SYCL][E2E] Enable bfloat16_example test everywhere

### DIFF
--- a/sycl/test-e2e/BFloat16/bfloat16_example.cpp
+++ b/sycl/test-e2e/BFloat16/bfloat16_example.cpp
@@ -1,11 +1,6 @@
-///
-/// Checks a simple case of bfloat16, also employed for AOT library fallback.
-///
+/// Checks a simple case of bfloat16
 
-// CUDA is not compatible with SPIR.
-// UNSUPPORTED: cuda
-
-// RUN: %clangxx -fsycl %s -o %t.out
+// RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
 #include "bfloat16_example.hpp"


### PR DESCRIPTION
The test was recently refactored and got accidentally enabled on HIP, causing post-commit failure. It failed because it had been originally written to only support JIT targets.

There seems to be no good reason for this test not to be run on CUDA & HIP backends, so instead of restricting devices it should be run on this patch refactors it to support AOT targets as well.