### PR TITLE
[CI] Change CODEOWNERS of `sycl/test-e2e/LLVMIntrinsicLowering/*` to intel/dpcpp-spirv-reviewers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -165,6 +165,7 @@ sycl/test-e2e/SeparateCompile/ @intel/dpcpp-tools-reviewers
 sycl/test-e2e/Printf/ @intel/dpcpp-tools-reviewers @intel/llvm-reviewers-runtime
 sycl/test-e2e/SpecConstants/ @intel/dpcpp-tools-reviewers
 sycl/test-e2e/NewOffloadDriver/ @intel/dpcpp-tools-reviewers
+sycl/test-e2e/LLVMIntrinsicLowering/ @intel/dpcpp-spirv-reviewers
 
 # Sanitizer
 clang/lib/Driver/SanitizerArgs.cpp @intel/dpcpp-sanitizers-review


### PR DESCRIPTION
Currently, the owners of [sycl/test-e2e/LLVMIntrinsicLowering/*](https://github.com/intel/llvm/tree/sycl/sycl/test-e2e/LLVMIntrinsicLowering) are SYCL RT reviewers but I see that all the test cases here related to llvm-spirv.
I propose changing the code owners of these tests to intel/dpcpp-spirv-reviewers instead.