### PR TITLE
[E2E] Fix no_zstd_warning.cpp when built with `clang-cl`

### DIFF
--- a/sycl/test-e2e/Compression/no_zstd_warning.cpp
+++ b/sycl/test-e2e/Compression/no_zstd_warning.cpp
@@ -1,4 +1,4 @@
 // using --offload-compress without zstd should throw an error.
 // REQUIRES: !zstd
-// RUN: not %{build} -O0 -g --offload-compress %S/Inputs/single_kernel.cpp -o %t_compress.out 2>&1 | FileCheck %s
+// RUN: not %{build} %O0 -g --offload-compress %S/Inputs/single_kernel.cpp -o %t_compress.out 2>&1 | FileCheck %s
 // CHECK: '--offload-compress' option is specified but zstd is not available. The device image will not be compressed.


### PR DESCRIPTION
Currently, when this test is built with a compiler that accepts MSVC-style flags, compilation fails because `-O0` is unrecognized. This PR updates the test to replace `-O0` with `%O0`.
Internal bug report: CMPLRTST-26037