### PR TITLE
[SYCL] Implement tracing for in-memory kernel and program cache

### DIFF
--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -181,8 +181,8 @@ public:
 
   /* Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
    * set.*/
-  static void traceProgram(const std::string &Msg,
-                           const ProgramCacheKeyT &CacheKey) {
+  static inline void traceProgram(const std::string &Msg,
+                                  const ProgramCacheKeyT &CacheKey) {
     static const bool traceEnabled =
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
     if (traceEnabled) {
@@ -205,8 +205,9 @@ public:
 
   /* Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
    * set.*/
-  static void traceKernel(const std::string &Msg, const std::string &KernelName,
-                          bool IsKernelFastCache = false) {
+  static inline void traceKernel(const std::string &Msg,
+                                 const std::string &KernelName,
+                                 bool IsKernelFastCache = false) {
     static const bool traceEnabled =
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
     if (traceEnabled) {

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -179,47 +179,50 @@ public:
 
   void setContextPtr(const ContextPtr &AContext) { MParentContext = AContext; }
 
-  /* Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
-   * set.*/
+  // Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
+  // set.
   static inline void traceProgram(const std::string &Msg,
                                   const ProgramCacheKeyT &CacheKey) {
     static const bool traceEnabled =
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
-    if (traceEnabled) {
 
-      int ImageId = CacheKey.first.second;
-      std::stringstream DeviceList;
-      for (const auto &Device : CacheKey.second)
-        DeviceList << "0x" << std::setbase(16)
-                   << reinterpret_cast<uintptr_t>(Device) << ",";
+    if (!traceEnabled)
+      return;
 
-      std::string Identifier = "[Key:{imageId = " + std::to_string(ImageId) +
-                               ",urDevice = " + DeviceList.str() + "}]: ";
+    int ImageId = CacheKey.first.second;
+    std::stringstream DeviceList;
+    for (const auto &Device : CacheKey.second)
+      DeviceList << "0x" << std::setbase(16)
+                 << reinterpret_cast<uintptr_t>(Device) << ",";
 
-      // Get TID of current thread.
-      thread_local std::thread::id this_id = std::this_thread::get_id();
-      std::cerr << "[In-Memory Cache][Thread Id:" << this_id
-                << "][Program Cache]" << Identifier << Msg << std::endl;
-    }
+    std::string Identifier = "[Key:{imageId = " + std::to_string(ImageId) +
+                             ",urDevice = " + DeviceList.str() + "}]: ";
+
+    // Get TID of current thread.
+    thread_local std::thread::id this_id = std::this_thread::get_id();
+    std::cerr << "[In-Memory Cache][Thread Id:" << this_id << "][Program Cache]"
+              << Identifier << Msg << std::endl;
   }
 
-  /* Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
-   * set.*/
+  // Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
+  // set.
   static inline void traceKernel(const std::string &Msg,
                                  const std::string &KernelName,
                                  bool IsKernelFastCache = false) {
     static const bool traceEnabled =
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
-    if (traceEnabled) {
-      std::string Identifier =
-          "[IsFastCache: " + std::to_string(IsKernelFastCache) +
-          "][Key:{Name = " + KernelName + "}]: ";
 
-      // Get TID of current thread.
-      thread_local std::thread::id this_id = std::this_thread::get_id();
-      std::cerr << "[In-Memory Cache][Thread Id:" << this_id
-                << "][Kernel Cache]" << Identifier << Msg << std::endl;
-    }
+    if (!traceEnabled)
+      return;
+
+    std::string Identifier =
+        "[IsFastCache: " + std::to_string(IsKernelFastCache) +
+        "][Key:{Name = " + KernelName + "}]: ";
+
+    // Get TID of current thread.
+    thread_local std::thread::id this_id = std::this_thread::get_id();
+    std::cerr << "[In-Memory Cache][Thread Id:" << this_id << "][Kernel Cache]"
+              << Identifier << Msg << std::endl;
   }
 
   Locked<ProgramCache> acquireCachedPrograms() {

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -183,10 +183,7 @@ public:
   // set.
   static inline void traceProgram(const std::string &Msg,
                                   const ProgramCacheKeyT &CacheKey) {
-    static const bool traceEnabled =
-        SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
-
-    if (!traceEnabled)
+    if (!SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache())
       return;
 
     int ImageId = CacheKey.first.second;
@@ -198,10 +195,8 @@ public:
     std::string Identifier = "[Key:{imageId = " + std::to_string(ImageId) +
                              ",urDevice = " + DeviceList.str() + "}]: ";
 
-    // Get TID of current thread.
-    thread_local std::thread::id this_id = std::this_thread::get_id();
-    std::cerr << "[In-Memory Cache][Thread Id:" << this_id << "][Program Cache]"
-              << Identifier << Msg << std::endl;
+    std::cerr << "[In-Memory Cache][Thread Id:" << std::this_thread::get_id()
+              << "][Program Cache]" << Identifier << Msg << std::endl;
   }
 
   // Sends message to std:cerr stream when SYCL_CACHE_TRACE environemnt is
@@ -209,20 +204,15 @@ public:
   static inline void traceKernel(const std::string &Msg,
                                  const std::string &KernelName,
                                  bool IsKernelFastCache = false) {
-    static const bool traceEnabled =
-        SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
-
-    if (!traceEnabled)
+    if (!SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache())
       return;
 
     std::string Identifier =
         "[IsFastCache: " + std::to_string(IsKernelFastCache) +
         "][Key:{Name = " + KernelName + "}]: ";
 
-    // Get TID of current thread.
-    thread_local std::thread::id this_id = std::this_thread::get_id();
-    std::cerr << "[In-Memory Cache][Thread Id:" << this_id << "][Kernel Cache]"
-              << Identifier << Msg << std::endl;
+    std::cerr << "[In-Memory Cache][Thread Id:" << std::this_thread::get_id()
+              << "][Kernel Cache]" << Identifier << Msg << std::endl;
   }
 
   Locked<ProgramCache> acquireCachedPrograms() {

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -194,7 +194,7 @@ public:
                    << reinterpret_cast<uintptr_t>(Device) << ",";
 
       std::string Identifier = "[Key:{imageId = " + std::to_string(ImageId) +
-                               ",urDevice = " + DeviceList.str() + "]}: ";
+                               ",urDevice = " + DeviceList.str() + "}]: ";
 
       // Get TID of current thread.
       thread_local std::thread::id this_id = std::this_thread::get_id();
@@ -212,8 +212,8 @@ public:
         SYCLConfig<SYCL_CACHE_TRACE>::isTraceInMemCache();
     if (traceEnabled) {
       std::string Identifier =
-          "[IsFastCache: " + std::to_string(IsKernelFastCache)
-                           + "][Key:{Name = " + KernelName + "]}: ";
+          "[IsFastCache: " + std::to_string(IsKernelFastCache) +
+          "][Key:{Name = " + KernelName + "}]: ";
 
       // Get TID of current thread.
       thread_local std::thread::id this_id = std::this_thread::get_id();
@@ -284,7 +284,7 @@ public:
       traceKernel("Kernel inserted.", KernelName);
     }
     else
-      traceKernel("Kernel fetched", KernelName);
+      traceKernel("Kernel fetched.", KernelName);
     return std::make_pair(It->second, DidInsert);
   }
 
@@ -293,7 +293,7 @@ public:
     std::unique_lock<std::mutex> Lock(MKernelFastCacheMutex);
     auto It = MKernelFastCache.find(CacheKey);
     if (It != MKernelFastCache.end()) {
-      traceKernel("Kernel fetched", std::get<3>(CacheKey), true);
+      traceKernel("Kernel fetched.", std::get<3>(CacheKey), true);
       return It->second;
     }
     return std::make_tuple(nullptr, nullptr, nullptr, nullptr);

--- a/sycl/source/detail/kernel_program_cache.hpp
+++ b/sycl/source/detail/kernel_program_cache.hpp
@@ -245,8 +245,7 @@ public:
           std::make_pair(CacheKey.first.second, CacheKey.second);
       ProgCache.KeyMap.emplace(CommonKey, CacheKey);
       traceProgram("Program inserted.", CacheKey);
-    }
-    else
+    } else
       traceProgram("Program fetched.", CacheKey);
     return std::make_pair(It->second, DidInsert);
   }
@@ -270,8 +269,7 @@ public:
           std::make_pair(CacheKey.first.second, CacheKey.second);
       ProgCache.KeyMap.emplace(CommonKey, CacheKey);
       traceProgram("Program inserted.", CacheKey);
-    }
-    else
+    } else
       traceProgram("Program fetched.", CacheKey);
     return DidInsert;
   }
@@ -285,8 +283,7 @@ public:
     if (DidInsert) {
       It->second = std::make_shared<KernelBuildResult>(getAdapter());
       traceKernel("Kernel inserted.", KernelName);
-    }
-    else
+    } else
       traceKernel("Kernel fetched.", KernelName);
     return std::make_pair(It->second, DidInsert);
   }

