### PR TITLE
[SYCL][NATIVECPU] Add Native CPU specific property mechanism and nd_range property

### DIFF
--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -47,6 +47,7 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/ProfileData/InstrProfCorrelator.h"
+#include "llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/CleanupSYCLMetadata.h"
 #include "llvm/SYCLLowerIR/CompileTimePropertiesPass.h"
 #include "llvm/SYCLLowerIR/ESIMD/ESIMDVerifier.h"
@@ -1165,6 +1166,11 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       if (LangOpts.EnableDAEInSpirKernels)
         MPM.addPass(DeadArgumentEliminationSYCLPass());
 
+      // We have to schedule the pass here because the native cpu pipeline
+      // is ran as part of a separate clang invocation, but we want the information
+      // in sycl-post-link.
+      if (LangOpts.SYCLIsNativeCPU)
+        MPM.addPass(CheckNDRangeSYCLNativeCPUPass());
       // Rerun aspect propagation without warning diagnostics.
       MPM.addPass(
           SYCLPropagateAspectsUsagePass(/*FP64ConvEmu=*/CodeGenOpts.FP64ConvEmu,

--- a/clang/lib/CodeGen/BackendUtil.cpp
+++ b/clang/lib/CodeGen/BackendUtil.cpp
@@ -47,7 +47,6 @@
 #include "llvm/Passes/PassPlugin.h"
 #include "llvm/Passes/StandardInstrumentations.h"
 #include "llvm/ProfileData/InstrProfCorrelator.h"
-#include "llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/CleanupSYCLMetadata.h"
 #include "llvm/SYCLLowerIR/CompileTimePropertiesPass.h"
 #include "llvm/SYCLLowerIR/ESIMD/ESIMDVerifier.h"
@@ -1166,11 +1165,8 @@ void EmitAssemblyHelper::RunOptimizationPipeline(
       if (LangOpts.EnableDAEInSpirKernels)
         MPM.addPass(DeadArgumentEliminationSYCLPass());
 
-      // We have to schedule the pass here because the native cpu pipeline
-      // is ran as part of a separate clang invocation, but we want the information
-      // in sycl-post-link.
       if (LangOpts.SYCLIsNativeCPU)
-        MPM.addPass(CheckNDRangeSYCLNativeCPUPass());
+        llvm::sycl::utils::addSYCLNativeCPUEarlyPasses(MPM);
       // Rerun aspect propagation without warning diagnostics.
       MPM.addPass(
           SYCLPropagateAspectsUsagePass(/*FP64ConvEmu=*/CodeGenOpts.FP64ConvEmu,

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -713,6 +713,8 @@ private:
                                     "__sycl_native_cpu_decls");
     auto *EntriesBegin = ConstantExpr::getGetElementPtr(GVar->getValueType(), GVar,
                                                  getSizetConstPair(0u, 0u));
+
+    // Add Native CPU specific properties to the nativecpu_program struct
     Constant *PropValue = NullPtr;
     if (NativeCPUProps.has_value()) {
       auto PropsOrErr = addSYCLPropertySetToModule(*NativeCPUProps);
@@ -724,6 +726,11 @@ private:
       auto T = addStructArrayToModule({S}, getSyclPropSetTy());
       PropValue = T.first;
     }
+
+    // Create the nativecpu_program struct.
+    // We add it to a ConstantArray of length 1 because the SYCL runtime expects a
+    // non-zero sized binary image, and this allows it to point the end of the binary
+    // image to the end of the array.
     auto *Program = ConstantStruct::get(NCPUProgramT, {EntriesBegin, PropValue});
     ArrayType *ProgramATy = ArrayType::get(NCPUProgramT, 1);
     Constant *CPA = ConstantArray::get(ProgramATy, {Program});

--- a/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
+++ b/clang/tools/clang-offload-wrapper/ClangOffloadWrapper.cpp
@@ -728,9 +728,9 @@ private:
     }
 
     // Create the nativecpu_program struct.
-    // We add it to a ConstantArray of length 1 because the SYCL runtime expects a
-    // non-zero sized binary image, and this allows it to point the end of the binary
-    // image to the end of the array.
+    // We add it to a ConstantArray of length 1 because the SYCL runtime expects
+    // a non-zero sized binary image, and this allows it to point the end of the
+    // binary image to the end of the array.
     auto *Program = ConstantStruct::get(NCPUProgramT, {EntriesBegin, PropValue});
     ArrayType *ProgramATy = ArrayType::get(NCPUProgramT, 1);
     Constant *CPA = ConstantArray::get(ProgramATy, {Program});

--- a/llvm/include/llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h
@@ -6,10 +6,11 @@
 //
 //===----------------------------------------------------------------------===//
 //
-// A transformation pass that:
-// * Handles the kernel calling convention and attributes.
-// * Materializes the spirv builtins so that they can be handled by the host
-//   runtime.
+// Checks if the kernel uses features from nd_item such as:
+// * local id
+// * local range
+// * local memory
+// * work group barrier
 //===----------------------------------------------------------------------===//
 
 #pragma once

--- a/llvm/include/llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h
@@ -1,0 +1,30 @@
+//===-- CheckNDRangeSYCLNativeCPU.h  -Check if a kernel uses nd_range features--===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// A transformation pass that:
+// * Handles the kernel calling convention and attributes.
+// * Materializes the spirv builtins so that they can be handled by the host
+//   runtime.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include "llvm/IR/Module.h"
+#include "llvm/IR/PassManager.h"
+
+namespace llvm {
+
+class ModulePass;
+
+class CheckNDRangeSYCLNativeCPUPass
+    : public PassInfoMixin<CheckNDRangeSYCLNativeCPUPass> {
+public:
+  PreservedAnalyses run(Module &M, ModuleAnalysisManager &MAM);
+};
+
+} // namespace llvm

--- a/llvm/include/llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h
@@ -11,12 +11,18 @@
 //===----------------------------------------------------------------------===//
 #pragma once
 #include "llvm/ADT/Twine.h"
+#include "llvm/IR/Module.h"
 #include "llvm/IR/PassManager.h"
 #include "llvm/Passes/OptimizationLevel.h"
 
 namespace llvm {
 namespace sycl {
 namespace utils {
+
+
+// Used to schedule passes in the device compiler cc1 invocation for
+// Native CPU.
+void addSYCLNativeCPUEarlyPasses(ModulePassManager &MPM);
 
 void addSYCLNativeCPUBackendPasses(ModulePassManager &MPM,
                                    ModuleAnalysisManager &MAM,

--- a/llvm/include/llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h
@@ -40,6 +40,8 @@ inline bool isSYCLNativeCPU(const Module &M) {
   return M.getModuleFlag("is-native-cpu") != nullptr;
 }
 
+constexpr unsigned SyclNativeCpuLocalAS = 3;
+
 } // namespace utils
 } // namespace sycl
 } // namespace llvm

--- a/llvm/include/llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h
+++ b/llvm/include/llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h
@@ -19,7 +19,6 @@ namespace llvm {
 namespace sycl {
 namespace utils {
 
-
 // Used to schedule passes in the device compiler cc1 invocation for
 // Native CPU.
 void addSYCLNativeCPUEarlyPasses(ModulePassManager &MPM);

--- a/llvm/include/llvm/Support/PropertySetIO.h
+++ b/llvm/include/llvm/Support/PropertySetIO.h
@@ -210,6 +210,7 @@ public:
   static constexpr char SYCL_DEVICE_REQUIREMENTS[] = "SYCL/device requirements";
   static constexpr char SYCL_HOST_PIPES[] = "SYCL/host pipes";
   static constexpr char SYCL_VIRTUAL_FUNCTIONS[] = "SYCL/virtual functions";
+  static constexpr char SYCL_NATIVE_CPU_PROPS[] = "SYCL/native cpu properties";
 
   /// Function for bulk addition of an entire property set in the given
   /// \p Category .

--- a/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
+++ b/llvm/lib/SYCLLowerIR/ComputeModuleRuntimeInfo.cpp
@@ -307,6 +307,11 @@ PropSetRegTy computeModuleProperties(const Module &M,
         PropSet.add(PropSetRegTy::SYCL_PROGRAM_METADATA, MetadataNames.back(),
                     *MaxLinearWGSize);
       }
+
+      if (auto IsNDRange = getKernelSingleEltMetadata<bool>(Func, "is_nd_range")) {
+        MetadataNames.push_back(Func.getName().str() + "@is_nd_range");
+        PropSet.add(PropSetRegTy::SYCL_NATIVE_CPU_PROPS, MetadataNames.back(), *IsNDRange);
+      }
     }
 
     // Add global_id_mapping information with mapping between device-global

--- a/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
+++ b/llvm/lib/SYCLNativeCPUUtils/CMakeLists.txt
@@ -5,6 +5,7 @@ add_llvm_component_library(LLVMSYCLNativeCPUUtils
   ConvertToMuxBuiltinsSYCLNativeCPU.cpp
   FixABIMuxBuiltinsSYCLNativeCPU.cpp
   FAtomicsNativeCPU.cpp
+  CheckNDRangeSYCLNativeCPU.cpp
 
   ADDITIONAL_HEADER_DIRS
   ${LLVM_MAIN_INCLUDE_DIR}/llvm/SYCLLowerIR

--- a/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
@@ -1,0 +1,75 @@
+//===------ PrepareSYCLNativeCPU.cpp - SYCL Native CPU Preparation Pass ---===//
+//
+// Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
+// See https://llvm.org/LICENSE.txt for license information.
+// SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+//
+//===----------------------------------------------------------------------===//
+//
+// Checks if the kernel uses features from nd_item such as:
+// * local id
+// * local range
+// * local memory
+// * work group barrier
+//===----------------------------------------------------------------------===//
+
+#include "llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h"
+#include "llvm/IR/CallingConv.h"
+#include "llvm/IR/Constants.h"
+#include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instructions.h"
+#include "llvm/IR/Metadata.h"
+
+using namespace llvm;
+
+// TODO: add other bts
+static std::array<const char *, 5> ndFunctions{
+    "_Z23__spirv_WorkgroupSize_xv", "_Z23__spirv_NumWorkgroups_xv",
+    "_Z21__spirv_WorkgroupId_xv", "_Z27__spirv_LocalInvocationId_xv",
+    "_Z22__spirv_ControlBarrierjjj"};
+
+static void addNDRangeMetadata(Function &F, bool Value) {
+  auto &Ctx = F.getContext();
+  F.setMetadata("is_nd_range",
+                MDNode::get(Ctx, ConstantAsMetadata::get(ConstantInt::get(
+                                     Type::getInt1Ty(Ctx), Value))));
+}
+
+PreservedAnalyses
+CheckNDRangeSYCLNativeCPUPass::run(Module &M, ModuleAnalysisManager &MAM) {
+  bool ModuleChanged = false;
+
+  for (auto &F : M) {
+    if (F.getCallingConv() == llvm::CallingConv::SPIR_KERNEL) {
+      bool IsNDRange = false;
+
+      // Check for local memory args
+      for (auto &A : F.args()) {
+        if (auto Ptr = dyn_cast<PointerType>(A.getType());
+            Ptr && Ptr->getAddressSpace() == 3) {
+          IsNDRange = true;
+        }
+      }
+
+      for (auto &BB : F) {
+        for (auto &I : BB) {
+          if (auto CI = dyn_cast<CallInst>(&I)) {
+            auto CalleeName = CI->getCalledFunction()->getName();
+            if (std::find(ndFunctions.begin(), ndFunctions.end(), CalleeName) !=
+                ndFunctions.end()) {
+              IsNDRange = true;
+              break;
+            }
+          }
+        }
+        if (IsNDRange) {
+          break;
+        }
+      }
+
+      addNDRangeMetadata(F, IsNDRange);
+    }
+  }
+  return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();
+}

--- a/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
@@ -14,16 +14,22 @@
 //===----------------------------------------------------------------------===//
 
 #include "llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h"
+#include "llvm/ADT/PriorityWorklist.h"
+#include "llvm/ADT/SmallPtrSet.h"
 #include "llvm/IR/CallingConv.h"
 #include "llvm/IR/Constants.h"
 #include "llvm/IR/DerivedTypes.h"
+#include "llvm/IR/Function.h"
 #include "llvm/IR/InstrTypes.h"
+#include "llvm/IR/Instruction.h"
 #include "llvm/IR/Instructions.h"
 #include "llvm/IR/Metadata.h"
+#include "llvm/SYCLLowerIR/UtilsSYCLNativeCPU.h"
+#include "llvm/Support/Casting.h"
 
 using namespace llvm;
 
-static std::array<const char *, 13> NdFunctions{
+static std::array<const char *, 13> NdBuiltins{
     "_Z23__spirv_WorkgroupSize_xv",     "_Z23__spirv_WorkgroupSize_yv",
     "_Z23__spirv_WorkgroupSize_zv",     "_Z23__spirv_NumWorkgroups_xv",
     "_Z23__spirv_NumWorkgroups_yv",     "_Z23__spirv_NumWorkgroups_zv",
@@ -42,6 +48,55 @@ static void addNDRangeMetadata(Function &F, bool Value) {
 PreservedAnalyses
 CheckNDRangeSYCLNativeCPUPass::run(Module &M, ModuleAnalysisManager &MAM) {
   bool ModuleChanged = false;
+  SmallPtrSet<Function *, 5> NdFuncs; // Functions that use NDRange features
+  SmallPtrSet<Function *, 5> Visited;
+  SmallPriorityWorklist<Function *, 5> WorkList;
+
+  // Add builtins to the set of functions that may use NDRange features
+  for (auto &FName : NdBuiltins) {
+    auto F = M.getFunction(FName);
+    if (F == nullptr)
+      continue;
+    WorkList.insert(F);
+    NdFuncs.insert(F);
+  }
+
+  // Add users of local AS global var to the set of functions that may use
+  // NDRange features
+  for (auto &GV : M.globals()) {
+    if (GV.getAddressSpace() != sycl::utils::SyclNativeCpuLocalAS)
+      continue;
+
+    for (auto U : GV.users()) {
+      if (auto I = dyn_cast<Instruction>(U)) {
+        auto F = I->getFunction();
+        if (F != nullptr && NdFuncs.insert(F).second) {
+          WorkList.insert(F);
+          NdFuncs.insert(F);
+        }
+      }
+    }
+  }
+
+  // Traverse the use chain to find Functions that may use NDRange features
+  // (or, recursively, Functions that call Functions that may use NDRange
+  // features)
+  while (!WorkList.empty()) {
+    auto F = WorkList.pop_back_val();
+
+    for (User *U : F->users()) {
+      if (auto CI = dyn_cast<CallInst>(U)) {
+        auto Caller = CI->getFunction();
+        if (!Caller)
+          continue;
+        if (!Visited.contains(Caller)) {
+          WorkList.insert(Caller);
+          NdFuncs.insert(Caller);
+        }
+      }
+    }
+    Visited.insert(F);
+  }
 
   for (auto &F : M) {
     if (F.getCallingConv() == llvm::CallingConv::SPIR_KERNEL) {
@@ -55,23 +110,11 @@ CheckNDRangeSYCLNativeCPUPass::run(Module &M, ModuleAnalysisManager &MAM) {
         }
       }
 
-      for (auto &BB : F) {
-        for (auto &I : BB) {
-          if (auto CI = dyn_cast<CallInst>(&I)) {
-            auto CalleeName = CI->getCalledFunction()->getName();
-            if (std::find(NdFunctions.begin(), NdFunctions.end(), CalleeName) !=
-                NdFunctions.end()) {
-              IsNDRange = true;
-              break;
-            }
-          }
-        }
-        if (IsNDRange) {
-          break;
-        }
-      }
+      // Check if the kernel calls one of the ND Range builtins
+      IsNDRange |= NdFuncs.contains(&F);
 
       addNDRangeMetadata(F, IsNDRange);
+      ModuleChanged = true;
     }
   }
   return ModuleChanged ? PreservedAnalyses::none() : PreservedAnalyses::all();

--- a/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
@@ -1,4 +1,4 @@
-//===------ PrepareSYCLNativeCPU.cpp - SYCL Native CPU Preparation Pass ---===//
+//- CheckNDRangeSYCLNativeCPU.cpp - Check if a kernel uses nd_range features -//
 //
 // Part of the LLVM Project, under the Apache License v2.0 with LLVM Exceptions.
 // See https://llvm.org/LICENSE.txt for license information.
@@ -23,10 +23,19 @@
 
 using namespace llvm;
 
-// TODO: add other bts
-static std::array<const char *, 5> ndFunctions{
-    "_Z23__spirv_WorkgroupSize_xv", "_Z23__spirv_NumWorkgroups_xv",
-    "_Z21__spirv_WorkgroupId_xv", "_Z27__spirv_LocalInvocationId_xv",
+static std::array<const char *, 13> NdFunctions{
+    "_Z23__spirv_WorkgroupSize_xv",
+    "_Z23__spirv_WorkgroupSize_yv",
+    "_Z23__spirv_WorkgroupSize_zv",
+    "_Z23__spirv_NumWorkgroups_xv",
+    "_Z23__spirv_NumWorkgroups_yv",
+    "_Z23__spirv_NumWorkgroups_zv",
+    "_Z21__spirv_WorkgroupId_xv",
+    "_Z21__spirv_WorkgroupId_yv",
+    "_Z21__spirv_WorkgroupId_zv",
+    "_Z27__spirv_LocalInvocationId_xv",
+    "_Z27__spirv_LocalInvocationId_yv",
+    "_Z27__spirv_LocalInvocationId_zv",
     "_Z22__spirv_ControlBarrierjjj"};
 
 static void addNDRangeMetadata(Function &F, bool Value) {
@@ -56,8 +65,8 @@ CheckNDRangeSYCLNativeCPUPass::run(Module &M, ModuleAnalysisManager &MAM) {
         for (auto &I : BB) {
           if (auto CI = dyn_cast<CallInst>(&I)) {
             auto CalleeName = CI->getCalledFunction()->getName();
-            if (std::find(ndFunctions.begin(), ndFunctions.end(), CalleeName) !=
-                ndFunctions.end()) {
+            if (std::find(NdFunctions.begin(), NdFunctions.end(), CalleeName) !=
+                NdFunctions.end()) {
               IsNDRange = true;
               break;
             }

--- a/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/CheckNDRangeSYCLNativeCPU.cpp
@@ -24,18 +24,12 @@
 using namespace llvm;
 
 static std::array<const char *, 13> NdFunctions{
-    "_Z23__spirv_WorkgroupSize_xv",
-    "_Z23__spirv_WorkgroupSize_yv",
-    "_Z23__spirv_WorkgroupSize_zv",
-    "_Z23__spirv_NumWorkgroups_xv",
-    "_Z23__spirv_NumWorkgroups_yv",
-    "_Z23__spirv_NumWorkgroups_zv",
-    "_Z21__spirv_WorkgroupId_xv",
-    "_Z21__spirv_WorkgroupId_yv",
-    "_Z21__spirv_WorkgroupId_zv",
-    "_Z27__spirv_LocalInvocationId_xv",
-    "_Z27__spirv_LocalInvocationId_yv",
-    "_Z27__spirv_LocalInvocationId_zv",
+    "_Z23__spirv_WorkgroupSize_xv",     "_Z23__spirv_WorkgroupSize_yv",
+    "_Z23__spirv_WorkgroupSize_zv",     "_Z23__spirv_NumWorkgroups_xv",
+    "_Z23__spirv_NumWorkgroups_yv",     "_Z23__spirv_NumWorkgroups_zv",
+    "_Z21__spirv_WorkgroupId_xv",       "_Z21__spirv_WorkgroupId_yv",
+    "_Z21__spirv_WorkgroupId_zv",       "_Z27__spirv_LocalInvocationId_xv",
+    "_Z27__spirv_LocalInvocationId_yv", "_Z27__spirv_LocalInvocationId_zv",
     "_Z22__spirv_ControlBarrierjjj"};
 
 static void addNDRangeMetadata(Function &F, bool Value) {

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -131,3 +131,7 @@ void llvm::sycl::utils::addSYCLNativeCPUBackendPasses(
     MPM.addPass(DumpIR());
   }
 }
+
+void llvm::sycl::utils::addSYCLNativeCPUEarlyPasses(ModulePassManager &MPM) {
+        MPM.addPass(CheckNDRangeSYCLNativeCPUPass());
+}

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -11,6 +11,7 @@
 // When NATIVECPU_USE_OCK is set, adds passes from the oneAPI Construction Kit.
 //
 //===----------------------------------------------------------------------===//
+#include "llvm/SYCLLowerIR/CheckNDRangeSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/ConvertToMuxBuiltinsSYCLNativeCPU.h"
 #include "llvm/SYCLLowerIR/FAtomicsNativeCPU.h"
 #include "llvm/SYCLLowerIR/FixABIMuxBuiltinsSYCLNativeCPU.h"

--- a/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
+++ b/llvm/lib/SYCLNativeCPUUtils/PipelineSYCLNativeCPU.cpp
@@ -133,5 +133,5 @@ void llvm::sycl::utils::addSYCLNativeCPUBackendPasses(
 }
 
 void llvm::sycl::utils::addSYCLNativeCPUEarlyPasses(ModulePassManager &MPM) {
-        MPM.addPass(CheckNDRangeSYCLNativeCPUPass());
+  MPM.addPass(CheckNDRangeSYCLNativeCPUPass());
 }

--- a/sycl/cmake/modules/FetchUnifiedRuntime.cmake
+++ b/sycl/cmake/modules/FetchUnifiedRuntime.cmake
@@ -116,7 +116,7 @@ if(SYCL_UR_USE_FETCH_CONTENT)
       CACHE PATH "Path to external '${name}' adapter source dir" FORCE)
   endfunction()
 
-  set(UNIFIED_RUNTIME_REPO "https://github.com/oneapi-src/unified-runtime.git")
+  set(UNIFIED_RUNTIME_REPO "https://github.com/PietroGhg/unified-runtime.git")
   include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/modules/UnifiedRuntimeTag.cmake)
 
   set(UMF_BUILD_EXAMPLES OFF CACHE INTERNAL "EXAMPLES")

--- a/sycl/cmake/modules/UnifiedRuntimeTag.cmake
+++ b/sycl/cmake/modules/UnifiedRuntimeTag.cmake
@@ -1,7 +1,1 @@
-# commit 9937d029c7fdcbf101e89f8515f640c145e059c5
-# Merge: 9ac6d5d9 10b0e101
-# Author: Callum Fare <callum@codeplay.com>
-# Date:   Wed Nov 20 14:49:17 2024 +0000
-#     Merge pull request #2258 from aarongreig/aaron/tryUseExtensionSubgroupInfo
-#     Use extension version of clGetKernelSubGroupInfo when necessary.
-set(UNIFIED_RUNTIME_TAG 9937d029c7fdcbf101e89f8515f640c145e059c5)
+set(UNIFIED_RUNTIME_TAG pietro/prop_ncpu_r_or_nd)

--- a/sycl/test/check_device_code/native_cpu/nd_range_attr.cpp
+++ b/sycl/test/check_device_code/native_cpu/nd_range_attr.cpp
@@ -1,5 +1,6 @@
 // REQUIRES: native_cpu
 // RUN: %clangxx -fsycl-device-only -fsycl-targets=native_cpu %s -S -o - | FileCheck %s
+// RUN: %clangxx -fsycl-device-only -O0 -fsycl-targets=native_cpu %s -S -o - | FileCheck %s
 
 #include <sycl/sycl.hpp>
 using namespace sycl;
@@ -7,6 +8,14 @@ using namespace sycl;
 class Test;
 class Test2;
 class Test3;
+class Test4;
+
+template <typename AccT>
+void use_local_acc(nd_item<1> it, AccT &acc,
+                   const local_accessor<int, 1> &local_acc) {
+  local_acc[it.get_local_id()[0]] = 1;
+  acc[it.get_local_id()[0]] = local_acc[0];
+}
 
 int main() {
   sycl::queue deviceQueue;
@@ -22,18 +31,25 @@ int main() {
     deviceQueue.submit([&](handler &h) {
       auto acc = buf.template get_access<access::mode::write>(h);
       local_accessor<int, 1> local_acc(1, h);
-      h.parallel_for<Test2>(r, [=](nd_item<1> it) {
-        local_acc[0] = 1;
-        acc[0] = local_acc[0];
-      });
+      h.parallel_for<Test2>(
+          r, [=](nd_item<1> it) { use_local_acc(it, acc, local_acc); });
     });
     // CHECK-DAG: @_ZTS5Test2({{.*}} !is_nd_range [[MDID:![0-9]*]]
   }
+
   deviceQueue.submit([&](handler &h) {
     h.parallel_for<Test3>(1, [=](item<1> it) { it.get_id(); });
   });
   // CHECK-DAG: @_ZTS5Test3({{.*}} !is_nd_range [[MDNOT:![0-9]*]]
 
+  buffer<int, 1> buf(&res, 1);
+  deviceQueue.submit([&](sycl::handler &cgh) {
+    auto acc = sycl::accessor(buf, cgh, sycl::write_only);
+    cgh.parallel_for_work_group<Test4>(
+        range<1>(1), range<1>(1),
+        [=](auto group) { acc[group.get_group_id()] = 42; });
+  });
+  // CHECK-DAG: @_ZTS5Test4({{.*}} !is_nd_range [[MDID:![0-9]*]]
 }
 
 //CHECK:[[MDID]] = !{i1 true}

--- a/sycl/test/check_device_code/native_cpu/nd_range_attr.cpp
+++ b/sycl/test/check_device_code/native_cpu/nd_range_attr.cpp
@@ -1,0 +1,40 @@
+// REQUIRES: native_cpu
+// RUN: %clangxx -fsycl-device-only -fsycl-targets=native_cpu %s -S -o - | FileCheck %s
+
+#include <sycl/sycl.hpp>
+using namespace sycl;
+
+class Test;
+class Test2;
+class Test3;
+
+int main() {
+  sycl::queue deviceQueue;
+  sycl::nd_range<1> r(1, 1);
+  deviceQueue.submit([&](handler &h) {
+    h.parallel_for<Test>(r, [=](nd_item<1> it) { it.barrier(); });
+  });
+  // CHECK-DAG: @_ZTS4Test({{.*}} !is_nd_range [[MDID:![0-9]*]]
+
+  int res = 0;
+  {
+    buffer<int, 1> buf(&res, 1);
+    deviceQueue.submit([&](handler &h) {
+      auto acc = buf.template get_access<access::mode::write>(h);
+      local_accessor<int, 1> local_acc(1, h);
+      h.parallel_for<Test2>(r, [=](nd_item<1> it) {
+        local_acc[0] = 1;
+        acc[0] = local_acc[0];
+      });
+    });
+    // CHECK-DAG: @_ZTS5Test2({{.*}} !is_nd_range [[MDID:![0-9]*]]
+  }
+  deviceQueue.submit([&](handler &h) {
+    h.parallel_for<Test3>(1, [=](item<1> it) { it.get_id(); });
+  });
+  // CHECK-DAG: @_ZTS5Test3({{.*}} !is_nd_range [[MDNOT:![0-9]*]]
+
+}
+
+//CHECK:[[MDID]] = !{i1 true}
+//CHECK:[[MDNOT]] = !{i1 false}


### PR DESCRIPTION
This PR adds a mechanism to process Native CPU-specific kernel properties, and uses that mechanism to process a kernel property to check whether or not a kernel uses features provided by `sycl::nd_range` (e.g. `get_local_id`, local memory, `workgroup_barrier`).
This information is employed when enqueueing the kernel: if the kernel doesn't use `nd_range` features, we can restructure the nd_range, allowing us to pack more work items into a work group, which plays well with the vectorization/scheduling process used by Native CPU.
In particular this PR:
* Adds a `CheckNDRangeSYCLNativeCPU` pass which checks if the kernels uses features from an `nd_range`
* Adds a `SYCL/native cpu properties` section in the properties file, which will contain kernel properties specific to Native CPU.