### PR TITLE
[GHA] Uplift Linux IGC Dev RT version to igc-dev-2fda260

### DIFF
--- a/devops/dependencies-igc-dev.json
+++ b/devops/dependencies-igc-dev.json
@@ -1,10 +1,10 @@
 {
   "linux": {
     "igc_dev": {
-      "github_tag": "igc-dev-a20debc",
-      "version": "a20debc",
-      "updated_at": "2024-09-15T13:44:38Z",
-      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/1934718090/zip",
+      "github_tag": "igc-dev-2fda260",
+      "version": "2fda260",
+      "updated_at": "2024-10-16T21:42:48Z",
+      "url": "https://api.github.com/repos/intel/intel-graphics-compiler/actions/artifacts/2065917189/zip",
       "root": "{DEPS_ROOT}/opencl/runtime/linux/oclgpu"
     }
   }


### PR DESCRIPTION
Scheduled igc dev drivers uplift