### PR TITLE
[SYCL] Fix the barrier dependency for OOO profiling tags

### DIFF
--- a/sycl/include/sycl/ext/oneapi/experimental/profiling_tag.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/profiling_tag.hpp
@@ -22,14 +22,6 @@ inline event submit_profiling_tag(queue &Queue,
                                   const sycl::detail::code_location &CodeLoc =
                                       sycl::detail::code_location::current()) {
   if (Queue.get_device().has(aspect::ext_oneapi_queue_profiling_tag)) {
-    // If the queue is out-of-order and profiling is enabled, the implementation
-    // can save some operations by just using the required barrier event
-    // directly.
-    if (!Queue.is_in_order() &&
-        Queue.has_property<sycl::property::queue::enable_profiling>())
-      return Queue.ext_oneapi_submit_barrier();
-
-    // Otherwise, we use the internal implementation of the profiling tag.
     return Queue.submit(
         [=](handler &CGH) {
           sycl::detail::HandlerAccess::internalProfilingTagImpl(CGH);

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3453,7 +3453,10 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
     // the event from a barrier.
     ur_event_handle_t PreTimestampMarkerEvent{};
     if (!IsInOrderQueue) {
-      Adapter->call<UrApiKind::urEnqueueEventsWait>(
+      // FIXME: urEnqueueEventsWait on the L0 adapter requires a double-release.
+      //        Use that instead once it has been fixed.
+      //        See https://github.com/oneapi-src/unified-runtime/issues/2347.
+      Adapter->call<UrApiKind::urEnqueueEventsWaitWithBarrier>(
           MQueue->getHandleRef(),
           /*num_events_in_wait_list=*/0,
           /*event_wait_list=*/nullptr, &PreTimestampMarkerEvent);

--- a/sycl/source/detail/scheduler/commands.cpp
+++ b/sycl/source/detail/scheduler/commands.cpp
@@ -3448,9 +3448,6 @@ ur_result_t ExecCGCommand::enqueueImpQueue() {
 
     // If the queue is not in-order, the implementation will need to first
     // insert a marker event that the timestamp waits for.
-    // Note that with newer versions, MQueue should never have event profiling
-    // enabled here, as an optimization path in the headers will simply return
-    // the event from a barrier.
     ur_event_handle_t PreTimestampMarkerEvent{};
     if (!IsInOrderQueue) {
       // FIXME: urEnqueueEventsWait on the L0 adapter requires a double-release.

--- a/sycl/unittests/Extensions/ProfilingTag.cpp
+++ b/sycl/unittests/Extensions/ProfilingTag.cpp
@@ -125,8 +125,6 @@ TEST_F(ProfilingTagTest, ProfilingTagSupportedProfilingQueue) {
       "urEnqueueTimestampRecordingExp", &after_urEnqueueTimestampRecordingExp);
   mock::getCallbacks().set_after_callback("urEventGetProfilingInfo",
                                           &after_urEventGetProfilingInfo);
-  mock::getCallbacks().set_after_callback(
-      "urEnqueueEventsWaitWithBarrier", &after_urEnqueueEventsWaitWithBarrier);
 
   sycl::context Ctx{sycl::platform()};
   sycl::queue Queue{Ctx,
@@ -136,11 +134,8 @@ TEST_F(ProfilingTagTest, ProfilingTagSupportedProfilingQueue) {
 
   ASSERT_TRUE(Dev.has(sycl::aspect::ext_oneapi_queue_profiling_tag));
 
-  // As an optimization, the implementation will use a single barrier when
-  // submitting a profiling tag on an out-of-order queue with profiling enabled.
   sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
   ASSERT_EQ(size_t{0}, counter_urEnqueueTimestampRecordingExp);
-  ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrier);
 
   E.get_profiling_info<sycl::info::event_profiling::command_start>();
   ASSERT_TRUE(LatestProfilingQuery.has_value());

--- a/sycl/unittests/Extensions/ProfilingTag.cpp
+++ b/sycl/unittests/Extensions/ProfilingTag.cpp
@@ -77,7 +77,9 @@ TEST_F(ProfilingTagTest, ProfilingTagSupportedDefaultQueue) {
 
   sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
   ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
-  ASSERT_EQ(size_t{1}, counter_urEnqueueEventsWaitWithBarrier);
+  // TODO: We expect two barriers for now, while marker events leak. Adjust when
+  //       addressed.
+  ASSERT_EQ(size_t{2}, counter_urEnqueueEventsWaitWithBarrier);
 
   E.get_profiling_info<sycl::info::event_profiling::command_start>();
   ASSERT_TRUE(LatestProfilingQuery.has_value());
@@ -135,7 +137,7 @@ TEST_F(ProfilingTagTest, ProfilingTagSupportedProfilingQueue) {
   ASSERT_TRUE(Dev.has(sycl::aspect::ext_oneapi_queue_profiling_tag));
 
   sycl::event E = sycl::ext::oneapi::experimental::submit_profiling_tag(Queue);
-  ASSERT_EQ(size_t{0}, counter_urEnqueueTimestampRecordingExp);
+  ASSERT_EQ(size_t{1}, counter_urEnqueueTimestampRecordingExp);
 
   E.get_profiling_info<sycl::info::event_profiling::command_start>();
   ASSERT_TRUE(LatestProfilingQuery.has_value());


### PR DESCRIPTION
This commit fixes an issue where the barrier before the timestamp enqueued for the profiling tag in an out-of-order queue did not prevent future work from being enqueued prior to the start/end of the profiling tag.