### PR TITLE
[SYCL][NFCI] Refactor `unittest::UrArray`

### DIFF
--- a/sycl/unittests/Extensions/DeviceGlobal.cpp
+++ b/sycl/unittests/Extensions/DeviceGlobal.cpp
@@ -65,11 +65,11 @@ static sycl::unittest::UrImage generateDeviceGlobalImage() {
   UrProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalName, sizeof(int) * 2, 0);
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 UrArray<UrProperty>{std::move(DevGlobInfo)});
+                 std::vector<UrProperty>{std::move(DevGlobInfo)});
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
@@ -96,11 +96,11 @@ static sycl::unittest::UrImage generateDeviceGlobalImgScopeImage() {
   UrProperty DevGlobInfo =
       makeDeviceGlobalInfo(DeviceGlobalImgScopeName, sizeof(int) * 2, 1);
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_GLOBALS,
-                 UrArray<UrProperty>{std::move(DevGlobInfo)});
+                 std::vector<UrProperty>{std::move(DevGlobInfo)});
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({DeviceGlobalImgScopeTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format

--- a/sycl/unittests/Extensions/USMMemcpy2D.cpp
+++ b/sycl/unittests/Extensions/USMMemcpy2D.cpp
@@ -132,7 +132,7 @@ static sycl::unittest::UrImage generateMemopsImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(
       {USMFillHelperKernelNameLong, USMFillHelperKernelNameChar,
        USMMemcpyHelperKernelNameLong, USMMemcpyHelperKernelNameChar});
 

--- a/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
+++ b/sycl/unittests/Extensions/VirtualFunctions/RuntimeLinking.cpp
@@ -50,7 +50,7 @@ static sycl::unittest::UrImage
 generateImage(std::initializer_list<std::string> KernelNames,
               const std::string &VFSets, bool UsesVFSets, unsigned char Magic) {
   sycl::unittest::UrPropertySet PropSet;
-  sycl::unittest::UrArray<sycl::unittest::UrProperty> Props;
+  std::vector<sycl::unittest::UrProperty> Props;
   uint64_t PropSize = VFSets.size();
   std::vector<char> Storage(/* bytes for size */ 8 + PropSize +
                             /* null terminator */ 1);
@@ -69,7 +69,7 @@ generateImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::UrArray<sycl::unittest::UrOffloadEntry> Entries =
+  std::vector<sycl::unittest::UrOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::UrImage Img{

--- a/sycl/unittests/SYCL2020/IsCompatible.cpp
+++ b/sycl/unittests/SYCL2020/IsCompatible.cpp
@@ -32,7 +32,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/KernelBundle.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundle.cpp
@@ -37,7 +37,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -46,7 +46,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames,
   static unsigned char NImage = 0;
   std::vector<unsigned char> Bin{NImage++};
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{BinaryType, // Format
               DeviceTargetSpec,

--- a/sycl/unittests/SYCL2020/KernelID.cpp
+++ b/sycl/unittests/SYCL2020/KernelID.cpp
@@ -55,7 +55,7 @@ generateDefaultImage(std::initializer_list<std::string> Kernels) {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(Kernels);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(Kernels);
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/SYCL2020/SpecializationConstant.cpp
+++ b/sycl/unittests/SYCL2020/SpecializationConstant.cpp
@@ -49,7 +49,7 @@ static sycl::unittest::UrImage generateImageWithSpecConsts() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({"SpecializationConstant_TestKernel"});
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/assert/assert.cpp
+++ b/sycl/unittests/assert/assert.cpp
@@ -86,7 +86,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -109,7 +109,7 @@ static sycl::unittest::UrImage generateCopierKernelImage() {
 
   std::vector<unsigned char> Bin{10, 11, 12, 13, 14, 15}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({CopierKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/helpers/UrImage.hpp
+++ b/sycl/unittests/helpers/UrImage.hpp
@@ -109,39 +109,34 @@ private:
   NativeType MNative;
 };
 
-/// Generic array of UR entries.
-template <typename T> class UrArray {
+namespace internal {
+// Content from this namespace shouldn't be used anywhere outside of this file
+
+/// "native" data structures used by SYCL RT do not hold the data, but only
+/// point to it. The data itself is embedded into the binary data sections in
+/// real applications.
+/// In unit-tests we mock those data structures and therefore we need to ensure
+/// that the lifetime of the underlying data is correct and we won't perform
+/// any illegal memory accesses in unit-tests.
+template <typename T> class LifetimeExtender {
 public:
-  explicit UrArray(std::vector<T> Entries) : MMockEntries(std::move(Entries)) {
-    updateEntries();
+  explicit LifetimeExtender(std::vector<T> Entries)
+      : MMockEntries(std::move(Entries)) {
+    MEntries.clear();
+    std::transform(MMockEntries.begin(), MMockEntries.end(),
+                   std::back_inserter(MEntries),
+                   [](const T &Entry) { return Entry.convertToNativeType(); });
   }
 
-  UrArray(std::initializer_list<T> Entries) : MMockEntries(std::move(Entries)) {
-    updateEntries();
-  }
-
-  UrArray() = default;
-
-  void push_back(const T &Entry) {
-    MMockEntries.push_back(Entry);
-    MEntriesNeedUpdate = true;
-  }
+  LifetimeExtender() = default;
 
   typename T::NativeType *begin() {
-    if (MEntriesNeedUpdate) {
-      updateEntries();
-    }
-
     if (MEntries.empty())
       return nullptr;
 
     return &*MEntries.begin();
   }
   typename T::NativeType *end() {
-    if (MEntriesNeedUpdate) {
-      updateEntries();
-    }
-
     if (MEntries.empty())
       return nullptr;
 
@@ -149,22 +144,14 @@ public:
   }
 
 private:
-  void updateEntries() {
-    MEntries.clear();
-    std::transform(MMockEntries.begin(), MMockEntries.end(),
-                   std::back_inserter(MEntries),
-                   [](const T &Entry) { return Entry.convertToNativeType(); });
-  }
   std::vector<T> MMockEntries;
   std::vector<typename T::NativeType> MEntries;
-  bool MEntriesNeedUpdate = false;
 };
 
 #ifdef __cpp_deduction_guides
-template <typename T> UrArray(std::vector<T>) -> UrArray<T>;
-
-template <typename T> UrArray(std::initializer_list<T>) -> UrArray<T>;
+template <typename T> LifetimeExtender(std::vector<T>) -> LifetimeExtender<T>;
 #endif // __cpp_deduction_guides
+} // namespace internal
 
 /// Convenience wrapper for sycl_device_binary_property_set.
 class UrPropertySet {
@@ -187,19 +174,23 @@ public:
     // Value must be an all-zero 32-bit mask, which would mean that no fallback
     // libraries are needed to be loaded.
     UrProperty DeviceLibReqMask("", Data, SYCL_PROPERTY_TYPE_UINT32);
-    insert(__SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK, UrArray{DeviceLibReqMask});
+    insert(__SYCL_PROPERTY_SET_DEVICELIB_REQ_MASK, std::move(DeviceLibReqMask));
+  }
+
+  /// Adds a new property to the set.
+  ///
+  /// \param Name is a property name. See ur.hpp for list of known names.
+  /// \param Prop is a property value.
+  void insert(const std::string &Name, UrProperty &&Props) {
+    insert(Name, internal::LifetimeExtender{std::vector{std::move(Props)}});
   }
 
   /// Adds a new array of properties to the set.
   ///
   /// \param Name is a property array name. See ur.hpp for list of known names.
   /// \param Props is an array of property values.
-  void insert(const std::string &Name, UrArray<UrProperty> Props) {
-    MNames.push_back(Name);
-    MMockProperties.push_back(std::move(Props));
-    MProperties.push_back(_sycl_device_binary_property_set_struct{
-        MNames.back().data(), MMockProperties.back().begin(),
-        MMockProperties.back().end()});
+  void insert(const std::string &Name, std::vector<UrProperty> &&Props) {
+    insert(Name, internal::LifetimeExtender{std::move(Props)});
   }
 
   _sycl_device_binary_property_set_struct *begin() {
@@ -215,36 +206,65 @@ public:
   }
 
 private:
+  /// Adds a new array of properties to the set.
+  ///
+  /// \param Name is a property array name. See ur.hpp for list of known names.
+  /// \param Props is an array of property values.
+  void insert(const std::string &Name,
+              internal::LifetimeExtender<UrProperty> Props) {
+    MNames.push_back(Name);
+    MMockProperties.push_back(std::move(Props));
+    MProperties.push_back(_sycl_device_binary_property_set_struct{
+        MNames.back().data(), MMockProperties.back().begin(),
+        MMockProperties.back().end()});
+  }
+
   std::vector<std::string> MNames;
-  std::vector<UrArray<UrProperty>> MMockProperties;
+  std::vector<internal::LifetimeExtender<UrProperty>> MMockProperties;
   std::vector<_sycl_device_binary_property_set_struct> MProperties;
 };
 
 /// Convenience wrapper around UR internal structures, that manages UR binary
 /// image data lifecycle.
 class UrImage {
-public:
+private:
   /// Constructs an arbitrary device image.
   UrImage(uint16_t Version, uint8_t Kind, uint8_t Format,
           const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
-          std::vector<char> Manifest, std::vector<unsigned char> Binary,
-          UrArray<UrOffloadEntry> OffloadEntries, UrPropertySet PropertySet)
+          std::vector<char> &&Manifest, std::vector<unsigned char> &&Binary,
+          internal::LifetimeExtender<UrOffloadEntry> OffloadEntries,
+          UrPropertySet PropertySet)
       : MVersion(Version), MKind(Kind), MFormat(Format),
         MDeviceTargetSpec(DeviceTargetSpec), MCompileOptions(CompileOptions),
         MLinkOptions(LinkOptions), MManifest(std::move(Manifest)),
         MBinary(std::move(Binary)), MOffloadEntries(std::move(OffloadEntries)),
         MPropertySet(std::move(PropertySet)) {}
 
+public:
+  /// Constructs an arbitrary device image.
+  UrImage(uint16_t Version, uint8_t Kind, uint8_t Format,
+          const std::string &DeviceTargetSpec,
+          const std::string &CompileOptions, const std::string &LinkOptions,
+          std::vector<char> &&Manifest, std::vector<unsigned char> &&Binary,
+          std::vector<UrOffloadEntry> &&OffloadEntries,
+          UrPropertySet PropertySet)
+      : UrImage(Version, Kind, Format, DeviceTargetSpec, CompileOptions,
+                LinkOptions, std::move(Manifest), std::move(Binary),
+                internal::LifetimeExtender(std::move(OffloadEntries)),
+                std::move(PropertySet)) {}
+
   /// Constructs a SYCL device image of the latest version.
   UrImage(uint8_t Format, const std::string &DeviceTargetSpec,
           const std::string &CompileOptions, const std::string &LinkOptions,
-          std::vector<unsigned char> Binary,
-          UrArray<UrOffloadEntry> OffloadEntries, UrPropertySet PropertySet)
+          std::vector<unsigned char> &&Binary,
+          std::vector<UrOffloadEntry> &&OffloadEntries,
+          UrPropertySet PropertySet)
       : UrImage(SYCL_DEVICE_BINARY_VERSION,
                 SYCL_DEVICE_BINARY_OFFLOAD_KIND_SYCL, Format, DeviceTargetSpec,
                 CompileOptions, LinkOptions, {}, std::move(Binary),
-                std::move(OffloadEntries), std::move(PropertySet)) {}
+                internal::LifetimeExtender(std::move(OffloadEntries)),
+                std::move(PropertySet)) {}
 
   sycl_device_binary_struct convertToNativeType() {
     return sycl_device_binary_struct{
@@ -275,7 +295,7 @@ private:
   std::string MLinkOptions;
   std::vector<char> MManifest;
   std::vector<unsigned char> MBinary;
-  UrArray<UrOffloadEntry> MOffloadEntries;
+  internal::LifetimeExtender<UrOffloadEntry> MOffloadEntries;
   UrPropertySet MPropertySet;
 };
 
@@ -392,7 +412,7 @@ inline UrProperty makeSpecConstant(std::vector<char> &ValData,
 /// Utility function to mark kernel as the one using assert
 inline void setKernelUsesAssert(const std::vector<std::string> &Names,
                                 UrPropertySet &Set) {
-  UrArray<UrProperty> Value;
+  std::vector<UrProperty> Value;
   for (const std::string &N : Names)
     Value.push_back({N, {0, 0, 0, 0}, SYCL_PROPERTY_TYPE_UINT32});
   Set.insert(__SYCL_PROPERTY_SET_SYCL_ASSERT_USED, std::move(Value));
@@ -401,16 +421,14 @@ inline void setKernelUsesAssert(const std::vector<std::string> &Names,
 /// Utility function to add specialization constants to property set.
 ///
 /// This function overrides the default spec constant values.
-inline void addSpecConstants(UrArray<UrProperty> SpecConstants,
+inline void addSpecConstants(std::vector<UrProperty> &&SpecConstants,
                              std::vector<char> ValData, UrPropertySet &Props) {
   Props.insert(__SYCL_PROPERTY_SET_SPEC_CONST_MAP, std::move(SpecConstants));
 
   UrProperty Prop{"all", std::move(ValData), SYCL_PROPERTY_TYPE_BYTE_ARRAY};
 
-  UrArray<UrProperty> DefaultValues{std::move(Prop)};
-
   Props.insert(__SYCL_PROPERTY_SET_SPEC_CONST_DEFAULT_VALUES_MAP,
-               std::move(DefaultValues));
+               std::move(Prop));
 }
 
 /// Utility function to add ESIMD kernel flag to property set.
@@ -419,15 +437,13 @@ inline void addESIMDFlag(UrPropertySet &Props) {
   ValData[0] = 1;
   UrProperty Prop{"isEsimdImage", ValData, SYCL_PROPERTY_TYPE_UINT32};
 
-  UrArray<UrProperty> Value{std::move(Prop)};
-
-  Props.insert(__SYCL_PROPERTY_SET_SYCL_MISC_PROP, std::move(Value));
+  Props.insert(__SYCL_PROPERTY_SET_SYCL_MISC_PROP, std::move(Prop));
 }
 
 /// Utility function to generate offload entries for kernels without arguments.
-inline UrArray<UrOffloadEntry>
+inline std::vector<UrOffloadEntry>
 makeEmptyKernels(std::initializer_list<std::string> KernelNames) {
-  UrArray<UrOffloadEntry> Entries;
+  std::vector<UrOffloadEntry> Entries;
 
   for (const auto &Name : KernelNames) {
     UrOffloadEntry E{Name, {}, 0};
@@ -531,7 +547,7 @@ inline void
 addDeviceRequirementsProps(UrPropertySet &Props,
                            const std::vector<sycl::aspect> &Aspects,
                            const std::vector<int> &ReqdWGSize = {}) {
-  UrArray<UrProperty> Value{makeAspectsProp(Aspects)};
+  std::vector<UrProperty> Value{makeAspectsProp(Aspects)};
   if (!ReqdWGSize.empty())
     Value.push_back(makeReqdWGSizeProp(ReqdWGSize));
   Props.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_REQUIREMENTS, std::move(Value));
@@ -550,7 +566,7 @@ generateDefaultImage(std::initializer_list<std::string> KernelNames) {
   std::vector<unsigned char> Bin(Combined.begin(), Combined.end());
   Bin.push_back(0);
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels(KernelNames);
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/kernel-and-program/Cache.cpp
+++ b/sycl/unittests/kernel-and-program/Cache.cpp
@@ -61,7 +61,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({"CacheTestKernel", "CacheTestKernel2"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format

--- a/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
+++ b/sycl/unittests/kernel-and-program/KernelBuildOptions.cpp
@@ -78,7 +78,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({"BuildOptsTestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/pipes/host_pipe_registration.cpp
+++ b/sycl/unittests/pipes/host_pipe_registration.cpp
@@ -39,11 +39,11 @@ static sycl::unittest::UrImage generateDefaultImage() {
   UrProperty HostPipeInfo =
       makeHostPipeInfo("test_host_pipe_unique_id", sizeof(int));
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_HOST_PIPES,
-                 UrArray<UrProperty>{std::move(HostPipeInfo)});
+                 std::vector<UrProperty>{std::move(HostPipeInfo)});
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({"TestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/program_manager/CompileTarget.cpp
+++ b/sycl/unittests/program_manager/CompileTarget.cpp
@@ -28,13 +28,13 @@ generateImageWithCompileTarget(std::string KernelName,
                                    SYCL_PROPERTY_TYPE_BYTE_ARRAY);
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_SYCL_DEVICE_REQUIREMENTS,
-                 {CompileTargetProperty});
+                 std::move(CompileTargetProperty));
 
   std::vector<unsigned char> Bin(CompileTarget.begin(), CompileTarget.end());
   // Null terminate the data so it can be interpreted as c string.
   Bin.push_back(0);
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({KernelName});
 
   auto DeviceTargetSpec = CompileTarget == "spir64_x86_64"
                               ? __SYCL_DEVICE_BINARY_TARGET_SPIRV64_X86_64

--- a/sycl/unittests/program_manager/DynamicLinking.cpp
+++ b/sycl/unittests/program_manager/DynamicLinking.cpp
@@ -37,10 +37,10 @@ KERNEL_INFO(AOTCaseKernel)
 } // namespace sycl
 
 namespace {
-sycl::unittest::UrArray<sycl::unittest::UrProperty>
+std::vector<sycl::unittest::UrProperty>
 createPropertySet(const std::vector<std::string> &Symbols) {
   sycl::unittest::UrPropertySet PropSet;
-  sycl::unittest::UrArray<sycl::unittest::UrProperty> Props;
+  std::vector<sycl::unittest::UrProperty> Props;
   for (const std::string &Symbol : Symbols) {
     std::vector<char> Storage(sizeof(uint32_t));
     uint32_t Val = 1;
@@ -70,7 +70,7 @@ sycl::unittest::UrImage generateImage(
                    createPropertySet(ImportedSymbols));
   std::vector<unsigned char> Bin{Magic};
 
-  sycl::unittest::UrArray<sycl::unittest::UrOffloadEntry> Entries =
+  std::vector<sycl::unittest::UrOffloadEntry> Entries =
       sycl::unittest::makeEmptyKernels(KernelNames);
 
   sycl::unittest::UrImage Img{BinType,

--- a/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
+++ b/sycl/unittests/program_manager/arg_mask/EliminatedArgMask.cpp
@@ -58,14 +58,14 @@ static sycl::unittest::UrImage generateEAMTestKernelImage() {
   std::vector<unsigned char> KernelEAM{0b00000101};
   UrProperty EAMKernelPOI = makeKernelParamOptInfo(
       EAMTestKernelName, EAMTestKernelNumArgs, KernelEAM);
-  UrArray<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  std::vector<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernelName});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -85,7 +85,7 @@ static sycl::unittest::UrImage generateEAMTestKernel2Image() {
 
   std::vector<unsigned char> Bin{6, 7, 8, 9, 10, 11}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel2Name});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec
@@ -105,14 +105,14 @@ static sycl::unittest::UrImage generateEAMTestKernel3Image() {
   std::vector<unsigned char> KernelEAM{0b00001010};
   UrProperty EAMKernelPOI = makeKernelParamOptInfo(
       EAMTestKernel3Name, EAMTestKernelNumArgs, KernelEAM);
-  UrArray<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  std::vector<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel3Name});
+  std::vector<UrOffloadEntry> Entries = makeEmptyKernels({EAMTestKernel3Name});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format
               __SYCL_DEVICE_BINARY_TARGET_SPIRV64, // DeviceTargetSpec

--- a/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
+++ b/sycl/unittests/program_manager/passing_link_and_compile_options.cpp
@@ -64,14 +64,14 @@ generateEAMTestKernelImage(std::string _cmplOptions, std::string _lnkOptions) {
   UrProperty EAMKernelPOI =
       makeKernelParamOptInfo(sycl::detail::KernelInfo<T>::getName(),
                              EAMTestKernelNumArgs1, KernelEAM1);
-  UrArray<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
+  std::vector<UrProperty> ImgKPOI{std::move(EAMKernelPOI)};
 
   UrPropertySet PropSet;
   PropSet.insert(__SYCL_PROPERTY_SET_KERNEL_PARAM_OPT_INFO, std::move(ImgKPOI));
 
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({sycl::detail::KernelInfo<T>::getName()});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format

--- a/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
+++ b/sycl/unittests/scheduler/CommandsWaitForEvents.cpp
@@ -109,7 +109,7 @@ static sycl::unittest::UrImage generateDefaultImage() {
   addESIMDFlag(PropSet);
   std::vector<unsigned char> Bin{0, 1, 2, 3, 4, 5}; // Random data
 
-  UrArray<UrOffloadEntry> Entries =
+  std::vector<UrOffloadEntry> Entries =
       makeEmptyKernels({"StreamAUXCmdsWait_TestKernel"});
 
   UrImage Img{SYCL_DEVICE_BINARY_TYPE_SPIRV,       // Format


### PR DESCRIPTION
This is a first patch in series of detaching unit-test classes from UR names.

In a previous attempts to do so (#14815) there were concerns about what to do with `UrArray` and this PR is another attempt (see also #15014) to do that.

This PR renames `UrArray` into `LifetimeExtender` to better communicate its purpose: data structures emitted by the compiler (and therefore used by the runtime) to describe device image and their properties do not store data, but only hold pointers to them. Therefore when we mock those in our unit-tests we need to ensure that their lifetime is long enough to cover the whole test.

This is a non-functional change by its spirit, but what used to be `UrArray` is now hidden from writers of unit-tests and the interface is switched to `std::vector` - that is done to hide an implementation detail and simplify amount of knowledge required to write unit-tests.