### PR TITLE
Revert "[DeviceASAN] Enable e2e test "private_nullptr.cpp""

### DIFF
--- a/sycl/test-e2e/AddressSanitizer/nullpointer/private_nullptr.cpp
+++ b/sycl/test-e2e/AddressSanitizer/nullpointer/private_nullptr.cpp
@@ -6,6 +6,9 @@
 // RUN: %{build} %device_asan_flags -O2 -g -o %t3.out
 // RUN: %{run} not %t3.out 2>&1 | FileCheck %s
 
+// FIXME: There's an issue in gfx driver, so this test pending here.
+// XFAIL: *
+
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/oneapi/experimental/address_cast.hpp>
 
@@ -19,14 +22,15 @@ int main() {
         sycl::nd_range<1>(N, 1), [=](sycl::nd_item<1> item) {
           auto private_array =
               sycl::ext::oneapi::experimental::static_address_cast<
-                  sycl::access::address_space::private_space>(array);
+                  sycl::access::address_space::private_space,
+                  sycl::access::decorated::no>(array);
           private_array[0] = 0;
         });
     Q.wait();
   });
   // CHECK: ERROR: DeviceSanitizer: null-pointer-access on Unknown Memory
   // CHECK: WRITE of size 4 at kernel {{<.*MyKernel>}} LID(0, 0, 0) GID({{.*}}, 0, 0)
-  // CHECK: {{.*private_nullptr.cpp}}:[[@LINE-6]]
+  // CHECK: {{.*private_nullptr.cpp}}:[[@LINE-5]]
 
   return 0;
 }

--- a/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
+++ b/sycl/test/e2e_test_requirements/no-xfail-without-tracker.cpp
@@ -51,12 +51,13 @@
 // tests to match the required format and in that case you should just update
 // (i.e. reduce) the number and the list below.
 //
-// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 141
+// NUMBER-OF-XFAIL-WITHOUT-TRACKER: 142
 //
 // List of improperly XFAIL-ed tests.
 // Remove the CHECK once the test has been properly XFAIL-ed.
 //
-// CHECK: Basic/aspects.cpp
+// CHECK: AddressSanitizer/nullpointer/private_nullptr.cpp
+// CHECK-NEXT: Basic/aspects.cpp
 // CHECK-NEXT: Basic/buffer/reinterpret.cpp
 // CHECK-NEXT: Basic/device_event.cpp
 // CHECK-NEXT: Basic/diagnostics/handler.cpp


### PR DESCRIPTION
Reverts intel/llvm#15995

@AllanZyne - It looks like this still fails on Arc in post-commit.