### PR TITLE
[SYCL][E2E] Update number of tests without XFAIL-TRACKER

### DIFF
--- a/sycl/test-e2e/no-xfail-without-tracker.cpp
+++ b/sycl/test-e2e/no-xfail-without-tracker.cpp
@@ -47,4 +47,4 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 179
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 178


### PR DESCRIPTION
Tracker was added to one of the tests here: https://github.com/intel/llvm/pull/15650
so total number of tests without a tracker need to be reduced.