--- a/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
+++ b/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
@@ -1,0 +1,61 @@
+// Tests tracing of in-memory kernel and program cache.
+
+// RUN: %{build} -o %t.out
+
+// There should be no tracing output when SYCL_CACHE_IN_MEM is not set
+// or SYCL_CACHE_TRACE is set to 0.
+
+// RUN: env SYCL_CACHE_IN_MEM=0 %{run} %t.out \
+// RUN: | FileCheck --allow-empty --check-prefix=CHECK-NO-TRACE %s
+// RUN: env SYCL_CACHE_TRACE=0 %{run} %t.out \
+// RUN: | FileCheck --allow-empty --check-prefix=CHECK-NO-TRACE %s
+
+// CHECK-NO-TRACE-NOT: [In-Memory Cache]{{.*}}
+
+// RUN: env SYCL_CACHE_TRACE=2 %{run} %t.out 2> %t.trace
+// RUN: FileCheck %s --input-file=%t.trace --check-prefix=CHECK-CACHE-TRACE
+
+#include <sycl/detail/core.hpp>
+
+#include <sycl/specialization_id.hpp>
+#include <sycl/usm.hpp>
+
+using namespace sycl;
+
+constexpr specialization_id<int> spec_id;
+
+int main() {
+  queue q;
+
+  // Check program insertion into cache and kernel insertion into fast and
+  // regular kernel cache.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Program Cache][Key:{{.*}}]: Program inserted.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Kernel Cache][IsFastCache: 0][Key:{Name = [[KERNELNAME1:.*]]]: Kernel inserted.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Kernel Cache][IsFastCache: 1][Key:{Name = [[KERNELNAME1]]]: Kernel inserted.
+
+  // In the 2nd and 3rd invocation of this loop, the kernel should be fetched
+  // from fast kernel cache.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Kernel Cache][IsFastCache: 1][Key:{Name = [[KERNELNAME1]]]: Kernel fetched.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Kernel Cache][IsFastCache: 1][Key:{Name = [[KERNELNAME1]]]: Kernel fetched.
+  for (int i = 0; i < 3; i++)
+    q.single_task([] {}).wait();
+
+  auto *p = malloc_device<int>(1, q);
+
+  // Check program and kernel insertion into cache. There should be different
+  // programs for different iterations of this loop, because of the different
+  // specialization constants.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Program Cache][Key:{{.*}}]: Program inserted.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Kernel Cache][IsFastCache: 0][Key:{Name = [[KERNELNAME2:.*]]]: Kernel inserted.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Program Cache][Key:{{.*}}]: Program inserted.
+  // CHECK-CACHE-TRACE: [In-Memory Cache][Thread Id:{{.*}}][Kernel Cache][IsFastCache: 0][Key:{Name = [[KERNELNAME2]]]: Kernel inserted.
+  for (int i = 0; i < 2; ++i)
+    q.submit([&](handler &cgh) {
+       cgh.set_specialization_constant<spec_id>(i);
+       cgh.parallel_for(1, [=](auto, kernel_handler kh) {
+         *p = kh.get_specialization_constant<spec_id>();
+       });
+     }).wait();
+
+  free(p, q);
+}

