### PR TITLE
[SYCL] Minor fixes to SYCLConditionalCallOnDevice pass

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLConditionalCallOnDevice.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLConditionalCallOnDevice.cpp
@@ -104,6 +104,7 @@ SYCLConditionalCallOnDevicePass::run(Module &M, ModuleAnalysisManager &) {
                          &M);
 
     NewFCaller->setCallingConv(FCaller->getCallingConv());
+    NewFCaller->setAttributes(FCaller->getAttributes());
 
     DenseMap<CallInst *, CallInst *> OldCallsToNewCalls;
 

--- a/llvm/test/SYCLLowerIR/ConditionalCallOnDevice/conditional-call-on-device-1.ll
+++ b/llvm/test/SYCLLowerIR/ConditionalCallOnDevice/conditional-call-on-device-1.ll
@@ -28,7 +28,7 @@ entry:
   ret void
 }
 
-; CHECK: declare spir_func void @call_if_on_device_conditionally_PREFIX_1(ptr, ptr, i32, i32)
+; CHECK: declare spir_func void @call_if_on_device_conditionally_PREFIX_1(ptr[[VAL1:.*]], ptr[[VAL2:.*]], i32[[VAL3:.*]], i32[[VAL4:.*]])
 
 attributes #2 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #6 = { convergent inlinehint mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }

--- a/llvm/test/SYCLLowerIR/ConditionalCallOnDevice/conditional-call-on-device-2.ll
+++ b/llvm/test/SYCLLowerIR/ConditionalCallOnDevice/conditional-call-on-device-2.ll
@@ -42,8 +42,8 @@ entry:
   ret void
 }
 
-; CHECK: declare spir_func void @call_if_on_device_conditionally1_PREFIX_1(ptr, ptr, i32, i32)
-; CHECK: declare spir_func void @call_if_on_device_conditionally2_PREFIX_2(ptr, ptr, i32, i32)
+; CHECK: declare spir_func void @call_if_on_device_conditionally1_PREFIX_1(ptr[[VAL1:.*]], ptr[[VAL2:.*]], i32[[VAL3:.*]], i32[[VAL4:.*]])
+; CHECK: declare spir_func void @call_if_on_device_conditionally2_PREFIX_2(ptr[[VAL1:.*]], ptr[[VAL2:.*]], i32[[VAL3:.*]], i32[[VAL4:.*]])
 
 attributes #2 = { convergent mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }
 attributes #6 = { convergent inlinehint mustprogress norecurse nounwind "frame-pointer"="all" "no-trapping-math"="true" "stack-protector-buffer-size"="8" }


### PR DESCRIPTION
This patch fixes minor issues in impl and tests for SYCLConditionalCallOnDevice pass:

- new FCaller function now have attributes from the old one
- fix tests to support RelWithDebInfo and Debug modes