### PR TITLE
[SYCL][ESIMD][E2E] Fix LSC USM store test failure

### DIFF
--- a/sycl/test-e2e/ESIMD/lsc/Inputs/common.hpp
+++ b/sycl/test-e2e/ESIMD/lsc/Inputs/common.hpp
@@ -8,6 +8,7 @@
 
 #pragma once
 
+#include <limits>
 #include <stdlib.h>
 #include <sycl/bit_cast.hpp>
 
@@ -23,5 +24,7 @@ template <typename T> T get_rand() {
   Tuint v = rand();
   if constexpr (sizeof(Tuint) > 4)
     v = (v << 32) | rand();
-  return sycl::bit_cast<T>(v);
+  T bitcast_v = sycl::bit_cast<T>(v);
+  return bitcast_v <= std::numeric_limits<T>::epsilon() ? static_cast<T>(0)
+                                                        : bitcast_v;
 }


### PR DESCRIPTION
`lsc_usm_store_u32.cpp` currently fails in syclos but passes in the internal compiler. The reason is that `rand` returns 0 and when `sycl::bit_cast` to `float`, it ends up as a very very small floating point number, like `1.4e-41`. In the internal compiler, this gets optimized to zero, probably due to unsafe fp math optimizations. It is also zero on-device. In syclos the host remains as that small number and ends up screwing up the correctness check because we need 0.

Just explicitly return zero when the bit-casted result is below epsilon for the type.