### PR TITLE
[SYCL] Do not pipe command output after redirect in no-xfail-without-tracker.cpp

### DIFF
--- a/sycl/test/no-xfail-without-tracker.cpp
+++ b/sycl/test/no-xfail-without-tracker.cpp
@@ -28,7 +28,7 @@
 // RUN: grep -rI "XFAIL:" %S/../test-e2e \
 // RUN: -A 1 --include=*.c --include=*.cpp --no-group-separator | \
 // RUN: grep -v "XFAIL:" | \
-// RUN: grep -Pv "XFAIL-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)" > %t | \
+// RUN: grep -Pv "XFAIL-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)" > %t
 // RUN: cat %t | wc -l | FileCheck %s --check-prefix NUMBER-OF-XFAIL-WITHOUT-TRACKER
 // RUN: cat %t | sed 's/\.cpp.*/.cpp/' | sort | FileCheck %s
 //


### PR DESCRIPTION
The test used `>` to redirect `stdout` to a file, and then pipes (`|`) into `cat`, I'm not sure if it is intended but this PR removes the `|` so that `cat` works on the file created by the previous command.