### PR TITLE
[SYCL] Enable nonsemantic.shader.debuginfo.200 by default

### DIFF
--- a/clang/lib/Driver/ToolChains/Clang.cpp
+++ b/clang/lib/Driver/ToolChains/Clang.cpp
@@ -10674,12 +10674,8 @@ static void getTripleBasedSPIRVTransOpts(Compilation &C,
                                          ArgStringList &TranslatorArgs) {
   bool IsCPU = Triple.isSPIR() &&
                Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64;
-  // Enable NonSemanticShaderDebugInfo.200 for CPU AOT and for non-Windows
-  const bool IsWindowsMSVC =
-      Triple.isWindowsMSVCEnvironment() ||
-      C.getDefaultToolChain().getTriple().isWindowsMSVCEnvironment();
-  const bool EnableNonSemanticDebug =
-      IsCPU || (!IsWindowsMSVC && !C.getDriver().IsFPGAHWMode());
+  // Enable NonSemanticShaderDebugInfo.200 for non-FPGA targets.
+  const bool EnableNonSemanticDebug = !C.getDriver().IsFPGAHWMode();
   if (EnableNonSemanticDebug) {
     TranslatorArgs.push_back(
         "-spirv-debug-info-version=nonsemantic-shader-200");

--- a/clang/test/Driver/sycl-spirv-default-options-old-model.c
+++ b/clang/test/Driver/sycl-spirv-default-options-old-model.c
@@ -1,0 +1,36 @@
+// Test for default llvm-spirv options
+
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64-unknown-unknown %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64-unknown-unknown %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fintelfpga %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xshardware %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
+// RUN: %clang -target x86_64-unknown-linux-gnu -fintelfpga -Xshardware %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xssimulation %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
+// RUN: %clang -target x86_64-unknown-linux-gnu -fintelfpga -Xssimulation %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-FPGA-HW
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_fpga-unknown-unknown -Xsemulator %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fintelfpga -Xsemulator %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_gen-unknown-unknown %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --no-offload-new-driver -fsycl-targets=spir64_x86_64-unknown-unknown %s -### 2>&1 \
+// RUN:  | FileCheck %s -check-prefixes=CHECK-DEFAULT
+
+// CHECK-DEFAULT: llvm-spirv{{.*}}-spirv-debug-info-version=nonsemantic-shader-200
+// CHECK-DEFAULT-NOT: -ocl-100
+
+// CHECL-FPGA-HW: llvm-spirv{{.*}}-ocl-100
+// CHECK-FPGA-HW-NOT: spirv-debug-info-version=nonsemantic-shader-200
+

--- a/clang/test/Driver/sycl-spirv-default-options.c
+++ b/clang/test/Driver/sycl-spirv-default-options.c
@@ -1,0 +1,16 @@
+// Generate .o file as SYCL device library file.
+//
+// RUN: touch %t.devicelib.cpp
+// RUN: %clang %t.devicelib.cpp -fsycl -fsycl-targets=spir64-unknown-unknown -c --offload-new-driver -o %t_1.devicelib.o
+// RUN: %clang %t.devicelib.cpp -fsycl -fsycl-targets=spir64_gen-unknown-unknown -c --offload-new-driver -o %t_2.devicelib.o
+// RUN: %clang %t.devicelib.cpp -fsycl -fsycl-targets=spir64_x86_64-unknown-unknown -c --offload-new-driver -o %t_3.devicelib.o
+
+// Test for default llvm-spirv options
+
+// RUN: %clang -target x86_64-unknown-linux-gnu -fsycl --offload-new-driver \
+// RUN:   -fsycl-targets=spir64-unknown-unknown -c %s -o %t_1.o
+// RUN: clang-linker-wrapper -sycl-device-libraries=%t_1.devicelib.o \
+// RUN:   "--host-triple=x86_64-unknown-linux-gnu" "--linker-path=/usr/bin/ld" \
+// RUN:   "--" "-o" "a.out" %t_1.o --dry-run 2>&1 | FileCheck  %s
+
+// CHECK: llvm-spirv{{.*}}-spirv-debug-info-version=nonsemantic-shader-200

--- a/clang/test/Driver/sycl-spirv-default-options.c
+++ b/clang/test/Driver/sycl-spirv-default-options.c
@@ -14,3 +14,4 @@
 // RUN:   "--" "-o" "a.out" %t_1.o --dry-run 2>&1 | FileCheck  %s
 
 // CHECK: llvm-spirv{{.*}}-spirv-debug-info-version=nonsemantic-shader-200
+// CHECK-NOT: ocl-100

--- a/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
+++ b/clang/tools/clang-linker-wrapper/ClangLinkerWrapper.cpp
@@ -830,19 +830,7 @@ getTripleBasedSPIRVTransOpts(const ArgList &Args,
                              const llvm::Triple Triple) {
   bool IsCPU = Triple.isSPIR() &&
                Triple.getSubArch() == llvm::Triple::SPIRSubArch_x86_64;
-  // Enable NonSemanticShaderDebugInfo.200 for CPU AOT and for non-Windows
-  const bool IsWindowsMSVC = Triple.isWindowsMSVCEnvironment() ||
-                             Args.hasArg(OPT_sycl_is_windows_msvc_env);
-  const bool EnableNonSemanticDebug = IsCPU || !IsWindowsMSVC;
-  if (EnableNonSemanticDebug) {
-    TranslatorArgs.push_back(
-        "-spirv-debug-info-version=nonsemantic-shader-200");
-  } else {
-    TranslatorArgs.push_back("-spirv-debug-info-version=ocl-100");
-    // Prevent crash in the translator if input IR contains DIExpression
-    // operations which don't have mapping to OpenCL.DebugInfo.100 spec.
-    TranslatorArgs.push_back("-spirv-allow-extra-diexpressions");
-  }
+  TranslatorArgs.push_back("-spirv-debug-info-version=nonsemantic-shader-200");
   std::string UnknownIntrinsics("-spirv-allow-unknown-intrinsics=llvm.genx.");
   if (IsCPU)
     UnknownIntrinsics += ",llvm.fpbuiltin";


### PR DESCRIPTION
It's left disabled only for FPGA target.