### PR TITLE
[SYCL] Move XFAIL tracker checker test to compile-time

### DIFF
--- a/sycl/test/no-xfail-without-tracker.cpp
+++ b/sycl/test/no-xfail-without-tracker.cpp
@@ -25,8 +25,8 @@
 //   verify that against the reference
 // - ...and check if the list of improperly XFAIL-ed tests needs to be updated.
 //
-// RUN: grep -rI "XFAIL:" %S -A 1 --include=*.c --include=*.cpp \
-// RUN:      --exclude=no-xfail-without-tracker.cpp --no-group-separator | \
+// RUN: grep -rI "XFAIL:" %S/../test-e2e \
+// RUN: -A 1 --include=*.c --include=*.cpp --no-group-separator | \
 // RUN: grep -v "XFAIL:" | \
 // RUN: grep -Pv "XFAIL-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)" > %t | \
 // RUN: cat %t | wc -l | FileCheck %s --check-prefix NUMBER-OF-XFAIL-WITHOUT-TRACKER


### PR DESCRIPTION
We have all the info at compile time, no need to run this on a device every time. 

Note the directory is moved from `test-e2e` to `test`, it's hard to see in the github UI.

We can drop the `--exclude` since the test isn't in the same folder anymore.

Using `../` is a little gross, but it's worth it to save the resources of running E2E tests multiple times trying to fix failures in this test.

Also manually tested that changing the XFAIL number causes the test to fail in `check-sycl`.