### PR TITLE
[SYCL][CUDA][HIP] Update images enable variable

### DIFF
--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/npmiller/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/npmiller/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,7 @@
-# commit 098deca1f9f3b9f3f0563ee823ac424d8db30668
-# Merge: 58e4d76c2ace 73ba29bfe9df
-# Author: Martin Grant <martin.morrisongrant@codeplay.com>
-# Date:   Wed Dec 11 17:23:43 2024 +0000
-#     Merge pull request #2299 from cppchedy/chedy/fix-mipmap-leak
-#     [CUDA][Bindless] Fix memory leak in interop mapping
-set(UNIFIED_RUNTIME_TAG 098deca1f9f3b9f3f0563ee823ac424d8db30668)
+# commit 9937d029c7fdcbf101e89f8515f640c145e059c5
+# Merge: 9ac6d5d9 10b0e101
+# Author: Callum Fare <callum@codeplay.com>
+# Date:   Wed Nov 20 14:49:17 2024 +0000
+#     Merge pull request #2258 from aarongreig/aaron/tryUseExtensionSubgroupInfo
+#     Use extension version of clGetKernelSubGroupInfo when necessary.
+set(UNIFIED_RUNTIME_TAG 1b373f83c71eb39d440ca2c1ed82faf3bfa9b720)

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,7 @@
-# commit 9937d029c7fdcbf101e89f8515f640c145e059c5
-# Merge: 9ac6d5d9 10b0e101
-# Author: Callum Fare <callum@codeplay.com>
-# Date:   Wed Nov 20 14:49:17 2024 +0000
-#     Merge pull request #2258 from aarongreig/aaron/tryUseExtensionSubgroupInfo
-#     Use extension version of clGetKernelSubGroupInfo when necessary.
-set(UNIFIED_RUNTIME_TAG 1b373f83c71eb39d440ca2c1ed82faf3bfa9b720)
+# commit 06f48f674445532d8c04be431474901b82c3c449
+# Merge: 098deca1f9f3 1b373f83c71e
+# Author: Martin Grant <martin.morrisongrant@codeplay.com>
+# Date:   Thu Dec 12 11:04:15 2024 +0000
+#     Merge pull request #2356 from npmiller/hip-images
+#     [HIP] Disable SYCL images by default
+set(UNIFIED_RUNTIME_TAG 06f48f674445532d8c04be431474901b82c3c449)

--- a/sycl/test-e2e/format.py
+++ b/sycl/test-e2e/format.py
@@ -212,7 +212,10 @@ class SYCLEndToEndTest(lit.formats.ShTest):
                 )
 
             if "cuda:gpu" in sycl_devices:
-                extra_env.append("SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1")
+                extra_env.append("UR_CUDA_ENABLE_IMAGE_SUPPORT=1")
+
+            if "hip:gpu" in sycl_devices:
+                extra_env.append("UR_HIP_ENABLE_IMAGE_SUPPORT=1")
 
             return extra_env
 

--- a/sycl/test-e2e/lit.cfg.py
+++ b/sycl/test-e2e/lit.cfg.py
@@ -663,7 +663,9 @@ for sycl_device in config.sycl_devices:
     env = copy.copy(llvm_config.config.environment)
     env["ONEAPI_DEVICE_SELECTOR"] = sycl_device
     if sycl_device.startswith("cuda:"):
-        env["SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT"] = "1"
+        env["UR_CUDA_ENABLE_IMAGE_SUPPORT"] = "1"
+    if sycl_device.startswith("hip:"):
+        env["UR_HIP_ENABLE_IMAGE_SUPPORT"] = "1"
     # When using the ONEAPI_DEVICE_SELECTOR environment variable, sycl-ls
     # prints warnings that might derail a user thinking something is wrong
     # with their test run. It's just us filtering here, so silence them unless


### PR DESCRIPTION
This patch adds a variable to enable image support for HIP, and updates
the one for CUDA to use the UR naming.

SYCL images support is similar for CUDA and HIP, so it makes sense to
treat them the same, and any future work on this will focus on bindless
images rather than SYCL images.

UR side PR: https://github.com/oneapi-src/unified-runtime/pull/2356