### PR TITLE
[SYCL][E2E] Change UNSUPPORTED to XFAIL in two SubGroup tests

### DIFF
--- a/sycl/test-e2e/SubGroup/attributes.cpp
+++ b/sycl/test-e2e/SubGroup/attributes.cpp
@@ -1,9 +1,9 @@
-// UNSUPPORTED: accelerator
-// TODO: FPGAs currently report supported subgroups as {4,8,16,32,64}, causing
-// this test to fail
-// UNSUPPORTED: cuda || hip
-// TODO: Device subgroup sizes reports {32}, but when we try to use it with a
-// kernel attribute and check it, we get a subgroup size of 0.
+// TODO: Despite using a supported required subgroup size compile_sub_group_size 
+// reports as 0 on fpga emu, cuda and hip
+// XFAIL: accelerator
+// XFAIL-TRACKER: URT-697
+// XFAIL: cuda || hip
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14357
 
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/SubGroup/info.cpp
+++ b/sycl/test-e2e/SubGroup/info.cpp
@@ -1,7 +1,6 @@
-// UNSUPPORTED: accelerator
-// TODO: FPGAs currently report supported subgroups as {4,8,16,32,64}, causing
-// this test to fail. Additionally, the kernel max_sub_group_size checks
-// crash on FPGAs
+// TODO: fpga emu crashes when querying sub_group_independent_forward_progress
+// XFAIL: accelerator
+// XFAIL-TRACKER: URT-697
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
@@ -20,21 +19,7 @@ using namespace sycl;
 int main() {
   queue Queue;
   device Device = Queue.get_device();
-
-  bool old_opencl = false;
-  if (Device.get_backend() == sycl::backend::opencl) {
-    // Extract the numerical version from the version string, OpenCL version
-    // string have the format "OpenCL <major>.<minor> <vendor specific data>".
-    std::string ver = Device.get_info<info::device::version>().substr(7, 3);
-    old_opencl = (ver < "2.1");
-  }
-
-  /* Check info::device parameters. */
-  if (!old_opencl) {
-    // Independent forward progress is missing on OpenCL backend prior to
-    // version 2.1
-    Device.get_info<info::device::sub_group_independent_forward_progress>();
-  }
+  Device.get_info<info::device::sub_group_independent_forward_progress>();
   Device.get_info<info::device::max_num_sub_groups>();
 
   try {


### PR DESCRIPTION
The failures related to these two tests were masked due to using unsupported rather than xfail.

This patch also removes the check for OpenCL version before querying `sub_group_independent_forward_progress`, as it masks the failure on the fpga emulator device.