### PR TITLE
[SYCL][Graph] Fix E2E Filecheck regex

### DIFF
--- a/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
+++ b/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
@@ -69,7 +69,7 @@ int main() {
   // CHECK: <--- urCommandBufferAppendKernelLaunchExp
   // CHECK-SAME: .hKernel = [[KERNEL_HANDLE1]]
   // CHECK-SAME: .numKernelAlternatives = 3
-  // CHECK-SAME: .phKernelAlternatives = {[[KERNEL_HANDLE2:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE3:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE4:[0-9a-fA-Fx]+]]}
+  // CHECK-SAME: .phKernelAlternatives = {{[0-9a-fA-Fx]* ?}}{[[KERNEL_HANDLE2:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE3:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE4:[0-9a-fA-Fx]+]]}
   auto DynamicCG =
       exp_ext::dynamic_command_group(Graph, {CGFA, CGFB, CGFC, CGFD});
   auto DynamicCGNode = Graph.add(DynamicCG);


### PR DESCRIPTION
CI is showing fails like https://github.com/intel/llvm/actions/runs/11969728548/job/33373742453?pr=15843
```
FAIL: SYCL :: Graph/Update/dyn_cgf_different_arg_nums.cpp (1219 of 2194)
******************** TEST 'SYCL :: Graph/Update/dyn_cgf_different_arg_nums.cpp' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
# RUN: at line 1
/__w/llvm/llvm/toolchain/bin//clang++  -Werror  -fsycl -fsycl-targets=nvptx64-nvidia-cuda  /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp -o /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out
# executed command: /__w/llvm/llvm/toolchain/bin//clang++ -Werror -fsycl -fsycl-targets=nvptx64-nvidia-cuda /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp -o /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out
# note: command had no output on stdout or stderr
# RUN: at line 2
env SYCL_UR_TRACE=2 env SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 ONEAPI_DEVICE_SELECTOR=cuda:gpu  /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out | /__w/llvm/llvm/toolchain/bin/FileCheck /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
# executed command: env SYCL_UR_TRACE=2 env SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 ONEAPI_DEVICE_SELECTOR=cuda:gpu /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out
# .---command stderr------------
# | UR ---> urContextRelease(Context)
# | UR <--- urContextRelease(Context)(UR_RESULT_SUCCESS)
# | UR ---> urDeviceRelease(Device)
# | UR <--- urDeviceRelease(Device)(UR_RESULT_SUCCESS)
# `-----------------------------
# executed command: /__w/llvm/llvm/toolchain/bin/FileCheck /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
# .---command stderr------------
# | /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp:72:17: error: CHECK-SAME: expected string not found in input
# |  // CHECK-SAME: .phKernelAlternatives = {[[KERNEL_HANDLE2:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE3:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE4:[0-9a-fA-Fx]+]]}
# |                 ^
# | <stdin>:180:245: note: scanning from here
# |  <--- urCommandBufferAppendKernelLaunchExp(.hCommandBuffer = 0x21d2ef0, .hKernel = 0x21e2e70, .workDim = 1, .pGlobalWorkOffset = 0x7ffca4f6fe70 (0), .pGlobalWorkSize = 0x7ffca4f6fe40 (1024), .pLocalWorkSize = nullptr, .numKernelAlternatives = 3, .phKernelAlternatives = 0x23b4070 {0x25529d0, 0x2555000, 0x25560a0}, .numSyncPointsInWaitList = 0, .pSyncPointWaitList = nullptr, .numEventsInWaitList = 0, .phEventWaitList = nullptr, .pSyncPoint = 0x7ffca4f6ff64 (0), .phEvent = nullptr, .phCommand = 0x7ffca4f6ff68 (0x1dbd370)) -> UR_RESULT_SUCCESS;
# |                                                                                                                                                                                                                                                     ^
# | 
# | Input file: <stdin>
# | Check file: /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
# | 
# | -dump-input=help explains the following input dump.
# | 
# | Input was:
# | <<<<<<
# |          .
# |          .
# |          .
# |        175:  ---> urKernelGetGroupInfo 
# |        176:  <--- urKernelGetGroupInfo(.hKernel = 0x21e2e70, .hDevice = 0x209bf40, .propName = UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, .propSize = 24, .pPropValue = {0, 0, 0}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS; 
# |        177:  ---> urCommandBufferGetInfoExp 
# |        178:  <--- urCommandBufferGetInfoExp(.hCommandBuffer = 0x21d2ef0, .propName = UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR, .propSize = 24, .pPropValue = 0x7ffca4f6fdc0 ((struct ur_exp_command_buffer_desc_t){.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, .pNext = nullptr, .isUpdatable = , .isInOrder = FAIL: SYCL :: Graph/Update/dyn_cgf_different_arg_nums.cpp (1219 of 2194)
******************** TEST 'SYCL :: Graph/Update/dyn_cgf_different_arg_nums.cpp' FAILED ********************
Exit Code: 1

Command Output (stdout):
--
# RUN: at line 1
/__w/llvm/llvm/toolchain/bin//clang++  -Werror  -fsycl -fsycl-targets=nvptx64-nvidia-cuda  /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp -o /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out
# executed command: /__w/llvm/llvm/toolchain/bin//clang++ -Werror -fsycl -fsycl-targets=nvptx64-nvidia-cuda /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp -o /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out
# note: command had no output on stdout or stderr
# RUN: at line 2
env SYCL_UR_TRACE=2 env SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 ONEAPI_DEVICE_SELECTOR=cuda:gpu  /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out | /__w/llvm/llvm/toolchain/bin/FileCheck /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
# executed command: env SYCL_UR_TRACE=2 env SYCL_PI_CUDA_ENABLE_IMAGE_SUPPORT=1 ONEAPI_DEVICE_SELECTOR=cuda:gpu /__w/llvm/llvm/build-e2e/Graph/Update/Output/dyn_cgf_different_arg_nums.cpp.tmp.out
# .---command stderr------------
# | UR ---> urContextRelease(Context)
# | UR <--- urContextRelease(Context)(UR_RESULT_SUCCESS)
# | UR ---> urDeviceRelease(Device)
# | UR <--- urDeviceRelease(Device)(UR_RESULT_SUCCESS)
# `-----------------------------
# executed command: /__w/llvm/llvm/toolchain/bin/FileCheck /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
# .---command stderr------------
# | /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp:72:17: error: CHECK-SAME: expected string not found in input
# |  // CHECK-SAME: .phKernelAlternatives = {[[KERNEL_HANDLE2:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE3:[0-9a-fA-Fx]+]], [[KERNEL_HANDLE4:[0-9a-fA-Fx]+]]}
# |                 ^
# | <stdin>:180:245: note: scanning from here
# |  <--- urCommandBufferAppendKernelLaunchExp(.hCommandBuffer = 0x21d2ef0, .hKernel = 0x21e2e70, .workDim = 1, .pGlobalWorkOffset = 0x7ffca4f6fe70 (0), .pGlobalWorkSize = 0x7ffca4f6fe40 (1024), .pLocalWorkSize = nullptr, .numKernelAlternatives = 3, .phKernelAlternatives = 0x23b4070 {0x25529d0, 0x2555000, 0x25560a0}, .numSyncPointsInWaitList = 0, .pSyncPointWaitList = nullptr, .numEventsInWaitList = 0, .phEventWaitList = nullptr, .pSyncPoint = 0x7ffca4f6ff64 (0), .phEvent = nullptr, .phCommand = 0x7ffca4f6ff68 (0x1dbd370)) -> UR_RESULT_SUCCESS;
# |                                                                                                                                                                                                                                                     ^
# | 
# | Input file: <stdin>
# | Check file: /__w/llvm/llvm/llvm/sycl/test-e2e/Graph/Update/dyn_cgf_different_arg_nums.cpp
# | 
# | -dump-input=help explains the following input dump.
# | 
# | Input was:
# | <<<<<<
# |          .
# |          .
# |          .
# |        175:  ---> urKernelGetGroupInfo 
# |        176:  <--- urKernelGetGroupInfo(.hKernel = 0x21e2e70, .hDevice = 0x209bf40, .propName = UR_KERNEL_GROUP_INFO_COMPILE_WORK_GROUP_SIZE, .propSize = 24, .pPropValue = {0, 0, 0}, .pPropSizeRet = nullptr) -> UR_RESULT_SUCCESS; 
# |        177:  ---> urCommandBufferGetInfoExp 
# |        178:  <--- urCommandBufferGetInfoExp(.hCommandBuffer = 0x21d2ef0, .propName = UR_EXP_COMMAND_BUFFER_INFO_DESCRIPTOR, .propSize = 24, .pPropValue = 0x7ffca4f6fdc0 ((struct ur_exp_command_buffer_desc_t){.stype = UR_STRUCTURE_TYPE_EXP_COMMAND_BUFFER_DESC, .pNext = nullptr, .isUpdatable = , .isInOrder = 
```


where the test is expecting output like:

```
.phKernelAlternatives = {0x12ed110, 0x1501ac0, 0x1502b60}
```

but the `SYCL_UR_TRACE` output is formed like:

```
.phKernelAlternatives = 0x23b4070 {0x25529d0, 0x2555000, 0x25560a0}
```

Fixed by updating the Filecheck regex