### PR TITLE
[SYCL] Fix SYCL-CTS regression after https://github.com/intel/llvm/pull/15543

### DIFF
--- a/devops/cts_exclude_filter_L0_GPU
+++ b/devops/cts_exclude_filter_L0_GPU
@@ -3,5 +3,3 @@ kernel_bundle
 marray
 # fix: https://github.com/KhronosGroup/SYCL-CTS/pull/964
 accessor_legacy
-# CMPLRLLVM-62822
-multi_ptr

--- a/devops/cts_exclude_filter_OCL_CPU
+++ b/devops/cts_exclude_filter_OCL_CPU
@@ -7,5 +7,3 @@ math_builtin_api
 hierarchical
 # fix: https://github.com/KhronosGroup/SYCL-CTS/pull/964
 accessor_legacy
-# CMPLRLLVM-62822
-multi_ptr

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -1285,7 +1285,6 @@ public:
 
   static constexpr access::address_space address_space = Space;
 
-public:
   // Constructors
   multi_ptr() : m_Pointer(nullptr) {}
   multi_ptr(const multi_ptr &) = default;

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -732,12 +732,28 @@ private:
   decorated_type *m_Pointer;
 };
 
+namespace detail {
+// See access.hpp's DecoratedType<..., access::address_space::constant_space>.
+//
+// This is only applicable to `access::decorated::legacy` mode because constant
+// AS is deprecated itself and is only accessible in legacy modes.
+template <auto Space>
+#ifdef __SYCL_DEVICE_ONLY__
+inline constexpr auto decoration_space =
+    deduce_AS<typename DecoratedType<void, Space>::type>::value;
+#else
+inline constexpr auto decoration_space = Space;
+#endif
+}
+
 // Legacy specialization of multi_ptr.
 // TODO: Add deprecation warning here when possible.
 template <typename ElementType, access::address_space Space>
 class __SYCL2020_DEPRECATED(
     "decorated::legacy multi_ptr specialization is deprecated since SYCL 2020.")
     multi_ptr<ElementType, Space, access::decorated::legacy> {
+  static constexpr auto DecorationSpace = detail::decoration_space<Space>;
+
 public:
   using value_type = ElementType;
   using element_type =
@@ -777,7 +793,8 @@ public:
 
   multi_ptr(ElementType *pointer)
       : m_Pointer(detail::dynamic_address_cast<
-                  Space, /* SupressNotImplementedAssert = */ true>(pointer)) {
+                  DecorationSpace, /* SupressNotImplementedAssert = */ true>(
+            pointer)) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
@@ -786,7 +803,8 @@ public:
   template <typename = typename detail::const_if_const_AS<Space, ElementType>>
   multi_ptr(const ElementType *pointer)
       : m_Pointer(detail::dynamic_address_cast<
-                  Space, /* SupressNotImplementedAssert = */ true>(pointer)) {}
+                  DecorationSpace, /* SupressNotImplementedAssert = */ true>(
+            pointer)) {}
 #endif
 
   multi_ptr(std::nullptr_t) : m_Pointer(nullptr) {}
@@ -814,7 +832,7 @@ public:
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
     m_Pointer = detail::dynamic_address_cast<
-        Space, /* SupressNotImplementedAssert = */ true>(pointer);
+        DecorationSpace, /* SupressNotImplementedAssert = */ true>(pointer);
     return *this;
   }
 
@@ -856,8 +874,8 @@ public:
   multi_ptr(accessor<ElementType, dimensions, Mode, target::device,
                      isPlaceholder, PropertyListT>
                 Accessor)
-      : multi_ptr(
-            detail::static_address_cast<Space>(Accessor.get_pointer().get())) {}
+      : multi_ptr(detail::static_address_cast<DecorationSpace>(
+            Accessor.get_pointer().get())) {}
 
   // Only if Space == local_space || generic_space
   template <
