### PR TITLE
[CI] Windows test hang detection should always run

### DIFF
--- a/.github/workflows/sycl-windows-run-tests.yml
+++ b/.github/workflows/sycl-windows-run-tests.yml
@@ -88,6 +88,7 @@ jobs:
         cmake --build build-e2e --target check-sycl-e2e
     - name: Detect hung tests
       shell: powershell
+      if: always()
       run: |
         $exitCode = 0
         $hungTests = Get-Process | Where-Object { ($_.Path -match "llvm\\install") -or ($_.Path -match "llvm\\build-e2e") }


### PR DESCRIPTION
If the tests fail or the job is cancelled this should run.