### PR TITLE
[LLVM] Fail if `LLVM_ENABLE_ZSTD` is `FORCE_ON` but static zstd libraries are not found

### DIFF
--- a/llvm/cmake/config-ix.cmake
+++ b/llvm/cmake/config-ix.cmake
@@ -161,6 +161,10 @@ endif()
 # If LLVM_USE_STATIC_ZSTD is specified, make sure we enable zstd only if static
 # libraries are found.
 if(LLVM_USE_STATIC_ZSTD AND NOT TARGET zstd::libzstd_static)
+  # Fail if LLVM_ENABLE_ZSTD is FORCE_ON.
+  if(LLVM_ENABLE_ZSTD STREQUAL FORCE_ON)
+      message(FATAL_ERROR "Failed to find static zstd libraries, but LLVM_USE_STATIC_ZSTD=ON and LLVM_ENABLE_ZSTD=FORCE_ON.")
+  endif()
 set(LLVM_ENABLE_ZSTD OFF)
 else()
 set(LLVM_ENABLE_ZSTD ${zstd_FOUND})


### PR DESCRIPTION
Currently, if we pass `LLVM_USE_STATIC_ZSTD=ON` and `LLVM_ENABLE_ZSTD=FORCE_ON`, we silently ignore zstd and proceed to build the compiler.
With `LLVM_ENABLE_ZSTD=FORCE_ON`, we should throw an error instead.

Thanks @tcreech-intel for find this.