### PR TITLE
[SYCL][RTC] Add support for errors and build log in JIT-based RTC

### DIFF
--- a/sycl-jit/jit-compiler/include/KernelFusion.h
+++ b/sycl-jit/jit-compiler/include/KernelFusion.h
@@ -62,8 +62,7 @@ public:
       : Failed{true}, BundleInfo{}, BuildLog{BuildLog} {}
 
   RTCResult(RTCBundleInfo &&BundleInfo, const char *BuildLog)
-      : Failed{false}, BundleInfo{std::move(BundleInfo)},
-        BuildLog{BuildLog} {}
+      : Failed{false}, BundleInfo{std::move(BundleInfo)}, BuildLog{BuildLog} {}
 
   bool failed() const { return Failed; }
 

--- a/sycl-jit/jit-compiler/include/KernelFusion.h
+++ b/sycl-jit/jit-compiler/include/KernelFusion.h
@@ -61,13 +61,13 @@ public:
   explicit RTCResult(const char *ErrorMessage)
       : Failed{true}, BundleInfo{}, ErrorMessage{ErrorMessage} {}
 
-  explicit RTCResult(RTCBundleInfo &&BundleInfo)
-      : Failed{false}, BundleInfo{std::move(BundleInfo)}, ErrorMessage{} {}
+  explicit RTCResult(RTCBundleInfo &&BundleInfo, const char *BuildLog)
+      : Failed{false}, BundleInfo{std::move(BundleInfo)}, ErrorMessage{
+                                                              BuildLog} {}
 
   bool failed() const { return Failed; }
 
   const char *getErrorMessage() const {
-    assert(failed() && "No error message present");
     return ErrorMessage.c_str();
   }
 

--- a/sycl-jit/jit-compiler/include/KernelFusion.h
+++ b/sycl-jit/jit-compiler/include/KernelFusion.h
@@ -61,7 +61,7 @@ public:
   explicit RTCResult(const char *ErrorMessage)
       : Failed{true}, BundleInfo{}, ErrorMessage{ErrorMessage} {}
 
-  explicit RTCResult(RTCBundleInfo &&BundleInfo, const char *BuildLog)
+  RTCResult(RTCBundleInfo &&BundleInfo, const char *BuildLog)
       : Failed{false}, BundleInfo{std::move(BundleInfo)},
         ErrorMessage{BuildLog} {}
 

