### PR TITLE
[SYCL][ESIMD][E2E] Fix group barrier test driver check

### DIFF
--- a/sycl/test-e2e/ESIMD/group_barrier.cpp
+++ b/sycl/test-e2e/ESIMD/group_barrier.cpp
@@ -6,7 +6,7 @@
 //
 //===-----------------------------------------------------------===//
 // REQUIRES: arch-intel_gpu_pvc || gpu-intel-dg2
-// REQUIRES-INTEL-DRIVER: lin: 30751
+// REQUIRES-INTEL-DRIVER: lin: 31155
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
This version is available in a new public released driver and it still fails, I double checked the required version and it was wrong, so fix it.