### PR TITLE
DRAFT: Avoid potential ambiguity in UrReturnHelper

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/hvdijk/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,13 @@
-# commit 3d58884b4939d9bd095c917f8dd823ac8486684c
-# Merge: 6ade245e b0bd146a
-# Author: aarongreig <aaron.greig@codeplay.com>
-# Date:   Thu Oct 31 14:05:55 2024 +0000
-#     Merge pull request #2228 from nrspruit/copy_engine_refactor
-#     [L0] Refactor Copy Engine Usage checks for Performance
-set(UNIFIED_RUNTIME_TAG 3d58884b4939d9bd095c917f8dd823ac8486684c)
+# commit f6d00b8a95ddc41e17ac2faeba13afacd48252d2
+# Author: Harald van Dijk <harald.vandijk@codeplay.com>
+# Date:   Fri Nov 1 11:08:39 2024 +0000
+#
+#     Avoid potential ambiguity in UrReturnHelper
+#
+#     If UrReturnHelper's operator() is explicitly called as
+#     operator()<T>(...), there is a potential for ambiguity when the
+#     specified RetType and the inferred T are the same: this is ambiguous
+#     with the version of operator() where only T is a template parameter,
+#     and T is specified explicitly. We already have code that explicitly
+#     calls operator()<T>(...), so prevent this from becoming a problem.
+set(UNIFIED_RUNTIME_TAG f6d00b8a95ddc41e17ac2faeba13afacd48252d2)


### PR DESCRIPTION
PR to test https://github.com/oneapi-src/unified-runtime/pull/2256