### PR TITLE
sub_byte_bitreverse no longer xfail for gpu

### DIFF
--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -3,10 +3,6 @@
 
 // UNSUPPORTED: hip || cuda
 
-// TODO: Remove XFAIL after fixing
-// https://github.com/intel/intel-graphics-compiler/issues/330
-// XFAIL: gpu
-
 // Make dump directory.
 // RUN: rm -rf %t.spvdir && mkdir %t.spvdir
 


### PR DESCRIPTION
GPU driver fixed.  Remove XFAIL.