### PR TITLE
[DeviceASAN] Fix missing return in MemToShadow function for DG2

### DIFF
--- a/libdevice/sanitizer_utils.cpp
+++ b/libdevice/sanitizer_utils.cpp
@@ -159,6 +159,8 @@ inline uptr MemToShadow_DG2(uptr addr, uint32_t as) {
                              (uptr)launch_info->GlobalShadowOffset);
           return 0;
         });
+
+    return shadow_ptr;
   } else if (as == ADDRESS_SPACE_LOCAL) { // local
     // The size of SLM is 64KB on DG2
     constexpr unsigned slm_size = 64 * 1024;

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/bad-context.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/bad-context.cpp
@@ -17,7 +17,7 @@ int main() {
   });
   gpu_queue.wait();
   // CHECK: DeviceSanitizer: invalid-argument on kernel
-  // CHECK: The 1th argument {{.*}} is allocated in other context
+  // CHECK: The {{[0-9]+}}th argument {{.*}} is allocated in other context
   // CHECK: {{.*}} is located inside of Device USM region
 
   sycl::free(data, cpu_queue);

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/host-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/host-pointer.cpp
@@ -21,7 +21,7 @@ int main() {
   Q.wait();
 
   // CHECK-GPU: ERROR: DeviceSanitizer: invalid-argument
-  // CHECK-GPU: The 1th argument {{.*}} is not a USM pointer
+  // CHECK-GPU: The {{[0-9]+}}th argument {{.*}} is not a USM pointer
   // CHECK-CPU-NOT: ERROR: DeviceSanitizer: invalid-argument
 
   delete hostPtr;

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
@@ -20,7 +20,7 @@ int main() {
   });
   Q.wait();
   // CHECK: ERROR: DeviceSanitizer: invalid-argument
-  // CHECK: The 1th argument {{.*}} is located outside of its region
+  // CHECK: The {{[0-9]+}}th argument {{.*}} is located outside of its region
 
   return 0;
 }

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
@@ -20,7 +20,7 @@ int main() {
   });
   Q.wait();
   // CHECK: ERROR: DeviceSanitizer: invalid-argument
-  // CHECK: The 1th argument {{.*}} is a released USM pointer
+  // CHECK: The {{[0-9]+}}th argument {{.*}} is a released USM pointer
   // CHECK: {{.*}} is located inside of Device USM region
   // CHECK: allocated here:
   // CHECK: freed here:

--- a/sycl/test-e2e/AddressSanitizer/lit.local.cfg
+++ b/sycl/test-e2e/AddressSanitizer/lit.local.cfg
@@ -11,9 +11,7 @@ config.substitutions.append(
 config.unsupported_features += ['cuda', 'hip']
 
 # FIXME: Skip some of gpu devices, waiting for gfx driver uplifting
-# FIXME: Enable dg2 device when post-commit failure
-# https://github.com/intel/llvm/actions/runs/11474026543/job/31930862668 is fixed
-config.unsupported_features += ['gpu-intel-gen9', 'gpu-intel-gen11', 'gpu-intel-gen12', 'gpu-intel-pvc', 'gpu-intel-dg2']
+config.unsupported_features += ['gpu-intel-gen9', 'gpu-intel-gen11', 'gpu-intel-gen12', 'gpu-intel-pvc']
 
 # GPU testing requires level_zero
 if 'opencl:gpu' in config.sycl_devices:


### PR DESCRIPTION
*Re-enable device sanitizer tests for dg2 device
*Update some invalid-argument tests