### PR TITLE
[Clang] Fix passing `-offload-compress` when compiling and linking device images separately

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10350,33 +10350,45 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
   assert(JA.getInputs().size() == Inputs.size() &&
          "Not have inputs for all dependence actions??");
 
-  // For FPGA, we wrap the host objects before archiving them when using
-  // -fsycl-link.  This allows for better extraction control from the
-  // archive when we need the host objects for subsequent compilations.
   if (OffloadingKind == Action::OFK_None &&
-      C.getArgs().hasArg(options::OPT_fintelfpga) &&
       C.getArgs().hasArg(options::OPT_fsycl_link_EQ)) {
 
-    // Add offload targets and inputs.
-    CmdArgs.push_back(C.getArgs().MakeArgString(
-        Twine("-kind=") + Action::GetOffloadKindName(OffloadingKind)));
-    CmdArgs.push_back(
-        TCArgs.MakeArgString(Twine("-target=") + Triple.getTriple()));
+    // When compiling and linking separately, we need to propagate the
+    // compression related CLI options to offload-wrapper.
+    if (C.getInputArgs().getLastArg(options::OPT_offload_compress)) {
+      CmdArgs.push_back(C.getArgs().MakeArgString(Twine("-offload-compress")));
+      // -offload-compression-level=<>
+      if (Arg *A = C.getInputArgs().getLastArg(
+              options::OPT_offload_compression_level_EQ))
+        CmdArgs.push_back(C.getArgs().MakeArgString(
+            Twine("-offload-compression-level=") + A->getValue()));
+    }
 
-    if (Inputs[0].getType() == types::TY_Tempfiletable ||
-        Inputs[0].getType() == types::TY_Tempfilelist)
-      // Input files are passed via the batch job file table.
-      CmdArgs.push_back(C.getArgs().MakeArgString("-batch"));
+    // For FPGA, we wrap the host objects before archiving them when using
+    // -fsycl-link.  This allows for better extraction control from the
+    // archive when we need the host objects for subsequent compilations.
+    if (C.getArgs().hasArg(options::OPT_fintelfpga)) {
+      // Add offload targets and inputs.
+      CmdArgs.push_back(C.getArgs().MakeArgString(
+          Twine("-kind=") + Action::GetOffloadKindName(OffloadingKind)));
+      CmdArgs.push_back(
+          TCArgs.MakeArgString(Twine("-target=") + Triple.getTriple()));
 
-    // Add input.
-    assert(Inputs[0].isFilename() && "Invalid input.");
-    CmdArgs.push_back(TCArgs.MakeArgString(Inputs[0].getFilename()));
+      if (Inputs[0].getType() == types::TY_Tempfiletable ||
+          Inputs[0].getType() == types::TY_Tempfilelist)
+        // Input files are passed via the batch job file table.
+        CmdArgs.push_back(C.getArgs().MakeArgString("-batch"));
 
-    C.addCommand(std::make_unique<Command>(
-        JA, *this, ResponseFileSupport::None(),
-        TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
-        CmdArgs, Inputs));
-    return;
+      // Add input.
+      assert(Inputs[0].isFilename() && "Invalid input.");
+      CmdArgs.push_back(TCArgs.MakeArgString(Inputs[0].getFilename()));
+
+      C.addCommand(std::make_unique<Command>(
+          JA, *this, ResponseFileSupport::None(),
+          TCArgs.MakeArgString(getToolChain().GetProgramPath(getShortName())),
+          CmdArgs, Inputs));
+      return;
+    }
   }
 
   // Add offload targets and inputs.

--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10354,20 +10354,25 @@ void OffloadWrapper::ConstructJob(Compilation &C, const JobAction &JA,
       C.getArgs().hasArg(options::OPT_fsycl_link_EQ)) {
 
     // When compiling and linking separately, we need to propagate the
-    // compression related CLI options to offload-wrapper.
-    if (C.getInputArgs().getLastArg(options::OPT_offload_compress)) {
-      CmdArgs.push_back(C.getArgs().MakeArgString(Twine("-offload-compress")));
-      // -offload-compression-level=<>
-      if (Arg *A = C.getInputArgs().getLastArg(
-              options::OPT_offload_compression_level_EQ))
-        CmdArgs.push_back(C.getArgs().MakeArgString(
-            Twine("-offload-compression-level=") + A->getValue()));
+    // compression related CLI options to offload-wrapper. Don't propagate
+    // these options when wrapping objects for FPGA.
+    if (!C.getArgs().hasArg(options::OPT_fintelfpga)) {
+
+      if (C.getInputArgs().getLastArg(options::OPT_offload_compress)) {
+        CmdArgs.push_back(
+            C.getArgs().MakeArgString(Twine("-offload-compress")));
+        // -offload-compression-level=<>
+        if (Arg *A = C.getInputArgs().getLastArg(
+                options::OPT_offload_compression_level_EQ))
+          CmdArgs.push_back(C.getArgs().MakeArgString(
+              Twine("-offload-compression-level=") + A->getValue()));
+      }
     }
 
     // For FPGA, we wrap the host objects before archiving them when using
     // -fsycl-link.  This allows for better extraction control from the
     // archive when we need the host objects for subsequent compilations.
-    if (C.getArgs().hasArg(options::OPT_fintelfpga)) {
+    else {
       // Add offload targets and inputs.
       CmdArgs.push_back(C.getArgs().MakeArgString(
           Twine("-kind=") + Action::GetOffloadKindName(OffloadingKind)));

--- a/sycl/test-e2e/Compression/compression_separate_compile.cpp
+++ b/sycl/test-e2e/Compression/compression_separate_compile.cpp
@@ -8,7 +8,14 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-host-compiler=clang++ -fsycl-host-compiler-options='-std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -DENABLE_KERNEL2' -DENABLE_KERNEL2 -c %s -o %t_kernel2_aot.o
 
 //////////////////////   Link device images
-// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -v
+// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o
+
+// Make sure the clang-offload-wrapper is called with the --offload-compress
+// option.
+// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -### &> %t_driver_opts.txt
+// RUN: FileCheck -input-file=%t_driver_opts.txt %s --check-prefix=CHECK-DRIVER-OPTS
+
+// CHECK-DRIVER-OPTS: clang-offload-wrapper{{.*}} "-offload-compress"
 
 //////////////////////   Compile the host program
 // RUN: %clangxx -fsycl -std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -c %s -o %t_main.o

--- a/sycl/test-e2e/Compression/compression_separate_compile.cpp
+++ b/sycl/test-e2e/Compression/compression_separate_compile.cpp
@@ -8,7 +8,7 @@
 // RUN: %clangxx -fsycl -fsycl-targets=spir64_x86_64 -fsycl-host-compiler=clang++ -fsycl-host-compiler-options='-std=c++17 -Wno-attributes -Wno-deprecated-declarations -fPIC -DENABLE_KERNEL2' -DENABLE_KERNEL2 -c %s -o %t_kernel2_aot.o
 
 //////////////////////   Link device images
-// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o
+// RUN: %clangxx --offload-compress -fsycl -fsycl-link -fsycl-targets=spir64_x86_64 -fPIC %t_kernel1_aot.o %t_kernel2_aot.o -o %t_compressed_image.o -v
 
 // Make sure the clang-offload-wrapper is called with the --offload-compress
 // option.


### PR DESCRIPTION
When compiling and linking device images separately, compression related flags are not propagated correctly to `offload-wrapper`. This PR fixes that and updates the test accordingly.