### PR TITLE
[SYCL][Driver] Fix sycl-device-lib test failures for non NVPTX or AMDGPU builds of DPC++

### DIFF
--- a/clang/test/Driver/sycl-device-lib-amdgcn.cpp
+++ b/clang/test/Driver/sycl-device-lib-amdgcn.cpp
@@ -44,7 +44,7 @@
 
 // Check that llvm-link uses the "-only-needed" flag.
 // Not using the flag breaks kernel bundles.
-// RUN: %clangxx -### -nogpulib --sysroot=%S/Inputs/SYCL \
+// RUN: %clangxx -### -nogpulib -fno-sycl-libspirv --sysroot=%S/Inputs/SYCL \
 // RUN: -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx906 %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ONLY-NEEDED %s
 

--- a/clang/test/Driver/sycl-device-lib-nvptx.cpp
+++ b/clang/test/Driver/sycl-device-lib-nvptx.cpp
@@ -44,7 +44,7 @@
 
 // Check that llvm-link uses the "-only-needed" flag.
 // Not using the flag breaks kernel bundles.
-// RUN: %clangxx -### --sysroot=%S/Inputs/SYCL -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
+// RUN: %clangxx -### -nocudalib -fno-sycl-libspirv --sysroot=%S/Inputs/SYCL -fsycl -fsycl-targets=nvptx64-nvidia-cuda %s 2>&1 \
 // RUN: | FileCheck -check-prefix=CHK-ONLY-NEEDED %s
 
 // CHK-ONLY-NEEDED: llvm-link"{{.*}}"-only-needed"{{.*}}"{{.*}}devicelib--cuda.bc"{{.*}}


### PR DESCRIPTION
These tests failed on non Cuda or Hip host machines due to missing installations. Additionally, the `-only-needed` tests don't need `libspirv` so passing `-fno-sycl-libspirv` to the invocation is also required to succeed.