### PR TITLE
[SYCL][E2E] Update some XFAIL tests

### DIFF
--- a/sycl/test-e2e/Basic/accessor/accessor.cpp
+++ b/sycl/test-e2e/Basic/accessor/accessor.cpp
@@ -1,8 +1,8 @@
 // RUN: %{build} -DSYCL2020_DISABLE_DEPRECATION_WARNINGS -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14826
 
 //==----------------accessor.cpp - SYCL accessor basic test ----------------==//
 //

--- a/sycl/test-e2e/Basic/fpga_tests/fpga_pipes_mixed_usage.cpp
+++ b/sycl/test-e2e/Basic/fpga_tests/fpga_pipes_mixed_usage.cpp
@@ -9,8 +9,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 
-// https://github.com/intel/llvm/issues/13887
 // XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/13887
 // If users need to use host pipe feature provided by experimental::pipe, all
 // pipes in their design should use the experimental::pipe (as a workround).
 

--- a/sycl/test-e2e/Basic/image/srgba-read.cpp
+++ b/sycl/test-e2e/Basic/image/srgba-read.cpp
@@ -1,6 +1,6 @@
 // REQUIRES: aspect-ext_oneapi_srgb, aspect-ext_intel_legacy_image
-// https://github.com/intel/llvm/issues/14387
 // XFAIL: gpu-intel-dg2
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14387
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out | FileCheck %s
 

--- a/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
+++ b/sycl/test-e2e/DeprecatedFeatures/set_arg_interop.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: opencl, opencl_icd
 
-// https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14826
 
 // RUN: %{build} -D__SYCL_INTERNAL_API -o %t.out %opencl_lib -O3
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/DeviceArchitecture/device_architecture_comparison_on_device_aot.cpp
+++ b/sycl/test-e2e/DeviceArchitecture/device_architecture_comparison_on_device_aot.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: arch-intel_gpu_pvc, ocloc
 
-// https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14826
 
 // RUN: %clangxx -fsycl -fsycl-targets=intel_gpu_pvc %s -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test-e2e/ESIMD/assert.cpp
+++ b/sycl/test-e2e/ESIMD/assert.cpp
@@ -8,6 +8,7 @@
 // as expected to fail, whilst it is being investigated, see intel/llvm#11359
 // FIXME: remove that XFAIL
 // XFAIL: linux
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/11359
 //
 // Hanging on gen12, remove when internal tracker fixed
 // UNSUPPORTED: gpu-intel-gen12

--- a/sycl/test-e2e/ESIMD/assert.cpp
+++ b/sycl/test-e2e/ESIMD/assert.cpp
@@ -6,7 +6,6 @@
 //
 // The test still fails after GPU driver update on Linux. Temporary marking it
 // as expected to fail, whilst it is being investigated, see intel/llvm#11359
-// FIXME: remove that XFAIL
 // XFAIL: linux
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/11359
 //

--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -3,7 +3,6 @@
 
 // UNSUPPORTED: hip || cuda
 
-// TODO: Remove XFAIL after fixing
 // XFAIL: gpu
 // XFAIL-TRACKER: https://github.com/intel/intel-graphics-compiler/issues/330
 

--- a/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
+++ b/sycl/test-e2e/LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
@@ -4,8 +4,8 @@
 // UNSUPPORTED: hip || cuda
 
 // TODO: Remove XFAIL after fixing
-// https://github.com/intel/intel-graphics-compiler/issues/330
 // XFAIL: gpu
+// XFAIL-TRACKER: https://github.com/intel/intel-graphics-compiler/issues/330
 
 // Make dump directory.
 // RUN: rm -rf %t.spvdir && mkdir %t.spvdir

--- a/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
+++ b/sycl/test-e2e/Plugin/interop-cuda-experimental.cpp
@@ -3,8 +3,8 @@
 // RUN: %{build} %cuda_options -o %t.out
 // RUN: %{run} %t.out
 
-// An issue has been reported in https://github.com/intel/llvm/issues/14116
 // XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14116
 
 #define SYCL_EXT_ONEAPI_BACKEND_CUDA_EXPERIMENTAL 1
 #include <sycl/backend.hpp>

