### PR TITLE
[NFCI][SYCL] More `properties`-related refactoring

### DIFF
--- a/sycl/include/sycl/ext/intel/experimental/grf_size_properties.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/grf_size_properties.hpp
@@ -56,29 +56,26 @@ template <typename Properties>
 struct ConflictingProperties<sycl::ext::intel::experimental::grf_size_key,
                              Properties>
     : std::bool_constant<
-          ContainsProperty<
-              sycl::ext::intel::experimental::grf_size_automatic_key,
-              Properties>::value ||
-          ContainsProperty<sycl::detail::register_alloc_mode_key,
-                           Properties>::value> {};
+          Properties::template has_property<
+              sycl::ext::intel::experimental::grf_size_automatic_key>() ||
+          Properties::template has_property<
+              sycl::detail::register_alloc_mode_key>()> {};
 
 template <typename Properties>
 struct ConflictingProperties<
     sycl::ext::intel::experimental::grf_size_automatic_key, Properties>
-    : std::bool_constant<
-          ContainsProperty<sycl::ext::intel::experimental::grf_size_key,
-                           Properties>::value ||
-          ContainsProperty<sycl::detail::register_alloc_mode_key,
-                           Properties>::value> {};
+    : std::bool_constant<Properties::template has_property<
+                             sycl::ext::intel::experimental::grf_size_key>() ||
+                         Properties::template has_property<
+                             sycl::detail::register_alloc_mode_key>()> {};
 
 template <typename Properties>
 struct ConflictingProperties<sycl::detail::register_alloc_mode_key, Properties>
     : std::bool_constant<
-          ContainsProperty<sycl::ext::intel::experimental::grf_size_key,
-                           Properties>::value ||
-          ContainsProperty<
-              sycl::ext::intel::experimental::grf_size_automatic_key,
-              Properties>::value> {};
+          Properties::template has_property<
+              sycl::ext::intel::experimental::grf_size_key>() ||
+          Properties::template has_property<
+              sycl::ext::intel::experimental::grf_size_automatic_key>()> {};
 
 } // namespace ext::oneapi::experimental::detail
 } // namespace _V1

--- a/sycl/include/sycl/ext/intel/experimental/pipes.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/pipes.hpp
@@ -376,21 +376,29 @@ private:
   static constexpr int32_t m_Capacity = _min_capacity;
 
   static constexpr int32_t m_ready_latency =
-      oneapi::experimental::detail::ValueOrDefault<
-          _propertiesT, ready_latency_key>::template get<int32_t>(0);
+      oneapi::experimental::detail::get_property_or<ready_latency_key,
+                                                    _propertiesT>(
+          ready_latency<0>)
+          .value;
+
   static constexpr int32_t m_bits_per_symbol =
-      oneapi::experimental::detail::ValueOrDefault<
-          _propertiesT, bits_per_symbol_key>::template get<int32_t>(8);
+      oneapi::experimental::detail::get_property_or<bits_per_symbol_key,
+                                                    _propertiesT>(
+          bits_per_symbol<8>)
+          .value;
   static constexpr bool m_uses_valid =
-      oneapi::experimental::detail::ValueOrDefault<
-          _propertiesT, uses_valid_key>::template get<bool>(true);
+      oneapi::experimental::detail::get_property_or<uses_valid_key,
+                                                    _propertiesT>(uses_valid_on)
+          .value;
   static constexpr bool m_first_symbol_in_high_order_bits =
