### PR TITLE
[CI] Re-enable clang-format workflow

### DIFF
--- a/.github/workflows/pr-code-format.yml
+++ b/.github/workflows/pr-code-format.yml
@@ -7,6 +7,9 @@ on:
   pull_request:
     branches:
       - main
+      - sycl
+      - sycl-devops-pr/**
+      - sycl-rel-**
       - 'users/**'
 
 jobs:


### PR DESCRIPTION
It looks like this has been disabled since September(!!) due to a bad merge [here](https://github.com/intel/llvm/commit/9379d84d1784fdac81b427508eb64a119fe82a5b#diff-6860ad0dc3584a2d702e231d5e9e9937e24f43777fd16954ce741eed68e94d50L12).

Thanks to Udit for finding this.