### PR TITLE
[SYCL][Bindless][E2E] XFAIL DX12 read_write_unsampled_semaphore

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled_semaphore.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled_semaphore.cpp
@@ -1,5 +1,7 @@
 // REQUIRES: cuda
 // REQUIRES: windows
+// XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15851
 
 // RUN: %{build} -l d3d12 -l dxgi -l dxguid -o %t.out
 // RUN: %{run-unfiltered-devices} %t.out


### PR DESCRIPTION
The test, dx12_interop/read_write_unsampled_semaphore, non-deterministically fails. We are XFAIL-ing the test until a fix is implemented.