### PR TITLE
cross check for compilation fixes in UR

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,14 +116,14 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/lslusarczyk/unified-runtime.git")
   # commit 0247d0966ca8c5d1e3245f375e48e6c997bed9af
   # Merge: 675dd292 04ffc909
   # Author: aarongreig <aaron.greig@codeplay.com>
   # Date:   Tue Oct 1 17:10:58 2024 +0100
   #     Merge pull request #2154 from npmiller/fix-graph-exce
   #     [CUDA][HIP] Fix exceptions throwing from adapter
-  set(UNIFIED_RUNTIME_TAG 0247d0966ca8c5d1e3245f375e48e6c997bed9af)
+  set(UNIFIED_RUNTIME_TAG fcdcc759259c50c5880191fdc23fe531d9724a5a)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need


### PR DESCRIPTION
Checking if https://github.com/oneapi-src/unified-runtime/pull/2071 does not break llvm code.