### PR TITLE
[SYCL][ESIMD][E2E] Add driver version check to rdtsc test

### DIFF
--- a/sycl/test-e2e/ESIMD/rdtsc.cpp
+++ b/sycl/test-e2e/ESIMD/rdtsc.cpp
@@ -1,5 +1,3 @@
-// RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
 //==- rdtsc.cpp - Test to verify rdtsc0 and sr0 functionlity----------------==//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
@@ -7,6 +5,11 @@
 // SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
 //
 //===----------------------------------------------------------------------===//
+
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// REQUIRES-INTEL-DRIVER: lin: 28690
 
 // This is basic test to validate rdtsc function.
 


### PR DESCRIPTION
We test on some platforms where the driver is too old. Also cleaned up the test a bit. Manually verified this version is right, we have it in CI here already too.