### PR TITLE
[CI] Fix syntax for multi-line expressions in sycl-linux-precommit.yml

### DIFF
--- a/.github/workflows/sycl-linux-precommit.yml
+++ b/.github/workflows/sycl-linux-precommit.yml
@@ -117,11 +117,11 @@ jobs:
       env: ${{ matrix.env || '{}' }}
 
       # Do not install drivers on AMD and CUDA runners.
-      install_igc_driver: |
+      install_igc_driver: >-
         ${{ !contains(matrix.target_devices, 'ext_oneapi_cuda') &&
         !contains(matrix.target_devices, 'ext_oneapi_hip') &&
         contains(needs.detect_changes.outputs.filters, 'drivers') }}
-      install_dev_igc_driver: |
+      install_dev_igc_driver: >-
         ${{ !contains(matrix.target_devices, 'ext_oneapi_cuda') &&
         !contains(matrix.target_devices, 'ext_oneapi_hip') &&
         matrix.use_igc_dev && contains(needs.detect_changes.outputs.filters, 'devigccfg') ||


### PR DESCRIPTION
Fixes: https://github.com/intel/llvm/pull/15481
Example of a successful run: https://github.com/intel/llvm/pull/15586

It seems that only `>-` actually works when we use multi-line expressions using `${{ }}`. https://github.com/orgs/community/discussions/25641#discussioncomment-10617902