### PR TITLE
[SYCL] Disable failing compression E2E tests on HIP

### DIFF
--- a/sycl/test-e2e/Compression/compression.cpp
+++ b/sycl/test-e2e/Compression/compression.cpp
@@ -1,5 +1,9 @@
 // End-to-End test for testing device image compression.
 // REQUIRES: zstd
+
+// XFAIL: hip_amd
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15829
+
 // RUN: %{build} -O0 -g %S/Inputs/single_kernel.cpp -o %t_not_compress.out
 // RUN: %{build} -O0 -g --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
 // RUN: %{run} %t_not_compress.out

--- a/sycl/test-e2e/Compression/compression_multiple_tu.cpp
+++ b/sycl/test-e2e/Compression/compression_multiple_tu.cpp
@@ -2,6 +2,9 @@
 // translation units, one compressed and one not compressed.
 // REQUIRES: zstd, linux
 
+// XFAIL: hip_amd
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15829
+
 // RUN: %{build} --offload-compress -DENABLE_KERNEL1 -shared -fPIC -o %T/kernel1.so
 // RUN: %{build} -DENABLE_KERNEL2 -shared -fPIC -o %T/kernel2.so
 


### PR DESCRIPTION
Failure: https://github.com/intel/llvm/actions/runs/11468699849/job/31915329901