### PR TITLE
[SYCL] Skip failing tests for PVC T1

### DIFF
--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -186,7 +186,7 @@ bool IsPVC_T1(sycl::device &d) {
 int main() {
   device d;
   // Check to skip the test for PVC T1
-  if(!IsPVC_T1(d)){ 
+  if (!IsPVC_T1(d)) {
     test_pvc(d);
   }
   test_non_pvc(d);

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_cslice.cpp
@@ -1,7 +1,5 @@
 // REQUIRES: level_zero
 // REQUIRES: aspect-ext_intel_device_id
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: arch-intel_gpu_pvc
 
 // RUN: %{build} -Wno-error=deprecated-declarations -o %t.out
 
@@ -180,10 +178,17 @@ void test_non_pvc(device &d) {
   }
 }
 
+bool IsPVC_T1(sycl::device &d) {
+  uint32_t device_id = d.get_info<sycl::ext::intel::info::device::device_id>();
+  return device_id == 0xbda;
+}
+
 int main() {
   device d;
-
-  test_pvc(d);
+  // Check to skip the test for PVC T1
+  if(!IsPVC_T1(d)){ 
+    test_pvc(d);
+  }
   test_non_pvc(d);
 
   return 0;

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -117,8 +117,8 @@ bool IsPVC_T1(sycl::device &d) {
 int main() {
   device d;
   // Check to skip the test for PVC T1
-  if (IsPVC_T1(d)){
-    return 0; 
+  if (IsPVC_T1(d)) {
+    return 0;
   }
 
   test_pvc(d);

--- a/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
+++ b/sycl/test-e2e/Plugin/level_zero_ext_intel_queue_index.cpp
@@ -1,8 +1,6 @@
 // REQUIRES: aspect-ext_intel_device_id
 // REQUIRES: level_zero
 
-// https://github.com/intel/llvm/issues/14826
-// XFAIL: arch-intel_gpu_pvc
 // RUN: %{build} -o %t.out
 
 // TODO: at this time PVC 1T systems are not correctly supporting CSLICE
@@ -111,9 +109,17 @@ void test_pvc(device &d) {
   std::cout << "Test PVC End" << std::endl;
   // CHECK-PVC: Test PVC End
 }
+bool IsPVC_T1(sycl::device &d) {
+  uint32_t device_id = d.get_info<sycl::ext::intel::info::device::device_id>();
+  return device_id == 0xbda;
+}
 
 int main() {
   device d;
+  // Check to skip the test for PVC T1
+  if (IsPVC_T1(d)){
+    return 0; 
+  }
 
   test_pvc(d);
 


### PR DESCRIPTION
The purpose of this change is to skip tests that are still failing exclusively on PVC T1.