-      oneapi::experimental::detail::ValueOrDefault<
-          _propertiesT,
-          first_symbol_in_high_order_bits_key>::template get<int32_t>(0);
-  static constexpr protocol_name m_protocol = oneapi::experimental::detail::
-      ValueOrDefault<_propertiesT, protocol_key>::template get<protocol_name>(
-          protocol_name::avalon_streaming_uses_ready);
+      oneapi::experimental::detail::get_property_or<
+          first_symbol_in_high_order_bits_key, _propertiesT>(
+          first_symbol_in_high_order_bits_off)
+          .value;
+  static constexpr protocol_name m_protocol =
+      oneapi::experimental::detail::get_property_or<protocol_key, _propertiesT>(
+          protocol_avalon_streaming_uses_ready)
+          .value;
 
 public:
   static constexpr struct ConstantPipeStorageExp m_Storage = {

--- a/sycl/include/sycl/ext/intel/experimental/task_sequence.hpp
+++ b/sycl/include/sycl/ext/intel/experimental/task_sequence.hpp
@@ -109,23 +109,28 @@ private:
   __spv::__spirv_TaskSequenceINTEL *taskSequence;
 #endif
   static constexpr int32_t pipelined =
-      oneapi::experimental::detail::ValueOrDefault<
-          property_list_t, pipelined_key>::template get<int32_t>(-1);
-  static constexpr int32_t fpga_cluster =
-      has_property<fpga_cluster_key>()
-          ? static_cast<
-                typename std::underlying_type<fpga_cluster_options_enum>::type>(
-                oneapi::experimental::detail::ValueOrDefault<property_list_t,
-                                                             fpga_cluster_key>::
-                    template get<fpga_cluster_options_enum>(
-                        fpga_cluster_options_enum::stall_free))
-          : -1;
+      oneapi::experimental::detail::get_property_or<pipelined_key,
+                                                    property_list_t>(
+          intel::experimental::pipelined<-1>)
+          .value;
+  static constexpr int32_t fpga_cluster = []() constexpr {
+    if constexpr (has_property<fpga_cluster_key>())
+      return static_cast<
+          typename std::underlying_type<fpga_cluster_options_enum>::type>(
+          get_property<fpga_cluster_key>().value);
+    else
+      return -1;
+  }();
   static constexpr uint32_t response_capacity =
-      oneapi::experimental::detail::ValueOrDefault<
-          property_list_t, response_capacity_key>::template get<uint32_t>(0);
+      oneapi::experimental::detail::get_property_or<response_capacity_key,
+                                                    property_list_t>(
+          intel::experimental::response_capacity<0>)
+          .value;
   static constexpr uint32_t invocation_capacity =
-      oneapi::experimental::detail::ValueOrDefault<
-          property_list_t, invocation_capacity_key>::template get<uint32_t>(0);
+      oneapi::experimental::detail::get_property_or<invocation_capacity_key,
+                                                    property_list_t>(
+          intel::experimental::invocation_capacity<0>)
+          .value;
 };
 
 } // namespace ext::intel::experimental

--- a/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/annotated_usm/alloc_base.hpp
@@ -41,9 +41,8 @@ template <typename propertyListA = empty_properties_t,
 std::enable_if_t<
     detail::CheckTAndPropLists<void, propertyListA, propertyListB>::value,
     annotated_ptr<void, propertyListB>>
