### PR TITLE
[CI] Fix AMDGPU arch flag for Codeplay runner

### DIFF
--- a/.github/workflows/sycl-linux-run-tests.yml
+++ b/.github/workflows/sycl-linux-run-tests.yml
@@ -284,7 +284,11 @@ jobs:
           echo "opts=$CMAKE_EXTRA_ARGS" >> $GITHUB_OUTPUT
         else
           if [ "${{ contains(inputs.target_devices, 'ext_oneapi_hip')  }}" == "true" ]; then
-            echo 'opts=-DHIP_PLATFORM="AMD" -DAMD_ARCH="gfx1031"' >> $GITHUB_OUTPUT
+            if [ "${{ runner.name }}" == "cp-amd-runner" ]; then
+              echo 'opts=-DHIP_PLATFORM="AMD" -DAMD_ARCH="gfx1030"' >> $GITHUB_OUTPUT
+            else
+              echo 'opts=-DHIP_PLATFORM="AMD" -DAMD_ARCH="gfx1031"' >> $GITHUB_OUTPUT
+            fi
           else
             echo 'opts=' >> $GITHUB_OUTPUT
           fi


### PR DESCRIPTION
New HIP runner is up and running but it's a different card so we need a different arch flag.

Not the cleanest solution but this isn't really going to scale.

Confirmed working [here](https://github.com/intel/llvm/actions/runs/11801446093/job/32875423501).