### PR TITLE
[SYCL] Re-enable unit-tests for virtual functions

### DIFF
--- a/sycl/unittests/Extensions/CMakeLists.txt
+++ b/sycl/unittests/Extensions/CMakeLists.txt
@@ -21,6 +21,4 @@ add_sycl_unittest(ExtensionsTests OBJECT
 )
 
 add_subdirectory(CommandGraph)
-
-# Disabled pending UR fix adding setDataAs to mock dummy handle.
-#add_subdirectory(VirtualFunctions)
+add_subdirectory(VirtualFunctions)


### PR DESCRIPTION
They were disabled because some helpers were missing in UR mock infrastructure. However, they can be built just fine, meaning that the mock infrastructure gap has been already closed.