### PR TITLE
[SPIRV] Align constant-loclist test to upstream

### DIFF
--- a/llvm-spirv/test/DebugInfo/X86/constant-loclist.ll
+++ b/llvm-spirv/test/DebugInfo/X86/constant-loclist.ll
@@ -1,33 +1,33 @@
 ; RUN: llvm-as < %s -o %t.bc
 ; RUN: llvm-spirv %t.bc -o %t.spv
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
-; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj %t.ll -o - -experimental-debug-variable-locations=false | llvm-dwarfdump -v -debug-info - | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj %t.ll -o - -experimental-debug-variable-locations=true | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-100
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
-; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj %t.ll -o - -experimental-debug-variable-locations=false | llvm-dwarfdump -v -debug-info - | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj %t.ll -o - -experimental-debug-variable-locations=true | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 ; RUN: llvm-spirv %t.bc -o %t.spv --spirv-debug-info-version=nonsemantic-shader-200
 ; RUN: llvm-spirv -r %t.spv -o - | llvm-dis -o %t.ll
-; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj %t.ll -o - -experimental-debug-variable-locations=false | llvm-dwarfdump -v -debug-info - | FileCheck %s
+; RUN: llc -mtriple=x86_64-unknown-linux-gnu -filetype=obj %t.ll -o - -experimental-debug-variable-locations=true | llvm-dwarfdump -v -debug-info - | FileCheck %s
 
 ; A hand-written testcase to check 64-bit constant handling in location lists.
 
 ; CHECK: .debug_info contents:
 ; CHECK: DW_TAG_variable
 ; CHECK-NEXT: DW_AT_location [DW_FORM_data4]	(
-; CHECK-NEXT:   0x{{.*}}, 0x{{.*}}: DW_OP_constu 0x4000000000000000)
-; CHECK-NEXT: DW_AT_name {{.*}}"d"
+; CHECK-NEXT:   {{.*}}: DW_OP_lit0
+; CHECK-NEXT:   {{.*}}: DW_OP_constu 0x4000000000000000)
+; CHECK-NEXT: DW_AT_name {{.*}}"u"
 ; CHECK: DW_TAG_variable
 ; CHECK-NEXT: DW_AT_location [DW_FORM_data4]	(
-; CHECK-NEXT:   0x{{.*}}, 0x{{.*}}: DW_OP_consts +0
-; CHECK-NEXT:   0x{{.*}}, 0x{{.*}}: DW_OP_consts +4611686018427387904)
+; CHECK-NEXT:   {{.*}}: DW_OP_consts +0
+; CHECK-NEXT:   {{.*}}: DW_OP_consts +4611686018427387904)
 ; CHECK-NEXT: DW_AT_name {{.*}}"i"
 ; CHECK: DW_TAG_variable
 ; CHECK-NEXT: DW_AT_location [DW_FORM_data4]	(
-; CHECK-NEXT:   0x{{.*}}, 0x{{.*}}: DW_OP_lit0
-; CHECK-NEXT:   0x{{.*}}, 0x{{.*}}: DW_OP_constu 0x4000000000000000)
-; CHECK-NEXT: DW_AT_name {{.*}}"u"
+; CHECK-NEXT:   {{.*}}: DW_OP_constu 0x4000000000000000)
+; CHECK-NEXT: DW_AT_name {{.*}}"d"
 
 source_filename = "test.c"
 target datalayout = "e-m:o-i64:64-f80:128-n8:16:32:64-S128"


### PR DESCRIPTION
Cherry-pick of
https://github.com/KhronosGroup/SPIRV-LLVM-Translator/pull/2756

The test has evolved upstream since it was forked into this repository and started failing now.  Re-align the invocations and FileCheck patterns with the test in llvm-project.