### PR TITLE
[SYCL][Graph] Reduce data sizes of some graph E2E tests

### DIFF
--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_host2target_2d.cpp
@@ -3,22 +3,26 @@
 
 #include "../graph_common.hpp"
 
+#include <cmath>
+
 int main() {
   queue Queue{};
 
   using T = int;
 
-  std::vector<T> DataA(Size * Size), DataB(Size * Size);
+  const size_t SizeX = std::sqrt(Size);
+  const size_t SizeY = SizeX;
+  std::vector<T> DataA(Size), DataB(Size);
   std::iota(DataA.begin(), DataA.end(), 1);
   std::iota(DataB.begin(), DataB.end(), 1000);
 
   std::vector<T> ReferenceA(DataA);
-  for (size_t i = 0; i < Size * Size; i++) {
+  for (size_t i = 0; i < Size; i++) {
     ReferenceA[i] = DataB[i];
   }
 
   // Make the buffers 2D so we can test the rect write path
-  buffer BufferA{DataA.data(), range<2>(Size, Size)};
+  buffer BufferA{DataA.data(), range<2>(SizeX, SizeY)};
   BufferA.set_write_back(false);
 
   {
@@ -37,9 +41,9 @@ int main() {
   }
   host_accessor HostAccA(BufferA);
 
-  for (size_t i = 0; i < Size; i++) {
-    for (size_t j = 0; j < Size; j++) {
-      const size_t index = i * Size + j;
+  for (size_t i = 0; i < SizeX; i++) {
+    for (size_t j = 0; j < SizeY; j++) {
+      const size_t index = i * SizeY + j;
       assert(check_value(index, ReferenceA[index], HostAccA[i][j], "HostAccA"));
     }
   }

--- a/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
+++ b/sycl/test-e2e/Graph/Inputs/buffer_copy_target2host_2d.cpp
@@ -3,23 +3,27 @@
 
 #include "../graph_common.hpp"
 
+#include <cmath>
+
 int main() {
   queue Queue{};
 
   using T = int;
 
-  std::vector<T> DataA(Size * Size), DataB(Size * Size);
+  const size_t SizeX = std::sqrt(Size);
+  const size_t SizeY = SizeX;
+  std::vector<T> DataA(Size), DataB(Size);
   std::iota(DataA.begin(), DataA.end(), 1);
   std::iota(DataB.begin(), DataB.end(), 1000);
 
   std::vector<T> ReferenceA(DataA), ReferenceB(DataB);
-  for (size_t i = 0; i < Size * Size; i++) {
+  for (size_t i = 0; i < Size; i++) {
     ReferenceA[i] = DataA[i];
     ReferenceB[i] = DataA[i];
   }
 
   // Make the buffers 2D so we can test the rect read path
-  buffer BufferA{DataA.data(), range<2>(Size, Size)};
+  buffer BufferA{DataA.data(), range<2>(SizeX, SizeY)};
   BufferA.set_write_back(false);
 
   {
@@ -39,7 +43,7 @@ int main() {
 
   host_accessor HostAccA(BufferA);
 
-  for (size_t i = 0; i < Size * Size; i++) {
+  for (size_t i = 0; i < Size; i++) {
     assert(check_value(i, ReferenceA[i], DataA[i], "DataA"));
     assert(check_value(i, ReferenceB[i], DataB[i], "DataB"));
   }

--- a/sycl/test-e2e/Graph/Threading/submit.cpp
+++ b/sycl/test-e2e/Graph/Threading/submit.cpp
@@ -19,8 +19,9 @@ int main() {
 
   using T = int;
 
-  const unsigned NumThreads = std::thread::hardware_concurrency();
-  const unsigned SubmitsPerThread = 128;
+  const unsigned HwThreads = std::thread::hardware_concurrency();
+  const unsigned NumThreads = std::min(HwThreads, static_cast<unsigned>(4));
+  const unsigned SubmitsPerThread = 8;
   std::vector<T> DataA(Size), DataB(Size), DataC(Size);
 
   std::iota(DataA.begin(), DataA.end(), 1);


### PR DESCRIPTION
- Reduce sizes used in some graph tests that were excessively large
- Improves testing performance in performance-limited testing scenarios