### PR TITLE
[Driver][SYCL][NFC] Fix memory sanitizer issue for AOT

### DIFF
--- a/clang/lib/Driver/ToolChains/SYCL.cpp
+++ b/clang/lib/Driver/ToolChains/SYCL.cpp
@@ -1889,8 +1889,8 @@ void SYCLToolChain::AddImpliedTargetArgs(const llvm::Triple &Triple,
         DeviceName = DevArg;
       StringRef BackendOptName = SYCL::gen::getGenGRFFlag("auto");
       if (IsGen)
-        PerDeviceArgs.push_back(
-            {DeviceName, Args.MakeArgString(BackendOptName)});
+        PerDeviceArgs.push_back({Args.MakeArgString(DeviceName),
+                                 Args.MakeArgString(BackendOptName)});
       else if (IsJIT)
         BeArgs.push_back(Args.MakeArgString(RegAllocModeOptName + DeviceName +
                                             ":" + BackendOptName));


### PR DESCRIPTION
When using AOT for GPU, we will setup implied options for PVC targets. The strings that are formed need to be added to the vector to be processed later.  One of these strings was a StringRef so the pointed to location can go away.  Make a copy of the string to satisfy the sanitizer.