### PR TITLE
[SYCL] Remove deprecation of legacy multi_ptr

### DIFF
--- a/sycl/include/sycl/access/access.hpp
+++ b/sycl/include/sycl/access/access.hpp
@@ -63,8 +63,7 @@ enum class address_space : int {
 enum class decorated : int {
   no = 0,
   yes = 1,
-  legacy __SYCL2020_DEPRECATED("sycl::access::decorated::legacy "
-                               "is deprecated since SYCL 2020") = 2
+  legacy = 2
 };
 } // namespace access
 

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -733,11 +733,8 @@ private:
 };
 
 // Legacy specialization of multi_ptr.
-// TODO: Add deprecation warning here when possible.
 template <typename ElementType, access::address_space Space>
-class __SYCL2020_DEPRECATED(
-    "decorated::legacy multi_ptr specialization is deprecated since SYCL 2020.")
-    multi_ptr<ElementType, Space, access::decorated::legacy> {
+class multi_ptr<ElementType, Space, access::decorated::legacy> {
 public:
   using value_type = ElementType;
   using element_type =
@@ -1083,11 +1080,8 @@ private:
 };
 
 // Legacy specialization of multi_ptr for void.
-// TODO: Add deprecation warning here when possible.
 template <access::address_space Space>
-class __SYCL2020_DEPRECATED(
-    "decorated::legacy multi_ptr specialization is deprecated since SYCL 2020.")
-    multi_ptr<void, Space, access::decorated::legacy> {
+class multi_ptr<void, Space, access::decorated::legacy> {
 public:
   using value_type = void;
   using element_type = void;
@@ -1244,11 +1238,8 @@ private:
 };
 
 // Legacy specialization of multi_ptr for const void.
-// TODO: Add deprecation warning here when possible.
 template <access::address_space Space>
-class __SYCL2020_DEPRECATED(
-    "decorated::legacy multi_ptr specialization is deprecated since SYCL 2020.")
-    multi_ptr<const void, Space, access::decorated::legacy> {
+class multi_ptr<const void, Space, access::decorated::legacy> {
 public:
   using value_type = const void;
   using element_type = const void;

--- a/sycl/test/warnings/sycl_2020_deprecations.cpp
+++ b/sycl/test/warnings/sycl_2020_deprecations.cpp
@@ -287,8 +287,6 @@ int main() {
         [=](sycl::nd_item<1> Idx) {
           int PrivateVal = 0;
 
-          // expected-warning@+6{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
-          // expected-warning@+8{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
           // expected-warning@+8{{'get_pointer' is deprecated: accessor::get_pointer() is deprecated, please use get_multi_ptr()}}
           // expected-warning@+7{{'get_pointer<sycl::access::target::global_buffer, void>' is deprecated: accessor::get_pointer() is deprecated, please use get_multi_ptr()}}
           // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::global_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
@@ -298,8 +296,6 @@ int main() {
                   sycl::make_ptr<int, sycl::access::address_space::global_space,
                                  sycl::access::decorated::legacy>(
                       GlobalAcc.get_pointer());
-          // expected-warning@+5{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
-          // expected-warning@+7{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
           // expected-warning@+7{{'get_pointer' is deprecated: local_accessor::get_pointer() is deprecated, please use get_multi_ptr()}}
           // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::local_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
           sycl::multi_ptr<int, sycl::access::address_space::local_space,
@@ -309,9 +305,7 @@ int main() {
                                  sycl::access::decorated::legacy>(
                       LocalAcc.get_pointer());
 
-          // expected-warning@+4{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
-          // expected-warning@+5{{'make_ptr<int, sycl::access::address_space::private_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
-          // expected-warning@+6{{'legacy' is deprecated: sycl::access::decorated::legacy is deprecated since SYCL 2020}}
+          // expected-warning@+4{{'make_ptr<int, sycl::access::address_space::private_space, sycl::access::decorated::legacy, void>' is deprecated: make_ptr is deprecated since SYCL 2020. Please use address_space_cast instead.}}
           sycl::multi_ptr<int, sycl::access::address_space::private_space,
                           sycl::access::decorated::legacy>
               LegacyPrivateMptr =


### PR DESCRIPTION
With https://github.com/KhronosGroup/SYCL-Docs/pull/604 the SYCL specification no longer deprecates legacy multi_ptr. This commit removes the corresponding deprecation warnings from the implementation of the specializations and the enum value.