### PR TITLE
[Driver] Do not compress bundle when offloading to HIP

### DIFF
--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
+++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
@@ -324,7 +324,7 @@ void HIP::constructHIPFatbinCommand(Compilation &C, const JobAction &JA,
       Args.MakeArgString(std::string("-output=").append(Output));
   BundlerArgs.push_back(BundlerOutputArg);
 
-  // For SYCL, the compression is occuring during the wrapping step, so we do
+  // For SYCL, the compression is occurring during the wrapping step, so we do
   // not want to do additional compression here.
   if (!JA.isDeviceOffloading(Action::OFK_SYCL))
     addOffloadCompressArgs(Args, BundlerArgs);

--- a/clang/lib/Driver/ToolChains/HIPUtility.cpp
+++ b/clang/lib/Driver/ToolChains/HIPUtility.cpp
@@ -324,7 +324,10 @@ void HIP::constructHIPFatbinCommand(Compilation &C, const JobAction &JA,
       Args.MakeArgString(std::string("-output=").append(Output));
   BundlerArgs.push_back(BundlerOutputArg);
 
-  addOffloadCompressArgs(Args, BundlerArgs);
+  // For SYCL, the compression is occuring during the wrapping step, so we do
+  // not want to do additional compression here.
+  if (!JA.isDeviceOffloading(Action::OFK_SYCL))
+    addOffloadCompressArgs(Args, BundlerArgs);
 
   const char *Bundler = Args.MakeArgString(
       T.getToolChain().GetProgramPath("clang-offload-bundler"));

--- a/clang/test/Driver/sycl-offload-wrapper-compression.cpp
+++ b/clang/test/Driver/sycl-offload-wrapper-compression.cpp
@@ -10,5 +10,13 @@
 // RUN: %clangxx -### -fsycl %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-COMPRESS
 // RUN: %clangxx -### -fsycl --offload-compression-level=3 %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-COMPRESS
 
+// For SYCL offloading to HIP, make sure we don't pass '--compress' to offload-bundler.
+// Clang thows an error in the following command "cannot find 'remangled-l64-signed_char.libspirv-amdgcn-amd-amdhsa.bc'", that's why adding 'not'.
+
+// RUN: not %clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa %s > %t.driver 2>&1
+// RUN: FileCheck %s --check-prefix=CHECK-NO-COMPRESS-BUNDLER --input-file=%t.driver
+
 // CHECK-NO-COMPRESS-NOT: {{.*}}clang-offload-wrapper{{.*}}"-offload-compress"{{.*}}
 // CHECK-NO-COMPRESS-NOT: {{.*}}clang-offload-wrapper{{.*}}"-offload-compression-level=3"{{.*}}
+
+// CHECK-NO-COMPRESS-BUNDLER-NOT: {{.*}}clang-offload-bundler{{.*}}"-compress"{{.*}}

--- a/clang/test/Driver/sycl-offload-wrapper-compression.cpp
+++ b/clang/test/Driver/sycl-offload-wrapper-compression.cpp
@@ -14,7 +14,7 @@
 // Clang throws an error in the following command "cannot find 'remangled-l64-signed_char.libspirv-amdgcn-amd-amdhsa.bc'" on some machine,
 // that's why appending '|| true'. This error should not affect the driver invocation, which this test intends to verify.
 
-// RUN: (%clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa %s > %t.driver 2>&1) || true
+// RUN: (%clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa %s &> %t.driver) || true
 // RUN: FileCheck %s --check-prefix=CHECK-NO-COMPRESS-BUNDLER --input-file=%t.driver
 
 // CHECK-NO-COMPRESS-NOT: {{.*}}clang-offload-wrapper{{.*}}"-offload-compress"{{.*}}

--- a/clang/test/Driver/sycl-offload-wrapper-compression.cpp
+++ b/clang/test/Driver/sycl-offload-wrapper-compression.cpp
@@ -11,10 +11,7 @@
 // RUN: %clangxx -### -fsycl --offload-compression-level=3 %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-COMPRESS
 
 // For SYCL offloading to HIP, make sure we don't pass '--compress' to offload-bundler.
-// Clang throws an error in the following command "cannot find 'remangled-l64-signed_char.libspirv-amdgcn-amd-amdhsa.bc'" on some machine,
-// that's why appending '|| true'. This error should not affect the driver invocation, which this test intends to verify.
-
-// RUN: (%clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa %s &> %t.driver) || true
+// RUN: %clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa -fno-sycl-libspirv -nogpulib %s &> %t.driver
 // RUN: FileCheck %s --check-prefix=CHECK-NO-COMPRESS-BUNDLER --input-file=%t.driver
 
 // CHECK-NO-COMPRESS-NOT: {{.*}}clang-offload-wrapper{{.*}}"-offload-compress"{{.*}}

--- a/clang/test/Driver/sycl-offload-wrapper-compression.cpp
+++ b/clang/test/Driver/sycl-offload-wrapper-compression.cpp
@@ -11,9 +11,10 @@
 // RUN: %clangxx -### -fsycl --offload-compression-level=3 %s 2>&1 | FileCheck %s --check-prefix=CHECK-NO-COMPRESS
 
 // For SYCL offloading to HIP, make sure we don't pass '--compress' to offload-bundler.
-// Clang thows an error in the following command "cannot find 'remangled-l64-signed_char.libspirv-amdgcn-amd-amdhsa.bc'", that's why adding 'not'.
+// Clang throws an error in the following command "cannot find 'remangled-l64-signed_char.libspirv-amdgcn-amd-amdhsa.bc'" on some machine,
+// that's why appending '|| true'. This error should not affect the driver invocation, which this test intends to verify.
 
-// RUN: not %clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa %s > %t.driver 2>&1
+// RUN: (%clangxx -### -fsycl --offload-compress -Xsycl-target-backend=amdgcn-amd-amdhsa --offload-arch=gfx1031 -fsycl-targets=amdgcn-amd-amdhsa %s > %t.driver 2>&1) || true
 // RUN: FileCheck %s --check-prefix=CHECK-NO-COMPRESS-BUNDLER --input-file=%t.driver
 
 // CHECK-NO-COMPRESS-NOT: {{.*}}clang-offload-wrapper{{.*}}"-offload-compress"{{.*}}

--- a/sycl/test-e2e/Compression/compression.cpp
+++ b/sycl/test-e2e/Compression/compression.cpp
@@ -1,9 +1,6 @@
 // End-to-End test for testing device image compression.
 // REQUIRES: zstd
 
-// XFAIL: hip_amd
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15829
-
 // RUN: %{build} -O0 -g %S/Inputs/single_kernel.cpp -o %t_not_compress.out
 // RUN: %{build} -O0 -g --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
 // RUN: %{run} %t_not_compress.out

--- a/sycl/test-e2e/Compression/compression_multiple_tu.cpp
+++ b/sycl/test-e2e/Compression/compression_multiple_tu.cpp
@@ -2,9 +2,6 @@
 // translation units, one compressed and one not compressed.
 // REQUIRES: zstd, linux
 
-// XFAIL: hip_amd
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15829
-
 // RUN: %{build} --offload-compress -DENABLE_KERNEL1 -shared -fPIC -o %T/kernel1.so
 // RUN: %{build} -DENABLE_KERNEL2 -shared -fPIC -o %T/kernel2.so
 


### PR DESCRIPTION
Fixes: https://github.com/intel/llvm/issues/15829

**Problem**
`--offload-compress` is being used by HIP in `clang-offload-bundler` and by us in `clang-offload-wrapper`. When we use ` --offload-compress` for SYCL offloading to HIP, the device images gets compressed twice: once in `offload-bundler` and then in `offload-wrapper`.

**~Solution~ Workaround** 
This PR intends to disable compression in `clang-offload-bundler` when offloading to HIP.