### PR TITLE
[SYCL] Fix zstd build when static zstd libraries are not found

### DIFF
--- a/buildbot/configure.py
+++ b/buildbot/configure.py
@@ -64,7 +64,7 @@ def do_configure(args):
 
     sycl_enable_xpti_tracing = "ON"
     xpti_enable_werror = "OFF"
-    llvm_enable_zstd = "OFF"
+    llvm_enable_zstd = "ON"
 
     if sys.platform != "darwin":
         sycl_enabled_backends.append("level_zero")
@@ -134,8 +134,6 @@ def do_configure(args):
 
         # For clang-format, clang-tidy and code coverage
         llvm_enable_projects += ";clang-tools-extra;compiler-rt"
-        # Build with zstd enabled on CI.
-        llvm_enable_zstd = "ON"
         if sys.platform != "darwin":
             # libclc is required for CI validation
             libclc_enabled = True

--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -157,7 +157,14 @@ if(LLVM_ENABLE_ZSTD)
     find_package(zstd QUIET)
   endif()
 endif()
+
+# If LLVM_USE_STATIC_ZSTD is specified, make sure we enable zstd only if static
+# libraries are found.
+if(LLVM_USE_STATIC_ZSTD AND NOT TARGET zstd::libzstd_static)
+set(LLVM_ENABLE_ZSTD OFF)
+else()
 set(LLVM_ENABLE_ZSTD ${zstd_FOUND})
+endif()
 
 if(LLVM_ENABLE_LIBXML2)
   if(LLVM_ENABLE_LIBXML2 STREQUAL FORCE_ON)


### PR DESCRIPTION
**Problem:**

When we use `LLVM_ENABLE_ZSTD=ON` along with `LLVM_USE_STATIC_ZSTD=ON`, LLVM config fails with the following error when libzstd.a is not found but libzstd.so is found:
```
CMake Error at lib/Support/CMakeLists.txt:327 (get_property):
  get_property could not find TARGET zstd::libzstd_static.  Perhaps it has
  not yet been created.


CMake Error at lib/Support/CMakeLists.txt:330 (get_property):
  get_property could not find TARGET zstd::libzstd_static.  Perhaps it has
  not yet been created.
```
The bug is in upstream and in the following lines: https://github.com/intel/llvm/blob/sycl/llvm/lib/Support/CMakeLists.txt#L32 - In the `else()`, the code just assumes that static libraries are available.

**Solution:**

When user specifies `LLVM_USE_STATIC_ZSTD=ON`, we should enable ZSTD only if static zstd library is present. Otherwise, the build should just proceed normally since zstd is optional, even in upstream.