### PR TITLE
[SYCL][E2E] Move sporadicly passing test vector_with_virtual_mem.cpp to UNSUPPORTED

### DIFF
--- a/sycl/test-e2e/VirtualMem/vector_with_virtual_mem.cpp
+++ b/sycl/test-e2e/VirtualMem/vector_with_virtual_mem.cpp
@@ -1,7 +1,7 @@
 // REQUIRES: aspect-usm_shared_allocations
 
-// XFAIL: linux && gpu-intel-dg2
-// XFAIL-TRACKER: https://github.com/intel/llvm/issues/15812
+// UNSUPPORTED: linux && gpu-intel-dg2
+// UNSUPPORTED-TRACKER: https://github.com/intel/llvm/issues/15812
 
 // RUN: %{build} -o %t.out
 // RUN: %{run} %t.out


### PR DESCRIPTION
XPASSing rarely like [here](https://github.com/intel/llvm/actions/runs/11859980629/job/33054700795). I updated the GH issue.