### PR TITLE
[SYCL] fix post-commit failures from kernel_compiler sycl cache PR

### DIFF
--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl.cpp
@@ -11,8 +11,15 @@
 
 // -- Test the kernel_compiler with SYCL source.
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
-// RUN: %{l0_leak_check} %{run} %t.out
+
+// If clang++ is not on the PATH, or if sycl was compiled with GCC < 8, then
+// the kernel_compiler is not available for SYCL language.
+// Note: this 'invoking clang++' version for SYCL language support is temporary,
+// and will be replaced by the SYCL_JIT version soon.
+// DEFINE: %{available} = %t.out available
+
+// RUN: %if available %{  %{run} %t.out  %}
+// RUN: %if available %{ %{l0_leak_check} %{run} %t.out %}
 
 // -- Test again, with caching.
 // 'reading-from-cache' is just a string we pass to differentiate between the
@@ -20,13 +27,13 @@
 
 // DEFINE: %{cache_vars} = %{l0_leak_check} env SYCL_CACHE_PERSISTENT=1 SYCL_CACHE_TRACE=5 SYCL_CACHE_DIR=%t/cache_dir
 // RUN: rm -rf %t/cache_dir
-// RUN:  %{cache_vars} %t.out 2>&1 |  FileCheck %s --check-prefixes=CHECK-WRITTEN-TO-CACHE
-// RUN:  %{cache_vars} %t.out reading-from-cache 2>&1 |  FileCheck %s --check-prefixes=CHECK-READ-FROM-CACHE
+// RUN:  %if available %{  %{cache_vars} %t.out 2>&1 |  FileCheck %s --check-prefixes=CHECK-WRITTEN-TO-CACHE %}
+// RUN:  %if available %{  %{cache_vars} %t.out reading-from-cache 2>&1 |  FileCheck %s --check-prefixes=CHECK-READ-FROM-CACHE %}
 
 // -- Add leak check.
 // RUN: rm -rf %t/cache_dir
-// RUN:   %{l0_leak_check} %{cache_vars} %t.out 2>&1 |  FileCheck %s --check-prefixes=CHECK-WRITTEN-TO-CACHE
-// RUN:   %{l0_leak_check} %{cache_vars} %t.out reading-from-cache 2>&1 |  FileCheck %s --check-prefixes=CHECK-READ-FROM-CACHE
+// RUN: %if available %{  %{l0_leak_check} %{cache_vars} %t.out 2>&1 |  FileCheck %s --check-prefixes=CHECK-WRITTEN-TO-CACHE  %}
+// RUN: %if available %{ %{l0_leak_check} %{cache_vars} %t.out reading-from-cache 2>&1 |  FileCheck %s --check-prefixes=CHECK-READ-FROM-CACHE  %}
 
 // CHECK-WRITTEN-TO-CACHE: [Persistent Cache]: enabled
 // CHECK-WRITTEN-TO-CACHE-NOT: [kernel_compiler Persistent Cache]: using cached binary
@@ -301,6 +308,7 @@ void test_esimd() {
 }
 
 int main(int argc, char *argv[]) {
+  namespace syclex = sycl::ext::oneapi::experimental;
   bool readingFromCache = false;
 
   // Check if the argument is present
@@ -308,6 +316,10 @@ int main(int argc, char *argv[]) {
     std::string argument(argv[1]);
     if (argument == "reading-from-cache") {
       readingFromCache = true;
+    } else if (argument == "available") {
+      sycl::device d;
+      bool avail = d.ext_oneapi_can_compile(syclex::source_language::sycl);
+      return avail;
     }
   }
 


### PR DESCRIPTION
in some of the post commit testing the SYCL support of the kernel_compiler is not available. Previously, the test just quietly exited,  but for the cache support the test grew a bit. Now we check the availability before proceeding.

Post commit checks for this are presently running here: https://github.com/intel/llvm/actions/runs/11636755314/job/32408707610