### PR TITLE
[SYCL][Joint Matrix][E2E] Remove xfail from Joint Matrix runtime dimension tests

### DIFF
--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: aspect-ext_intel_matrix
-// XFAIL: arch-intel_gpu_pvc
 
 // RUN: %{build} -o %t_arg_dim_vnni.out %fp-model-precise -DARG_DIM -DVNNI
 // RUN: %{run} %t_arg_dim_vnni.out

--- a/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
+++ b/sycl/test-e2e/Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
@@ -6,7 +6,6 @@
 //
 //===----------------------------------------------------------------------===//
 // REQUIRES: aspect-ext_intel_matrix
-// XFAIL: arch-intel_gpu_pvc
 
 // RUN: %{build} -o %t_runtime_dim_vnni.out %fp-model-precise -DRUNTIME_DIM -DVNNI
 // RUN: %{run} %t_runtime_dim_vnni.out 256

--- a/sycl/test/no-xfail-without-tracker.cpp
+++ b/sycl/test/no-xfail-without-tracker.cpp
@@ -50,7 +50,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 159
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 157
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been propely XFAIL-ed.
@@ -169,8 +169,6 @@
 // CHECK-NEXT: Matrix/SPVCooperativeMatrix/joint_matrix_su_int8.cpp
 // CHECK-NEXT: Matrix/SPVCooperativeMatrix/joint_matrix_us_int8.cpp
 // CHECK-NEXT: Matrix/SPVCooperativeMatrix/joint_matrix_uu_int8.cpp
-// CHECK-NEXT: Matrix/joint_matrix_bf16_fill_k_cache_arg_dim.cpp
-// CHECK-NEXT: Matrix/joint_matrix_bf16_fill_k_cache_runtime_dim.cpp
 // CHECK-NEXT: Matrix/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
 // CHECK-NEXT: Matrix/joint_matrix_colA_rowB_colC.cpp
 // CHECK-NEXT: Matrix/joint_matrix_int8_colmajorA_colmajorB.cpp


### PR DESCRIPTION
Description: 
The failure of the tests joint_matrix_bf16_fill_k_cache_arg_dim.cpp and joint_matrix_bf16_fill_k_cache_runtime_dim.cpp has been addressed in commit https://github.com/intel/intel-graphics-compiler/commit/92236dc2d0c769b97ba3700b361652013b2cf1c8. The commit solves the issue by changing the Acc 32x64 and Acc 32x32 matrix types from using the array type [2 x <float x 64>] to a structure type { <float x 64>, <float x 64> }