### PR TITLE
[SYCL][Joint Matrix] Add missing arch with matrix support to matrix aspect

### DIFF
--- a/sycl/source/detail/device_impl.cpp
+++ b/sycl/source/detail/device_impl.cpp
@@ -675,7 +675,9 @@ bool device_impl::has(aspect Aspect) const {
     const std::vector<arch> supported_archs = {
         arch::intel_cpu_spr,     arch::intel_cpu_gnr,
         arch::intel_gpu_pvc,     arch::intel_gpu_dg2_g10,
-        arch::intel_gpu_dg2_g11, arch::intel_gpu_dg2_g12};
+        arch::intel_gpu_dg2_g11, arch::intel_gpu_dg2_g12,
+        arch::intel_gpu_bmg_g21, arch::intel_gpu_lnl_m,
+        arch::intel_gpu_arl_h};
     try {
       return std::any_of(
           supported_archs.begin(), supported_archs.end(),


### PR DESCRIPTION
Recently added devices `architecture::intel_gpu_bmg_g21, architecture::intel_gpu_lnl_m, and architecture::intel_gpu_arl_h` have matrix support. 
This patch updates the aspect `aspect::ext_intel_matrix` so things like `sycl-ls --verbose` and kernel query show this support when used on these new devices.