### PR TITLE
[SYCL] Enable SPV_INTEL_maximum_registers by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10757,7 +10757,8 @@ static void getTripleBasedSPIRVTransOpts(Compilation &C,
               ",+SPV_INTEL_optnone"
               ",+SPV_KHR_non_semantic_info"
               ",+SPV_KHR_cooperative_matrix"
-              ",+SPV_EXT_shader_atomic_float16_add";
+              ",+SPV_EXT_shader_atomic_float16_add"
+              ",+SPV_INTEL_maximum_registers";
   if (IsCPU)
     ExtArg += ",+SPV_INTEL_fp_max_error";
 

--- a/clang/test/Driver/sycl-spirv-ext-old-model.c
+++ b/clang/test/Driver/sycl-spirv-ext-old-model.c
@@ -61,7 +61,8 @@
 // CHECK-DEFAULT-SAME:,+SPV_INTEL_optnone
 // CHECK-DEFAULT-SAME:,+SPV_KHR_non_semantic_info
 // CHECK-DEFAULT-SAME:,+SPV_KHR_cooperative_matrix
-// CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float16_add"
+// CHECK-DEFAULT-SAME:,+SPV_EXT_shader_atomic_float16_add
+// CHECK-DEFAULT-SAME:,+SPV_INTEL_maximum_registers"
 // CHECK-FPGA-HW: llvm-spirv{{.*}}"-spirv-ext=-all
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_add
 // CHECK-FPGA-HW-SAME:,+SPV_EXT_shader_atomic_float_min_max

--- a/clang/test/Driver/sycl-spirv-metadata-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-metadata-old-model.cpp
@@ -9,7 +9,7 @@
 // RUN:  FileCheck -check-prefix CHECK-WITHOUT %s
 
 // CHECK-WITH: llvm-spirv{{.*}} "--spirv-preserve-auxdata"
-// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_EXT_shader_atomic_float16_add"
+// CHECK-WITH-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_maximum_registers"
 
 // CHECK-WITHOUT: "{{.*}}llvm-spirv"
 // CHECK-WITHOUT-NOT: --spirv-preserve-auxdata

--- a/clang/test/Driver/sycl-spirv-obj-old-model.cpp
+++ b/clang/test/Driver/sycl-spirv-obj-old-model.cpp
@@ -11,7 +11,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[DEVICE_BC:.+\.bc]]"
 // SPIRV_DEVICE_OBJ: llvm-spirv{{.*}} "-o" "[[DEVICE_SPV:.+\.spv]]"
 // SPIRV_DEVICE_OBJ-SAME: "--spirv-preserve-auxdata"
-// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_EXT_shader_atomic_float16_add"
+// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_maximum_registers"
 // SPIRV_DEVICE_OBJ-SAME: "[[DEVICE_BC]]"
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"
 // SPIRV_DEVICE_OBJ-SAME: "-fsycl-is-host"

--- a/clang/test/Driver/sycl-spirv-obj.cpp
+++ b/clang/test/Driver/sycl-spirv-obj.cpp
@@ -11,7 +11,7 @@
 // SPIRV_DEVICE_OBJ-SAME: "-o" "[[DEVICE_BC:.+\.bc]]"
 // SPIRV_DEVICE_OBJ: llvm-spirv{{.*}} "-o" "[[DEVICE_SPV:.+\.spv]]"
 // SPIRV_DEVICE_OBJ-SAME: "--spirv-preserve-auxdata"
-// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_EXT_shader_atomic_float16_add"
+// SPIRV_DEVICE_OBJ-SAME: "-spirv-ext=-all,{{.*}},+SPV_INTEL_maximum_registers"
 // SPIRV_DEVICE_OBJ-SAME: "[[DEVICE_BC]]"
 // SPIRV_DEVICE_OBJ: clang-offload-packager{{.*}} "--image=file=[[DEVICE_SPV]]{{.*}}"
 // SPIRV_DEVICE_OBJ: clang{{.*}} "-cc1" "-triple" "x86_64-unknown-linux-gnu"

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -887,7 +887,8 @@ getTripleBasedSPIRVTransOpts(const ArgList &Args,
             ",+SPV_INTEL_optnone"
             ",+SPV_KHR_non_semantic_info"
             ",+SPV_KHR_cooperative_matrix"
-            ",+SPV_EXT_shader_atomic_float16_add";
+            ",+SPV_EXT_shader_atomic_float16_add"
+            ",+SPV_INTEL_maximum_registers";
   if (IsCPU)
     ExtArg += ",+SPV_INTEL_fp_max_error";
   TranslatorArgs.push_back(Args.MakeArgString(ExtArg));

--- a/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
+++ b/llvm/lib/SYCLLowerIR/CompileTimePropertiesPass.cpp
@@ -10,7 +10,6 @@
 
 #include "llvm/SYCLLowerIR/CompileTimePropertiesPass.h"
 #include "llvm/SYCLLowerIR/DeviceGlobals.h"
-#include "llvm/SYCLLowerIR/ESIMD/ESIMDUtils.h"
 #include "llvm/SYCLLowerIR/HostPipes.h"
 #include "llvm/SYCLLowerIR/TargetHelpers.h"
 
@@ -483,23 +482,19 @@ attributeToExecModeMetadata(const Attribute &Attr, Function &F) {
                                             MDNode::get(Ctx, ClusterMDArgs));
   }
 
