### PR TITLE
[SYCL] Do not use handler::addAccessorReq()

### DIFF
--- a/sycl/include/sycl/handler.hpp
+++ b/sycl/include/sycl/handler.hpp
@@ -618,7 +618,6 @@ private:
     detail::AccessorBaseHost *AccBase = (detail::AccessorBaseHost *)&Arg;
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
     detail::AccessorImplHost *Req = AccImpl.get();
-    addAccessorReq(std::move(AccImpl));
     // Add accessor to the list of arguments.
     addArg(detail::kernel_param_kind_t::kind_accessor, Req,
            static_cast<int>(AccessTarget), ArgIndex);
@@ -2580,9 +2579,6 @@ public:
 
     MSrcPtr = static_cast<void *>(AccImpl.get());
     MDstPtr = static_cast<void *>(Dst);
-    // Store copy of accessor to the local storage to make sure it is alive
-    // until we finish
-    addAccessorReq(std::move(AccImpl));
   }
 
   /// Copies the content of memory pointed by Src into the memory object
@@ -2618,9 +2614,6 @@ public:
 
     MSrcPtr = const_cast<T_Src *>(Src);
     MDstPtr = static_cast<void *>(AccImpl.get());
-    // Store copy of accessor to the local storage to make sure it is alive
-    // until we finish
-    addAccessorReq(std::move(AccImpl));
   }
 
   /// Copies the content of memory object accessed by Src to the memory
@@ -2675,10 +2668,6 @@ public:
 
     MSrcPtr = AccImplSrc.get();
     MDstPtr = AccImplDst.get();
-    // Store copy of accessor to the local storage to make sure it is alive
-    // until we finish
-    addAccessorReq(std::move(AccImplSrc));
-    addAccessorReq(std::move(AccImplDst));
   }
 
   /// Provides guarantees that the memory object accessed via Acc is updated
@@ -2704,7 +2693,6 @@ public:
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
 
     MDstPtr = static_cast<void *>(AccImpl.get());
-    addAccessorReq(std::move(AccImpl));
   }
 
 public:
@@ -3459,7 +3447,6 @@ private:
     detail::AccessorImplPtr AccImpl = detail::getSyclObjImpl(*AccBase);
 
     MDstPtr = static_cast<void *>(AccImpl.get());
-    addAccessorReq(std::move(AccImpl));
 
     MPattern.resize(sizeof(T));
     auto PatternPtr = reinterpret_cast<T *>(MPattern.data());

--- a/sycl/include/sycl/reduction.hpp
+++ b/sycl/include/sycl/reduction.hpp
@@ -1014,7 +1014,7 @@ public:
             }
           });
         } else {
-          accessor OutAcc{Out, CGH};
+          accessor OutAcc{Out, CopyHandler};
           CopyHandler.copy(Mem, OutAcc);
         }
       });

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -2055,8 +2055,13 @@ void handler::SetHostTask(std::function<void(interop_handle)> &&Func) {
   setType(detail::CGType::CodeplayHostTask);
 }
 
-void handler::addAccessorReq(detail::AccessorImplPtr) {
-    assert(false && "The function must not be used.");
+// TODO: This function is not used anymore, remove it in the next
+// ABI-breaking window.
+void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
+  // Add accessor to the list of requirements.
+  impl->CGData.MRequirements.push_back(Accessor.get());
+  // Store copy of the accessor.
+  impl->CGData.MAccStorage.push_back(std::move(Accessor));
 }
 
 void handler::addLifetimeSharedPtrStorage(std::shared_ptr<const void> SPtr) {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -2055,6 +2055,7 @@ void handler::SetHostTask(std::function<void(interop_handle)> &&Func) {
   setType(detail::CGType::CodeplayHostTask);
 }
 
+#ifndef __INTEL_PREVIEW_BREAKING_CHANGES
 // TODO: This function is not used anymore, remove it in the next
 // ABI-breaking window.
 void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
@@ -2063,6 +2064,7 @@ void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
   // Store copy of the accessor.
   impl->CGData.MAccStorage.push_back(std::move(Accessor));
 }
+#endif
 
 void handler::addLifetimeSharedPtrStorage(std::shared_ptr<const void> SPtr) {
   impl->CGData.MSharedPtrStorage.push_back(std::move(SPtr));

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -2056,6 +2056,7 @@ void handler::SetHostTask(std::function<void(interop_handle)> &&Func) {
 }
 
 void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
+#if 0
   // Constructor of accessors add them to MRequirements and MAccStorage
   // of the associated handler, so do not add duplicates if use same
   // handler as during construction.
@@ -2068,6 +2069,7 @@ void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
   impl->CGData.MRequirements.push_back(Accessor.get());
   // Store copy of the accessor.
   impl->CGData.MAccStorage.push_back(std::move(Accessor));
+#endif
 }
 
 void handler::addLifetimeSharedPtrStorage(std::shared_ptr<const void> SPtr) {

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -2056,6 +2056,14 @@ void handler::SetHostTask(std::function<void(interop_handle)> &&Func) {
 }
 
 void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
+  // Constructor of accessors add them to MRequirements and MAccStorage
+  // of the associated handler, so do not add duplicates if use same
+  // handler as during construction.
+  if (impl->CGData.MRequirements.end() !=
+      std::find(impl->CGData.MRequirements.begin(),
+                impl->CGData.MRequirements.end(), Accessor.get()))
+    return;
+
   // Add accessor to the list of requirements.
   impl->CGData.MRequirements.push_back(Accessor.get());
   // Store copy of the accessor.

--- a/sycl/source/handler.cpp
+++ b/sycl/source/handler.cpp
@@ -2055,21 +2055,8 @@ void handler::SetHostTask(std::function<void(interop_handle)> &&Func) {
   setType(detail::CGType::CodeplayHostTask);
 }
 
-void handler::addAccessorReq(detail::AccessorImplPtr Accessor) {
-#if 0
-  // Constructor of accessors add them to MRequirements and MAccStorage
-  // of the associated handler, so do not add duplicates if use same
-  // handler as during construction.
-  if (impl->CGData.MRequirements.end() !=
-      std::find(impl->CGData.MRequirements.begin(),
-                impl->CGData.MRequirements.end(), Accessor.get()))
-    return;
-
-  // Add accessor to the list of requirements.
-  impl->CGData.MRequirements.push_back(Accessor.get());
-  // Store copy of the accessor.
-  impl->CGData.MAccStorage.push_back(std::move(Accessor));
-#endif
+void handler::addAccessorReq(detail::AccessorImplPtr) {
+    assert(false && "The function must not be used.");
 }
 
 void handler::addLifetimeSharedPtrStorage(std::shared_ptr<const void> SPtr) {


### PR DESCRIPTION
This function might be useful only when an accessor is connected with different
CG that was used during a construction of the accessor. Currently it’s helpful 
only in single case of reduction, and in this case the accessor can be connected
to a right CG in the constructor. Modify the use case and remove all calls to 
addAccessorReq().