### PR TITLE
[SYCL] Modernize prefetch property_key creation

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/prefetch.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/prefetch.hpp
@@ -20,7 +20,8 @@ enum class cache_level { L1 = 0, L2 = 1, L3 = 2, L4 = 3 };
 
 struct nontemporal;
 
-struct prefetch_hint_key {
+struct prefetch_hint_key
+    : detail::compile_time_property_key<detail::PropKind::Prefetch> {
   template <cache_level Level, typename Hint>
   using value_t =
       property_value<prefetch_hint_key,
@@ -50,8 +51,6 @@ inline constexpr prefetch_hint_key::value_t<cache_level::L4, nontemporal>
 
 namespace detail {
 using namespace sycl::detail;
-
-template <> struct IsCompileTimeProperty<prefetch_hint_key> : std::true_type {};
 
 template <cache_level Level, typename Hint>
 struct PropertyMetaInfo<prefetch_hint_key::value_t<Level, Hint>> {

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -214,8 +214,9 @@ enum PropKind : uint32_t {
   ResponseCapacity = 73,
   MaxWorkGroupSize = 74,
   MaxLinearWorkGroupSize = 75,
+  Prefetch = 76,
   // PropKindSize must always be the last value.
-  PropKindSize = 76,
+  PropKindSize = 77,
 };
 
 struct property_key_base_tag {};


### PR DESCRIPTION
Simplified key creation was introduced in
https://github.com/intel/llvm/pull/12831 but this one was never updated. I think it happened because this property never defined `PropKind` enum entry and I'm not even sure how it worked or what are scenarios where it was broken.

Regardless, fix and unify with all other properties with this PR.