### PR TITLE
[UR] update to latest

### DIFF
--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,7 @@
-# commit a9c7aef861988d4b8421f3e760e63f4e3da9398d (HEAD, origin/main, origin/HEAD)
-# Merge: dbd168c 3142142
-# Author: aarongreig <aaron.greig@codeplay.com>
-# Date:   Mon Oct 28 15:56:46 2024 +0000
-#    Merge pull request #2152 from Bensuo/fabio/binary_update_fix
-#    Fix command-buffer binary update implementation
-set(UNIFIED_RUNTIME_TAG a9c7aef861988d4b8421f3e760e63f4e3da9398d)
+# commit 6ade245ef11de42f91e1a35e67c38389788abb3d
+# Merge: 8c0cc4cd 9d1d3ac4
+# Author: Piotr Balcer <piotr.balcer@intel.com>
+# Date:   Thu Oct 31 09:17:21 2024 +0100
+#    Merge pull request #2230 from pbalcer/check-xpti-enabled
+#    don't call xpti if there are no subscribers
+set(UNIFIED_RUNTIME_TAG 6ade245ef11de42f91e1a35e67c38389788abb3d)


### PR DESCRIPTION
Pulls in a few L0 and sanitizer changes, and an optimization for the tracing layer.

https://github.com/oneapi-src/unified-runtime/pull/2230