--- a/sycl-jit/jit-compiler/include/KernelFusion.h
+++ b/sycl-jit/jit-compiler/include/KernelFusion.h
@@ -58,16 +58,16 @@ private:
 
 class RTCResult {
 public:
-  explicit RTCResult(const char *ErrorMessage)
-      : Failed{true}, BundleInfo{}, ErrorMessage{ErrorMessage} {}
+  explicit RTCResult(const char *BuildLog)
+      : Failed{true}, BundleInfo{}, BuildLog{BuildLog} {}
 
   RTCResult(RTCBundleInfo &&BundleInfo, const char *BuildLog)
       : Failed{false}, BundleInfo{std::move(BundleInfo)},
-        ErrorMessage{BuildLog} {}
+        BuildLog{BuildLog} {}
 
   bool failed() const { return Failed; }
 
-  const char *getErrorMessage() const { return ErrorMessage.c_str(); }
+  const char *getBuildLog() const { return BuildLog.c_str(); }
 
   const RTCBundleInfo &getBundleInfo() const {
     assert(!failed() && "No bundle info");
@@ -77,7 +77,7 @@ public:
 private:
   bool Failed;
   RTCBundleInfo BundleInfo;
-  sycl::detail::string ErrorMessage;
+  sycl::detail::string BuildLog;
 };
 
 extern "C" {

--- a/sycl-jit/jit-compiler/include/KernelFusion.h
+++ b/sycl-jit/jit-compiler/include/KernelFusion.h
@@ -62,14 +62,12 @@ public:
       : Failed{true}, BundleInfo{}, ErrorMessage{ErrorMessage} {}
 
   explicit RTCResult(RTCBundleInfo &&BundleInfo, const char *BuildLog)
-      : Failed{false}, BundleInfo{std::move(BundleInfo)}, ErrorMessage{
-                                                              BuildLog} {}
+      : Failed{false}, BundleInfo{std::move(BundleInfo)},
+        ErrorMessage{BuildLog} {}
 
   bool failed() const { return Failed; }
 
-  const char *getErrorMessage() const {
-    return ErrorMessage.c_str();
-  }
+  const char *getErrorMessage() const { return ErrorMessage.c_str(); }
 
   const RTCBundleInfo &getBundleInfo() const {
     assert(!failed() && "No bundle info");

--- a/sycl-jit/jit-compiler/lib/KernelFusion.cpp
+++ b/sycl-jit/jit-compiler/lib/KernelFusion.cpp
@@ -244,7 +244,10 @@ compileSYCL(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
   }
   llvm::opt::InputArgList UserArgList = std::move(*UserArgListOrErr);
 
-  auto ModuleOrErr = compileDeviceCode(SourceFile, IncludeFiles, UserArgList);
+  std::string BuildLog;
+
+  auto ModuleOrErr =
+      compileDeviceCode(SourceFile, IncludeFiles, UserArgList, BuildLog);
   if (!ModuleOrErr) {
     return errorTo<RTCResult>(ModuleOrErr.takeError(),
                               "Device compilation failed");
@@ -254,7 +257,7 @@ compileSYCL(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
   std::unique_ptr<llvm::Module> Module = std::move(*ModuleOrErr);
   Context.reset(&Module->getContext());
 
-  if (auto Error = linkDeviceLibraries(*Module, UserArgList)) {
+  if (auto Error = linkDeviceLibraries(*Module, UserArgList, BuildLog)) {
     return errorTo<RTCResult>(std::move(Error), "Device linking failed");
   }
 
@@ -274,7 +277,7 @@ compileSYCL(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
   }
   BundleInfo.BinaryInfo = std::move(*BinaryInfoOrError);
 
-  return RTCResult{std::move(BundleInfo)};
+  return RTCResult{std::move(BundleInfo), BuildLog.c_str()};
 }
 
 extern "C" KF_EXPORT_SYMBOL void resetJITConfiguration() {

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -180,10 +180,9 @@ class ClangDiagnosticWrapper {
 
 public:
   ClangDiagnosticWrapper(std::string &LogString, DiagnosticOptions *DiagOpts)
-      : LogStream(LogString) {
-
-    LogPrinter = std::make_unique<TextDiagnosticPrinter>(LogStream, DiagOpts);
-  }
+      : LogStream(LogString),
+        LogPrinter(
+            std::make_unique<TextDiagnosticPrinter>(LogStream, DiagOpts)) {}
 
   clang::TextDiagnosticPrinter *consumer() { return LogPrinter.get(); }
 

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.cpp
@@ -13,11 +13,15 @@
 #include <clang/CodeGen/CodeGenAction.h>
 #include <clang/Driver/Compilation.h>
 #include <clang/Driver/Options.h>
+#include <clang/Frontend/ChainedDiagnosticConsumer.h>
 #include <clang/Frontend/CompilerInstance.h>
 #include <clang/Frontend/TextDiagnosticBuffer.h>
+#include <clang/Frontend/TextDiagnosticPrinter.h>
 #include <clang/Tooling/CompilationDatabase.h>
 #include <clang/Tooling/Tooling.h>
 
+#include <llvm/IR/DiagnosticInfo.h>
+#include <llvm/IR/DiagnosticPrinter.h>
 #include <llvm/IR/PassInstrumentation.h>
 #include <llvm/IR/PassManager.h>
 #include <llvm/IRReader/IRReader.h>
@@ -26,6 +30,10 @@
 #include <llvm/SYCLLowerIR/ModuleSplitter.h>
 #include <llvm/SYCLLowerIR/SYCLJointMatrixTransform.h>
 #include <llvm/Support/PropertySetIO.h>
+
+#include <algorithm>
+#include <array>
+#include <sstream>
 
 using namespace clang;
 using namespace clang::tooling;
@@ -132,6 +140,9 @@ struct GetLLVMModuleAction : public ToolAction {
     CompilerInstance Compiler(std::move(PCHContainerOps));
     Compiler.setInvocation(std::move(Invocation));
     Compiler.setFileManager(Files);
+    // Suppress summary with number of warnings and errors being printed to
+    // stdout.
+    Compiler.setVerboseOutputStream(std::make_unique<llvm::raw_null_ostream>());
 
     // Create the compiler's actual diagnostics engine.
     Compiler.createDiagnostics(DiagConsumer, /*ShouldOwnClient=*/false);
@@ -161,12 +172,56 @@ struct GetLLVMModuleAction : public ToolAction {
   std::unique_ptr<llvm::Module> Module;
 };
 
+class ClangDiagnosticWrapper {
+
+  llvm::raw_string_ostream LogStream;
+
+  std::unique_ptr<clang::TextDiagnosticPrinter> LogPrinter;
+
+public:
+  ClangDiagnosticWrapper(std::string &LogString, DiagnosticOptions *DiagOpts)
+      : LogStream(LogString) {
+
+    LogPrinter = std::make_unique<TextDiagnosticPrinter>(LogStream, DiagOpts);
+  }
+
+  clang::TextDiagnosticPrinter *consumer() { return LogPrinter.get(); }
+
+  llvm::raw_ostream &stream() { return LogStream; }
+};
+
+class LLVMDiagnosticWrapper : public llvm::DiagnosticHandler {
+  llvm::raw_string_ostream LogStream;
+
+  DiagnosticPrinterRawOStream LogPrinter;
+
+public:
+  LLVMDiagnosticWrapper(std::string &BuildLog)
+      : LogStream(BuildLog), LogPrinter(LogStream) {}
+
+  bool handleDiagnostics(const DiagnosticInfo &DI) override {
+    auto Prefix = [](DiagnosticSeverity Severity) -> llvm::StringLiteral {
+      switch (Severity) {
+      case llvm::DiagnosticSeverity::DS_Error:
+        return "ERROR";
+      case llvm::DiagnosticSeverity::DS_Warning:
+        return "WARNING";
+      default:
+        return "NOTE:";
+      }
+    }(DI.getSeverity());
+    LogPrinter << Prefix;
+    DI.print(LogPrinter);
+    LogPrinter << "\n";
+    return true;
+  }
+};
+
 } // anonymous namespace
 
-Expected<std::unique_ptr<llvm::Module>>
-jit_compiler::compileDeviceCode(InMemoryFile SourceFile,
-                                View<InMemoryFile> IncludeFiles,
-                                const InputArgList &UserArgList) {
+Expected<std::unique_ptr<llvm::Module>> jit_compiler::compileDeviceCode(
+    InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
+    const InputArgList &UserArgList, std::string &BuildLog) {
   const std::string &DPCPPRoot = getDPCPPRoot();
   if (DPCPPRoot == InvalidDPCPPRoot) {
     return createStringError("Could not locate DPCPP root directory");
@@ -197,11 +252,18 @@ jit_compiler::compileDeviceCode(InMemoryFile SourceFile,
   FixedCompilationDatabase DB{".", CommandLine};
   ClangTool Tool{DB, {SourceFile.Path}};
 
+  IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts{new DiagnosticOptions};
+  ClangDiagnosticWrapper Wrapper(BuildLog, DiagOpts.get());
+  Tool.setDiagnosticConsumer(Wrapper.consumer());
+
   // Set up in-memory filesystem.
   Tool.mapVirtualFile(SourceFile.Path, SourceFile.Contents);
   for (const auto &IF : IncludeFiles) {
     Tool.mapVirtualFile(IF.Path, IF.Contents);
   }
+
+  // Suppress message "Error while processing" being printed to stdout.
+  Tool.setPrintErrorMessage(false);
 
   // Reset argument adjusters to drop the `-fsyntax-only` flag which is added by
   // default by this API.
@@ -222,15 +284,15 @@ jit_compiler::compileDeviceCode(InMemoryFile SourceFile,
     return std::move(Action.Module);
   }
 
-  // TODO: Capture compiler errors from the ClangTool.
-  return createStringError("Unable to obtain LLVM module");
+  return createStringError(BuildLog);
 }
 
 // This function is a simplified copy of the device library selection process in
 // `clang::driver::tools::SYCL::getDeviceLibraries`, assuming a SPIR-V target
 // (no AoT, no third-party GPUs, no native CPU). Keep in sync!
-static SmallVector<std::string, 8>
-getDeviceLibraries(const ArgList &Args, DiagnosticsEngine &Diags) {
+static bool getDeviceLibraries(const ArgList &Args,
+                               SmallVectorImpl<std::string> &LibraryList,
+                               DiagnosticsEngine &Diags) {
   struct DeviceLibOptInfo {
     StringRef DeviceLibName;
     StringRef DeviceLibOption;
@@ -246,6 +308,8 @@ getDeviceLibraries(const ArgList &Args, DiagnosticsEngine &Diags) {
   // linkage of libraries specified by DeviceLibLinkInfo. Linkage of "internal"
   // libraries cannot be affected via -fno-sycl-device-lib.
   bool ExcludeDeviceLibs = false;
+
+  bool FoundUnknownLib = false;
 
   if (Arg *A = Args.getLastArg(OPT_fsycl_device_lib_EQ,
                                OPT_fno_sycl_device_lib_EQ)) {
@@ -268,6 +332,7 @@ getDeviceLibraries(const ArgList &Args, DiagnosticsEngine &Diags) {
         if (LinkInfoIter == DeviceLibLinkInfo.end() || Val == "internal") {
           Diags.Report(diag::err_drv_unsupported_option_argument)
               << A->getSpelling() << Val;
+          FoundUnknownLib = true;
         }
         DeviceLibLinkInfo[Val] = !ExcludeDeviceLibs;
       }
@@ -292,7 +357,6 @@ getDeviceLibraries(const ArgList &Args, DiagnosticsEngine &Diags) {
       {"libsycl-itt-compiler-wrappers", "internal"},
       {"libsycl-itt-stubs", "internal"}};
 
-  SmallVector<std::string, 8> LibraryList;
   StringRef LibSuffix = ".bc";
   auto AddLibraries = [&](const SYCLDeviceLibsList &LibsList) {
     for (const DeviceLibOptInfo &Lib : LibsList) {
@@ -312,37 +376,33 @@ getDeviceLibraries(const ArgList &Args, DiagnosticsEngine &Diags) {
     AddLibraries(SYCLDeviceAnnotationLibs);
   }
 
-  return LibraryList;
+  return FoundUnknownLib;
 }
 
 Error jit_compiler::linkDeviceLibraries(llvm::Module &Module,
-                                        const InputArgList &UserArgList) {
+                                        const InputArgList &UserArgList,
+                                        std::string &BuildLog) {
   const std::string &DPCPPRoot = getDPCPPRoot();
   if (DPCPPRoot == InvalidDPCPPRoot) {
     return createStringError("Could not locate DPCPP root directory");
   }
 
-  // TODO: Seems a bit excessive to set up this machinery for one warning and
-  //       one error. Rethink when implementing the build log/error reporting as
-  //       mandated by the extension.
   IntrusiveRefCntPtr<DiagnosticIDs> DiagID{new DiagnosticIDs};
   IntrusiveRefCntPtr<DiagnosticOptions> DiagOpts{new DiagnosticOptions};
-  TextDiagnosticBuffer *DiagBuffer = new TextDiagnosticBuffer;
-  DiagnosticsEngine Diags(DiagID, DiagOpts, DiagBuffer);
+  ClangDiagnosticWrapper Wrapper(BuildLog, DiagOpts.get());
+  DiagnosticsEngine Diags(DiagID, DiagOpts, Wrapper.consumer(),
+                          /* ShouldOwnClient=*/false);
 
-  auto LibNames = getDeviceLibraries(UserArgList, Diags);
-  if (std::distance(DiagBuffer->err_begin(), DiagBuffer->err_end()) > 0) {
-    std::string DiagMsg;
-    raw_string_ostream SOS{DiagMsg};
-    interleave(
-        DiagBuffer->err_begin(), DiagBuffer->err_end(),
-        [&](const auto &D) { SOS << D.second; }, [&]() { SOS << '\n'; });
+  SmallVector<std::string> LibNames;
+  bool FoundUnknownLib = getDeviceLibraries(UserArgList, LibNames, Diags);
+  if (FoundUnknownLib) {
     return createStringError("Could not determine list of device libraries: %s",
-                             DiagMsg.c_str());
+                             BuildLog.c_str());
   }
-  // TODO: Add warnings to build log.
 
   LLVMContext &Context = Module.getContext();
+  Context.setDiagnosticHandler(
+      std::make_unique<LLVMDiagnosticWrapper>(BuildLog));
   for (const std::string &LibName : LibNames) {
     std::string LibPath = DPCPPRoot + "/lib/" + LibName;
 
@@ -356,10 +416,8 @@ Error jit_compiler::linkDeviceLibraries(llvm::Module &Module,
     }
 
     if (Linker::linkModules(Module, std::move(Lib), Linker::LinkOnlyNeeded)) {
-      // TODO: Obtain detailed error message from the context's diagnostics
-      //       handler.
-      return createStringError("Unable to link device library: %s",
-                               LibPath.c_str());
+      return createStringError("Unable to link device library %s: %s",
+                               LibPath.c_str(), BuildLog.c_str());
     }
   }
 

--- a/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.h
+++ b/sycl-jit/jit-compiler/lib/rtc/DeviceCompilation.h
@@ -17,15 +17,18 @@
 #include <llvm/Support/Error.h>
 
 #include <memory>
+#include <string>
 
 namespace jit_compiler {
 
 llvm::Expected<std::unique_ptr<llvm::Module>>
 compileDeviceCode(InMemoryFile SourceFile, View<InMemoryFile> IncludeFiles,
-                  const llvm::opt::InputArgList &UserArgList);
+                  const llvm::opt::InputArgList &UserArgList,
+                  std::string &BuildLog);
 
 llvm::Error linkDeviceLibraries(llvm::Module &Module,
-                                const llvm::opt::InputArgList &UserArgList);
+                                const llvm::opt::InputArgList &UserArgList,
+                                std::string &BuildLog);
 
 llvm::Expected<RTCBundleInfo>
 performPostLink(llvm::Module &Module,

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -1243,11 +1243,11 @@ sycl_device_binaries jit_compiler::compileSYCL(
   auto Result = CompileSYCLHandle(SourceFile, IncludeFilesView, UserArgsView);
 
   if (LogPtr) {
-    LogPtr->append(Result.getErrorMessage());
+    LogPtr->append(Result.getBuildLog());
   }
 
   if (Result.failed()) {
-    throw sycl::exception(sycl::errc::build, Result.getErrorMessage());
+    throw sycl::exception(sycl::errc::build, Result.getBuildLog());
   }
 
   return createDeviceBinaryImage(Result.getBundleInfo());

--- a/sycl/source/detail/jit_compiler.cpp
+++ b/sycl/source/detail/jit_compiler.cpp
@@ -1242,12 +1242,13 @@ sycl_device_binaries jit_compiler::compileSYCL(
 
   auto Result = CompileSYCLHandle(SourceFile, IncludeFilesView, UserArgsView);
 
+  if (LogPtr) {
+    LogPtr->append(Result.getErrorMessage());
+  }
+
   if (Result.failed()) {
     throw sycl::exception(sycl::errc::build, Result.getErrorMessage());
   }
-
-  // TODO: We currently don't have a meaningful build log.
-  (void)LogPtr;
 
   return createDeviceBinaryImage(Result.getBundleInfo());
 }

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
@@ -294,7 +294,7 @@ int test_warning() {
   return 0;
 }
 
-int main(int argc, char**) {
+int main(int argc, char **) {
 #ifdef SYCL_EXT_ONEAPI_KERNEL_COMPILER
   int optional_tests = (argc > 1) ? test_warning() : 0;
   return test_build_and_run() || test_unsupported_options() || test_error() ||

--- a/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
+++ b/sycl/test-e2e/KernelCompiler/kernel_compiler_sycl_jit.cpp
@@ -10,8 +10,8 @@
 // UNSUPPORTED: accelerator
 
 // RUN: %{build} -o %t.out
-// RUN: %{run} %t.out
-// RUN: %{l0_leak_check} %{run} %t.out
+// RUN: %{run} %t.out 1
+// RUN: %{l0_leak_check} %{run} %t.out 1
 
 // -- Test again, with caching.
 
@@ -74,6 +74,34 @@ void ff_templated(T *ptr, T *unused) {
 
   sycl::id<1> GId = Item.get_global_id();
   ptr[GId.get(0)] = PlusEm(GId.get(0), 38);
+}
+)===";
+
+auto constexpr BadSource = R"===(
+#include <sycl/sycl.hpp>
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((sycl::ext::oneapi::experimental::nd_range_kernel<1>))
+void ff_cp(int *ptr) {
+
+  sycl::nd_item<1> Item = sycl::ext::oneapi::this_work_item::get_nd_item<1>();
+
+  sycl::id<1> GId = Item.get_global_id() + no semi colon !!
+  ptr[GId.get(0)] = GId.get(0) + 41;
+}
+)===";
+
+auto constexpr WarningSource = R"===(
+#include <sycl/sycl.hpp>
+
+extern "C" SYCL_EXTERNAL SYCL_EXT_ONEAPI_FUNCTION_PROPERTY((sycl::ext::oneapi::experimental::nd_range_kernel<1>))
+void ff_cp(int *ptr) {
+
+  // intentionally using deprecated routine, as opposed to this_work_item::get_nd_item<1>()
+  // to provoke a warning.
+  sycl::nd_item<1> Item = sycl::ext::oneapi::experimental::this_nd_item<1>();
+
+  sycl::id<1> GId = Item.get_global_id();
+  ptr[GId.get(0)] = GId.get(0) + 41;
 }
 )===";
 
@@ -211,10 +239,66 @@ int test_unsupported_options() {
   return 0;
 }
 
-int main() {
+int test_error() {
+  namespace syclex = sycl::ext::oneapi::experimental;
+  using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
+  using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
 
+  sycl::queue q;
+  sycl::context ctx = q.get_context();
+
+  bool ok =
+      q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl_jit);
+  if (!ok) {
+    return 0;
+  }
+
+  source_kb kbSrc = syclex::create_kernel_bundle_from_source(
+      ctx, syclex::source_language::sycl_jit, BadSource);
+  try {
+    exe_kb kbExe = syclex::build(kbSrc);
+    assert(false && "we should not be here");
+  } catch (sycl::exception &e) {
+    // yas!
+    assert(e.code() == sycl::errc::build);
+    assert(std::string(e.what()).find(
+               "error: expected ';' at end of declaration") !=
+           std::string::npos);
+  }
+  return 0;
+}
+
+int test_warning() {
+  namespace syclex = sycl::ext::oneapi::experimental;
+  using source_kb = sycl::kernel_bundle<sycl::bundle_state::ext_oneapi_source>;
+  using exe_kb = sycl::kernel_bundle<sycl::bundle_state::executable>;
+
+  sycl::queue q;
+  sycl::context ctx = q.get_context();
+
+  bool ok =
+      q.get_device().ext_oneapi_can_compile(syclex::source_language::sycl_jit);
+  if (!ok) {
+    return 0;
+  }
+  std::string build_log;
+
+  source_kb kbSrc = syclex::create_kernel_bundle_from_source(
+      ctx, syclex::source_language::sycl_jit, WarningSource);
+  exe_kb kbExe =
+      syclex::build(kbSrc, syclex::properties{syclex::save_log{&build_log}});
+  bool found_warning =
+      (build_log.find("warning: 'this_nd_item<1>' is deprecated") !=
+       std::string::npos);
+  assert(found_warning);
+  return 0;
+}
+
+int main(int argc, char**) {
 #ifdef SYCL_EXT_ONEAPI_KERNEL_COMPILER
-  return test_build_and_run() || test_unsupported_options();
+  int optional_tests = (argc > 1) ? test_warning() : 0;
+  return test_build_and_run() || test_unsupported_options() || test_error() ||
+         optional_tests;
 #else
   static_assert(false, "Kernel Compiler feature test macro undefined");
 #endif


### PR DESCRIPTION
Adds support for correct error message routing and the `save_log` property to the SYCL-RTC implementation based on the SYCL-JIT library. 

The diagnostic messages associated with any errors encountered during runtime compilation is stored in the `what` of the exception thrown. 

If the user passes the `save_log` property defined in the `kernel_compiler` extension, all diagnostics encountered during compilation (errors, warnings, notes and remarks) are stored in the user-provided string.