--- a/sycl/test-e2e/Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
+++ b/sycl/test-e2e/Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
@@ -2,8 +2,8 @@
 // RUN: %{build} %cuda_options -lcudart -lcuda -x cuda -o %t.out
 // RUN: %{run} %t.out
 
-// An issue has been reported in https://github.com/intel/llvm/issues/14115
 // XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14116
 
 #include <cuda.h>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-call.cpp
@@ -3,8 +3,8 @@
 // VTables are global variables with possibly external linkage and that causes
 // them to be copied into every module we produce during device code split
 // which in turn leads to multiple definitions error at runtime.
-// https://github.com/intel/llvm/issues/15069
 // XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15069
 //
 // This test covers a scenario where virtual functions defintion and their uses
 // are split into different translation units. In particular:

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
@@ -5,8 +5,8 @@
 // function definitions and therefore we won't mark construct kernel as using
 // virtual functions and link operation at runtime will fail due to undefined
 // references to virtual functions from vtable.
-// https://github.com/intel/llvm/issues/15071
 // XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15071
 //
 // This test covers a scenario where virtual functions defintion and their uses
 // are all split into different translation units.

--- a/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
+++ b/sycl/test-e2e/VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
@@ -5,8 +5,8 @@
 // function definitions and therefore we won't mark construct kernel as using
 // virtual functions and link operation at runtime will fail due to undefined
 // references to virtual functions from vtable.
-// https://github.com/intel/llvm/issues/15071
 // XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15071
 //
 // This test covers a scenario where virtual functions defintion and their uses
 // are split into different translation units. In particular:

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -20,7 +20,7 @@ from lit.llvm.subst import ToolSubst, FindTool
 config.name = "SYCL"
 
 # suffixes: A list of file extensions to treat as test files.
-config.suffixes = [".c", ".cpp"]
+config.suffixes = [".cpp"]
 
 config.excludes = ["Inputs"]
 

--- a/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
+++ b/sycl/test-e2e/syclcompat/launch/launch_policy_lmem.cpp
@@ -20,8 +20,8 @@
  *     launch<F> with policy & use local memory tests
  **************************************************************************/
 
-// https://github.com/intel/llvm/issues/14826
 // XFAIL: arch-intel_gpu_pvc
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/14826
 
 // RUN: %{build} -fsycl-device-code-split=per_kernel -o %t.out
 // RUN: %{run} %t.out

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -30,7 +30,7 @@
 // - ...and check if the list of improperly UNSUPPORTED tests needs to be updated.
 //
 // RUN: grep -rI "UNSUPPORTED:" %S/../../test-e2e \
-// RUN: -A 1 --include=*.c --include=*.cpp --no-group-separator | \
+// RUN: -A 1 --include=*.cpp --no-group-separator | \
 // RUN: grep -v "UNSUPPORTED:" | \
 // RUN: grep -Pv "UNSUPPORTED-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)|(?:UNSUPPORTED-INTENDED:\s*.+)" > %t
 // RUN: cat %t | wc -l | FileCheck %s --check-prefix NUMBER-OF-UNSUPPORTED-WITHOUT-INFO

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -27,7 +27,7 @@
 // - ...and check if the list of improperly XFAIL-ed tests needs to be updated.
 //
 // RUN: grep -rI "XFAIL:" %S/../../test-e2e \
-// RUN: -A 1 --include=*.c --include=*.cpp --no-group-separator | \
+// RUN: -A 1 --include=*.cpp --no-group-separator | \
 // RUN: grep -v "XFAIL:" | \
 // RUN: grep -Pv "XFAIL-TRACKER:\s+(?:https://github.com/[\w\d-]+/[\w\d-]+/issues/[\d]+)|(?:[\w]+-[\d]+)" > %t
 // RUN: cat %t | wc -l | FileCheck %s --check-prefix NUMBER-OF-XFAIL-WITHOUT-TRACKER
@@ -51,20 +51,17 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 156
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 143
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been propely XFAIL-ed.
 //
 // CHECK: AddressSanitizer/nullpointer/private_nullptr.cpp
