### PR TITLE
[opencl-aot][sycl][CMake][MSVC]: Wrap Linker flags for ICX

### DIFF
--- a/opencl/opencl-aot/CMakeLists.txt
+++ b/opencl/opencl-aot/CMakeLists.txt
@@ -14,7 +14,7 @@ add_llvm_tool(${OPENCL_AOT_PROJECT_NAME} ${TARGET_SOURCES})
 
 if (WIN32)
   # 0x2000: exclude CWD from DLL loading path
-  target_link_options(${OPENCL_AOT_PROJECT_NAME} PRIVATE "/DEPENDENTLOADFLAG:0x2000")
+  target_link_options(${OPENCL_AOT_PROJECT_NAME} PRIVATE "LINKER:/DEPENDENTLOADFLAG:0x2000")
 endif()
 
 if(NOT MSVC)

--- a/sycl/cmake/modules/SYCLUtils.cmake
+++ b/sycl/cmake/modules/SYCLUtils.cmake
@@ -7,11 +7,11 @@ include(CheckLinkerFlag)
 # file as ${ARG_TARGET_NAME}.pdb in bin folder.
 # NOTE: LLD does not currently support /PDBSTRIPPED so the PDB file is optional.
 macro(add_stripped_pdb ARG_TARGET_NAME)
-  check_linker_flag(CXX "/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb"
+  check_linker_flag(CXX "LINKER:/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb"
                          LINKER_SUPPORTS_PDBSTRIPPED)
   if(LINKER_SUPPORTS_PDBSTRIPPED)
     target_link_options(${ARG_TARGET_NAME}
-                        PRIVATE "/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb")
+                        PRIVATE "LINKER:/PDBSTRIPPED:${ARG_TARGET_NAME}.stripped.pdb")
     install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${ARG_TARGET_NAME}.stripped.pdb"
             DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
             RENAME "${ARG_TARGET_NAME}.pdb"

--- a/sycl/source/CMakeLists.txt
+++ b/sycl/source/CMakeLists.txt
@@ -84,7 +84,7 @@ function(add_sycl_rt_library LIB_NAME LIB_OBJ_NAME)
     # Embed manifest into the sycl.dll where ur_win_proxy_loader.dll is described as sycl.dll's private dll and will always be loaded from the same directory.
     # 0x2000: LOAD_LIBRARY_SAFE_CURRENT_DIRS flag. Using this flag means that loading dependency DLLs (of sycl.dll)
     # from the current directory is only allowed if it is under a directory in the Safe load list.
-    target_link_options(${LIB_NAME} PRIVATE /DEPENDENTLOADFLAG:0x2000 /MANIFEST:NO /MANIFEST:EMBED /MANIFESTINPUT:${CMAKE_CURRENT_SOURCE_DIR}/${MANIFEST_FILE_NAME})
+    target_link_options(${LIB_NAME} PRIVATE "LINKER:/DEPENDENTLOADFLAG:0x2000" "LINKER:/MANIFEST:NO" "LINKER:/MANIFEST:EMBED" "LINKER:/MANIFESTINPUT:${CMAKE_CURRENT_SOURCE_DIR}/${MANIFEST_FILE_NAME}")
   endif()
 
   target_compile_definitions(${LIB_OBJ_NAME} PRIVATE __SYCL_INTERNAL_API )

--- a/sycl/tools/sycl-ls/CMakeLists.txt
+++ b/sycl/tools/sycl-ls/CMakeLists.txt
@@ -19,7 +19,7 @@ target_link_libraries(sycl-ls
 )
 if (WIN32)
   # 0x900: Search for the dependency DLLs only in the System32 directory and in the directory with sycl-ls.exe
-  target_link_options(sycl-ls PRIVATE /DEPENDENTLOADFLAG:0x900)
+  target_link_options(sycl-ls PRIVATE LINKER:/DEPENDENTLOADFLAG:0x900)
 endif()
 install(TARGETS sycl-ls
   RUNTIME DESTINATION "bin" COMPONENT sycl-ls)

--- a/sycl/ur_win_proxy_loader/CMakeLists.txt
+++ b/sycl/ur_win_proxy_loader/CMakeLists.txt
@@ -60,8 +60,8 @@ if (MSVC)
   target_link_libraries(ur_win_proxy_loader PRIVATE shlwapi)
   # 0x2000: LOAD_LIBRARY_SAFE_CURRENT_DIRS flag. Using this flag means that loading dependency DLLs
   # from the current directory is only allowed if it is under a directory in the Safe load list.
-  target_link_options(ur_win_proxy_loaderd PRIVATE /DEPENDENTLOADFLAG:0x2000)
-  target_link_options(ur_win_proxy_loader PRIVATE /DEPENDENTLOADFLAG:0x2000)
+  target_link_options(ur_win_proxy_loaderd PRIVATE LINKER:/DEPENDENTLOADFLAG:0x2000)
+  target_link_options(ur_win_proxy_loader PRIVATE LINKER:/DEPENDENTLOADFLAG:0x2000)
   install(TARGETS ur_win_proxy_loaderd
     RUNTIME DESTINATION "bin" COMPONENT ur_win_proxy_loader)
 endif()


### PR DESCRIPTION
From CMake 3.25+ linker options need to be wrapped for ICX on Windows. Use the `LINKER:` prefix, which expands to the correct option for ICX, and for the empty string for MSVC or clang-cl.

See also LLVM RFC: https://discourse.llvm.org/t/rfc-cmake-linker-flags-need-wl-equivalent-for-intel-c-icx-on-windows/82446

Fixes: #15755