### PR TITLE
[SYCL][NFC] Public headers cleanup

### DIFF
--- a/sycl/include/sycl/context.hpp
+++ b/sycl/include/sycl/context.hpp
@@ -12,7 +12,6 @@
 #include <sycl/backend_types.hpp>             // for backend, backend_return_t
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
-#include <sycl/detail/helpers.hpp>            // for context_impl
 #include <sycl/detail/info_desc_helpers.hpp>  // for is_context_info_desc
 #include <sycl/detail/owner_less_base.hpp>    // for OwnerLessBase
 #include <sycl/platform.hpp>                  // for platform

--- a/sycl/include/sycl/detail/info_desc_helpers.hpp
+++ b/sycl/include/sycl/detail/info_desc_helpers.hpp
@@ -8,8 +8,6 @@
 
 #pragma once
 
-#include <ur_api.h>
-
 #include <type_traits> // for true_type
 
 // FIXME: .def files included to this file use all sorts of SYCL objects like
@@ -22,8 +20,6 @@
 namespace sycl {
 inline namespace _V1 {
 namespace detail {
-template <typename T> struct PiInfoCode;
-template <typename T> struct UrInfoCode;
 template <typename T> struct is_platform_info_desc : std::false_type {};
 template <typename T> struct is_context_info_desc : std::false_type {};
 template <typename T> struct is_device_info_desc : std::false_type {};
@@ -47,10 +43,6 @@ template <typename T> struct is_backend_info_desc : std::false_type {};
 // Similar approach to limit valid get_backend_info template argument
 
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr ur_##DescType##_info_t value =                            \
-        static_cast<ur_##DescType##_info_t>(UrCode);                           \
-  };                                                                           \
   template <>                                                                  \
   struct is_##DescType##_info_desc<info::DescType::Desc> : std::true_type {    \
     using return_type = info::DescType::Desc::return_type;                     \
@@ -63,9 +55,6 @@ template <typename T> struct is_backend_info_desc : std::false_type {};
 #undef __SYCL_PARAM_TRAITS_SPEC
 
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr ur_profiling_info_t value = UrCode;                       \
-  };                                                                           \
   template <>                                                                  \
   struct is_##DescType##_info_desc<info::DescType::Desc> : std::true_type {    \
     using return_type = info::DescType::Desc::return_type;                     \
@@ -92,25 +81,14 @@ struct IsKernelInfo<info::kernel_device_specific::ext_codeplay_num_regs>
     : std::true_type {};
 
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr typename std::conditional<                                \
-        IsSubGroupInfo<info::DescType::Desc>::value,                           \
-        ur_kernel_sub_group_info_t,                                            \
-        std::conditional<IsKernelInfo<info::DescType::Desc>::value,            \
-                         ur_kernel_info_t,                                     \
-                         ur_kernel_group_info_t>::type>::type value = UrCode;  \
-  };                                                                           \
   template <>                                                                  \
   struct is_##DescType##_info_desc<info::DescType::Desc> : std::true_type {    \
     using return_type = info::DescType::Desc::return_type;                     \
   };
 #include <sycl/info/kernel_device_specific_traits.def>
 #undef __SYCL_PARAM_TRAITS_SPEC
+
 #define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
-  template <> struct UrInfoCode<info::DescType::Desc> {                        \
-    static constexpr ur_device_info_t value =                                  \
-        static_cast<ur_device_info_t>(UrCode);                                 \
-  };                                                                           \
   template <>                                                                  \
   struct is_##DescType##_info_desc<info::DescType::Desc> : std::true_type {    \
     using return_type = info::DescType::Desc::return_type;                     \
@@ -122,11 +100,8 @@ struct IsKernelInfo<info::kernel_device_specific::ext_codeplay_num_regs>
 
 #undef __SYCL_PARAM_TRAITS_SPEC
 #undef __SYCL_PARAM_TRAITS_SPEC_SPECIALIZED
+
 #define __SYCL_PARAM_TRAITS_SPEC(Namespace, DescType, Desc, ReturnT, UrCode)   \