-aligned_alloc_annotated(size_t alignment, size_t numBytes,
-                        const device &syclDevice, const context &syclContext,
-                        sycl::usm::alloc kind,
+aligned_alloc_annotated(size_t align, size_t numBytes, const device &syclDevice,
+                        const context &syclContext, sycl::usm::alloc kind,
                         const propertyListA &propList = propertyListA{}) {
   detail::ValidAllocPropertyList<void, propertyListA>::value;
 
@@ -53,12 +52,12 @@ aligned_alloc_annotated(size_t alignment, size_t numBytes,
   static_cast<void>(propList);
 
   constexpr size_t alignFromPropList =
-      detail::GetAlignFromPropList<propertyListA>::value;
+      detail::get_property_or<alignment_key, propertyListA>(alignment<0>).value;
   const property_list &usmPropList = get_usm_property_list<propertyListA>();
 
-  if constexpr (detail::HasUsmKind<propertyListA>::value) {
+  if constexpr (propertyListA::template has_property<usm_kind_key>()) {
     constexpr sycl::usm::alloc usmKind =
-        detail::GetUsmKindFromPropList<propertyListA>::value;
+        propertyListA::template get_property<usm_kind_key>().value;
     if (usmKind != kind) {
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::invalid),
@@ -72,7 +71,7 @@ aligned_alloc_annotated(size_t alignment, size_t numBytes,
                           "Unknown USM allocation kind was specified.");
 
   void *rawPtr =
-      sycl::aligned_alloc(combine_align(alignment, alignFromPropList), numBytes,
+      sycl::aligned_alloc(combine_align(align, alignFromPropList), numBytes,
                           syclDevice, syclContext, kind, usmPropList);
   return annotated_ptr<void, propertyListB>(rawPtr);
 }
@@ -83,9 +82,8 @@ template <typename T, typename propertyListA = empty_properties_t,
 std::enable_if_t<
     detail::CheckTAndPropLists<T, propertyListA, propertyListB>::value,
     annotated_ptr<T, propertyListB>>
-aligned_alloc_annotated(size_t alignment, size_t count,
-                        const device &syclDevice, const context &syclContext,
-                        sycl::usm::alloc kind,
+aligned_alloc_annotated(size_t align, size_t count, const device &syclDevice,
+                        const context &syclContext, sycl::usm::alloc kind,
                         const propertyListA &propList = propertyListA{}) {
   detail::ValidAllocPropertyList<T, propertyListA>::value;
 
@@ -95,12 +93,12 @@ aligned_alloc_annotated(size_t alignment, size_t count,
   static_cast<void>(propList);
 
   constexpr size_t alignFromPropList =
-      detail::GetAlignFromPropList<propertyListA>::value;
+      detail::get_property_or<alignment_key, propertyListA>(alignment<0>).value;
   const property_list &usmPropList = get_usm_property_list<propertyListA>();
 
-  if constexpr (detail::HasUsmKind<propertyListA>::value) {
+  if constexpr (propertyListA::template has_property<usm_kind_key>()) {
     constexpr sycl::usm::alloc usmKind =
-        detail::GetUsmKindFromPropList<propertyListA>::value;
+        propertyListA::template get_property<usm_kind_key>().value;
     if (usmKind != kind) {
       throw sycl::exception(
           sycl::make_error_code(sycl::errc::invalid),
@@ -113,7 +111,7 @@ aligned_alloc_annotated(size_t alignment, size_t count,
     throw sycl::exception(sycl::make_error_code(sycl::errc::invalid),
                           "Unknown USM allocation kind was specified.");
 
-  size_t combinedAlign = combine_align(alignment, alignFromPropList);
+  size_t combinedAlign = combine_align(align, alignFromPropList);
   T *rawPtr = sycl::aligned_alloc<T>(combinedAlign, count, syclDevice,
                                      syclContext, kind, usmPropList);
   return annotated_ptr<T, propertyListB>(rawPtr);
@@ -212,7 +210,9 @@ std::enable_if_t<
 malloc_annotated(size_t numBytes, const device &syclDevice,
                  const context &syclContext, const propertyListA &propList) {
   constexpr sycl::usm::alloc usmKind =
-      detail::GetUsmKindFromPropList<propertyListA>::value;
+      detail::get_property_or<usm_kind_key, propertyListA>(
+          usm_kind<sycl::usm::alloc::unknown>)
+          .value;
   static_assert(usmKind != sycl::usm::alloc::unknown,
                 "USM kind is not specified. Please specify it as an argument "
                 "or in the input property list.");
@@ -228,7 +228,9 @@ std::enable_if_t<
 malloc_annotated(size_t count, const device &syclDevice,
                  const context &syclContext, const propertyListA &propList) {
   constexpr sycl::usm::alloc usmKind =
-      detail::GetUsmKindFromPropList<propertyListA>::value;
+      detail::get_property_or<usm_kind_key, propertyListA>(
+          usm_kind<sycl::usm::alloc::unknown>)
+          .value;
   static_assert(usmKind != sycl::usm::alloc::unknown,
                 "USM kind is not specified. Please specify it as an argument "
                 "or in the input property list.");

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -104,6 +104,8 @@ struct property_value<work_group_size_key, std::integral_constant<size_t, Dim0>,
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
+
+  constexpr size_t size() const { return sizeof...(Dims) + 1; }
 };
 
 template <size_t Dim0, size_t... Dims>
@@ -190,6 +192,8 @@ struct property_value<max_work_group_size_key,
   constexpr size_t operator[](int Dim) const {
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
+
+  constexpr size_t size() const { return sizeof...(Dims) + 1; }
 };
 
 template <>
@@ -389,78 +393,53 @@ struct HasKernelPropertiesGetMethod<T,
       decltype(std::declval<T>().get(std::declval<properties_tag>()));
 };
 
-// Trait for property compile-time meta names and values.
-template <typename PropertyT> struct WGSizePropertyMetaInfo {
-  static constexpr std::array<size_t, 0> WGSize = {};
-  static constexpr size_t LinearSize = 0;
-};
-
-template <size_t Dim0, size_t... Dims>
-struct WGSizePropertyMetaInfo<work_group_size_key::value_t<Dim0, Dims...>> {
-  static constexpr std::array<size_t, sizeof...(Dims) + 1> WGSize = {Dim0,
-                                                                     Dims...};
-  static constexpr size_t LinearSize = (Dim0 * ... * Dims);
-};
-
-template <size_t Dim0, size_t... Dims>
-struct WGSizePropertyMetaInfo<max_work_group_size_key::value_t<Dim0, Dims...>> {
-  static constexpr std::array<size_t, sizeof...(Dims) + 1> WGSize = {Dim0,
-                                                                     Dims...};
-  static constexpr size_t LinearSize = (Dim0 * ... * Dims);
-};
-
-// Get the value of a work-group size related property from a property list
-template <typename PropKey, typename PropertiesT>
-struct GetWGPropertyFromPropList {};
-
-template <typename PropKey, typename... PropertiesT>
-struct GetWGPropertyFromPropList<PropKey, std::tuple<PropertiesT...>> {
-  using prop_val_t = std::conditional_t<
-      ContainsProperty<PropKey, std::tuple<PropertiesT...>>::value,
-      typename FindCompileTimePropertyValueType<
-          PropKey, std::tuple<PropertiesT...>>::type,
-      void>;
-  static constexpr auto WGSize =
-      WGSizePropertyMetaInfo<std::remove_const_t<prop_val_t>>::WGSize;
-  static constexpr size_t LinearSize =
-      WGSizePropertyMetaInfo<std::remove_const_t<prop_val_t>>::LinearSize;
-};
-
 // If work_group_size and max_work_group_size coexist, check that the
 // dimensionality matches and that the required work-group size doesn't
 // trivially exceed the maximum size.
 template <typename Properties>
-struct ConflictingProperties<max_work_group_size_key, Properties>
-    : std::false_type {
-  using WGSizeVal = GetWGPropertyFromPropList<work_group_size_key, Properties>;
-  using MaxWGSizeVal =
-      GetWGPropertyFromPropList<max_work_group_size_key, Properties>;
-  // If work_group_size_key doesn't exist in the list of properties, WGSize is
-  // an empty array and so Dims == 0.
-  static constexpr size_t Dims = WGSizeVal::WGSize.size();
-  static_assert(
-      Dims == 0 || Dims == MaxWGSizeVal::WGSize.size(),
-      "work_group_size and max_work_group_size dimensionality must match");
-  static_assert(Dims < 1 || WGSizeVal::WGSize[0] <= MaxWGSizeVal::WGSize[0],
-                "work_group_size must not exceed max_work_group_size");
-  static_assert(Dims < 2 || WGSizeVal::WGSize[1] <= MaxWGSizeVal::WGSize[1],
-                "work_group_size must not exceed max_work_group_size");
-  static_assert(Dims < 3 || WGSizeVal::WGSize[2] <= MaxWGSizeVal::WGSize[2],
-                "work_group_size must not exceed max_work_group_size");
+struct ConflictingProperties<max_work_group_size_key, Properties> {
+  static constexpr bool value = []() constexpr {
+    if constexpr (Properties::template has_property<work_group_size_key>()) {
+      constexpr auto wg_size =
+          Properties::template get_property<work_group_size_key>();
+      constexpr auto max_wg_size =
+          Properties::template get_property<max_work_group_size_key>();
+      static_assert(
+          wg_size.size() == max_wg_size.size(),
+          "work_group_size and max_work_group_size dimensionality must match");
+      if constexpr (wg_size.size() == max_wg_size.size()) {
+        constexpr auto Dims = wg_size.size();
+        static_assert(Dims < 1 || wg_size[0] <= max_wg_size[0],
+                      "work_group_size must not exceed max_work_group_size");
+        static_assert(Dims < 2 || wg_size[1] <= max_wg_size[1],
+                      "work_group_size must not exceed max_work_group_size");
+        static_assert(Dims < 3 || wg_size[2] <= max_wg_size[2],
+                      "work_group_size must not exceed max_work_group_size");
+      }
+    }
+    return false;
+  }();
 };
 
 // If work_group_size and max_linear_work_group_size coexist, check that the
 // required linear work-group size doesn't trivially exceed the maximum size.
 template <typename Properties>
-struct ConflictingProperties<max_linear_work_group_size_key, Properties>
-    : std::false_type {
-  using WGSizeVal = GetWGPropertyFromPropList<work_group_size_key, Properties>;
-  using MaxLinearWGSizeVal =
-      GetPropertyValueFromPropList<max_linear_work_group_size_key, size_t, void,
-                                   Properties>;
-  static_assert(WGSizeVal::WGSize.empty() ||
-                    WGSizeVal::LinearSize <= MaxLinearWGSizeVal::value,
-                "work_group_size must not exceed max_linear_work_group_size");
+struct ConflictingProperties<max_linear_work_group_size_key, Properties> {
+  static constexpr bool value = []() constexpr {
+    if constexpr (Properties::template has_property<work_group_size_key>()) {
+      constexpr auto wg_size =
+          Properties::template get_property<work_group_size_key>();
+      constexpr auto dims = wg_size.size();
+      constexpr auto linear_size = wg_size[0] * (dims > 1 ? wg_size[1] : 1) *
+                                   (dims > 2 ? wg_size[2] : 1);
+      constexpr auto max_linear_wg_size =
+          Properties::template get_property<max_linear_work_group_size_key>();
+      static_assert(
+          linear_size < max_linear_wg_size.value,
+          "work_group_size must not exceed max_linear_work_group_size");
+    }
+    return false;
+  }();
 };
 
 } // namespace detail

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -105,7 +105,10 @@ struct property_value<work_group_size_key, std::integral_constant<size_t, Dim0>,
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
 
+private:
   constexpr size_t size() const { return sizeof...(Dims) + 1; }
+
+  template <typename, typename> friend struct detail::ConflictingProperties;
 };
 
 template <size_t Dim0, size_t... Dims>
@@ -193,7 +196,10 @@ struct property_value<max_work_group_size_key,
     return std::array<size_t, sizeof...(Dims) + 1>{Dim0, Dims...}[Dim];
   }
 
+private:
   constexpr size_t size() const { return sizeof...(Dims) + 1; }
+
+  template <typename, typename> friend struct detail::ConflictingProperties;
 };
 
 template <>

--- a/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property_utils.hpp
@@ -160,28 +160,6 @@ struct SizeListToStr : SizeListToStrHelper<SizeList<Sizes...>, CharList<>> {};
 template <typename PropKey, typename Properties>
 struct ConflictingProperties : std::false_type {};
 
-template <typename Properties, typename T>
-struct NoConflictingPropertiesHelper {};
-
-template <typename Properties, typename... Ts>
-struct NoConflictingPropertiesHelper<Properties, std::tuple<Ts...>>
-    : std::true_type {};
-
-template <typename Properties, typename T, typename... Ts>
-struct NoConflictingPropertiesHelper<Properties, std::tuple<T, Ts...>>
-    : NoConflictingPropertiesHelper<Properties, std::tuple<Ts...>> {};
-
-template <typename Properties, typename... Rest, typename PropT,
-          typename... PropValuesTs>
-struct NoConflictingPropertiesHelper<
-    Properties, std::tuple<property_value<PropT, PropValuesTs...>, Rest...>>
-    : std::conditional_t<
-          ConflictingProperties<PropT, Properties>::value, std::false_type,
-          NoConflictingPropertiesHelper<Properties, std::tuple<Rest...>>> {};
-template <typename PropertiesT>
-struct NoConflictingProperties
-    : NoConflictingPropertiesHelper<PropertiesT, PropertiesT> {};
-
 //******************************************************************************
 // Conditional property meta-info
 //******************************************************************************

--- a/sycl/test/extensions/properties/mock_compile_time_properties.hpp
+++ b/sycl/test/extensions/properties/mock_compile_time_properties.hpp
@@ -101,11 +101,11 @@ struct is_property_key_of<fir_key, syclObjectT> : std::true_type {};
 namespace detail {
 template <typename Properties>
 struct ConflictingProperties<boo_key, Properties>
-    : ContainsProperty<fir_key, Properties> {};
+    : std::bool_constant<Properties::template has_property<fir_key>()> {};
 
 template <typename Properties>
 struct ConflictingProperties<fir_key, Properties>
-    : ContainsProperty<boo_key, Properties> {};
+    : std::bool_constant<Properties::template has_property<boo_key>()> {};
 
 } // namespace detail
 } // namespace experimental


### PR DESCRIPTION
* Modify `detail::ConflictingProperties` to accept `properties` list instead of `std::tuple` with individual property values
* Remove some "useless" helpers
* Change `detail::ValueOrDefault` type-trait to `detail::get_property_or` as it seems a better interface (and can, in theory, work with runtime properties too)