### PR TITLE
[SYCL] Remove `sycl::ext::oneapi::experimental::is_property_key`

### DIFF
--- a/sycl/doc/extensions/experimental/sycl_ext_intel_cache_controls.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_intel_cache_controls.asciidoc
@@ -196,8 +196,6 @@ inline constexpr read_hint_key::value_t<Cs...> read_hint;
 namespace oneapi {
 namespace experimental {
 
-template <>
-struct is_property_key<intel::experimental::read_hint_key> : std::true_type {};
 template <typename T, typename PropertyListT>
 struct is_property_key_of<intel::experimental::read_hint_key,
                           annotated_ptr<T, PropertyListT>> : std::true_type {};
@@ -261,8 +259,6 @@ inline constexpr write_hint_key::value_t<Cs...> write_hint;
 namespace oneapi {
 namespace experimental {
 
-template <>
-struct is_property_key<intel::experimental::write_hint_key> : std::true_type {};
 template <typename T, typename PropertyListT>
 struct is_property_key_of<intel::experimental::write_hint_key,
                           annotated_ptr<T, PropertyListT>> : std::true_type {};
@@ -336,9 +332,6 @@ inline constexpr read_assertion_key::value_t<Cs...> read_assertion;
 namespace oneapi {
 namespace experimental {
 
-template <>
-struct is_property_key<intel::experimental::read_assertion_key>
-    : std::true_type {};
 template <typename T, typename PropertyListT>
 struct is_property_key_of<intel::experimental::read_assertion_key,
                           annotated_ptr<T, PropertyListT>> : std::true_type {};

--- a/sycl/doc/extensions/experimental/sycl_ext_intel_fpga_task_sequence.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_intel_fpga_task_sequence.asciidoc
@@ -299,10 +299,6 @@ inline constexpr invocation_capacity_key::value_t<Size> invocation_capacity;
 template <uint32_t Size>
 inline constexpr response_capacity_key::value_t<Size> response_capacity;
 
-template <> struct is_property_key<balanced_key> : std::true_type {};
-template <> struct is_property_key<invocation_capacity_key> : std::true_type {};
-template <> struct is_property_key<response_capacity_key> : std::true_type {};
-
 template <auto &f, typename PropertyListT>
 struct is_property_key_of<balanced_key, task_sequence<f, PropertyListT>>
   : std::true_type {};

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_device_global.asciidoc
@@ -688,11 +688,6 @@ inline constexpr implement_in_csr_key::value_t<Enable> implement_in_csr;
 inline constexpr implement_in_csr_key::value_t<true> implement_in_csr_on;
 inline constexpr implement_in_csr_key::value_t<false> implement_in_csr_off;
 
-template <> struct is_property_key<device_image_scope_key> : std::true_type {};
-template <> struct is_property_key<host_access_key> : std::true_type {};
-template <> struct is_property_key<init_mode_key> : std::true_type {};
-template <> struct is_property_key<implement_in_csr_key> : std::true_type {};
-
 template <typename T, typename PropertyListT>
 struct is_property_key_of<device_image_scope_key, device_global<T, PropertyListT>>
   : std::true_type {};

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_arg_properties.asciidoc
@@ -104,9 +104,6 @@ struct restrict_key {
 
 inline constexpr restrict_key::value_t restrict;
 
-template<>
-struct is_property_key<restrict_key> : std::true_type {};
-
 template<typename T, typename PropertyListT>
 struct is_property_key_of<
   restrict_key, annotated_ptr<T, PropertyListT>> : std::true_type {};
@@ -131,9 +128,6 @@ struct alignment_key {
 
 template<int K>
 inline constexpr alignment_key::value_t<K> alignment;
-
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::alignment_key> : std::true_type {};
 
 template<typename T, typename PropertyListT>
 struct is_property_key_of<

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_compiler.asciidoc
@@ -311,9 +311,6 @@ struct build_options {
 };
 using build_options_key = build_options;
 
-template<>
-struct is_property_key<build_options_key> : std::true_type {};
-
 } // namespace sycl::ext::oneapi::experimental
 ----
 !====
@@ -344,9 +341,6 @@ struct save_log {
   save_log(std::string *to);  (1)
 };
 using save_log_key = save_log;
-
-template<>
-struct is_property_key<save_log_key> : std::true_type {};
 
 } // namespace sycl::ext::oneapi::experimental
 ----

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_kernel_properties.asciidoc
@@ -181,11 +181,6 @@ inline constexpr sub_group_size_key::value_t<Size> sub_group_size;
 template <sycl::aspect... Aspects>
 inline constexpr device_has_key::value_t<Aspects...> device_has;
 
-template <> struct is_property_key<work_group_size_key> : std::true_type {};
-template <> struct is_property_key<work_group_size_hint_key> : std::true_type {};
-template <> struct is_property_key<sub_group_size_key> : std::true_type {};
-template <> struct is_property_key<device_has_key> : std::true_type {};
-
 } // namespace experimental
 } // namespace oneapi
 } // namespace ext
@@ -260,9 +255,6 @@ inline constexpr max_work_group_size_key::value_t<Dims...> max_work_group_size;
 
 template <size_t Size>
 inline constexpr max_linear_work_group_size_key::value_t<Size> max_linear_work_group_size;
-
-template <> struct is_property_key<max_work_group_size_key> : std::true_type {};
-template <> struct is_property_key<max_linear_work_group_size_key> : std::true_type {};
 
 } // namespace experimental
 } // namespace oneapi

--- a/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
+++ b/sycl/doc/extensions/experimental/sycl_ext_oneapi_properties.asciidoc
@@ -199,21 +199,14 @@ inline constexpr boo_key::value_t<Ts...> boo;
 
 === Property traits
 
-All runtime and compile-time-constant properties must have a specialization of 
-`is_property_key` and `is_property_value` that inherits from
-`std::true_type`, and they must have a specialization of `is_property_key_of`
-and `is_property_value_of`
-that inherits from `std::true_type` for each SYCL runtime class that the
-property can be applied to. All have a base case which inherits from `std::false_type`.
+Properties may add a specialization of `is_property_key_of` that inherits from
+`std::true_type` for each SYCL runtime class that the property can be applied
+to. All have a base case which inherits from `std::false_type`.
 
 ```c++
 namespace sycl::ext::oneapi::experimental {
 //Base case
-template<typename> struct is_property_key : std::false_type {};
 template<typename, typename> struct is_property_key_of : std::false_type {};
-
-template<> struct is_property_key<foo_key> : std::true_type {};
-template<> struct is_property_key<bar_key> : std::true_type {};
 
 // These properties can be applied to any SYCL object.
 template<typename SyclObjectT>
@@ -221,17 +214,11 @@ struct is_property_key_of<foo_key, SyclObjectT> : std::true_type {};
 template<typename SyclObjectT>
 struct is_property_key_of<bar_key, SyclObjectT> : std::true_type {};
 
-// is_property_value and is_property_value_of based on is_property_key(_of)
-template<typename V, typename=void> struct is_property_value;
-template<typename V, typename O, typename=void> struct is_property_value_of;
-// Specialization for runtime properties
-template<typename V> struct is_property_value<V, std::enable_if_t<(sizeof(V)>0)>> : is_property_key<V> {};
-template<typename V, typename O> struct is_property_value_of<V, O, std::enable_if_t<(sizeof(V)>0)>> : is_property_key_of<V,O> {};
-// Specialization for compile-time-constant properties
-template<typename V> struct is_property_value<V, std::void_t<typename V::key_t>> :
-  is_property_key<typename V::key_t> {};
-template<typename V, typename O> struct is_property_value_of<V, O, std::void_t<typename V::key_t>> :
-  is_property_key_of<typename V::key_t, O> {};
+
+// is_property_value is provided by the properties infrastructure in implementation-defined way
+template<typename V> struct is_property_value;
+// is_property_value_of is based on is_property_key_of, implementation is provided by the properties infrastructure
+template<typename V, typename O> struct is_property_value_of;
 
 } // namespace experimental::oneapi::ext::sycl
 ```
@@ -636,7 +623,7 @@ This section provides more detailed information for implementers. It is non-norm
 Adding a new compile-time constant property requires implementers to introduce the following:
 
 * A new class representing the property key
-* Specializations of `sycl::is_property_key` and `sycl::is_property_key_of` for the new property class
+* Specialization of `sycl::is_property_key_of` for the new property class
 * A global variable that represents an object of the property value
 
 === Example of a Compile-time Constant Property
@@ -656,10 +643,6 @@ struct foo_key {
 // property list with this property
 template<int K>
 inline constexpr foo::value_t<K> foo;
-
-// foo is a property
-template<>
-struct is_property_key<foo_key> : std::true_type {};
 
 // foo can be applied to any object
 template<typename SyclObjectT>

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_arg_properties.asciidoc
@@ -236,27 +236,6 @@ inline constexpr wait_request_key::value_t<false>
 
 // Type trait specializations
 namespace sycl::ext::oneapi::experimental {
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::conduit_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::register_map_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::stable_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::buffer_location_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::awidth_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::dwidth_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::read_write_mode_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::latency_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::maxburst_key> : std::true_type {};
-template<> struct is_property_key<
-  sycl::ext::intel::experimental::wait_request_key> : std::true_type {};
-
 template <typename T, typename PropertyListT>
 struct is_property_key_of<
   sycl::ext::intel::experimental::conduit_key,

--- a/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_intel_fpga_kernel_interface_properties.asciidoc
@@ -167,10 +167,6 @@ inline constexpr fpga_cluster_key::value_t<
 inline constexpr fpga_cluster_key::value_t<
   fpga_cluster_options_enum::stall_free_clusters> stall_free_clusters;
 
-template <> struct is_property_key<streaming_interface_key> : std::true_type {};
-template <> struct is_property_key<register_map_interface_key> : std::true_type {};
-template <> struct is_property_key<fpga_cluster_key> : std::true_type {};
-
 } // namespace sycl::ext::intel::experimental
 ```
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_forward_progress.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_forward_progress.asciidoc
@@ -423,10 +423,6 @@ inline constexpr sub_group_progress_key::value_t<Guarantee, CoordinationScope> s
 template <forward_progress_guarantee Guarantee, execution_scope CoordinationScope>
 inline constexpr work_item_progress_key::value_t<Guarantee, CoordinationScope> work_item_progress;
 
-template <> struct is_property_key<work_group_progress_key> : std::true_type {};
-template <> struct is_property_key<sub_group_progress_key> : std::true_type {};
-template <> struct is_property_key<work_item_progress_key> : std::true_type {};
-
 }
 ----
 

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_free_function_kernels.asciidoc
@@ -177,9 +177,6 @@ struct nd_range_kernel_key {
 template<int Dims>
 inline constexpr nd_range_kernel_key::value_t<Dims> nd_range_kernel;
 
-template<>
-struct is_property_key<nd_range_kernel_key> : std::true_type {};
-
 } // namespace sycl::ext::oneapi::experimental
 ----
 !====
@@ -218,9 +215,6 @@ struct single_task_kernel_key {
 };
 
 inline constexpr single_task_kernel_key::value_t single_task_kernel;
-
-template<>
-struct is_property_key<single_task_kernel_key> : std::true_type {};
 
 } // namespace sycl::ext::oneapi::experimental
 ----

--- a/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_static.asciidoc
+++ b/sycl/doc/extensions/proposed/sycl_ext_oneapi_work_group_static.asciidoc
@@ -225,8 +225,6 @@ struct work_group_static_size {
 
 using work_group_static_size_key = work_group_static_size;
 
-template <>struct is_property_key<work_group_static_size_key> : std::true_type {};
-
 } // namespace sycl::ext::oneapi::experimental
 ----
 

--- a/sycl/include/sycl/ext/oneapi/experimental/cluster_group_prop.hpp
+++ b/sycl/include/sycl/ext/oneapi/experimental/cluster_group_prop.hpp
@@ -32,13 +32,6 @@ template <int Dim> using cluster_size_key = cluster_size<Dim>;
 
 } // namespace cuda
 
-template <>
-struct is_property_key<cuda::cluster_size_key<1>> : std::true_type {};
-template <>
-struct is_property_key<cuda::cluster_size_key<2>> : std::true_type {};
-template <>
-struct is_property_key<cuda::cluster_size_key<3>> : std::true_type {};
-
 template <typename T>
 struct is_property_key_of<cuda::cluster_size_key<1>, T> : std::true_type {};
 
@@ -47,16 +40,6 @@ struct is_property_key_of<cuda::cluster_size_key<2>, T> : std::true_type {};
 
 template <typename T>
 struct is_property_key_of<cuda::cluster_size_key<3>, T> : std::true_type {};
-
-template <>
-struct is_property_value<cuda::cluster_size_key<1>>
-    : is_property_key<cuda::cluster_size_key<1>> {};
-template <>
-struct is_property_value<cuda::cluster_size_key<2>>
-    : is_property_key<cuda::cluster_size_key<2>> {};
-template <>
-struct is_property_value<cuda::cluster_size_key<3>>
-    : is_property_key<cuda::cluster_size_key<3>> {};
 
 template <typename O>
 struct is_property_value_of<cuda::cluster_size_key<1>, O>

--- a/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
+++ b/sycl/include/sycl/ext/oneapi/kernel_properties/properties.hpp
@@ -327,10 +327,6 @@ template <forward_progress_guarantee Guarantee,
 inline constexpr work_item_progress_key::value_t<Guarantee, CoordinationScope>
     work_item_progress;
 
-template <> struct is_property_key<work_group_progress_key> : std::true_type {};
-template <> struct is_property_key<sub_group_progress_key> : std::true_type {};
-template <> struct is_property_key<work_item_progress_key> : std::true_type {};
-
 namespace detail {
 
 template <size_t... Dims>

--- a/sycl/include/sycl/ext/oneapi/properties/property.hpp
+++ b/sycl/include/sycl/ext/oneapi/properties/property.hpp
@@ -301,11 +301,6 @@ template <typename> struct HasCompileTimeEffect : std::false_type {};
 
 } // namespace detail
 
-template <typename T>
-struct is_property_key
-    : std::bool_constant<!is_property_list_v<T> &&
-                         std::is_base_of_v<detail::property_key_base_tag, T>> {
-};
 template <typename, typename> struct is_property_key_of : std::false_type {};
 
 } // namespace experimental

--- a/sycl/test/extensions/annotated_arg/annotated_arg_properties.cpp
+++ b/sycl/test/extensions/annotated_arg/annotated_arg_properties.cpp
@@ -47,9 +47,6 @@ template <typename T> void checkIsPropertyOf() {
 }
 
 int main() {
-  static_assert(is_property_key<register_map_key>::value);
-  static_assert(is_property_key<buffer_location_key>::value);
-
   checkIsPropertyOf<decltype(AnnotatedArg1)>();
   static_assert(!AnnotatedArg1.has_property<register_map_key>());
   static_assert(!AnnotatedArg1.has_property<buffer_location_key>());

--- a/sycl/test/extensions/annotated_ptr/annotated_ptr_properties.cpp
+++ b/sycl/test/extensions/annotated_ptr/annotated_ptr_properties.cpp
@@ -54,9 +54,6 @@ template <typename T> void checkIsValidPropertyOfNonPtr() {
 }
 
 int main() {
-  static_assert(is_property_key<register_map_key>::value);
-  static_assert(is_property_key<buffer_location_key>::value);
-
   checkIsPropertyOf<decltype(AnnotatedPtr1)>();
   static_assert(!AnnotatedPtr1.has_property<register_map_key>());
   static_assert(!AnnotatedPtr1.has_property<buffer_location_key>());

--- a/sycl/test/extensions/annotated_usm/fake_properties.hpp
+++ b/sycl/test/extensions/annotated_usm/fake_properties.hpp
@@ -133,40 +133,6 @@ using rt_prop31_key = rt_prop31;
 using rt_prop32_key = rt_prop32;
 using rt_prop33_key = rt_prop33;
 
-template <> struct is_property_key<rt_prop1_key> : std::true_type {};
-template <> struct is_property_key<rt_prop2_key> : std::true_type {};
-template <> struct is_property_key<rt_prop3_key> : std::true_type {};
-template <> struct is_property_key<rt_prop4_key> : std::true_type {};
-template <> struct is_property_key<rt_prop5_key> : std::true_type {};
-template <> struct is_property_key<rt_prop6_key> : std::true_type {};
-template <> struct is_property_key<rt_prop7_key> : std::true_type {};
-template <> struct is_property_key<rt_prop8_key> : std::true_type {};
-template <> struct is_property_key<rt_prop9_key> : std::true_type {};
-template <> struct is_property_key<rt_prop10_key> : std::true_type {};
-template <> struct is_property_key<rt_prop11_key> : std::true_type {};
-template <> struct is_property_key<rt_prop12_key> : std::true_type {};
-template <> struct is_property_key<rt_prop13_key> : std::true_type {};
-template <> struct is_property_key<rt_prop14_key> : std::true_type {};
-template <> struct is_property_key<rt_prop15_key> : std::true_type {};
-template <> struct is_property_key<rt_prop16_key> : std::true_type {};
-template <> struct is_property_key<rt_prop17_key> : std::true_type {};
-template <> struct is_property_key<rt_prop18_key> : std::true_type {};
-template <> struct is_property_key<rt_prop19_key> : std::true_type {};
-template <> struct is_property_key<rt_prop20_key> : std::true_type {};
-template <> struct is_property_key<rt_prop21_key> : std::true_type {};
-template <> struct is_property_key<rt_prop22_key> : std::true_type {};
-template <> struct is_property_key<rt_prop23_key> : std::true_type {};
-template <> struct is_property_key<rt_prop24_key> : std::true_type {};
-template <> struct is_property_key<rt_prop25_key> : std::true_type {};
-template <> struct is_property_key<rt_prop26_key> : std::true_type {};
-template <> struct is_property_key<rt_prop27_key> : std::true_type {};
-template <> struct is_property_key<rt_prop28_key> : std::true_type {};
-template <> struct is_property_key<rt_prop29_key> : std::true_type {};
-template <> struct is_property_key<rt_prop30_key> : std::true_type {};
-template <> struct is_property_key<rt_prop31_key> : std::true_type {};
-template <> struct is_property_key<rt_prop32_key> : std::true_type {};
-template <> struct is_property_key<rt_prop33_key> : std::true_type {};
-
 template <typename objectT>
 struct is_property_key_of<foo_key, objectT> : std::true_type {};
 template <typename objectT>

--- a/sycl/test/extensions/device_global/device_global_properties.cpp
+++ b/sycl/test/extensions/device_global/device_global_properties.cpp
@@ -45,11 +45,6 @@ template <typename T> void checkIsPropertyOf() {
 }
 
 int main() {
-  static_assert(is_property_key<device_image_scope_key>::value);
-  static_assert(is_property_key<host_access_key>::value);
-  static_assert(is_property_key<init_mode_key>::value);
-  static_assert(is_property_key<implement_in_csr_key>::value);
-
   static_assert(is_property_value<decltype(device_image_scope)>::value);
   static_assert(is_property_value<decltype(host_access_read)>::value);
   static_assert(is_property_value<decltype(host_access_write)>::value);

--- a/sycl/test/extensions/fpga_mem/fpga_mem_properties.cpp
+++ b/sycl/test/extensions/fpga_mem/fpga_mem_properties.cpp
@@ -39,18 +39,6 @@ template <typename T> void checkIsPropertyOf() {
 }
 
 int main() {
-  // Are all keys usable
-  static_assert(oneapi::is_property_key<intel::resource_key>::value);
-  static_assert(oneapi::is_property_key<intel::num_banks_key>::value);
-  static_assert(oneapi::is_property_key<intel::stride_size_key>::value);
-  static_assert(oneapi::is_property_key<intel::word_size_key>::value);
-  static_assert(
-      oneapi::is_property_key<intel::bi_directional_ports_key>::value);
-  static_assert(oneapi::is_property_key<intel::clock_2x_key>::value);
-  static_assert(oneapi::is_property_key<intel::ram_stitching_key>::value);
-  static_assert(oneapi::is_property_key<intel::max_private_copies_key>::value);
-  static_assert(oneapi::is_property_key<intel::num_replicates_key>::value);
-
   // Are all common values usable
   static_assert(
       oneapi::is_property_value<decltype(intel::resource_mlab)>::value);

--- a/sycl/test/extensions/properties/properties_device_global.cpp
+++ b/sycl/test/extensions/properties/properties_device_global.cpp
@@ -11,12 +11,6 @@ constexpr host_access_enum TestAccess = host_access_enum::read_write;
 constexpr init_mode_enum TestTrigger = init_mode_enum::reset;
 
 int main() {
-  // Check that is_property_key is correctly specialized.
-  static_assert(is_property_key<device_image_scope_key>::value);
-  static_assert(is_property_key<host_access_key>::value);
-  static_assert(is_property_key<init_mode_key>::value);
-  static_assert(is_property_key<implement_in_csr_key>::value);
-
   // Check that is_property_value is correctly specialized.
   static_assert(is_property_value<decltype(device_image_scope)>::value);
   static_assert(is_property_value<decltype(host_access<TestAccess>)>::value);

--- a/sycl/test/extensions/properties/properties_is_property_key.cpp
+++ b/sycl/test/extensions/properties/properties_is_property_key.cpp
@@ -8,43 +8,6 @@
 class NotAPropertyKey {};
 
 int main() {
-  // Check is_property_key for compile-time property keys.
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::bar_key>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::baz_key>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::boo_key>::value);
-
-  // Check is_property_key for runtime property keys.
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::foo_key>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::foz_key>::value);
-
-  // Check is_property_key for compile-time property values.
-  static_assert(!sycl::ext::oneapi::experimental::is_property_key<
-                decltype(sycl::ext::oneapi::experimental::bar)>::value);
-  static_assert(!sycl::ext::oneapi::experimental::is_property_key<
-                decltype(sycl::ext::oneapi::experimental::baz<42>)>::value);
-  static_assert(!sycl::ext::oneapi::experimental::is_property_key<
-                decltype(sycl::ext::oneapi::experimental::boo<int>)>::value);
-  static_assert(
-      !sycl::ext::oneapi::experimental::is_property_key<
-          decltype(sycl::ext::oneapi::experimental::boo<bool, float>)>::value);
-
-  // Check is_property_key for runtime property values.
-  // NOTE: For runtime properties the key is an alias of the value.
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::foo>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::oneapi::experimental::foz>::value);
-
-  // Check is_property_key for non-property-key types.
-  static_assert(!sycl::ext::oneapi::experimental::is_property_key<int>::value);
-  static_assert(!sycl::ext::oneapi::experimental::is_property_key<
-                NotAPropertyKey>::value);
-
   // Check is_property_key_of for compile-time property keys.
   static_assert(sycl::ext::oneapi::experimental::is_property_key_of<
                 sycl::ext::oneapi::experimental::bar_key, sycl::queue>::value);
@@ -60,8 +23,6 @@ int main() {
                 sycl::ext::oneapi::experimental::foz_key, sycl::queue>::value);
 
   // Check is_property_key_of for compile-time property values.
-  static_assert(!sycl::ext::oneapi::experimental::is_property_key<
-                decltype(sycl::ext::oneapi::experimental::bar)>::value);
   static_assert(!sycl::ext::oneapi::experimental::is_property_key_of<
                 decltype(sycl::ext::oneapi::experimental::baz<42>),
                 sycl::queue>::value);

--- a/sycl/test/extensions/properties/properties_kernel.cpp
+++ b/sycl/test/extensions/properties/properties_kernel.cpp
@@ -37,11 +37,6 @@ template <aspect Aspect> inline void singleAspectDeviceHasChecks() {
 }
 
 int main() {
-  static_assert(is_property_key<work_group_size_key>::value);
-  static_assert(is_property_key<work_group_size_hint_key>::value);
-  static_assert(is_property_key<sub_group_size_key>::value);
-  static_assert(is_property_key<device_has_key>::value);
-
   static_assert(sycl::ext::oneapi::experimental::detail::HasCompileTimeEffect<
                 work_group_size_key::value_t<1>>::value);
   static_assert(sycl::ext::oneapi::experimental::detail::HasCompileTimeEffect<

--- a/sycl/test/extensions/properties/properties_kernel_cache_config.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_cache_config.cpp
@@ -5,10 +5,6 @@
 using namespace sycl::ext::intel::experimental;
 
 int main() {
-  // Check that oneapi::experimental::is_property_key is correctly specialized
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                cache_config_key>::value);
-
   // Check that oneapi::experimental::is_property_value is correctly specialized
   static_assert(sycl::ext::oneapi::experimental::is_property_value<
                 decltype(cache_config{large_slm})>::value);

--- a/sycl/test/extensions/properties/properties_kernel_fpga.cpp
+++ b/sycl/test/extensions/properties/properties_kernel_fpga.cpp
@@ -8,16 +8,6 @@
 using namespace sycl::ext;
 
 int main() {
-  // Check that oneapi::experimental::is_property_key is correctly specialized
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::streaming_interface_key>::value);
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::register_map_interface_key>::value);
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::pipelined_key>::value);
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::fpga_cluster_key>::value);
-
   // Check that oneapi::experimental::detail::HasCompileTimeEffect is
   // correctly specialized
   static_assert(oneapi::experimental::detail::HasCompileTimeEffect<

--- a/sycl/test/extensions/properties/properties_latency_control.cpp
+++ b/sycl/test/extensions/properties/properties_latency_control.cpp
@@ -8,12 +8,6 @@
 using namespace sycl::ext;
 
 int main() {
-  // Check that oneapi::experimental::is_property_key is correctly specialized
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::latency_anchor_id_key>::value);
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::latency_constraint_key>::value);
-
   // Check that oneapi::experimental::is_property_value is correctly specialized
   static_assert(oneapi::experimental::is_property_value<
                 decltype(intel::experimental::latency_anchor_id<-1>)>::value);

--- a/sycl/test/extensions/properties/properties_pipe.cpp
+++ b/sycl/test/extensions/properties/properties_pipe.cpp
@@ -11,20 +11,6 @@ constexpr sycl::ext::intel::experimental::protocol_name TestProtocol =
     sycl::ext::intel::experimental::protocol_name::avalon_streaming;
 
 int main() {
-  // Check that is_property_key is correctly specialized.
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::intel::experimental::ready_latency_key>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::intel::experimental::bits_per_symbol_key>::value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::intel::experimental::uses_valid_key>::value);
-  static_assert(
-      sycl::ext::oneapi::experimental::is_property_key<
-          sycl::ext::intel::experimental::first_symbol_in_high_order_bits_key>::
-          value);
-  static_assert(sycl::ext::oneapi::experimental::is_property_key<
-                sycl::ext::intel::experimental::protocol_key>::value);
-
   // Check that is_property_value is correctly specialized.
   static_assert(
       sycl::ext::oneapi::experimental::is_property_value<

--- a/sycl/test/extensions/properties/properties_task_sequence.cpp
+++ b/sycl/test/extensions/properties/properties_task_sequence.cpp
@@ -10,14 +10,6 @@ using namespace sycl::ext;
 constexpr uint32_t TestResponseCapacity = 7;
 constexpr uint32_t TestInvocationCapacity = 5;
 int main() {
-  // Check that is_property_key is correctly specialized
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::balanced_key>::value);
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::response_capacity_key>::value);
-  static_assert(oneapi::experimental::is_property_key<
-                intel::experimental::invocation_capacity_key>::value);
-
   // Check that is_property_value is correctly specialized
   static_assert(oneapi::experimental::is_property_value<
                 decltype(intel::experimental::balanced)>::value);

--- a/sycl/test/extensions/task_sequence/task_sequence_properties.cpp
+++ b/sycl/test/extensions/task_sequence/task_sequence_properties.cpp
@@ -40,12 +40,6 @@ template <typename T> void checkIsPropertyOf() {
 }
 
 int main() {
-  static_assert(is_property_key<balanced_key>::value);
-  static_assert(is_property_key<response_capacity_key>::value);
-  static_assert(is_property_key<invocation_capacity_key>::value);
-  static_assert(is_property_key<pipelined_key>::value);
-  static_assert(is_property_key<fpga_cluster_key>::value);
-
   static_assert(is_property_value<decltype(balanced)>::value);
   static_assert(is_property_value<decltype(response_capacity<1>)>::value);
   static_assert(is_property_value<decltype(invocation_capacity<1>)>::value);

--- a/sycl/test/virtual-functions/properties-positive.cpp
+++ b/sycl/test/virtual-functions/properties-positive.cpp
@@ -44,10 +44,6 @@ public:
 int main() {
   sycl::queue q;
 
-  static_assert(
-      oneapi::is_property_key<oneapi::indirectly_callable_key>::value);
-  static_assert(oneapi::is_property_key<oneapi::calls_indirectly_key>::value);
-
   oneapi::properties props_empty{oneapi::assume_indirect_calls};
   oneapi::properties props_void{oneapi::assume_indirect_calls_to<void>};
   oneapi::properties props_int{oneapi::assume_indirect_calls_to<int>};


### PR DESCRIPTION
This is an API-breaking change, but for an experimental feature and we don't expect this particular interface was used by customers.