### PR TITLE
[SYCL][E2E] Re-enable `Subgroup/info.cpp` e2e test on FPGA

### DIFF
--- a/sycl/test-e2e/SubGroup/info.cpp
+++ b/sycl/test-e2e/SubGroup/info.cpp
@@ -1,6 +1,3 @@
-// TODO: fpga emu crashes when querying sub_group_independent_forward_progress
-// XFAIL: accelerator
-// XFAIL-TRACKER: URT-697
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
This test passes after #15872