### PR TITLE
[SYCL][E2E] Re-enable and fix `Basic/interop/get_native_ocl.cpp` test

### DIFF
--- a/sycl/test-e2e/Basic/interop/get_native_ocl.cpp
+++ b/sycl/test-e2e/Basic/interop/get_native_ocl.cpp
@@ -1,5 +1,5 @@
-// REQUIRES: opencl, opencl_dev_kit
-// RUN: %{build} %opencl_options -o %t.ocl.out
+// REQUIRES: opencl, opencl_icd
+// RUN: %{build} %opencl_lib -o %t.out
 // RUN: %{run} %t.out
 
 #include <CL/cl.h>


### PR DESCRIPTION
This test was never ran due to requiring the feature `opencl_dev_kit`. This patch replaces this with the feature `opencl_icd`, and fixes the build line to use the `%opencl_lib` expansion.

Fixes part of #15838