### PR TITLE
[SYCL][E2E] Add `%{run}` to new tests that did not use it

### DIFF
--- a/sycl/test-e2e/bindless_images/3_channel_format.cpp
+++ b/sycl/test-e2e/bindless_images/3_channel_format.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
-// RUN: %t.out
+// RUN: %{run} %t.out
 
 #include <iostream>
 #include <sycl/detail/core.hpp>

--- a/sycl/test-e2e/bindless_images/examples/example_3_1D_mipmap_anisotropic_filtering_and_levels.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_3_1D_mipmap_anisotropic_filtering_and_levels.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
-// RUN: %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>

--- a/sycl/test-e2e/bindless_images/examples/example_5_sample_cubemap.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_5_sample_cubemap.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
-// RUN: %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>


### PR DESCRIPTION
Added `%{run}` to lit lines that execute the test binary.
Same change as #15636 to some tests that were added recently.