### PR TITLE
[SYCL][ESIMD] Use passthrough for mask_expand_load

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -14257,7 +14257,8 @@ mask_expand_load(const T *p, simd_mask<N> mask, PropertyListT props = {}) {
   // becomes an index for compressed store/expanded load operation.
   simd<uint32_t, N> offset =
       cbit(simd<uint32_t, N>(offsets::value) & pack_mask(mask));
-  return gather(p, offset * sizeof(T), mask, props);
+  simd<T, N> pass_thru = 0;
+  return gather(p, offset * sizeof(T), mask, pass_thru, props);
 }
 
 /// template <typename T, int N, typename AccessorTy,
@@ -14305,7 +14306,9 @@ mask_expand_load(AccessorTy acc, uint32_t global_offset, simd_mask<N> mask,
   // becomes an index for compressed store/expanded load operation.
   simd<uint32_t, N> offset =
       cbit(simd<uint32_t, N>(offsets::value) & pack_mask(mask));
-  return gather<T>(acc, offset * sizeof(T) + global_offset, mask, props);
+  simd<T, N> pass_thru = 0;
+  return gather<T>(acc, offset * sizeof(T) + global_offset, mask, pass_thru,
+                   props);
 }
 
 /// template <typename T, int N,

--- a/sycl/include/sycl/ext/intel/esimd/memory.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory.hpp
@@ -14258,7 +14258,9 @@ mask_expand_load(const T *p, simd_mask<N> mask, PropertyListT props = {}) {
   simd<uint32_t, N> offset =
       cbit(simd<uint32_t, N>(offsets::value) & pack_mask(mask));
   simd<T, N> pass_thru = 0;
-  return gather(p, offset * sizeof(T), mask, pass_thru, props);
+  simd<T, N> res = gather(p, offset * sizeof(T), mask, props);
+  res.merge(pass_thru, !mask);
+  return res;
 }
 
 /// template <typename T, int N, typename AccessorTy,
@@ -14307,8 +14309,10 @@ mask_expand_load(AccessorTy acc, uint32_t global_offset, simd_mask<N> mask,
   simd<uint32_t, N> offset =
       cbit(simd<uint32_t, N>(offsets::value) & pack_mask(mask));
   simd<T, N> pass_thru = 0;
-  return gather<T>(acc, offset * sizeof(T) + global_offset, mask, pass_thru,
-                   props);
+  simd<T, N> res =
+      gather<T>(acc, offset * sizeof(T) + global_offset, mask, props);
+  res.merge(pass_thru, !mask);
+  return res;
 }
 
 /// template <typename T, int N,

--- a/sycl/test-e2e/ESIMD/mask_expand_load.cpp
+++ b/sycl/test-e2e/ESIMD/mask_expand_load.cpp
@@ -9,9 +9,6 @@
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: arch-intel_gpu_pvc
-
 // This is a basic test to validate the expanded load API.
 
 #include "esimd_test_utils.hpp"


### PR DESCRIPTION
The unread elements had undefined values, causing sporadic failures.

We can't use the pass_thru arg to gather because that breaks Gen12 which was working before.

Closes: https://github.com/intel/llvm/issues/15257
Closes: https://github.com/intel/llvm/issues/15653 