### PR TITLE
Fix the invalid interator after removal

### DIFF
--- a/llvm/lib/SYCLLowerIR/SYCLJointMatrixTransform.cpp
+++ b/llvm/lib/SYCLLowerIR/SYCLJointMatrixTransform.cpp
@@ -26,8 +26,9 @@ static constexpr char MATRIX_TYPE[] = "spirv.CooperativeMatrixKHR";
 // its users and operands to make LLVM IR more SPIR-V friendly.
 bool transformAccessChain(Function *F) {
   bool ModuleChanged = false;
-  for (auto I : F->users()) {
-    auto *CI = dyn_cast<CallInst>(I);
+  for (auto I = F->user_begin(), E = F->user_end(); I != E;) {
+    User *U = *I++;
+    auto *CI = dyn_cast<CallInst>(U);
     if (!CI)
       continue;
 


### PR DESCRIPTION
Can be exposed in windows debug build on the tests added by the original patch: LLVM::SYCLLowerIR/JointMatrixTransform/access-chain-no-uses.ll

Author: Jinsong Ji <jinsong.ji@intel.com>