### PR TITLE
[NFC][SYCL] Refactor `all_props_are_keys_of`

### DIFF
--- a/sycl/include/sycl/ext/oneapi/properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/properties.hpp
@@ -312,38 +312,15 @@ constexpr auto get_property_or(default_t value) {
     return value;
 }
 
-// helper: check_all_props_are_keys_of
-template <typename SyclT> constexpr bool check_all_props_are_keys_of() {
-  return true;
-}
-
-template <typename SyclT, typename FirstProp, typename... RestProps>
-constexpr bool check_all_props_are_keys_of() {
-  return ext::oneapi::experimental::is_property_key_of<FirstProp,
-                                                       SyclT>::value &&
-         check_all_props_are_keys_of<SyclT, RestProps...>();
-}
-
-// all_props_are_keys_of
-template <typename SyclT, typename PropertiesT>
-struct all_props_are_keys_of : std::false_type {};
-
-template <typename SyclT>
-struct all_props_are_keys_of<SyclT,
-                             ext::oneapi::experimental::empty_properties_t>
-    : std::true_type {};
-
-template <typename SyclT, typename PropT>
-struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::detail::properties_t<PropT>>
-    : std::bool_constant<
-          ext::oneapi::experimental::is_property_key_of<PropT, SyclT>::value> {
-};
-
+template <typename SyclT, typename PropListT>
+struct all_are_properties_of : std::false_type /* not a properties list */ {};
 template <typename SyclT, typename... Props>
-struct all_props_are_keys_of<
-    SyclT, ext::oneapi::experimental::detail::properties_t<Props...>>
-    : std::bool_constant<check_all_props_are_keys_of<SyclT, Props...>()> {};
+struct all_are_properties_of<SyclT, properties_t<Props...>>
+    : std::bool_constant<((is_property_value_of<Props, SyclT>::value && ...))> {
+};
+template <typename SyclT, typename PropListT>
+inline constexpr bool all_are_properties_of_v =
+    all_are_properties_of<SyclT, PropListT>::value;
 
 } // namespace detail
 } // namespace ext::oneapi::experimental

--- a/sycl/include/sycl/kernel_bundle.hpp
+++ b/sycl/include/sycl/kernel_bundle.hpp
@@ -1058,12 +1058,9 @@ build_from_source(kernel_bundle<bundle_state::ext_oneapi_source> &SourceKB,
 /////////////////////////
 // syclex::create_kernel_bundle_from_source
 /////////////////////////
-template <
-    typename PropertyListT = empty_properties_t,
-    typename = std::enable_if_t<
-        is_property_list_v<PropertyListT> &&
-        detail::all_props_are_keys_of<detail::create_bundle_from_source_props,
-                                      PropertyListT>::value>>
+template <typename PropertyListT = empty_properties_t,
+          typename = std::enable_if_t<detail::all_are_properties_of_v<
+              detail::create_bundle_from_source_props, PropertyListT>>>
 kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
     const context &SyclContext, source_language Language,
     const std::string &Source, PropertyListT props = {}) {
@@ -1077,12 +1074,9 @@ kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
 }
 
 #if (!defined(_HAS_STD_BYTE) || _HAS_STD_BYTE != 0)
-template <
-    typename PropertyListT = empty_properties_t,
-    typename = std::enable_if_t<
-        is_property_list_v<PropertyListT> &&
-        detail::all_props_are_keys_of<detail::create_bundle_from_source_props,
-                                      PropertyListT>::value>>
+template <typename PropertyListT = empty_properties_t,
+          typename = std::enable_if_t<detail::all_are_properties_of_v<
+              detail::create_bundle_from_source_props, PropertyListT>>>
 kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
     const context &SyclContext, source_language Language,
     const std::vector<std::byte> &Bytes, PropertyListT props = {}) {
@@ -1101,10 +1095,8 @@ kernel_bundle<bundle_state::ext_oneapi_source> create_kernel_bundle_from_source(
 /////////////////////////
 
 template <typename PropertyListT = empty_properties_t,
-          typename = std::enable_if_t<
-              is_property_list_v<PropertyListT> &&
-              detail::all_props_are_keys_of<detail::build_source_bundle_props,
-                                            PropertyListT>::value>>
+          typename = std::enable_if_t<detail::all_are_properties_of_v<
+              detail::build_source_bundle_props, PropertyListT>>>
 
 kernel_bundle<bundle_state::executable>
 build(kernel_bundle<bundle_state::ext_oneapi_source> &SourceKB,
@@ -1127,10 +1119,8 @@ build(kernel_bundle<bundle_state::ext_oneapi_source> &SourceKB,
 }
 
 template <typename PropertyListT = empty_properties_t,
-          typename = std::enable_if_t<
-              is_property_list_v<PropertyListT> &&
-              detail::all_props_are_keys_of<detail::build_source_bundle_props,
-                                            PropertyListT>::value>>
+          typename = std::enable_if_t<detail::all_are_properties_of_v<
+              detail::build_source_bundle_props, PropertyListT>>>
 kernel_bundle<bundle_state::executable>
 build(kernel_bundle<bundle_state::ext_oneapi_source> &SourceKB,
       PropertyListT props = {}) {


### PR DESCRIPTION
First, rename it, because it's just the accident that all its current users only supply runtime properties that just happen to be property keys in addition to being property values.

Second, use C++17.