### PR TITLE
[NFC][SYCL] Drop scalar `half`/`bfloat16` type traits

### DIFF
--- a/sycl/include/sycl/detail/generic_type_lists.hpp
+++ b/sycl/include/sycl/detail/generic_type_lists.hpp
@@ -70,8 +70,6 @@ using scalar_vector_bfloat16_list =
 using bfloat16_list =
     tl_append<scalar_bfloat16_list, vector_bfloat16_list, marray_bfloat16_list>;
 
-using half_bfloat16_list = tl_append<scalar_half_list, scalar_bfloat16_list>;
-
 using scalar_float_list = type_list<float>;
 
 using vector_float_list =

--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -32,17 +32,6 @@ inline constexpr bool is_svgenfloatf_v =
     is_contained_v<T, gtl::scalar_vector_float_list>;
 
 template <typename T>
-inline constexpr bool is_half_v = is_contained_v<T, gtl::scalar_half_list>;
-
-template <typename T>
-inline constexpr bool is_bfloat16_v =
-    is_contained_v<T, gtl::scalar_bfloat16_list>;
-
-template <typename T>
-inline constexpr bool is_half_or_bf16_v =
-    is_contained_v<T, gtl::half_bfloat16_list>;
-
-template <typename T>
 inline constexpr bool is_svgenfloath_v =
     is_contained_v<T, gtl::scalar_vector_half_list>;
 
@@ -141,10 +130,11 @@ template <typename T> auto convertToOpenCLType(T &&x) {
     // sycl::half may convert to _Float16, and we would try to instantiate
     // vec class with _Float16 DataType, which is not expected there. As
     // such, leave vector<half, N> as-is.
-    using MatchingVec = vec<std::conditional_t<is_half_v<ElemTy>, ElemTy,
-                                               decltype(convertToOpenCLType(
-                                                   std::declval<ElemTy>()))>,
-                            no_ref::size()>;
+    using MatchingVec =
+        vec<std::conditional_t<std::is_same_v<ElemTy, half>, ElemTy,
+                               decltype(convertToOpenCLType(
+                                   std::declval<ElemTy>()))>,
+            no_ref::size()>;
 #ifdef __SYCL_DEVICE_ONLY__
     return sycl::bit_cast<typename MatchingVec::vector_t>(x);
 #else
@@ -160,11 +150,11 @@ template <typename T> auto convertToOpenCLType(T &&x) {
                                           fixed_width_unsigned<sizeof(no_ref)>>;
     static_assert(sizeof(OpenCLType) == sizeof(T));
     return static_cast<OpenCLType>(x);
-  } else if constexpr (is_half_v<no_ref>) {
+  } else if constexpr (std::is_same_v<no_ref, half>) {
     using OpenCLType = sycl::detail::half_impl::BIsRepresentationT;
     static_assert(sizeof(OpenCLType) == sizeof(T));
     return static_cast<OpenCLType>(x);
-  } else if constexpr (is_bfloat16_v<no_ref>) {
+  } else if constexpr (std::is_same_v<no_ref, ext::oneapi::bfloat16>) {
     // On host, don't interpret BF16 as uint16.
 #ifdef __SYCL_DEVICE_ONLY__
     using OpenCLType = sycl::ext::oneapi::detail::Bfloat16StorageT;

--- a/sycl/test/basic_tests/generic_type_traits.cpp
+++ b/sycl/test/basic_tests/generic_type_traits.cpp
@@ -23,12 +23,6 @@ int main() {
   static_assert(d::is_genfloat_v<s::opencl::cl_float> == true);
   static_assert(d::is_genfloat_v<s::vec<s::opencl::cl_float, 4>> == true);
 
-  static_assert(d::is_half_v<s::half>);
-
-  static_assert(d::is_bfloat16_v<sycl::ext::oneapi::bfloat16>);
-  static_assert(d::is_half_or_bf16_v<s::half>);
-  static_assert(d::is_half_or_bf16_v<sycl::ext::oneapi::bfloat16>);
-
   // TODO add checks for the following type traits
   /*
   is_doublen


### PR DESCRIPTION
`std::is_same_v` is much clearer when checking for a single specific type, and the helper in `sycl/vector.hpp` could include more than these two types to increase its readability too.