-  if ((AttrKindStr == SYCL_REGISTER_ALLOC_MODE_ATTR ||
-       AttrKindStr == SYCL_GRF_SIZE_ATTR) &&
-      !llvm::esimd::isESIMD(F)) {
+  if (AttrKindStr == SYCL_REGISTER_ALLOC_MODE_ATTR ||
+      AttrKindStr == SYCL_GRF_SIZE_ATTR) {
     // TODO: Remove SYCL_REGISTER_ALLOC_MODE_ATTR support in next ABI break.
     uint32_t PropVal = getAttributeAsInteger<uint32_t>(Attr);
-    if (AttrKindStr == SYCL_GRF_SIZE_ATTR) {
-      // The RegisterAllocMode metadata supports only 0, 128, and 256 for
-      // PropVal.
-      if (PropVal != 0 && PropVal != 128 && PropVal != 256)
-        return std::nullopt;
-      // Map sycl-grf-size values to RegisterAllocMode values used in SPIR-V.
+    if (AttrKindStr == SYCL_REGISTER_ALLOC_MODE_ATTR) {
+      // Map sycl-register-alloc-mode values to RegisterAllocMode values used in
+      // SPIR-V.
       static constexpr int SMALL_GRF_REGALLOCMODE_VAL = 1;
       static constexpr int LARGE_GRF_REGALLOCMODE_VAL = 2;
-      if (PropVal == 128)
-        PropVal = SMALL_GRF_REGALLOCMODE_VAL;
-      else if (PropVal == 256)
-        PropVal = LARGE_GRF_REGALLOCMODE_VAL;
+      if (PropVal == SMALL_GRF_REGALLOCMODE_VAL)
+        PropVal = 128;
+      else if (PropVal == LARGE_GRF_REGALLOCMODE_VAL)
+        PropVal = 256;
     }
     Metadata *AttrMDArgs[] = {ConstantAsMetadata::get(
         Constant::getIntegerValue(Type::getInt32Ty(Ctx), APInt(32, PropVal)))};

--- a/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/kernel-attributes/grf-size.ll
+++ b/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/kernel-attributes/grf-size.ll
@@ -1,12 +1,13 @@
-; Check we create RegisterAllocMode metadata if there is a non-ESIMD kernel with that property
+; Check we create RegisterAllocMode metadata if there is a kernel with that property
 ; RUN: opt -passes=compile-time-properties %s -S | FileCheck %s --check-prefix CHECK-IR
 
 ; Function Attrs: convergent norecurse
 define weak_odr dso_local spir_kernel void @sycl_grf_size() #1 {
 ; CHECK-IR-NOT: !RegisterAllocMode
 ; CHECK-IR: sycl_grf_size() #[[#Attr1:]]{{.*}}!RegisterAllocMode ![[#MDVal:]] {
+; CHECK-IR: esimd_grf_size() #[[#Attr2:]]{{.*}}!RegisterAllocMode ![[#MDVal]] {
 ; CHECK-IR-NOT: !RegisterAllocMode
-; CHECK-IR: ![[#MDVal]] = !{i32 2}
+; CHECK-IR: ![[#MDVal]] = !{i32 256}
 entry:
   ret void
 }

--- a/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/kernel-attributes/register-alloc-mode.ll
+++ b/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/kernel-attributes/register-alloc-mode.ll
@@ -1,12 +1,13 @@
-; Check we create RegisterAllocMode metadata if there is a non-ESIMD kernel with that property
+; Check we create RegisterAllocMode metadata if there is a ESIMD kernel with that property
 ; RUN: opt -passes=compile-time-properties %s -S | FileCheck %s --check-prefix CHECK-IR
 
 ; Function Attrs: convergent norecurse
 define weak_odr dso_local spir_kernel void @sycl_regallocmode() #1 {
 ; CHECK-IR-NOT: !RegisterAllocMode
 ; CHECK-IR: sycl_regallocmode() #[[#Attr1:]]{{.*}}!RegisterAllocMode ![[#MDVal:]] {
+; CHECK-IR: esimd_regallocmode() #[[#Attr2:]]{{.*}}!RegisterAllocMode ![[#MDVal]] {
 ; CHECK-IR-NOT: !RegisterAllocMode
-; CHECK-IR: ![[#MDVal]] = !{i32 2}
+; CHECK-IR: ![[#MDVal]] = !{i32 256}
 entry:
   ret void
 }

--- a/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/sycl-grf-mode.ll
+++ b/llvm/test/SYCLLowerIR/CompileTimePropertiesPass/sycl-grf-mode.ll
@@ -1,7 +1,9 @@
-; Check we don't assert for different GRF values and don't add the RegisterAllocMode metadata
+; Check we don't assert for different GRF values and add the RegisterAllocMode metadata
 ; RUN: opt -passes=compile-time-properties %s -S | FileCheck %s --implicit-check-not=RegisterAllocMode
 
-; CHECK: spir_kernel void @foo()
+; CHECK: spir_kernel void @foo() #[[#Attr:]]{{.*}}!RegisterAllocMode ![[#MDVal:]] {
+; CHECK-IR: ![[#MDVal]] = !{i32 16384}
+
 define weak_odr dso_local spir_kernel void @foo() #0 {
 entry:
   ret void


### PR DESCRIPTION
Use the `SPV_INTEL_maximum_registers` extension to implement per-kernel GRF selection. Previously we were doing it was a hack adding an annotation on the entry point which only worked for the scalar IGC backend.

This extension has long been supported in scalar IGC, and it never worked previously for ESIMD using the old path and support was recently added for ESIMD using this extension.

There should be no ABI break, previously-generated object files and executable generated with an old compiler will still have the same behavior as before this change.