### PR TITLE
[Driver][SYCL] Use only PATH when searching for user host compiler

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5194,7 +5194,10 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   if (HostCompilerDefArg) {
     ExecPath = HostCompilerDefArg->getValue();
     if (!ExecPath.empty() && ExecPath == llvm::sys::path::stem(ExecPath))
-      ExecPath = TC.GetProgramPath(ExecPath.c_str());
+      // Use PATH to find executable.
+      if (llvm::ErrorOr<std::string> Prog =
+              llvm::sys::findProgramByName(ExecPath))
+        ExecPath = *Prog;
   }
 
   // Add any user-specified arguments.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -5194,7 +5194,7 @@ void Clang::ConstructHostCompilerJob(Compilation &C, const JobAction &JA,
   if (HostCompilerDefArg) {
     ExecPath = HostCompilerDefArg->getValue();
     if (!ExecPath.empty() && ExecPath == llvm::sys::path::stem(ExecPath))
-      // Use PATH to find executable.
+      // Use PATH to find executable passed in from -fsycl-host-compiler.
       if (llvm::ErrorOr<std::string> Prog =
               llvm::sys::findProgramByName(ExecPath))
         ExecPath = *Prog;

--- a/clang/test/Driver/sycl-host-compiler-old-model.cpp
+++ b/clang/test/Driver/sycl-host-compiler-old-model.cpp
@@ -94,7 +94,7 @@
 /// Test to verify binary from PATH is used
 // RUN: rm -rf %t && mkdir -p %t/test_path
 // RUN: touch %t/test_path/clang++ && chmod +x %t/test_path/clang++
-// RUN: env PATH=%t/test_path \
+// RUN: env "PATH=%t/test_path%{pathsep}%PATH%" \
 // RUN: %clangxx -### -fsycl -fsycl-host-compiler=clang++ \
 // RUN:   -fsycl-host-compiler-options=-DDUMMY_OPT --no-offload-new-driver \
 // RUN:   %s 2>&1 \

--- a/clang/test/Driver/sycl-host-compiler-old-model.cpp
+++ b/clang/test/Driver/sycl-host-compiler-old-model.cpp
@@ -90,3 +90,13 @@
 // CHECK_SAVE_TEMPS-NEXT: g++{{.*}} "[[APPEND_CPP]]" "-c"
 // CHECK_SAVE_TEMPS-SAME: "-o" "[[HOST_OBJ:.+\.o]]"
 // CHECK_SAVE_TEMPS-NEXT: clang-offload-bundler{{.*}} "-input=[[DEVICE_BC]]" "-input=[[HOST_OBJ]]"
+
+/// Test to verify binary from PATH is used
+// RUN: rm -rf %t && mkdir -p %t/test_path
+// RUN: touch %t/test_path/clang++ && chmod +x %t/test_path/clang++
+// RUN: env PATH=%t/test_path \
+// RUN: %clangxx -### -fsycl -fsycl-host-compiler=clang++ \
+// RUN:   -fsycl-host-compiler-options=-DDUMMY_OPT --no-offload-new-driver \
+// RUN:   %s 2>&1 \
+// RUN: | FileCheck -check-prefix=PATH_CHECK %s
+// PATH_CHECK: {{(/|\\\\)}}test_path{{(/|\\\\)}}clang++{{.*}} "-DDUMMY_OPT"


### PR DESCRIPTION
When using -fsycl-host-compiler, be sure that we only use the available PATH settings to find the compiler given (if given without a full PATH qualifier).  This allows for only known locations to be searched for the given compiler instead of possible internal settings unknown to the user.