### PR TITLE
[SYCL] Enable image write tests for CUDA

### DIFF
--- a/sycl/test-e2e/Basic/image/image_write.cpp
+++ b/sycl/test-e2e/Basic/image/image_write.cpp
@@ -2,7 +2,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// UNSUPPORTED: cuda || hip
+// UNSUPPORTED: hip
 // TODO: re-enable on cuda device.
 // See https://github.com/intel/llvm/issues/1542#issuecomment-707877817 for more
 // details.

--- a/sycl/test-e2e/Basic/image/image_write_fp16.cpp
+++ b/sycl/test-e2e/Basic/image/image_write_fp16.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aspect-fp16, aspect-ext_intel_legacy_image
 
-// UNSUPPORTED: cuda, hip
+// UNSUPPORTED: hip
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
With the bindless image work already in those tests should be fixed. Test pass consistently in our local testing.