### PR TITLE
[SYCL][E2E] Disable some USM tests on HIP AMD

### DIFF
--- a/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_dhost_to_shared.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_host_to_shared.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_dhost.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/copy2d_shared_to_host.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "copy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_dhost_to_shared.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_host_to_shared.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "memcpy2d_common.hpp"
 

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_dhost.cpp
@@ -11,7 +11,7 @@
 // RUN: %{run} %t.out
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 // Temporarily disabled until the failure is addressed.
 // UNSUPPORTED: (level_zero && windows)

--- a/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
+++ b/sycl/test-e2e/USM/memops2d/memcpy2d_shared_to_host.cpp
@@ -14,7 +14,7 @@
 // UNSUPPORTED: (level_zero && windows)
 
 // https://github.com/intel/llvm/issues/15648
-// UNSUPPORTED: gpu-intel-dg2 && linux
+// UNSUPPORTED: (gpu-intel-dg2 || hip_amd) && linux
 
 #include "memcpy2d_common.hpp"
 


### PR DESCRIPTION
These tests fail sporadically on HIP, as well as DG2. I've updated the [issue](https://github.com/intel/llvm/issues/15648) to track the HIP failures too.

Examples:
https://github.com/intel/llvm/actions/runs/11438947494/job/31821989889

https://github.com/intel/llvm/actions/runs/11434776085/job/31809454917