### PR TITLE
[NFCI][SYCL] Move `IsProperty[*Value]` to `property[_value].hpp`

### DIFF
--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -264,6 +264,13 @@ struct IsCompileTimeProperty
           std::is_base_of_v<property_key_base_tag, PropertyT> &&
           std::is_base_of_v<compile_time_property_key_base_tag, PropertyT>> {};
 
+// Checks if a type is either a runtime property or if it is a compile-time
+// property
+template <typename T> struct IsProperty {
+  static constexpr bool value =
+      IsRuntimeProperty<T>::value || IsCompileTimeProperty<T>::value;
+};
+
 // Trait for property compile-time meta names and values.
 template <typename PropertyT> struct PropertyMetaInfo {
   // Some properties don't have meaningful compile-time values.

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -12,7 +12,8 @@
 #include <sycl/detail/boost/mp11/detail/mp_list.hpp>   // for mp_list
 #include <sycl/detail/boost/mp11/detail/mp_rename.hpp> // for mp_rename
 #include <sycl/detail/boost/mp11/integral.hpp>         // for mp_bool
-#include <sycl/ext/oneapi/properties/property.hpp> // for PropertyID, IsRun...
+#include <sycl/ext/oneapi/properties/property.hpp>
+#include <sycl/ext/oneapi/properties/property_value.hpp>
 
 #include <array>       // for tuple_element
 #include <stddef.h>    // for size_t
@@ -48,33 +49,9 @@ struct PrependTuple<T, std::tuple<Ts...>> {
   using type = std::tuple<T, Ts...>;
 };
 
-// Checks if a type T has a static value member variable.
-template <typename T, typename U = int> struct HasValue : std::false_type {};
-template <typename T>
-struct HasValue<T, decltype((void)T::value, 0)> : std::true_type {};
-
 //******************************************************************************
 // Property identification
 //******************************************************************************
-
-// Checks if a type is a compile-time property values.
-// Note: This is specialized for property_value elsewhere.
-template <typename PropertyT>
-struct IsCompileTimePropertyValue : std::false_type {};
-
-// Checks if a type is either a runtime property or if it is a compile-time
-// property
-template <typename T> struct IsProperty {
-  static constexpr bool value =
-      IsRuntimeProperty<T>::value || IsCompileTimeProperty<T>::value;
-};
-
-// Checks if a type is a valid property value, i.e either runtime property or
-// property_value with a valid compile-time property
-template <typename T> struct IsPropertyValue {
-  static constexpr bool value =
-      IsRuntimeProperty<T>::value || IsCompileTimePropertyValue<T>::value;
-};
 
 // Checks that all types in a tuple are valid properties.
 template <typename T> struct AllPropertyValues {};

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -8,8 +8,7 @@
 
 #pragma once
 
-#include <sycl/ext/oneapi/properties/property.hpp>       // for IsCompileTi...
-#include <sycl/ext/oneapi/properties/property_utils.hpp> // for HasValue
+#include <sycl/ext/oneapi/properties/property.hpp>
 
 #include <type_traits> // for enable_if_t
 
@@ -17,6 +16,11 @@ namespace sycl {
 inline namespace _V1 {
 namespace ext::oneapi::experimental {
 namespace detail {
+
+// Checks if a type T has a static value member variable.
+template <typename T, typename U = int> struct HasValue : std::false_type {};
+template <typename T>
+struct HasValue<T, decltype((void)T::value, 0)> : std::true_type {};
 
 // Base class for property values with a single non-type value
 template <typename T, typename = void> struct SingleNontypePropertyValueBase {};
@@ -80,11 +84,19 @@ template <typename PropertyT, typename... PropertyValueTs>
 struct PropertyID<property_value<PropertyT, PropertyValueTs...>>
     : PropertyID<PropertyT> {};
 
-// Specialization of IsCompileTimePropertyValue for property values.
+// Checks if a type is a compile-time property values.
+template <typename PropertyT>
+struct IsCompileTimePropertyValue : std::false_type {};
 template <typename PropertyT, typename... PropertyValueTs>
 struct IsCompileTimePropertyValue<property_value<PropertyT, PropertyValueTs...>>
     : IsCompileTimeProperty<PropertyT> {};
 
+// Checks if a type is a valid property value, i.e either runtime property or
+// property_value with a valid compile-time property
+template <typename T> struct IsPropertyValue {
+  static constexpr bool value =
+      IsRuntimeProperty<T>::value || IsCompileTimePropertyValue<T>::value;
+};
 } // namespace detail
 } // namespace ext::oneapi::experimental
 } // namespace _V1

--- a/sycl/test/include_deps/sycl_detail_core.hpp.cpp
+++ b/sycl/test/include_deps/sycl_detail_core.hpp.cpp
@@ -136,8 +136,8 @@
 // CHECK-NEXT: ext/oneapi/device_global/properties.hpp
 // CHECK-NEXT: ext/oneapi/properties/property.hpp
 // CHECK-NEXT: ext/oneapi/properties/property_value.hpp
-// CHECK-NEXT: ext/oneapi/properties/property_utils.hpp
 // CHECK-NEXT: ext/oneapi/properties/properties.hpp
+// CHECK-NEXT: ext/oneapi/properties/property_utils.hpp
 // CHECK-NEXT: ext/oneapi/experimental/graph.hpp
 // CHECK-NEXT: handler.hpp
 // CHECK-NEXT: detail/cl.h


### PR DESCRIPTION
This should make it easier to follow the logic and understand if template parameters (like `PropertyT`) refer to keys or values.