### PR TITLE
[SYCL][E2E] Fix VirtualMem tests

### DIFF
--- a/sycl/test-e2e/VirtualMem/vector_with_virtual_mem.cpp
+++ b/sycl/test-e2e/VirtualMem/vector_with_virtual_mem.cpp
@@ -1,4 +1,4 @@
-// REQUIRES: aspect-ext_oneapi_virtual_mem, usm_shared_allocations
+// REQUIRES: aspect-ext_oneapi_virtual_mem, aspect-usm_shared_allocations
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
@@ -16,8 +16,8 @@ namespace syclext = sycl::ext::oneapi::experimental;
 // value can be used for aligning both physical memory allocations and for
 // reserving virtual memory ranges.
 size_t GetLCMGranularity(const sycl::device &Dev, const sycl::context &Ctx) {
-  size_t CtxGranularity = syclext::get_mem_granularity(MContext);
-  size_t DevGranularity = syclext::get_mem_granularity(MDevice, MContext);
+  size_t CtxGranularity = syclext::get_mem_granularity(Ctx);
+  size_t DevGranularity = syclext::get_mem_granularity(Dev, Ctx);
 
   size_t GCD = CtxGranularity;
   size_t Rem = DevGranularity % GCD;
@@ -25,7 +25,7 @@ size_t GetLCMGranularity(const sycl::device &Dev, const sycl::context &Ctx) {
     std::swap(GCD, Rem);
     Rem %= GCD;
   }
-  return (DevGranularity / GCD) * LCMGranularity;
+  return (DevGranularity / GCD) * CtxGranularity;
 }
 
 template <typename T> class VirtualVector {


### PR DESCRIPTION
Fixed compilation issues with the test and re-enabled it: `usm_shared_allocations` aspect requirement was not spelled correctly and therefore the test was always skipped