### PR TITLE
[SYCL][E2E] XFAIL test failing on AMD HIP

### DIFF
--- a/sycl/test-e2e/DeviceImageDependencies/free_function_kernels.cpp
+++ b/sycl/test-e2e/DeviceImageDependencies/free_function_kernels.cpp
@@ -7,6 +7,9 @@
 // The name mangling for free function kernels currently does not work with PTX.
 // UNSUPPORTED: cuda
 
+// XFAIL: hip_amd
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15742
+
 #include <iostream>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/free_function_queries.hpp>


### PR DESCRIPTION
I finally got us a working AMDGPU runner. This test consistently fails and is the only failure. 

With this change we should be able to get all green postcommit CI since what seems like forever.

Ex [here](https://github.com/intel/llvm/actions/runs/11385190600/job/31674912072)