### PR TITLE
[SYCL][Doc] Fix enqueue functions spec passing handler by reference ...

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_functions.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_enqueue_functions.asciidoc
@@ -278,7 +278,7 @@ template <typename KernelName, typename KernelType>
 void single_task(sycl::queue q, const KernelType& k);
 
 template <typename KernelName, typename KernelType>
-void single_task(sycl::handler h, const KernelType& k);
+void single_task(sycl::handler &h, const KernelType& k);
 
 }
 ----
@@ -298,7 +298,7 @@ template <typename Args...>
 void single_task(sycl::queue q, const sycl::kernel& k, Args&&... args);
 
 template <typename Args...>
-void single_task(sycl::handler h, const sycl::kernel& k, Args&&... args);
+void single_task(sycl::handler &h, const sycl::kernel& k, Args&&... args);
 
 }
 ----
@@ -328,7 +328,7 @@ void parallel_for(sycl::queue q, sycl::range<Dimensions> r,
 
 template <typename KernelName, int Dimensions,
           typename KernelType, typename... Reductions>
-void parallel_for(sycl::handler h, sycl::range<Dimensions> r,
+void parallel_for(sycl::handler &h, sycl::range<Dimensions> r,
                   const KernelType& k, Reductions&&... reductions);
 
 }
@@ -357,7 +357,7 @@ void parallel_for(sycl::queue q,
 
 template <typename KernelName, int Dimensions,
           typename Properties, typename KernelType, typename... Reductions>
-void parallel_for(sycl::handler h,
+void parallel_for(sycl::handler &h,
                   launch_config<sycl::range<Dimensions>, Properties> c,
                   const KernelType& k, Reductions&&... reductions);
 
@@ -384,7 +384,7 @@ void parallel_for(sycl::queue q, sycl::range<Dimensions> r,
                   const sycl::kernel& k, Args&&... args);
 
 template <typename KernelName, int Dimensions, typename... Args>
-void parallel_for(sycl::handler h, sycl::range<Dimensions> r,
+void parallel_for(sycl::handler &h, sycl::range<Dimensions> r,
                   const sycl::kernel& k, Args&&... args);
 
 }
@@ -410,7 +410,7 @@ void parallel_for(sycl::queue q,
 
 template <typename KernelName, int Dimensions,
           typename Properties, typename... Args>
-void parallel_for(sycl::handler h,
+void parallel_for(sycl::handler &h,
                   launch_config<sycl::range<Dimensions>, Properties> c,
                   const sycl::kernel& k, Args&& args...);
 
@@ -443,7 +443,7 @@ void nd_launch(sycl::queue q, sycl::nd_range<Dimensions> r,
 
 template <typename KernelName, int Dimensions,
           typename KernelType, typename... Reductions>
-void nd_launch(sycl::handler h, sycl::nd_range<Dimensions> r,
+void nd_launch(sycl::handler &h, sycl::nd_range<Dimensions> r,
                const KernelType& k, Reductions&&... reductions);
 
 }
@@ -474,7 +474,7 @@ void nd_launch(sycl::queue q,
 template <typename KernelName, int Dimensions,
           typename Properties,
           typename KernelType, typename... Reductions>
-void nd_launch(sycl::handler h,
+void nd_launch(sycl::handler &h,
                launch_config<sycl::nd_range<Dimensions>, Properties> c,
                const KernelType& k, Reductions&&... reductions);
 
@@ -501,7 +501,7 @@ void nd_launch(sycl::queue q, sycl::nd_range<Dimensions> r,
                const sycl::kernel& k, Args&&... args);
 
 template <typename KernelName, int Dimensions, typename... Args>
-void nd_launch(sycl::handler h, sycl::nd_range<Dimensions> r,
+void nd_launch(sycl::handler &h, sycl::nd_range<Dimensions> r,
                const sycl::kernel& k, Args&&... args);
 
 }
@@ -528,7 +528,7 @@ void nd_launch(sycl::queue q,
 
 template <typename KernelName, int Dimensions,
           typename Properties, typename... Args>
-void nd_launch(sycl::handler h,
+void nd_launch(sycl::handler &h,
                launch_config<sycl::nd_range<Dimensions>, Properties> c,
                const sycl::kernel& k, Args&& args...);
 
@@ -556,7 +556,7 @@ namespace sycl::ext::oneapi::experimental {
 
 void memcpy(sycl::queue q, void* dest, const void* src, size_t numBytes);
 
-void memcpy(sycl::handler h, void* dest, const void* src, size_t numBytes);
+void memcpy(sycl::handler &h, void* dest, const void* src, size_t numBytes);
 
 }
 ----
@@ -575,7 +575,7 @@ template <typename T>
 void copy(sycl::queue q, const T* src, T* dest, size_t count);
 
 template <typename T>
-void copy(sycl::handler h, const T* src, T* dest, size_t count);
+void copy(sycl::handler &h, const T* src, T* dest, size_t count);
 
 }
 ----
@@ -592,7 +592,7 @@ namespace sycl::ext::oneapi::experimental {
 
 void memset(sycl::queue q, void* ptr, int value, size_t numBytes);
 
-void memset(sycl::handler h, void* ptr, int value, size_t numBytes);
+void memset(sycl::handler &h, void* ptr, int value, size_t numBytes);
 
 }
 ----
@@ -611,7 +611,7 @@ template <typename T>
 void fill(sycl::queue q, T* ptr, const T& pattern, size_t count);
 
 template <typename T>
-void fill(sycl::handler h, T* ptr, const T& pattern, size_t count);
+void fill(sycl::handler &h, T* ptr, const T& pattern, size_t count);
 
 }
 ----
@@ -628,7 +628,7 @@ namespace sycl::ext::oneapi::experimental {
 
 void prefetch(sycl::queue q, void* ptr, size_t numBytes);
 
-void prefetch(sycl::handler h, void* ptr, size_t numBytes);
+void prefetch(sycl::handler &h, void* ptr, size_t numBytes);
 
 }
 ----
@@ -645,7 +645,7 @@ namespace sycl::ext::oneapi::experimental {
 
 void mem_advise(sycl::queue q, void* ptr, size_t numBytes, int advice);
 
-void mem_advise(sycl::handler h, void* ptr, size_t numBytes, int advice);
+void mem_advise(sycl::handler &h, void* ptr, size_t numBytes, int advice);
 
 }
 ----
@@ -672,7 +672,7 @@ namespace sycl::ext::oneapi::experimental {
 
 void barrier(sycl::queue q);
 
-void barrier(sycl::handler h);
+void barrier(sycl::handler &h);
 
 }
 ----
@@ -692,7 +692,7 @@ namespace sycl::ext::oneapi::experimental {
 
 void partial_barrier(sycl::queue q, const std::vector<sycl::event>& events);
 
-void partial_barrier(sycl::handler h, const std::vector<sycl::event>& events);
+void partial_barrier(sycl::handler &h, const std::vector<sycl::event>& events);
 
 }
 ----


### PR DESCRIPTION
... always instead of by value sometimes. 
This fixes a mismatch between implementation and spec.