### PR TITLE
[Driver][SYCL] Fix crash with empty -fsycl-targets option

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1502,18 +1502,13 @@ static void parseTargetOpts(StringRef ArgString, const llvm::opt::ArgList &Args,
 void SYCLToolChain::TranslateGPUTargetOpt(const llvm::opt::ArgList &Args,
                                           llvm::opt::ArgStringList &CmdArgs,
                                           OptSpecifier Opt_EQ) const {
-  for (auto *A : Args) {
-    if (A->getOption().matches(Opt_EQ)) {
-      if (auto GpuDevice =
-              tools::SYCL::gen::isGPUTarget<tools::SYCL::gen::AmdGPU>(
-                  A->getValue())) {
-        StringRef ArgString;
-        SmallString<64> OffloadArch("--offload-arch=");
-        OffloadArch += GpuDevice->data();
-        ArgString = OffloadArch;
-        parseTargetOpts(ArgString, Args, CmdArgs);
-        A->claim();
-      }
+  if (const Arg *TargetArg = Args.getLastArg(Opt_EQ)) {
+    StringRef Val = TargetArg->getValue();
+    if (auto GpuDevice =
+            tools::SYCL::gen::isGPUTarget<tools::SYCL::gen::AmdGPU>(Val)) {
+      SmallString<64> OffloadArch("--offload-arch=");
+      OffloadArch += GpuDevice->data();
+      parseTargetOpts(OffloadArch, Args, CmdArgs);
     }
   }
 }

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -107,4 +107,6 @@
 
 /// Compilation checks to make sure an early empty -fsycl-targets does not
 /// crash.
-// RUN: %clangxx -### -fsycl -fsycl-targets= -fsycl-targets=spir64 %s
+// RUN: %clangxx -### -fsycl -fsycl-targets= -fsycl-targets=spir64 %s 2>&1 \
+// RUN:  | FileCheck %s -check-prefix=CHECK_SPIR64
+// CHECK_SPIR64: clang{{.*}} "-cc1" "-triple" "spir64-unknown-unknown"{{.*}} "-fsycl-is-device"

--- a/clang/test/Driver/sycl-offload.cpp
+++ b/clang/test/Driver/sycl-offload.cpp
@@ -104,3 +104,7 @@
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-NOT: clang{{.*}} "-cc1" "-triple x86_64-unknown-linux-gnu" {{.*}} "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-DAG: clang{{.*}} "-cc1" "-triple" "spir64_gen{{.*}}" "-fsycl-fp64-conv-emu"
 // CHECK_FSYCL_FP64_CONV_EMU_WIN-DAG: clang-offload-packager{{.*}} "--image=file={{.*}}.bc,triple=spir64_gen-unknown-unknown,arch=,kind=sycl,compile-opts={{.*}}-options -ze-fp64-gen-conv-emu{{.*}}"
+
+/// Compilation checks to make sure an early empty -fsycl-targets does not
+/// crash.
+// RUN: %clangxx -### -fsycl -fsycl-targets= -fsycl-targets=spir64 %s


### PR DESCRIPTION
When -fsycl-targets= -fsycl-targets=arg is passed on the command line, the empty -fsycl-targets= is processed and crashes due to the empty argument.  Update the specific option parsing to use 'getLastArg' to avoid this situation.  When the last arg has an empty argument, the driver will diagnose this situation and emit a friendly diagnostic.