### PR TITLE
[libclc] Split off library build system into helpers

### DIFF
--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -337,7 +337,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       list( APPEND opencl_gen_files clspv-convert.cl )
     elseif ( NOT ENABLE_RUNTIME_SUBNORMAL )
       list( APPEND opencl_gen_files convert-clc.cl )
-      list( APPEND opencl_lib_files generic/lib/subnormal_use_default.ll )
+      list( APPEND opencl_lib_files generic/libspirv/subnormal_use_default.ll )
     endif()
   endif()
 

--- a/libclc/CMakeLists.txt
+++ b/libclc/CMakeLists.txt
@@ -181,7 +181,7 @@ if( "spirv-mesa3d-" IN_LIST LIBCLC_TARGETS_TO_BUILD OR "spirv64-mesa3d-" IN_LIST
 endif()
 
 add_custom_target(libspirv-builtins COMMENT "Build libspirv builtins")
-add_custom_target(libclc-builtins COMMENT "Build libclc builtins")
+add_custom_target(libopencl-builtins COMMENT "Build libclc builtins")
 
 set(LIBCLC_TARGET_TO_TEST)
 
@@ -329,19 +329,40 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       " configuration, some SYCL programs may fail to build.")
   endif()
 
-  set( lib_files )
-  set( lib_gen_files )
-  libclc_configure_lib_source(lib_files lib_gen_files
-    LIB_DIR lib
-    DIRS ${dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
-    DEPS convert-clc.cl )
+  set( opencl_lib_files )
+  set( opencl_gen_files )
 
-  set( libspirv_files )
+  if( NOT ARCH STREQUAL spirv AND NOT ARCH STREQUAL spirv64 )
+    if( ARCH STREQUAL clspv OR ARCH STREQUAL clspv64 )
+      list( APPEND opencl_gen_files clspv-convert.cl )
+    elseif ( NOT ENABLE_RUNTIME_SUBNORMAL )
+      list( APPEND opencl_gen_files convert-clc.cl )
+      list( APPEND opencl_lib_files generic/lib/subnormal_use_default.ll )
+    endif()
+  endif()
+
+  libclc_configure_lib_source(
+    opencl_lib_files
+    DIRS ${dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
+  )
+
+  set( libspirv_lib_files )
   set( libspirv_gen_files )
-  libclc_configure_lib_source(libspirv_files libspirv_gen_files
+
+  if( NOT ARCH STREQUAL spirv AND NOT ARCH STREQUAL spirv64 )
+    if( ARCH STREQUAL clspv OR ARCH STREQUAL clspv64 )
+      list( APPEND libspirv_gen_files clspv-convert.cl )
+    elseif ( NOT ENABLE_RUNTIME_SUBNORMAL )
+      list( APPEND libspirv_gen_files convert-spirv.cl convert-core.cl )
+      list( APPEND libspirv_lib_files generic/libspirv/subnormal_use_default.ll )
+    endif()
+  endif()
+
+  libclc_configure_lib_source(
+    libspirv_lib_files
     LIB_DIR libspirv
     DIRS ${dirs} ${DARCH} ${DARCH}-${OS} ${DARCH}-${VENDOR}-${OS}
-    DEPS convert-spirv.cl convert-core.cl)
+  )
 
   foreach( d ${${t}_devices} )
     get_libclc_device_info(
@@ -353,27 +374,23 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     )
 
     # Some targets don't have a specific GPU to target
-    set( flags )
+    set( build_flags )
     if( d STREQUAL none OR ARCH STREQUAL spirv OR ARCH STREQUAL spirv64 )
       # FIXME: Ideally we would not be tied to a specific PTX ISA version
       if( ARCH STREQUAL nvptx OR ARCH STREQUAL nvptx64 )
         # Disables NVVM reflection to defer to after linking
-        list( APPEND flags -Xclang -target-feature -Xclang +ptx72
+        list( APPEND build_flags -Xclang -target-feature -Xclang +ptx72
              -march=sm_86 -mllvm --nvvm-reflect-enable=false)
       elseif( ARCH STREQUAL amdgcn )
         # AMDGCN needs libclc to be compiled to high bc version since all atomic
         # clang builtins need to be accessible
-        list( APPEND flags -mcpu=gfx940 -mllvm --amdgpu-oclc-reflect-enable=false )
+        list( APPEND build_flags -mcpu=gfx940 -mllvm --amdgpu-oclc-reflect-enable=false )
       elseif( IS_NATIVE_CPU_ARCH )
-        list( APPEND flags -Xclang -fsycl-is-native-cpu )
+        list( APPEND build_flags -Xclang -fsycl-is-native-cpu )
         if( ARCH  STREQUAL x86_64 )
-          list( APPEND flags ${LIBCLC_NATIVECPU_FLAGS_X86_64})
+          list( APPEND build_flags ${LIBCLC_NATIVECPU_FLAGS_X86_64})
         endif()
       endif()
-    endif()
-
-    if( NOT "${cpu}" STREQUAL "" )
-      list( APPEND flags -mcpu=${cpu} )
     endif()
 
     message( STATUS "  device: ${d} ( ${${d}_aliases} )" )
@@ -410,7 +427,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
 
     # Enable SPIR-V builtin function declarations, so they don't
     # have to be explicity declared in the soruce.
-    list( APPEND flags -Xclang -fdeclare-spirv-builtins)
+    list( APPEND build_flags -Xclang -fdeclare-spirv-builtins)
     set( LIBCLC_ARCH_OBJFILE_DIR "${LIBCLC_OBJFILE_DIR}/${arch_suffix}" )
     file( MAKE_DIRECTORY ${LIBCLC_ARCH_OBJFILE_DIR} )
 
@@ -428,7 +445,7 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
     if( supports_generic_addrspace )
       string( APPEND CL_3_0_EXTENSIONS ",+__opencl_c_generic_address_space" )
       if( has_distinct_generic_addrspace )
-        list( APPEND flags -D__CLC_DISTINCT_GENERIC_ADDRSPACE__ )
+        list( APPEND build_flags -D__CLC_DISTINCT_GENERIC_ADDRSPACE__ )
       endif()
     else()
       # Explictly disable opencl_c_generic_address_space (it may be enabled
@@ -438,42 +455,60 @@ foreach( t ${LIBCLC_TARGETS_TO_BUILD} )
       string( APPEND CL_3_0_EXTENSIONS ",-__opencl_c_pipes" )
       string( APPEND CL_3_0_EXTENSIONS ",-__opencl_c_device_enqueue" )
     endif()
-    list( APPEND flags -cl-std=CL3.0 "-Xclang" ${CL_3_0_EXTENSIONS} )
+    list( APPEND build_flags -cl-std=CL3.0 "-Xclang" ${CL_3_0_EXTENSIONS} )
 
     # Add platform specific flags
     if(WIN32)
-      list(APPEND flags -D_WIN32)
+      list(APPEND build_flags -D_WIN32)
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
-      list(APPEND flags -D__APPLE__)
+      list(APPEND build_flags -D__APPLE__)
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
-      list(APPEND flags -D__unix__ -D__linux__)
+      list(APPEND build_flags -D__unix__ -D__linux__)
     else()
       # Assume some UNIX system otherwise
-      list(APPEND flags -D__unix__)
+      list(APPEND build_flags -D__unix__)
     endif()
 
-    add_libclc_builtin_set(libspirv-${arch_suffix}
+    string( TOUPPER "CLC_${ARCH}" CLC_TARGET_DEFINE )
+
+    list( APPEND build_flags
+      -D__CLC_INTERNAL
+      -D${CLC_TARGET_DEFINE}
+      -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
+      # FIXME: Fix libclc to not require disabling this noisy warning
+      -Wno-bitwise-conditional-parentheses
+    )
+
+    if( NOT "${cpu}" STREQUAL "" )
+      list( APPEND build_flags -mcpu=${cpu} )
+    endif()
+
+    add_libclc_builtin_set(
+      ARCH ${ARCH}
+      ARCH_SUFFIX libspirv-${arch_suffix}
       TRIPLE ${clang_triple}
-      TARGET_ENV libspirv
-      COMPILE_OPT ${flags}
+      TARGET_ENV libspirv-
+      COMPILE_FLAGS ${build_flags}
       OPT_FLAGS ${opt_flags}
-      FILES ${libspirv_files}
+      LIB_FILES ${libspirv_lib_files}
       GEN_FILES ${libspirv_gen_files}
       ALIASES ${${d}_aliases}
       GENERATE_TARGET "generate_convert_spirv.cl" "generate_convert_core.cl"
-      PARENT_TARGET libspirv-builtins)
+      PARENT_TARGET libspirv-builtins
+    )
 
-    add_libclc_builtin_set(clc-${arch_suffix}
+    add_libclc_builtin_set(
+      ARCH ${ARCH}
+      ARCH_SUFFIX ${arch_suffix}
       TRIPLE ${clang_triple}
-      TARGET_ENV clc
-      COMPILE_OPT ${flags}
+      COMPILE_FLAGS ${build_flags}
       OPT_FLAGS ${opt_flags}
-      FILES ${lib_files}
-      GEN_FILES ${lib_gen_files}
-      LIB_DEP libspirv-${arch_suffix}
+      LIB_FILES ${opencl_lib_files}
+      GEN_FILES ${opencl_gen_files}
       ALIASES ${${d}_aliases}
       GENERATE_TARGET "generate_convert_clc.cl"
-      PARENT_TARGET libclc-builtins)
+      PARENT_TARGET libopencl-builtins
+    )
   endforeach( d )
 endforeach( t )
 

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -266,39 +266,48 @@ function(process_bc out_file)
   )
 endfunction()
 
-# add_libclc_builtin_set(arch_suffix
-#   TRIPLE string
-#     Triple used to compile
-#   TARGET_ENV string
-#     "clc" or "libspirv"
-#   FILES string ...
-#     List of file that should be built for this library
-#   ALIASES string ...
-#     List of alises
-#   COMPILE_OPT
-#     Compilation options
-#   LIB_DEP
-#     Library to include to the builtin set
-#   )
-macro(add_libclc_builtin_set arch_suffix)
+# Compiles a list of library source files (provided by LIB_FILES/GEN_FILES) and
+# compiles them to LLVM bytecode (or SPIR-V), links them together and optimizes
+# them.
+#
+# For bytecode libraries, a list of ALIASES may optionally be provided to
+# produce additional symlinks.
+#
+# Arguments:
+#  * ARCH <string>
+#      libclc architecture being built
+#  * ARCH_SUFFIX <string>
+#      libclc architecture/triple suffix
+#  * TRIPLE <string>
+#      Triple used to compile
+#
+# Optional Arguments:
+#  * LIB_FILES <string> ...
+#      List of files that should be built for this library
+#  * GEN_FILES <string> ...
+#      List of generated files (in build dir) that should be built for this library
+#  * COMPILE_FLAGS <string> ...
+#      Compilation options (for clang)
+#  * OPT_FLAGS <string> ...
+#      Optimization options (for opt)
+#  * TARGET_ENV <string>
+#      Prefix to give the final builtin library aliases
+#  * ALIASES <string> ...
+#      List of aliases
+function(add_libclc_builtin_set)
   cmake_parse_arguments(ARG
     ""
-    "TRIPLE;TARGET_ENV;LIB_DEP;PARENT_TARGET"
-    "GEN_FILES;FILES;ALIASES;GENERATE_TARGET;COMPILE_OPT;OPT_FLAGS"
-    ${ARGN})
-
-  string( TOUPPER "CLC_${ARCH}" CLC_TARGET_DEFINE )
-
-  list( APPEND ARG_COMPILE_OPT
-    -D__CLC_INTERNAL
-    -D${CLC_TARGET_DEFINE}
-    -I${CMAKE_CURRENT_SOURCE_DIR}/generic/include
-    # FIXME: Fix libclc to not require disabling this noisy warning
-    -Wno-bitwise-conditional-parentheses
+    "ARCH;TRIPLE;ARCH_SUFFIX;TARGET_ENV;PARENT_TARGET"
+    "LIB_FILES;GEN_FILES;COMPILE_FLAGS;OPT_FLAGS;ALIASES"
+    ${ARGN}
   )
 
+  if( NOT ARG_ARCH OR NOT ARG_ARCH_SUFFIX OR NOT ARG_TRIPLE)
+    message( FATAL_ERROR "Must provide ARCH, ARCH_SUFFIX, and TRIPLE" )
+  endif()
+
   set( bytecode_files "" )
-  foreach( file IN LISTS ARG_GEN_FILES ARG_FILES )
+  foreach( file IN LISTS ARG_GEN_FILES ARG_LIB_FILES )
     # We need to take each file and produce an absolute input file, as well
     # as a unique architecture-specific output file. We deal with a mix of
     # different input files, which makes this trickier.
@@ -326,18 +335,19 @@ macro(add_libclc_builtin_set arch_suffix)
       INPUT ${input_file}
       OUTPUT ${output_file}
       EXTRA_OPTS -fno-builtin -nostdlib
-          "${ARG_COMPILE_OPT}" -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
+        "${ARG_COMPILE_FLAGS}" -I${CMAKE_CURRENT_SOURCE_DIR}/${file_dir}
       DEPENDENCIES generate_convert.cl clspv-generate_convert.cl
     )
-    list(APPEND bytecode_files ${output_file})
+    list( APPEND bytecode_files ${output_file} )
   endforeach()
 
-  set( builtins_comp_lib_tgt builtins.comp.${arch_suffix} )
+  set( builtins_comp_lib_tgt builtins.comp.${ARG_ARCH_SUFFIX} )
   add_custom_target( ${builtins_comp_lib_tgt}
     DEPENDS ${bytecode_files}
   )
+  set_target_properties( ${builtins_comp_lib_tgt} PROPERTIES FOLDER "libclc/Device IR/Comp" )
 
-  set( builtins_link_lib_tgt builtins.link.${arch_suffix} )
+  set( builtins_link_lib_tgt builtins.link.${ARG_ARCH_SUFFIX} )
   link_bc(
     TARGET ${builtins_link_lib_tgt}
     INPUTS ${bytecode_files}
@@ -351,9 +361,23 @@ macro(add_libclc_builtin_set arch_suffix)
     COMMAND ${CMAKE_COMMAND} -E make_directory ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
     DEPENDS ${builtins_link_lib} prepare_builtins )
 
-  set( builtins_opt_lib_tgt builtins.opt.${arch_suffix} )
+  if( ARG_ARCH STREQUAL spirv OR ARG_ARCH STREQUAL spirv64 )
+    set( spv_suffix ${ARG_ARCH_SUFFIX}.spv )
+    add_custom_command( OUTPUT ${spv_suffix}
+      COMMAND ${llvm-spirv_exe} ${spvflags} -o ${spv_suffix} ${builtins_link_lib}
+      DEPENDS ${llvm-spirv_target} ${builtins_link_lib} ${builtins_link_lib_tgt}
+    )
+    add_custom_target( "prepare-${spv_suffix}" ALL DEPENDS "${spv_suffix}" )
+    set_target_properties( "prepare-${spv_suffix}" PROPERTIES FOLDER "libclc/Device IR/Prepare" )
+    install( FILES ${CMAKE_CURRENT_BINARY_DIR}/${spv_suffix}
+       DESTINATION "${CMAKE_INSTALL_DATADIR}/clc" )
 
-  process_bc(${arch_suffix}.bc
+    return()
+  endif()
+
+  set( builtins_opt_lib_tgt builtins.opt.${ARG_ARCH_SUFFIX} )
+
+  process_bc(${ARG_ARCH_SUFFIX}.bc
     LIB_TGT ${builtins_opt_lib_tgt}
     IN_FILE ${builtins_link_lib}
     OUT_DIR ${LIBCLC_LIBRARY_OUTPUT_INTDIR}
@@ -362,7 +386,7 @@ macro(add_libclc_builtin_set arch_suffix)
 
   # Add dependency to top-level pseudo target to ease making other
   # targets dependent on libclc.
-  set( obj_suffix ${arch_suffix}.bc )
+  set( obj_suffix ${ARG_ARCH_SUFFIX}.bc )
   add_dependencies(${ARG_PARENT_TARGET} prepare-${obj_suffix})
   set( builtins_lib $<TARGET_PROPERTY:prepare-${obj_suffix},TARGET_FILE> )
 
@@ -436,7 +460,7 @@ macro(add_libclc_builtin_set arch_suffix)
   endif()
 
   # nvptx-- targets don't include workitem builtins
-  if( NOT ${t} MATCHES ".*ptx.*--$" )
+  if( NOT ARG_TRIPLE MATCHES ".*ptx.*--$" )
     add_test( NAME external-calls-${obj_suffix}
       COMMAND ./check_external_calls.sh ${builtins-lib}
       WORKING_DIRECTORY ${LIBCLC_LIBRARY_OUTPUT_INTDIR} )
@@ -445,26 +469,50 @@ macro(add_libclc_builtin_set arch_suffix)
   endif()
 
   foreach( a ${$ARG_ALIASES} )
-    set( alias_suffix "${ARG_TARGET_ENV}-${a}-${ARG_TRIPLE}.bc" )
+    set( alias_suffix "${ARG_TARGET_ENV}${a}-${ARG_TRIPLE}.bc" )
     add_libclc_alias( ${alias_suffix}
       ${arch_suffix}
       PARENT_TARGET ${ARG_PARENT_TARGET})
   endforeach( a )
 
-endmacro(add_libclc_builtin_set arch_suffix)
+endfunction(add_libclc_builtin_set)
 
-function(libclc_configure_lib_source OUT_LIST OUT_GEN_LIST)
+# Produces a list of libclc source files by walking over SOURCES files in a
+# given directory. Outputs the list of files in LIB_FILE_LIST.
+#
+# LIB_FILE_LIST may be pre-populated and is appended to.
+#
+# Arguments:
+# * LIB_ROOT_DIR <string>
+#     Root directory containing target's lib files, relative to libclc root
+#     directory. If not provided, is set to '.'.
+# * LIB_DIR <string>
+#     Name of the directory containing the target's lib files. If not provided,
+#     is set to 'lib'.
+# * DIRS <string> ...
+#     List of directories under LIB_ROOT_DIR to walk over searching for SOURCES
+#     files
+function(libclc_configure_lib_source LIB_FILE_LIST)
   cmake_parse_arguments(ARG
     ""
-    "LIB_DIR"
-    "DIRS;DEPS"
-    ${ARGN})
+    "LIB_DIR;LIB_ROOT_DIR"
+    "DIRS"
+    ${ARGN}
+  )
+
+  if( NOT ARG_LIB_ROOT_DIR )
+    set(ARG_LIB_ROOT_DIR  ".")
+  endif()
+
+  if( NOT ARG_LIB_DIR )
+    set(ARG_LIB_DIR  "lib")
+  endif()
 
   # Enumerate SOURCES* files
   set( source_list )
   foreach( l ${ARG_DIRS} )
     foreach( s "SOURCES" "SOURCES_${LLVM_VERSION_MAJOR}.${LLVM_VERSION_MINOR}" )
-      file( TO_CMAKE_PATH ${l}/${ARG_LIB_DIR}/${s} file_loc )
+      file( TO_CMAKE_PATH ${ARG_LIB_ROOT_DIR}/${l}/${ARG_LIB_DIR}/${s} file_loc )
       file( TO_CMAKE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/${file_loc} loc )
       # Prepend the location to give higher priority to
       # specialized implementation
@@ -476,15 +524,8 @@ function(libclc_configure_lib_source OUT_LIST OUT_GEN_LIST)
 
   ## Add the generated convert files here to prevent adding the ones listed in
   ## SOURCES
-  set( objects ${ARG_DEPS} )   # A "set" of already-added input files
-  set( rel_files )             # Source directory input files, relative to the root dir
-  set( gen_files ${ARG_DEPS} ) # Generated binary input files, relative to the binary dir
-
-  if( NOT ENABLE_RUNTIME_SUBNORMAL )
-    if( EXISTS generic/${ARG_LIB_DIR}/subnormal_use_default.ll )
-      list( APPEND rel_files generic/${ARG_LIB_DIR}/subnormal_use_default.ll )
-    endif()
-  endif()
+  set( rel_files ${${LIB_FILE_LIST}} ) # Source directory input files, relative to the root dir
+  set( objects ${${LIB_FILE_LIST}} )   # A "set" of already-added input files
 
   foreach( l ${source_list} )
     file( READ ${l} file_list )
@@ -499,7 +540,5 @@ function(libclc_configure_lib_source OUT_LIST OUT_GEN_LIST)
     endforeach()
   endforeach()
 
-  set( ${OUT_LIST} ${rel_files} PARENT_SCOPE )
-  set( ${OUT_GEN_LIST} ${gen_files} PARENT_SCOPE )
-
-endfunction(libclc_configure_lib_source OUT_LIST OUT_GEN_LIST)
+  set( ${LIB_FILE_LIST} ${rel_files} PARENT_SCOPE )
+endfunction(libclc_configure_lib_source LIB_FILE_LIST)

--- a/libclc/cmake/modules/AddLibclc.cmake
+++ b/libclc/cmake/modules/AddLibclc.cmake
@@ -302,7 +302,7 @@ function(add_libclc_builtin_set)
     ${ARGN}
   )
 
-  if( NOT ARG_ARCH OR NOT ARG_ARCH_SUFFIX OR NOT ARG_TRIPLE)
+  if( NOT ARG_ARCH OR NOT ARG_ARCH_SUFFIX OR NOT ARG_TRIPLE )
     message( FATAL_ERROR "Must provide ARCH, ARCH_SUFFIX, and TRIPLE" )
   endif()
 

--- a/libclc/generic/lib/SOURCES
+++ b/libclc/generic/lib/SOURCES
@@ -46,7 +46,6 @@ cl_khr_int64_extended_atomics/atom_max.cl
 cl_khr_int64_extended_atomics/atom_min.cl
 cl_khr_int64_extended_atomics/atom_or.cl
 cl_khr_int64_extended_atomics/atom_xor.cl
-convert-clc.cl
 common/degrees.cl
 common/mix.cl
 common/radians.cl


### PR DESCRIPTION
This splits off several key parts of the build system into utility methods. This will be used in upcoming patches to help provide additional sets of target-specific builtin libraries.

Running llvm-diff on the resulting LLVM bytecode binaries, and regular diff on SPIR-V binaries, shows no differences before and after this patch.


---------

This is a cherry-pick of upstream commit 183b38eb2261164fdfd6b7deac002edf27a39fe7. The conflicts weren't trivial so I thought I'd resolve them myself and not wait for a pulldown. CC @jsji 