### PR TITLE
Reenable CodeGen/SPIRV/transcoding/TransFNeg.ll on Windows

### DIFF
--- a/llvm/test/CodeGen/SPIRV/transcoding/TransFNeg.ll
+++ b/llvm/test/CodeGen/SPIRV/transcoding/TransFNeg.ll
@@ -1,8 +1,5 @@
 ; RUN: llc -O0 -mtriple=spirv32-unknown-unknown %s -o - | FileCheck %s --check-prefix=CHECK-SPIRV
 
-; https://github.com/intel/llvm/issues/14372
-; UNSUPPORTED: windows
-
 ; CHECK-SPIRV: OpFNegate
 ; CHECK-SPIRV: OpFNegate
 ; CHECK-SPIRV: OpFNegate


### PR DESCRIPTION
Fixes #14372.