### PR TITLE
[NFCI][SYCL] Introduce `oneapi::experimental::detail::property_base`

### DIFF
--- a/sycl/include/sycl/ext/intel/esimd/memory_properties.hpp
+++ b/sycl/include/sycl/ext/intel/esimd/memory_properties.hpp
@@ -289,22 +289,34 @@ namespace ext::oneapi::experimental {
 
 template <__ESIMD_NS::cache_hint Hint>
 struct property_value<__ESIMD_NS::cache_hint_L1_key,
-                      std::integral_constant<__ESIMD_NS::cache_hint, Hint>> {
-  using key_t = __ESIMD_NS::cache_hint_L1_key;
+                      std::integral_constant<__ESIMD_NS::cache_hint, Hint>>
+    : detail::property_base<
+          property_value<__ESIMD_NS::cache_hint_L1_key,
+                         std::integral_constant<__ESIMD_NS::cache_hint, Hint>>,
+          oneapi::experimental::detail::PropKind::ESIMDL1CacheHint,
+          __ESIMD_NS::cache_hint_L1_key> {
   static constexpr __ESIMD_NS::cache_level level = __ESIMD_NS::cache_level::L1;
   static constexpr __ESIMD_NS::cache_hint hint = Hint;
 };
 template <__ESIMD_NS::cache_hint Hint>
 struct property_value<__ESIMD_NS::cache_hint_L2_key,
-                      std::integral_constant<__ESIMD_NS::cache_hint, Hint>> {
-  using key_t = __ESIMD_NS::cache_hint_L2_key;
+                      std::integral_constant<__ESIMD_NS::cache_hint, Hint>>
+    : detail::property_base<
+          property_value<__ESIMD_NS::cache_hint_L2_key,
+                         std::integral_constant<__ESIMD_NS::cache_hint, Hint>>,
+          oneapi::experimental::detail::PropKind::ESIMDL2CacheHint,
+          __ESIMD_NS::cache_hint_L2_key> {
   static constexpr __ESIMD_NS::cache_level level = __ESIMD_NS::cache_level::L2;
   static constexpr __ESIMD_NS::cache_hint hint = Hint;
 };
 template <__ESIMD_NS::cache_hint Hint>
 struct property_value<__ESIMD_NS::cache_hint_L3_key,
-                      std::integral_constant<__ESIMD_NS::cache_hint, Hint>> {
-  using key_t = __ESIMD_NS::cache_hint_L3_key;
+                      std::integral_constant<__ESIMD_NS::cache_hint, Hint>>
+    : detail::property_base<
+          property_value<__ESIMD_NS::cache_hint_L3_key,
+                         std::integral_constant<__ESIMD_NS::cache_hint, Hint>>,
+          oneapi::experimental::detail::PropKind::ESIMDL3CacheHint,
+          __ESIMD_NS::cache_hint_L3_key> {
   static constexpr __ESIMD_NS::cache_level level = __ESIMD_NS::cache_level::L3;
   static constexpr __ESIMD_NS::cache_hint hint = Hint;
 };

--- a/sycl/include/sycl/ext/intel/experimental/kernel_execution_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/kernel_execution_properties.hpp
@@ -26,8 +26,9 @@ inline constexpr cache_config_enum large_slm =
 inline constexpr cache_config_enum large_data =
     cache_config_enum::large_data;
 
-struct cache_config : oneapi::experimental::detail::run_time_property_key<
-                          oneapi::experimental::detail::PropKind::CacheConfig> {
+struct cache_config
+    : oneapi::experimental::detail::run_time_property_key<
+          cache_config, oneapi::experimental::detail::PropKind::CacheConfig> {
   cache_config(cache_config_enum v) : value(v) {}
   cache_config_enum value;
 };

--- a/sycl/include/sycl/ext/oneapi/experimental/cluster_group_prop.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/cluster_group_prop.hpp
@@ -19,6 +19,7 @@ namespace cuda {
 template <int Dim>
 struct cluster_size
     : ::sycl::ext::oneapi::experimental::detail::run_time_property_key<
+          cluster_size<Dim>,
           ::sycl::ext::oneapi::experimental::detail::ClusterLaunch> {
   cluster_size(const range<Dim> &size) : size(size) {}
   sycl::range<Dim> get_cluster_size() { return size; }

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -60,13 +60,15 @@ struct device_has_key
                                  std::integral_constant<aspect, Aspects>...>;
 };
 
-struct nd_range_kernel_key {
+struct nd_range_kernel_key
+    : detail::compile_time_property_key<detail::PropKind::NDRangeKernel> {
   template <int Dims>
   using value_t =
       property_value<nd_range_kernel_key, std::integral_constant<int, Dims>>;
 };
 
-struct single_task_kernel_key {
+struct single_task_kernel_key
+    : detail::compile_time_property_key<detail::PropKind::SingleTaskKernel> {
   using value_t = property_value<single_task_kernel_key>;
 };
 
@@ -87,14 +89,17 @@ struct max_linear_work_group_size_key
 
 template <size_t Dim0, size_t... Dims>
 struct property_value<work_group_size_key, std::integral_constant<size_t, Dim0>,
-                      std::integral_constant<size_t, Dims>...> {
+                      std::integral_constant<size_t, Dims>...>
+    : detail::property_base<
+          property_value<work_group_size_key,
+                         std::integral_constant<size_t, Dim0>,
+                         std::integral_constant<size_t, Dims>...>,
+          detail::PropKind::WorkGroupSize, work_group_size_key> {
   static_assert(
       sizeof...(Dims) + 1 <= 3,
       "work_group_size property currently only supports up to three values.");
   static_assert(detail::AllNonZero<Dim0, Dims...>::value,
                 "work_group_size property must only contain non-zero values.");
-
-  using key_t = work_group_size_key;
 
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
@@ -104,15 +109,18 @@ struct property_value<work_group_size_key, std::integral_constant<size_t, Dim0>,
 template <size_t Dim0, size_t... Dims>
 struct property_value<work_group_size_hint_key,
                       std::integral_constant<size_t, Dim0>,
-                      std::integral_constant<size_t, Dims>...> {
+                      std::integral_constant<size_t, Dims>...>
+    : detail::property_base<
+          property_value<work_group_size_hint_key,
+                         std::integral_constant<size_t, Dim0>,
+                         std::integral_constant<size_t, Dims>...>,
+          detail::PropKind::WorkGroupSizeHint, work_group_size_hint_key> {
   static_assert(sizeof...(Dims) + 1 <= 3,
                 "work_group_size_hint property currently "
                 "only supports up to three values.");
   static_assert(
       detail::AllNonZero<Dim0, Dims...>::value,
       "work_group_size_hint property must only contain non-zero values.");
-
-  using key_t = work_group_size_hint_key;
 
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
@@ -121,41 +129,57 @@ struct property_value<work_group_size_hint_key,
 
 template <uint32_t Size>
 struct property_value<sub_group_size_key,
-                      std::integral_constant<uint32_t, Size>> {
+                      std::integral_constant<uint32_t, Size>>
+    : detail::property_base<
+          property_value<sub_group_size_key,
+                         std::integral_constant<uint32_t, Size>>,
+          detail::PropKind::SubGroupSize, sub_group_size_key> {
   static_assert(Size != 0,
                 "sub_group_size_key property must contain a non-zero value.");
 
-  using key_t = sub_group_size_key;
   using value_t = std::integral_constant<uint32_t, Size>;
   static constexpr uint32_t value = Size;
 };
 
 template <aspect... Aspects>
 struct property_value<device_has_key,
-                      std::integral_constant<aspect, Aspects>...> {
-  using key_t = device_has_key;
+                      std::integral_constant<aspect, Aspects>...>
+    : detail::property_base<
+          property_value<device_has_key,
+                         std::integral_constant<aspect, Aspects>...>,
+          detail::PropKind::DeviceHas, device_has_key> {
   static constexpr std::array<aspect, sizeof...(Aspects)> value{Aspects...};
 };
 
 template <int Dims>
-struct property_value<nd_range_kernel_key, std::integral_constant<int, Dims>> {
+struct property_value<nd_range_kernel_key, std::integral_constant<int, Dims>>
+    : detail::property_base<property_value<nd_range_kernel_key,
+                                           std::integral_constant<int, Dims>>,
+                            detail::PropKind::NDRangeKernel,
+                            nd_range_kernel_key> {
   static_assert(
       Dims >= 1 && Dims <= 3,
       "nd_range_kernel_key property must use dimension of 1, 2 or 3.");
 
-  using key_t = nd_range_kernel_key;
   using value_t = int;
   static constexpr int dimensions = Dims;
 };
 
-template <> struct property_value<single_task_kernel_key> {
-  using key_t = single_task_kernel_key;
-};
+template <>
+struct property_value<single_task_kernel_key>
+    : detail::property_base<property_value<single_task_kernel_key>,
+                            detail::PropKind::SingleTaskKernel,
+                            single_task_kernel_key> {};
 
 template <size_t Dim0, size_t... Dims>
 struct property_value<max_work_group_size_key,
                       std::integral_constant<size_t, Dim0>,
-                      std::integral_constant<size_t, Dims>...> {
+                      std::integral_constant<size_t, Dims>...>
+    : detail::property_base<
+          property_value<max_work_group_size_key,
+                         std::integral_constant<size_t, Dim0>,
+                         std::integral_constant<size_t, Dims>...>,
+          detail::PropKind::MaxWorkGroupSize, max_work_group_size_key> {
   static_assert(sizeof...(Dims) + 1 <= 3,
                 "max_work_group_size property currently "
                 "only supports up to three values.");
@@ -163,16 +187,16 @@ struct property_value<max_work_group_size_key,
       detail::AllNonZero<Dim0, Dims...>::value,
       "max_work_group_size property must only contain non-zero values.");
 
-  using key_t = max_work_group_size_key;
-
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
 };
 
-template <> struct property_value<max_linear_work_group_size_key> {
-  using key_t = max_linear_work_group_size_key;
-};
+template <>
+struct property_value<max_linear_work_group_size_key>
+    : detail::property_base<property_value<max_linear_work_group_size_key>,
+                            detail::PropKind::MaxLinearWorkGroupSize,
+                            max_linear_work_group_size_key> {};
 
 template <size_t Dim0, size_t... Dims>
 inline constexpr work_group_size_key::value_t<Dim0, Dims...> work_group_size;
@@ -235,8 +259,13 @@ template <forward_progress_guarantee Guarantee,
 struct property_value<
     work_group_progress_key,
     std::integral_constant<forward_progress_guarantee, Guarantee>,
-    std::integral_constant<execution_scope, CoordinationScope>> {
-  using key_t = work_group_progress_key;
+    std::integral_constant<execution_scope, CoordinationScope>>
+    : detail::property_base<
+          property_value<
+              work_group_progress_key,
+              std::integral_constant<forward_progress_guarantee, Guarantee>,
+              std::integral_constant<execution_scope, CoordinationScope>>,
+          detail::PropKind::WorkGroupProgress, work_group_progress_key> {
   static constexpr forward_progress_guarantee guarantee = Guarantee;
   static constexpr execution_scope coordinationScope = CoordinationScope;
 };
@@ -246,8 +275,13 @@ template <forward_progress_guarantee Guarantee,
 struct property_value<
     sub_group_progress_key,
     std::integral_constant<forward_progress_guarantee, Guarantee>,
-    std::integral_constant<execution_scope, CoordinationScope>> {
-  using key_t = work_group_progress_key;
+    std::integral_constant<execution_scope, CoordinationScope>>
+    : detail::property_base<
+          property_value<
+              sub_group_progress_key,
+              std::integral_constant<forward_progress_guarantee, Guarantee>,
+              std::integral_constant<execution_scope, CoordinationScope>>,
+          detail::PropKind::SubGroupProgress, sub_group_progress_key> {
   static constexpr forward_progress_guarantee guarantee = Guarantee;
   static constexpr execution_scope coordinationScope = CoordinationScope;
 };
@@ -257,8 +291,13 @@ template <forward_progress_guarantee Guarantee,
 struct property_value<
     work_item_progress_key,
     std::integral_constant<forward_progress_guarantee, Guarantee>,
-    std::integral_constant<execution_scope, CoordinationScope>> {
-  using key_t = work_group_progress_key;
+    std::integral_constant<execution_scope, CoordinationScope>>
+    : detail::property_base<
+          property_value<
+              work_item_progress_key,
+              std::integral_constant<forward_progress_guarantee, Guarantee>,
+              std::integral_constant<execution_scope, CoordinationScope>>,
+          detail::PropKind::WorkItemProgress, work_item_progress_key> {
   static constexpr forward_progress_guarantee guarantee = Guarantee;
   static constexpr execution_scope coordinationScope = CoordinationScope;
 };

--- a/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/latency_control/properties.hpp
@@ -58,8 +58,15 @@ struct property_value<
     intel::experimental::latency_constraint_key,
     std::integral_constant<int, Target>,
     std::integral_constant<intel::experimental::latency_control_type, Type>,
-    std::integral_constant<int, Cycle>> {
-  using key_t = intel::experimental::latency_constraint_key;
+    std::integral_constant<int, Cycle>>
+    : detail::property_base<
+          property_value<intel::experimental::latency_constraint_key,
+                         std::integral_constant<int, Target>,
+                         std::integral_constant<
+                             intel::experimental::latency_control_type, Type>,
+                         std::integral_constant<int, Cycle>>,
+          oneapi::experimental::detail::PropKind::LatencyConstraint,
+          intel::experimental::latency_constraint_key> {
   static constexpr int target = Target;
   static constexpr intel::experimental::latency_control_type type = Type;
   static constexpr int cycle = Cycle;

--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -200,6 +200,10 @@ public:
     static_assert(NumContainedProps == sizeof...(PropertyValueTs),
                   "One or more property argument is not a property in the "
                   "property list.");
+    // We're in process of refactoring properties infrastructure, make sure that
+    // any newly added properties use `detail::property_base`!
+    static_assert(
+        (std::is_base_of_v<detail::property_tag, PropertyValueTs> && ...));
   }
 
   template <typename PropertyT>

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -94,7 +94,7 @@ enum PropKind : uint32_t {
 namespace sycl::ext::oneapi::experimental {
 
 // (2.)
-struct foo : detail::run_time_property_key<PropKind::Foo> {
+struct foo : detail::run_time_property_key<foo, PropKind::Foo> {
   foo(int v) : value(v) {}
   int value;
 };
@@ -215,10 +215,35 @@ enum PropKind : uint32_t {
   PropKindSize = 79,
 };
 
+template <typename PropertyT> struct PropertyToKind {
+  static constexpr PropKind Kind = PropertyT::Kind;
+};
+
+struct property_tag {};
+template <typename property_t, PropKind Kind,
+          typename property_key_t = property_t>
+struct property_base : property_tag {
+  using key_t = property_key_t;
+#if !defined(_MSC_VER)
+  // Temporary, to ensure new code matches previous behavior and to catch any
+  // silly copy-paste mistakes. MSVC can't compile it, but linux-only is enough
+  // for this temporary check.
+  static_assert([]() constexpr {
+    if constexpr (std::is_same_v<property_t, key_t>)
+      // key_t is incomplete at this point for runtime properties.
+      return true;
+    else
+      return Kind == PropertyToKind<key_t>::Kind;
+  }());
+#endif
+};
+
 struct property_key_base_tag {};
 struct compile_time_property_key_base_tag : property_key_base_tag {};
 
-template <PropKind Kind_> struct run_time_property_key : property_key_base_tag {
+template <typename property_t, PropKind Kind_>
+struct run_time_property_key : property_key_base_tag,
+                               property_base<property_t, Kind_> {
 protected:
   static constexpr PropKind Kind = Kind_;
 
@@ -233,12 +258,6 @@ protected:
 
   template <typename T>
   friend struct PropertyToKind;
-};
-
-// This trait must be specialized for all properties and must have a unique
-// constexpr PropKind member named Kind.
-template <typename PropertyT> struct PropertyToKind {
-  static constexpr PropKind Kind = PropertyT::Kind;
 };
 
 // Get unique ID for property.

--- a/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_value.hpp
@@ -41,9 +41,11 @@ struct PropertyValueBase<T> : public detail::SingleNontypePropertyValueBase<T> {
 } // namespace detail
 
 template <typename PropertyT, typename... Ts>
-struct property_value : public detail::PropertyValueBase<Ts...> {
-  using key_t = PropertyT;
-};
+struct property_value
+    : public detail::PropertyValueBase<Ts...>,
+      public detail::property_base<property_value<PropertyT, Ts...>,
+                                   detail::PropertyToKind<PropertyT>::Kind,
+                                   PropertyT> {};
 
 template <typename PropertyT, typename... A, typename... B>
 constexpr std::enable_if_t<detail::IsCompileTimeProperty<PropertyT>::value,

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -901,7 +901,8 @@ struct build_source_bundle_props;
 // PropertyT syclex::include_files
 /////////////////////////
 struct include_files
-    : detail::run_time_property_key<detail::PropKind::IncludeFiles> {
+    : detail::run_time_property_key<include_files,
+                                    detail::PropKind::IncludeFiles> {
   include_files();
   include_files(const std::string &name, const std::string &content) {
     record.emplace_back(std::make_pair(name, content));
@@ -922,7 +923,8 @@ struct is_property_key_of<include_files_key,
 // PropertyT syclex::build_options
 /////////////////////////
 struct build_options
-    : detail::run_time_property_key<detail::PropKind::BuildOptions> {
+    : detail::run_time_property_key<build_options,
+                                    detail::PropKind::BuildOptions> {
   std::vector<std::string> opts;
   build_options(const std::string &optsArg) : opts{optsArg} {}
   build_options(const std::vector<std::string> &optsArg) : opts(optsArg) {}
@@ -936,7 +938,8 @@ struct is_property_key_of<build_options_key, detail::build_source_bundle_props>
 /////////////////////////
 // PropertyT syclex::save_log
 /////////////////////////
-struct save_log : detail::run_time_property_key<detail::PropKind::BuildLog> {
+struct save_log
+    : detail::run_time_property_key<save_log, detail::PropKind::BuildLog> {
   std::string *log;
   save_log(std::string *logArg) : log(logArg) {}
 };
@@ -950,7 +953,8 @@ struct is_property_key_of<save_log_key, detail::build_source_bundle_props>
 // PropertyT syclex::registered_kernel_names
 /////////////////////////
 struct registered_kernel_names
-    : detail::run_time_property_key<detail::PropKind::RegisteredKernelNames> {
+    : detail::run_time_property_key<registered_kernel_names,
+                                    detail::PropKind::RegisteredKernelNames> {
   std::vector<std::string> kernel_names;
   registered_kernel_names() {}
   registered_kernel_names(const std::string &knArg) : kernel_names{knArg} {}

--- a/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
+++ b/sycl/test/abi/sycl_classes_abi_neutral_test.cpp
@@ -16,9 +16,8 @@
 // member is not crossing ABI boundary. All current exclusions are listed below.
 
 // CHECK: 0 | struct sycl::ext::oneapi::experimental::build_options
-// CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key<sycl::ext::oneapi::experimental::detail::BuildOptions> (base) (empty)
-// CHECK-NEXT:         0 |     struct sycl::ext::oneapi::experimental::detail::property_key_base_tag (base) (empty)
-// CHECK-NEXT:         0 |   class std::vector<class std::basic_string<char> > opts
+// CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key
+// CHECK:              0 |   class std::vector<class std::basic_string<char> > opts
 // CHECK-NEXT:         0 |     struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > > (base)
 // CHECK-NEXT:         0 |       struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl _M_impl
 // CHECK-NEXT:         0 |         class std::allocator<class std::basic_string<char> > (base) (empty)
@@ -26,9 +25,8 @@
 // CHECK-NEXT:         0 |         {{(struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl_data \(base\)|pointer _M_start)}}
 
 // CHECK: 0 | struct sycl::ext::oneapi::experimental::include_files
-// CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key<sycl::ext::oneapi::experimental::detail::IncludeFiles> (base) (empty)
-// CHECK-NEXT:         0 |     struct sycl::ext::oneapi::experimental::detail::property_key_base_tag (base) (empty)
-// CHECK-NEXT:         0 |   class std::vector<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > record
+// CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key
+// CHECK:              0 |   class std::vector<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > record
 // CHECK-NEXT:         0 |     struct std::_Vector_base<struct std::pair<class std::basic_string<char>, class std::basic_string<char> >, class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > > (base)
 // CHECK-NEXT:         0 |       struct std::_Vector_base<struct std::pair<class std::basic_string<char>, class std::basic_string<char> >, class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > >::_Vector_impl _M_impl
 // CHECK-NEXT:         0 |         class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > (base) (empty)
@@ -36,9 +34,8 @@
 // CHECK-NEXT:         0 |         {{(struct std::_Vector_base<struct std::pair<class std::basic_string<char>, class std::basic_string<char> >, class std::allocator<struct std::pair<class std::basic_string<char>, class std::basic_string<char> > > >::_Vector_impl_data \(base\)|pointer _M_start)}}
 
 // CHECK: 0 | struct sycl::ext::oneapi::experimental::registered_kernel_names
-// CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key<sycl::ext::oneapi::experimental::detail::RegisteredKernelNames> (base) (empty)
-// CHECK-NEXT:         0 |     struct sycl::ext::oneapi::experimental::detail::property_key_base_tag (base) (empty)
-// CHECK-NEXT:         0 |   class std::vector<class std::basic_string<char> > kernel_names
+// CHECK-NEXT:         0 |   struct sycl::ext::oneapi::experimental::detail::run_time_property_key
+// CHECK:              0 |   class std::vector<class std::basic_string<char> > kernel_names
 // CHECK-NEXT:         0 |     struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > > (base)
 // CHECK-NEXT:         0 |       struct std::_Vector_base<class std::basic_string<char>, class std::allocator<class std::basic_string<char> > >::_Vector_impl _M_impl
 // CHECK-NEXT:         0 |         class std::allocator<class std::basic_string<char> > (base) (empty)

--- a/sycl/test/extensions/annotated_usm/fake_properties.hpp
+++ b/sycl/test/extensions/annotated_usm/fake_properties.hpp
@@ -49,51 +49,53 @@ struct is_property_key_of<boo_key, objectT> : std::true_type {};
 
 // Runtime properties
 enum foo_enum : unsigned { a, b, c };
-struct foo : detail::run_time_property_key<fakePropKind(3)> {
+struct foo : detail::run_time_property_key<foo, fakePropKind(3)> {
   constexpr foo(foo_enum v) : value(v) {}
   foo_enum value;
 };
 
-struct foz  : detail::run_time_property_key<fakePropKind(4)> {
+struct foz : detail::run_time_property_key<foz, fakePropKind(4)> {
   float value1;
   bool value2;
 
   foz(float value1, bool value2) : value1(value1), value2(value2) {}
 };
 
-struct rt_prop1 : detail::run_time_property_key<fakePropKind(5)> {};
-struct rt_prop2 : detail::run_time_property_key<fakePropKind(6)> {};
-struct rt_prop3 : detail::run_time_property_key<fakePropKind(7)> {};
-struct rt_prop4 : detail::run_time_property_key<fakePropKind(8)> {};
-struct rt_prop5 : detail::run_time_property_key<fakePropKind(9)> {};
-struct rt_prop6 : detail::run_time_property_key<fakePropKind(10)> {};
-struct rt_prop7 : detail::run_time_property_key<fakePropKind(11)> {};
-struct rt_prop8 : detail::run_time_property_key<fakePropKind(12)> {};
-struct rt_prop9 : detail::run_time_property_key<fakePropKind(13)> {};
-struct rt_prop10 : detail::run_time_property_key<fakePropKind(14)> {};
-struct rt_prop11 : detail::run_time_property_key<fakePropKind(15)> {};
-struct rt_prop12 : detail::run_time_property_key<fakePropKind(16)> {};
-struct rt_prop13 : detail::run_time_property_key<fakePropKind(17)> {};
-struct rt_prop14 : detail::run_time_property_key<fakePropKind(18)> {};
-struct rt_prop15 : detail::run_time_property_key<fakePropKind(19)> {};
-struct rt_prop16 : detail::run_time_property_key<fakePropKind(20)> {};
-struct rt_prop17 : detail::run_time_property_key<fakePropKind(21)> {};
-struct rt_prop18 : detail::run_time_property_key<fakePropKind(22)> {};
-struct rt_prop19 : detail::run_time_property_key<fakePropKind(23)> {};
-struct rt_prop20 : detail::run_time_property_key<fakePropKind(24)> {};
-struct rt_prop21 : detail::run_time_property_key<fakePropKind(25)> {};
-struct rt_prop22 : detail::run_time_property_key<fakePropKind(26)> {};
-struct rt_prop23 : detail::run_time_property_key<fakePropKind(27)> {};
-struct rt_prop24 : detail::run_time_property_key<fakePropKind(28)> {};
-struct rt_prop25 : detail::run_time_property_key<fakePropKind(29)> {};
-struct rt_prop26 : detail::run_time_property_key<fakePropKind(30)> {};
-struct rt_prop27 : detail::run_time_property_key<fakePropKind(31)> {};
-struct rt_prop28 : detail::run_time_property_key<fakePropKind(32)> {};
-struct rt_prop29 : detail::run_time_property_key<fakePropKind(33)> {};
-struct rt_prop30 : detail::run_time_property_key<fakePropKind(34)> {};
-struct rt_prop31 : detail::run_time_property_key<fakePropKind(35)> {};
-struct rt_prop32 : detail::run_time_property_key<fakePropKind(36)> {};
-struct rt_prop33 : detail::run_time_property_key<fakePropKind(37)> {};
+// clang-format off
+struct rt_prop1 : detail::run_time_property_key<rt_prop1, fakePropKind(5)> {};
+struct rt_prop2 : detail::run_time_property_key<rt_prop2, fakePropKind(6)> {};
+struct rt_prop3 : detail::run_time_property_key<rt_prop3, fakePropKind(7)> {};
+struct rt_prop4 : detail::run_time_property_key<rt_prop4, fakePropKind(8)> {};
+struct rt_prop5 : detail::run_time_property_key<rt_prop5, fakePropKind(9)> {};
+struct rt_prop6 : detail::run_time_property_key<rt_prop6, fakePropKind(10)> {};
+struct rt_prop7 : detail::run_time_property_key<rt_prop7, fakePropKind(11)> {};
+struct rt_prop8 : detail::run_time_property_key<rt_prop8, fakePropKind(12)> {};
+struct rt_prop9 : detail::run_time_property_key<rt_prop9, fakePropKind(13)> {};
+struct rt_prop10 : detail::run_time_property_key<rt_prop10, fakePropKind(14)> {};
+struct rt_prop11 : detail::run_time_property_key<rt_prop11, fakePropKind(15)> {};
+struct rt_prop12 : detail::run_time_property_key<rt_prop12, fakePropKind(16)> {};
+struct rt_prop13 : detail::run_time_property_key<rt_prop13, fakePropKind(17)> {};
+struct rt_prop14 : detail::run_time_property_key<rt_prop14, fakePropKind(18)> {};
+struct rt_prop15 : detail::run_time_property_key<rt_prop15, fakePropKind(19)> {};
+struct rt_prop16 : detail::run_time_property_key<rt_prop16, fakePropKind(20)> {};
+struct rt_prop17 : detail::run_time_property_key<rt_prop17, fakePropKind(21)> {};
+struct rt_prop18 : detail::run_time_property_key<rt_prop18, fakePropKind(22)> {};
+struct rt_prop19 : detail::run_time_property_key<rt_prop19, fakePropKind(23)> {};
+struct rt_prop20 : detail::run_time_property_key<rt_prop20, fakePropKind(24)> {};
+struct rt_prop21 : detail::run_time_property_key<rt_prop21, fakePropKind(25)> {};
+struct rt_prop22 : detail::run_time_property_key<rt_prop22, fakePropKind(26)> {};
+struct rt_prop23 : detail::run_time_property_key<rt_prop23, fakePropKind(27)> {};
+struct rt_prop24 : detail::run_time_property_key<rt_prop24, fakePropKind(28)> {};
+struct rt_prop25 : detail::run_time_property_key<rt_prop25, fakePropKind(29)> {};
+struct rt_prop26 : detail::run_time_property_key<rt_prop26, fakePropKind(30)> {};
+struct rt_prop27 : detail::run_time_property_key<rt_prop27, fakePropKind(31)> {};
+struct rt_prop28 : detail::run_time_property_key<rt_prop28, fakePropKind(32)> {};
+struct rt_prop29 : detail::run_time_property_key<rt_prop29, fakePropKind(33)> {};
+struct rt_prop30 : detail::run_time_property_key<rt_prop30, fakePropKind(34)> {};
+struct rt_prop31 : detail::run_time_property_key<rt_prop31, fakePropKind(35)> {};
+struct rt_prop32 : detail::run_time_property_key<rt_prop32, fakePropKind(36)> {};
+struct rt_prop33 : detail::run_time_property_key<rt_prop33, fakePropKind(37)> {};
+// clang-format on
 
 using foo_key = foo;
 using foz_key = foz;

--- a/sycl/test/extensions/properties/mock_compile_time_properties.hpp
+++ b/sycl/test/extensions/properties/mock_compile_time_properties.hpp
@@ -34,7 +34,7 @@ struct boo_key : detail::compile_time_property_key<fakePropKind(2)> {
   template <typename... Ts> using value_t = property_value<boo_key, Ts...>;
 };
 
-struct foo : detail::run_time_property_key<fakePropKind(3)> {
+struct foo : detail::run_time_property_key<foo, fakePropKind(3)> {
   constexpr foo(int v = 0) : value(v) {}
   int value;
 };
@@ -44,7 +44,7 @@ inline bool operator==(const foo &lhs, const foo &rhs) {
 }
 inline bool operator!=(const foo &lhs, const foo &rhs) { return !(lhs == rhs); }
 
-struct foz : detail::run_time_property_key<fakePropKind(4)> {
+struct foz : detail::run_time_property_key<foz, fakePropKind(4)> {
   constexpr foz(float v1, bool v2) : value1(v1), value2(v2) {}
   // Define copy constructor to make foz non-trivially copyable
   constexpr foz(const foz &f) {
@@ -60,7 +60,7 @@ inline bool operator==(const foz &lhs, const foz &rhs) {
 }
 inline bool operator!=(const foz &lhs, const foz &rhs) { return !(lhs == rhs); }
 
-struct fir : detail::run_time_property_key<fakePropKind(5)> {
+struct fir : detail::run_time_property_key<fir, fakePropKind(5)> {
   // Intentionally not constexpr to test for properties that cannot be constexpr
   fir(float v1, bool v2) : value1(v1), value2(v2) {}
   // Define copy constructor to make foz non-trivially copyable


### PR DESCRIPTION
This lays some ground base for subsequent refactoring PRs by isolating simple but noisy diff into a separate change.

We're anticipating at least two changes that would be built on top of this:
* Change implementation of `has_property`/`get_property` to be inheritance-based vs type-lists/boost.
* Bigger design-wise refactoring of the compile time properties, e.g. removal of `property_value` class template.