### PR TITLE
[SYCL][E2E] Fix aot tests after driver update

### DIFF
--- a/sycl/test-e2e/AOT/double.cpp
+++ b/sycl/test-e2e/AOT/double.cpp
@@ -6,10 +6,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 
-// ocloc on windows does not have support for PVC/CFL, so this command will
+// ocloc on windows does not have support for PVC, so this command will
 // result in an error when on windows. (In general, there is no support
-// for pvc/cfl on windows.)
-// RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s %}
+// for pvc on windows.)
 // RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_pvc -o %t.pvc.out %s %}
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/AOT/half.cpp
+++ b/sycl/test-e2e/AOT/half.cpp
@@ -6,10 +6,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
 // RUN: %if cpu %{ %{run} %t.x86.out %}
 
-// ocloc on windows does not have support for PVC/CFL, so this command will
+// ocloc on windows does not have support for PVC, so this command will
 // result in an error when on windows. (In general, there is no support
-// for pvc/cfl on windows.)
-// RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s %}
+// for pvc on windows.)
 // RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_pvc -o %t.pvc.out %s %}
 
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/AOT/reqd-sg-size.cpp
+++ b/sycl/test-e2e/AOT/reqd-sg-size.cpp
@@ -5,10 +5,9 @@
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_tgllp -o %t.tgllp.out %s
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -o %t.x86.out %s
 
-// ocloc on windows does not have support for PVC/CFL, so this command will
+// ocloc on windows does not have support for PVC, so this command will
 // result in an error when on windows. (In general, there is no support
-// for pvc/cfl on windows.)
-// RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_cfl -o %t.cfl.out %s %}
+// for pvc on windows.)
 // RUN: %if !windows %{ %clangxx -fsycl -fsycl-targets=intel_gpu_pvc -o %t.pvc.out %s %}
 
 #include <cstdio>


### PR DESCRIPTION
cfl support is dropped in the new version of the driver, so remove cfl AOT from tests.