### PR TITLE
[NFCI][SYCL] Remove `boost::mp11` dependency from `invoke_simd.hpp`

### DIFF
--- a/sycl/include/sycl/detail/helpers.hpp
+++ b/sycl/include/sycl/detail/helpers.hpp
@@ -240,11 +240,11 @@ getSPIRVMemorySemanticsMask(const access::fence_space AccessSpace,
 
 // To ensure loop unrolling is done when processing dimensions.
 template <size_t... Inds, class F>
-void loop_impl(std::integer_sequence<size_t, Inds...>, F &&f) {
+constexpr void loop_impl(std::integer_sequence<size_t, Inds...>, F &&f) {
   (f(std::integral_constant<size_t, Inds>{}), ...);
 }
 
-template <size_t count, class F> void loop(F &&f) {
+template <size_t count, class F> constexpr void loop(F &&f) {
   loop_impl(std::make_index_sequence<count>{}, std::forward<F>(f));
 }
 inline constexpr bool is_power_of_two(int x) { return (x & (x - 1)) == 0; }

--- a/sycl/test/invoke_simd/no_callee_found.cpp
+++ b/sycl/test/invoke_simd/no_callee_found.cpp
@@ -26,5 +26,5 @@ void foo() {
 
 int main() {
   foo();
-  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement 'found_invoke_simd_target': No callable invoke_simd target found. Confirm the invoke_simd invocation argument types are convertible to the invoke_simd target argument types{{.*}}
+  // CHECK: {{.*}}error:{{.*}}static assertion failed due to requirement 'num_found != 0': No callable invoke_simd target found. Confirm the invoke_simd invocation argument types are convertible to the invoke_simd target argument types{{.*}}
 }


### PR DESCRIPTION
C++17 implementation is about as readable as boost-based one, and we want to drop the external boost dependency for upstreaming purposes.