### PR TITLE
[XPTI][CMake] Make xptid depend on xpti-headers as well

### DIFF
--- a/xpti/CMakeLists.txt
+++ b/xpti/CMakeLists.txt
@@ -91,6 +91,9 @@ if (LLVM_BINARY_DIR)
     COMMENT "Copying XPTI headers ..."
   )
   add_dependencies(xpti xpti-headers)
+  if (MSVC)
+    add_dependencies(xptid xpti-headers)
+  endif()
 endif()
 
 include(GNUInstallDirs)


### PR DESCRIPTION
When building xpti we arrange to copy xpti headers into the build
directory. On Windows we may instead be building the debug version,
xptid, so copy the headers in that case too.
