### PR TITLE
[SYCL] Fix logic in virtual function analysis

### DIFF
--- a/llvm/test/SYCLLowerIR/SYCLVirtualFunctionsAnalysis/calls-indirectly-propagation-4.ll
+++ b/llvm/test/SYCLLowerIR/SYCLVirtualFunctionsAnalysis/calls-indirectly-propagation-4.ll
@@ -35,7 +35,20 @@ entry:
   ret void
 }
 
+define internal spir_func void @helper2(ptr addrspace(1) noundef align 8 %arg) {
+entry:
+  call void @helper(ptr addrspace(1) %arg)
+  ret void
+}
+
+define weak_odr dso_local spir_kernel void @kernel2(ptr addrspace(1) noundef align 8 %_arg_StorageAcc) #2 {
+entry:
+  call void @helper2(ptr addrspace(1) %_arg_StorageAcc)
+  ret void
+}
+
 ; CHECK: @kernel{{.*}} #[[#KERNEL_ATTRS:]]
+; CHECK: @kernel2{{.*}} #[[#KERNEL_ATTRS]]
 ;
 ; CHECK: attributes #[[#KERNEL_ATTRS]] = {{.*}}"calls-indirectly"="set-foo,set-bar"
 


### PR DESCRIPTION
`computeFunctionToKernelsMapping` did not compute the mapping correctly for leaves of its call graph if the call graph for leaves 3 levels or more deep, which results in some kernels not having inferred `calls-indirectly` being attached. This fixes the logic and cleans up the duplication a bit in the function.