### PR TITLE
[SYCL] Add missed `#include <functional>` for `property_list_base.hpp`

### DIFF
--- a/sycl/include/sycl/detail/property_list_base.hpp
+++ b/sycl/include/sycl/detail/property_list_base.hpp
@@ -13,6 +13,7 @@
 
 #include <algorithm>   // for iter_swap
 #include <bitset>      // for bitset
+#include <functional>  // for function
 #include <memory>      // for shared_ptr, __shared_ptr_...
 #include <type_traits> // for enable_if_t
 #include <utility>     // for move


### PR DESCRIPTION
Unlike GCC 11, GCC 12 doesn't happen to `#include` it implicitly from `<algorithm>`.