-// CHECK-NEXT: Basic/accessor/accessor.cpp
 // CHECK-NEXT: Basic/aspects.cpp
 // CHECK-NEXT: Basic/buffer/reinterpret.cpp
 // CHECK-NEXT: Basic/built-ins.cpp
 // CHECK-NEXT: Basic/device_event.cpp
 // CHECK-NEXT: Basic/diagnostics/handler.cpp
-// CHECK-NEXT: Basic/fpga_tests/fpga_pipes_mixed_usage.cpp
-// CHECK-NEXT: Basic/image/srgba-read.cpp
 // CHECK-NEXT: Basic/max_linear_work_group_size_props.cpp
 // CHECK-NEXT: Basic/max_work_group_size_props.cpp
 // CHECK-NEXT: Basic/partition_supported.cpp
@@ -73,12 +70,9 @@
 // CHECK-NEXT: Basic/span.cpp
 // CHECK-NEXT: Basic/stream/auto_flush.cpp
 // CHECK-NEXT: DeprecatedFeatures/queue_old_interop.cpp
-// CHECK-NEXT: DeprecatedFeatures/set_arg_interop.cpp
-// CHECK-NEXT: DeviceArchitecture/device_architecture_comparison_on_device_aot.cpp
 // CHECK-NEXT: DeviceCodeSplit/split-per-kernel.cpp
 // CHECK-NEXT: DeviceCodeSplit/split-per-source-main.cpp
 // CHECK-NEXT: DeviceLib/assert-windows.cpp
-// CHECK-NEXT: ESIMD/assert.cpp
 // CHECK-NEXT: ESIMD/hardware_dispatch.cpp
 // CHECK-NEXT: GroupAlgorithm/root_group.cpp
 // CHECK-NEXT: GroupLocalMemory/group_local_memory.cpp
@@ -93,7 +87,6 @@
 // CHECK-NEXT: InvokeSimd/Spec/tuple_return.cpp
 // CHECK-NEXT: InvokeSimd/Spec/tuple_vadd.cpp
 // CHECK-NEXT: KernelAndProgram/kernel-bundle-merge-options.cpp
-// CHECK-NEXT: LLVMIntrinsicLowering/sub_byte_bitreverse.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_annotated_ptr.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_bfloat16_colmajorA_colmajorB.cpp
 // CHECK-NEXT: Matrix/SG32/joint_matrix_bfloat16_packedB.cpp
@@ -177,8 +170,6 @@
 // CHECK-NEXT: NewOffloadDriver/sycl-external-with-optional-features.cpp
 // CHECK-NEXT: OptionalKernelFeatures/throw-exception-for-out-of-registers-on-kernel-launch.cpp
 // CHECK-NEXT: PerformanceTests/Reduction/reduce_over_sub_group.cpp
-// CHECK-NEXT: Plugin/interop-cuda-experimental.cpp
-// CHECK-NEXT: Plugin/interop-experimental-single-TU-SYCL-CUDA-compilation.cpp
 // CHECK-NEXT: Printf/int.cpp
 // CHECK-NEXT: Printf/mixed-address-space.cpp
 // CHECK-NEXT: Printf/percent-symbol.cpp
@@ -208,7 +199,3 @@
 // CHECK-NEXT: Scheduler/MultipleDevices.cpp
 // CHECK-NEXT: Scheduler/ReleaseResourcesTest.cpp
 // CHECK-NEXT: Tracing/buffer_printers.cpp
-// CHECK-NEXT: VirtualFunctions/multiple-translation-units/separate-call.cpp
-// CHECK-NEXT: VirtualFunctions/multiple-translation-units/separate-vf-defs-and-call.cpp
-// CHECK-NEXT: VirtualFunctions/multiple-translation-units/separate-vf-defs.cpp
-// CHECK-NEXT: syclcompat/launch/launch_policy_lmem.cpp


### PR DESCRIPTION
Update the tests that already contain a link.
Also update lit config and tests to not include `.c` files, we don't have such tests in SYCL.