### PR TITLE
[SYCL][E2E] Update pf-wg-atomic64.cpp

### DIFF
--- a/sycl/test-e2e/Regression/pf-wg-atomic64.cpp
+++ b/sycl/test-e2e/Regression/pf-wg-atomic64.cpp
@@ -1,4 +1,5 @@
-// DISABLED: aspect-atomic64
+// UNSUPPORTED: aspect-atomic64
+// UNSUPPORTED-INTENDED: The test is intended for devices without atomic64 support.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 

--- a/sycl/test-e2e/Regression/pf-wg-atomic64.cpp
+++ b/sycl/test-e2e/Regression/pf-wg-atomic64.cpp
@@ -1,5 +1,6 @@
 // UNSUPPORTED: aspect-atomic64
-// UNSUPPORTED-INTENDED: The test is intended for devices without atomic64 support.
+// UNSUPPORTED-INTENDED: The test is intended for devices without atomic64
+// support.
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out
 


### PR DESCRIPTION
This DISABLED does nothing. As I understand this test should be run on a device without atomic64 support.