### PR TITLE
[NFCI][SYCL] Remove most uses of `ContainsProperty`

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -319,28 +319,25 @@ struct propagateToPtrAnnotation<buffer_location_key> : std::true_type {};
 //===----------------------------------------------------------------------===//
 //
 namespace detail {
-template <typename... Args> struct checkValidFPGAPropertySet {
-  using list = std::tuple<Args...>;
-  static constexpr bool has_BufferLocation =
-      ContainsProperty<buffer_location_key, list>::value;
+template <typename property_list_t> struct checkValidFPGAPropertySet {
+  template <typename... Keys>
+  static constexpr bool has_one_of =
+      ((property_list_t::template has_property<Keys>() || ...));
+
+  static constexpr bool has_BufferLocation = has_one_of<buffer_location_key>;
 
   static constexpr bool has_InterfaceConfig =
-      ContainsProperty<awidth_key, list>::value ||
-      ContainsProperty<dwidth_key, list>::value ||
-      ContainsProperty<latency_key, list>::value ||
-      ContainsProperty<read_write_mode_key, list>::value ||
-      ContainsProperty<maxburst_key, list>::value ||
-      ContainsProperty<wait_request_key, list>::value;
+      has_one_of<buffer_location_key, awidth_key, dwidth_key, latency_key,
+                 read_write_mode_key, maxburst_key, wait_request_key>;
 
   static constexpr bool value = !(!has_BufferLocation && has_InterfaceConfig);
 };
 
-template <typename... Args> struct checkHasConduitAndRegisterMap {
-  using list = std::tuple<Args...>;
+template <typename property_list_t> struct checkHasConduitAndRegisterMap {
   static constexpr bool has_Conduit =
-      ContainsProperty<conduit_key, list>::value;
+      property_list_t::template has_property<conduit_key>();
   static constexpr bool has_RegisterMap =
-      ContainsProperty<register_map_key, list>::value;
+      property_list_t::template has_property<register_map_key>();
   static constexpr bool value = !(has_Conduit && has_RegisterMap);
 };
 } // namespace detail

--- a/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/fpga_annotated_properties.hpp
@@ -327,8 +327,8 @@ template <typename property_list_t> struct checkValidFPGAPropertySet {
   static constexpr bool has_BufferLocation = has_one_of<buffer_location_key>;
 
   static constexpr bool has_InterfaceConfig =
-      has_one_of<buffer_location_key, awidth_key, dwidth_key, latency_key,
-                 read_write_mode_key, maxburst_key, wait_request_key>;
+      has_one_of<awidth_key, dwidth_key, latency_key, read_write_mode_key,
+                 maxburst_key, wait_request_key>;
 
   static constexpr bool value = !(!has_BufferLocation && has_InterfaceConfig);
 };

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_arg/annotated_arg.hpp
@@ -214,13 +214,13 @@ public:
                 "The property list contains invalid property.");
   // check the set if FPGA specificed properties are used
   static constexpr bool hasValidFPGAProperties =
-      detail::checkValidFPGAPropertySet<Props...>::value;
+      detail::checkValidFPGAPropertySet<property_list_t>::value;
   static_assert(hasValidFPGAProperties,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.) "
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static constexpr bool hasConduitAndRegisterMapProperties =
-      detail::checkHasConduitAndRegisterMap<Props...>::value;
+      detail::checkHasConduitAndRegisterMap<property_list_t>::value;
   static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");
@@ -447,13 +447,13 @@ public:
                 "The property list contains invalid property.");
   // check the set if FPGA specificed properties are used
   static constexpr bool hasValidFPGAProperties =
-      detail::checkValidFPGAPropertySet<Props...>::value;
+      detail::checkValidFPGAPropertySet<property_list_t>::value;
   static_assert(hasValidFPGAProperties,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.) "
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static constexpr bool hasConduitAndRegisterMapProperties =
-      detail::checkHasConduitAndRegisterMap<Props...>::value;
+      detail::checkHasConduitAndRegisterMap<property_list_t>::value;
   static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr.hpp
@@ -50,10 +50,6 @@ template <class T>
 constexpr bool is_ann_ref_v =
     is_ann_ref_impl<std::remove_reference_t<T>>::value;
 