--- a/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
+++ b/sycl/test-e2e/KernelAndProgram/trace_kernel_program_cache.cpp
@@ -5,15 +5,13 @@
 // There should be no tracing output when SYCL_CACHE_IN_MEM is not set
 // or SYCL_CACHE_TRACE is set to 0.
 
-// RUN: env SYCL_CACHE_IN_MEM=0 %{run} %t.out \
-// RUN: | FileCheck --allow-empty --check-prefix=CHECK-NO-TRACE %s
-// RUN: env SYCL_CACHE_TRACE=0 %{run} %t.out \
-// RUN: | FileCheck --allow-empty --check-prefix=CHECK-NO-TRACE %s
+// RUN: env SYCL_CACHE_IN_MEM=0 %{run} %t.out 2> %t.trace1
+// RUN: FileCheck --allow-empty --input-file=%t.trace1 --implicit-check-not "In-Memory Cache" %s
+// RUN: env SYCL_CACHE_TRACE=0 %{run} %t.out 2> %t.trace2
+// RUN: FileCheck --allow-empty --input-file=%t.trace2 --implicit-check-not "In-Memory Cache" %s
 
-// CHECK-NO-TRACE-NOT: [In-Memory Cache]{{.*}}
-
-// RUN: env SYCL_CACHE_TRACE=2 %{run} %t.out 2> %t.trace
-// RUN: FileCheck %s --input-file=%t.trace --check-prefix=CHECK-CACHE-TRACE
+// RUN: env SYCL_CACHE_TRACE=2 %{run} %t.out 2> %t.trace3
+// RUN: FileCheck %s --input-file=%t.trace3 --check-prefix=CHECK-CACHE-TRACE
 
 #include <sycl/detail/core.hpp>
 


### PR DESCRIPTION
I'm working on implementing cache eviction and it gets difficult to debug/write test cases without tracing. So, this PR implements tracing for in-memory kernel and program cache.