### PR TITLE
[SYCL][ESIMD][E2E] Disable warning in fast math test

### DIFF
--- a/sycl/test-e2e/ESIMD/ext_math_fast.cpp
+++ b/sycl/test-e2e/ESIMD/ext_math_fast.cpp
@@ -6,7 +6,7 @@
 //
 //===----------------------------------------------------------------------===//
 // DEFINE: %{slpflags} = %if cl_options %{/clang:-fno-slp-vectorize%} %else %{-fno-slp-vectorize%}
-// RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math %{slpflags} -o %t.out
+// RUN: %{build} -fsycl-device-code-split=per_kernel -ffast-math -Wno-overriding-option %{slpflags} -o %t.out
 // RUN: %{run} %t.out
 
 // This test checks extended math operations. Combinations of


### PR DESCRIPTION
Can cause build to fail if using `-Werror`, so disable the warning.