-template <typename... Ts>
-using contains_alignment =
-    detail::ContainsProperty<alignment_key, std::tuple<Ts...>>;
-
 // filter properties that are applied on annotations
 template <typename PropertyListTy>
 using annotation_filter = decltype(filter_properties<propagateToPtrAnnotation>(
@@ -392,38 +388,38 @@ public:
   // turned off for these operators to make sure the complete error notes are
   // printed
   // clang-format off
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<!has_alignment>>
   reference operator[](std::ptrdiff_t idx) const noexcept {
     return reference(m_Ptr + idx);
   }
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<has_alignment>>
   auto operator[](std::ptrdiff_t idx) const noexcept -> decltype("operator[] is not available when alignment is specified!") = delete;
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<!has_alignment>>
   annotated_ptr operator+(size_t offset) const noexcept {
     return annotated_ptr(m_Ptr + offset);
   }
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<has_alignment>>
   auto operator+(size_t offset) const noexcept -> decltype("operator+ is not available when alignment is specified!") = delete;
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<!has_alignment>>
   annotated_ptr &operator++() noexcept {
     m_Ptr += 1;
     return *this;
   }
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<has_alignment>>
   auto operator++() noexcept -> decltype("operator++ is not available when alignment is specified!") = delete;
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<!has_alignment>>
   annotated_ptr operator++(int) noexcept {
     auto tmp = *this;
@@ -431,22 +427,22 @@ public:
     return tmp;
   }
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<has_alignment>>
   auto operator++(int) noexcept -> decltype("operator++ is not available when alignment is specified!") = delete;
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<!has_alignment>>
   annotated_ptr &operator--() noexcept {
     m_Ptr -= 1;
     return *this;
   }
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<has_alignment>>
   auto operator--() noexcept -> decltype("operator-- is not available when alignment is specified!") = delete;
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<!has_alignment>>
   annotated_ptr operator--(int) noexcept {
     auto tmp = *this;
@@ -454,7 +450,7 @@ public:
     return tmp;
   }
 
-  template <bool has_alignment = detail::contains_alignment<Props...>::value,
+  template <bool has_alignment = property_list_t::template has_property<alignment_key>(),
             class = std::enable_if_t<has_alignment>>
   auto operator--(int) noexcept -> decltype("operator-- is not available when alignment is specified!") = delete;
 
@@ -485,13 +481,13 @@ public:
                 "The property list contains invalid property.");
   // check the set if FPGA specificed properties are used
   static constexpr bool hasValidFPGAProperties =
-      detail::checkValidFPGAPropertySet<Props...>::value;
+      detail::checkValidFPGAPropertySet<property_list_t>::value;
   static_assert(hasValidFPGAProperties,
                 "FPGA Interface properties (i.e. awidth, dwidth, etc.) "
                 "can only be set with BufferLocation together.");
   // check if conduit and register_map properties are specified together
   static constexpr bool hasConduitAndRegisterMapProperties =
-      detail::checkHasConduitAndRegisterMap<Props...>::value;
+      detail::checkHasConduitAndRegisterMap<property_list_t>::value;
   static_assert(hasConduitAndRegisterMapProperties,
                 "The properties conduit and register_map cannot be "
                 "specified at the same time.");

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr_properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_ptr/annotated_ptr_properties.hpp
@@ -55,24 +55,26 @@ struct PropertyMetaInfo<usm_kind_key::value_t<Kind>> {
   static constexpr sycl::usm::alloc value = Kind;
 };
 
-template <typename PropertyListT> struct IsUsmKindDevice : std::false_type {};
-template <typename... Props>
-struct IsUsmKindDevice<detail::properties_t<Props...>>
-    : detail::ContainsProperty<std::remove_const_t<decltype(usm_kind_device)>,
-                               std::tuple<Props...>> {};
+template <typename PropertyListT, sycl::usm::alloc Kind>
+inline constexpr bool is_usm_kind = []() constexpr {
+  if constexpr (PropertyListT::template has_property<usm_kind_key>())
+    return PropertyListT::template get_property<usm_kind_key>() ==
+           usm_kind<Kind>;
+  else
+    return false;
+}();
 
-template <typename PropertyListT> struct IsUsmKindHost : std::false_type {};
-template <typename... Props>
-struct IsUsmKindHost<detail::properties_t<Props...>>
-    : detail::ContainsProperty<std::remove_const_t<decltype(usm_kind_host)>,
-                               std::tuple<Props...>> {};
-
-template <typename PropertyListT> struct IsUsmKindShared : std::false_type {};
-template <typename... Props>
-struct IsUsmKindShared<detail::properties_t<Props...>>
-    : detail::ContainsProperty<std::remove_const_t<decltype(usm_kind_shared)>,
-                               std::tuple<Props...>> {};
-
+template <typename PropertyListT>
+struct IsUsmKindDevice
+    : std::bool_constant<is_usm_kind<PropertyListT, sycl::usm::alloc::device>> {
+};
+template <typename PropertyListT>
+struct IsUsmKindHost
+    : std::bool_constant<is_usm_kind<PropertyListT, sycl::usm::alloc::host>> {};
+template <typename PropertyListT>
+struct IsUsmKindShared
+    : std::bool_constant<is_usm_kind<PropertyListT, sycl::usm::alloc::shared>> {
+};
 } // namespace detail
 
 } // namespace experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_util.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_util.hpp
@@ -32,11 +32,9 @@ using MergeUsmKind =
                                 decltype(properties{usm_kind<Kind>})>;
 
 // Check if a property list contains the a certain property
-template <typename PropKey, typename PropertyListT> struct HasProperty {};
-
-template <typename PropKey, typename... Props>
-struct HasProperty<PropKey, detail::properties_t<Props...>>
-    : detail::ContainsProperty<PropKey, std::tuple<Props...>> {};
+template <typename PropKey, typename PropertyListT>
+struct HasProperty
+    : std::bool_constant<PropertyListT::template has_property<PropKey>()> {};
 
 template <typename PropertyListT>
 using HasAlign = HasProperty<alignment_key, PropertyListT>;


### PR DESCRIPTION
First, `properties` itself has an interface that does exactly that. Second, this trait uses `std::tuple` which is relatively expensive to instantiate and that happens *on top* of the normal `properties` instantation that doesn't use `std::tuple` anymore.

Remaining uses are related to `ConflictingProperties` which is ugly enough to be addressed in a separate PR.