### PR TITLE
[SYCL][COMPAT] Specialize reverse_bits for nvptx

### DIFF
--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -162,9 +162,11 @@ template <typename T> inline T reverse_bits(T a) {
   static_assert(std::is_unsigned<T>::value && std::is_integral<T>::value,
                 "unsigned integer required");
 #if defined(__NVPTX__)
-  unsigned result;
-  asm volatile("brev.b32 %0, %1;" : "=r"(result) : "r"(a));
-  return result;
+  if constexpr (sizeof(T) == 4) {
+    unsigned result;
+    asm volatile("brev.b32 %0, %1;" : "=r"(result) : "r"(a));
+    return result;
+  }
 #endif // __NVPTX__
   if (!a)
     return 0;

--- a/sycl/include/syclcompat/util.hpp
+++ b/sycl/include/syclcompat/util.hpp
@@ -161,6 +161,11 @@ inline double cast_ints_to_double(int high32, int low32) {
 template <typename T> inline T reverse_bits(T a) {
   static_assert(std::is_unsigned<T>::value && std::is_integral<T>::value,
                 "unsigned integer required");
+#if defined(__NVPTX__)
+  unsigned result;
+  asm volatile("brev.b32 %0, %1;" : "=r"(result) : "r"(a));
+  return result;
+#endif // __NVPTX__
   if (!a)
     return 0;
   T mask = 0;


### PR DESCRIPTION
This uses a ptx instruction to specialize `syclcompat::bit_reverse` for NVPTX backend.