### PR TITLE
[CI][Container] Create new container that combines build and intel driver containers

### DIFF
--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -51,6 +51,13 @@ jobs:
             file: ubuntu2204_intel_drivers
             tag: unstable
             build_args: "use_latest=true"
+          - name: All Dependencies Docker image
+            file: ubuntu2204_intel_drivers
+            tag: alldeps
+            build_args: |
+              base_image=ghcr.io/intel/llvm/ubuntu2204_build
+              base_tag=latest
+              use_latest=false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -67,30 +74,3 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}
           build-args: ${{ matrix.build_args }}
-
-  build_all_deps_image:
-    if: github.repository == 'intel/llvm'
-    name: Build and Push Docker Image - Build With Drivers
-    runs-on: ubuntu-22.04
-    permissions:
-      packages: write
-    needs: build_and_push_images
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 2
-      - name: Build and Push Container
-        uses: ./devops/actions/build_container
-        with:
-          push: ${{ github.event_name != 'pull_request' }}
-          file: ubuntu2204_intel_drivers
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-          tags: |
-            ghcr.io/${{ github.repository }}/ubuntu2204_alldeps:latest-${{ github.sha }}
-            ghcr.io/${{ github.repository }}/ubuntu2204_alldeps:latest
-          build-args: |
-              base_image=ghcr.io/intel/llvm/ubuntu2204_build
-              base_tag=latest
-              use_latest=false

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -51,6 +51,13 @@ jobs:
             file: ubuntu2204_intel_drivers
             tag: unstable
             build_args: "use_latest=true"
+          - name: All Dependencies Docker image
+            file: ubuntu2204_intel_drivers
+            tag: build
+            build-args: |
+              base_image=ghcr.io/intel/llvm/ubuntu2204_build
+              base_tag=latest
+              use_latest=false
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -74,3 +74,4 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}-${{ github.sha }}
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}
           build-args: ${{ matrix.build_args }}
+

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -51,13 +51,6 @@ jobs:
             file: ubuntu2204_intel_drivers
             tag: unstable
             build_args: "use_latest=true"
-          - name: All Dependencies Docker image
-            file: ubuntu2204_intel_drivers
-            tag: build
-            build_args: |
-              base_image=ghcr.io/intel/llvm/ubuntu2204_build
-              base_tag=latest
-              use_latest=false
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -75,3 +68,29 @@ jobs:
             ghcr.io/${{ github.repository }}/${{ matrix.file }}:${{ matrix.tag }}
           build-args: ${{ matrix.build_args }}
 
+  build_all_deps_image:
+    if: github.repository == 'intel/llvm'
+    name: Build and Push Docker Image - Build With Drivers
+    runs-on: ubuntu-22.04
+    permissions:
+      packages: write
+    needs: build_and_push_images
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 2
+      - name: Build and Push Container
+        uses: ./devops/actions/build_container
+        with:
+          push: ${{ github.event_name != 'pull_request' }}
+          file: ubuntu2204_intel_drivers
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          tags: |
+            ghcr.io/${{ github.repository }}/ubuntu2204_alldeps:latest-${{ github.sha }}
+            ghcr.io/${{ github.repository }}/ubuntu2204_alldeps:latest
+          build_args: |
+              base_image=ghcr.io/intel/llvm/ubuntu2204_build
+              base_tag=latest
+              use_latest=false

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -90,7 +90,7 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository }}/ubuntu2204_alldeps:latest-${{ github.sha }}
             ghcr.io/${{ github.repository }}/ubuntu2204_alldeps:latest
-          build_args: |
+          build-args: |
               base_image=ghcr.io/intel/llvm/ubuntu2204_build
               base_tag=latest
               use_latest=false

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -51,7 +51,7 @@ jobs:
             file: ubuntu2204_intel_drivers
             tag: unstable
             build_args: "use_latest=true"
-          - name: All Dependencies Docker image
+          - name: Build + Intel Drivers Ubuntu 22.04 Docker image
             file: ubuntu2204_intel_drivers
             tag: alldeps
             build_args: |

--- a/.github/workflows/sycl-containers.yaml
+++ b/.github/workflows/sycl-containers.yaml
@@ -54,7 +54,7 @@ jobs:
           - name: All Dependencies Docker image
             file: ubuntu2204_intel_drivers
             tag: build
-            build-args: |
+            build_args: |
               base_image=ghcr.io/intel/llvm/ubuntu2204_build
               base_tag=latest
               use_latest=false

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -260,13 +260,3 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build
-    - name: Build Container (Build image with drivers)
-      uses: ./devops/actions/build_container
-      with:
-        push: false
-        file: ubuntu2204_intel_drivers
-        username: ${{ github.repository_owner }}
-        password: ${{ secrets.GITHUB_TOKEN }}
-        build-args: |
-          base_image=ghcr.io/intel/llvm/ubuntu2204_build
-          base_tag=latest

--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -260,3 +260,13 @@ jobs:
         tags: |
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build-${{ github.sha }}
           ghcr.io/${{ github.repository }}/sycl_ubuntu2204_nightly:build
+    - name: Build Container (Build image with drivers)
+      uses: ./devops/actions/build_container
+      with:
+        push: false
+        file: ubuntu2204_intel_drivers
+        username: ${{ github.repository_owner }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+        build-args: |
+          base_image=ghcr.io/intel/llvm/ubuntu2204_build
+          base_tag=latest

--- a/sycl/doc/developer/DockerBKMs.md
+++ b/sycl/doc/developer/DockerBKMs.md
@@ -40,7 +40,7 @@ The following containers are publicly available for DPC++ compiler development:
    building DPC++ compiler from source.
 - `ghcr.io/intel/llvm/ubuntu2204_intel_drivers`: contains everything from the
    base container + pre-installed Intel drivers.
-   The image comes in three flavors/tags:
+   The image comes in four flavors/tags:
    * `latest`: Intel drivers are downloaded from release/tag and saved in
     dependencies.json. The drivers are tested/validated everytime we upgrade
     the driver.
@@ -48,6 +48,8 @@ The following containers are publicly available for DPC++ compiler development:
    other drivers are downloaded from release/tag and saved in dependencies.json.
    * `unstable`: Intel drivers are downloaded from release/latest.
    The drivers are installed as it is, not tested or validated.
+   * `alldeps`: Includes the same Intel drivers as `latest`, as well as the
+   development kits for NVidia/AMD from the `ubuntu2204_build` container.
 - `ghcr.io/intel/llvm/ubuntu2204_build`: has development kits installed for
    NVidia/AMD and can be used for building DPC++ compiler from source with all
    backends enabled or for end-to-end testing with HIP/CUDA on machines with


### PR DESCRIPTION
This container is a version of the intel_drivers container that is built on top of our build container, instead of base. This container is needed to be able to build all e2e tests.