### PR TITLE
[SYCL] Add tests for work group memory extension

### DIFF
--- a/sycl/test-e2e/WorkGroupMemory/reduction_free_function.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/reduction_free_function.cpp
@@ -1,0 +1,263 @@
+// REQUIRES: aspect-usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+// The name mangling for free function kernels currently does not work with PTX.
+// UNSUPPORTED: cuda
+
+// Usage of work group memory parameters in free function kernels is not yet
+// implemented.
+// TODO: Remove the following directive once
+// https://github.com/intel/llvm/pull/15861 is merged.
+// XFAIL: *
+// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15927
+
+#include <cassert>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/intel/math.hpp>
+#include <sycl/ext/oneapi/experimental/work_group_memory.hpp>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+#include <sycl/group_barrier.hpp>
+#include <sycl/usm.hpp>
+
+using namespace sycl;
+
+// Basic usage reduction test using free function kernels.
+// A global buffer is allocated using USM and it is passed to the kernel on the
+// device. On the device, a work group memory buffer is allocated and each item
+// copies the correspondng element of the global buffer to the corresponding
+// element of the work group memory buffer using its global index. The leader of
+// every work-group, after waiting for every work-item to complete, then sums
+// these values storing the result in another work group memory object. Finally,
+// each work item then verifies that the sum of the work group memory elements
+// equals the sum of the global buffer elements. This is repeated for several
+// data types.
+
+queue q;
+context ctx = q.get_context();
+
+constexpr size_t SIZE = 128;
+constexpr size_t VEC_SIZE = 16;
+constexpr float tolerance = 0.01f;
+
+template <typename T>
+void sum_helper(sycl::ext::oneapi::experimental::work_group_memory<T[]> mem,
+                sycl::ext::oneapi::experimental::work_group_memory<T> ret,
+                size_t WGSIZE) {
+  for (int i = 0; i < WGSIZE; ++i) {
+    ret = ret + mem[i];
+  }
+}
+
+template <typename T>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (ext::oneapi::experimental::nd_range_kernel<1>))
+void sum(sycl::ext::oneapi::experimental::work_group_memory<T[]> mem, T *buf,
+         sycl::ext::oneapi::experimental::work_group_memory<T> result,
+         T expected, size_t WGSIZE, bool UseHelper) {
+  const auto it = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+  size_t local_id = it.get_local_id();
+  mem[local_id] = buf[local_id];
+  group_barrier(it.get_group());
+  if (it.get_group().leader()) {
+    result = 0;
+    if (!UseHelper) {
+      for (int i = 0; i < WGSIZE; ++i) {
+        result = result + mem[i];
+      }
+    } else {
+      sum_helper(mem, result, WGSIZE);
+    }
+    assert(result == expected);
+  }
+}
+
+// Explicit instantiations for the relevant data types.
+#define SUM(T)                                                                 \
+  template void sum<T>(                                                        \
+      sycl::ext::oneapi::experimental::work_group_memory<T[]> mem, T * buf,    \
+      sycl::ext::oneapi::experimental::work_group_memory<T> result,            \
+      T expected, size_t WGSIZE, bool UseHelper);
+
+SUM(int)
+SUM(uint16_t)
+SUM(half)
+SUM(double)
+SUM(float)
+SUM(char)
+SUM(bool)
+
+template <typename T>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (ext::oneapi::experimental::nd_range_kernel<1>))
+void sum_marray(
+    sycl::ext::oneapi::experimental::work_group_memory<sycl::marray<T, 16>> mem,
+    T *buf, sycl::ext::oneapi::experimental::work_group_memory<T> result,
+    T expected) {
+  const auto it = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+  size_t local_id = it.get_local_id();
+  constexpr float tolerance = 0.01f;
+  sycl::marray<T, 16> &data = mem;
+  data[local_id] = buf[local_id];
+  group_barrier(it.get_group());
+  if (it.get_group().leader()) {
+    result = 0;
+    for (int i = 0; i < 16; ++i) {
+      result = result + data[i];
+    }
+    assert((result - expected) * (result - expected) <= tolerance);
+  }
+}
+
+// Explicit instantiations for the relevant data types.
+#define SUM_MARRAY(T)                                                          \
+  template void sum_marray<T>(                                                 \
+      sycl::ext::oneapi::experimental::work_group_memory<sycl::marray<T, 16>>  \
+          mem,                                                                 \
+      T * buf, sycl::ext::oneapi::experimental::work_group_memory<T> result,   \
+      T expected);
+
+SUM_MARRAY(int);
+SUM_MARRAY(float);
+SUM_MARRAY(double);
+SUM_MARRAY(char);
+SUM_MARRAY(bool);
+SUM_MARRAY(half);
+
+template <typename T>
+SYCL_EXT_ONEAPI_FUNCTION_PROPERTY(
+    (ext::oneapi::experimental::nd_range_kernel<1>))
+void sum_vec(
+    sycl::ext::oneapi::experimental::work_group_memory<sycl::vec<T, 16>> mem,
+    T *buf, sycl::ext::oneapi::experimental::work_group_memory<T> result,
+    T expected) {
+  const auto it = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+  size_t local_id = it.get_local_id();
+  constexpr float tolerance = 0.01f;
+  sycl::vec<T, 16> &data = mem;
+  data[local_id] = buf[local_id];
+  group_barrier(it.get_group());
+  if (it.get_group().leader()) {
+    result = 0;
+    for (int i = 0; i < 16; ++i) {
+      result = result + data[i];
+    }
+    assert((result - expected) * (result - expected) <= tolerance);
+  }
+}
+
+// Explicit instantiations for the relevant data types.
+#define SUM_VEC(T)                                                             \
+  template void sum_vec<T>(                                                    \
+      sycl::ext::oneapi::experimental::work_group_memory<sycl::vec<T, 16>>     \
+          mem,                                                                 \
+      T * buf, sycl::ext::oneapi::experimental::work_group_memory<T> result,   \
+      T expected);
+
+SUM_VEC(int);
+SUM_VEC(float);
+SUM_VEC(double);
+SUM_VEC(char);
+SUM_VEC(bool);
+SUM_VEC(half);
+
+template <typename T, typename... Ts> void test_marray() {
+  if (std::is_same_v<sycl::half, T> && !q.get_device().has(sycl::aspect::fp16))
+    return;
+  constexpr size_t WGSIZE = VEC_SIZE;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = ext::intel::math::sqrt(T(i));
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+#ifndef __SYCL_DEVICE_ONLY__
+  // Get the kernel object for the "mykernel" kernel.
+  auto Bundle = get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+  kernel_id sum_id = ext::oneapi::experimental::get_kernel_id<sum_marray<T>>();
+  kernel k_sum = Bundle.get_kernel(sum_id);
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<marray<T, WGSIZE>> mem{cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.set_args(mem, buf, result, expected);
+     cgh.parallel_for(ndr, k_sum);
+   }).wait();
+#endif // __SYCL_DEVICE_ONLY
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test_marray<Ts...>();
+}
+
+template <typename T, typename... Ts> void test_vec() {
+  if (std::is_same_v<sycl::half, T> && !q.get_device().has(sycl::aspect::fp16))
+    return;
+  constexpr size_t WGSIZE = VEC_SIZE;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = ext::intel::math::sqrt(T(i));
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+#ifndef __SYCL_DEVICE_ONLY__
+  // Get the kernel object for the "mykernel" kernel.
+  auto Bundle = get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+  kernel_id sum_id = ext::oneapi::experimental::get_kernel_id<sum_vec<T>>();
+  kernel k_sum = Bundle.get_kernel(sum_id);
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<vec<T, WGSIZE>> mem{cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.set_args(mem, buf, result, expected);
+     cgh.parallel_for(ndr, k_sum);
+   }).wait();
+#endif // __SYCL_DEVICE_ONLY
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test_vec<Ts...>();
+}
+
+template <typename T, typename... Ts>
+void test(size_t SIZE, size_t WGSIZE, bool UseHelper) {
+  if (std::is_same_v<sycl::half, T> && !q.get_device().has(sycl::aspect::fp16))
+    return;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = T(i);
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  // The following ifndef is required due to a number of limitations of free
+  // function kernels. See CMPLRLLVM-61498.
+  // TODO: Remove it once these limitations are no longer there.
+#ifndef __SYCL_DEVICE_ONLY__
+  // Get the kernel object for the "mykernel" kernel.
+  auto Bundle = get_kernel_bundle<sycl::bundle_state::executable>(ctx);
+  kernel_id sum_id = ext::oneapi::experimental::get_kernel_id<sum<T>>();
+  kernel k_sum = Bundle.get_kernel(sum_id);
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<T[]> mem{WGSIZE, cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.set_args(mem, buf, result, expected, WGSIZE, UseHelper);
+     cgh.parallel_for(ndr, k_sum);
+   }).wait();
+
+#endif // __SYCL_DEVICE_ONLY
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test<Ts...>(SIZE, WGSIZE, UseHelper);
+}
+
+int main() {
+  test<int, uint16_t, half, double, float>(SIZE, SIZE, true /* UseHelper */);
+  test<int, float, half>(SIZE, SIZE, false);
+  test<int, double, char>(SIZE, SIZE / 2, false);
+  test<int, bool, char>(SIZE, SIZE / 4, false);
+  test_marray<float, double, half>();
+  test_vec<float, double, half>();
+  return 0;
+}

