### PR TITLE
[SYCL] Support sycl::kernel_bundle for multi-device scenario

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,12 +116,8 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
-  # commit 568a96aabc6edabe8514ae163aecc64cd5a41878
-  # Author: Mateusz P. Nowak <112635238+mateuszpn@users.noreply.github.com>
-  # Date:   Tue Oct 15 13:57:26 2024 +0200
-  #     Benchmark updates for faster run and more reliable results (#2164)
-  set(UNIFIED_RUNTIME_TAG 568a96aabc6edabe8514ae163aecc64cd5a41878)
+  set(UNIFIED_RUNTIME_REPO "https://github.com/againull/unified-runtime")
+  set(UNIFIED_RUNTIME_TAG 8054db458c818f3f4552d808ea9e478708476e06)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")
   # Due to the use of dependentloadflag and no installer for UMF and hwloc we need

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -21,6 +21,7 @@
 #include <sycl/property_list.hpp>
 
 #include <algorithm>
+#include <set>
 
 namespace sycl {
 inline namespace _V1 {
@@ -492,7 +493,7 @@ std::optional<ur_program_handle_t> context_impl::getProgramForDevImgs(
     auto &Cache = LockedCache.get().Cache;
     ur_device_handle_t &DevHandle = getSyclObjImpl(Device)->getHandleRef();
     for (std::uintptr_t ImageIDs : ImgIdentifiers) {
-      auto OuterKey = std::make_pair(ImageIDs, DevHandle);
+      auto OuterKey = std::make_pair(ImageIDs, std::set{DevHandle});
       size_t NProgs = KeyMap.count(OuterKey);
       if (NProgs == 0)
         continue;

--- a/sycl/source/detail/helpers.cpp
+++ b/sycl/source/detail/helpers.cpp
@@ -65,8 +65,8 @@ retrieveKernelBinary(const QueueImplPtr &Queue, const char *KernelName,
     auto DeviceImpl = Queue->getDeviceImplPtr();
     auto Device = detail::createSyclObjFromImpl<device>(DeviceImpl);
     ur_program_handle_t Program =
-        detail::ProgramManager::getInstance().createURProgram(**DeviceImage,
-                                                              Context, Device);
+        detail::ProgramManager::getInstance().createURProgram(
+            **DeviceImage, Context, {Device});
     return {*DeviceImage, Program};
   }
 
@@ -94,7 +94,7 @@ retrieveKernelBinary(const QueueImplPtr &Queue, const char *KernelName,
     DeviceImage = &detail::ProgramManager::getInstance().getDeviceImage(
         KernelName, Context, Device);
     Program = detail::ProgramManager::getInstance().createURProgram(
-        *DeviceImage, Context, Device);
+        *DeviceImage, Context, {Device});
   }
   return {DeviceImage, Program};
 }

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -20,6 +20,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <mutex>
+#include <set>
 #include <type_traits>
 
 #include <boost/unordered/unordered_flat_map.hpp>
@@ -118,9 +119,10 @@ public:
    * when debugging environment variables are set and we can just ignore them
    * since all kernels will have their build options overridden with the same
    * string*/
-  using ProgramCacheKeyT =
-      std::pair<std::pair<SerializedObj, std::uintptr_t>, ur_device_handle_t>;
-  using CommonProgramKeyT = std::pair<std::uintptr_t, ur_device_handle_t>;
+  using ProgramCacheKeyT = std::pair<std::pair<SerializedObj, std::uintptr_t>,
+                                     std::set<ur_device_handle_t>>;
+  using CommonProgramKeyT =
+      std::pair<std::uintptr_t, std::set<ur_device_handle_t>>;
 
   struct ProgramCache {
     ::boost::unordered_map<ProgramCacheKeyT, ProgramBuildResultPtr> Cache;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -73,31 +73,27 @@ ProgramManager &ProgramManager::getInstance() {
 }
 
 static ur_program_handle_t
-createBinaryProgram(const ContextImplPtr Context, const device &Device,
-                    const unsigned char *Data, size_t DataLen,
+createBinaryProgram(const ContextImplPtr Context,
+                    const std::vector<device> &Devices,
+                    const uint8_t **Binaries, size_t *Lengths,
                     const std::vector<ur_program_metadata_t> Metadata) {
   const AdapterPtr &Adapter = Context->getAdapter();
-#ifndef _NDEBUG
-  uint32_t NumDevices = 0;
-  Adapter->call<UrApiKind::urContextGetInfo>(Context->getHandleRef(),
-                                             UR_CONTEXT_INFO_NUM_DEVICES,
-                                             sizeof(NumDevices), &NumDevices,
-                                             /*param_value_size_ret=*/nullptr);
-  assert(NumDevices > 0 &&
-         "Only a single device is supported for AOT compilation");
-#endif
-
   ur_program_handle_t Program;
-  ur_device_handle_t UrDevice = getSyclObjImpl(Device)->getHandleRef();
+  std::vector<ur_device_handle_t> DeviceHandles;
+  std::transform(
+      Devices.begin(), Devices.end(), std::back_inserter(DeviceHandles),
+      [](const device &Dev) { return getSyclObjImpl(Dev)->getHandleRef(); });
   ur_result_t BinaryStatus = UR_RESULT_SUCCESS;
   ur_program_properties_t Properties = {};
   Properties.stype = UR_STRUCTURE_TYPE_PROGRAM_PROPERTIES;
   Properties.pNext = nullptr;
   Properties.count = Metadata.size();
   Properties.pMetadatas = Metadata.data();
-  Adapter->call<UrApiKind::urProgramCreateWithBinary>(
-      Context->getHandleRef(), UrDevice, DataLen, Data, &Properties, &Program);
 
+  assert(Devices.size() > 0 && "No devices provided for program creation");
+  Adapter->call<UrApiKind::urProgramCreateWithBinary>(
+      Context->getHandleRef(), DeviceHandles.size(), DeviceHandles.data(),
+      Lengths, Binaries, &Properties, &Program);
   if (BinaryStatus != UR_RESULT_SUCCESS) {
     throw detail::set_ur_error(
         exception(make_error_code(errc::runtime),
@@ -178,13 +174,28 @@ static bool isDeviceBinaryTypeSupported(const context &C,
   return "unknown";
 }
 
+[[maybe_unused]] auto VecToString = [](auto &Vec) -> std::string {
+  std::ostringstream Out;
+  Out << "{";
+  for (auto Elem : Vec)
+    Out << Elem << " ";
+  Out << "}";
+  return Out.str();
+};
+
 ur_program_handle_t
 ProgramManager::createURProgram(const RTDeviceBinaryImage &Img,
-                                const context &Context, const device &Device) {
-  if constexpr (DbgProgMgr > 0)
+                                const context &Context,
+                                const std::vector<device> &Devices) {
+  if constexpr (DbgProgMgr > 0) {
+    std::vector<ur_device_handle_t> URDevices;
+    std::transform(
+        Devices.begin(), Devices.end(), std::back_inserter(URDevices),
+        [](const device &Dev) { return getSyclObjImpl(Dev)->getHandleRef(); });
     std::cerr << ">>> ProgramManager::createPIProgram(" << &Img << ", "
-              << getSyclObjImpl(Context).get() << ", "
-              << getSyclObjImpl(Device).get() << ")\n";
+              << getSyclObjImpl(Context).get() << ", " << VecToString(URDevices)
+              << ")\n";
+  }
   const sycl_device_binary_struct &RawImg = Img.getRawData();
 
   // perform minimal sanity checks on the device image and the descriptor
@@ -221,10 +232,13 @@ ProgramManager::createURProgram(const RTDeviceBinaryImage &Img,
 
   // Load the image
   const ContextImplPtr Ctx = getSyclObjImpl(Context);
+  std::vector<const uint8_t *> Binaries(
+      Devices.size(), const_cast<uint8_t *>(RawImg.BinaryStart));
+  std::vector<size_t> Lengths(Devices.size(), ImgSize);
   ur_program_handle_t Res =
       Format == SYCL_DEVICE_BINARY_TYPE_SPIRV
           ? createSpirvProgram(Ctx, RawImg.BinaryStart, ImgSize)
-          : createBinaryProgram(Ctx, Device, RawImg.BinaryStart, ImgSize,
+          : createBinaryProgram(Ctx, Devices, Binaries.data(), Lengths.data(),
                                 ProgMetadata);
 
   {
@@ -233,7 +247,7 @@ ProgramManager::createURProgram(const RTDeviceBinaryImage &Img,
     NativePrograms.insert({Res, &Img});
   }
 
-  Ctx->addDeviceGlobalInitializer(Res, {Device}, &Img);
+  Ctx->addDeviceGlobalInitializer(Res, Devices, &Img);
 
   if constexpr (DbgProgMgr > 1)
     std::cerr << "created program: " << Res
@@ -491,12 +505,12 @@ static void applyOptionsFromEnvironment(std::string &CompileOpts,
 std::pair<ur_program_handle_t, bool> ProgramManager::getOrCreateURProgram(
     const RTDeviceBinaryImage &MainImg,
     const std::vector<const RTDeviceBinaryImage *> &AllImages,
-    const context &Context, const device &Device,
+    const context &Context, const std::vector<device> &Devices,
     const std::string &CompileAndLinkOptions, SerializedObj SpecConsts) {
   ur_program_handle_t NativePrg; // TODO: Or native?
 
   auto BinProg = PersistentDeviceCodeCache::getItemFromDisc(
-      Device, AllImages, SpecConsts, CompileAndLinkOptions);
+      Devices[0], AllImages, SpecConsts, CompileAndLinkOptions);
   if (BinProg.size()) {
     // Get program metadata from properties
     std::vector<ur_program_metadata_t> ProgMetadataVector;
@@ -505,12 +519,14 @@ std::pair<ur_program_handle_t, bool> ProgramManager::getOrCreateURProgram(
       ProgMetadataVector.insert(ProgMetadataVector.end(),
                                 ImgProgMetadata.begin(), ImgProgMetadata.end());
     }
-    // TODO: Build for multiple devices once supported by program manager
-    NativePrg = createBinaryProgram(getSyclObjImpl(Context), Device,
-                                    (const unsigned char *)BinProg[0].data(),
-                                    BinProg[0].size(), ProgMetadataVector);
+    std::vector<const uint8_t *> Binaries(Devices.size(),
+                                          (const uint8_t *)BinProg[0].data());
+    std::vector<size_t> Lengths(Devices.size(), BinProg[0].size());
+    NativePrg =
+        createBinaryProgram(getSyclObjImpl(Context), Devices, Binaries.data(),
+                            Lengths.data(), ProgMetadataVector);
   } else {
-    NativePrg = createURProgram(MainImg, Context, Device);
+    NativePrg = createURProgram(MainImg, Context, Devices);
   }
   return {NativePrg, BinProg.size()};
 }
@@ -797,7 +813,7 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
     appendCompileEnvironmentVariablesThatAppend(CompileOpts);
     appendLinkEnvironmentVariablesThatAppend(LinkOpts);
     auto [NativePrg, DeviceCodeWasInCache] = getOrCreateURProgram(
-        Img, AllImages, Context, Device, CompileOpts + LinkOpts, SpecConsts);
+        Img, AllImages, Context, {Device}, CompileOpts + LinkOpts, SpecConsts);
 
     if (!DeviceCodeWasInCache) {
       if (Img.supportsSpecConstants())
@@ -838,7 +854,7 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
             DeviceImageImpl->get_spec_const_blob_ref();
 
         ur_program_handle_t NativePrg =
-            createURProgram(*BinImg, Context, Device);
+            createURProgram(*BinImg, Context, {Device});
 
         if (BinImg->supportsSpecConstants())
           setSpecializationConstants(DeviceImageImpl, NativePrg, Adapter);
@@ -846,11 +862,13 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
         ProgramsToLink.push_back(NativePrg);
       }
     }
-    ProgramPtr BuiltProgram =
-        build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
-              getSyclObjImpl(Device).get()->getHandleRef(), DeviceLibReqMask,
-              ProgramsToLink, /*CreatedFromBinary*/ Img.getFormat() !=
-                                  SYCL_DEVICE_BINARY_TYPE_SPIRV);
+    std::vector<ur_device_handle_t> Devs = {
+        getSyclObjImpl(Device).get()->getHandleRef()};
+    ;
+    ProgramPtr BuiltProgram = build(
+        std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts, Devs,
+        DeviceLibReqMask, ProgramsToLink,
+        /*CreatedFromBinary*/ Img.getFormat() != SYCL_DEVICE_BINARY_TYPE_SPIRV);
     // Those extra programs won't be used anymore, just the final linked result
     for (ur_program_handle_t Prg : ProgramsToLink)
       Adapter->call<UrApiKind::urProgramRelease>(Prg);
@@ -878,8 +896,8 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
 
   uint32_t ImgId = Img.getImageID();
   const ur_device_handle_t UrDevice = Dev->getHandleRef();
-  auto CacheKey =
-      std::make_pair(std::make_pair(std::move(SpecConsts), ImgId), UrDevice);
+  auto CacheKey = std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
+                                 std::set{UrDevice});
 
   auto GetCachedBuildF = [&Cache, &CacheKey]() {
     return Cache.getOrInsertProgram(CacheKey);
@@ -1170,46 +1188,86 @@ static ur_result_t doCompile(const AdapterPtr &Adapter,
   return Result;
 }
 
-static ur_program_handle_t loadDeviceLibFallback(const ContextImplPtr Context,
-                                                 DeviceLibExt Extension,
-                                                 ur_device_handle_t Device,
-                                                 bool UseNativeLib) {
+static ur_program_handle_t
+loadDeviceLibFallback(const ContextImplPtr Context, DeviceLibExt Extension,
+                      std::vector<ur_device_handle_t> &Devices,
+                      bool UseNativeLib) {
 
   auto LibFileName = getDeviceLibFilename(Extension, UseNativeLib);
-
   auto LockedCache = Context->acquireCachedLibPrograms();
-  auto CachedLibPrograms = LockedCache.get();
-  auto CacheResult = CachedLibPrograms.emplace(
-      std::make_pair(std::make_pair(Extension, Device), nullptr));
-  bool Cached = !CacheResult.second;
-  auto LibProgIt = CacheResult.first;
-  ur_program_handle_t &LibProg = LibProgIt->second;
+  auto &CachedLibPrograms = LockedCache.get();
+  // Collect list of devices to compile the library for. Library was already
+  // compiled for a device if there is a corresponding record in the per-context
+  // cache.
+  std::vector<ur_device_handle_t> DevicesToCompile;
+  ur_program_handle_t URProgram = nullptr;
+  assert(Devices.size() > 0 &&
+         "At least one device is expected in the input vector");
+  // Vector of devices that don't have the library cached.
+  for (auto Dev : Devices) {
+    auto CacheResult = CachedLibPrograms.emplace(
+        std::make_pair(std::make_pair(Extension, Dev), nullptr));
+    auto Cached = !CacheResult.second;
+    if (!Cached) {
+      DevicesToCompile.push_back(Dev);
+    } else {
+      auto CachedURProgram = CacheResult.first->second;
+      assert(CachedURProgram && "If device lib UR program was cached then is "
+                                "expected to be not a nullptr");
+      assert(((URProgram && URProgram == CachedURProgram) || (!URProgram)) &&
+             "All cached UR programs should be the same");
+      if (!URProgram)
+        URProgram = CachedURProgram;
+    }
+  }
+  if (DevicesToCompile.empty())
+    return URProgram;
 
-  if (Cached)
-    return LibProg;
+  auto EraseProgramForDevices = [&]() {
+    for (auto Dev : DevicesToCompile)
+      CachedLibPrograms.erase(std::make_pair(Extension, Dev));
+  };
+  bool IsProgramCreated = !URProgram;
 
-  if (!loadDeviceLib(Context, LibFileName, LibProg)) {
-    CachedLibPrograms.erase(LibProgIt);
+  // Create UR program for device lib if we don't have it yet.
+  if (!URProgram && !loadDeviceLib(Context, LibFileName, URProgram)) {
+    EraseProgramForDevices();
     throw exception(make_error_code(errc::build),
                     std::string("Failed to load ") + LibFileName);
   }
 
+  // Insert URProgram into the cache for all devices that we compiled it for.
+  // Retain UR program for each record in the cache.
   const AdapterPtr &Adapter = Context->getAdapter();
+
+  // UR program handle is stored in the cache for each device that we compiled
+  // it for. We have to retain UR program for each record in the cache. We need
+  // to take into account that UR program creation makes its reference count to
+  // be 1.
+  size_t RetainCount =
+      IsProgramCreated ? DevicesToCompile.size() - 1 : DevicesToCompile.size();
+  for (size_t I = 0; I < RetainCount; ++I)
+    Adapter->call<UrApiKind::urProgramRetain>(URProgram);
+
+  for (auto Dev : DevicesToCompile)
+    CachedLibPrograms[std::make_pair(Extension, Dev)] = URProgram;
+
   // TODO no spec constants are used in the std libraries, support in the future
   // Do not use compile options for library programs: it is not clear if user
   // options (image options) are supposed to be applied to library program as
   // well, and what actually happens to a SPIR-V program if we apply them.
   ur_result_t Error =
-      doCompile(Adapter, LibProg, 1, &Device, Context->getHandleRef(), "");
+      doCompile(Adapter, URProgram, DevicesToCompile.size(),
+                DevicesToCompile.data(), Context->getHandleRef(), "");
   if (Error != UR_RESULT_SUCCESS) {
-    CachedLibPrograms.erase(LibProgIt);
+    EraseProgramForDevices();
     throw detail::set_ur_error(
         exception(make_error_code(errc::build),
-                  ProgramManager::getProgramBuildLog(LibProg, Context)),
+                  ProgramManager::getProgramBuildLog(URProgram, Context)),
         Error);
   }
 
-  return LibProg;
+  return URProgram;
 }
 
 ProgramManager::ProgramManager() : m_AsanFoundInImage(false) {
@@ -1462,7 +1520,7 @@ static bool isDeviceLibRequired(DeviceLibExt Ext, uint32_t DeviceLibReqMask) {
 
 static std::vector<ur_program_handle_t>
 getDeviceLibPrograms(const ContextImplPtr Context,
-                     const ur_device_handle_t &Device,
+                     std::vector<ur_device_handle_t> &Devices,
                      uint32_t DeviceLibReqMask) {
   std::vector<ur_program_handle_t> Programs;
 
@@ -1481,50 +1539,65 @@ getDeviceLibPrograms(const ContextImplPtr Context,
 
   // Disable all devicelib extensions requiring fp64 support if at least
   // one underlying device doesn't support cl_khr_fp64.
-  std::string DevExtList =
-      Context->getPlatformImpl()->getDeviceImpl(Device)->get_device_info_string(
-          UrInfoCode<info::device::extensions>::value);
-  const bool fp64Support = (DevExtList.npos != DevExtList.find("cl_khr_fp64"));
+  const bool fp64Support = std::all_of(
+      Devices.begin(), Devices.end(), [&Context](ur_device_handle_t Device) {
+        std::string DevExtList =
+            Context->getPlatformImpl()
+                ->getDeviceImpl(Device)
+                ->get_device_info_string(
+                    UrInfoCode<info::device::extensions>::value);
+        return (DevExtList.npos != DevExtList.find("cl_khr_fp64"));
+      });
 
-  // Load a fallback library for an extension if the device does not
+  // Load a fallback library for an extension if the any device does not
   // support it.
-  for (auto &Pair : RequiredDeviceLibExt) {
-    DeviceLibExt Ext = Pair.first;
-    bool &FallbackIsLoaded = Pair.second;
+  for (auto Device : Devices) {
+    std::string DevExtList =
+        Context->getPlatformImpl()
+            ->getDeviceImpl(Device)
+            ->get_device_info_string(
+                UrInfoCode<info::device::extensions>::value);
 
-    if (FallbackIsLoaded) {
-      continue;
-    }
+    for (auto &Pair : RequiredDeviceLibExt) {
+      DeviceLibExt Ext = Pair.first;
+      bool &FallbackIsLoaded = Pair.second;
 
-    if (!isDeviceLibRequired(Ext, DeviceLibReqMask)) {
-      continue;
-    }
+      if (FallbackIsLoaded) {
+        continue;
+      }
 
-    if ((Ext == DeviceLibExt::cl_intel_devicelib_math_fp64 ||
-         Ext == DeviceLibExt::cl_intel_devicelib_complex_fp64 ||
-         Ext == DeviceLibExt::cl_intel_devicelib_imf_fp64) &&
-        !fp64Support) {
-      continue;
-    }
+      if (!isDeviceLibRequired(Ext, DeviceLibReqMask)) {
+        continue;
+      }
 
-    auto ExtName = getDeviceLibExtensionStr(Ext);
+      // Skip loading the fallback library that requires fp64 support if any
+      // device in the list doesn't support fp64.
+      if ((Ext == DeviceLibExt::cl_intel_devicelib_math_fp64 ||
+           Ext == DeviceLibExt::cl_intel_devicelib_complex_fp64 ||
+           Ext == DeviceLibExt::cl_intel_devicelib_imf_fp64) &&
+          !fp64Support) {
+        continue;
+      }
 
-    bool InhibitNativeImpl = false;
-    if (const char *Env = getenv("SYCL_DEVICELIB_INHIBIT_NATIVE")) {
-      InhibitNativeImpl = strstr(Env, ExtName) != nullptr;
-    }
+      auto ExtName = getDeviceLibExtensionStr(Ext);
 
-    bool DeviceSupports = DevExtList.npos != DevExtList.find(ExtName);
-    if (!DeviceSupports || InhibitNativeImpl) {
-      Programs.push_back(
-          loadDeviceLibFallback(Context, Ext, Device, /*UseNativeLib=*/false));
-      FallbackIsLoaded = true;
-    } else {
-      // bfloat16 needs native library if device supports it
-      if (Ext == DeviceLibExt::cl_intel_devicelib_bfloat16) {
-        Programs.push_back(
-            loadDeviceLibFallback(Context, Ext, Device, /*UseNativeLib=*/true));
+      bool InhibitNativeImpl = false;
+      if (const char *Env = getenv("SYCL_DEVICELIB_INHIBIT_NATIVE")) {
+        InhibitNativeImpl = strstr(Env, ExtName) != nullptr;
+      }
+
+      bool DeviceSupports = DevExtList.npos != DevExtList.find(ExtName);
+      if (!DeviceSupports || InhibitNativeImpl) {
+        Programs.push_back(loadDeviceLibFallback(Context, Ext, Devices,
+                                                 /*UseNativeLib=*/false));
         FallbackIsLoaded = true;
+      } else {
+        // bfloat16 needs native library if device supports it
+        if (Ext == DeviceLibExt::cl_intel_devicelib_bfloat16) {
+          Programs.push_back(loadDeviceLibFallback(Context, Ext, Devices,
+                                                   /*UseNativeLib=*/true));
+          FallbackIsLoaded = true;
+        }
       }
     }
   }
@@ -1534,14 +1607,16 @@ getDeviceLibPrograms(const ContextImplPtr Context,
 ProgramManager::ProgramPtr ProgramManager::build(
     ProgramPtr Program, const ContextImplPtr Context,
     const std::string &CompileOptions, const std::string &LinkOptions,
-    ur_device_handle_t Device, uint32_t DeviceLibReqMask,
+    std::vector<ur_device_handle_t> &Devices, uint32_t DeviceLibReqMask,
     const std::vector<ur_program_handle_t> &ExtraProgramsToLink,
     bool CreatedFromBinary) {
 
   if constexpr (DbgProgMgr > 0) {
     std::cerr << ">>> ProgramManager::build(" << Program.get() << ", "
-              << CompileOptions << ", " << LinkOptions << ", ... " << Device
-              << ")\n";
+              << CompileOptions << ", " << LinkOptions << ", "
+              << VecToString(Devices) << ", " << std::hex << DeviceLibReqMask
+              << std::dec << ", " << VecToString(ExtraProgramsToLink) << ", "
+              << CreatedFromBinary << ")\n";
   }
 
   bool LinkDeviceLibs = (DeviceLibReqMask != 0);
@@ -1555,7 +1630,7 @@ ProgramManager::ProgramPtr ProgramManager::build(
 
   std::vector<ur_program_handle_t> LinkPrograms;
   if (LinkDeviceLibs) {
-    LinkPrograms = getDeviceLibPrograms(Context, Device, DeviceLibReqMask);
+    LinkPrograms = getDeviceLibPrograms(Context, Devices, DeviceLibReqMask);
   }
 
   static const char *ForceLinkEnv = std::getenv("SYCL_FORCE_LINK");
@@ -1567,8 +1642,7 @@ ProgramManager::ProgramPtr ProgramManager::build(
                                      ? CompileOptions
                                      : (CompileOptions + " " + LinkOptions);
     ur_result_t Error = Adapter->call_nocheck<UrApiKind::urProgramBuildExp>(
-        Program.get(),
-        /*num devices =*/1, &Device, Options.c_str());
+        Program.get(), Devices.size(), Devices.data(), Options.c_str());
     if (Error == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
       Error = Adapter->call_nocheck<UrApiKind::urProgramBuild>(
           Context->getHandleRef(), Program.get(), Options.c_str());
@@ -1585,7 +1659,7 @@ ProgramManager::ProgramPtr ProgramManager::build(
 
   // Include the main program and compile/link everything together
   if (!CreatedFromBinary) {
-    auto Res = doCompile(Adapter, Program.get(), /*num devices =*/1, &Device,
+    auto Res = doCompile(Adapter, Program.get(), Devices.size(), Devices.data(),
                          Context->getHandleRef(), CompileOptions.c_str());
     Adapter->checkUrResult<errc::build>(Res);
   }
@@ -1593,7 +1667,7 @@ ProgramManager::ProgramPtr ProgramManager::build(
 
   for (ur_program_handle_t Prg : ExtraProgramsToLink) {
     if (!CreatedFromBinary) {
-      auto Res = doCompile(Adapter, Prg, /*num devices =*/1, &Device,
+      auto Res = doCompile(Adapter, Prg, Devices.size(), Devices.data(),
                            Context->getHandleRef(), CompileOptions.c_str());
       Adapter->checkUrResult<errc::build>(Res);
     }
@@ -1603,9 +1677,9 @@ ProgramManager::ProgramPtr ProgramManager::build(
   ur_program_handle_t LinkedProg = nullptr;
   auto doLink = [&] {
     auto Res = Adapter->call_nocheck<UrApiKind::urProgramLinkExp>(
-        Context->getHandleRef(),
-        /*num devices =*/1, &Device, LinkPrograms.size(), LinkPrograms.data(),
-        LinkOptions.c_str(), &LinkedProg);
+        Context->getHandleRef(), Devices.size(), Devices.data(),
+        LinkPrograms.size(), LinkPrograms.data(), LinkOptions.c_str(),
+        &LinkedProg);
     if (Res == UR_RESULT_ERROR_UNSUPPORTED_FEATURE) {
       Res = Adapter->call_nocheck<UrApiKind::urProgramLink>(
           Context->getHandleRef(), LinkPrograms.size(), LinkPrograms.data(),
@@ -2345,21 +2419,10 @@ ProgramManager::compile(const device_image_plain &DeviceImage,
   const AdapterPtr &Adapter =
       getSyclObjImpl(InputImpl->get_context())->getAdapter();
 
-  // TODO: Add support for creating non-SPIRV programs from multiple devices.
-  if (InputImpl->get_bin_image_ref()->getFormat() !=
-          SYCL_DEVICE_BINARY_TYPE_SPIRV &&
-      Devs.size() > 1)
-    // FIXME: It was probably intended to be thrown, but a unittest starts
-    // failing if we do so, investigate independently of switching to SYCL 2020
-    // `exception`.
-    exception(make_error_code(errc::feature_not_supported),
-              "Creating a program from AOT binary for multiple device is "
-              "not supported");
-
   // Device is not used when creating program from SPIRV, so passing only one
   // device is OK.
   ur_program_handle_t Prog = createURProgram(*InputImpl->get_bin_image_ref(),
-                                             InputImpl->get_context(), Devs[0]);
+                                             InputImpl->get_context(), Devs);
 
   if (InputImpl->get_bin_image_ref()->supportsSpecConstants())
     setSpecializationConstants(InputImpl, Prog, Adapter);
@@ -2545,21 +2608,11 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
     // Should always come last!
     appendCompileEnvironmentVariablesThatAppend(CompileOpts);
     appendLinkEnvironmentVariablesThatAppend(LinkOpts);
-    // TODO: Add support for creating non-SPIRV programs from multiple devices.
-    if (InputImpl->get_bin_image_ref()->getFormat() !=
-            SYCL_DEVICE_BINARY_TYPE_SPIRV &&
-        Devs.size() > 1)
-      // FIXME: It was probably intended to be thrown, but a unittest starts
-      // failing if we do so, investigate independently of switching to SYCL
-      // 2020 `exception`.
-      exception(make_error_code(errc::feature_not_supported),
-                "Creating a program from AOT binary for multiple device "
-                "is not supported");
 
     // Device is not used when creating program from SPIRV, so passing only one
     // device is OK.
     auto [NativePrg, DeviceCodeWasInCache] = getOrCreateURProgram(
-        Img, {&Img}, Context, Devs[0], CompileOpts + LinkOpts, SpecConsts);
+        Img, {&Img}, Context, Devs, CompileOpts + LinkOpts, SpecConsts);
 
     if (!DeviceCodeWasInCache &&
         InputImpl->get_bin_image_ref()->supportsSpecConstants())
@@ -2582,10 +2635,13 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
     // TODO: Add support for dynamic linking with kernel bundles
     std::vector<ur_program_handle_t> ExtraProgramsToLink;
+    std::vector<ur_device_handle_t> URDevices;
+    for (auto Dev : Devs) {
+      URDevices.push_back(getSyclObjImpl(Dev).get()->getHandleRef());
+    }
     ProgramPtr BuiltProgram =
         build(std::move(ProgramManaged), ContextImpl, CompileOpts, LinkOpts,
-              getSyclObjImpl(Devs[0]).get()->getHandleRef(), DeviceLibReqMask,
-              ExtraProgramsToLink);
+              URDevices, DeviceLibReqMask, ExtraProgramsToLink);
 
     emitBuiltProgramInfo(BuiltProgram.get(), ContextImpl);
 
@@ -2617,9 +2673,14 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
   }
 
   uint32_t ImgId = Img.getImageID();
-  ur_device_handle_t UrDevice = getSyclObjImpl(Devs[0]).get()->getHandleRef();
-  auto CacheKey =
-      std::make_pair(std::make_pair(std::move(SpecConsts), ImgId), UrDevice);
+  std::set<ur_device_handle_t> URDevicesSet;
+  std::transform(Devs.begin(), Devs.end(),
+                 std::inserter(URDevicesSet, URDevicesSet.begin()),
+                 [](const device &Dev) {
+                   return getSyclObjImpl(Dev).get()->getHandleRef();
+                 });
+  auto CacheKey = std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
+                                 URDevicesSet);
 
   // CacheKey is captured by reference so when we overwrite it later we can
   // reuse this function.
@@ -2633,26 +2694,33 @@ device_image_plain ProgramManager::build(const device_image_plain &DeviceImage,
 
   ur_program_handle_t ResProgram = BuildResult->Val;
 
-  // Cache supports key with once device only, but here we have multiple
-  // devices a program is built for, so add the program to the cache for all
-  // other devices.
+  // Here we have multiple devices a program is built for, so add the program to
+  // the cache for all subsets of provided list of devices.
   const AdapterPtr &Adapter = ContextImpl->getAdapter();
-  auto CacheOtherDevices = [ResProgram, &Adapter]() {
+  auto CacheSubsets = [ResProgram, &Adapter]() {
     Adapter->call<UrApiKind::urProgramRetain>(ResProgram);
     return ResProgram;
   };
 
-  // The program for device "0" is already added to the cache during the first
-  // call to getOrBuild, so starting with "1"
-  for (size_t Idx = 1; Idx < Devs.size(); ++Idx) {
-    const ur_device_handle_t UrDeviceAdd =
-        getSyclObjImpl(Devs[Idx]).get()->getHandleRef();
-
-    // Change device in the cache key to reduce copying of spec const data.
-    CacheKey.second = UrDeviceAdd;
-    Cache.getOrBuild<errc::build>(GetCachedBuildF, CacheOtherDevices);
-    // getOrBuild is not supposed to return nullptr
-    assert(BuildResult != nullptr && "Invalid build result");
+  if (URDevicesSet.size() > 1) {
+    // emplace all subsets of the current set of devices into the cache.
+    // Set of all devices is not included in the loop as it was already added
+    // into the cache.
+    for (int Mask = 1; Mask < (1 << URDevicesSet.size()) - 1; ++Mask) {
+      std::set<ur_device_handle_t> Subset;
+      int Index = 0;
+      for (auto It = URDevicesSet.begin(); It != URDevicesSet.end();
+           ++It, ++Index) {
+        if (Mask & (1 << Index)) {
+          Subset.insert(*It);
+        }
+      }
+      // Change device in the cache key to reduce copying of spec const data.
+      CacheKey.second = Subset;
+      Cache.getOrBuild<errc::build>(GetCachedBuildF, CacheSubsets);
+      // getOrBuild is not supposed to return nullptr
+      assert(BuildResult != nullptr && "Invalid build result");
+    }
   }
 
   // devive_image_impl shares ownership of PIProgram with, at least, program
@@ -2776,7 +2844,7 @@ ur_kernel_handle_t ProgramManager::getOrCreateMaterializedKernel(
 
   if constexpr (DbgProgMgr > 0)
     std::cerr << ">>> Adding the kernel to the cache.\n";
-  auto Program = createURProgram(Img, Context, Device);
+  auto Program = createURProgram(Img, Context, {Device});
   auto DeviceImpl = detail::getSyclObjImpl(Device);
   auto &Adapter = DeviceImpl->getAdapter();
   UrFuncInfo<UrApiKind::urProgramRelease> programReleaseInfo;
@@ -2789,9 +2857,10 @@ ur_kernel_handle_t ProgramManager::getOrCreateMaterializedKernel(
   applyOptionsFromEnvironment(CompileOpts, LinkOpts);
   // No linking of extra programs reqruired.
   std::vector<ur_program_handle_t> ExtraProgramsToLink;
+  std::vector<ur_device_handle_t> Devs = {DeviceImpl->getHandleRef()};
   auto BuildProgram =
       build(std::move(ProgramManaged), detail::getSyclObjImpl(Context),
-            CompileOpts, LinkOpts, DeviceImpl->getHandleRef(),
+            CompileOpts, LinkOpts, Devs,
             /*For non SPIR-V devices DeviceLibReqdMask is always 0*/ 0,
             ExtraProgramsToLink);
   ur_kernel_handle_t UrKernel{nullptr};

--- a/sycl/source/detail/program_manager/program_manager.hpp
+++ b/sycl/source/detail/program_manager/program_manager.hpp
@@ -104,7 +104,7 @@ public:
 
   ur_program_handle_t createURProgram(const RTDeviceBinaryImage &Img,
                                       const context &Context,
-                                      const device &Device);
+                                      const std::vector<device> &Devices);
   /// Creates a UR program using either a cached device code binary if present
   /// in the persistent cache or from the supplied device image otherwise.
   /// \param Img The device image used to create the program.
@@ -127,7 +127,7 @@ public:
   std::pair<ur_program_handle_t, bool> getOrCreateURProgram(
       const RTDeviceBinaryImage &Img,
       const std::vector<const RTDeviceBinaryImage *> &AllImages,
-      const context &Context, const device &Device,
+      const context &Context, const std::vector<device> &Devices,
       const std::string &CompileAndLinkOptions, SerializedObj SpecConsts);
   /// Builds or retrieves from cache a program defining the kernel with given
   /// name.
@@ -302,7 +302,8 @@ private:
                                      decltype(&::urProgramRelease)>;
   ProgramPtr build(ProgramPtr Program, const ContextImplPtr Context,
                    const std::string &CompileOptions,
-                   const std::string &LinkOptions, ur_device_handle_t Device,
+                   const std::string &LinkOptions,
+                   std::vector<ur_device_handle_t> &Devices,
                    uint32_t DeviceLibReqMask,
                    const std::vector<ur_program_handle_t> &ProgramsToLink,
                    bool CreatedFromBinary = false);

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/build_twice.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/build_twice.cpp
@@ -1,0 +1,54 @@
+// REQUIRES: gpu && linux && (opencl || level_zero)
+
+// Test to check that we can create input kernel bundle and call build twice for
+// overlapping set of devices and execute the kernel on each device.
+
+// RUN: %{build} -o %t.out
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=3 SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s
+
+#include <sycl/detail/core.hpp>
+
+class Kernel;
+
+int main() {
+  sycl::platform platform;
+  auto devices = platform.get_devices();
+  if (!(devices.size() >= 3))
+    return 0;
+
+  auto dev1 = devices[0], dev2 = devices[1], dev3 = devices[2];
+
+  auto ctx = sycl::context({dev1, dev2, dev3});
+  sycl::queue queues[3] = {sycl::queue(ctx, dev1), sycl::queue(ctx, dev2),
+                           sycl::queue(ctx, dev3)};
+  sycl::kernel_id kid = sycl::get_kernel_id<Kernel>();
+  sycl::kernel_bundle kernelBundleInput =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {kid});
+  // CHECK: urProgramCreateWithIL
+  // CHECK: urProgramBuildExp
+  auto KernelBundleExe1 = build(kernelBundleInput, {dev1, dev2});
+  // CHECK: urProgramCreateWithIL
+  // CHECK: urProgramBuildExp
+  auto KernelBundleExe2 = build(kernelBundleInput, {dev2, dev3});
+  // No other program creation calls are expected.
+  // CHECK-NOT: urProgramCreateWithIL
+  auto KernelObj1 = KernelBundleExe1.get_kernel(kid);
+  auto KernelObj2 = KernelBundleExe2.get_kernel(kid);
+  queues[0].submit([=](sycl::handler &cgh) {
+    cgh.use_kernel_bundle(KernelBundleExe1);
+    cgh.single_task<Kernel>([=]() {});
+  });
+  queues[1].submit([=](sycl::handler &cgh) {
+    cgh.use_kernel_bundle(KernelBundleExe1);
+    cgh.single_task(KernelObj1);
+  });
+  queues[1].submit([=](sycl::handler &cgh) {
+    cgh.use_kernel_bundle(KernelBundleExe2);
+    cgh.single_task(KernelObj2);
+  });
+  queues[2].submit([=](sycl::handler &cgh) {
+    cgh.use_kernel_bundle(KernelBundleExe2);
+    cgh.single_task(KernelObj2);
+  });
+  return 0;
+}

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/compile_link.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/compile_link.cpp
@@ -1,0 +1,35 @@
+// REQUIRES: gpu && linux && (opencl || level_zero)
+
+// RUN: %{build} -o %t.out
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=3 SYCL_UR_TRACE=2 %{run} %t.out
+
+// Test to check that we can compile and link a kernel bundle for multiple
+// devices and run the kernel on each device.
+#include <sycl/detail/core.hpp>
+
+class Kernel;
+
+int main() {
+  sycl::platform platform;
+  auto devices = platform.get_devices();
+  if (!(devices.size() >= 3))
+    return 0;
+  auto dev1 = devices[0], dev2 = devices[1], dev3 = devices[2];
+
+  auto ctx = sycl::context({dev1, dev2, dev3});
+  sycl::queue queues[3] = {sycl::queue(ctx, dev1), sycl::queue(ctx, dev2),
+                           sycl::queue(ctx, dev3)};
+  sycl::kernel_id kid = sycl::get_kernel_id<Kernel>();
+  sycl::kernel_bundle kernelBundleInput =
+      sycl::get_kernel_bundle<sycl::bundle_state::input>(ctx, {kid});
+  auto KernelBundleCompiled = compile(kernelBundleInput, {dev1, dev2, dev3});
+  auto KernelBundleLinked = link(KernelBundleCompiled, {dev1, dev2, dev3});
+  for (int i = 0; i < 3; i++) {
+    queues[i].submit([=](sycl::handler &cgh) {
+      cgh.use_kernel_bundle(KernelBundleLinked);
+      cgh.single_task<Kernel>([=]() {});
+    });
+    queues[i].wait();
+  }
+  return 0;
+}

--- a/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
+++ b/sycl/test-e2e/ProgramManager/multi_device_bundle/device_libs_and_caching.cpp
@@ -1,0 +1,158 @@
+// REQUIRES: gpu && linux && (opencl || level_zero)
+
+// Test to check several use cases for multi-device kernel bundles.
+// Test covers AOT and JIT cases. Kernel is using some math functions to enforce
+// using device libraries to excersise additional logic in the program manager.
+// Checks are used to test that program and device libraries caching works as
+// expected.
+
+// Test JIT first.
+// Intentionally use jit linking of device libraries to check that program
+// manager can handle this as well. With this option program manager will
+// compile the main program, load and compile device libraries and then link
+// everything together.
+// RUN: %{build} -fsycl-device-lib-jit-link -o %t.out
+
+// Check the default case when in-memory caching is enabled.
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=4 SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s --check-prefixes=CHECK-SPIRV-JIT-LINK-TRACE
+
+// Check the case when in-memory caching of the programs is disabled.
+// RUNL env SYCL_CACHE_IN_MEM=0 NEOReadDebugKeys=1 CreateMultipleRootDevices=4
+// %{run} %t.out
+
+// Test AOT next.
+// RUN: %{build} -fsycl-targets=spir64_gen -Xsycl-target-backend=spir64_gen "-device *" -o %t.out
+
+// Check the default case when in-memory caching is enabled.
+// RUN: env NEOReadDebugKeys=1 CreateMultipleRootDevices=4 SYCL_UR_TRACE=2 %{run} %t.out | FileCheck %s --check-prefixes=CHECK-AOT-TRACE
+
+// Check the case when in-memory caching of the programs is disabled.
+// RUNL env SYCL_CACHE_IN_MEM=0 NEOReadDebugKeys=1 CreateMultipleRootDevices=4
+// %{run} %t.out
+
+#include <cmath>
+#include <complex>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/intel/math.hpp>
+#include <sycl/usm.hpp>
+
+class Kernel;
+class Kernel2;
+class Kernel3;
+
+int main() {
+  sycl::platform platform;
+  auto devices = platform.get_devices();
+  if (!(devices.size() >= 4))
+    return 0;
+  auto dev1 = devices[0], dev2 = devices[1], dev3 = devices[2],
+       dev4 = devices[3];
+  auto ctx = sycl::context({dev1, dev2, dev3, dev4});
+  sycl::queue queues[4] = {sycl::queue(ctx, dev1), sycl::queue(ctx, dev2),
+                           sycl::queue(ctx, dev3), sycl::queue(ctx, dev4)};
+
+  auto res = sycl::malloc_host<int>(3, ctx);
+  auto KernelLambda = [=]() {
+    res[0] = sycl::ext::intel::math::float2int_rd(4.0) + (int)sqrtf(4.0f) +
+             std::exp(std::complex<float>(0.f, 0.f)).real();
+  };
+  // Test case 1
+  // Get bundle in executable state for multiple devices in a context, enqueue a
+  // kernel to each device.
+  {
+    sycl::kernel_id kid = sycl::get_kernel_id<Kernel>();
+    // Create the main program containing the kernel.
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCreateWithIL
+
+    // Create and compile the program for required device libraries (2 of them
+    // in this case).
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCreateWithIL
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCompileExp
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCreateWithIL
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCompileExp
+
+    // Compile the main program
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCompileExp
+
+    // Link main program and device libraries.
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramLinkExp
+
+    // CHECK-AOT-TRACE: urProgramCreateWithBinary
+    // CHECK-AOT-TRACE: urProgramBuildExp
+    sycl::kernel_bundle kernelBundleExecutable =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev1, dev2, dev3}, {kid});
+
+    for (int i = 0; i < 3; i++) {
+      queues[i].submit([=](sycl::handler &cgh) {
+        cgh.use_kernel_bundle(kernelBundleExecutable);
+        cgh.single_task<Kernel>(KernelLambda);
+      });
+      queues[i].wait();
+    }
+    std::cout << "Test #1 passed." << std::endl;
+  }
+
+  // Test case 2
+  // Get two bundles in executable state: for the first two devices in the
+  // context and for the new set of devices which includes the dev4. This checks
+  // caching of the programs and device libraries.
+  {
+    sycl::kernel_id kid = sycl::get_kernel_id<Kernel>();
+    // Program associated with {dev1, dev2, dev3} is supposed to be cached from
+    // the first test case, we don't expect any additional program creation and
+    // compilation calls for the following bundles because they are all created
+    // for subsets of {dev1, dev2, dev3} which means that the program handle
+    // from cache will be used.
+    sycl::kernel_bundle kernelBundleExecutableSubset1 =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev1, dev2}, {kid});
+    sycl::kernel_bundle kernelBundleExecutableSubset2 =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev2, dev3}, {kid});
+    sycl::kernel_bundle kernelBundleExecutableSubset3 =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev1, dev3}, {kid});
+    sycl::kernel_bundle kernelBundleExecutableSubset4 =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(ctx, {dev3},
+                                                                {kid});
+
+    // Here we create a bundle with a different set of devices which includes
+    // dev4, so we expect new UR program creation.
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCreateWithIL
+
+    // Device libraries will be additionally compiled for dev4, but no program
+    // creation is expected for device libraries as program handle already
+    // exists in the per-context cache.
+    // CHECK-SPIRV-JIT-LINK-TRACE-NOT: urProgramCreateWithIL
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCompileExp
+
+    // Main program will be compiled for new set of devices.
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramCompileExp
+
+    // Main program will be linked with device libraries.
+    // CHECK-SPIRV-JIT-LINK-TRACE: urProgramLinkExp
+
+    // CHECK-AOT-TRACE: urProgramCreateWithBinary
+    // CHECK-AOT-TRACE: urProgramBuildExp
+    sycl::kernel_bundle kernelBundleExecutableNewSet =
+        sycl::get_kernel_bundle<sycl::bundle_state::executable>(
+            ctx, {dev2, dev3, dev4}, {kid});
+
+    for (int i = 0; i < 3; i++) {
+      queues[0].submit([=](sycl::handler &cgh) {
+        cgh.use_kernel_bundle(kernelBundleExecutableSubset1);
+        cgh.single_task<Kernel>(KernelLambda);
+      });
+      queues[0].wait();
+
+      queues[2].submit([=](sycl::handler &cgh) {
+        cgh.use_kernel_bundle(kernelBundleExecutableNewSet);
+        cgh.single_task<Kernel>(KernelLambda);
+      });
+      queues[2].wait();
+    }
+    std::cout << "Test #2 passed." << std::endl;
+  }
+  return 0;
+}

--- a/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
+++ b/sycl/unittests/SYCL2020/KernelBundleStateFiltering.cpp
@@ -105,7 +105,8 @@ ur_result_t redefinedUrProgramCreate(void *pParams) {
 
 ur_result_t redefinedUrProgramCreateWithBinary(void *pParams) {
   auto params = *static_cast<ur_program_create_with_binary_params_t *>(pParams);
-  redefinedUrProgramCreateCommon(*params.ppBinary);
+  for (uint32_t i = 0; i < *params.pnumDevices; ++i)
+    redefinedUrProgramCreateCommon(*params.pppBinaries[i]);
   return UR_RESULT_SUCCESS;
 }
 
@@ -155,7 +156,6 @@ TEST(KernelBundle, DeviceImageStateFiltering) {
                                           &redefinedUrProgramCreate);
   mock::getCallbacks().set_after_callback("urProgramCreateWithBinary",
                                           &redefinedUrProgramCreateWithBinary);
-
   // No kernel ids specified.
   {
     const sycl::device Dev = sycl::platform().get_devices()[0];

--- a/sycl/unittests/helpers/RuntimeLinkingCommon.hpp
+++ b/sycl/unittests/helpers/RuntimeLinkingCommon.hpp
@@ -40,7 +40,7 @@ static ur_result_t redefined_urProgramCreateWithIL(void *pParams) {
 
 static ur_result_t redefined_urProgramCreateWithBinary(void *pParams) {
   auto Params = *static_cast<ur_program_create_with_binary_params_t *>(pParams);
-  auto *Magic = reinterpret_cast<const unsigned char *>(*Params.ppBinary);
+  auto *Magic = reinterpret_cast<const unsigned char *>(*Params.pppBinaries[0]);
   ur_program_handle_t *res = *Params.pphProgram;
   *res = mock::createDummyHandle<ur_program_handle_t>(sizeof(unsigned));
   reinterpret_cast<mock::dummy_handle_t>(*res)->setDataAs<unsigned>(*Magic);

--- a/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
+++ b/sycl/unittests/kernel-and-program/MultipleDevsCache.cpp
@@ -17,6 +17,8 @@
 
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <cstdint>
 #include <iostream>
 
 using namespace sycl;
@@ -25,6 +27,8 @@ class MultipleDevsCacheTestKernel;
 
 MOCK_INTEGRATION_HEADER(MultipleDevsCacheTestKernel)
 
+static constexpr uint32_t NumDevices = 3;
+
 static sycl::unittest::UrImage Img =
     sycl::unittest::generateDefaultImage({"MultipleDevsCacheTestKernel"});
 static sycl::unittest::UrImageArray<1> ImgArray{&Img};
@@ -32,13 +36,13 @@ static sycl::unittest::UrImageArray<1> ImgArray{&Img};
 static ur_result_t redefinedDeviceGetAfter(void *pParams) {
   auto params = *static_cast<ur_device_get_params_t *>(pParams);
   if (*params.ppNumDevices) {
-    **params.ppNumDevices = static_cast<uint32_t>(2);
+    **params.ppNumDevices = static_cast<uint32_t>(NumDevices);
     return UR_RESULT_SUCCESS;
   }
 
-  if (*params.pNumEntries == 2 && *params.pphDevices) {
-    (*params.pphDevices)[0] = reinterpret_cast<ur_device_handle_t>(1111);
-    (*params.pphDevices)[1] = reinterpret_cast<ur_device_handle_t>(2222);
+  if (*params.pNumEntries == NumDevices && *params.pphDevices) {
+    for (std::uintptr_t i = 0; i < NumDevices; ++i)
+      (*params.pphDevices)[i] = reinterpret_cast<ur_device_handle_t>(i + 1);
   }
   return UR_RESULT_SUCCESS;
 }
@@ -103,38 +107,52 @@ protected:
   platform Plt;
 };
 
-// Test that program is retained for each device and each kernel is released
-// once
+// Test that program is retained for each subset of the list of devices and that
+// number of urKernelRelease calls is correct.
 TEST_F(MultipleDeviceCacheTest, ProgramRetain) {
   {
     std::vector<sycl::device> Devices = Plt.get_devices(info::device_type::gpu);
     sycl::context Context(Devices);
     sycl::queue Queue(Context, Devices[0]);
-    assert(Devices.size() == 2 && Context.get_devices().size() == 2);
+    assert(Devices.size() == NumDevices &&
+           Context.get_devices().size() == NumDevices);
 
     auto KernelID = sycl::get_kernel_id<MultipleDevsCacheTestKernel>();
     auto Bundle = sycl::get_kernel_bundle<sycl::bundle_state::input>(
         Queue.get_context(), {KernelID});
-    assert(Bundle.get_devices().size() == 2);
+    assert(Bundle.get_devices().size() == NumDevices);
 
+    // Internally we create a kernel_bundle for the device associated with the
+    // queue and obtain the kernel object from it. So, as a result UR program
+    // for a single device is created (handle owned by device_image) and
+    // retained (because it is cached), as well as UR kernel is created using
+    // that UR program and retained because copy of the handle is returned to
+    // the caller.
     Queue.submit([&](sycl::handler &cgh) {
       cgh.single_task<MultipleDevsCacheTestKernel>([]() {});
     });
 
+    // Here we create a kernel_bundle for each device in the context and obtain
+    // the kernel object from it. We can't reuse the UR program that was created
+    // earlier as it is associated with just one device. So we create new UR
+    // program associated with all devices in the context and retain it (put it
+    // into the cache). We also create a new UR kernel from the UR program and
+    // retain it becaise copy of the handle returned to the caller.
     auto BundleObject = sycl::build(Bundle, Bundle.get_devices());
     auto Kernel = BundleObject.get_kernel(KernelID);
 
-    // Because of emulating 2 devices program is retained for each one in
-    // build(). It is also depends on number of device images. This test has one
-    // image, but other tests can create other images. Additional variable is
-    // added to control count of urProgramRetain calls
+    // Because of emulating multiple devices program is retained for each
+    // non-empty subset of provided list of devices in build(). It also depends
+    // on number of device images. This test has one image, but other tests can
+    // create other images. Additional variable is added to control count of
+    // urProgramRetain calls.
     auto BundleImpl = getSyclObjImpl(Bundle);
 
     // Bundle should only contain a single image, specifically the one with
     // MultipleDevsCacheTestKernel.
     EXPECT_EQ(BundleImpl->size(), size_t{1});
 
-    int NumRetains = 1 + BundleImpl->size() * 2;
+    int NumRetains = BundleImpl->size() * std::pow(2, NumDevices) - 1;
     EXPECT_EQ(RetainCounter, NumRetains)
         << "Expect " << NumRetains << " piProgramRetain calls";
 
@@ -142,8 +160,8 @@ TEST_F(MultipleDeviceCacheTest, ProgramRetain) {
     detail::KernelProgramCache::KernelCacheT &KernelCache =
         CtxImpl->getKernelProgramCache().acquireKernelsPerProgramCache().get();
 
-    EXPECT_EQ(KernelCache.size(), (size_t)1)
-        << "Expect 1 program in kernel cache";
+    EXPECT_EQ(KernelCache.size(), (size_t)2)
+        << "Expect 2 programs in kernel cache";
     for (auto &KernelProgIt : KernelCache)
       EXPECT_EQ(KernelProgIt.second.size(), (size_t)1)
           << "Expect 1 kernel cache";
@@ -154,5 +172,9 @@ TEST_F(MultipleDeviceCacheTest, ProgramRetain) {
   // kernel is removed from cache if urKernelRelease was called for it, so it
   // will not be removed twice for the other programs. As a result we must
   // expect 3 urKernelRelease calls.
-  EXPECT_EQ(KernelReleaseCounter, 3) << "Expect 3 piKernelRelease calls";
+
+  // We create 2 kernels in the test. So, we expect
+  // 4 urKernelRelease calls (correpsonding to 2 create calls + 2 retain calls
+  // when handle is returned to the caller).
+  EXPECT_EQ(KernelReleaseCounter, 4) << "Expect 4 piKernelRelease calls";
 }

--- a/sycl/unittests/program_manager/CompileTarget.cpp
+++ b/sycl/unittests/program_manager/CompileTarget.cpp
@@ -138,8 +138,9 @@ static ur_result_t redefinedDeviceGet(void *pParams) {
 std::vector<std::string> createWithBinaryLog;
 static ur_result_t redefinedProgramCreateWithBinary(void *pParams) {
   auto params = *static_cast<ur_program_create_with_binary_params_t *>(pParams);
-  createWithBinaryLog.push_back(
-      reinterpret_cast<const char *>(*params.ppBinary));
+  for (uint32_t i = 0; i < *params.pnumDevices; ++i)
+    createWithBinaryLog.push_back(
+        reinterpret_cast<const char *>(*params.pppBinaries[i]));
   return UR_RESULT_SUCCESS;
 }
 


### PR DESCRIPTION
This PR includes:
* Changes in the program manager methods to be able to properly create/build UR program for multiple devices. So far, we were mostly using only the first device in the vector to create/build UR program which made UR program unusable on other devices.

* UR tag update brings the version of urProgramCreateWithBinary which allows to create UR program from multiple device binaries.

* Our program cache key allowed only a single device. I have changed it to contain a set of devices. If UR program is created and built for a set of devices then the same UR program is usable whenver we have any subset of this set. That's why if we have a program built for a set of devices then add all subsets to the cache. Before we were adding a record to the cache for each device from the set which is incorrect. For example, if someone requests a UR program for {dev2, dev3} from the cache then it is expected that this UR progam must be usable to submit a kernel to dev3. But we could get a program for {dev1, dev2} from the cache which is unusable on dev3.