### PR TITLE
[SYCL][E2E] Fix build flag for device_global_copy

### DIFF
--- a/sycl/test-e2e/DeviceGlobal/device_global_copy.cpp
+++ b/sycl/test-e2e/DeviceGlobal/device_global_copy.cpp
@@ -1,4 +1,6 @@
-// RUN: %{build} -std=c++23 -o %t.out
+// DEFINE: %{cpp23} = %if cl_options %{/std:c++23%} %else %{-std=c++23%}
+
+// RUN: %{build} %{cpp23} -o %t.out
 // RUN: %{run} %t.out
 //
 // UNSUPPORTED: opencl && gpu


### PR DESCRIPTION
The new test device_global_copy fails to build on Windows due to unrecognized -std option. This commit fixes the flag.