### PR TITLE
[SYCL][HIP] Add --only-needed flag to llvm-link for AMDGCN

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -599,6 +599,7 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
       // NativeCPU links against libclc (libspirv)
       if (IsSYCLNativeCPU && InputFilename.contains("libspirv"))
         return true;
+      // AMDGCN links against our libdevice (devicelib)
       if (IsAMDGCN && InputFilename.starts_with("devicelib-"))
         return true;
       // NVPTX links against our libclc (libspirv), our libdevice (devicelib),

--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -579,6 +579,7 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
     auto isSYCLDeviceLib = [&](const InputInfo &II) {
       const ToolChain *HostTC = C.getSingleOffloadToolChain<Action::OFK_Host>();
       const bool IsNVPTX = this->getToolChain().getTriple().isNVPTX();
+      const bool IsAMDGCN = this->getToolChain().getTriple().isAMDGCN();
       const bool IsFPGA = this->getToolChain().getTriple().isSPIR() &&
                           this->getToolChain().getTriple().getSubArch() ==
                               llvm::Triple::SPIRSubArch_fpga;
@@ -597,6 +598,8 @@ const char *SYCL::Linker::constructLLVMLinkCommand(
       StringRef InputFilename = llvm::sys::path::filename(FileName);
       // NativeCPU links against libclc (libspirv)
       if (IsSYCLNativeCPU && InputFilename.contains("libspirv"))
+        return true;
+      if (IsAMDGCN && InputFilename.starts_with("devicelib-"))
         return true;
       // NVPTX links against our libclc (libspirv), our libdevice (devicelib),
       // and the CUDA libdevice

--- a/clang/test/Driver/sycl-device-lib-amdgcn.cpp
+++ b/clang/test/Driver/sycl-device-lib-amdgcn.cpp
@@ -44,7 +44,7 @@
 
 // Check that llvm-link uses the "-only-needed" flag.
 // Not using the flag breaks kernel bundles.
-// RUN: %clangxx -### -std=c++11 -nogpulib --sysroot=%S/Inputs/SYCL \
+// RUN: %clangxx -### -nogpulib --sysroot=%S/Inputs/SYCL \
 // RUN: -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ONLY-NEEDED %s
 

--- a/clang/test/Driver/sycl-device-lib-amdgcn.cpp
+++ b/clang/test/Driver/sycl-device-lib-amdgcn.cpp
@@ -42,3 +42,10 @@
 // CHK-ALL: [[DEVLIB:[0-9]+]]: input, "{{.*}}devicelib--amd.bc", ir, (device-sycl, gfx906)
 // CHK-ALL: {{[0-9]+}}: linker, {{{.*}}[[DEVLIB]]{{.*}}}, ir, (device-sycl, gfx906)
 
+// Check that llvm-link uses the "-only-needed" flag.
+// Not using the flag breaks kernel bundles.
+// RUN: %clangxx -### -std=c++11 -nogpulib --sysroot=%S/Inputs/SYCL \
+// RUN: -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-ONLY-NEEDED %s
+
+// CHK-ONLY-NEEDED: llvm-link"{{.*}}"-only-needed"{{.*}}"{{.*}}devicelib--amd.bc"{{.*}}

--- a/clang/test/Driver/sycl-device-lib-nvptx.cpp
+++ b/clang/test/Driver/sycl-device-lib-nvptx.cpp
@@ -42,3 +42,10 @@
 // CHK-ALL: [[DEVLIB:[0-9]+]]: input, "{{.*}}devicelib--cuda.bc", ir, (device-sycl, sm_50)
 // CHK-ALL: {{[0-9]+}}: linker, {{{.*}}[[DEVLIB]]{{.*}}}, ir, (device-sycl, sm_50)
 
+// Check that llvm-link uses the "-only-needed" flag.
+// Not using the flag breaks kernel bundles.
+// RUN: %clangxx -### -std=c++11 --sysroot=%S/Inputs/SYCL \
+// RUN:  -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
+// RUN: | FileCheck -check-prefix=CHK-ONLY-NEEDED %s
+
+// CHK-ONLY-NEEDED: llvm-link"{{.*}}"-only-needed"{{.*}}"{{.*}}devicelib--cuda.bc"{{.*}}

--- a/clang/test/Driver/sycl-device-lib-nvptx.cpp
+++ b/clang/test/Driver/sycl-device-lib-nvptx.cpp
@@ -44,8 +44,7 @@
 
 // Check that llvm-link uses the "-only-needed" flag.
 // Not using the flag breaks kernel bundles.
-// RUN: %clangxx -### -std=c++11 --sysroot=%S/Inputs/SYCL \
-// RUN:  -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
+// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ONLY-NEEDED %s
 
 // CHK-ONLY-NEEDED: llvm-link"{{.*}}"-only-needed"{{.*}}"{{.*}}devicelib--cuda.bc"{{.*}}


### PR DESCRIPTION
Add the -only-needed flag for AMDGCN when linking against devicelib.

Fixes several test cases that use kernel bundles.