### PR TITLE
[NFC][SYCL] Move vector/marray type traits into a standalone header

### DIFF
--- a/sycl/include/sycl/builtins_utils_vec.hpp
+++ b/sycl/include/sycl/builtins_utils_vec.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <sycl/detail/type_traits/vec_marray_traits.hpp>
+
 #include <sycl/builtins_utils_scalar.hpp>
 
 #include <sycl/detail/type_traits.hpp>
@@ -40,19 +42,6 @@ struct is_valid_elem_type<multi_ptr<ElementType, Space, DecorateAddress>, Ts...>
 template <typename ElementType, typename... Ts>
 struct is_valid_elem_type<ElementType *, Ts...>
     : std::bool_constant<check_type_in_v<ElementType, Ts...>> {};
-
-// Utility trait for getting the number of elements in T.
-template <typename T>
-struct num_elements : std::integral_constant<size_t, 1> {};
-template <typename T, size_t N>
-struct num_elements<marray<T, N>> : std::integral_constant<size_t, N> {};
-template <typename T, int N>
-struct num_elements<vec<T, N>> : std::integral_constant<size_t, size_t(N)> {};
-template <typename VecT, typename OperationLeftT, typename OperationRightT,
-          template <typename> class OperationCurrentT, int... Indexes>
-struct num_elements<SwizzleOp<VecT, OperationLeftT, OperationRightT,
-                              OperationCurrentT, Indexes...>>
-    : std::integral_constant<size_t, sizeof...(Indexes)> {};
 
 // Utilty trait for checking that the number of elements in T is in Ns.
 template <typename T, size_t... Ns>

--- a/sycl/include/sycl/detail/type_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits.hpp
@@ -8,6 +8,8 @@
 
 #pragma once
 
+#include <sycl/detail/type_traits/vec_marray_traits.hpp>
+
 #include <sycl/access/access.hpp>             // for decorated, address_space
 #include <sycl/detail/generic_type_lists.hpp> // for vec, marray, integer_list
 #include <sycl/detail/type_list.hpp>          // for is_contained, find_twi...
@@ -171,18 +173,6 @@ template <typename ElementType> struct get_elem_type_unqual<ElementType *> {
   using type = ElementType;
 };
 
