### PR TITLE
[SYCL][E2E] Use `/clang:` when using MSVC driver on bindless images test

### DIFF
--- a/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
+++ b/sycl/test-e2e/bindless_images/dx12_interop/read_write_unsampled.cpp
@@ -1,7 +1,8 @@
 // REQUIRES: aspect-ext_oneapi_bindless_images
 // REQUIRES: windows
 
-// RUN: %{build} -l d3d12 -l dxgi -l dxguid -o %t.out
+// DEFINE: %{link-flags}=%if cl_options %{ /clang:-ld3d12 /clang:-ldxgi /clang:-ldxguid %} %else %{ -ld3d12 -ldxgi -ldxguid %}
+// RUN: %{build} %{link-flags} -o %t.out
 // RUN: %{run-unfiltered-devices} env NEOReadDebugKeys=1 UseBindlessMode=1 UseExternalAllocatorForSshAndDsh=1 %t.out
 
 #pragma clang diagnostic ignored "-Waddress-of-temporary"


### PR DESCRIPTION
this should fix the compfail on this test when using clang-cl.