### PR TITLE
[SYCL][NFC] Fix ctad warnings

### DIFF
--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -493,7 +493,8 @@ std::optional<ur_program_handle_t> context_impl::getProgramForDevImgs(
     auto &Cache = LockedCache.get().Cache;
     ur_device_handle_t &DevHandle = getSyclObjImpl(Device)->getHandleRef();
     for (std::uintptr_t ImageIDs : ImgIdentifiers) {
-      auto OuterKey = std::make_pair(ImageIDs, std::set<ur_device_handle_t>{DevHandle});
+      auto OuterKey =
+          std::make_pair(ImageIDs, std::set<ur_device_handle_t>{DevHandle});
       size_t NProgs = KeyMap.count(OuterKey);
       if (NProgs == 0)
         continue;

--- a/sycl/source/detail/context_impl.cpp
+++ b/sycl/source/detail/context_impl.cpp
@@ -493,7 +493,7 @@ std::optional<ur_program_handle_t> context_impl::getProgramForDevImgs(
     auto &Cache = LockedCache.get().Cache;
     ur_device_handle_t &DevHandle = getSyclObjImpl(Device)->getHandleRef();
     for (std::uintptr_t ImageIDs : ImgIdentifiers) {
-      auto OuterKey = std::make_pair(ImageIDs, std::set{DevHandle});
+      auto OuterKey = std::make_pair(ImageIDs, std::set<ur_device_handle_t>{DevHandle});
       size_t NProgs = KeyMap.count(OuterKey);
       if (NProgs == 0)
         continue;

--- a/sycl/source/detail/program_manager/program_manager.cpp
+++ b/sycl/source/detail/program_manager/program_manager.cpp
@@ -911,7 +911,7 @@ ur_program_handle_t ProgramManager::getBuiltURProgram(
   uint32_t ImgId = Img.getImageID();
   const ur_device_handle_t UrDevice = Dev->getHandleRef();
   auto CacheKey = std::make_pair(std::make_pair(std::move(SpecConsts), ImgId),
-                                 std::set{UrDevice});
+                                 std::set<ur_device_handle_t>{UrDevice});
 
   auto GetCachedBuildF = [&Cache, &CacheKey]() {
     return Cache.getOrInsertProgram(CacheKey);

--- a/sycl/unittests/helpers/MockDeviceImage.hpp
+++ b/sycl/unittests/helpers/MockDeviceImage.hpp
@@ -187,7 +187,8 @@ public:
   /// \param Name is a property name. See ur.hpp for list of known names.
   /// \param Prop is a property value.
   void insert(const std::string &Name, MockProperty &&Props) {
-    insert(Name, internal::LifetimeExtender{std::vector{std::move(Props)}});
+    insert(Name, internal::LifetimeExtender{
+                     std::vector<MockProperty>{std::move(Props)}});
   }
 
   /// Adds a new array of properties to the set.


### PR DESCRIPTION
llvm/sycl/source/detail/context_impl.cpp:496:48: error: 'std::set' may
not intend to support class template argument deduction
[-Werror,-Wctad-maybe-unsupported]
