### PR TITLE
[CI] Turn on test_kernel_bundle and marray

### DIFF
--- a/devops/cts_exclude_filter_L0_GPU
+++ b/devops/cts_exclude_filter_L0_GPU
@@ -1,6 +1,3 @@
-# These two take too much time
-kernel_bundle
-marray
 # fix: https://github.com/KhronosGroup/SYCL-CTS/pull/964
 accessor_legacy
 # CMPLRLLVM-61839

--- a/devops/cts_exclude_filter_OCL_CPU
+++ b/devops/cts_exclude_filter_OCL_CPU
@@ -1,6 +1,3 @@
-# These two take too much time
-kernel_bundle
-marray
 # https://github.com/intel/llvm/issues/13477
 math_builtin_api
 # https://github.com/intel/llvm/issues/13574


### PR DESCRIPTION
These tests were turned off as we used some unstable runner previously. Turning them on since we moved to reliable runners.