--- a/sycl/test-e2e/WorkGroupMemory/reduction_lambda.cpp
+++ b/sycl/test-e2e/WorkGroupMemory/reduction_lambda.cpp
@@ -1,0 +1,268 @@
+// REQUIRES: aspect-usm_shared_allocations
+// RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
+
+#include <cassert>
+#include <sycl/atomic_ref.hpp>
+#include <sycl/detail/core.hpp>
+#include <sycl/ext/intel/math.hpp>
+#include <sycl/ext/oneapi/experimental/work_group_memory.hpp>
+#include <sycl/ext/oneapi/free_function_queries.hpp>
+#include <sycl/group_barrier.hpp>
+#include <sycl/marray.hpp>
+#include <sycl/usm.hpp>
+#include <sycl/vector.hpp>
+
+using namespace sycl;
+
+queue q;
+context ctx = q.get_context();
+
+constexpr size_t SIZE = 128;
+
+template <typename T> struct S {
+  T val;
+};
+
+template <typename T> struct M {
+  T val;
+};
+
+union U {
+  S<int> s;
+  M<int> m;
+};
+
+template <typename T, typename... Ts>
+void test_struct(size_t SIZE, size_t WGSIZE) {
+  S<T> *buf = malloc_shared<S<T>>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i].val = T(i);
+    expected = expected + buf[i].val;
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<S<T>[]> mem{WGSIZE, cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.parallel_for(ndr, [=](nd_item<> it) {
+       size_t local_id = it.get_local_id();
+       mem[local_id] = buf[local_id];
+       group_barrier(it.get_group());
+       if (it.get_group().leader()) {
+         result = 0;
+         for (int i = 0; i < WGSIZE; ++i) {
+           result = result + mem[i].val;
+         }
+         assert(result == expected);
+       }
+     });
+   }).wait();
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test_struct<Ts...>(SIZE, WGSIZE);
+}
+
+void test_union(size_t SIZE, size_t WGSIZE) {
+  U *buf = malloc_shared<U>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  int expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    if (i % 2)
+      buf[i].s = S<int>{i};
+    else
+      buf[i].m = M<int>{i};
+    expected = expected + (i % 2) ? buf[i].s.val : buf[i].m.val;
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<U[]> mem{WGSIZE, cgh};
+     ext::oneapi::experimental::work_group_memory<int> result{cgh};
+     cgh.parallel_for(ndr, [=](nd_item<> it) {
+       size_t local_id = it.get_local_id();
+       mem[local_id] = buf[local_id];
+       group_barrier(it.get_group());
+       if (it.get_group().leader()) {
+         result = 0;
+         for (int i = 0; i < WGSIZE; ++i) {
+           result = result + (i % 2) ? mem[i].s.val : mem[i].m.val;
+         }
+         assert(result == expected);
+       }
+     });
+   }).wait();
+  free(buf, q);
+}
+
+template <typename T>
+void sum_helper(sycl::ext::oneapi::experimental::work_group_memory<T[]> mem,
+                sycl::ext::oneapi::experimental::work_group_memory<T> ret,
+                size_t WGSIZE) {
+  for (int i = 0; i < WGSIZE; ++i) {
+    ret = ret + mem[i];
+  }
+}
+
+template <typename T, typename... Ts>
+void test(size_t SIZE, size_t WGSIZE, bool UseHelper) {
+  if (std::is_same_v<sycl::half, T> && !q.get_device().has(sycl::aspect::fp16))
+    return;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = T(i);
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<T[]> mem{WGSIZE, cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.parallel_for(ndr, [=](nd_item<> it) {
+       size_t local_id = it.get_local_id();
+       mem[local_id] = buf[local_id];
+       group_barrier(it.get_group());
+       if (it.get_group().leader()) {
+         result = 0;
+         if (!UseHelper) {
+           for (int i = 0; i < WGSIZE; ++i) {
+             result = result + mem[i];
+           }
+         } else {
+           sum_helper(mem, result, WGSIZE);
+         }
+         assert(result == expected);
+       }
+     });
+   }).wait();
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test<Ts...>(SIZE, WGSIZE, UseHelper);
+}
+
+template <typename T, typename... Ts> void test_marray() {
+  if (std::is_same_v<sycl::half, T> && !q.get_device().has(sycl::aspect::fp16))
+    return;
+  constexpr size_t WGSIZE = SIZE;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = T(i);
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<marray<T, WGSIZE>> mem{cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.parallel_for(ndr, [=](nd_item<> it) {
+       size_t local_id = it.get_local_id();
+       constexpr T tolerance = 0.0001;
+       // User-defined conversion from work group memory to underlying type is
+       // not applied during member access calls so we have to explicitly
+       // convert to the value_type ourselves.
+       marray<T, WGSIZE> &data = mem;
+       data[local_id] = buf[local_id];
+       group_barrier(it.get_group());
+       if (it.get_group().leader()) {
+         result = 0;
+         for (int i = 0; i < WGSIZE; ++i) {
+           result = result + data[i];
+         }
+         assert((result - expected) * (result - expected) <= tolerance);
+       }
+     });
+   }).wait();
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test_marray<Ts...>();
+}
+
+template <typename T, typename... Ts> void test_vec() {
+  if (std::is_same_v<sycl::half, T> && !q.get_device().has(sycl::aspect::fp16))
+    return;
+  constexpr size_t WGSIZE = 8;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = ext::intel::math::sqrt(T(i));
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<vec<T, WGSIZE>> mem{cgh};
+     ext::oneapi::experimental ::work_group_memory<T> result{cgh};
+     cgh.parallel_for(ndr, [=](nd_item<> it) {
+       size_t local_id = it.get_local_id();
+       constexpr T tolerance = 0.0001;
+       vec<T, WGSIZE> &data = mem;
+       data[local_id] = buf[local_id];
+       group_barrier(it.get_group());
+       if (it.get_group().leader()) {
+         result = 0;
+         for (int i = 0; i < WGSIZE; ++i) {
+           result = result + data[i];
+         }
+         assert((result - expected) * (result - expected) <= tolerance);
+       }
+     });
+   }).wait();
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test_vec<Ts...>();
+}
+
+template <typename T, typename... Ts> void test_atomic_ref() {
+  assert(sizeof(T) == 4 ||
+         (sizeof(T) == 8 && q.get_device().has(aspect::atomic64)));
+  constexpr size_t WGSIZE = 8;
+  T *buf = malloc_shared<T>(WGSIZE, q);
+  assert(buf && "Shared USM allocation failed!");
+  T expected = 0;
+  for (int i = 0; i < WGSIZE; ++i) {
+    buf[i] = T(i);
+    expected = expected + buf[i];
+  }
+  nd_range ndr{{SIZE}, {WGSIZE}};
+  q.submit([&](sycl::handler &cgh) {
+     ext::oneapi::experimental::work_group_memory<T[]> mem{WGSIZE, cgh};
+     ext::oneapi::experimental::work_group_memory<T> result{cgh};
+     cgh.parallel_for(ndr, [=](nd_item<> it) {
+       size_t local_id = it.get_local_id();
+       mem[local_id] = buf[local_id];
+       atomic_ref<T, memory_order::acq_rel, memory_scope::work_group>
+           atomic_val{result};
+       if (it.get_group().leader()) {
+         atomic_val.store(0);
+       }
+       group_barrier(it.get_group());
+       atomic_val += mem[local_id];
+       group_barrier(it.get_group());
+       assert(atomic_val.load() == expected);
+     });
+   }).wait();
+  free(buf, q);
+  if constexpr (sizeof...(Ts))
+    test_atomic_ref<Ts...>();
+}
+
+int main() {
+  test<int, uint16_t, half, double, float>(SIZE, SIZE /* WorkGroupSize */,
+                                           true /* UseHelper */);
+  test<int, float, half>(SIZE, SIZE, false);
+  test<int, double, char>(SIZE, SIZE / 2, false);
+  test<int, bool, char>(SIZE, SIZE / 4, false);
+  test<int, float>(SIZE, 1, false);
+  test<int, float>(SIZE, 2, true);
+  test_marray<float, double, half>();
+  test_vec<float, double, half>();
+  test_atomic_ref<int, long, float, double>();
+  test_struct<int, float, double>(SIZE, 4);
+  test_union(SIZE, SIZE);
+  test_union(SIZE, SIZE / 2);
+  test_union(SIZE, 1);
+  test_union(SIZE, 2);
+  return 0;
+}

