### PR TITLE
[SYCL][E2E] Add `%{run}` to bindless_images tests

### DIFF
--- a/sycl/test-e2e/bindless_images/examples/example_1_1D_read_write.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_1_1D_read_write.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
-// RUN: %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>

--- a/sycl/test-e2e/bindless_images/examples/example_2_2D_dynamic_read.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_2_2D_dynamic_read.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
-// RUN: %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>

--- a/sycl/test-e2e/bindless_images/examples/example_4_1D_array_read_write.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_4_1D_array_read_write.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
-// RUN: %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>

--- a/sycl/test-e2e/bindless_images/examples/example_6_import_memory_and_semaphores.cpp
+++ b/sycl/test-e2e/bindless_images/examples/example_6_import_memory_and_semaphores.cpp
@@ -1,6 +1,7 @@
 // REQUIRES: cuda
 
 // RUN: %{build} -o %t.out
+// RUN: %{run} %t.out
 
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/bindless_images.hpp>


### PR DESCRIPTION
Add `%{run}` to bindless_images tests missed in #15943, also add a run line to one test that did not run.