### PR TITLE
[SYCL][ESIMD][NFCI] Fix coverity issues in use of demangler

### DIFF
--- a/llvm/include/llvm/SYCLLowerIR/ESIMD/ESIMDUtils.h
+++ b/llvm/include/llvm/SYCLLowerIR/ESIMD/ESIMDUtils.h
@@ -61,6 +61,7 @@ Type *getVectorTyOrNull(StructType *STy);
 class SimpleAllocator {
 protected:
   SmallVector<void *, 128> Ptrs;
+  SimpleAllocator &operator=(const SimpleAllocator &) = delete;
 
 public:
   void reset() {
@@ -84,6 +85,10 @@ public:
     return Ptr;
   }
 
+  SimpleAllocator() = default;
+  SimpleAllocator(const SimpleAllocator &) : SimpleAllocator() {
+    assert(false && "Unreachable");
+  }
   ~SimpleAllocator() { reset(); }
 };
 


### PR DESCRIPTION
Need to follow rule of three since there is a user defined destructor, the copy constructor is called never hit at runtime, the copy assignment constructor is never called.