### PR TITLE
[NFC][SYCL][ESIMD] Don't use boost/mp11 in e2e tests

### DIFF
--- a/sycl/test-e2e/InvokeSimd/Spec/simd_mask.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_mask.cpp
@@ -14,7 +14,6 @@
  * This test also runs with all types of VISA link time optimizations enabled.
  */
 
-#include <sycl/detail/boost/mp11.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>
@@ -141,18 +140,22 @@ int main() {
             << "\n";
   bool passed = true;
   const bool SupportsDouble = dev.has(aspect::fp64);
-  using namespace sycl::detail::boost::mp11;
   using MaskTypes =
       std::tuple<char, char16_t, char32_t, wchar_t, signed char, signed short,
                  signed int, signed long, signed long long, unsigned char,
                  unsigned short, unsigned int, unsigned long,
                  unsigned long long, float, double>;
-  tuple_for_each(MaskTypes{}, [&](auto &&x) {
-    using T = std::remove_reference_t<decltype(x)>;
-    if (std::is_same_v<T, double> && !SupportsDouble)
-      return;
-    passed &= !test<T>(q);
-  });
+  std::apply(
+      [&](auto &&...xs) {
+        auto f = [&](auto &&x) {
+          using T = std::remove_reference_t<decltype(x)>;
+          if (std::is_same_v<T, double> && !SupportsDouble)
+            return;
+          passed &= !test<T>(q);
+        };
+        ((f(std::forward<decltype(xs)>(xs)), ...));
+      },
+      MaskTypes{});
   std::cout << (passed ? "Test passed\n" : "TEST FAILED\n");
   return passed ? 0 : 1;
 }

--- a/sycl/test-e2e/InvokeSimd/Spec/simd_mask_merge.cpp
+++ b/sycl/test-e2e/InvokeSimd/Spec/simd_mask_merge.cpp
@@ -1,7 +1,6 @@
 // Check that full compilation works:
 // RUN: %{build} -fno-sycl-device-code-split-esimd -Xclang -fsycl-allow-func-ptr -o %t.out
 // RUN: env IGC_VCSaveStackCallLinkage=1 IGC_VCDirectCallsOnly=1 %{run} %t.out
-#include <sycl/detail/boost/mp11.hpp>
 #include <sycl/detail/core.hpp>
 #include <sycl/ext/intel/esimd.hpp>
 #include <sycl/ext/oneapi/experimental/invoke_simd.hpp>


### PR DESCRIPTION
I believe that was the last explicit usage of it in the project. Can't remove CMake support for it still because we use boost's `unordered_*map` that depends on mp11.