### PR TITLE
[sycl][P2P] Fix info query for P2P

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/JackAKirk/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -4,4 +4,4 @@
 # Date:   Thu Oct 24 13:37:02 2024 +0100
 #     Merge pull request #2160 from aarongreig/aaron/clQuerySourceWGSize
 #     Query out and use local size set in program IL in CL adapter
-set(UNIFIED_RUNTIME_TAG 58abf8fa778376546274c52304b9f924314d65e6)
+set(UNIFIED_RUNTIME_TAG 4f1fd54e4d5bfb480f7ca3ea58ee85334809a641)

--- a/sycl/source/device.cpp
+++ b/sycl/source/device.cpp
@@ -234,9 +234,6 @@ bool device::ext_oneapi_can_access_peer(const device &peer,
     return true;
   }
 
-  size_t returnSize = 0;
-  int value = 0;
-
   ur_exp_peer_info_t UrAttr = [&]() {
     switch (attr) {
     case ext::oneapi::peer_access::access_supported:
@@ -248,11 +245,9 @@ bool device::ext_oneapi_can_access_peer(const device &peer,
                           "Unrecognized peer access attribute.");
   }();
   auto Adapter = impl->getAdapter();
+  int value;
   Adapter->call<detail::UrApiKind::urUsmP2PPeerAccessGetInfoExp>(
-      Device, Peer, UrAttr, 0, nullptr, &returnSize);
-
-  Adapter->call<detail::UrApiKind::urUsmP2PPeerAccessGetInfoExp>(
-      Device, Peer, UrAttr, returnSize, &value, nullptr);
+      Device, Peer, UrAttr, sizeof(int), &value, nullptr);
 
   return value == 1;
 }


### PR DESCRIPTION
There has been some confusion I think originating in the fact that L0 backend returned bool type instead of int for P2P queries. This issue is fixed here https://github.com/oneapi-src/unified-runtime/pull/2246

This PR correspondingly updates the dpc++ runtime.