### PR TITLE
[clang][SYCL] Print canonical types in free function shim functions

### DIFF
--- a/clang/lib/Sema/SemaSYCL.cpp
+++ b/clang/lib/Sema/SemaSYCL.cpp
@@ -6510,6 +6510,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
     std::string ParmList;
     bool FirstParam = true;
     Policy.SuppressDefaultTemplateArgs = false;
+    Policy.PrintCanonicalTypes = true;
     for (ParmVarDecl *Param : K.SyclKernel->parameters()) {
       if (FirstParam)
         FirstParam = false;
@@ -6518,6 +6519,7 @@ void SYCLIntegrationHeader::emit(raw_ostream &O) {
       ParmList += Param->getType().getCanonicalType().getAsString(Policy);
     }
     FunctionTemplateDecl *FTD = K.SyclKernel->getPrimaryTemplate();
+    Policy.PrintCanonicalTypes = false;
     Policy.SuppressDefinition = true;
     Policy.PolishForDeclaration = true;
     Policy.FullyQualifiedName = true;


### PR DESCRIPTION
Somehow even if the outer type was canonical, TypePrinter manages to skip nns printing in case of nested default template arguments. See added test case for the example.