### PR TITLE
[CI] force overwrite for iga64 in igc dev driver

### DIFF
--- a/devops/scripts/install_drivers.sh
+++ b/devops/scripts/install_drivers.sh
@@ -143,7 +143,9 @@ InstallIGFX () {
     echo "Download IGC dev git hash $IGC_DEV_VER"
     get_pre_release_igfx $IGC_DEV_URL $IGC_DEV_VER
     echo "Install IGC dev git hash $IGC_DEV_VER"
-    dpkg -i *.deb
+    # New dev IGC packaged iga64 conflicting with iga64 from intel-igc-media
+    # force overwrite to workaround it first.
+    dpkg -i --force-overwrite *.deb
     echo "Install libopencl-clang"
     # Workaround only, will download deb and install with dpkg once fixed.
     cp -d libopencl-clang.so.14*  /usr/local/lib/


### PR DESCRIPTION
Fix the installation failures.

dpkg: error processing archive intel-igc-opencl-devel_2.1.0+0_amd64.deb (--install):
 trying to overwrite '/usr/local/bin/iga64', which is also in package intel-igc-media 1.0.17791.9
dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)
Setting up intel-igc-core-2 (2.1.0) ...
