### PR TITLE
[SYCL][E2E] Avoid unused argument warning for imf_fp16_trivial_test

### DIFF
--- a/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
+++ b/sycl/test-e2e/DeviceLib/imf_fp16_trivial_test.cpp
@@ -5,7 +5,7 @@
 
 // RUN: %{build} %{mathflags} -c -DSOURCE1 -o %t1.o
 // RUN: %{build} %{mathflags} -c -DSOURCE2 -o %t2.o
-// RUN: %clangxx -fsycl  %t1.o %t2.o  -o %t.out
+// RUN: %clangxx -Wno-error=unused-command-line-argument -fsycl  %t1.o %t2.o  -o %t.out
 // RUN: %{run} %t.out
 
 // UNSUPPORTED: cuda, hip


### PR DESCRIPTION
The imf_fp16_trivial_test has a clangxx invocation with only object files. On Windows, this invocation may have /EHsc, which in this case will be ignored. This issues a warning, which in turn becomes an error when -Werror is set. To avoid this, we ignore unused-argument warnings for this specific invocation.