### PR TITLE
[SYCL][E2E] Use `%O0` instead of `-O0` in Compression tests

### DIFF
--- a/sycl/test-e2e/Compression/compression.cpp
+++ b/sycl/test-e2e/Compression/compression.cpp
@@ -4,8 +4,8 @@
 // XFAIL: hip_amd
 // XFAIL-TRACKER: https://github.com/intel/llvm/issues/15829
 
-// RUN: %{build} -O0 -g %S/Inputs/single_kernel.cpp -o %t_not_compress.out
-// RUN: %{build} -O0 -g --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
+// RUN: %{build} %O0 -g %S/Inputs/single_kernel.cpp -o %t_not_compress.out
+// RUN: %{build} %O0 -g --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
 // RUN: %{run} %t_not_compress.out
 // RUN: %{run} %t_compress.out
 // RUN: not diff %t_not_compress.out %t_compress.out

--- a/sycl/test-e2e/Compression/compression_aot.cpp
+++ b/sycl/test-e2e/Compression/compression_aot.cpp
@@ -1,5 +1,5 @@
 // End-to-End test for testing device image compression in AOT.
 // REQUIRES: zstd, opencl-aot, cpu
 
-// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -O0 --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
+// RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 %O0 --offload-compress --offload-compression-level=3 %S/Inputs/single_kernel.cpp -o %t_compress.out
 // RUN: %{run} %t_compress.out


### PR DESCRIPTION
Few Compression E2E tests fails with `clang-cl` because they use `-O0`. This PR updates the tests to use `%O0` instead. 