### PR TITLE
[SYCL] Re-enable tests on PVC

### DIFF
--- a/sycl/test-e2e/DeviceCodeSplit/grf.cpp
+++ b/sycl/test-e2e/DeviceCodeSplit/grf.cpp
@@ -14,10 +14,8 @@
 //   compiler option
 
 // REQUIRES: arch-intel_gpu_pvc
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: *
 
-// RUN: %{build} -o %t.out
+// RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
 // Don't use SYCL_UR_TRACE as the output from the L0 adapter logging interferes
 // with the regular UR traces we are checking.
 // RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
@@ -25,7 +23,7 @@
 // RUN: %{build} -DUSE_NEW_API=1 -o %t.out
 // RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-NO-VAR
 // RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-WITH-VAR
-// RUN: %{build} -DUSE_AUTO_GRF=1 -o %t.out
+// RUN: %{build} -DUSE_AUTO_GRF=1 -Wno-error=deprecated-declarations -o %t.out
 // RUN: env UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-NO-VAR
 // RUN: env SYCL_PROGRAM_COMPILE_OPTIONS="-g" UR_LOG_TRACING="level:info;output:stdout;flush:info" UR_ENABLE_LAYERS=UR_LAYER_TRACING %{run} %t.out 2>&1 | FileCheck %s --check-prefixes=CHECK,CHECK-AUTO-WITH-VAR
 // RUN: %{build} -DUSE_NEW_API=1 -DUSE_AUTO_GRF=1 -o %t.out

--- a/sycl/test-e2e/KernelAndProgram/target_register_alloc_mode.cpp
+++ b/sycl/test-e2e/KernelAndProgram/target_register_alloc_mode.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: arch-intel_gpu_pvc
 
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: arch-intel_gpu_pvc
-
 // RUN: %{build} -ftarget-register-alloc-mode=pvc:auto -o %t_with.out
 // RUN: %{build} -o %t_without.out
 // RUN: %{build} -ftarget-register-alloc-mode=pvc:default -o %t_default.out
@@ -11,7 +8,7 @@
 // RUN: env SYCL_UR_TRACE=2 %{run} %t_without.out 2>&1 | FileCheck %if system-windows %{ --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %} %else %{ --check-prefix=CHECK-OPT %} %s
 // RUN: env SYCL_UR_TRACE=2 %{run} %t_default.out 2>&1 | FileCheck --implicit-check-not=-ze-intel-enable-auto-large-GRF-mode %s
 
-// CHECK-OPT: ---> urProgramBuild(
+// CHECK-OPT: ---> urProgramBuildExp(
 // CHECK-SAME-OPT: -ze-intel-enable-auto-large-GRF-mode
 
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Re-enable the KernelAndProgram/target_register_alloc_mode.cpp and DeviceCodeSplit/grf.cpp E2E tests on PVC by adding compiler flag for DeviceCodeSplit/grf.cpp in runs when old API is used and changing expected output in KernelAndProgram/target_register_alloc_mode.cpp to `urProgramBuildExp` instead of `urProgramBuild`.