@@ -1088,6 +1106,8 @@ template <access::address_space Space>
 class __SYCL2020_DEPRECATED(
     "decorated::legacy multi_ptr specialization is deprecated since SYCL 2020.")
     multi_ptr<void, Space, access::decorated::legacy> {
+  static constexpr auto DecorationSpace = detail::decoration_space<Space>;
+
 public:
   using value_type = void;
   using element_type = void;
@@ -1113,17 +1133,17 @@ public:
                                   !std::is_same_v<RelayPointerT, void *>>>
   multi_ptr(void *pointer)
       : m_Pointer(detail::dynamic_address_cast<
-                  Space, /* SupressNotImplementedAssert = */ true>(pointer)) {
+                  DecorationSpace, /* SupressNotImplementedAssert = */ true>(
+            pointer)) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
 #if defined(RESTRICT_WRITE_ACCESS_TO_CONSTANT_PTR)
   template <typename = typename detail::const_if_const_AS<Space, void>>
   multi_ptr(const void *pointer)
-      : m_Pointer(
-            detail::dynamic_address_cast<
-                pointer_t, /* SupressNotImplementedAssert = */ true>(pointer)) {
-  }
+      : m_Pointer(detail::dynamic_address_cast<
+                  DecorationSpace, /* SupressNotImplementedAssert = */ true>(
+            pointer)) {}
 #endif
 #endif
   multi_ptr(std::nullptr_t) : m_Pointer(nullptr) {}
@@ -1154,7 +1174,7 @@ public:
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
     m_Pointer = detail::dynamic_address_cast<
-        Space, /* SupressNotImplementedAssert = */ true>(pointer);
+        DecorationSpace, /* SupressNotImplementedAssert = */ true>(pointer);
     return *this;
   }
 #endif
@@ -1249,6 +1269,8 @@ template <access::address_space Space>
 class __SYCL2020_DEPRECATED(
     "decorated::legacy multi_ptr specialization is deprecated since SYCL 2020.")
     multi_ptr<const void, Space, access::decorated::legacy> {
+  static constexpr auto DecorationSpace = detail::decoration_space<Space>;
+
 public:
   using value_type = const void;
   using element_type = const void;
@@ -1263,6 +1285,7 @@ public:
 
   static constexpr access::address_space address_space = Space;
 
+public:
   // Constructors
   multi_ptr() : m_Pointer(nullptr) {}
   multi_ptr(const multi_ptr &) = default;
@@ -1275,7 +1298,8 @@ public:
                                   !std::is_same_v<RelayPointerT, const void *>>>
   multi_ptr(const void *pointer)
       : m_Pointer(detail::dynamic_address_cast<
-                  Space, /* SupressNotImplementedAssert = */ true>(pointer)) {
+                  DecorationSpace, /* SupressNotImplementedAssert = */ true>(
+            pointer)) {
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
   }
@@ -1283,7 +1307,8 @@ public:
   template <typename = typename detail::const_if_const_AS<Space, void>>
   multi_ptr(const void *pointer)
       : m_Pointer(detail::dynamic_address_cast<
-                  Space, /* SupressNotImplementedAssert = */ true>(pointer)) {}
+                  DecorationSpace, /* SupressNotImplementedAssert = */ true>(
+            pointer)) {}
 #endif
 #endif
   multi_ptr(std::nullptr_t) : m_Pointer(nullptr) {}
@@ -1314,7 +1339,7 @@ public:
     // TODO An implementation should reject an argument if the deduced
     // address space is not compatible with Space.
     m_Pointer = detail::dynamic_address_cast<
-        pointer_t, /* SupressNotImplementedAssert = */ true>(pointer);
+        DecorationSpace, /* SupressNotImplementedAssert = */ true>(pointer);
     return *this;
   }
 #endif
@@ -1442,7 +1467,7 @@ address_space_cast(ElementType *pointer) {
   // space is not compatible with Space.
   // Use LegacyPointerTypes here to also allow constant_space
   return multi_ptr<ElementType, Space, DecorateAddress>(
-      detail::dynamic_address_cast<Space,
+      detail::dynamic_address_cast<detail::decoration_space<Space>,
                                    /* SupressNotImplementedAssert = */ true>(
           pointer));
 }

--- a/sycl/include/sycl/multi_ptr.hpp
+++ b/sycl/include/sycl/multi_ptr.hpp
@@ -744,7 +744,7 @@ inline constexpr auto decoration_space =
 #else
 inline constexpr auto decoration_space = Space;
 #endif
-}
+} // namespace detail
 
 // Legacy specialization of multi_ptr.
 // TODO: Add deprecation warning here when possible.


### PR DESCRIPTION


Apparently, we perform some hacks around constant address space that I wasn't aware of. Make sure new address cast helpers are called consistently with the previous behavior.