### PR TITLE
[SYCL][E2E] Disable HIP test causing kernel page fault

### DIFF
--- a/sycl/test-e2e/Basic/built-ins.cpp
+++ b/sycl/test-e2e/Basic/built-ins.cpp
@@ -4,8 +4,8 @@
 // RUN: %{build} -D__SYCL_USE_VARIADIC_SPIRV_OCL_PRINTF__ -Wno-#warnings -o %t_var.out
 // RUN: %{run} %t_var.out | FileCheck %s
 
-// Hits an assertion with AMD:
-// XFAIL: hip_amd
+// Hits an assertion and kernel page fault with AMD:
+// UNSUPPORTED: hip_amd
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/builtins.hpp>

--- a/sycl/test-e2e/Basic/built-ins.cpp
+++ b/sycl/test-e2e/Basic/built-ins.cpp
@@ -6,6 +6,7 @@
 
 // Hits an assertion and kernel page fault with AMD:
 // UNSUPPORTED: hip_amd
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/14404
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/builtins.hpp>

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 487
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 488
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -76,6 +76,7 @@
 // CHECK-NEXT: Basic/buffer/buffer_create.cpp
 // CHECK-NEXT: Basic/buffer/subbuffer.cpp
 // CHECK-NEXT: Basic/build_log.cpp
+// CHECK-NEXT: Basic/built-ins.cpp
 // CHECK-NEXT: Basic/code_location_e2e.cpp
 // CHECK-NEXT: Basic/free_function_queries/free_function_queries.cpp
 // CHECK-NEXT: Basic/free_function_queries/free_function_queries_sub_group.cpp

--- a/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
+++ b/sycl/test/e2e_test_requirements/no-unsupported-without-info.cpp
@@ -54,7 +54,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 488
+// NUMBER-OF-UNSUPPORTED-WITHOUT-INFO: 487
 //
 // List of improperly UNSUPPORTED tests.
 // Remove the CHECK once the test has been properly UNSUPPORTED.
@@ -76,7 +76,6 @@
 // CHECK-NEXT: Basic/buffer/buffer_create.cpp
 // CHECK-NEXT: Basic/buffer/subbuffer.cpp
 // CHECK-NEXT: Basic/build_log.cpp
-// CHECK-NEXT: Basic/built-ins.cpp
 // CHECK-NEXT: Basic/code_location_e2e.cpp
 // CHECK-NEXT: Basic/free_function_queries/free_function_queries.cpp
 // CHECK-NEXT: Basic/free_function_queries/free_function_queries_sub_group.cpp

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -51,7 +51,7 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 143
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 142
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been properly XFAIL-ed.
@@ -59,7 +59,6 @@
 // CHECK: AddressSanitizer/nullpointer/private_nullptr.cpp
 // CHECK-NEXT: Basic/aspects.cpp
 // CHECK-NEXT: Basic/buffer/reinterpret.cpp
-// CHECK-NEXT: Basic/built-ins.cpp
 // CHECK-NEXT: Basic/device_event.cpp
 // CHECK-NEXT: Basic/diagnostics/handler.cpp
 // CHECK-NEXT: Basic/max_linear_work_group_size_props.cpp


### PR DESCRIPTION
This is causing page faults on every run, which may be contributing to the instability of the runner. 