### PR TITLE
[SYCL] Deprecate `__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__`

### DIFF
--- a/sycl/include/CL/__spirv/spirv_ops.hpp
+++ b/sycl/include/CL/__spirv/spirv_ops.hpp
@@ -1365,7 +1365,15 @@ __clc_BarrierTestWait(int64_t *state, int64_t arrival) noexcept;
 __SYCL_CONVERGENT__ extern __DPCPP_SYCL_EXTERNAL __SYCL_EXPORT void
 __clc_BarrierArriveAndWait(int64_t *state) noexcept;
 
-#ifdef __SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__
+#if defined(__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__) &&                         \
+    !defined(__INTEL_PREVIEW_BREAKING_CHANGES)
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpedantic"
+#warning                                                                       \
+    "__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ is deprecated and will be removed in a future release."
+#pragma clang diagnostic pop
+#endif
 extern __DPCPP_SYCL_EXTERNAL int
 __spirv_ocl_printf(const __attribute__((opencl_constant)) char *Format, ...);
 extern __DPCPP_SYCL_EXTERNAL int __spirv_ocl_printf(const char *Format, ...);

--- a/sycl/test-e2e/Basic/built-ins.cpp
+++ b/sycl/test-e2e/Basic/built-ins.cpp
@@ -1,7 +1,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 
-// RUN: %{build} -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -o %t_var.out
+// RUN: %{build} -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -Wno-#warnings -o %t_var.out
 // RUN: %{run} %t_var.out | FileCheck %s
 
 // Hits an assertion with AMD:

--- a/sycl/test-e2e/DeviceLib/built-ins/printf.cpp
+++ b/sycl/test-e2e/DeviceLib/built-ins/printf.cpp
@@ -5,7 +5,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 //
-// RUN: %{build} -fsycl-device-code-split=per_kernel -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -o %t_var.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -Wno-#warnings -o %t_var.out
 // RUN: %{run} %t_var.out | FileCheck %s
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/ESIMD/printf.cpp
+++ b/sycl/test-e2e/ESIMD/printf.cpp
@@ -10,7 +10,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 //
-// RUN: %{build} -fsycl-device-code-split=per_kernel -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -o %t_var.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -Wno-#warnings -o %t_var.out
 // RUN: %{run} %t_var.out | FileCheck %s
 //
 //===----------------------------------------------------------------------===//

--- a/sycl/test-e2e/Printf/float.cpp
+++ b/sycl/test-e2e/Printf/float.cpp
@@ -9,7 +9,7 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 // FIXME: Remove dedicated variadic printf testing once the option is removed.
-// RUN: %{build} -o %t.nonvar.out -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__
+// RUN: %{build} -o %t.nonvar.out -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -Wno-#warnings
 // RUN: %{run} %t.nonvar.out | FileCheck %s
 // FIXME: Remove dedicated constant address space testing once generic AS
 //        support is considered stable.

--- a/sycl/test/warnings/variadic_ocl_printf.cpp
+++ b/sycl/test/warnings/variadic_ocl_printf.cpp
@@ -1,0 +1,5 @@
+// RUN: %clangxx -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -fsycl -fsycl-device-only -fsyntax-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s
+
+// expected-warning@*:* {{__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ is deprecated and will be removed in a future release.}}
+#include <sycl/sycl.hpp>
+


### PR DESCRIPTION
The default was flipped in https://github.com/intel/llvm/pull/13055, we can deprecate now and remove during the next ABI breaking window. Also, guard with `__INTEL_PREVIEW_BREAKING_CHANGES` to ensure that removal will actually happen.