### PR TITLE
[SYCL][E2E] Add more xfails to recently re-enabled test

### DIFF
--- a/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
+++ b/sycl/test-e2e/Basic/interop/interop_all_backends.cpp
@@ -1,4 +1,4 @@
-// XFAIL: any-device-is-opencl, any-device-is-cuda, (windows && any-device-is-level_zero)
+// XFAIL: any-device-is-opencl, any-device-is-cuda, (windows && any-device-is-level_zero), gpu-intel-dg2, hip_amd
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15819
 // RUN: %if any-device-is-opencl %{ %{build} -o %t-opencl.out %}
 // RUN: %if any-device-is-level_zero %{ %{build} -DBUILD_FOR_L0 -o %t-l0.out %}


### PR DESCRIPTION
This test was failing on post commit in these cases after being re-enabled. 
https://github.com/intel/llvm/actions/runs/11523103039