### PR TITLE
[Driver][SYCL] Match up -device_options with -device for AOT GPU

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1033,7 +1033,7 @@ static OclocInfo PVCDevices[] = {
 
 // Determine if any of the given arguments contain any PVC based values for
 // the -device option.
-static bool hasPVCDevice(const ArgStringList &CmdArgs) {
+static bool hasPVCDevice(const ArgStringList &CmdArgs, std::string &DevArg) {
   bool DeviceSeen = false;
   StringRef DeviceArg;
   for (StringRef Arg : CmdArgs) {
@@ -1074,16 +1074,22 @@ static bool hasPVCDevice(const ArgStringList &CmdArgs) {
     // Check for device, version or hex (literal values)
     for (unsigned int I = 0; I < std::size(PVCDevices); I++) {
       if (SingleArg.equals_insensitive(PVCDevices[I].DeviceName) ||
-          SingleArg.equals_insensitive(PVCDevices[I].Version))
+          SingleArg.equals_insensitive(PVCDevices[I].Version)) {
+        DevArg = SingleArg.str();
         return true;
+      }
       for (int HexVal : PVCDevices[I].HexValues) {
         int Value = 0;
-        if (!SingleArg.getAsInteger(0, Value) && Value == HexVal)
+        if (!SingleArg.getAsInteger(0, Value) && Value == HexVal) {
+          DevArg = SingleArg.str();
           return true;
+        }
       }
       if (CheckShortVersion &&
-          StringRef(PVCDevices[I].Version).starts_with(SingleArg))
+          StringRef(PVCDevices[I].Version).starts_with(SingleArg)) {
+        DevArg = SingleArg.str();
         return true;
+      }
     }
   }
   return false;
@@ -1659,8 +1665,13 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
     Args.AddAllArgValues(TargArgs, options::OPT_Xs, options::OPT_Xs_separate);
     Args.AddAllArgValues(TargArgs, options::OPT_Xsycl_backend);
     // Check for any -device settings.
-    if (IsJIT || Device == "pvc" || hasPVCDevice(TargArgs)) {
+    std::string DevArg("");
+    if (IsJIT || Device == "pvc" || hasPVCDevice(TargArgs, DevArg)) {
+      // The -device option passed in by the user may not be 'pvc'. Use the
+      // value provided by the user if it was specified.
       StringRef DeviceName = "pvc";
+      if (!DevArg.empty())
+        DeviceName = DevArg;
       StringRef BackendOptName = SYCL::gen::getGenGRFFlag("auto");
       if (IsGen)
         PerDeviceArgs.push_back(

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode-old-model.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode-old-model.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:auto %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=AUTO_AOT %s
+// RUN:   | FileCheck -check-prefix=AUTO_AOT %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:large %s 2>&1 \
@@ -18,19 +18,19 @@
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device pvc" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 0x0BD5" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=0x0BD5
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 12.60.7" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=12.60.7
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device pvc,mtl-s" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:small,pvc:large %s 2>&1 \
@@ -88,7 +88,7 @@
 
 // AUTO_AOT: ocloc{{.*}} "-output"
 // AUTO_AOT: -device_options
-// AUTO_AOT: pvc
+// AUTO_AOT: [[DEVICE]]
 // AUTO_AOT: "-ze-intel-enable-auto-large-GRF-mode"
 
 // LARGE_AOT: ocloc{{.*}} "-output"

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
@@ -2,7 +2,7 @@
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:auto %s 2>&1 \
-// RUN:   | FileCheck -check-prefix=AUTO_AOT %s
+// RUN:   | FileCheck -check-prefix=AUTO_AOT %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:large %s 2>&1 \
@@ -18,19 +18,19 @@
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device pvc" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 0x0BD5" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=0x0BD5
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 12.60.7" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=12.60.7
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device pvc,mtl-s" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -ftarget-register-alloc-mode=pvc:small,pvc:large %s 2>&1 \
@@ -88,7 +88,7 @@
 // NO_PVC-NOT: -device_options
 // NO_PVC-NOT: -ze-opt-large-register-file
 
-// AUTO_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch={{.*}},kind=sycl,compile-opts=-device_options pvc -ze-intel-enable-auto-large-GRF-mode{{.*}}"
+// AUTO_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch={{.*}},kind=sycl,compile-opts=-device_options [[DEVICE]] -ze-intel-enable-auto-large-GRF-mode{{.*}}"
 
 // LARGE_AOT: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=,kind=sycl,compile-opts=-device_options pvc -ze-opt-large-register-file"
 


### PR DESCRIPTION
The driver will add additional -ftarget-register-alloc-mode values to the spir64_gen AOT call to ocloc.  These additional options are applied when a user specifies any of the accepted PVC values that can be handled by ocloc.  These values can be 'pvc' or associated hex or version values.

Match up the -device_options arg value with the -device arg that is passed on the command line.  ocloc expects these to match in order to properly associate the option given after -device_options.