### PR TITLE
Simplify execution graph via analysis of dependencies

### DIFF
--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -161,6 +161,13 @@ public:
     return MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess;
   }
 
+  bool isCleanupSubject() const {
+    return MLeafCounter && // if already no leaves, can't be duplicate
+      MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess &&
+      // host task may be available by ThreadPool, can't cleanup it up
+      !isHostTask();
+  }
+
   // Shows that command could not be enqueued, now it may be true for empty task
   // only
   bool isEnqueueBlocked() const {

--- a/sycl/source/detail/scheduler/commands.hpp
+++ b/sycl/source/detail/scheduler/commands.hpp
@@ -163,9 +163,9 @@ public:
 
   bool isCleanupSubject() const {
     return MLeafCounter && // if already no leaves, can't be duplicate
-      MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess &&
-      // host task may be available by ThreadPool, can't cleanup it up
-      !isHostTask();
+           MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess &&
+           // host task may be available by ThreadPool, can't cleanup it up
+           !isHostTask();
   }
 
   // Shows that command could not be enqueued, now it may be true for empty task

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1072,7 +1072,7 @@ Command *Scheduler::GraphBuilder::addCG(
     addNodeToLeaves(Record, NewCmd.get(), Req->MAccessMode, ToEnqueue);
   }
 
-  for (detail::EventImplPtr e : Events) {
+  for (const detail::EventImplPtr &e : Events) {
     // Register all the events as dependencies
     if (Command *ConnCmd = NewCmd->addDep(e, ToCleanUp))
       ToEnqueue.push_back(ConnCmd);

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -247,7 +247,7 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
 void Scheduler::GraphBuilder::updateLeaves(
     Command *NewCmd, const std::set<Command *> &Cmds, MemObjRecord *Record,
     access::mode AccessMode, const MapOfDependentCmds &DependentCmdsOfNewCmd,
-    const QueueImplPtr &Queue, std::vector<Command *> &ToCleanUp,
+    const QueueImplPtr &/*Queue*/, std::vector<Command *> &ToCleanUp,
     std::vector<Command *> &ToEnqueue) {
 
   const bool ReadOnlyReq = AccessMode == access::mode::read;
@@ -448,7 +448,8 @@ Command *Scheduler::GraphBuilder::insertMemoryMove(
       ToEnqueue.push_back(ConnCmd);
   }
   const MapOfDependentCmds DependentCmdsOfNewCmd(NewCmd->MDeps);
-  updateLeaves(NewCmd, Deps, Record, access::mode::read_write, DependentCmdsOfNewCmd, Queue, ToCleanUp, ToEnqueue);
+  updateLeaves(NewCmd, Deps, Record, access::mode::read_write,
+               DependentCmdsOfNewCmd, Queue, ToCleanUp, ToEnqueue);
   addNodeToLeaves(Record, NewCmd, access::mode::read_write, ToEnqueue);
   for (Command *Cmd : ToCleanUp)
     cleanupCommand(Cmd);

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -261,10 +261,8 @@ void Scheduler::GraphBuilder::updateLeaves(const std::set<Command *> &Cmds,
     detectDuplicates(Cmd, DependentCmdsOfNewCmd, ToCleanUp);
 
     // For in-order queue, we may cleanup all dependent command from our queue
-    if (Queue && Queue->isInOrder() && Cmd->getQueue() == Queue
-        && Cmd->getType() == Command::RUN_CG
-        && Cmd->MLeafCounter
-        && Cmd->MEnqueueStatus == EnqueueResultT::SyclEnqueueSuccess)
+    if (Queue && Queue->isInOrder() && Cmd->getQueue() == Queue &&
+        Cmd->isCleanupSubject())
       commandToCleanup(Cmd, ToCleanUp);
   }
 }
@@ -282,8 +280,7 @@ void Scheduler::GraphBuilder::addNodeToLeaves(
 void Scheduler::GraphBuilder::detectDuplicates(
     Command *DepCommand, const MapOfDependentCmds &DependentCmdsOfNewCmd,
     std::vector<Command *> &ToCleanUp) {
-  if (!DepCommand->MLeafCounter || // already no leaves, can't be duplicate
-      DepCommand->MEnqueueStatus != EnqueueResultT::SyclEnqueueSuccess)
+  if (!DepCommand->isCleanupSubject())
     return;
   // any dependence of DepCommand already covered by NewCmd
   bool Duplicate = std::all_of(DepCommand->MDeps.begin(), DepCommand->MDeps.end(),

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -1072,8 +1072,8 @@ Command *Scheduler::GraphBuilder::addCG(
     addNodeToLeaves(Record, NewCmd.get(), Req->MAccessMode, ToEnqueue);
   }
 
+  // Register all the events as dependencies
   for (const detail::EventImplPtr &e : Events) {
-    // Register all the events as dependencies
     if (Command *ConnCmd = NewCmd->addDep(e, ToCleanUp))
       ToEnqueue.push_back(ConnCmd);
     // If NewCmd depends on another command, and all dependences of that command

--- a/sycl/source/detail/scheduler/graph_builder.cpp
+++ b/sycl/source/detail/scheduler/graph_builder.cpp
@@ -247,7 +247,7 @@ Scheduler::GraphBuilder::getOrInsertMemObjRecord(const QueueImplPtr &Queue,
 void Scheduler::GraphBuilder::updateLeaves(
     Command *NewCmd, const std::set<Command *> &Cmds, MemObjRecord *Record,
     access::mode AccessMode, const MapOfDependentCmds &DependentCmdsOfNewCmd,
-    const QueueImplPtr &/*Queue*/, std::vector<Command *> &ToCleanUp,
+    const QueueImplPtr &Queue, std::vector<Command *> &ToCleanUp,
     std::vector<Command *> &ToEnqueue) {
 
   const bool ReadOnlyReq = AccessMode == access::mode::read;
@@ -262,7 +262,7 @@ void Scheduler::GraphBuilder::updateLeaves(
     }
     if (detectDuplicates(Cmd, DependentCmdsOfNewCmd))
       commandToCleanup(NewCmd, Cmd, ToEnqueue);
-#if 0
+#if 1
     // CGType::CopyAccToAcc implementation requires that dependent command is
     // not a cleanup subject. So disable this code for now.
 

--- a/sycl/source/detail/scheduler/leaves_collection.hpp
+++ b/sycl/source/detail/scheduler/leaves_collection.hpp
@@ -42,8 +42,8 @@ public:
   using EnqueueListT = std::vector<Command *>;
 
   // Make first command depend on the second
-  using AllocateDependencyF =
-      std::function<void(Command *, Command *, const MemObjRecord *, EnqueueListT &)>;
+  using AllocateDependencyF = std::function<void(
+      Command *, Command *, const MemObjRecord *, EnqueueListT &)>;
 
   template <bool IsConst> class IteratorT;
 

--- a/sycl/source/detail/scheduler/leaves_collection.hpp
+++ b/sycl/source/detail/scheduler/leaves_collection.hpp
@@ -43,7 +43,7 @@ public:
 
   // Make first command depend on the second
   using AllocateDependencyF =
-      std::function<void(Command *, Command *, MemObjRecord *, EnqueueListT &)>;
+      std::function<void(Command *, Command *, const MemObjRecord *, EnqueueListT &)>;
 
   template <bool IsConst> class IteratorT;
 

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -623,17 +623,19 @@ protected:
 
     /// Removes commands from leaves.
     void updateLeaves(Command *NewCmd, const std::set<Command *> &Cmds,
-                             MemObjRecord *Record, access::mode AccessMode,
-                             const MapOfDependentCmds &DependentCmdsOfNewCmd,
-                             const QueueImplPtr &Queue,
-                             std::vector<Command *> &ToCleanUp,
-                             std::vector<Command *> &ToEnqueue);
+                      MemObjRecord *Record, access::mode AccessMode,
+                      const MapOfDependentCmds &DependentCmdsOfNewCmd,
+                      const QueueImplPtr &Queue,
+                      std::vector<Command *> &ToCleanUp,
+                      std::vector<Command *> &ToEnqueue);
 
     /// Prepare a command to cleanup
-    void commandToCleanup(Command *NewCmd, Command *DepCommand, MemObjRecord *Record,
+    void commandToCleanup(Command *NewCmd, Command *DepCommand,
+                          MemObjRecord *Record,
                           std::vector<Command *> &ToEnqueue);
 
-    void commandToCleanup(Command *DepCommand, std::vector<Command *> &ToCleanUp);
+    void commandToCleanup(Command *DepCommand,
+                          std::vector<Command *> &ToCleanUp);
 
     /// Perform connection of events in multiple contexts
     /// \param Cmd dependant command
@@ -704,7 +706,8 @@ protected:
 
     /// If all dependences of a dependent cmd already covered by NewCmd,
     /// move the dependent cmd in ToCleanUp
-    bool detectDuplicates(Command *DepCommand, const MapOfDependentCmds &DependentCmdsOfNewCmd);
+    bool detectDuplicates(Command *DepCommand,
+                          const MapOfDependentCmds &DependentCmdsOfNewCmd);
 
   protected:
     /// Finds a command dependency corresponding to the record.
@@ -923,8 +926,7 @@ class MapOfDependentCmds {
 
   std::array<std::byte, 4 * 1024> MDependentCmdsOfNewCmdBuf;
   std::pmr::monotonic_buffer_resource MDependentCmdsOfNewCmdBufRes{
-      MDependentCmdsOfNewCmdBuf.data(),
-                                                                   MDependentCmdsOfNewCmdBuf.size()};
+      MDependentCmdsOfNewCmdBuf.data(), MDependentCmdsOfNewCmdBuf.size()};
   CommandModePairSet MDependentCmdsOfNewCmd{&MDependentCmdsOfNewCmdBufRes};
 
   void addDep(const DepDesc &Dep) {

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -622,15 +622,18 @@ protected:
                          std::vector<Command *> &ToEnqueue);
 
     /// Removes commands from leaves.
-    static void updateLeaves(const std::set<Command *> &Cmds,
+    void updateLeaves(Command *NewCmd, const std::set<Command *> &Cmds,
                              MemObjRecord *Record, access::mode AccessMode,
                              const MapOfDependentCmds &DependentCmdsOfNewCmd,
                              const QueueImplPtr &Queue,
-                             std::vector<Command *> &ToCleanUp);
+                             std::vector<Command *> &ToCleanUp,
+                             std::vector<Command *> &ToEnqueue);
 
     /// Prepare a command to cleanup
-    static void commandToCleanup(Command *DepCommand,
-                                 std::vector<Command *> &ToCleanUp);
+    void commandToCleanup(Command *NewCmd, Command *DepCommand, MemObjRecord *Record,
+                          std::vector<Command *> &ToEnqueue);
+
+    void commandToCleanup(Command *DepCommand, std::vector<Command *> &ToCleanUp);
 
     /// Perform connection of events in multiple contexts
     /// \param Cmd dependant command
@@ -701,13 +704,11 @@ protected:
 
     /// If all dependences of a dependent cmd already covered by NewCmd,
     /// move the dependent cmd in ToCleanUp
-    static void detectDuplicates(Command *DepCommand,
-                          const MapOfDependentCmds &DependentCmdsOfNewCmd,
-                          std::vector<Command *> &ToCleanUp);
+    bool detectDuplicates(Command *DepCommand, const MapOfDependentCmds &DependentCmdsOfNewCmd);
 
   protected:
     /// Finds a command dependency corresponding to the record.
-    DepDesc findDepForRecord(Command *Cmd, MemObjRecord *Record);
+    DepDesc findDepForRecord(Command *Cmd, const MemObjRecord *Record);
 
     /// Searches for suitable alloca in memory record.
     AllocaCommandBase *findAllocaForReq(MemObjRecord *Record,
@@ -735,6 +736,8 @@ protected:
     std::queue<Command *> MCmdsToVisit;
     /// Used to track commands that have been visited during graph traversal.
     std::vector<Command *> MVisitedCmds;
+
+    LeavesCollection::AllocateDependencyF MAllocateDependency;
 
     /// Prints contents of graph to text file in DOT format
     ///

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -631,11 +631,7 @@ protected:
 
     /// Prepare a command to cleanup
     void commandToCleanup(Command *NewCmd, Command *DepCommand,
-                          MemObjRecord *Record,
                           std::vector<Command *> &ToEnqueue);
-
-    void commandToCleanup(Command *DepCommand,
-                          std::vector<Command *> &ToCleanUp);
 
     /// Perform connection of events in multiple contexts
     /// \param Cmd dependant command

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -622,13 +622,15 @@ protected:
                          std::vector<Command *> &ToEnqueue);
 
     /// Removes commands from leaves.
-    static void updateLeaves(const std::set<Command *> &Cmds, MemObjRecord *Record,
-                      access::mode AccessMode, const MapOfDependentCmds &DependentCmdsOfNewCmd,
-                      const QueueImplPtr &Queue,
-                      std::vector<Command *> &ToCleanUp);
+    static void updateLeaves(const std::set<Command *> &Cmds,
+                             MemObjRecord *Record, access::mode AccessMode,
+                             const MapOfDependentCmds &DependentCmdsOfNewCmd,
+                             const QueueImplPtr &Queue,
+                             std::vector<Command *> &ToCleanUp);
 
     /// Prepare a command to cleanup
-    static void commandToCleanup(Command *DepCommand, std::vector<Command *> &ToCleanUp);
+    static void commandToCleanup(Command *DepCommand,
+                                 std::vector<Command *> &ToCleanUp);
 
     /// Perform connection of events in multiple contexts
     /// \param Cmd dependant command
@@ -907,23 +909,27 @@ class MapOfDependentCmds {
   using CommandModePair = std::pair<SYCLMemObjI *, access::mode>;
 
   struct CommandModePairHash {
-    std::size_t operator()(const CommandModePair& p) const noexcept {
-      return std::hash<SYCLMemObjI *>{}(p.first) ^ std::hash<access::mode>{}(p.second);
+    std::size_t operator()(const CommandModePair &p) const noexcept {
+      return std::hash<SYCLMemObjI *>{}(p.first) ^
+             std::hash<access::mode>{}(p.second);
     }
   };
 
-  using CommandModePairSet = std::pmr::unordered_set<CommandModePair, CommandModePairHash>;
+  using CommandModePairSet =
+      std::pmr::unordered_set<CommandModePair, CommandModePairHash>;
 
-  std::array<std::byte, 4*1024> MDependentCmdsOfNewCmdBuf;
-  std::pmr::monotonic_buffer_resource MDependentCmdsOfNewCmdBufRes{MDependentCmdsOfNewCmdBuf.data(),
+  std::array<std::byte, 4 * 1024> MDependentCmdsOfNewCmdBuf;
+  std::pmr::monotonic_buffer_resource MDependentCmdsOfNewCmdBufRes{
+      MDependentCmdsOfNewCmdBuf.data(),
                                                                    MDependentCmdsOfNewCmdBuf.size()};
   CommandModePairSet MDependentCmdsOfNewCmd{&MDependentCmdsOfNewCmdBufRes};
 
   void addDep(const DepDesc &Dep) {
-    MDependentCmdsOfNewCmd.emplace(Dep.MDepRequirement->MSYCLMemObj, Dep.MDepRequirement->MAccessMode);
+    MDependentCmdsOfNewCmd.emplace(Dep.MDepRequirement->MSYCLMemObj,
+                                   Dep.MDepRequirement->MAccessMode);
   }
-public:
 
+public:
   MapOfDependentCmds(const std::vector<DepDesc> &Deps) {
     for (const DepDesc &Dep : Deps)
       addDep(Dep);

--- a/sycl/source/detail/scheduler/scheduler.hpp
+++ b/sycl/source/detail/scheduler/scheduler.hpp
@@ -15,6 +15,7 @@
 
 #include <cstddef>
 #include <memory>
+#include <memory_resource>
 #include <queue>
 #include <set>
 #include <shared_mutex>
@@ -598,7 +599,7 @@ protected:
 
     /// \return a pointer to the corresponding memory object record for the
     /// SYCL memory object provided, or nullptr if it does not exist.
-    MemObjRecord *getMemObjRecord(SYCLMemObjI *MemObject);
+    static MemObjRecord *getMemObjRecord(SYCLMemObjI *MemObject);
 
     /// \return a pointer to MemObjRecord for pointer to memory object. If the
     /// record is not found, nullptr is returned.
@@ -620,9 +621,17 @@ protected:
                          std::vector<Command *> &ToEnqueue);
 
     /// Removes commands from leaves.
-    void updateLeaves(const std::set<Command *> &Cmds, MemObjRecord *Record,
+    static void updateLeaves(const std::set<Command *> &Cmds, MemObjRecord *Record,
                       access::mode AccessMode,
                       std::vector<Command *> &ToCleanUp);
+
+    /// If dependent cmd do same as NewCmd, move it to cleanup
+    static void detectDuplicates(Command *DepCommand,
+                          const std::pmr::unordered_set<Command *> &DependentCmdsOfNewCmd,
+                          std::vector<Command *> &ToCleanUp);
+
+    /// Prepare a command to cleanup
+    static void commandToCleanup(Command *DepCommand, std::vector<Command *> &ToCleanUp);
 
     /// Perform connection of events in multiple contexts
     /// \param Cmd dependant command

--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -270,7 +270,8 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
           MS.addNodeToLeaves(Record, MockCmd.get(), access::mode::read_write,
                              ToEnqueue);
         }
-        const detail::MapOfDependentCmds DependentCmdsOfNewCmd(AllocaCmd->MDeps);
+        const detail::MapOfDependentCmds DependentCmdsOfNewCmd(
+            AllocaCmd->MDeps);
         for (std::unique_ptr<MockCommand> &MockCmd : Leaves)
           MS.updateLeaves({MockCmd.get()}, Record, access::mode::read_write,
                           DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);

--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -87,8 +87,8 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
   EXPECT_TRUE(ToCleanUp.empty());
   MS.addNodeToLeaves(Record, MockCmd, access::mode::read_write, ToEnqueue);
   detail::MapOfDependentCmds DependentCmdsOfNewCmd(MockCmd->MDeps);
-  MS.updateLeaves({AllocaCmd}, Record, access::mode::read_write,
-                  DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);
+  MS.updateLeaves(MockCmd, {AllocaCmd}, Record, access::mode::read_write,
+                  DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
 
   EXPECT_TRUE(ToCleanUp.empty());
   std::unique_ptr<detail::CG> CG{
@@ -110,8 +110,8 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
   addEdge(MockCmd, Cmd, AllocaCmd);
   MS.addNodeToLeaves(Record, MockCmd, access::mode::read_write, ToEnqueue);
   DependentCmdsOfNewCmd.addDeps(MockCmd->MDeps);
-  MS.updateLeaves({Cmd}, Record, access::mode::read_write,
-                  DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);
+  MS.updateLeaves(MockCmd, {Cmd}, Record, access::mode::read_write,
+                  DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
   MS.addHostAccessor(&MockReq);
   verifyCleanup(Record, AllocaCmd, MockCmd, CommandDeleted);
 
@@ -137,8 +137,8 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
     // cleaned up during removal from leaves.
     ToCleanUp.clear();
     detail::MapOfDependentCmds DependentCmdsOfNewCmd(LeafMockCmd->MDeps);
-    MS.updateLeaves({MockCmd}, Record, access::mode::read_write,
-                    DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);
+    MS.updateLeaves(LeafMockCmd, {MockCmd}, Record, access::mode::read_write,
+                    DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
     EXPECT_EQ(ToCleanUp.size(), 1U);
     EXPECT_EQ(ToCleanUp[0], MockCmd);
     MS.cleanupCommands({MockCmd});
@@ -150,8 +150,8 @@ static void checkCleanupOnEnqueue(MockScheduler &MS,
     MS.addNodeToLeaves(Record, LeafMockCmd, access::mode::read_write,
                        ToEnqueue);
     DependentCmdsOfNewCmd.addDeps(LeafMockCmd->MDeps);
-    MS.updateLeaves({MockCmd}, Record, access::mode::read_write,
-                    DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);
+    MS.updateLeaves(LeafMockCmd, {MockCmd}, Record, access::mode::read_write,
+                    DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
     return MockCmd;
   };
 
@@ -193,8 +193,8 @@ static void checkCleanupOnLeafUpdate(
   EXPECT_TRUE(ToCleanUp.empty());
   MS.addNodeToLeaves(Record, MockCmd, access::mode::read_write, ToEnqueue);
   const detail::MapOfDependentCmds DependentCmdsOfNewCmd(MockCmd->MDeps);
-  MS.updateLeaves({AllocaCmd}, Record, access::mode::read_write,
-                  DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);
+  MS.updateLeaves(MockCmd, {AllocaCmd}, Record, access::mode::read_write,
+                  DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
   detail::EnqueueResultT Res;
   MockScheduler::enqueueCommand(MockCmd, Res, detail::BLOCKING);
 
@@ -273,8 +273,8 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
         const detail::MapOfDependentCmds DependentCmdsOfNewCmd(
             AllocaCmd->MDeps);
         for (std::unique_ptr<MockCommand> &MockCmd : Leaves)
-          MS.updateLeaves({MockCmd.get()}, Record, access::mode::read_write,
-                          DependentCmdsOfNewCmd, QueueImpl, ToCleanUp);
+          MS.updateLeaves(AllocaCmd, {MockCmd.get()}, Record, access::mode::read_write,
+                          DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
         EXPECT_TRUE(ToCleanUp.empty());
       });
 }

--- a/sycl/unittests/scheduler/GraphCleanup.cpp
+++ b/sycl/unittests/scheduler/GraphCleanup.cpp
@@ -273,8 +273,9 @@ TEST_F(SchedulerTest, PostEnqueueCleanup) {
         const detail::MapOfDependentCmds DependentCmdsOfNewCmd(
             AllocaCmd->MDeps);
         for (std::unique_ptr<MockCommand> &MockCmd : Leaves)
-          MS.updateLeaves(AllocaCmd, {MockCmd.get()}, Record, access::mode::read_write,
-                          DependentCmdsOfNewCmd, QueueImpl, ToCleanUp, ToEnqueue);
+          MS.updateLeaves(AllocaCmd, {MockCmd.get()}, Record,
+                          access::mode::read_write, DependentCmdsOfNewCmd,
+                          QueueImpl, ToCleanUp, ToEnqueue);
         EXPECT_TRUE(ToCleanUp.empty());
       });
 }

--- a/sycl/unittests/scheduler/LeavesCollection.cpp
+++ b/sycl/unittests/scheduler/LeavesCollection.cpp
@@ -54,7 +54,7 @@ TEST_F(LeavesCollectionTest, PushBack) {
   std::vector<sycl::detail::Command *> ToEnqueue;
 
   LeavesCollection::AllocateDependencyF AllocateDependency =
-      [&](Command *, Command *, MemObjRecord *,
+      [&](Command *, Command *, const MemObjRecord *,
           std::vector<sycl::detail::Command *> &) { ++TimesGenericWasFull; };
 
   // add only generic commands
@@ -121,7 +121,7 @@ TEST_F(LeavesCollectionTest, Remove) {
   std::vector<sycl::detail::Command *> ToEnqueue;
 
   LeavesCollection::AllocateDependencyF AllocateDependency =
-      [](Command *, Command *Old, MemObjRecord *,
+      [](Command *, Command *Old, const MemObjRecord *,
          std::vector<sycl::detail::Command *> &) { --Old->MLeafCounter; };
 
   {

--- a/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
+++ b/sycl/unittests/scheduler/LinkedAllocaDependencies.cpp
@@ -65,7 +65,7 @@ TEST_F(SchedulerTest, LinkedAllocaDependencies) {
   sycl::detail::QueueImplPtr Q1 = sycl::detail::getSyclObjImpl(Queue1);
 
   auto AllocaDep = [](sycl::detail::Command *, sycl::detail::Command *,
-                      sycl::detail::MemObjRecord *,
+                      const sycl::detail::MemObjRecord *,
                       std::vector<sycl::detail::Command *> &) {};
 
   std::shared_ptr<sycl::detail::MemObjRecord> Record{

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -132,15 +132,17 @@ public:
     return MGraphBuilder.addNodeToLeaves(Rec, Cmd, Mode, ToEnqueue);
   }
 
-  void updateLeaves(sycl::detail::Command *NewCmd, const std::set<sycl::detail::Command *> &Cmds,
-                    sycl::detail::MemObjRecord *Record,
-                    sycl::access::mode AccessMode,
-                    const sycl::detail::MapOfDependentCmds &DependentCmdsOfNewCmd,
-                    const sycl::detail::QueueImplPtr &Queue,
-                    std::vector<sycl::detail::Command *> &ToCleanUp,
-                    std::vector<sycl::detail::Command *> &ToEnqueue) {
-    return MGraphBuilder.updateLeaves(NewCmd, Cmds, Record, AccessMode, DependentCmdsOfNewCmd,
-                                      Queue, ToCleanUp, ToEnqueue);
+  void
+  updateLeaves(sycl::detail::Command *NewCmd, const std::set<sycl::detail::Command *> &Cmds,
+               sycl::detail::MemObjRecord *Record,
+               sycl::access::mode AccessMode,
+               const sycl::detail::MapOfDependentCmds &DependentCmdsOfNewCmd,
+               const sycl::detail::QueueImplPtr &Queue,
+               std::vector<sycl::detail::Command *> &ToCleanUp,
+                std::vector<sycl::detail::Command *> &ToEnqueue) {
+    return MGraphBuilder.updateLeaves(NewCmd, Cmds, Record, AccessMode,
+                                      DependentCmdsOfNewCmd, Queue, ToCleanUp,
+                                      ToEnqueue);
   }
 
   static bool enqueueCommand(sycl::detail::Command *Cmd,

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -133,13 +133,14 @@ public:
   }
 
   void
-  updateLeaves(sycl::detail::Command *NewCmd, const std::set<sycl::detail::Command *> &Cmds,
+  updateLeaves(sycl::detail::Command *NewCmd,
+               const std::set<sycl::detail::Command *> &Cmds,
                sycl::detail::MemObjRecord *Record,
                sycl::access::mode AccessMode,
                const sycl::detail::MapOfDependentCmds &DependentCmdsOfNewCmd,
                const sycl::detail::QueueImplPtr &Queue,
                std::vector<sycl::detail::Command *> &ToCleanUp,
-                std::vector<sycl::detail::Command *> &ToEnqueue) {
+               std::vector<sycl::detail::Command *> &ToEnqueue) {
     return MGraphBuilder.updateLeaves(NewCmd, Cmds, Record, AccessMode,
                                       DependentCmdsOfNewCmd, Queue, ToCleanUp,
                                       ToEnqueue);

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -135,8 +135,11 @@ public:
   void updateLeaves(const std::set<sycl::detail::Command *> &Cmds,
                     sycl::detail::MemObjRecord *Record,
                     sycl::access::mode AccessMode,
+                    const sycl::detail::MapOfDependentCmds &DependentCmdsOfNewCmd,
+                    const sycl::detail::QueueImplPtr &Queue,
                     std::vector<sycl::detail::Command *> &ToCleanUp) {
-    return MGraphBuilder.updateLeaves(Cmds, Record, AccessMode, ToCleanUp);
+    return MGraphBuilder.updateLeaves(Cmds, Record, AccessMode, DependentCmdsOfNewCmd,
+                                      Queue, ToCleanUp);
   }
 
   static bool enqueueCommand(sycl::detail::Command *Cmd,

--- a/sycl/unittests/scheduler/SchedulerTestUtils.hpp
+++ b/sycl/unittests/scheduler/SchedulerTestUtils.hpp
@@ -132,14 +132,15 @@ public:
     return MGraphBuilder.addNodeToLeaves(Rec, Cmd, Mode, ToEnqueue);
   }
 
-  void updateLeaves(const std::set<sycl::detail::Command *> &Cmds,
+  void updateLeaves(sycl::detail::Command *NewCmd, const std::set<sycl::detail::Command *> &Cmds,
                     sycl::detail::MemObjRecord *Record,
                     sycl::access::mode AccessMode,
                     const sycl::detail::MapOfDependentCmds &DependentCmdsOfNewCmd,
                     const sycl::detail::QueueImplPtr &Queue,
-                    std::vector<sycl::detail::Command *> &ToCleanUp) {
-    return MGraphBuilder.updateLeaves(Cmds, Record, AccessMode, DependentCmdsOfNewCmd,
-                                      Queue, ToCleanUp);
+                    std::vector<sycl::detail::Command *> &ToCleanUp,
+                    std::vector<sycl::detail::Command *> &ToEnqueue) {
+    return MGraphBuilder.updateLeaves(NewCmd, Cmds, Record, AccessMode, DependentCmdsOfNewCmd,
+                                      Queue, ToCleanUp, ToEnqueue);
   }
 
   static bool enqueueCommand(sycl::detail::Command *Cmd,


### PR DESCRIPTION
If a dependent command has all dependencies that has newly added command, the dependent command can be excluded from the execution graph.

For in-order queue, all dependent command from current queue can be excluded from an execution graph.

In current implementation, case with single accessor is supported, but for 
auto e = queue.submit([&](auto &h) {
            sycl::accessor acc(DataBuf, h);
            sycl::accessor acc1(DataBuf1, h, sycl::read_only);
            h.parallel_for(range, ...);
});
called in loop a size of dependency graph is limited by LeafLimit.