--- a/sycl/test/extensions/WorkGroupMemory/api_misuse_test.cpp
+++ b/sycl/test/extensions/WorkGroupMemory/api_misuse_test.cpp
@@ -1,0 +1,45 @@
+// RUN: %clangxx -fsycl -fsyntax-only -ferror-limit=30 -Xclang -verify -Xclang -verify-ignore-unexpected=note,warning %s
+
+#include <sycl/sycl.hpp>
+
+using namespace sycl;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+queue Q;
+
+// This test verifies the type restrictions on the two non-default constructors
+// of work group memory.
+
+template <typename DataT> void convertToDataT(DataT &data) {}
+
+template <typename DataT> void test_bounded_arr() {
+  Q.submit([&](sycl::handler &cgh) {
+    nd_range<1> ndr{1, 1};
+    // expected-error-re@+1 5{{no matching constructor for initialization of 'syclexp::work_group_memory<{{.*}}>'}}
+    syclexp::work_group_memory<DataT[1]> mem{1, cgh};
+    // expected-error@+1 5{{no viable overloaded '='}}
+    cgh.parallel_for(ndr, [=](nd_item<1> it) { mem = {DataT{}}; });
+  });
+}
+
+template <typename DataT> void test_unbounded_arr() {
+  Q.submit([&](sycl::handler &cgh) {
+    nd_range<1> ndr{1, 1};
+    // expected-error-re@+1 5{{no matching constructor for initialization of 'syclexp::work_group_memory<{{.*}}>'}}
+    syclexp::work_group_memory<DataT[]> mem{cgh};
+    // expected-error@+1 5{{no viable overloaded '='}}
+    cgh.parallel_for(ndr, [=](nd_item<1> it) { mem = {DataT{}}; });
+  });
+}
+
+template <typename DataT, typename... DataTs> void test() {
+  test_bounded_arr<DataT>();
+  test_unbounded_arr<DataT>();
+  if constexpr (sizeof...(DataTs))
+    test<DataTs...>();
+}
+
+int main() {
+  test<char, int16_t, int[1], double[2], half[3]>();
+  return 0;
+}

