### PR TITLE
[SYCL] Fix barrier submission after command which bypasses the scheduler

### DIFF
--- a/sycl/source/detail/queue_impl.cpp
+++ b/sycl/source/detail/queue_impl.cpp
@@ -455,6 +455,7 @@ event queue_impl::submitMemOpHelper(const std::shared_ptr<queue_impl> &Self,
         MemOpFunc(MemOpArgs..., getUrEvents(ExpandedDepEvents), &UREvent,
                   EventImpl);
         EventImpl->setHandle(UREvent);
+        EventImpl->setEnqueued();
       }
 
       if (isInOrder()) {


### PR DESCRIPTION
Currently we mistakenly don't mark commands like memcpy, copy, fill etc. as enqueued, this happens because they are enqueued differently bypassing the scheduler.

Problem is that if barrier is submitted depending on such event then it is just omitted.

So, fix the problem by marking such commands as enqueued.