-template <typename T, typename = void>
-struct is_ext_vector : std::false_type {};
-
-// FIXME: unguarded use of non-standard built-in
-template <typename T>
-struct is_ext_vector<
-    T, std::void_t<decltype(__builtin_reduce_max(std::declval<T>()))>>
-    : std::true_type {};
-
-template <typename T>
-inline constexpr bool is_ext_vector_v = is_ext_vector<T>::value;
-
 // FIXME: unguarded use of non-standard built-in
 template <typename T>
 struct get_elem_type_unqual<T, std::enable_if_t<is_ext_vector_v<T>>> {
@@ -255,11 +245,6 @@ template <typename T, int N, template <typename> class S>
 inline constexpr bool is_gen_based_on_type_sizeof_v =
     S<T>::value && (sizeof(vector_element_t<T>) == N);
 
-template <typename> struct is_vec : std::false_type {};
-template <typename T, int N> struct is_vec<sycl::vec<T, N>> : std::true_type {};
-
-template <typename T> constexpr bool is_vec_v = is_vec<T>::value;
-
 template <typename> struct get_vec_size {
   static constexpr int size = 1;
 };
@@ -267,27 +252,6 @@ template <typename> struct get_vec_size {
 template <typename T, int N> struct get_vec_size<sycl::vec<T, N>> {
   static constexpr int size = N;
 };
-
-// is_swizzle
-template <typename> struct is_swizzle : std::false_type {};
-template <typename VecT, typename OperationLeftT, typename OperationRightT,
-          template <typename> class OperationCurrentT, int... Indexes>
-struct is_swizzle<SwizzleOp<VecT, OperationLeftT, OperationRightT,
-                            OperationCurrentT, Indexes...>> : std::true_type {};
-
-template <typename T> constexpr bool is_swizzle_v = is_swizzle<T>::value;
-
-// is_swizzle_or_vec_v
-
-template <typename T>
-constexpr bool is_vec_or_swizzle_v = is_vec_v<T> || is_swizzle_v<T>;
-
-// is_marray
-template <typename> struct is_marray : std::false_type {};
-template <typename T, size_t N>
-struct is_marray<sycl::marray<T, N>> : std::true_type {};
-
-template <typename T> constexpr bool is_marray_v = is_marray<T>::value;
 
 // is_integral
 template <typename T>

--- a/sycl/include/sycl/detail/type_traits/vec_marray_traits.hpp
+++ b/sycl/include/sycl/detail/type_traits/vec_marray_traits.hpp
@@ -1,0 +1,104 @@
+//==---------- Forward declarations and traits for vector/marray types -----==//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <cstddef>
+#include <type_traits>
+
+#include <sycl/detail/defines_elementary.hpp>
+
+namespace sycl {
+inline namespace _V1 {
+template <typename DataT, int NumElements> class __SYCL_EBO vec;
+
+template <typename DataT, std::size_t N> class marray;
+
+namespace detail {
+template <typename VecT, typename OperationLeftT, typename OperationRightT,
+          template <typename> class OperationCurrentT, int... Indexes>
+class SwizzleOp;
+
+// --------- is_* traits ------------------ //
+template <typename> struct is_vec : std::false_type {};
+template <typename T, int N> struct is_vec<vec<T, N>> : std::true_type {};
+template <typename T> constexpr bool is_vec_v = is_vec<T>::value;
+
+template <typename T, typename = void>
+struct is_ext_vector : std::false_type {};
+#if defined(__has_extension)
+#if __has_extension(attribute_ext_vector_type)
+template <typename T, int N>
+struct is_ext_vector<T __attribute__((ext_vector_type(N)))> : std::true_type {};
+#endif
+#endif
+template <typename T>
+inline constexpr bool is_ext_vector_v = is_ext_vector<T>::value;
+
+template <typename> struct is_swizzle : std::false_type {};
+template <typename VecT, typename OperationLeftT, typename OperationRightT,
+          template <typename> class OperationCurrentT, int... Indexes>
+struct is_swizzle<SwizzleOp<VecT, OperationLeftT, OperationRightT,
+                            OperationCurrentT, Indexes...>> : std::true_type {};
+template <typename T> constexpr bool is_swizzle_v = is_swizzle<T>::value;
+
+template <typename T>
+constexpr bool is_vec_or_swizzle_v = is_vec_v<T> || is_swizzle_v<T>;
+
+template <typename> struct is_marray : std::false_type {};
+template <typename T, std::size_t N>
+struct is_marray<marray<T, N>> : std::true_type {};
+template <typename T> constexpr bool is_marray_v = is_marray<T>::value;
+
+// --------- num_elements trait ------------------ //
+template <typename T>
+struct num_elements : std::integral_constant<std::size_t, 1> {};
+template <typename T, std::size_t N>
+struct num_elements<marray<T, N>> : std::integral_constant<std::size_t, N> {};
+template <typename T, int N>
+struct num_elements<vec<T, N>>
+    : std::integral_constant<std::size_t, std::size_t(N)> {};
+#if defined(__has_extension)
+#if __has_extension(attribute_ext_vector_type)
+template <typename T, int N>
+struct num_elements<T __attribute__((ext_vector_type(N)))>
+    : std::integral_constant<std::size_t, N> {};
+#endif
+#endif
+template <typename VecT, typename OperationLeftT, typename OperationRightT,
+          template <typename> class OperationCurrentT, int... Indexes>
+struct num_elements<SwizzleOp<VecT, OperationLeftT, OperationRightT,
+                              OperationCurrentT, Indexes...>>
+    : std::integral_constant<std::size_t, sizeof...(Indexes)> {};
+
+template <typename T>
+inline constexpr std::size_t num_elements_v = num_elements<T>::value;
+
+// --------- element_type trait ------------------ //
+template <typename T, typename = void> struct element_type {
+  using type = T;
+};
+template <typename T, int N> struct element_type<vec<T, N>> {
+  using type = T;
+};
+template <typename T, std::size_t N> struct element_type<marray<T, N>> {
+  using type = T;
+};
+#if defined(__has_extension)
+#if __has_extension(attribute_ext_vector_type)
+template <typename T, int N>
+struct element_type<T __attribute__((ext_vector_type(N)))> {
+  using type = T;
+};
+#endif
+#endif
+template <typename T> using element_type_t = typename element_type<T>::type;
+
+} // namespace detail
+} // namespace _V1
+} // namespace sycl

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -24,6 +24,7 @@
 // CHECK-NEXT: info/aspects.def
 // CHECK-NEXT: info/aspects_deprecated.def
 // CHECK-NEXT: detail/type_traits.hpp
+// CHECK-NEXT: detail/type_traits/vec_marray_traits.hpp
 // CHECK-NEXT: detail/generic_type_lists.hpp
 // CHECK-NEXT: detail/type_list.hpp
 // CHECK-NEXT: detail/boost/mp11/algorithm.hpp
@@ -112,5 +113,5 @@
 // CHECK-NEXT: detail/string_view.hpp
 // CHECK-NEXT: detail/util.hpp
 // CHECK-NEXT: device_selector.hpp
-// CHECK-NEXT: buffer_properties.def
+// CHECK-NEXT: properties/buffer_properties.def
 // CHECK-EMPTY:

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -25,6 +25,7 @@
 // CHECK-NEXT: info/aspects.def
 // CHECK-NEXT: info/aspects_deprecated.def
 // CHECK-NEXT: detail/type_traits.hpp
+// CHECK-NEXT: detail/type_traits/vec_marray_traits.hpp
 // CHECK-NEXT: detail/generic_type_lists.hpp
 // CHECK-NEXT: detail/type_list.hpp
 // CHECK-NEXT: detail/boost/mp11/algorithm.hpp


### PR DESCRIPTION
Use `sycl::vec`/`sycl::marray` forward declaration to remove all the dependencies, so that the new header could later be used in various type traits without introducing circular dependency.