### PR TITLE
[Driver][SYCL] do not pass along HEX values to -device_options

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1081,7 +1081,9 @@ static bool hasPVCDevice(const ArgStringList &CmdArgs, std::string &DevArg) {
       for (int HexVal : PVCDevices[I].HexValues) {
         int Value = 0;
         if (!SingleArg.getAsInteger(0, Value) && Value == HexVal) {
-          DevArg = SingleArg.str();
+          // TODO: Pass back the hex string to use for -device_options when
+          // IGC is updated to allow.  Currently -device_options only accepts
+          // the device ID (i.e. pvc) or the version (12.60.7).
           return true;
         }
       }

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode-old-model.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode-old-model.cpp
@@ -22,7 +22,7 @@
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 0x0BD5" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=0x0BD5
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --no-offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 12.60.7" %s 2>&1 \

--- a/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
+++ b/clang/test/Driver/sycl-ftarget-register-alloc-mode.cpp
@@ -22,7 +22,7 @@
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 0x0BD5" %s 2>&1 \
-// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=0x0BD5
+// RUN:   | FileCheck %if system-windows %{ -check-prefix=DEFAULT_AOT %} %else %{ -check-prefix=AUTO_AOT %} %s -DDEVICE=pvc
 
 // RUN: %clang -### -fsycl --offload-new-driver \
 // RUN:    -fsycl-targets=spir64_gen -Xs "-device 12.60.7" %s 2>&1 \


### PR DESCRIPTION
The use of ocloc -device_options arg only allows for the arg to be a device ID or a version value.