### PR TITLE
 info::device::atomic64 is deprecated

### DIFF
--- a/sycl/include/sycl/info/device_traits_2020_deprecated.def
+++ b/sycl/include/sycl/info/device_traits_2020_deprecated.def
@@ -1,0 +1,17 @@
+// Marked deprecated in SYCL 2020 spec
+__SYCL_PARAM_TRAITS_DEPRECATED(image_support, "deprecated in SYCL 2020, use device::has(aspect::ext_intel_legacy_image) to query for SYCL 1.2.1 image support")
+__SYCL_PARAM_TRAITS_DEPRECATED(max_constant_buffer_size,"deprecated in SYCL 2020")
+__SYCL_PARAM_TRAITS_DEPRECATED(max_constant_args,"deprecated in SYCL 2020")
+__SYCL_PARAM_TRAITS_DEPRECATED(host_unified_memory,"deprecated in SYCL 2020, use device::has() with "
+                                                    "one of the aspect::usm_* aspects instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(is_endian_little,"deprecated in SYCL 2020, check the byte order of "
+                                                "the host system instead, the host and the device "
+                                                "are required to have the same byte order")
+__SYCL_PARAM_TRAITS_DEPRECATED(is_compiler_available,"deprecated in SYCL 2020, use device::has(aspect::online_compiler) instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(is_linker_available, "deprecated in SYCL 2020, use device::has(aspect::online_linker) instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(queue_profiling, "deprecated in SYCL 2020, use device::has(aspect::queue_profiling) instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(built_in_kernels,"deprecated in SYCL 2020, use info::device::built_in_kernel_ids instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(profile,"deprecated in SYCL 2020")
+__SYCL_PARAM_TRAITS_DEPRECATED(extensions,"deprecated in SYCL 2020, use info::device::aspects instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(printf_buffer_size,"deprecated in SYCL 2020")
+__SYCL_PARAM_TRAITS_DEPRECATED(preferred_interop_user_sync,"deprecated in SYCL 2020")

--- a/sycl/include/sycl/info/device_traits_deprecated.def
+++ b/sycl/include/sycl/info/device_traits_deprecated.def
@@ -1,24 +1,7 @@
-// Marked deprecated in SYCL 2020 spec
-__SYCL_PARAM_TRAITS_DEPRECATED(image_support, "deprecated in SYCL 2020, use device::has(aspect::ext_intel_legacy_image) to query for SYCL 1.2.1 image support")
-__SYCL_PARAM_TRAITS_DEPRECATED(max_constant_buffer_size,"deprecated in SYCL 2020")
-__SYCL_PARAM_TRAITS_DEPRECATED(max_constant_args,"deprecated in SYCL 2020")
-__SYCL_PARAM_TRAITS_DEPRECATED(host_unified_memory,"deprecated in SYCL 2020, use device::has() with "
-                                                    "one of the aspect::usm_* aspects instead")
-__SYCL_PARAM_TRAITS_DEPRECATED(is_endian_little,"deprecated in SYCL 2020, check the byte order of "
-                                                "the host system instead, the host and the device "
-                                                "are required to have the same byte order")
-__SYCL_PARAM_TRAITS_DEPRECATED(is_compiler_available,"deprecated in SYCL 2020, use device::has(aspect::online_compiler) instead")
-__SYCL_PARAM_TRAITS_DEPRECATED(is_linker_available, "deprecated in SYCL 2020, use device::has(aspect::online_linker) instead")
-__SYCL_PARAM_TRAITS_DEPRECATED(queue_profiling, "deprecated in SYCL 2020, use device::has(aspect::queue_profiling) instead")
-__SYCL_PARAM_TRAITS_DEPRECATED(built_in_kernels,"deprecated in SYCL 2020, use info::device::built_in_kernel_ids instead")
-__SYCL_PARAM_TRAITS_DEPRECATED(profile,"deprecated in SYCL 2020")
-__SYCL_PARAM_TRAITS_DEPRECATED(extensions,"deprecated in SYCL 2020, use info::device::aspects instead")
-__SYCL_PARAM_TRAITS_DEPRECATED(printf_buffer_size,"deprecated in SYCL 2020")
-__SYCL_PARAM_TRAITS_DEPRECATED(preferred_interop_user_sync,"deprecated in SYCL 2020")
-
 // Deprecated and not part of SYCL 2020 spec
 __SYCL_PARAM_TRAITS_DEPRECATED(image_max_array_size,"support for image arrays has been removed in SYCL 2020")
 __SYCL_PARAM_TRAITS_DEPRECATED(opencl_c_version,"use device::get_backend_info instead")
+__SYCL_PARAM_TRAITS_DEPRECATED(atomic64, "use sycl::aspect::atomic64 instead")
 
 //TODO:Remove when possible
 __SYCL_PARAM_TRAITS_DEPRECATED(ext_intel_pci_address,"use ext::intel::info::device::pci_address instead")

--- a/sycl/include/sycl/info/info_desc.hpp
+++ b/sycl/include/sycl/info/info_desc.hpp
@@ -150,6 +150,11 @@ struct atomic_fence_scope_capabilities;
 
 #define __SYCL_PARAM_TRAITS_DEPRECATED(Desc, Message)                          \
   struct __SYCL2020_DEPRECATED(Message) Desc;
+#include <sycl/info/device_traits_2020_deprecated.def>
+#undef __SYCL_PARAM_TRAITS_DEPRECATED
+
+#define __SYCL_PARAM_TRAITS_DEPRECATED(Desc, Message)                          \
+  struct __SYCL_DEPRECATED(Message) Desc;
 #include <sycl/info/device_traits_deprecated.def>
 #undef __SYCL_PARAM_TRAITS_DEPRECATED
 

--- a/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
+++ b/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: windows
 
-// RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc -I%sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
+// RUN: %clangxx -Wno-error=deprecated-declarations --driver-mode=cl /std:c++17 /EHsc -I%sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
 // RUN: %{run} %t.out
 
 // This test checks that if program is linked with version-agnostic import library sycl.lib then sycl program works as expected.

--- a/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
+++ b/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: windows
 
-// RUN: %clangxx -Wno-error=deprecated-declarations --driver-mode=cl /std:c++17 /EHsc -I%sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
+// RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc -isystem %sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
 // RUN: %{run} %t.out
 
 // This test checks that if program is linked with version-agnostic import library sycl.lib then sycl program works as expected.

--- a/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
+++ b/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: windows
 
-// RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc /isystem %sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
+// RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc /imsvc %sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
 // RUN: %{run} %t.out
 
 // This test checks that if program is linked with version-agnostic import library sycl.lib then sycl program works as expected.

--- a/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
+++ b/sycl/test-e2e/Basic/windows_version_agnostic_sycl_lib.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: windows
 
-// RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc -isystem %sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
+// RUN: %clangxx --driver-mode=cl /std:c++17 /EHsc /isystem %sycl_include -I%opencl_include_dir %s -o %t.out /link /defaultlib:%sycl_static_libs_dir/sycl.lib
 // RUN: %{run} %t.out
 
 // This test checks that if program is linked with version-agnostic import library sycl.lib then sycl program works as expected.

--- a/sycl/test-e2e/Config/kernel_from_file.cpp
+++ b/sycl/test-e2e/Config/kernel_from_file.cpp
@@ -14,7 +14,7 @@
 // RUN: %if linux %{ llvm-link -o=%t_app.bc %t.bc %t_compiler_wrappers.bc %t_sanitizer.bc %} %else %{ llvm-link -o=%t_app.bc %t.bc %t_compiler_wrappers.bc %}
 // >> ---- translate to SPIR-V
 // RUN: llvm-spirv -o %t.spv %t_app.bc
-// RUN: %clangxx -Wno-error=ignored-attributes -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option %t.h %s -o %t.out %sycl_options -fno-sycl-dead-args-optimization -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=deprecated-declarations -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option %t.h %s -o %t.out %sycl_options -fno-sycl-dead-args-optimization -Xclang -verify-ignore-unexpected=note,warning
 // RUN: env SYCL_USE_KERNEL_SPV=%t.spv %{run} %t.out | FileCheck %s
 // CHECK: Passed
 

--- a/sycl/test-e2e/Config/kernel_from_file.cpp
+++ b/sycl/test-e2e/Config/kernel_from_file.cpp
@@ -14,7 +14,7 @@
 // RUN: %if linux %{ llvm-link -o=%t_app.bc %t.bc %t_compiler_wrappers.bc %t_sanitizer.bc %} %else %{ llvm-link -o=%t_app.bc %t.bc %t_compiler_wrappers.bc %}
 // >> ---- translate to SPIR-V
 // RUN: llvm-spirv -o %t.spv %t_app.bc
-// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=deprecated-declarations -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option %t.h %s -o %t.out %sycl_options -fno-sycl-dead-args-optimization -Xclang -verify-ignore-unexpected=note,warning
+// RUN: %clangxx -Wno-error=ignored-attributes -isystem %sycl_include -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option %t.h %s -o %t.out %sycl_options -fno-sycl-dead-args-optimization -Xclang -verify-ignore-unexpected=note,warning
 // RUN: env SYCL_USE_KERNEL_SPV=%t.spv %{run} %t.out | FileCheck %s
 // CHECK: Passed
 

--- a/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
+++ b/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
@@ -3,13 +3,13 @@
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...
-// RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict %{mathflags}
+// RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict %{mathflags}
 // RUN: %clangxx %t_host.o %t_device.o -Wno-unused-command-line-argument -o %t.out %sycl_options %{mathflags}
 // RUN: %{run} %t.out
 
 // RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...
-// RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict %{mathflags}
+// RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict %{mathflags}
 // RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -Wno-unused-command-line-argument -o %t_fp64.out %sycl_options %{mathflags}
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
+++ b/sycl/test-e2e/DeviceLib/separate_compile_test.cpp
@@ -3,13 +3,13 @@
 // RUN: %clangxx -fsycl -fsycl-link %S/std_complex_math_test.cpp -o %t_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_test_ihdr.h %S/std_complex_math_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...
-// RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict %{mathflags}
+// RUN: %clangxx -Wno-error=unused-command-line-argument -isystem %sycl_include -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_test_ihdr.h -c %S/std_complex_math_test.cpp -o %t_host.o %sycl_options -Wno-sycl-strict %{mathflags}
 // RUN: %clangxx %t_host.o %t_device.o -Wno-unused-command-line-argument -o %t.out %sycl_options %{mathflags}
 // RUN: %{run} %t.out
 
 // RUN: %clangxx -fsycl -fsycl-link  %S/std_complex_math_fp64_test.cpp -o %t_fp64_device.o %{mathflags}
 // RUN: %clangxx -fsycl-device-only -Xclang -fsycl-int-header=std_complex_math_fp64_test_ihdr.h %S/std_complex_math_fp64_test.cpp -Wno-sycl-strict %{mathflags}
 // >> host compilation...
-// RUN: %clangxx -Wno-error=unused-command-line-argument -Wno-error=deprecated-declarations -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict %{mathflags}
+// RUN: %clangxx -Wno-error=unused-command-line-argument -isystem %sycl_include -Wno-error=ignored-attributes %cxx_std_optionc++17 %include_option std_complex_math_fp64_test_ihdr.h -c %S/std_complex_math_fp64_test.cpp -o %t_fp64_host.o %sycl_options -Wno-sycl-strict %{mathflags}
 // RUN: %clangxx %t_fp64_host.o %t_fp64_device.o -Wno-unused-command-line-argument -o %t_fp64.out %sycl_options %{mathflags}
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/SeparateCompile/test.cpp
+++ b/sycl/test-e2e/SeparateCompile/test.cpp
@@ -8,13 +8,13 @@
 // >> device compilation...
 // RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT -fno-sycl-dead-args-optimization -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -o a_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
+// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=deprecated-declarations -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
 // RUN: %clangxx -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 -fno-sycl-dead-args-optimization -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -o b_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 %cxx_std_optionc++17 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
+// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=deprecated-declarations -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 %cxx_std_optionc++17 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
 //
 // >> ---- bundle .o with .spv
 // >> run bundler

--- a/sycl/test-e2e/SeparateCompile/test.cpp
+++ b/sycl/test-e2e/SeparateCompile/test.cpp
@@ -8,13 +8,13 @@
 // >> device compilation...
 // RUN: %clangxx -DSYCL_DISABLE_FALLBACK_ASSERT -fno-sycl-dead-args-optimization -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_a.h %s -o a_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=deprecated-declarations -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
+// RUN: %clangxx -Wno-error=ignored-attributes -isystem %sycl_include -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT %cxx_std_optionc++17 %include_option sycl_ihdr_a.h %debug_option -c %s -o a.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
 //
 // >> ---- compile src2
 // >> device compilation...
 // RUN: %clangxx -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 -fno-sycl-dead-args-optimization -fsycl-device-only -Xclang -fsycl-int-header=sycl_ihdr_b.h %s -o b_kernel.bc -Wno-sycl-strict
 // >> host compilation...
-// RUN: %clangxx -Wno-error=ignored-attributes -Wno-error=deprecated-declarations -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 %cxx_std_optionc++17 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
+// RUN: %clangxx -Wno-error=ignored-attributes -isystem %sycl_include -Wno-error=unused-command-line-argument -DSYCL_DISABLE_FALLBACK_ASSERT -DB_CPP=1 %cxx_std_optionc++17 %include_option sycl_ihdr_b.h %debug_option -c %s -o b.o %sycl_options -fno-sycl-dead-args-optimization -Wno-sycl-strict
 //
 // >> ---- bundle .o with .spv
 // >> run bundler

--- a/sycl/test/include_deps/sycl_accessor.hpp.cpp
+++ b/sycl/test/include_deps/sycl_accessor.hpp.cpp
@@ -97,6 +97,7 @@
 // CHECK-NEXT: ext/oneapi/matrix/matrix-unified-utils.hpp
 // CHECK-NEXT: info/platform_traits.def
 // CHECK-NEXT: info/context_traits.def
+// CHECK-NEXT: info/device_traits_2020_deprecated.def
 // CHECK-NEXT: info/device_traits_deprecated.def
 // CHECK-NEXT: info/device_traits.def
 // CHECK-NEXT: info/queue_traits.def

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -98,6 +98,7 @@
 // CHECK-NEXT: ext/oneapi/matrix/matrix-unified-utils.hpp
 // CHECK-NEXT: info/platform_traits.def
 // CHECK-NEXT: info/context_traits.def
+// CHECK-NEXT: info/device_traits_2020_deprecated.def
 // CHECK-NEXT: info/device_traits_deprecated.def
 // CHECK-NEXT: info/device_traits.def
 // CHECK-NEXT: info/queue_traits.def

--- a/sycl/test/warnings/warnings_deprecated.cpp
+++ b/sycl/test/warnings/warnings_deprecated.cpp
@@ -1,0 +1,11 @@
+// RUN: %clangxx -fsycl -sycl-std=2020 -fsycl-device-only -Xclang -verify -Xclang -verify-ignore-unexpected=note %s -fsyntax-only -Wall -Wextra
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+int main() {
+  // expected-warning@+1{{'atomic64' is deprecated: use sycl::aspect::atomic64 instead}}
+  sycl::info::device::atomic64 atomic_64;
+  (void)atomic_64;
+  return 0;
+}


### PR DESCRIPTION
1. A separate .def file was created for deprecated features that are not part of SYCL 2020 spec
2. info::device::atomic64 was deprecated
3. Test for  info::device::atomic64 deprecated was added into separate file due to -Wno-deprecated-declarations flag in warnings.cpp tests file.