-  template <> struct UrInfoCode<Namespace::info::DescType::Desc> {             \
-    static constexpr ur_device_info_t value =                                  \
-        static_cast<ur_device_info_t>(UrCode);                                 \
-  };                                                                           \
   template <>                                                                  \
   struct is_##DescType##_info_desc<Namespace::info::DescType::Desc>            \
       : std::true_type {                                                       \

--- a/sycl/include/sycl/exception.hpp
+++ b/sycl/include/sycl/exception.hpp
@@ -10,7 +10,6 @@
 
 // 4.9.2 Exception Class Interface
 
-#include <sycl/detail/cl.h>                   // for cl_int
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
 #include <sycl/detail/string.hpp>

--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -12,6 +12,7 @@
 #include <sycl/accessor.hpp>
 #include <sycl/context.hpp>
 #include <sycl/detail/cg_types.hpp>
+#include <sycl/detail/cl.h>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/defines_elementary.hpp>
 #include <sycl/detail/export.hpp>

--- a/sycl/include/sycl/stream.hpp
+++ b/sycl/include/sycl/stream.hpp
@@ -17,7 +17,6 @@
 #include <sycl/detail/defines.hpp> // for __SYCL_SPECIAL_CLASS, __S...
 #include <sycl/detail/defines_elementary.hpp> // for __SYCL2020_DEPRECATED
 #include <sycl/detail/export.hpp>             // for __SYCL_EXPORT
-#include <sycl/detail/item_base.hpp>          // for id, range
 #include <sycl/detail/owner_less_base.hpp>    // for OwnerLessBase
 #include <sycl/ext/oneapi/bfloat16.hpp>       // for bfloat16
 #include <sycl/group.hpp>                     // for group

--- a/sycl/source/detail/context_info.hpp
+++ b/sycl/source/detail/context_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <detail/context_impl.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/info/info_desc.hpp>

--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -9,6 +9,7 @@
 #include <detail/device_impl.hpp>
 #include <detail/device_info.hpp>
 #include <detail/platform_impl.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/detail/ur.hpp>
 #include <sycl/device.hpp>
 

--- a/sycl/source/detail/device_info.hpp
+++ b/sycl/source/detail/device_info.hpp
@@ -13,6 +13,7 @@
 #include <detail/platform_impl.hpp>
 #include <detail/platform_util.hpp>
 #include <detail/program_manager/program_manager.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/detail/defines.hpp>
 #include <sycl/detail/os_util.hpp>
 #include <sycl/detail/ur.hpp>

--- a/sycl/source/detail/event_info.hpp
+++ b/sycl/source/detail/event_info.hpp
@@ -10,6 +10,7 @@
 
 #include <detail/adapter.hpp>
 #include <detail/event_impl.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/info/info_desc.hpp>

--- a/sycl/source/detail/kernel_info.hpp
+++ b/sycl/source/detail/kernel_info.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <detail/error_handling/error_handling.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/detail/ur.hpp>

--- a/sycl/source/detail/platform_impl.cpp
+++ b/sycl/source/detail/platform_impl.cpp
@@ -14,6 +14,7 @@
 #include <detail/global_handler.hpp>
 #include <detail/platform_impl.hpp>
 #include <detail/platform_info.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/backend.hpp>
 #include <sycl/detail/iostream_proxy.hpp>
 #include <sycl/detail/ur.hpp>

--- a/sycl/source/detail/platform_impl.hpp
+++ b/sycl/source/detail/platform_impl.hpp
@@ -10,6 +10,7 @@
 
 #include <detail/adapter.hpp>
 #include <detail/platform_info.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/backend.hpp>
 #include <sycl/backend_types.hpp>
 #include <sycl/detail/cl.h>

--- a/sycl/source/detail/platform_info.hpp
+++ b/sycl/source/detail/platform_info.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 #include <detail/adapter.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/info_desc_helpers.hpp>
 #include <sycl/detail/ur.hpp>

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -19,6 +19,7 @@
 #include <detail/queue_impl.hpp>
 #include <detail/spec_constant_impl.hpp>
 #include <detail/split_string.hpp>
+#include <detail/ur_info_code.hpp>
 #include <sycl/aspects.hpp>
 #include <sycl/backend_types.hpp>
 #include <sycl/context.hpp>

--- a/sycl/source/detail/ur_info_code.hpp
+++ b/sycl/source/detail/ur_info_code.hpp
@@ -1,0 +1,77 @@
+//==--------------------------- ur_info_code.hpp ---------------------------==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <sycl/detail/info_desc_helpers.hpp>
+
+#include <ur_api.h>
+
+namespace sycl {
+inline namespace _V1 {
+namespace detail {
+template <typename T> struct UrInfoCode;
+
+#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
+  template <> struct UrInfoCode<info::DescType::Desc> {                        \
+    static constexpr ur_##DescType##_info_t value =                            \
+        static_cast<ur_##DescType##_info_t>(UrCode);                           \
+  };
+#include <sycl/info/context_traits.def>
+#include <sycl/info/event_traits.def>
+#include <sycl/info/kernel_traits.def>
+#include <sycl/info/platform_traits.def>
+#include <sycl/info/queue_traits.def>
+#undef __SYCL_PARAM_TRAITS_SPEC
+
+#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
+  template <> struct UrInfoCode<info::DescType::Desc> {                        \
+    static constexpr ur_profiling_info_t value = UrCode;                       \
+  };
+#include <sycl/info/event_profiling_traits.def>
+#undef __SYCL_PARAM_TRAITS_SPEC
+
+#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
+  template <> struct UrInfoCode<info::DescType::Desc> {                        \
+    static constexpr typename std::conditional<                                \
+        IsSubGroupInfo<info::DescType::Desc>::value,                           \
+        ur_kernel_sub_group_info_t,                                            \
+        std::conditional<IsKernelInfo<info::DescType::Desc>::value,            \
+                         ur_kernel_info_t,                                     \
+                         ur_kernel_group_info_t>::type>::type value = UrCode;  \
+  };
+#include <sycl/info/kernel_device_specific_traits.def>
+#undef __SYCL_PARAM_TRAITS_SPEC
+
+#define __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, UrCode)              \
+  template <> struct UrInfoCode<info::DescType::Desc> {                        \
+    static constexpr ur_device_info_t value =                                  \
+        static_cast<ur_device_info_t>(UrCode);                                 \
+  };
+#define __SYCL_PARAM_TRAITS_SPEC_SPECIALIZED(DescType, Desc, ReturnT, PiCode)  \
+  __SYCL_PARAM_TRAITS_SPEC(DescType, Desc, ReturnT, PiCode)
+
+#include <sycl/info/device_traits.def>
+
+#undef __SYCL_PARAM_TRAITS_SPEC
+#undef __SYCL_PARAM_TRAITS_SPEC_SPECIALIZED
+
+#define __SYCL_PARAM_TRAITS_SPEC(Namespace, DescType, Desc, ReturnT, UrCode)   \
+  template <> struct UrInfoCode<Namespace::info::DescType::Desc> {             \
+    static constexpr ur_device_info_t value =                                  \
+        static_cast<ur_device_info_t>(UrCode);                                 \
+  };
+
+#include <sycl/info/ext_codeplay_device_traits.def>
+#include <sycl/info/ext_intel_device_traits.def>
+#include <sycl/info/ext_oneapi_device_traits.def>
+#undef __SYCL_PARAM_TRAITS_SPEC
+
+} // namespace detail
+} // namespace _V1
+} // namespace sycl

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -22,6 +22,7 @@
 #include <detail/queue_impl.hpp>
 #include <detail/scheduler/commands.hpp>
 #include <detail/scheduler/scheduler.hpp>
+#include <detail/ur_info_code.hpp>
 #include <detail/usm/usm_impl.hpp>
 #include <sycl/detail/common.hpp>
 #include <sycl/detail/helpers.hpp>

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -59,11 +59,6 @@
 // CHECK-NEXT: backend_types.hpp
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: exception.hpp
-// CHECK-NEXT: detail/cl.h
-// CHECK-NEXT: CL/cl.h
-// CHECK-NEXT: CL/cl_version.h
-// CHECK-NEXT: CL/cl_platform.h
-// CHECK-NEXT: CL/cl_ext.h
 // CHECK-NEXT: detail/string.hpp
 // CHECK-NEXT: ur_api.h
 // CHECK-NEXT: detail/common.hpp

--- a/sycl/test/include_deps/sycl_buffer.hpp.cpp
+++ b/sycl/test/include_deps/sycl_buffer.hpp.cpp
@@ -14,11 +14,6 @@
 // CHECK-NEXT: backend_types.hpp
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: exception.hpp
-// CHECK-NEXT: detail/cl.h
-// CHECK-NEXT: CL/cl.h
-// CHECK-NEXT: CL/cl_version.h
-// CHECK-NEXT: CL/cl_platform.h
-// CHECK-NEXT: CL/cl_ext.h
 // CHECK-NEXT: detail/string.hpp
 // CHECK-NEXT: ur_api.h
 // CHECK-NEXT: detail/common.hpp

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -60,11 +60,6 @@
 // CHECK-NEXT: backend_types.hpp
 // CHECK-NEXT: detail/array.hpp
 // CHECK-NEXT: exception.hpp
-// CHECK-NEXT: detail/cl.h
-// CHECK-NEXT: CL/cl.h
-// CHECK-NEXT: CL/cl_version.h
-// CHECK-NEXT: CL/cl_platform.h
-// CHECK-NEXT: CL/cl_ext.h
 // CHECK-NEXT: detail/string.hpp
 // CHECK-NEXT: ur_api.h
 // CHECK-NEXT: detail/common.hpp
@@ -143,6 +138,11 @@
 // CHECK-NEXT: ext/oneapi/properties/properties.hpp
 // CHECK-NEXT: ext/oneapi/experimental/graph.hpp
 // CHECK-NEXT: handler.hpp
+// CHECK-NEXT: detail/cl.h
+// CHECK-NEXT: CL/cl.h
+// CHECK-NEXT: CL/cl_version.h
+// CHECK-NEXT: CL/cl_platform.h
+// CHECK-NEXT: CL/cl_ext.h
 // CHECK-NEXT: detail/reduction_forward.hpp
 // CHECK-NEXT: detail/ur.hpp
 // CHECK-NEXT: ur_api_funcs.def


### PR DESCRIPTION
The main change is that specializations of `UrInfoCode` were moved into library, because they are not used in public headers.

Also removed some of unnecessary `#include`s here and there.