### PR TITLE
[SYCL][E2E] Remove use of deprecated device selectors in FilterSelector tests

### DIFF
--- a/sycl/test-e2e/FilterSelector/select_device.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device.cpp
@@ -29,34 +29,29 @@ int main() {
   }
   if (!envVal.empty() || forcedPIs == "*" ||
       forcedPIs.find("level_zero:gpu") != std::string::npos) {
-    default_selector ds;
-    device d = ds.select_device();
+    device d(default_selector_v);
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("Level-Zero") != string::npos);
   }
   if (envVal.empty() && forcedPIs != "*" &&
       forcedPIs.find("opencl:gpu") != std::string::npos) {
-    gpu_selector gs;
-    device d = gs.select_device();
+    device d(gpu_selector_v);
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("OpenCL") != string::npos);
   }
   if (!envVal.empty() || forcedPIs == "*" ||
       forcedPIs.find("cpu") != std::string::npos) {
-    cpu_selector cs;
-    device d = cs.select_device();
+    device d(cpu_selector_v);
   }
   if (!envVal.empty() || forcedPIs == "*" ||
       forcedPIs.find("fpga") != std::string::npos) {
-    accelerator_selector as;
-    device d = as.select_device();
+    device d(accelerator_selector_v);
   }
   if (envVal.empty() && (forcedPIs.find("cpu") == std::string::npos &&
                          forcedPIs.find("opencl") == std::string::npos &&
                          forcedPIs.find("*") == std::string::npos)) {
     try {
-      cpu_selector cs;
-      device d = cs.select_device();
+      device d(cpu_selector_v);
     } catch (...) {
       return 0; // expected
     }

--- a/sycl/test-e2e/FilterSelector/select_device_opencl.cpp
+++ b/sycl/test-e2e/FilterSelector/select_device_opencl.cpp
@@ -23,26 +23,22 @@ int main() {
   }
 
   {
-    default_selector ds;
-    device d = ds.select_device();
+    device d(default_selector_v);
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("OpenCL") != string::npos &&
-           "default_selector failed to find an opencl device");
+           "default_selector_v failed to find an opencl device");
   }
   {
-    gpu_selector gs;
-    device d = gs.select_device();
+    device d(gpu_selector_v);
     string name = d.get_platform().get_info<info::platform::name>();
     assert(name.find("OpenCL") != string::npos &&
-           "gpu_selector failed to find an opencl device");
+           "gpu_selector_v failed to find an opencl device");
   }
   {
-    cpu_selector cs;
-    device d = cs.select_device();
+    device d(cpu_selector_v);
   }
   {
-    accelerator_selector as;
-    device d = as.select_device();
+    device d(accelerator_selector_v);
   }
 
   return 0;


### PR DESCRIPTION
Use new device selector callables, instead of deprecated device selector objects.

These tests do not run on CI because they require multiple devices, so they were missed by the addition of `-Werror` to e2e tests.