### PR TITLE
[SYCL] removal of interfering assert 

### DIFF
--- a/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
+++ b/sycl/include/sycl/ext/oneapi/backend/level_zero.hpp
@@ -83,8 +83,6 @@ inline std::optional<sycl::device> find_matching_descendent_device(
           return maybe_device;
       }
     }
-
-    assert(false && "Unexpected partitioning scheme for a Level-Zero device!");
   }
 
   return {};


### PR DESCRIPTION
`find_matching_descendent_device` return type is `std::optional`, meaning it does not need to return a match if none is found. The calling code anticipates this.  But the assert here precludes that path. Removing.

This is causing a bug on one of our big systems so we need the fix. But I'm not sure if a test needs to be added nor how to write such, as we don't see this problem on the lab or CI systems. 