### PR TITLE
[SYCL] Make CollectorLibraryWrapper and BinaryWrapper classes comply with Rule of Three.

### DIFF
--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -1359,6 +1359,9 @@ public:
     ObjcopyPath = *ObjcopyPathOrErr;
   }
 
+  BinaryWrapper(const BinaryWrapper &BW) = delete;
+  BinaryWrapper &operator=(const BinaryWrapper &BW) = delete;
+
   ~BinaryWrapper() {
     if (TempFiles.empty())
       return;

--- a/sycl/tools/sycl-trace/collector.cpp
+++ b/sycl/tools/sycl-trace/collector.cpp
@@ -44,6 +44,9 @@ class CollectorLibraryWrapper {
 public:
   CollectorLibraryWrapper(const std::string &LibraryName)
       : MLibraryName(LibraryName){};
+  CollectorLibraryWrapper(const CollectorLibraryWrapper &Other) = delete;
+  CollectorLibraryWrapper &
+  operator=(const CollectorLibraryWrapper &Other) = delete;
   ~CollectorLibraryWrapper() { clear(); };
 
   const std::string InitFuncName = "init";


### PR DESCRIPTION
`CollectorLibraryWrapper` and `BinaryWrapper` had a custom destructor, but no copy constructor and no copy assignment operator, so they were not complying with the Rule of Three. Explicitly add the two latter as deleted to comply.