### PR TITLE
[SYCL][E2E] Add UNSUPPORTED trackers to device_global tests

### DIFF
--- a/sycl/test-e2e/DeviceGlobal/device_global_arrow.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_arrow.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests operator-> on device_global.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_arrow_dis.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_arrow_dis.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests operator-> on device_global with device_image_scope.
 // NOTE: USE_DEVICE_IMAGE_SCOPE needs both kernels to be in the same image so

--- a/sycl/test-e2e/DeviceGlobal/device_global_device_only.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_device_only.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests basic device_global access through device kernels.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_device_only_dis.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_device_only_dis.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests basic device_global with device_image_scope access through device
 // kernels.

--- a/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests the passthrough of operators on device_global.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough_dis.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_operator_passthrough_dis.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests the passthrough of operators on device_global with device_image_scope.
 // NOTE: USE_DEVICE_IMAGE_SCOPE needs both kernels to be in the same image so

--- a/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_static.cpp
@@ -1,12 +1,11 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
+// UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
-// UNSUPPORTED: hip_amd, opencl && gpu
-//
-// For HIP see https://github.com/intel/llvm/issues/15329
+// UNSUPPORTED: hip_amd
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15329
 //
 // Tests static device_global access through device kernels.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_subscript.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_subscript.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests operator[] on device_global.
 

--- a/sycl/test-e2e/DeviceGlobal/device_global_subscript_dis.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_subscript_dis.cpp
@@ -1,9 +1,8 @@
 // RUN: %{build} -fsycl-device-code-split=per_source -DUSE_DEVICE_IMAGE_SCOPE -o %t.out
 // RUN: %{run} %t.out
 //
-// The OpenCL GPU backends do not currently support device_global backend
-// calls.
 // UNSUPPORTED: opencl && gpu
+// UNSUPPORTED-TRACKER: GSD-4287
 //
 // Tests operator[] on device_global with device_image_scope.
 // NOTE: USE_DEVICE_IMAGE_SCOPE needs both kernels to be in the same image so

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 487
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 478
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been propely UNSUPPORTED.
@@ -104,15 +104,6 @@
 // CHECK-NEXT: Config/kernel_from_file.cpp
 // CHECK-NEXT: DeviceArchitecture/device_architecture_comparison_on_host.cpp
 // CHECK-NEXT: DeviceCodeSplit/aot-gpu.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_arrow.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_arrow_dis.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_device_only.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_device_only_dis.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_operator_passthrough.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_operator_passthrough_dis.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_static.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_subscript.cpp
-// CHECK-NEXT: DeviceGlobal/device_global_subscript_dis.cpp
 // CHECK-NEXT: DeviceImageDependencies/dynamic.cpp
 // CHECK-NEXT: DeviceImageDependencies/free_function_kernels.cpp
 // CHECK-NEXT: DeviceImageDependencies/math_device_lib.cpp


### PR DESCRIPTION
This commit adds the UNSUPPORTED-TRACKER line to device_global E2E tests.