### PR TITLE
[SYCL] Update the test

### DIFF
--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
@@ -222,7 +222,8 @@ template <typename T> bool test() {
     for (unsigned i = 0; i < N; ++i) {
       std::complex<T> r = acc[i];
       // If z is (+/-0, +0), the result is (1, +0)
-      if (testcases[i].real() == 0 && testcases[i].imag() == 0) {
+      if (testcases[i].real() == 0 && testcases[i].imag() == 0 &&
+          !std::signbit(testcases[i].imag())) {
         CHECK(r.real() == 1.0, passed, i);
         CHECK(r.imag() == 0, passed, i);
         CHECK(std::signbit(testcases[i].imag()) == std::signbit(r.imag()),

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
@@ -291,6 +291,7 @@ template <typename T> bool test() {
         CHECK(!std::signbit(r.real()), passed, i);
 // TODO: This case fails on win. Need to investigate and remove this macro
 // check.
+// CMPLRLLVM-62905
 #ifndef _WIN32
         CHECK(std::signbit(r.imag()) == std::signbit(testcases[i].imag()),
               passed, i);


### PR DESCRIPTION
test-e2e/DeviceLib/exp/exp-std-complex-double-edge-cases.hpp

Removed redundant info, fixed the device code input data, turned off one case for win