### PR TITLE
[CI] Don't run nightly OCL CPU testing on the AMD runner

### DIFF
--- a/.github/workflows/sycl-nightly.yml
+++ b/.github/workflows/sycl-nightly.yml
@@ -67,14 +67,7 @@ jobs:
             reset_intel_gpu: true
             tests_selector: e2e
             extra_lit_opts: --param gpu-intel-gen12=True
-
-          - name: OCL CPU (AMD)
-            runner: '["Linux", "amdgpu"]'
-            image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest
-            image_options: -u 1001
-            target_devices: opencl:cpu
-            tests_selector: e2e
-
+      
           - name: OCL CPU (Intel/GEN12)
             runner: '["Linux", "gen12"]'
             image: ghcr.io/intel/llvm/ubuntu2204_intel_drivers:latest


### PR DESCRIPTION
The AMD runner is really unstable, and doing anything intensive on the CPU seems to have high likelihood to lock it up.

Until we can get a more stable machine, disable OCL CPU (not GPU) testing on the AMD runner in the nightly. We have OCL CPU coverage on two other CPUs in the nightly already.

Nightly run with this change: https://github.com/intel/llvm/actions/runs/11351538946, the failures aren't related.