### PR TITLE
[SYCL][E2E] Use `/clang:` flag on test failing on MSVC driver

### DIFF
--- a/sycl/test-e2e/syclcompat/launch/kernel_properties.cpp
+++ b/sycl/test-e2e/syclcompat/launch/kernel_properties.cpp
@@ -23,7 +23,7 @@
 // We need hardware which can support at least 2 sub-group sizes, since that
 // hardware (presumably) supports the `intel_reqd_sub_group_size` attribute.
 // REQUIRES: sg-32 && sg-16
-// RUN: %{build} -S -emit-llvm -o - | FileCheck %s
+// RUN: %{build} %if cl_options %{/clang:-S /clang:-emit-llvm%} %else %{-S -emit-llvm%} -o - | FileCheck %s
 
 #include <sycl/ext/oneapi/kernel_properties/properties.hpp>
 #include <sycl/detail/core.hpp>


### PR DESCRIPTION
Fixing the options for another test that slipped through the cracks of #15364 