### PR TITLE
[DeviceASAN] Temporarily disable device address sanitizer tests

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/lit.local.cfg
+++ b/sycl/test-e2e/AddressSanitizer/lit.local.cfg
@@ -11,7 +11,9 @@ config.substitutions.append(
 config.unsupported_features += ['cuda', 'hip']
 
 # FIXME: Skip some of gpu devices, waiting for gfx driver uplifting
-config.unsupported_features += ['gpu-intel-gen9', 'gpu-intel-gen11', 'gpu-intel-gen12', 'gpu-intel-pvc']
+# FIXME: Enable dg2 device when post-commit failure
+# https://github.com/intel/llvm/actions/runs/11474026543/job/31930862668 is fixed
+config.unsupported_features += ['gpu-intel-gen9', 'gpu-intel-gen11', 'gpu-intel-gen12', 'gpu-intel-pvc', 'gpu-intel-dg2']
 
 # GPU testing requires level_zero
 if 'opencl:gpu' in config.sycl_devices:


### PR DESCRIPTION
Will re-enable them when post-commit failure
https://github.com/intel/llvm/actions/runs/11474026543/job/31930862668 is fixed.