### PR TITLE
[SYCL] Fix a thread pool data race during shutdown

### DIFF
--- a/sycl/test-e2e/Regression/unwaited_for_host_task.cpp
+++ b/sycl/test-e2e/Regression/unwaited_for_host_task.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-#include <sycl/sycl.hpp>
+#include <sycl/detail/core.hpp>
 
 using namespace sycl;
 

--- a/sycl/test-e2e/Regression/unwaited_for_host_task.cpp
+++ b/sycl/test-e2e/Regression/unwaited_for_host_task.cpp
@@ -1,0 +1,16 @@
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+
+// This test checks that host tasks that haven't been waited for do not cause
+// issues during shutdown.
+int main(int argc, char *argv[]) {
+  queue q;
+
+  q.submit([&](handler &h) { h.host_task([=]() {}); });
+
+  return 0;
+}


### PR DESCRIPTION
The flag that kills the threads waiting for work was an atomic bool, but that is not enough: any modification of a condition must be made under the mutex associated with that condition variable. Otherwise, the bool value flip and the call to notify might happen after the condition check in the other thread, but before it starts waiting for notifications.