### PR TITLE
[SYCL] Pass OCL_ICD_VENDORS to LIT

### DIFF
--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -75,6 +75,7 @@ llvm_config.with_system_environment(
     [
         "PATH",
         "OCL_ICD_FILENAMES",
+        "OCL_ICD_VENDORS",
         "CL_CONFIG_DEVICES",
         "SYCL_DEVICE_ALLOWLIST",
         "SYCL_CONFIG_FILE_NAME",


### PR DESCRIPTION
Tests can fail if `OCL_ICD_VENDORS` is needed but not set.