### PR TITLE
[CI] Move Mac runner to MacOS 13

### DIFF
--- a/.github/workflows/sycl-macos-build-and-test.yml
+++ b/.github/workflows/sycl-macos-build-and-test.yml
@@ -24,7 +24,7 @@ permissions: read-all
 jobs:
   build:
     name: Build
-    runs-on: macos-12
+    runs-on: macos-13
     env:
       CCACHE_DIR: $GITHUB_WORKSPACE/build_cache_${{ inputs.build_cache_suffix }}
       CCACHE_MAXSIZE: ${{ inputs.build_cache_size }}


### PR DESCRIPTION
Github Actions no longer [supports](https://github.com/actions/runner-images/issues/10721) MacOS 12 and it's causing postcommit to [fail](https://github.com/intel/llvm/actions/runs/11669376491/job/32491193990). This is confirmed working [here](https://github.com/intel/llvm/actions/runs/11669692319/job/32492218310?pr=15978), build in progress but the runner starts now. Will confirm build passes before merging.