### PR TITLE
[CI] Detect hung tests on Windows

### DIFF
--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -86,6 +86,17 @@ jobs:
         # Run E2E tests.
         export LIT_OPTS="-v --no-progress-bar --show-unsupported --show-pass --show-xfail --max-time 3600 --time-tests ${{ inputs.extra_lit_opts }}"
         cmake --build build-e2e --target check-sycl-e2e
+    - name: Detect hung tests
+      shell: powershell
+      run: |
+        $exitCode = 0
+        $hungTests = Get-Process | Where-Object { ($_.Path -match "llvm\\install") -or ($_.Path -match "llvm\\build-e2e") }
+        $hungTests | Foreach-Object {
+         $exitCode = 1
+         echo "Test $($_.Path) hung!"
+         Stop-Process -Force $_
+        }
+        exit $exitCode
     - name: Cleanup
       shell: cmd
       if: always()


### PR DESCRIPTION
Look for any open processes inside the folders we extract to. I tried a few ideas but this one was the simplest and most stable.

The command only shows processes by the current user by default, and the account isn't an administrator so we can't do anything weird.