### PR TITLE
[SYCL] ABI-Neutralize graph API

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/graph.hpp
@@ -13,8 +13,11 @@
 #include <sycl/detail/export.hpp>          // for __SYCL_EXPORT
 #include <sycl/detail/kernel_desc.hpp>     // for kernel_param_kind_t
 #include <sycl/detail/property_helper.hpp> // for DataLessPropKind, PropWith...
-#include <sycl/device.hpp>                 // for device
-#include <sycl/nd_range.hpp>               // for range, nd_range
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#include <sycl/detail/string_view.hpp>
+#endif
+#include <sycl/device.hpp>                     // for device
+#include <sycl/nd_range.hpp>                   // for range, nd_range
 #include <sycl/properties/property_traits.hpp> // for is_property, is_property_of
 #include <sycl/property_list.hpp>              // for property_list
 
@@ -314,7 +317,13 @@ public:
   /// @param path The path to write the DOT file to.
   /// @param verbose If true, print additional information about the nodes such
   /// as kernel args or memory access where applicable.
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  void print_graph(const std::string path, bool verbose = false) const {
+    print_graph(sycl::detail::string_view{path}, verbose);
+  }
+#else
   void print_graph(const std::string path, bool verbose = false) const;
+#endif
 
   /// Get a list of all nodes contained in this graph.
   std::vector<node> get_nodes() const;
@@ -350,7 +359,9 @@ protected:
   sycl::detail::getSyclObjImpl(const Obj &SyclObject);
   template <class T>
   friend T sycl::detail::createSyclObjFromImpl(decltype(T::impl) ImplObj);
-
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  void print_graph(sycl::detail::string_view path, bool verbose = false) const;
+#endif
   std::shared_ptr<detail::graph_impl> impl;
 };
 

--- a/sycl/source/detail/graph_impl.cpp
+++ b/sycl/source/detail/graph_impl.cpp
@@ -14,6 +14,9 @@
 #include <detail/scheduler/commands.hpp>
 #include <detail/sycl_mem_obj_t.hpp>
 #include <sycl/detail/common.hpp>
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+#include <sycl/detail/string_view.hpp>
+#endif
 #include <sycl/feature_test.hpp>
 #include <sycl/queue.hpp>
 
@@ -1680,8 +1683,15 @@ void modifiable_command_graph::end_recording(
   }
 }
 
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+void modifiable_command_graph::print_graph(sycl::detail::string_view pathstr,
+#else
 void modifiable_command_graph::print_graph(std::string path,
+#endif
                                            bool verbose) const {
+#ifdef __INTEL_PREVIEW_BREAKING_CHANGES
+  std::string path{pathstr.data()};
+#endif
   graph_impl::ReadLock Lock(impl->MMutex);
   if (path.substr(path.find_last_of(".") + 1) == "dot") {
     impl->printGraphAsDot(path, verbose);


### PR DESCRIPTION
print_graph should use sycl::string_view instead of std::string which is not ABI-neutral.