--- a/sycl/test/extensions/WorkGroupMemory/api_test.cpp
+++ b/sycl/test/extensions/WorkGroupMemory/api_test.cpp
@@ -1,0 +1,104 @@
+// RUN: %clangxx -fsycl -fsyntax-only %s
+
+#include <cassert>
+#include <sycl/sycl.hpp>
+#include <type_traits>
+
+using namespace sycl;
+namespace syclexp = sycl::ext::oneapi::experimental;
+
+queue Q;
+
+struct S {
+  int a;
+  char b;
+};
+
+union U {
+  int a;
+  char b;
+};
+
+template <typename DataT> void convertToDataT(DataT &data) {}
+
+template <typename DataT> void test_constness() {
+  Q.submit([&](sycl::handler &cgh) {
+    nd_range<1> ndr{1, 1};
+    syclexp::work_group_memory<DataT>
+        mem; // technically undefined behavior but this is a syntax only test.
+    cgh.parallel_for(ndr, [=](nd_item<1> it) {
+      const auto mem1 = mem;
+      // since mem1 is const, all of the following should succeed.
+      if constexpr (!std::is_array_v<DataT>)
+        mem1 = DataT{};
+      convertToDataT(mem1);
+      const auto *ptr = &mem1;
+      const auto &mptr = mem1.template get_multi_ptr<>();
+    });
+  });
+}
+
+template <typename DataT>
+void test_helper(syclexp::work_group_memory<DataT> mem) {
+  static_assert(
+      std::is_same_v<typename syclexp::work_group_memory<DataT>::value_type,
+                     std::remove_all_extents_t<DataT>>);
+  syclexp::work_group_memory<DataT> dummy{mem};
+  mem = dummy;
+  Q.submit([&](sycl::handler &cgh) {
+    if constexpr (sycl::detail::is_unbounded_array_v<DataT>)
+      mem = syclexp::work_group_memory<DataT>{1, cgh};
+    else
+      mem = syclexp::work_group_memory<DataT>{cgh};
+    nd_range<1> ndr{1, 1};
+    cgh.parallel_for(ndr, [=](nd_item<1> it) {
+      convertToDataT(mem);
+      if constexpr (!std::is_array_v<DataT>)
+        mem = DataT{};
+      static_assert(
+          std::is_same_v<
+              multi_ptr<typename syclexp::work_group_memory<DataT>::value_type,
+                        access::address_space::local_space,
+                        access::decorated::no>,
+              decltype(mem.template get_multi_ptr<access::decorated::no>())>);
+      static_assert(
+          std::is_same_v<
+              multi_ptr<typename syclexp::work_group_memory<DataT>::value_type,
+                        access::address_space::local_space,
+                        access::decorated::no>,
+              decltype(mem.template get_multi_ptr<>())>);
+      static_assert(
+          std::is_same_v<
+              multi_ptr<typename syclexp::work_group_memory<DataT>::value_type,
+                        access::address_space::local_space,
+                        access::decorated::no>,
+              decltype(mem.template get_multi_ptr<access::decorated::no>())>);
+
+      static_assert(
+          std::is_same_v<
+              multi_ptr<typename syclexp::work_group_memory<DataT>::value_type,
+                        access::address_space::local_space,
+                        access::decorated::yes>,
+              decltype(mem.template get_multi_ptr<access::decorated::yes>())>);
+    });
+  });
+}
+
+template <typename Type, typename... rest> void test() {
+  syclexp::work_group_memory<Type> mem;
+  test_constness<Type>();
+  test_helper(mem);
+  if constexpr (sizeof...(rest))
+    test<rest...>();
+}
+
+int main() {
+  test<char, int16_t, int, double, half>();
+  test<marray<int, 1>, marray<int, 2>, marray<int, 8>>();
+  test<vec<int, 1>, vec<int, 2>, vec<int, 8>>();
+  test<char *, int16_t *, int *, double *, half *>();
+  test<S, U>();
+  test<char[1], char[2], int[1], int[2]>();
+  test<double[], half[]>();
+  return 0;
+}


### PR DESCRIPTION
This PR adds tests for the work group memory extension [here](https://github.com/gmlueck/llvm/blob/e64d1e7eae960543fc54b107d28ebb7a6d828b62/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_memory.asciidoc).
The test plan is [here](https://github.com/intel/llvm/blob/sycl/sycl/test-e2e/WorkGroupMemory/test-plan.md).