### PR TITLE
[SYCL][DeviceSanitizer] Re-enable XPASSing tests on DG2

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/out-of-bounds.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: linux, gpu
 
-// XFAIL: gpu-intel-dg2 && linux
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15648
-
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
 // RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
 

--- a/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
+++ b/sycl/test-e2e/AddressSanitizer/invalid-argument/released-pointer.cpp
@@ -1,8 +1,5 @@
 // REQUIRES: linux, gpu
 
-// XFAIL: gpu-intel-dg2 && linux
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15648
-
 // RUN: %{build} %device_asan_flags -O2 -g -o %t
 // RUN: env SYCL_PREFER_UR=1 UR_LAYER_ASAN_OPTIONS="quarantine_size_mb:1;detect_kernel_arguments:1" %{run} not %t 2>&1 | FileCheck %s
 

--- a/sycl/test/no-xfail-without-tracker.cpp
+++ b/sycl/test/no-xfail-without-tracker.cpp
@@ -50,7 +50,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 157
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 155
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been propely XFAIL-ed.

--- a/sycl/test/no-xfail-without-tracker.cpp
+++ b/sycl/test/no-xfail-without-tracker.cpp
@@ -50,7 +50,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 155
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 157
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been propely XFAIL-ed.


### PR DESCRIPTION
They're [passing](https://github.com/intel/llvm/actions/runs/11500888153/job/32012969913) now. I updated the Github issue.