### PR TITLE
[SYCL][libdevice] Fix complex exp corner cases on Windows

### DIFF
--- a/libdevice/cmath_wrapper_fp64.cpp
+++ b/libdevice/cmath_wrapper_fp64.cpp
@@ -394,9 +394,9 @@ short _Exp(double *px, double y,
   _Dconst _Inf = {INIT(_DMAX << _DOFF)};
   short ret = 0;
   if (*px < -HUGE_EXP || y == 0.0) // certain underflow
-    *px = 0.0;
+    *px = __spirv_ocl_copysign(0.0, y);
   else if (HUGE_EXP < *px) { // certain overflow
-    *px = _Inf._Double * (y < 0.F ? -1.F : 1.F);
+    *px = __spirv_ocl_copysign(_Inf._Double, y);
     ret = _INFCODE;
   } else { // xexp won't overflow
     double g = *px * invln2;

--- a/libdevice/msvc_math.cpp
+++ b/libdevice/msvc_math.cpp
@@ -193,9 +193,9 @@ short _FExp(float *px, float y,
   static const float invln2 = 1.4426950408889634073599246810018921F;
   short ret = 0;
   if (*px < -hugexp || y == 0.0F) { // certain underflow
-    *px = 0.0F;
+    *px = __spirv_ocl_copysign(0.0F, y);
   } else if (hugexp < *px) { // certain overflow
-    *px = _FInf._Float * (y < 0.F ? -1.F : 1.F);
+    *px = __spirv_ocl_copysign(_FInf._Float, y);
     ret = _INFCODE;
   } else { // xexp won't overflow
     float g = *px * invln2;

--- a/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
+++ b/sycl/test-e2e/DeviceLib/exp/exp-std-complex-edge-cases.hpp
@@ -290,13 +290,8 @@ template <typename T> bool test() {
       } else if (std::isfinite(testcases[i].imag()) &&
                  std::abs(testcases[i].imag()) <= 1) {
         CHECK(!std::signbit(r.real()), passed, i);
-// TODO: This case fails on win. Need to investigate and remove this macro
-// check.
-// CMPLRLLVM-62905
-#ifndef _WIN32
         CHECK(std::signbit(r.imag()) == std::signbit(testcases[i].imag()),
               passed, i);
-#endif
         // Those tests were taken from oneDPL, not sure what is the corner case
         // they are covering here
       } else if (std::isinf(r.real()) && testcases[i].imag() == 0) {


### PR DESCRIPTION
Currently, some corner case test is disabled in exp complex edge test due to some bug in _Exp util function in libdevice, this PR fixes it.