### PR TITLE
[NFC][SYCL] Inline/drop `is_genint_v` type trait

### DIFF
--- a/sycl/include/sycl/detail/generic_type_traits.hpp
+++ b/sycl/include/sycl/detail/generic_type_traits.hpp
@@ -58,9 +58,6 @@ inline constexpr bool is_vgenfloat_v =
     is_contained_v<T, gtl::vector_floating_list>;
 
 template <typename T>
-inline constexpr bool is_genint_v = is_contained_v<T, gtl::signed_int_list>;
-
-template <typename T>
 inline constexpr bool is_geninteger_v = is_contained_v<T, gtl::integer_list>;
 
 template <typename T>


### PR DESCRIPTION
It's only used in a single header for extra filtering of `cl_int` and `cl_float`. We don't need the entirety of "generic" integer types to do that.

Note `(Dims > 0) && ` that I'm dropping here seemed to have no effect as `IsValidCoordDataT` helper ensures `Dims` can't be non-positive. Also, it would be a compiler error and not an SFINAE-based selection because of that helper anyway.